### PR TITLE
Add --create option to `flutter emulators` command

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' show ProcessResult;
 
 import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:meta/meta.dart';
@@ -11,7 +11,6 @@ import 'package:meta/meta.dart';
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../base/file_system.dart';
-import '../base/process.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -5,12 +5,12 @@
 import 'dart:async';
 import 'dart:io' show ProcessResult;
 
-import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:meta/meta.dart';
 
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../base/file_system.dart';
+import '../base/process_manager.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:meta/meta.dart';
 
 import '../android/android_sdk.dart';
@@ -42,8 +43,8 @@ class AndroidEmulator extends Emulator {
   @override
   Future<void> launch() async {
     final Future<void> launchResult =
-        runAsync(<String>[getEmulatorPath(), '-avd', id])
-            .then((RunResult runResult) {
+        processManager.run(<String>[getEmulatorPath(), '-avd', id])
+            .then((ProcessResult runResult) {
               if (runResult.exitCode != 0) {
                 throw '$runResult';
               }
@@ -65,10 +66,12 @@ List<AndroidEmulator> getEmulatorAvds() {
     return <AndroidEmulator>[];
   }
 
-  final String listAvdsOutput = runSync(<String>[emulatorPath, '-list-avds']);
+  final String listAvdsOutput = processManager.runSync(<String>[emulatorPath, '-list-avds']).stdout;
 
   final List<AndroidEmulator> emulators = <AndroidEmulator>[];
-  extractEmulatorAvdInfo(listAvdsOutput, emulators);
+  if (listAvdsOutput != null) {
+    extractEmulatorAvdInfo(listAvdsOutput, emulators);
+  }
   return emulators;
 }
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -81,11 +81,11 @@ List<AndroidEmulator> getEmulatorAvds() {
 /// of emulators by reading information from the relevant ini files.
 void extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
   for (String id in text.trim().split('\n').where((String l) => l != '')) {
-    emulators.add(_createEmulator(id));
+    emulators.add(_loadEmulatorInfo(id));
   }
 }
 
-AndroidEmulator _createEmulator(String id) {
+AndroidEmulator _loadEmulatorInfo(String id) {
   id = id.trim();
   final File iniFile = fs.file(fs.path.join(getAvdPath(), '$id.ini'));
   if (iniFile.existsSync()) {

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:meta/meta.dart';
@@ -32,13 +33,15 @@ class AndroidEmulator extends Emulator {
   Map<String, String> _properties;
 
   @override
-  String get name => _properties['hw.device.name'];
+  String get name => _prop('hw.device.name');
 
   @override
-  String get manufacturer => _properties['hw.device.manufacturer'];
+  String get manufacturer => _prop('hw.device.manufacturer');
 
   @override
   String get label => _properties['avd.ini.displayname'];
+
+  String _prop(String name) => _properties != null ? _properties[name] : null;
 
   @override
   Future<void> launch() async {
@@ -86,14 +89,15 @@ void extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
 AndroidEmulator _createEmulator(String id) {
   id = id.trim();
   final File iniFile = fs.file(fs.path.join(getAvdPath(), '$id.ini'));
-  final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
-
-  if (ini['path'] != null) {
-    final File configFile = fs.file(fs.path.join(ini['path'], 'config.ini'));
-    if (configFile.existsSync()) {
-      final Map<String, String> properties =
-          parseIniLines(configFile.readAsLinesSync());
-      return new AndroidEmulator(id, properties);
+  if (iniFile.existsSync()) {
+    final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
+    if (ini['path'] != null) {
+      final File configFile = fs.file(fs.path.join(ini['path'], 'config.ini'));
+      if (configFile.existsSync()) {
+        final Map<String, String> properties =
+            parseIniLines(configFile.readAsLinesSync());
+        return new AndroidEmulator(id, properties);
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -87,15 +87,19 @@ void extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
 
 AndroidEmulator _loadEmulatorInfo(String id) {
   id = id.trim();
-  final File iniFile = fs.file(fs.path.join(getAvdPath(), '$id.ini'));
-  if (iniFile.existsSync()) {
-    final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
-    if (ini['path'] != null) {
-      final File configFile = fs.file(fs.path.join(ini['path'], 'config.ini'));
-      if (configFile.existsSync()) {
-        final Map<String, String> properties =
-            parseIniLines(configFile.readAsLinesSync());
-        return new AndroidEmulator(id, properties);
+  final String avdPath = getAvdPath();
+  if (avdPath != null) {
+    final File iniFile = fs.file(fs.path.join(avdPath, '$id.ini'));
+    if (iniFile.existsSync()) {
+      final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
+      if (ini['path'] != null) {
+        final File configFile =
+            fs.file(fs.path.join(ini['path'], 'config.ini'));
+        if (configFile.existsSync()) {
+          final Map<String, String> properties =
+              parseIniLines(configFile.readAsLinesSync());
+          return new AndroidEmulator(id, properties);
+        }
       }
     }
   }

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show ProcessResult;
 
 import 'package:meta/meta.dart';
 
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/process_manager.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -48,7 +48,7 @@ class AndroidEmulator extends Emulator {
         processManager.run(<String>[getEmulatorPath(), '-avd', id])
             .then((ProcessResult runResult) {
               if (runResult.exitCode != 0) {
-                throw '$runResult';
+                throw '${runResult.stdout}\n${runResult.stderr}'.trimRight();
               }
             });
     // emulator continues running on a successful launch so if we

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -104,6 +104,23 @@ String getAvdPath() {
   );
 }
 
+/// Locate 'avdmanager'. Prefer to use one from an Android SDK, if we can locate that.
+/// This should be used over accessing androidSdk.avdManagerPath directly because it
+/// will work for those users who have Android Tools installed but
+/// not the full SDK.
+String getAvdManagerPath([AndroidSdk existingSdk]) {
+  if (existingSdk?.avdManagerPath != null)
+    return existingSdk.avdManagerPath;
+
+  final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+
+  if (sdk?.latestVersion == null) {
+    return os.which('avdmanager')?.path;
+  } else {
+    return sdk.avdManagerPath;
+  }
+}
+
 class AndroidNdkSearchError {
   AndroidNdkSearchError(this.reason);
 
@@ -314,6 +331,8 @@ class AndroidSdk {
 
   String get emulatorPath => getEmulatorPath();
 
+  String get avdManagerPath => getAvdManagerPath();
+
   /// Validate the Android SDK. This returns an empty list if there are no
   /// issues; otherwise, it returns a list of issues found.
   List<String> validateSdkWellFormed() {
@@ -340,6 +359,14 @@ class AndroidSdk {
       if (fs.file(path).existsSync())
         return path;
     }
+    return null;
+  }
+
+  String getAvdManagerPath() {
+    final String binaryName = platform.isWindows ? 'avdmanager.exe' : 'avdmanager';
+    final String path = fs.path.join(directory, 'tools', 'bin', binaryName);
+    if (fs.file(path).existsSync())
+      return path;
     return null;
   }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -101,16 +101,8 @@ String getAvdPath() {
 /// will work for those users who have Android Tools installed but
 /// not the full SDK.
 String getAvdManagerPath([AndroidSdk existingSdk]) {
-  if (existingSdk?.avdManagerPath != null)
-    return existingSdk.avdManagerPath;
-
-  final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-
-  if (sdk?.latestVersion == null) {
-    return os.which('avdmanager')?.path;
-  } else {
-    return sdk.avdManagerPath;
-  }
+  return existingSdk?.avdManagerPath ??
+    AndroidSdk.locateAndroidSdk()?.avdManagerPath;
 }
 
 class AndroidNdkSearchError {

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -347,7 +347,7 @@ class AndroidSdk {
   }
 
   String getAvdManagerPath() {
-    final String binaryName = platform.isWindows ? 'avdmanager.exe' : 'avdmanager';
+    final String binaryName = platform.isWindows ? 'avdmanager.bat' : 'avdmanager';
     final String path = fs.path.join(directory, 'tools', 'bin', binaryName);
     if (fs.file(path).existsSync())
       return path;

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -64,16 +64,8 @@ String getAdbPath([AndroidSdk existingSdk]) {
 /// will work for those users who have Android Tools installed but
 /// not the full SDK.
 String getEmulatorPath([AndroidSdk existingSdk]) {
-  if (existingSdk?.emulatorPath != null)
-    return existingSdk.emulatorPath;
-
-  final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-
-  if (sdk?.latestVersion == null) {
-    return os.which('emulator')?.path;
-  } else {
-    return sdk.emulatorPath;
-  }
+  return existingSdk?.emulatorPath ??
+    AndroidSdk.locateAndroidSdk()?.emulatorPath;
 }
 
 /// Locate the path for storing AVD emulator images. Returns null if none found.

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -27,7 +27,7 @@ class EmulatorsCommand extends FlutterCommand {
   final String name = 'emulators';
 
   @override
-  final String description = 'List and launch available emulators.';
+  final String description = 'List, launch and create emulators.';
 
   @override
   final List<String> aliases = <String>['emulator'];
@@ -79,7 +79,7 @@ class EmulatorsCommand extends FlutterCommand {
 
   Future<Null> _createEmulator(String name) async {
     if (name == null) {
-      const String autoName = "flutter_emulator";
+      const String autoName = 'flutter_emulator';
       final Set<String> takenNames =
           (await emulatorManager.getEmulatorsMatching(autoName))
           .map((Emulator e) => e.id)
@@ -97,10 +97,8 @@ class EmulatorsCommand extends FlutterCommand {
       printStatus("Emulator '$name' created successfully.");
     } else {
       printStatus("Failed to create emulator '$name'.\n");
-      printStatus(createResult.error);
-      printStatus('You can find more information on managing emulators at the links below:\n'
-        '  https://developer.android.com/studio/run/managing-avds\n'
-        '  https://developer.android.com/studio/command-line/avdmanager');
+      printStatus(createResult.error.trim());
+      _printAdditionalInfo();
     }
   }
 
@@ -110,11 +108,8 @@ class EmulatorsCommand extends FlutterCommand {
         : await emulatorManager.getEmulatorsMatching(searchText);
 
     if (emulators.isEmpty) {
-      printStatus('No emulators available.\n\n'
-          // TODO(dantup): Change these when we support creation
-          // 'You may need to create images using "flutter emulators --create"\n'
-          'You may need to create one using Android Studio '
-          'or visit https://flutter.io/setup/ for troubleshooting tips.');
+      printStatus('No emulators available.');
+      _printAdditionalInfo(showCreateInstruction: true);
     } else {
       _printEmulatorList(
         emulators,
@@ -126,7 +121,28 @@ class EmulatorsCommand extends FlutterCommand {
   void _printEmulatorList(List<Emulator> emulators, String message) {
     printStatus('$message\n');
     Emulator.printEmulators(emulators);
-    printStatus(
-        "\nTo run an emulator, run 'flutter emulators --launch <emulator id>'.");
+    _printAdditionalInfo(showCreateInstruction: true, showRunInstruction: true);
+  }
+
+  void _printAdditionalInfo({ bool showRunInstruction = false,
+      bool showCreateInstruction = false }) {
+    printStatus('');
+    if (showRunInstruction) {
+      printStatus(
+          "To run an emulator, run 'flutter emulators --launch <emulator id>'.");
+    }
+    if (showCreateInstruction) {
+      printStatus(
+          "To create a new emulator, run 'flutter emulators --create [--name xyz]'.");
+    }
+
+    if (showRunInstruction || showCreateInstruction) {
+      printStatus('');
+    }
+    // TODO(dantup): Update this link to flutter.io if/when we have a better page.
+    // That page can then link out to these places if required.
+    printStatus('You can find more information on managing emulators at the links below:\n'
+        '  https://developer.android.com/studio/run/managing-avds\n'
+        '  https://developer.android.com/studio/command-line/avdmanager');
   }
 }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -16,6 +16,8 @@ class EmulatorsCommand extends FlutterCommand {
   EmulatorsCommand() {
     argParser.addOption('launch',
         help: 'The full or partial ID of the emulator to launch.');
+    argParser.addOption('create',
+        help: 'A name for the Android emulator to create.');
   }
 
   @override
@@ -40,6 +42,8 @@ class EmulatorsCommand extends FlutterCommand {
 
     if (argResults.wasParsed('launch')) {
       await _launchEmulator(argResults['launch']);
+    } else if (argResults.wasParsed('create')) {
+      await _createEmulator(argResults['create']);
     } else {
       final String searchText =
           argResults.rest != null && argResults.rest.isNotEmpty
@@ -67,6 +71,18 @@ class EmulatorsCommand extends FlutterCommand {
       catch (e) {
         printError(e);
       }
+    }
+  }
+
+  Future<Null> _createEmulator(String name) async {
+    final CreateEmulatorResult createResult =
+        await emulatorManager.createEmulator(name);
+
+    if (createResult.success) {
+      printStatus("Emulator '$name' created successfully.");
+    } else {
+      printStatus(createResult.error);
+      printStatus("Failed to create emulator '$name'.");
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -78,23 +78,11 @@ class EmulatorsCommand extends FlutterCommand {
   }
 
   Future<Null> _createEmulator(String name) async {
-    if (name == null) {
-      const String autoName = 'flutter_emulator';
-      final Set<String> takenNames =
-          (await emulatorManager.getEmulatorsMatching(autoName))
-          .map((Emulator e) => e.id)
-          .toSet();
-      int suffix = 1;
-      name = autoName;
-      while (takenNames.contains(name)) {
-        name = '${name}_${++suffix}';
-      }
-    }
     final CreateEmulatorResult createResult =
         await emulatorManager.createEmulator(name);
 
     if (createResult.success) {
-      printStatus("Emulator '$name' created successfully.");
+      printStatus("Emulator '${createResult.createdEmulatorName}' created successfully.");
     } else {
       printStatus("Failed to create emulator '$name'.\n");
       printStatus(createResult.error.trim());

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -16,8 +16,11 @@ class EmulatorsCommand extends FlutterCommand {
   EmulatorsCommand() {
     argParser.addOption('launch',
         help: 'The full or partial ID of the emulator to launch.');
-    argParser.addOption('create',
-        help: 'A name for the Android emulator to create.');
+    argParser.addFlag('create',
+        help: 'Creates a new Android emulator.',
+        negatable: false);
+    argParser.addOption('name',
+        help: 'The name for the emulator being created.');
   }
 
   @override
@@ -43,7 +46,7 @@ class EmulatorsCommand extends FlutterCommand {
     if (argResults.wasParsed('launch')) {
       await _launchEmulator(argResults['launch']);
     } else if (argResults.wasParsed('create')) {
-      await _createEmulator(argResults['create']);
+      await _createEmulator(argResults['name']);
     } else {
       final String searchText =
           argResults.rest != null && argResults.rest.isNotEmpty
@@ -75,6 +78,18 @@ class EmulatorsCommand extends FlutterCommand {
   }
 
   Future<Null> _createEmulator(String name) async {
+    if (name == null) {
+      const String autoName = "flutter_emulator";
+      final Set<String> takenNames =
+          (await emulatorManager.getEmulatorsMatching(autoName))
+          .map((Emulator e) => e.id)
+          .toSet();
+      int suffix = 1;
+      name = autoName;
+      while (takenNames.contains(name)) {
+        name = '${name}_${++suffix}';
+      }
+    }
     final CreateEmulatorResult createResult =
         await emulatorManager.createEmulator(name);
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -46,7 +46,7 @@ class EmulatorsCommand extends FlutterCommand {
     if (argResults.wasParsed('launch')) {
       await _launchEmulator(argResults['launch']);
     } else if (argResults.wasParsed('create')) {
-      await _createEmulator(argResults['name']);
+      await _createEmulator(name: argResults['name']);
     } else {
       final String searchText =
           argResults.rest != null && argResults.rest.isNotEmpty
@@ -77,9 +77,9 @@ class EmulatorsCommand extends FlutterCommand {
     }
   }
 
-  Future<Null> _createEmulator([String name]) async {
+  Future<Null> _createEmulator({String name}) async {
     final CreateEmulatorResult createResult =
-        await emulatorManager.createEmulator(name);
+        await emulatorManager.createEmulator(name: name);
 
     if (createResult.success) {
       printStatus("Emulator '${createResult.emulatorName}' created successfully.");

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -77,7 +77,7 @@ class EmulatorsCommand extends FlutterCommand {
     }
   }
 
-  Future<Null> _createEmulator(String name) async {
+  Future<Null> _createEmulator([String name]) async {
     final CreateEmulatorResult createResult =
         await emulatorManager.createEmulator(name);
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -81,8 +81,11 @@ class EmulatorsCommand extends FlutterCommand {
     if (createResult.success) {
       printStatus("Emulator '$name' created successfully.");
     } else {
+      printStatus("Failed to create emulator '$name'.\n");
       printStatus(createResult.error);
-      printStatus("Failed to create emulator '$name'.");
+      printStatus('You can find more information on managing emulators at the links below:\n'
+        '  https://developer.android.com/studio/run/managing-avds\n'
+        '  https://developer.android.com/studio/command-line/avdmanager');
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -17,7 +17,7 @@ class EmulatorsCommand extends FlutterCommand {
     argParser.addOption('launch',
         help: 'The full or partial ID of the emulator to launch.');
     argParser.addFlag('create',
-        help: 'Creates a new Android emulator.',
+        help: 'Creates a new Android emulator based on a Pixel device.',
         negatable: false);
     argParser.addOption('name',
         help: 'Used with flag --create. Specifies a name for the emulator being created.');

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -20,7 +20,7 @@ class EmulatorsCommand extends FlutterCommand {
         help: 'Creates a new Android emulator.',
         negatable: false);
     argParser.addOption('name',
-        help: 'The name for the emulator being created.');
+        help: 'Used with flag --create. Specifies a name for the emulator being created.');
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -82,9 +82,9 @@ class EmulatorsCommand extends FlutterCommand {
         await emulatorManager.createEmulator(name);
 
     if (createResult.success) {
-      printStatus("Emulator '${createResult.createdEmulatorName}' created successfully.");
+      printStatus("Emulator '${createResult.emulatorName}' created successfully.");
     } else {
-      printStatus("Failed to create emulator '$name'.\n");
+      printStatus("Failed to create emulator '${createResult.emulatorName}'.\n");
       printStatus(createResult.error.trim());
       _printAdditionalInfo();
     }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -8,7 +8,7 @@ import 'dart:math' as math;
 import 'android/android_emulator.dart';
 import 'android/android_sdk.dart';
 import 'base/context.dart';
-import 'base/process.dart';
+import 'base/process_manager.dart';
 import 'globals.dart';
 import 'ios/ios_emulators.dart';
 
@@ -95,7 +95,7 @@ class EmulatorManager {
       '-k', sdkId,
       '-d', device
     ];
-    final RunResult runResult = await runAsync(args);
+    final ProcessResult runResult = processManager.runSync(args);
     return new CreateEmulatorResult(
       success: runResult.exitCode == 0,
       output: runResult.stdout,
@@ -114,7 +114,7 @@ class EmulatorManager {
       'device',
       '-c'
     ];
-    final RunResult runResult = await runAsync(args);
+    final ProcessResult runResult = processManager.runSync(args);
     if (runResult.exitCode != 0)
       return null;
 
@@ -138,7 +138,7 @@ class EmulatorManager {
       'avd',
       '-n', 'temp',
     ];
-    final RunResult runResult = await runAsync(args);
+    final ProcessResult runResult = processManager.runSync(args);
    
     // Get the list of IDs that match our criteria
     final List<String> availableIDs = runResult.stderr

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 
 import 'android/android_emulator.dart';
 import 'android/android_sdk.dart';
 import 'base/context.dart';
+import 'base/io.dart' show ProcessResult;
 import 'base/process_manager.dart';
 import 'globals.dart';
 import 'ios/ios_emulators.dart';

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -61,7 +61,7 @@ class EmulatorManager {
   }
 
   /// Return the list of all available emulators.
-  Future<CreateEmulatorResult> createEmulator([String name]) async {
+  Future<CreateEmulatorResult> createEmulator({String name}) async {
     if (name == null || name == '') {
       const String autoName = 'flutter_emulator';
       // Don't use getEmulatorsMatching here, as it will only return one

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -92,7 +92,9 @@ class EmulatorManager {
       return new CreateEmulatorResult(
         name,
         success: false,
-        error: 'No Android AVD system images are available'
+        error: 'No suitable Android AVD system images are available. You may need to install these'
+            ' using sdkmanager, for example:\n'
+            '  sdkmanager "system-images;android-27;google_apis_playstore;x86"'
     );
 
     // Cleans up error output from avdmanager to make it more suitable to show

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'android/android_emulator.dart';
@@ -138,7 +139,8 @@ class EmulatorManager {
 
     final List<String> availableDevices = runResult.stdout
       .split('\n')
-      .where((String l) => preferredDevices.contains(l.trim()));
+      .where((String l) => preferredDevices.contains(l.trim()))
+      .toList();
 
     return preferredDevices.firstWhere(
       (String d) => availableDevices.contains(d),
@@ -163,7 +165,8 @@ class EmulatorManager {
       .split('\n')
       .where((String l) => androidApiVersion.hasMatch(l))
       .where((String l) => l.contains('system-images'))
-      .where((String l) => l.contains('google_apis_playstore'));
+      .where((String l) => l.contains('google_apis_playstore'))
+      .toList();
 
     // Get the highest Android API version or whats left
     final int apiVersion =

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -105,7 +105,7 @@ class EmulatorManager {
     }
 
     final List<String> args = <String>[
-      getAvdManagerPath(),
+      getAvdManagerPath(androidSdk),
       'create',
       'avd',
       '-n', name,
@@ -127,7 +127,7 @@ class EmulatorManager {
   ];
   Future<String> _getPreferredAvailableDevice() async {
     final List<String> args = <String>[
-      getAvdManagerPath(),
+      getAvdManagerPath(androidSdk),
       'list',
       'device',
       '-c'
@@ -151,7 +151,7 @@ class EmulatorManager {
     // It seems that to get the available list of images, we need to send a
     // request to create without the image and it'll provide us a list :-(
     final List<String> args = <String>[
-      getAvdManagerPath(),
+      getAvdManagerPath(androidSdk),
       'create',
       'avd',
       '-n', 'temp',

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -168,12 +168,14 @@ class EmulatorManager {
       .where((String l) => l.contains('google_apis_playstore'))
       .toList();
 
+    final List<int> availableApiVersions = availableIDs
+      .map((String id) => androidApiVersion.firstMatch(id).group(1))
+      .map((String apiVersion) => int.parse(apiVersion));
+
     // Get the highest Android API version or whats left
-    final int apiVersion =
-      availableIDs
-        .map((String id) => androidApiVersion.firstMatch(id).group(1))
-        .map((String apiVersion) => int.parse(apiVersion))
-        .reduce(math.max);
+    final int apiVersion = availableApiVersions.isNotEmpty
+      ? availableApiVersions.reduce(math.max)
+      : -1; // Don't match below
     
     // We're out of preferences, we just have to return the first one with the high
     // API version.

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -174,7 +174,8 @@ class EmulatorManager {
 
     final List<int> availableApiVersions = availableIDs
       .map((String id) => androidApiVersion.firstMatch(id).group(1))
-      .map((String apiVersion) => int.parse(apiVersion));
+      .map((String apiVersion) => int.parse(apiVersion))
+      .toList();
 
     // Get the highest Android API version or whats left
     final int apiVersion = availableApiVersions.isNotEmpty

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -61,7 +61,7 @@ class EmulatorManager {
   }
 
   /// Return the list of all available emulators.
-  Future<CreateEmulatorResult> createEmulator(String name) async {
+  Future<CreateEmulatorResult> createEmulator([String name]) async {
     if (name == null || name == '') {
       const String autoName = 'flutter_emulator';
       // Don't use getEmulatorsMatching here, as it will only return one

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -82,6 +82,7 @@ class EmulatorManager {
     final String device =  await _getPreferredAvailableDevice();
     if (device == null)
       return new CreateEmulatorResult(
+        name,
         success: false,
         error: 'No device definitions are available'
     );
@@ -89,6 +90,7 @@ class EmulatorManager {
     final String sdkId =  await _getPreferredSdkId();
     if (sdkId == null)
       return new CreateEmulatorResult(
+        name,
         success: false,
         error: 'No Android AVD system images are available'
     );
@@ -115,8 +117,8 @@ class EmulatorManager {
     ];
     final ProcessResult runResult = processManager.runSync(args);
     return new CreateEmulatorResult(
+      name,
       success: runResult.exitCode == 0,
-      createdEmulatorName: runResult.exitCode == 0 ? name : null,
       output: runResult.stdout,
       error: cleanError(runResult.stderr),
     );
@@ -268,9 +270,9 @@ abstract class Emulator {
 
 class CreateEmulatorResult {
   final bool success;
-  final String createdEmulatorName;
+  final String emulatorName;
   final String output;
   final String error;
 
-  CreateEmulatorResult({this.success, this.createdEmulatorName, this.output, this.error});
+  CreateEmulatorResult(this.emulatorName, {this.success, this.output, this.error});
 }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -37,8 +37,8 @@ class EmulatorManager {
         emulator.id?.toLowerCase()?.startsWith(searchText) == true ||
         emulator.name?.toLowerCase()?.startsWith(searchText) == true;
 
-    final Emulator exactMatch = emulators.firstWhere(
-        exactlyMatchesEmulatorId, orElse: () => null);
+    final Emulator exactMatch =
+        emulators.firstWhere(exactlyMatchesEmulatorId, orElse: () => null);
     if (exactMatch != null) {
       return <Emulator>[exactMatch];
     }
@@ -78,24 +78,20 @@ class EmulatorManager {
         name = '${autoName}_${++suffix}';
       }
     }
-    
-    final String device =  await _getPreferredAvailableDevice();
-    if (device == null)
-      return new CreateEmulatorResult(
-        name,
-        success: false,
-        error: 'No device definitions are available'
-    );
 
-    final String sdkId =  await _getPreferredSdkId();
+    final String device = await _getPreferredAvailableDevice();
+    if (device == null)
+      return new CreateEmulatorResult(name,
+          success: false, error: 'No device definitions are available');
+
+    final String sdkId = await _getPreferredSdkId();
     if (sdkId == null)
-      return new CreateEmulatorResult(
-        name,
-        success: false,
-        error: 'No suitable Android AVD system images are available. You may need to install these'
-            ' using sdkmanager, for example:\n'
-            '  sdkmanager "system-images;android-27;google_apis_playstore;x86"'
-    );
+      return new CreateEmulatorResult(name,
+          success: false,
+          error:
+              'No suitable Android AVD system images are available. You may need to install these'
+              ' using sdkmanager, for example:\n'
+              '  sdkmanager "system-images;android-27;google_apis_playstore;x86"');
 
     // Cleans up error output from avdmanager to make it more suitable to show
     // to flutter users. Specifically:
@@ -103,10 +99,11 @@ class EmulatorManager {
     // - Removes lines that tell the user to use '--force' to overwrite emulators
     String cleanError(String error) {
       return (error ?? '')
-        .split('\n')
-        .where((String l) => l.trim() != 'null')
-        .where((String l) => l.trim() != 'Use --force if you want to replace it.')
-        .join('\n');
+          .split('\n')
+          .where((String l) => l.trim() != 'null')
+          .where((String l) =>
+              l.trim() != 'Use --force if you want to replace it.')
+          .join('\n');
     }
 
     final List<String> args = <String>[
@@ -142,9 +139,9 @@ class EmulatorManager {
       return null;
 
     final List<String> availableDevices = runResult.stdout
-      .split('\n')
-      .where((String l) => preferredDevices.contains(l.trim()))
-      .toList();
+        .split('\n')
+        .where((String l) => preferredDevices.contains(l.trim()))
+        .toList();
 
     return preferredDevices.firstWhere(
       (String d) => availableDevices.contains(d),
@@ -163,25 +160,25 @@ class EmulatorManager {
       '-n', 'temp',
     ];
     final ProcessResult runResult = processManager.runSync(args);
-   
+
     // Get the list of IDs that match our criteria
     final List<String> availableIDs = runResult.stderr
-      .split('\n')
-      .where((String l) => androidApiVersion.hasMatch(l))
-      .where((String l) => l.contains('system-images'))
-      .where((String l) => l.contains('google_apis_playstore'))
-      .toList();
+        .split('\n')
+        .where((String l) => androidApiVersion.hasMatch(l))
+        .where((String l) => l.contains('system-images'))
+        .where((String l) => l.contains('google_apis_playstore'))
+        .toList();
 
     final List<int> availableApiVersions = availableIDs
-      .map((String id) => androidApiVersion.firstMatch(id).group(1))
-      .map((String apiVersion) => int.parse(apiVersion))
-      .toList();
+        .map((String id) => androidApiVersion.firstMatch(id).group(1))
+        .map((String apiVersion) => int.parse(apiVersion))
+        .toList();
 
     // Get the highest Android API version or whats left
     final int apiVersion = availableApiVersions.isNotEmpty
-      ? availableApiVersions.reduce(math.max)
-      : -1; // Don't match below
-    
+        ? availableApiVersions.reduce(math.max)
+        : -1; // Don't match below
+
     // We're out of preferences, we just have to return the first one with the high
     // API version.
     return availableIDs.firstWhere(
@@ -257,11 +254,13 @@ abstract class Emulator {
 
     // Join columns into lines of text
     final RegExp whiteSpaceAndDots = new RegExp(r'[•\s]+$');
-    return table.map((List<String> row) {
-      return indices
-        .map((int i) => row[i].padRight(widths[i]))
-        .join(' • ') + ' • ${row.last}';
-    })
+    return table
+        .map((List<String> row) {
+          return indices
+                  .map((int i) => row[i].padRight(widths[i]))
+                  .join(' • ') +
+              ' • ${row.last}';
+        })
         .map((String line) => line.replaceAll(whiteSpaceAndDots, ''))
         .toList();
   }

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -71,6 +71,8 @@ List<IOSEmulator> getEmulators() {
 }
 
 String getSimulatorPath() {
+  if (xcode.xcodeSelectPath == null)
+    return null;
   final List<String> searchPaths = <String>[
     fs.path.join(xcode.xcodeSelectPath, 'Applications', 'Simulator.app'),
   ];

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -68,7 +68,7 @@ void main() {
 
     testUsingContext('create emulator with an empty name does not fail',
         () async {
-      final CreateEmulatorResult res = await emulatorManager.createEmulator('');
+      final CreateEmulatorResult res = await emulatorManager.createEmulator();
       expect(res.success, equals(true));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -79,7 +79,7 @@ void main() {
     testUsingContext('create emulator with a unique name does not throw',
         () async {
       final CreateEmulatorResult res =
-          await emulatorManager.createEmulator('test');
+          await emulatorManager.createEmulator(name: 'test');
       expect(res.success, equals(true));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -89,7 +89,7 @@ void main() {
 
     testUsingContext('create emulator with an existing name errors', () async {
       final CreateEmulatorResult res =
-          await emulatorManager.createEmulator('existing-avd-1');
+          await emulatorManager.createEmulator(name: 'existing-avd-1');
       expect(res.success, equals(false));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -101,18 +101,18 @@ void main() {
         'create emulator without a name but when default exists adds a suffix',
         () async {
       // First will get default name.
-      CreateEmulatorResult res = await emulatorManager.createEmulator('');
+      CreateEmulatorResult res = await emulatorManager.createEmulator();
       expect(res.success, equals(true));
 
       final String defaultName = res.emulatorName;
 
       // Second...
-      res = await emulatorManager.createEmulator('');
+      res = await emulatorManager.createEmulator();
       expect(res.success, equals(true));
       expect(res.emulatorName, equals('${defaultName}_2'));
 
       // Third...
-      res = await emulatorManager.createEmulator('');
+      res = await emulatorManager.createEmulator();
       expect(res.success, equals(true));
       expect(res.emulatorName, equals('${defaultName}_3'));
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -213,7 +213,6 @@ class MockProcessManager extends Mock implements ProcessManager {
       // tracking any created emulators and reject when they already exist so this
       // mock will compare the name of the AVD being created with the fake existing
       // list and either reject if it exists, or add it to the list and return success.
-      // Push this name into the list of existing AVDs.
       final String name = args[3];
       // Error if this AVD already existed
       if (_existingAvds.contains(name)) {

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -129,17 +129,17 @@ void main() {
       CreateEmulatorResult res = await emulatorManager.createEmulator('');
       expect(res.success, equals(true));
       
-      final String defaultName = res.createdEmulatorName;
+      final String defaultName = res.emulatorName;
 
       // Second...
       res = await emulatorManager.createEmulator('');
       expect(res.success, equals(true));
-      expect(res.createdEmulatorName, equals('${defaultName}_2'));
+      expect(res.emulatorName, equals('${defaultName}_2'));
 
       // Third...
       res = await emulatorManager.createEmulator('');
       expect(res.success, equals(true));
-      expect(res.createdEmulatorName, equals('${defaultName}_3'));
+      expect(res.emulatorName, equals('${defaultName}_3'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:collection/collection.dart' show ListEquality;
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -16,79 +18,46 @@ import 'src/context.dart';
 import 'src/mocks.dart';
 
 void main() {
-  final MockProcessManager mockProcessManager = new MockProcessManager();
-  final MockConfig mockConfig = new MockConfig();
-  final MockAndroidSdk mockSdk = new MockAndroidSdk();
+  MockProcessManager mockProcessManager;
+  MockConfig mockConfig;
+  MockAndroidSdk mockSdk;
 
-  /// We have to send a command that fails in order to get the list of valid
-  /// system images paths. This is an example of the output to use in the mock.
-  const String mockCreateFailureOutput =
-      'Error: Package path (-k) not specified. Valid system image paths are:\n'
-      'system-images;android-27;google_apis;x86\n'
-      'system-images;android-P;google_apis;x86\n'
-      'system-images;android-27;google_apis_playstore;x86\n'
-      'null\n'; // Yep, these really end with null (on dantup's machine at least)
-  
   setUp(() {
+    mockProcessManager = new MockProcessManager();
+    mockConfig = new MockConfig();
+    mockSdk = new MockAndroidSdk();
+
     when(mockSdk.avdManagerPath).thenReturn('avdmanager');
     when(mockSdk.emulatorPath).thenReturn('emulator');
-
-    // Emulate not having XCode/iOS Simulator.
-    when(mockProcessManager.runSync(<String>['/usr/bin/xcode-select',
-        '--print-path'],
-    )).thenThrow(const ProcessException('/usr/bin/xcode-select', const <String>[]));
-
-    final List<String> existingAvds = <String>['existing-avd-1'];
-
-    // Mock the responses to commands required for creating/listing emulators
-    when(mockProcessManager.runSync(<String>['emulator', '-list-avds']))
-        .thenAnswer((Invocation inv) => new ProcessResult(101, 0, '${existingAvds.join('\n')}\n', ''));
-    when(mockProcessManager.runSync(<String>['avdmanager', 'list', 'device', '-c']))
-        .thenReturn(new ProcessResult(101, 0, 'test\ntest2\npixel\npixel-xl\n', ''));
-    when(mockProcessManager.runSync(<String>['avdmanager', 'create', 'avd', '-n', 'temp']))
-        .thenReturn(new ProcessResult(101, 1, '', mockCreateFailureOutput));
-
-    // In order to support testing auto generation of names we need to support
-    // tracking any created emulators and reject when they already exist so this
-    // mock will compare the name of the AVD being created with the fake existing
-    // list and either reject if it exists, or add it to the list and return success.
-    when(mockProcessManager.runSync(<String>['avdmanager',
-        'create', 'avd', '-n', any, '-k', any, '-d', any]))
-        .thenAnswer((Invocation inv) {
-          // Push this name into the list of existing AVDs.
-          //   [0] is args
-          //   [4] is the value after '-n' (the supplied name)
-          final String name = inv.positionalArguments[0][4];
-          // Error if this AVD already existed
-          if (existingAvds.contains(name)) {
-            return new ProcessResult(101, 1, '',
-              "Error: Android Virtual Device '$name' already exists.\n"
-              'Use --force if you want to replace it.'
-            );
-          } else {
-            existingAvds.add(name);
-            return new ProcessResult(101, 0, '', '');
-          }
-        });
   });
 
   group('EmulatorManager', () {
     testUsingContext('getEmulators', () async {
       // Test that EmulatorManager.getEmulators() doesn't throw.
-      final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators();
+      final List<Emulator> emulators =
+          await emulatorManager.getAllAvailableEmulators();
       expect(emulators, isList);
     });
 
     testUsingContext('getEmulatorsById', () async {
-      final _MockEmulator emulator1 = new _MockEmulator('Nexus_5', 'Nexus 5', 'Google', '');
-      final _MockEmulator emulator2 = new _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google', '');
-      final _MockEmulator emulator3 = new _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple', '');
-      final List<Emulator> emulators = <Emulator>[emulator1, emulator2, emulator3];
-      final TestEmulatorManager testEmulatorManager = new TestEmulatorManager(emulators);
-      
+      final _MockEmulator emulator1 =
+          new _MockEmulator('Nexus_5', 'Nexus 5', 'Google', '');
+      final _MockEmulator emulator2 =
+          new _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google', '');
+      final _MockEmulator emulator3 =
+          new _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple', '');
+      final List<Emulator> emulators = <Emulator>[
+        emulator1,
+        emulator2,
+        emulator3
+      ];
+      final TestEmulatorManager testEmulatorManager =
+          new TestEmulatorManager(emulators);
+
       Future<Null> expectEmulator(String id, List<Emulator> expected) async {
         expect(await testEmulatorManager.getEmulatorsMatching(id), expected);
       }
+
       expectEmulator('Nexus_5', <Emulator>[emulator1]);
       expectEmulator('Nexus_5X', <Emulator>[emulator2]);
       expectEmulator('Nexus_5X_API_27_x86', <Emulator>[emulator2]);
@@ -97,7 +66,8 @@ void main() {
       expectEmulator('ios', <Emulator>[emulator3]);
     });
 
-    testUsingContext('create emulator with an empty name does not fail', () async {
+    testUsingContext('create emulator with an empty name does not fail',
+        () async {
       final CreateEmulatorResult res = await emulatorManager.createEmulator('');
       expect(res.success, equals(true));
     }, overrides: <Type, Generator>{
@@ -106,8 +76,10 @@ void main() {
       AndroidSdk: () => mockSdk,
     });
 
-    testUsingContext('create emulator with a unique name does not throw', () async {
-      final CreateEmulatorResult res = await emulatorManager.createEmulator('test');
+    testUsingContext('create emulator with a unique name does not throw',
+        () async {
+      final CreateEmulatorResult res =
+          await emulatorManager.createEmulator('test');
       expect(res.success, equals(true));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -116,7 +88,8 @@ void main() {
     });
 
     testUsingContext('create emulator with an existing name errors', () async {
-      final CreateEmulatorResult res = await emulatorManager.createEmulator('existing-avd-1');
+      final CreateEmulatorResult res =
+          await emulatorManager.createEmulator('existing-avd-1');
       expect(res.success, equals(false));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -124,11 +97,13 @@ void main() {
       AndroidSdk: () => mockSdk,
     });
 
-    testUsingContext('create emulator without a name but when default exists adds a suffix', () async {
+    testUsingContext(
+        'create emulator without a name but when default exists adds a suffix',
+        () async {
       // First will get default name.
       CreateEmulatorResult res = await emulatorManager.createEmulator('');
       expect(res.success, equals(true));
-      
+
       final String defaultName = res.emulatorName;
 
       // Second...
@@ -160,14 +135,15 @@ class TestEmulatorManager extends EmulatorManager {
 }
 
 class _MockEmulator extends Emulator {
-  _MockEmulator(String id, this.name, this.manufacturer, this.label) : super(id, true);
+  _MockEmulator(String id, this.name, this.manufacturer, this.label)
+      : super(id, true);
 
   @override
   final String name;
- 
+
   @override
   final String manufacturer;
- 
+
   @override
   final String label;
 
@@ -177,5 +153,81 @@ class _MockEmulator extends Emulator {
   }
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
 class MockConfig extends Mock implements Config {}
+
+class MockProcessManager extends Mock implements ProcessManager {
+  /// We have to send a command that fails in order to get the list of valid
+  /// system images paths. This is an example of the output to use in the mock.
+  static const String mockCreateFailureOutput =
+      'Error: Package path (-k) not specified. Valid system image paths are:\n'
+      'system-images;android-27;google_apis;x86\n'
+      'system-images;android-P;google_apis;x86\n'
+      'system-images;android-27;google_apis_playstore;x86\n'
+      'null\n'; // Yep, these really end with null (on dantup's machine at least)
+
+  static const ListEquality<String> _equality = const ListEquality<String>();
+  final List<String> _existingAvds = <String>['existing-avd-1'];
+
+  @override
+  ProcessResult runSync(
+    List<dynamic> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding,
+    Encoding stderrEncoding
+  }) {
+    final String program = command[0];
+    final List<String> args = command.sublist(1);
+    switch (command[0]) {
+      case '/usr/bin/xcode-select':
+        throw new ProcessException(program, args);
+        break;
+      case 'emulator':
+        return _handleEmulator(args);
+      case 'avdmanager':
+        return _handleAvdManager(args);
+    }
+    throw new StateError('Unexpected process call: $command');
+  }
+
+  ProcessResult _handleEmulator(List<String> args) {
+    if (_equality.equals(args, <String>['-list-avds'])) {
+      return new ProcessResult(101, 0, '${_existingAvds.join('\n')}\n', '');
+    }
+    throw new ProcessException('emulator', args);
+  }
+
+  ProcessResult _handleAvdManager(List<String> args) {
+    if (_equality.equals(args, <String>['list', 'device', '-c'])) {
+      return new ProcessResult(101, 0, 'test\ntest2\npixel\npixel-xl\n', '');
+    }
+    if (_equality.equals(args, <String>['create', 'avd', '-n', 'temp'])) {
+      return new ProcessResult(101, 1, '', mockCreateFailureOutput);
+    }
+    if (args.length == 8 &&
+        _equality.equals(args,
+            <String>['create', 'avd', '-n', args[3], '-k', args[5], '-d', args[7]])) {
+      // In order to support testing auto generation of names we need to support
+      // tracking any created emulators and reject when they already exist so this
+      // mock will compare the name of the AVD being created with the fake existing
+      // list and either reject if it exists, or add it to the list and return success.
+      // Push this name into the list of existing AVDs.
+      final String name = args[3];
+      // Error if this AVD already existed
+      if (_existingAvds.contains(name)) {
+        return new ProcessResult(
+            101,
+            1,
+            '',
+            "Error: Android Virtual Device '$name' already exists.\n"
+            'Use --force if you want to replace it.');
+      } else {
+        _existingAvds.add(name);
+        return new ProcessResult(101, 0, '', '');
+      }
+    }
+    throw new ProcessException('emulator', args);
+  }
+}

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -4,16 +4,78 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/emulator.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 import 'package:test/test.dart';
 
 import 'src/context.dart';
+import 'src/mocks.dart';
 
 void main() {
+  final MockProcessManager mockProcessManager = new MockProcessManager();
+  final MockConfig mockConfig = new MockConfig();
+  final MockAndroidSdk mockSdk = new MockAndroidSdk();
+
+  /// We have to send a command that fails in order to get the list of valid
+  /// system images paths. This is an example of the output to use in the mock.
+  const String mockCreateFailureOutput =
+      'Error: Package path (-k) not specified. Valid system image paths are:\n'
+      'system-images;android-27;google_apis;x86\n'
+      'system-images;android-P;google_apis;x86\n'
+      'system-images;android-27;google_apis_playstore;x86\n'
+      'null\n'; // Yep, these really end with null (on dantup's machine at least)
+  
+  setUp(() {
+    when(mockSdk.avdManagerPath).thenReturn('avdmanager');
+    when(mockSdk.emulatorPath).thenReturn('emulator');
+
+    // Emulate not having XCode/iOS Simulator.
+    when(mockProcessManager.runSync(<String>['/usr/bin/xcode-select',
+        '--print-path'],
+    )).thenThrow(const ProcessException('/usr/bin/xcode-select', const <String>[]));
+
+    final List<String> existingAvds = <String>['existing-avd-1'];
+
+    // Mock the responses to commands required for creating/listing emulators
+    when(mockProcessManager.runSync(<String>['emulator', '-list-avds']))
+        .thenAnswer((Invocation inv) => new ProcessResult(101, 0, '${existingAvds.join('\n')}\n', ''));
+    when(mockProcessManager.runSync(<String>['avdmanager', 'list', 'device', '-c']))
+        .thenReturn(new ProcessResult(101, 0, 'test\ntest2\npixel\npixel-xl\n', ''));
+    when(mockProcessManager.runSync(<String>['avdmanager', 'create', 'avd', '-n', 'temp']))
+        .thenReturn(new ProcessResult(101, 1, '', mockCreateFailureOutput));
+
+    // In order to support testing auto generation of names we need to support
+    // tracking any created emulators and reject when they already exist so this
+    // mock will compare the name of the AVD being created with the fake existing
+    // list and either reject if it exists, or add it to the list and return success.
+    when(mockProcessManager.runSync(<String>['avdmanager',
+        'create', 'avd', '-n', any, '-k', any, '-d', any]))
+        .thenAnswer((Invocation inv) {
+          // Push this name into the list of existing AVDs.
+          //   [0] is args
+          //   [4] is the value after '-n' (the supplied name)
+          final String name = inv.positionalArguments[0][4];
+          // Error if this AVD already existed
+          if (existingAvds.contains(name)) {
+            return new ProcessResult(101, 1, '',
+              "Error: Android Virtual Device '$name' already exists.\n"
+              'Use --force if you want to replace it.'
+            );
+          } else {
+            existingAvds.add(name);
+            return new ProcessResult(101, 0, '', '');
+          }
+        });
+  });
+
   group('EmulatorManager', () {
     testUsingContext('getEmulators', () async {
       // Test that EmulatorManager.getEmulators() doesn't throw.
-      final EmulatorManager emulatorManager = new EmulatorManager();
       final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators();
       expect(emulators, isList);
     });
@@ -23,10 +85,10 @@ void main() {
       final _MockEmulator emulator2 = new _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google', '');
       final _MockEmulator emulator3 = new _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple', '');
       final List<Emulator> emulators = <Emulator>[emulator1, emulator2, emulator3];
-      final EmulatorManager emulatorManager = new TestEmulatorManager(emulators);
-
+      final TestEmulatorManager testEmulatorManager = new TestEmulatorManager(emulators);
+      
       Future<Null> expectEmulator(String id, List<Emulator> expected) async {
-        expect(await emulatorManager.getEmulatorsMatching(id), expected);
+        expect(await testEmulatorManager.getEmulatorsMatching(id), expected);
       }
       expectEmulator('Nexus_5', <Emulator>[emulator1]);
       expectEmulator('Nexus_5X', <Emulator>[emulator2]);
@@ -34,6 +96,55 @@ void main() {
       expectEmulator('Nexus', <Emulator>[emulator1, emulator2]);
       expectEmulator('iOS Simulator', <Emulator>[emulator3]);
       expectEmulator('ios', <Emulator>[emulator3]);
+    });
+
+    testUsingContext('create emulator with an empty name does not fail', () async {
+      final CreateEmulatorResult res = await emulatorManager.createEmulator('');
+      expect(res.success, equals(true));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Config: () => mockConfig,
+      AndroidSdk: () => mockSdk,
+    });
+
+    testUsingContext('create emulator with a unique name does not throw', () async {
+      final CreateEmulatorResult res = await emulatorManager.createEmulator('test');
+      expect(res.success, equals(true));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Config: () => mockConfig,
+      AndroidSdk: () => mockSdk,
+    });
+
+    testUsingContext('create emulator with an existing name errors', () async {
+      final CreateEmulatorResult res = await emulatorManager.createEmulator('existing-avd-1');
+      expect(res.success, equals(false));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Config: () => mockConfig,
+      AndroidSdk: () => mockSdk,
+    });
+
+    testUsingContext('create emulator without a name but when default exists adds a suffix', () async {
+      // First will get default name.
+      CreateEmulatorResult res = await emulatorManager.createEmulator('');
+      expect(res.success, equals(true));
+      
+      final String defaultName = res.createdEmulatorName;
+
+      // Second...
+      res = await emulatorManager.createEmulator('');
+      expect(res.success, equals(true));
+      expect(res.createdEmulatorName, equals('${defaultName}_2'));
+
+      // Third...
+      res = await emulatorManager.createEmulator('');
+      expect(res.success, equals(true));
+      expect(res.createdEmulatorName, equals('${defaultName}_3'));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Config: () => mockConfig,
+      AndroidSdk: () => mockSdk,
     });
   });
 }
@@ -66,3 +177,6 @@ class _MockEmulator extends Emulator {
     throw new UnimplementedError('Not implemented in Mock');
   }
 }
+
+class MockProcessManager extends Mock implements ProcessManager {}
+class MockConfig extends Mock implements Config {}


### PR DESCRIPTION
This is still a bit rough and has no tests, but I wanted to nail down the logic before I start adding tests against it. This is based on the logic described in https://github.com/flutter/flutter/issues/13379#issuecomment-394686208. I don't entirely like how we have to do it (for ex. trying to create on without the sdk ID because we can't get a list of these, only devices/targets) but (on my Macbook at least) it seems to work.

LMK what you think. We may also wish to review the device we pick (currently we try `pixel` and `pixel_xl`) and whether we want to lock to a specific Android API version or just take the highest (which is what this currently does).

<img width="661" alt="screen shot 2018-06-06 at 1 13 35 pm" src="https://user-images.githubusercontent.com/1078012/41037511-75e1a718-698b-11e8-8e91-180b82f6da34.png">

(cc @devoncarew @mit-mit)