### PR TITLE
_markNeedsClip() when clipper type has changed.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -154,8 +154,5 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
   }
 
   @override
-  bool shouldReclip(CustomClipper<Path> oldClipper) {
-    final _BottomAppBarClipper typedOldClipper = oldClipper;
-    return typedOldClipper.geometry != geometry;
-  }
+  bool shouldReclip(_BottomAppBarClipper oldClipper) => oldClipper.geometry != geometry;
 }

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -155,9 +155,6 @@ class _BottomAppBarClipper extends CustomClipper<Path> {
 
   @override
   bool shouldReclip(CustomClipper<Path> oldClipper) {
-    if (oldClipper.runtimeType != _BottomAppBarClipper)
-      return true;
-
     final _BottomAppBarClipper typedOldClipper = oldClipper;
     return typedOldClipper.geometry != geometry;
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1106,7 +1106,7 @@ abstract class _RenderCustomClip<T> extends RenderProxyBox {
     _clipper = newClipper;
     assert(newClipper != null || oldClipper != null);
     if (newClipper == null || oldClipper == null ||
-        oldClipper.runtimeType != oldClipper.runtimeType ||
+        newClipper.runtimeType != oldClipper.runtimeType ||
         newClipper.shouldReclip(oldClipper)) {
       _markNeedsClip();
     }


### PR DESCRIPTION
A bug in _RenderCustomClip was compaeing the type of oldClipper to
itself instead to the type of newClipper.

This was the root cause for the crash #14937 worked around.
This also reverts the workaround introduced in #14937.