### PR TITLE
Update flutter daemon docs

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -1,20 +1,20 @@
-# Flutter Daemon Modes
+# Flutter Daemon
 
 ## Overview
 
-The `flutter` command-line tool supports two daemon modes for use by IDEs and other tools. Both modes create a JSON-RPC server for communication.
+The `flutter` command-line tool supports a daemon server mode for use by IDEs and other tools.
 
-### flutter daemon
+```
+flutter daemon
+```
 
-This mode provides device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
+It runs a persistent, JSON-RPC based server to communicate with devices. IDEs and other tools can start the flutter tool in this mode and get device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
 
-### flutter run --machine
-
-This mode launches a Flutter application on a device just like `flutter run` but provides notifications in a machine-consumable JSON format and accepts JSON commands to programatically control the running application (for example hot reload).
+A subset of the `flutter daemon` commands/events are also exposed via `flutter run --machine` which allows IDEs and tools to launch flutter applications and interact to send commands like Hot Reload. Which commands/events are available in this mode is documented at the bottom of this document.
 
 ## Protocol
 
-The daemons speak [JSON-RPC](http://json-rpc.org/) to clients. They uses stdin and stdout as the protocol transport. To send a command to the server, create your command as a JSON-RPC message, encode it to json, surround the encoded text with square brackets, and write it as one line of text to the stdin of the process:
+The daemon speaks [JSON-RPC](http://json-rpc.org/) to clients. It uses stdin and stdout as the protocol transport. To send a command to the server, create your command as a JSON-RPC message, encode it to json, surround the encoded text with square brackets, and write it as one line of text to the stdin of the process:
 
 ```
 [{"method":"daemon.version","id":0}]
@@ -46,7 +46,7 @@ Any params for that command should be passed in through a `params` field. Here's
 
 ### daemon domain
 
-#### version (_`daemon`, `run`_)
+#### version
 
 The `version()` command responds with a String with the protocol version.
 
@@ -179,6 +179,37 @@ This is sent when a device is connected (and polling has been enabled via `enabl
 #### device.removed
 
 This is sent when a device is disconnected (and polling has been enabled via `enable()`). The `params` field will be a map with the fields `id`, `name`, `platform`, and `emulator`.
+
+## Flutter Run --machine
+
+When running `flutter run --machine` the following subset of the daemon is available:
+
+### daemon domain
+
+The following subset of the daemon domain is available in `flutter run --machine`. Refer to the documentation above for details.
+
+- Commands
+  - [`version`](#version)
+  - [`shutdown`](#shutdown)
+- Events
+  - [`connected`](#connected)
+  - [`logMessage`](#logMessage)
+
+### app domain
+
+The following subset of the app domain is available in `flutter run --machine`. Refer to the documentation above for details.
+
+- Commands
+  - [`restart`](#restart)
+  - [`callServiceExtension`](#callServiceExtension)
+  - [`stop`](#stop)
+- Events
+  - [`start`](#appstart)
+  - [`debugPort`](#appdebugPort)
+  - [`started`](#appstarted)
+  - [`log`](#applog)
+  - [`progress`](#appprogress)
+  - [`stop`](#appstop)
 
 ## Source
 

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -1,18 +1,20 @@
-# Flutter Daemon
+# Flutter Daemon Modes
 
 ## Overview
 
-The `flutter` command-line tool supports a daemon server mode for use by IDEs and other tools.
+The `flutter` command-line tool supports two daemon modes for use by IDEs and other tools. Both modes create a JSON-RPC server for communication.
 
-```
-flutter daemon
-```
+### flutter daemon
 
-It runs a persistent, JSON-RPC based server to communicate with devices. IDEs and other tools can start the flutter tool in this mode and get device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
+This mode provides device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
+
+### flutter run --machine
+
+This mode launches a Flutter application on a device just like `flutter run` but provides notifications in a machine-consumable JSON format and accepts JSON commands to programatically control the running application (for example hot reload).
 
 ## Protocol
 
-The daemon speaks [JSON-RPC](http://json-rpc.org/) to clients. It uses stdin and stdout as the protocol transport. To send a command to the server, create your command as a JSON-RPC message, encode it to json, surround the encoded text with square brackets, and write it as one line of text to the stdin of the process:
+The daemons speak [JSON-RPC](http://json-rpc.org/) to clients. They uses stdin and stdout as the protocol transport. To send a command to the server, create your command as a JSON-RPC message, encode it to json, surround the encoded text with square brackets, and write it as one line of text to the stdin of the process:
 
 ```
 [{"method":"daemon.version","id":0}]
@@ -44,7 +46,7 @@ Any params for that command should be passed in through a `params` field. Here's
 
 ### daemon domain
 
-#### version
+#### version (_`daemon`, `run`_)
 
 The `version()` command responds with a String with the protocol version.
 

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -46,29 +46,29 @@ Any params for that command should be passed in through a `params` field. Here's
 
 ### daemon domain
 
-#### version
+#### daemon.version
 
 The `version()` command responds with a String with the protocol version.
 
-#### shutdown
+#### daemon.shutdown
 
 The `shutdown()` command will terminate the flutter daemon. It is not necessary to call this before shutting down the daemon; it is perfectly acceptable to just kill the daemon process.
 
 #### Events
 
-#### connected
+#### daemon.connected
 
 The `daemon.connected` event is sent when the daemon starts. The `params` field will be a map with the following fields:
 
 - `version`: The protocol version. This is the same version returned by the `version()` command.
 - `pid`: The `pid` of the daemon process.
 
-#### logMessage
+#### daemon.logMessage
 
 The `daemon.logMessage` event is sent whenever a log message is created - either a status level message or an error. The JSON message will contains an `event` field with the value `daemon.logMessage`, and an `params` field containing a map with `level`, `message`, and (optionally) `stackTrace` fields.
 
 
-#### showMessage
+#### daemon.showMessage
 
 The `daemon.showMessage` event is sent by the daemon when some if would be useful to show a message to the user. This could be an error notification or a notification that some development tools are not configured or not installed. The JSON message will contains an `event` field with the value `daemon.showMessage`, and an `params` field containing a map with `level`, `title`, and `message` fields. The valid options for `level` are `info`, `warning`, and `error`.
 
@@ -76,7 +76,7 @@ It is up to the client to decide how best to display the message; for some clien
 
 ### app domain
 
-#### start
+#### app.start
 
 The `start()` command is used to start applications.
 
@@ -94,7 +94,7 @@ On success, returns a map with the fields:
 - `directory`
 - `supportsRestart`
 
-#### restart
+#### app.restart
 
 The `restart()` restarts the given application. It returns a Map of `{ int code, String message, String hintMessage, String hintId }` to indicate success or failure in restarting the app. A `code` of `0` indicates success, and non-zero indicates a failure. If `hintId` is non-null and equal to `restartRecommended`, that indicates that the reload was successful, but not all reloaded elements were executed during view reassembly (i.e., the user might not see all the changes in the current UI, and a restart could be necessary).
 
@@ -102,7 +102,7 @@ The `restart()` restarts the given application. It returns a Map of `{ int code,
 - `fullRestart`: optional; whether to do a full (rather than an incremental) restart of the application
 - `pause`: optional; when doing a hot restart the isolate should enter a paused mode
 
-#### callServiceExtension
+#### app.callServiceExtension
 
 The `callServiceExtension()` allows clients to make arbitrary calls to service protocol extensions. It returns a `Map` - the result returned by the service protocol method.
 
@@ -110,13 +110,13 @@ The `callServiceExtension()` allows clients to make arbitrary calls to service p
 - `methodName`: the name of the service protocol extension to invoke; this is required.
 - `params`: an optional Map of parameters to pass to the service protocol extension.
 
-#### stop
+#### app.stop
 
 The `stop()` command takes one parameter, `appId`. It returns a `bool` to indicate success or failure in stopping an app.
 
 - `appId`: the id of a previously started app; this is required.
 
-#### discover
+#### app.discover
 
 The `discover()` command takes one parameter, a `deviceId`. It returns a list of applications discovered on the device. Each application is represented by a map with two fields, an `id` - an Android or iOS application id - and an `observatoryDevicePort`. The `observatoryDevicePort` is the device port to connect to to debug the application. The port may first have to be made accessable via `device.forward`.
 
@@ -148,25 +148,25 @@ This is sent when an app is stopped. The `params` field will be a map with the f
 
 ### device domain
 
-#### getDevices
+#### device.getDevices
 
 Return a list of all connected devices. The `params` field will be a List; each item is a map with the fields `id`, `name`, `platform`, and `emulator` (a boolean).
 
-#### enable
+#### device.enable
 
 Turn on device polling. This will poll for newly connected devices, and fire `device.added` and `device.removed` events.
 
-#### disable
+#### device.disable
 
 Turn off device polling.
 
-#### forward
+#### device.forward
 
 Forward a host port to a device port. This call takes two required arguments, `deviceId` and `devicePort`, and one optional argument, `hostPort`. If `hostPort` is not specified, the host port will be any available port.
 
 This method returns a map with a `hostPort` field set.
 
-#### unforward
+#### device.unforward
 
 Removed a forwarded port. It takes `deviceId`, `devicePort`, and `hostPort` as required arguments.
 
@@ -189,20 +189,20 @@ When running `flutter run --machine` the following subset of the daemon is avail
 The following subset of the daemon domain is available in `flutter run --machine`. Refer to the documentation above for details.
 
 - Commands
-  - [`version`](#version)
-  - [`shutdown`](#shutdown)
+  - [`version`](#daemonversion)
+  - [`shutdown`](#daemonshutdown)
 - Events
-  - [`connected`](#connected)
-  - [`logMessage`](#logMessage)
+  - [`connected`](#daemonconnected)
+  - [`logMessage`](#daemonlogMessage)
 
 ### app domain
 
 The following subset of the app domain is available in `flutter run --machine`. Refer to the documentation above for details.
 
 - Commands
-  - [`restart`](#restart)
-  - [`callServiceExtension`](#callServiceExtension)
-  - [`stop`](#stop)
+  - [`restart`](#apprestart)
+  - [`callServiceExtension`](#appcallServiceExtension)
+  - [`stop`](#appstop)
 - Events
   - [`start`](#appstart)
   - [`debugPort`](#appdebugPort)


### PR DESCRIPTION
@devoncarew I started adding some notes to this doc about `flutter run --machine`. We need to document which notifications/commands are available in each mode - do you have a preference for how we do this? We could add a table at the top, but it's a bit far from the rest of the docs so it might be easy to forget to update. Another option is adding which mode each command/notification is available in next to its docs (such as what I've done next to `version` here).

LMK what you think and I can go through the rest.