### PR TITLE
Improve update checking

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -263,7 +263,10 @@ class FlutterVersion {
     final bool canShowWarning = isNewRemoteVersion || isNewRemoteVersion == null && installationSeemsOutdated;
     
     if (beenAWhileSinceWarningWasPrinted && canShowWarning) {
-      printStatus(versionOutOfDateMessage(frameworkAge), emphasis: true);
+      final String updateMessage = isNewRemoteVersion
+          ? newVersionAvailableMessage()
+          : versionOutOfDateMessage(frameworkAge);
+      printStatus(updateMessage, emphasis: true);
       await Future.wait<Null>(<Future<Null>>[
         stamp.store(
           newTimeWarningWasPrinted: _clock.now(),
@@ -282,6 +285,17 @@ class FlutterVersion {
     return '''
   ╔════════════════════════════════════════════════════════════════════════════╗
   ║ $warning ║
+  ║                                                                            ║
+  ║ To update to the latest version, run "flutter upgrade".                    ║
+  ╚════════════════════════════════════════════════════════════════════════════╝
+''';
+  }
+
+  @visibleForTesting
+  static String newVersionAvailableMessage() {
+    return '''
+  ╔════════════════════════════════════════════════════════════════════════════╗
+  ║ A new version of Flutter is available!                                     ║
   ║                                                                            ║
   ║ To update to the latest version, run "flutter upgrade".                    ║
   ╚════════════════════════════════════════════════════════════════════════════╝

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -237,9 +237,6 @@ class FlutterVersion {
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
 
     /// Gets whether or not there is a new version of Flutter available on the remote.
-    ///
-    /// Returns null if the cached version is out-of-date or missing, and we are
-    /// unable to reach the server to get the latest version.
     Future<VersionCheckResult> newerFrameworkVersionAvailable() async {
       final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -260,10 +260,10 @@ class FlutterVersion {
 
     // We show a warning if either we know there is a new remote version, or we couldn't tell but the local
     // version is outdated.
-    final bool canShowWarning = isNewRemoteVersion || isNewRemoteVersion == null && installationSeemsOutdated;
+    final bool canShowWarning = isNewRemoteVersion == true || isNewRemoteVersion == null && installationSeemsOutdated;
     
     if (beenAWhileSinceWarningWasPrinted && canShowWarning) {
-      final String updateMessage = isNewRemoteVersion
+      final String updateMessage = isNewRemoteVersion == true
           ? newVersionAvailableMessage()
           : versionOutOfDateMessage(frameworkAge);
       printStatus(updateMessage, emphasis: true);

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -244,11 +244,11 @@ class FlutterVersion {
       final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
 
       if (latestFlutterCommitDate == null)
-        return VersionCheckResult.Unknown;
+        return VersionCheckResult.unknown;
 
       return latestFlutterCommitDate.isAfter(localFrameworkCommitDate)
-          ? VersionCheckResult.NewVersionAvailable
-          : VersionCheckResult.VersionIsCurrent;
+          ? VersionCheckResult.newVersionAvailable
+          : VersionCheckResult.versionIsCurrent;
     }
 
     // Get whether there's a newer version on the remote. This only goes
@@ -263,11 +263,11 @@ class FlutterVersion {
     // We show a warning if either we know there is a new remote version, or we couldn't tell but the local
     // version is outdated.
     final bool canShowWarning =
-      remoteVersion == VersionCheckResult.NewVersionAvailable
-      || remoteVersion == VersionCheckResult.Unknown && installationSeemsOutdated;
+      remoteVersion == VersionCheckResult.newVersionAvailable
+      || remoteVersion == VersionCheckResult.unknown && installationSeemsOutdated;
     
     if (beenAWhileSinceWarningWasPrinted && canShowWarning) {
-      final String updateMessage = remoteVersion == VersionCheckResult.NewVersionAvailable
+      final String updateMessage = remoteVersion == VersionCheckResult.newVersionAvailable
           ? newVersionAvailableMessage()
           : versionOutOfDateMessage(frameworkAge);
       printStatus(updateMessage, emphasis: true);
@@ -548,9 +548,9 @@ class GitTagVersion {
 enum VersionCheckResult {
   /// Unable to check whether a new version is available, possibly due to
   /// a connectivity issue.
-  Unknown,
+  unknown,
   /// The current version is up to date.
-  VersionIsCurrent,
+  versionIsCurrent,
   /// A newer version is available.
-  NewVersionAvailable,
+  newVersionAvailable,
 }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -238,7 +238,7 @@ class FlutterVersion {
     final Duration frameworkAge = _clock.now().difference(localFrameworkCommitDate);
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
 
-// Get whether there's a newer version on the remote. This only goes
+    // Get whether there's a newer version on the remote. This only goes
     // to the server if we haven't checked recently so won't happen often.
     final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
     final VersionCheckResult remoteVersion =

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -250,7 +250,7 @@ class FlutterVersion {
 
     // Get whether there's a newer version on the remote. This only goes
     // to the server if we haven't checked recently so won't happen often.
-    // Note: This must come before the stamp load below because it also reads/writes
+    // This must come before the stamp load below because it also reads/writes
     // the stamp and otherwise one will be stale.
     final VersionCheckResult remoteVersion = await isNewerFrameworkVersionAvailable();
     final VersionCheckStamp stamp = await VersionCheckStamp.load();

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -234,6 +234,11 @@ class FlutterVersion {
   /// This function must run while [Cache.lock] is acquired because it reads and
   /// writes shared cache files.
   Future<Null> checkFlutterVersionFreshness() async {
+    // Don't perform update checks if we're not on an official channel.
+    if (!officialChannels.contains(_channel)) {
+      return;
+    }
+
     final DateTime localFrameworkCommitDate = DateTime.parse(frameworkCommitDate);
     final Duration frameworkAge = _clock.now().difference(localFrameworkCommitDate);
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
@@ -323,8 +328,7 @@ class FlutterVersion {
 
     // Cache is empty or it's been a while since the last server ping. Ping the server.
     try {
-      final String branch = officialChannels.contains(_channel) ? _channel : 'master';
-      final DateTime remoteFrameworkCommitDate = DateTime.parse(await FlutterVersion.fetchRemoteFrameworkCommitDate(branch));
+      final DateTime remoteFrameworkCommitDate = DateTime.parse(await FlutterVersion.fetchRemoteFrameworkCommitDate(_channel));
       await versionCheckStamp.store(
         newTimeVersionWasChecked: _clock.now(),
         newKnownRemoteVersion: remoteFrameworkCommitDate,

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -206,7 +206,7 @@ class FlutterVersion {
   /// The amount of time we wait before pinging the server to check for the
   /// availability of a newer version of Flutter.
   @visibleForTesting
-  static const Duration kCheckAgeConsideredUpToDate = const Duration(days: 7);
+  static const Duration kCheckAgeConsideredUpToDate = const Duration(days: 3);
 
   /// We warn the user if the age of their Flutter installation is greater than
   /// this duration.
@@ -335,6 +335,11 @@ class FlutterVersion {
       // there's no Internet connectivity. Remote version check is best effort
       // only. We do not prevent the command from running when it fails.
       printTrace('Failed to check Flutter version in the remote repository: $error');
+      // Still update the timestamp to avoid us hitting the server on every single
+      // command if for some reason we cannot connect (eg. we may be offline).
+      await versionCheckStamp.store(
+        newTimeVersionWasChecked: _clock.now(),
+      );
       return null;
     }
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -224,7 +224,7 @@ class FlutterVersion {
   ///
   /// This can be customized in tests to speed them up.
   @visibleForTesting
-  static Duration kPauseToLetUserReadTheMessage = const Duration(seconds: 2);
+  static Duration timeToPauseToLetUserReadTheMessage = const Duration(seconds: 2);
 
   /// Checks if the currently installed version of Flutter is up-to-date, and
   /// warns the user if it isn't.
@@ -272,7 +272,7 @@ class FlutterVersion {
         stamp.store(
           newTimeWarningWasPrinted: _clock.now(),
         ),
-        new Future<Null>.delayed(kPauseToLetUserReadTheMessage),
+        new Future<Null>.delayed(timeToPauseToLetUserReadTheMessage),
       ]);
     }
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -210,8 +210,10 @@ class FlutterVersion {
 
   /// We warn the user if the age of their Flutter installation is greater than
   /// this duration.
+  /// 
+  /// This is set to 5 weeks because releases are currently around every 4 weeks. 
   @visibleForTesting
-  static final Duration kVersionAgeConsideredUpToDate = kCheckAgeConsideredUpToDate * 4;
+  static const Duration kVersionAgeConsideredUpToDate = const Duration(days: 35);
 
   /// The amount of time we wait between issuing a warning.
   ///

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -255,8 +255,8 @@ class FlutterVersion {
     // We show a warning if either we know there is a new remote version, or we couldn't tell but the local
     // version is outdated.
     final bool canShowWarning =
-      remoteVersion == VersionCheckResult.newVersionAvailable
-      || remoteVersion == VersionCheckResult.unknown && installationSeemsOutdated;
+        remoteVersion == VersionCheckResult.newVersionAvailable
+        || remoteVersion == VersionCheckResult.unknown && installationSeemsOutdated;
     
     if (beenAWhileSinceWarningWasPrinted && canShowWarning) {
       final String updateMessage = remoteVersion == VersionCheckResult.newVersionAvailable

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -238,23 +238,16 @@ class FlutterVersion {
     final Duration frameworkAge = _clock.now().difference(localFrameworkCommitDate);
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
 
-    /// Gets whether or not there is a new version of Flutter available on the remote.
-    Future<VersionCheckResult> isNewerFrameworkVersionAvailable() async {
-      final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
-
-      if (latestFlutterCommitDate == null)
-        return VersionCheckResult.unknown;
-
-      return latestFlutterCommitDate.isAfter(localFrameworkCommitDate)
-          ? VersionCheckResult.newVersionAvailable
-          : VersionCheckResult.versionIsCurrent;
-    }
-
-    // Get whether there's a newer version on the remote. This only goes
+// Get whether there's a newer version on the remote. This only goes
     // to the server if we haven't checked recently so won't happen often.
-    // This must come before the stamp load below because it also reads/writes
-    // the stamp and otherwise one will be stale.
-    final VersionCheckResult remoteVersion = await isNewerFrameworkVersionAvailable();
+    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
+    final VersionCheckResult remoteVersion =
+        latestFlutterCommitDate == null
+            ? VersionCheckResult.unknown
+            : latestFlutterCommitDate.isAfter(localFrameworkCommitDate)
+                ? VersionCheckResult.newVersionAvailable
+                : VersionCheckResult.versionIsCurrent;
+
     final VersionCheckStamp stamp = await VersionCheckStamp.load();
     final DateTime lastTimeWarningWasPrinted = stamp.lastTimeWarningWasPrinted ?? _clock.agoBy(kMaxTimeSinceLastWarning * 2);
     final bool beenAWhileSinceWarningWasPrinted = _clock.now().difference(lastTimeWarningWasPrinted) > kMaxTimeSinceLastWarning;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -239,10 +239,10 @@ class FlutterVersion {
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
 
     // Get whether there's a newer version on the remote. This only goes
-    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterDate();
-    final VersionCheckResult remoteVersionStatus =
     // to the server if we haven't checked recently so won't happen on every
     // command.
+    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterDate();
+    final VersionCheckResult remoteVersionStatus =
         latestFlutterCommitDate == null
             ? VersionCheckResult.unknown
             : latestFlutterCommitDate.isAfter(localFrameworkCommitDate)

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -240,7 +240,7 @@ class FlutterVersion {
 
     // Get whether there's a newer version on the remote. This only goes
     // to the server if we haven't checked recently so won't happen often.
-    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
+    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterDate();
     final VersionCheckResult remoteVersion =
         latestFlutterCommitDate == null
             ? VersionCheckResult.unknown
@@ -305,7 +305,7 @@ class FlutterVersion {
   ///
   /// Returns null if the cached version is out-of-date or missing, and we are
   /// unable to reach the server to get the latest version.
-  Future<DateTime> _getLatestAvailableFlutterVersion() async {
+  Future<DateTime> _getLatestAvailableFlutterDate() async {
     Cache.checkLockAcquired();
     final VersionCheckStamp versionCheckStamp = await VersionCheckStamp.load();
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -237,7 +237,7 @@ class FlutterVersion {
     final bool installationSeemsOutdated = frameworkAge > kVersionAgeConsideredUpToDate;
 
     /// Gets whether or not there is a new version of Flutter available on the remote.
-    Future<VersionCheckResult> newerFrameworkVersionAvailable() async {
+    Future<VersionCheckResult> isNewerFrameworkVersionAvailable() async {
       final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterVersion();
 
       if (latestFlutterCommitDate == null)
@@ -252,7 +252,7 @@ class FlutterVersion {
     // to the server if we haven't checked recently so won't happen often.
     // Note: This must come before the stamp load below because it also reads/writes
     // the stamp and otherwise one will be stale.
-    final VersionCheckResult remoteVersion = await newerFrameworkVersionAvailable();
+    final VersionCheckResult remoteVersion = await isNewerFrameworkVersionAvailable();
     final VersionCheckStamp stamp = await VersionCheckStamp.load();
     final DateTime lastTimeWarningWasPrinted = stamp.lastTimeWarningWasPrinted ?? _clock.agoBy(kMaxTimeSinceLastWarning * 2);
     final bool beenAWhileSinceWarningWasPrinted = _clock.now().difference(lastTimeWarningWasPrinted) > kMaxTimeSinceLastWarning;

--- a/packages/flutter_tools/test/version_test.dart
+++ b/packages/flutter_tools/test/version_test.dart
@@ -121,7 +121,7 @@ void main() {
       );
 
       await version.checkFlutterVersionFreshness();
-      _expectVersionMessage(FlutterVersion.versionOutOfDateMessage(_testClock.now().difference(_outOfDateVersion)));
+      _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
     }, overrides: <Type, Generator>{
       FlutterVersion: () => new FlutterVersion(_testClock),
       ProcessManager: () => mockProcessManager,
@@ -143,7 +143,7 @@ void main() {
       );
 
       await version.checkFlutterVersionFreshness();
-      _expectVersionMessage(FlutterVersion.versionOutOfDateMessage(_testClock.now().difference(_outOfDateVersion)));
+      _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
       expect((await VersionCheckStamp.load()).lastTimeWarningWasPrinted, _testClock.now());
 
       await version.checkFlutterVersionFreshness();
@@ -167,7 +167,7 @@ void main() {
       );
 
       await version.checkFlutterVersionFreshness();
-      _expectVersionMessage(FlutterVersion.versionOutOfDateMessage(_testClock.now().difference(_outOfDateVersion)));
+      _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
 
       // Immediate subsequent check is not expected to ping the server.
       fakeData(
@@ -201,7 +201,7 @@ void main() {
       );
 
       await version.checkFlutterVersionFreshness();
-      _expectVersionMessage(FlutterVersion.versionOutOfDateMessage(_testClock.now().difference(_outOfDateVersion)));
+      _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
     }, overrides: <Type, Generator>{
       FlutterVersion: () => new FlutterVersion(_testClock),
       ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/version_test.dart
+++ b/packages/flutter_tools/test/version_test.dart
@@ -217,6 +217,7 @@ void main() {
         localCommitDate: _upToDateVersion,
         errorOnFetch: true,
         expectServerPing: true,
+        expectSetStamp: true,
       );
 
       await version.checkFlutterVersionFreshness();

--- a/packages/flutter_tools/test/version_test.dart
+++ b/packages/flutter_tools/test/version_test.dart
@@ -36,7 +36,7 @@ void main() {
       <String>['git', 'rev-parse', '--abbrev-ref', '--symbolic', '@{u}'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
-    )).thenReturn(new ProcessResult(101, 0, 'channel', ''));
+    )).thenReturn(new ProcessResult(101, 0, 'master', ''));
     when(mockProcessManager.runSync(
       <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),

--- a/packages/flutter_tools/test/version_test.dart
+++ b/packages/flutter_tools/test/version_test.dart
@@ -62,7 +62,7 @@ void main() {
   group('$FlutterVersion', () {
     setUpAll(() {
       Cache.disableLocking();
-      FlutterVersion.kPauseToLetUserReadTheMessage = Duration.zero;
+      FlutterVersion.timeToPauseToLetUserReadTheMessage = Duration.zero;
     });
 
     testUsingContext('prints nothing when Flutter installation looks fresh', () async {


### PR DESCRIPTION
This change enables pinging the server to check for updates regardless of whether the local version is "out of date". The server code already has a 7-day cache so the result is that we can now ping the server once every 7 days instead of waiting for the local install to be 4 weeks out of date before pinging.

The original 4 week period is still used for when we'll start warning the user they're out of date if we could not confirm with the server whether there's a new version.

Please see the annotations on the PR code below for things I'm unsure about or would like specific feedback on. Thanks!

Fixes #14920.