### PR TITLE
showOnScreen Improvements

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -658,6 +658,8 @@ class RenderListWheelViewport
     super.showOnScreen(
       // Omitting `descendant` to get this viewport on screen.
       rect: rect,
+      duration: duration,
+      curve: curve,
     );
   }
 }

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -614,24 +614,25 @@ class RenderListWheelViewport
   }
 
   @override
-  double getOffsetToReveal(RenderObject target, double alignment) {
-    final ListWheelParentData parentData = target.parentData;
-    final double centerPosition = parentData.offset.dy;
-
-    if (alignment < 0.5) {
-      return centerPosition + _topScrollMarginExtent * alignment * 2.0;
-    } else if (alignment > 0.5) {
-      return centerPosition - _topScrollMarginExtent * (alignment - 0.5) * 2.0;
-    } else {
-      return centerPosition;
-    }
+  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect}) {
+//    final ListWheelParentData parentData = target.parentData;
+//    final double centerPosition = parentData.offset.dy;
+//
+//    if (alignment < 0.5) {
+//      return centerPosition + _topScrollMarginExtent * alignment * 2.0;
+//    } else if (alignment > 0.5) {
+//      return centerPosition - _topScrollMarginExtent * (alignment - 0.5) * 2.0;
+//    } else {
+//      return centerPosition;
+//    }
+    return null;
   }
 
   @override
-  void showOnScreen([RenderObject child]) {
-    if (child != null) {
+  void showOnScreen({RenderObject descendant, Rect rect}) {
+    if (descendant != null) {
       // Shows the child in the selected/center position.
-      offset.jumpTo(getOffsetToReveal(child, 0.5));
+      offset.jumpTo(getOffsetToReveal(descendant, 0.5).offset);
     }
 
     // Make sure the viewport itself is on screen.

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
@@ -637,11 +638,20 @@ class RenderListWheelViewport
   }
 
   @override
-  void showOnScreen({RenderObject descendant, Rect rect}) {
+  void showOnScreen({
+    RenderObject descendant,
+    Rect rect,
+    Duration duration: Duration.zero,
+    Curve curve: Curves.ease,
+  }) {
     if (descendant != null) {
       // Shows the descendant in the selected/center position.
       final RevealedOffset revealedOffset = getOffsetToReveal(descendant, 0.5, rect: rect);
-      offset.jumpTo(revealedOffset.offset);
+      if (duration == Duration.zero) {
+        offset.jumpTo(revealedOffset.offset);
+      } else {
+        offset.animateTo(revealedOffset.offset, duration: duration, curve: curve);
+      }
       rect = revealedOffset.rect;
     }
 

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -622,7 +622,7 @@ class RenderListWheelViewport
 
     rect ??= target.paintBounds;
 
-    // The child will be the topmost object before we get to the viewport.
+    // `child` will be the last RenderObject before the viewport when walking up from `target`.
     RenderObject child = target;
     while (child.parent != this)
       child = child.parent;
@@ -656,7 +656,6 @@ class RenderListWheelViewport
     }
 
     super.showOnScreen(
-      // Omitting `descendant` to get this viewport on screen.
       rect: rect,
       duration: duration,
       curve: curve,

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -641,8 +641,8 @@ class RenderListWheelViewport
   void showOnScreen({
     RenderObject descendant,
     Rect rect,
-    Duration duration: Duration.zero,
-    Curve curve: Curves.ease,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
   }) {
     if (descendant != null) {
       // Shows the descendant in the selected/center position.

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -632,7 +632,7 @@ class RenderListWheelViewport
 
     final Matrix4 transform = target.getTransformTo(this);
     final Rect bounds = MatrixUtils.transformRect(transform, rect);
-    final Rect targetRect = bounds.translate(0.0,  (size.height - itemExtent) / 2);
+    final Rect targetRect = bounds.translate(0.0, (size.height - itemExtent) / 2);
 
     return new RevealedOffset(offset: targetOffset, rect: targetRect);
   }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2580,8 +2580,8 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// If `descendant` is provided, that [RenderObject] is made visible. If
   /// `descendant` is omitted, this [RenderObject] is made visible.
   ///
-  /// The optional `rect` parameter describes which area of the [RenderObject]
-  /// should be shown on screen. If `rect` is null, that entire
+  /// The optional `rect` parameter describes which area of that [RenderObject]
+  /// should be shown on screen. If `rect` is null, the entire
   /// [RenderObject] (as defined by its [paintBounds]) will be revealed. The
   /// `rect` parameter is interpreted relative to the coordinate system of
   /// `descendant` if that argument is provided and relative to this

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2572,12 +2572,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
   /// Attempt to make this or a descendant RenderObject visible on screen.
   ///
-  /// If [child] is provided, that [RenderObject] is made visible. If [child] is
+  /// If [descendant] is provided, that [RenderObject] is made visible. If [descendant] is
   /// omitted, this [RenderObject] is made visible.
-  void showOnScreen([RenderObject child]) {
+  void showOnScreen({RenderObject descendant, Rect rect}) {
     if (parent is RenderObject) {
       final RenderObject renderParent = parent;
-      renderParent.showOnScreen(child ?? this);
+      renderParent.showOnScreen(descendant: descendant ?? this, rect: rect);
     }
   }
 }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2588,8 +2588,8 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   void showOnScreen({
     RenderObject descendant,
     Rect rect,
-    Duration duration: Duration.zero,
-    Curve curve: Curves.ease,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
   }) {
     if (parent is RenderObject) {
       final RenderObject renderParent = parent;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2571,10 +2571,17 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   @override
   List<DiagnosticsNode> debugDescribeChildren() => <DiagnosticsNode>[];
 
-  /// Attempt to make this or a descendant [RenderObject] visible on screen.
+  /// Attempt to make (a portion of) this or a descendant [RenderObject] visible
+  /// on screen.
   ///
   /// If `descendant` is provided, that [RenderObject] is made visible. If
   /// `descendant` is omitted, this [RenderObject] is made visible.
+  ///
+  /// The optional `rect` parameter describes which area of the [RenderObject]
+  /// should be shown on screen. If `rect` is null, the entire
+  /// [RenderObject] will be revealed. The `rect` parameter is interpreted
+  /// relative to the coordinate system of `descendant` if that argument is
+  /// provided or relative to this [RenderObject] otherwise.
   ///
   /// The `duration` parameter can be set to a non-zero value to bring the
   /// target object on screen in an animation defined by `curve`.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5,6 +5,7 @@
 import 'dart:developer';
 import 'dart:ui' as ui show PictureRecorder;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
@@ -2570,14 +2571,27 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   @override
   List<DiagnosticsNode> debugDescribeChildren() => <DiagnosticsNode>[];
 
-  /// Attempt to make this or a descendant RenderObject visible on screen.
+  /// Attempt to make this or a descendant [RenderObject] visible on screen.
   ///
-  /// If [descendant] is provided, that [RenderObject] is made visible. If [descendant] is
-  /// omitted, this [RenderObject] is made visible.
-  void showOnScreen({RenderObject descendant, Rect rect}) {
+  /// If `descendant` is provided, that [RenderObject] is made visible. If
+  /// `descendant` is omitted, this [RenderObject] is made visible.
+  ///
+  /// The `duration` parameter can be set to a non-zero value to bring the
+  /// target object on screen in an animation defined by `curve`.
+  void showOnScreen({
+    RenderObject descendant,
+    Rect rect,
+    Duration duration: Duration.zero,
+    Curve curve: Curves.ease,
+  }) {
     if (parent is RenderObject) {
       final RenderObject renderParent = parent;
-      renderParent.showOnScreen(descendant: descendant ?? this, rect: rect);
+      renderParent.showOnScreen(
+        descendant: descendant ?? this,
+        rect: rect,
+        duration: duration,
+        curve: curve,
+      );
     }
   }
 }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2037,6 +2037,9 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
   /// An estimate of the bounds within which this render object will paint.
   /// Useful for debugging flags such as [debugPaintLayerBordersEnabled].
+  ///
+  /// These are also the bounds used by [showOnScreen] to make a [RenderObject]
+  /// visible on screen.
   Rect get paintBounds;
 
   /// Override this method to paint debugging information.
@@ -2578,10 +2581,11 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// `descendant` is omitted, this [RenderObject] is made visible.
   ///
   /// The optional `rect` parameter describes which area of the [RenderObject]
-  /// should be shown on screen. If `rect` is null, the entire
-  /// [RenderObject] will be revealed. The `rect` parameter is interpreted
-  /// relative to the coordinate system of `descendant` if that argument is
-  /// provided or relative to this [RenderObject] otherwise.
+  /// should be shown on screen. If `rect` is null, that entire
+  /// [RenderObject] (as defined by its [paintBounds]) will be revealed. The
+  /// `rect` parameter is interpreted relative to the coordinate system of
+  /// `descendant` if that argument is provided and relative to this
+  /// [RenderObject] otherwise.
   ///
   /// The `duration` parameter can be set to a non-zero value to bring the
   /// target object on screen in an animation defined by `curve`.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -920,21 +920,29 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     // to `trailingEdgeOffset`, the one on the right by setting it to
     // `leadingEdgeOffset`.
 
-    // TODO(goderbauer): this one is incorrect
-    assert(leadingEdgeOffset.offset >= trailingEdgeOffset.offset);
-
-    if (currentOffset > leadingEdgeOffset.offset) {
-      // `child` currently starts above the leading edge and can be shown fully
-      // on screen by scrolling down (which means: moving viewport up).
+    if (leadingEdgeOffset.offset < trailingEdgeOffset.offset) {
+      // `descendant` is too big to be visible on screen in its entirety. Let's
+      // align it with the edge that requires the least amount of scrolling.
+      final double leadingEdgeDiff = (offset.pixels - leadingEdgeOffset.offset).abs();
+      final double trailingEdgeDiff = (offset.pixels - trailingEdgeOffset.offset).abs();
+      if (leadingEdgeDiff < trailingEdgeDiff) {
+        offset.jumpTo(leadingEdgeOffset.offset);
+        return leadingEdgeOffset.rect;
+      }
+      offset.jumpTo(trailingEdgeOffset.offset);
+      return trailingEdgeOffset.rect;
+    } else if (currentOffset > leadingEdgeOffset.offset) {
+      // `descendant` currently starts above the leading edge and can be shown
+      // fully on screen by scrolling down (which means: moving viewport up).
       offset.jumpTo(leadingEdgeOffset.offset);
       return leadingEdgeOffset.rect;
     } else if (currentOffset < trailingEdgeOffset.offset) {
-      // `child currently ends below the trailing edge and can be shown fully
-      // on screen by scrolling up (which means: moving viewport down)
+      // `descendant currently ends below the trailing edge and can be shown
+      // fully on screen by scrolling up (which means: moving viewport down)
       offset.jumpTo(trailingEdgeOffset.offset);
       return trailingEdgeOffset.rect;
     }
-    // else: `child` is between leading and trailing edge and hence already
+    // else: `descendant` is between leading and trailing edge and hence already
     //     fully shown on screen. No action necessary.
     final Matrix4 transform = descendant.getTransformTo(viewport.parent);
     return MatrixUtils.transformRect(transform, rect ?? descendant.paintBounds);

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -114,7 +114,7 @@ class RevealedOffset {
   /// regardless of the current viewport offset.
   ///
   /// In other words: [rect] describes where the revealed element would be
-  /// located relative of the top left corner of the visible part of the
+  /// located relative to the top left corner of the visible part of the
   /// viewport if the viewport's offset is set to [offset].
   ///
   /// See also:
@@ -889,11 +889,24 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     );
   }
 
-  /// Make the given `child` of the given `viewport` fully visible in the
-  /// `viewport` by manipulating the provided [ViewportOffset] `offset`.
+  /// Make (a portions of) the given `descendant` of the given `viewport` fully
+  /// visible in the `viewport` by manipulating the provided [ViewportOffset]
+  /// `offset`.
+  ///
+  /// The optional `rect` parameter describes which area of the `descendant`
+  /// should be shown in the viewport. If `rect` is null, the entire
+  /// `descendant` will be revealed. The `rect` parameter is interpreted
+  /// relative to the coordinate system of `descendant`.
+  ///
+  /// The returned [Rect] describes the new location of `descendant` or `rect`
+  /// in the viewport after it has been revealed. See [RevealedOffset.rect]
+  /// for a full definition of this [Rect].
   ///
   /// The parameters `viewport` and `offset` are required and cannot be null.
-  /// If `child` is null this is a no-op.
+  /// If `descendant` is null this is a no-op and `rect` is returned.
+  ///
+  /// The `duration` parameter can be set to a non-zero value to animate the
+  /// target object into the viewport with an animation defined by `curve`.
   static Rect showInViewport({
     RenderObject descendant,
     Rect rect,

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -58,8 +58,8 @@ abstract class RenderAbstractViewport extends RenderObject {
   /// descendant of the viewport and there must not be any other
   /// [RenderAbstractViewport] objects between the target and this object.
   ///
-  /// This method assumes that the viewport scrolls linearly, i.e. when the
-  /// scroll offset of the viewport is changed by x then `target` also moves
+  /// This method assumes that the content of the viewport moves linearly, i.e.
+  /// when the offset of the viewport is changed by x then `target` also moves
   /// by x within the viewport.
   ///
   /// See also:

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -870,8 +870,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   void showOnScreen({
     RenderObject descendant,
     Rect rect,
-    Duration duration: Duration.zero,
-    Curve curve: Curves.ease,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
   }) {
     final Rect newRect = RenderViewportBase.showInViewport(
       descendant: descendant,
@@ -912,8 +912,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     Rect rect,
     @required RenderAbstractViewport viewport,
     @required ViewportOffset offset,
-    Duration duration: Duration.zero,
-    Curve curve: Curves.ease,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
   }) {
     assert(viewport != null);
     assert(offset != null);

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -45,9 +45,10 @@ abstract class RenderAbstractViewport extends RenderObject {
   /// [RenderObject].
   ///
   /// The optional `rect` parameter describes which area of the `target` object
-  /// should be revealed in the viewport. If `rect` is null, the entire
-  /// `target` [RenderObject] will be revealed. If `rect` is provided it has to
-  /// be given in the coordinate system of the `target` object.
+  /// should be revealed in the viewport. If `rect` is null, that entire
+  /// `target` [RenderObject] (as defined by its [RenderObject.paintBounds])
+  /// will be revealed. If `rect` is provided it has to be given in the
+  /// coordinate system of the `target` object.
   ///
   /// The `alignment` argument describes where the target should be positioned
   /// after applying the returned offset. If `alignment` is 0.0, the child must
@@ -65,6 +66,7 @@ abstract class RenderAbstractViewport extends RenderObject {
   /// by x within the viewport.
   ///
   /// See also:
+  ///
   ///  * [RevealedOffset], which describes the return value of this method.
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect});
 
@@ -87,18 +89,19 @@ class RevealedOffset {
   /// Instantiates a return value for [RenderAbstractViewport.getOffsetToReveal].
   const RevealedOffset({
     @required this.offset,
-    @required this.rect
-  }) : assert (offset != null), assert(rect != null);
+    @required this.rect,
+  }) : assert(offset != null), assert(rect != null);
 
   /// Offset for the viewport to reveal a specific element in the viewport.
   ///
   /// See also:
+  ///
   ///  * [RenderAbstractViewport.getOffsetToReveal], which calculates this
-  ///    value fort a specific element.
+  ///    value for a specific element.
   final double offset;
 
-  /// The [Rect] in the outer coordinate system of the viewport at which the to be
-  /// revealed element would be located if the viewport's offset is set
+  /// The [Rect] in the outer coordinate system of the viewport at which the
+  /// to-be-revealed element would be located if the viewport's offset is set
   /// to [offset].
   ///
   /// A viewport usually has two coordinate systems and works as an adapter
@@ -118,6 +121,7 @@ class RevealedOffset {
   /// viewport if the viewport's offset is set to [offset].
   ///
   /// See also:
+  ///
   ///  * [RenderAbstractViewport.getOffsetToReveal], which calculates this
   ///    value for a specific element.
   final Rect rect;
@@ -882,14 +886,13 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       curve: curve,
     );
     super.showOnScreen(
-      // Omitting `descendant` to get this viewport on screen.
       rect: newRect,
       duration: duration,
       curve: curve,
     );
   }
 
-  /// Make (a portions of) the given `descendant` of the given `viewport` fully
+  /// Make (a portion of) the given `descendant` of the given `viewport` fully
   /// visible in the `viewport` by manipulating the provided [ViewportOffset]
   /// `offset`.
   ///
@@ -903,7 +906,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// for a full definition of this [Rect].
   ///
   /// The parameters `viewport` and `offset` are required and cannot be null.
-  /// If `descendant` is null this is a no-op and `rect` is returned.
+  /// If `descendant` is null, this is a no-op and `rect` is returned.
   ///
   /// The `duration` parameter can be set to a non-zero value to animate the
   /// target object into the viewport with an animation defined by `curve`.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -614,7 +614,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       }
       descendant = pivot;
     } else if (target is RenderSliver) {
-      // TODO
       final RenderSliver targetSliver = target;
       leadingScrollOffset = 0.0;
       targetMainAxisExtent = targetSliver.geometry.scrollExtent;
@@ -881,7 +880,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     //    viewport position |  |         |
     // with `descendant` at |  |         | _
     //        trailing edge |_ | xxxxxxx |  | viewport position
-    //                         |         |  | with `child` at
+    //                         |         |  | with `descendant` at
     //                         |         | _| leading edge
     //                         |         |
     //                     800 +---------+

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -42,7 +42,7 @@ abstract class RenderAbstractViewport extends RenderObject {
 
   /// Returns the offset that would be needed to reveal the `target` render object.
   ///
-  /// The optional `rect` parameter describes which area of the `target render
+  /// The optional `rect` parameter describes which area of the `target` render
   /// object should be revealed in the viewport. If `rect` is null, the entire
   /// `target` render object will be revealed. If `rect` is provided it has to
   /// be given in the coordinate system of the `target` render object.
@@ -57,6 +57,13 @@ abstract class RenderAbstractViewport extends RenderObject {
   /// The target might not be a direct child of this viewport but it must be a
   /// descendant of the viewport and there must not be any other
   /// [RenderAbstractViewport] objects between the target and this object.
+  ///
+  /// This method assumes that the viewport scrolls linearly, i.e. when the
+  /// scroll offset of the viewport is changed by x then `target` also moves
+  /// by x within the viewport.
+  ///
+  /// See also:
+  ///  * [RevealedOffset], which describes the return value of this method.
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect});
 
   /// The default value for the cache extent of the viewport.
@@ -71,8 +78,8 @@ abstract class RenderAbstractViewport extends RenderObject {
 /// Return value for [RenderAbstractViewport.getOffsetToReveal].
 ///
 /// It indicates the scroll [offset] required to reveal an element in a
-/// viewport and the position that element would have in the viewport at that
-/// [offset].
+/// viewport and the [rect] position said element would have in the viewport at
+/// that [offset].
 class RevealedOffset {
 
   /// Instantiates a return value for [RenderAbstractViewport.getOffsetToReveal].
@@ -88,13 +95,29 @@ class RevealedOffset {
   ///    value fort a specific element.
   final double offset;
 
-  /// The rect in the coordinate system of the viewport at which a specific
-  /// element would be located if the viewport's scroll offset is set to
-  /// [offset].
+  /// The [Rect] in the outer coordinate system of the viewport at which the to be
+  /// revealed element would be located if the viewport's offset is set
+  /// to [offset].
+  ///
+  /// A viewport usually has two coordinate systems and works as an adapter
+  /// between the two:
+  ///
+  /// The inner coordinate system has its origin at the top left corner of the
+  /// content that moves inside the viewport. The origin of this coordinate
+  /// system usually moves around relative to the leading edge of the viewport
+  /// when the viewport offset changes.
+  ///
+  /// The outer coordinate system has its origin at the top left corner of the
+  /// visible part of the viewport. This origin stays at the same position
+  /// regardless of the current viewport offset.
+  ///
+  /// In other words: [rect] describes where the revealed element would be
+  /// located relative of the top left corner of the visible part of the
+  /// viewport if the viewport's offset is set to [offset].
   ///
   /// See also:
   ///  * [RenderAbstractViewport.getOffsetToReveal], which calculates this
-  ///    value fort a specific element.
+  ///    value for a specific element.
   final Rect rect;
 
   @override
@@ -849,8 +872,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       offset: offset,
       rect: rect,
     );
-    // Make sure the viewport itself is on screen.
-    super.showOnScreen(rect: newRect);
+    super.showOnScreen(
+      // Omitting `descendant` to get this viewport on screen.
+    rect: newRect,
+    );
   }
 
   /// Make the given `child` of the given `viewport` fully visible in the

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -44,8 +44,8 @@ abstract class RenderAbstractViewport extends RenderObject {
   /// Returns the offset that would be needed to reveal the `target`
   /// [RenderObject].
   ///
-  /// The optional `rect` parameter describes which area of the `target` object
-  /// should be revealed in the viewport. If `rect` is null, that entire
+  /// The optional `rect` parameter describes which area of that `target` object
+  /// should be revealed in the viewport. If `rect` is null, the entire
   /// `target` [RenderObject] (as defined by its [RenderObject.paintBounds])
   /// will be revealed. If `rect` is provided it has to be given in the
   /// coordinate system of the `target` object.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -40,12 +40,13 @@ abstract class RenderAbstractViewport extends RenderObject {
     return null;
   }
 
-  /// Returns the offset that would be needed to reveal the `target` render object.
+  /// Returns the offset that would be needed to reveal the `target`
+  /// [RenderObject].
   ///
-  /// The optional `rect` parameter describes which area of the `target` render
-  /// object should be revealed in the viewport. If `rect` is null, the entire
-  /// `target` render object will be revealed. If `rect` is provided it has to
-  /// be given in the coordinate system of the `target` render object.
+  /// The optional `rect` parameter describes which area of the `target` object
+  /// should be revealed in the viewport. If `rect` is null, the entire
+  /// `target` [RenderObject] will be revealed. If `rect` is provided it has to
+  /// be given in the coordinate system of the `target` object.
   ///
   /// The `alignment` argument describes where the target should be positioned
   /// after applying the returned offset. If `alignment` is 0.0, the child must
@@ -77,9 +78,9 @@ abstract class RenderAbstractViewport extends RenderObject {
 
 /// Return value for [RenderAbstractViewport.getOffsetToReveal].
 ///
-/// It indicates the scroll [offset] required to reveal an element in a
-/// viewport and the [rect] position said element would have in the viewport at
-/// that [offset].
+/// It indicates the [offset] required to reveal an element in a viewport and
+/// the [rect] position said element would have in the viewport at that
+/// [offset].
 class RevealedOffset {
 
   /// Instantiates a return value for [RenderAbstractViewport.getOffsetToReveal].

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -908,6 +908,9 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// The parameters `viewport` and `offset` are required and cannot be null.
   /// If `descendant` is null, this is a no-op and `rect` is returned.
   ///
+  /// If both `decedent` and `rect` are null, null is returned because there is
+  /// nothing to be shown in the viewport.
+  ///
   /// The `duration` parameter can be set to a non-zero value to animate the
   /// target object into the viewport with an animation defined by `curve`.
   static Rect showInViewport({

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -845,7 +845,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @override
   void showOnScreen({RenderObject descendant, Rect rect}) {
     final Rect newRect = RenderViewportBase.showInViewport(
-      child: descendant,
+      descendant: descendant,
       viewport: this,
       offset: offset,
       rect: rect,
@@ -860,31 +860,31 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// The parameters `viewport` and `offset` are required and cannot be null.
   /// If `child` is null this is a no-op.
   static Rect showInViewport({
-    RenderObject child,
+    RenderObject descendant,
     Rect rect,
     @required RenderAbstractViewport viewport,
     @required ViewportOffset offset,
   }) {
     assert(viewport != null);
     assert(offset != null);
-    if (child == null) {
+    if (descendant == null) {
       return rect;
     }
-    final RevealedOffset leadingEdgeOffset = viewport.getOffsetToReveal(child, 0.0, rect: rect);
-    final RevealedOffset trailingEdgeOffset = viewport.getOffsetToReveal(child, 1.0, rect: rect);
+    final RevealedOffset leadingEdgeOffset = viewport.getOffsetToReveal(descendant, 0.0, rect: rect);
+    final RevealedOffset trailingEdgeOffset = viewport.getOffsetToReveal(descendant, 1.0, rect: rect);
     final double currentOffset = offset.pixels;
 
-    //        scrollOffset
-    //                    0 +---------+
-    //                      |         |
-    //                    _ |         |
-    // viewport position |  |         |
-    //   with `child` at |  |         | _
-    //     trailing edge |_ | xxxxxxx |  | viewport position
-    //                      |         |  | with `child` at
-    //                      |         | _| leading edge
-    //                      |         |
-    //                  800 +---------+
+    //           scrollOffset
+    //                       0 +---------+
+    //                         |         |
+    //                       _ |         |
+    //    viewport position |  |         |
+    // with `descendant` at |  |         | _
+    //        trailing edge |_ | xxxxxxx |  | viewport position
+    //                         |         |  | with `child` at
+    //                         |         | _| leading edge
+    //                         |         |
+    //                     800 +---------+
     //
     // `trailingEdgeOffset`: Distance from scrollOffset 0 to the start of the
     //                       viewport on the left in image above.
@@ -911,8 +911,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     }
     // else: `child` is between leading and trailing edge and hence already
     //     fully shown on screen. No action necessary.
-    final Matrix4 transform = child.getTransformTo(viewport.parent);
-    return MatrixUtils.transformRect(transform, rect ?? child.paintBounds);
+    final Matrix4 transform = descendant.getTransformTo(viewport.parent);
+    return MatrixUtils.transformRect(transform, rect ?? descendant.paintBounds);
   }
 }
 

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -246,10 +246,7 @@ class _FixedViewportOffset extends ViewportOffset {
   Future<Null> animateTo(double to, {
     @required Duration duration,
     @required Curve curve,
-  }) {
-    // Do nothing, viewport is fixed.
-    return new Future<Null>.value();
-  }
+  }) async => null;
 
   @override
   ScrollDirection get userScrollDirection => ScrollDirection.idle;

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -176,7 +176,6 @@ abstract class ViewportOffset extends ChangeNotifier {
   ///
   /// The duration must not be zero. To jump to a particular value without an
   /// animation, use [jumpTo].
-  ///
   Future<Null> animateTo(double to, {
     @required Duration duration,
     @required Curve curve,

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
 /// The direction of a scroll, relative to the positive scroll offset axis given
@@ -157,7 +160,7 @@ abstract class ViewportOffset extends ChangeNotifier {
   ///    [jumpTo] applies the change immediately and notifies its listeners.
   void correctBy(double correction);
 
-  /// Jumps the scroll position from its current value to the given value,
+  /// Jumps [pixels] from its current value to the given value,
   /// without animation, and without checking if the new value is in range.
   ///
   /// See also:
@@ -165,6 +168,19 @@ abstract class ViewportOffset extends ChangeNotifier {
   ///  * [correctBy], for changing the current offset in the middle of layout
   ///    and that defers the notification of its listeners until after layout.
   void jumpTo(double pixels);
+
+  /// Animates [pixels] from its current value to the given value.
+  ///
+  /// The returned [Future] will complete when the animation ends, whether it
+  /// completed successfully or whether it was interrupted prematurely.
+  ///
+  /// The duration must not be zero. To jump to a particular value without an
+  /// animation, use [jumpTo].
+  ///
+  Future<Null> animateTo(double to, {
+    @required Duration duration,
+    @required Curve curve,
+  });
 
   /// The direction in which the user is trying to change [pixels], relative to
   /// the viewport's [RenderViewport.axisDirection].
@@ -225,6 +241,15 @@ class _FixedViewportOffset extends ViewportOffset {
   @override
   void jumpTo(double pixels) {
     // Do nothing, viewport is fixed.
+  }
+
+  @override
+  Future<Null> animateTo(double to, {
+    @required Duration duration,
+    @required Curve curve,
+  }) {
+    // Do nothing, viewport is fixed.
+    return new Future<Null>.value();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -497,7 +497,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     final RenderAbstractViewport viewport = RenderAbstractViewport.of(object);
     assert(viewport != null);
 
-    final double target = viewport.getOffsetToReveal(object, alignment).clamp(minScrollExtent, maxScrollExtent);
+    final double target = viewport.getOffsetToReveal(object, alignment).offset.clamp(minScrollExtent, maxScrollExtent);
 
     if (target == pixels)
       return new Future<Null>.value();

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -544,6 +544,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// animation, use [jumpTo].
   ///
   /// The animation is typically handled by an [DrivenScrollActivity].
+  @override
   Future<Null> animateTo(double to, {
     @required Duration duration,
     @required Curve curve,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -598,8 +598,10 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
       offset: offset,
       rect: rect,
     );
-    // Make sure the viewport itself is on screen.
-    super.showOnScreen(rect: newRect);
+    super.showOnScreen(
+      // Omitting `descendant` to get this viewport on screen.
+      rect: newRect,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -591,7 +591,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
 
   @override
   void showOnScreen({RenderObject descendant, Rect rect}) {
-    Rect newRect = RenderViewportBase.showInViewport(
+    final Rect newRect = RenderViewportBase.showInViewport(
       child: descendant,
       viewport: this,
       offset: offset,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -547,7 +547,6 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
 
   @override
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect}) {
-    print(axisDirection);
     rect ??= target.paintBounds;
     if (target is! RenderBox)
       return new RevealedOffset(offset: offset.pixels, rect: rect);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -593,8 +593,8 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   void showOnScreen({
     RenderObject descendant,
     Rect rect,
-    Duration duration: Duration.zero,
-    Curve curve: Curves.ease,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
   }) {
     final Rect newRect = RenderViewportBase.showInViewport(
       descendant: descendant,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -547,6 +547,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
 
   @override
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect}) {
+    print(axisDirection);
     rect ??= target.paintBounds;
     if (target is! RenderBox)
       return new RevealedOffset(offset: offset.pixels, rect: rect);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -484,17 +484,19 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent);
   }
 
-  Offset get _paintOffset {
+  Offset get _paintOffset => _paintOffsetForPosition(offset.pixels);
+
+  Offset _paintOffsetForPosition(double position) {
     assert(axisDirection != null);
     switch (axisDirection) {
       case AxisDirection.up:
-        return new Offset(0.0, _offset.pixels - child.size.height + size.height);
+        return new Offset(0.0, position - child.size.height + size.height);
       case AxisDirection.down:
-        return new Offset(0.0, -_offset.pixels);
+        return new Offset(0.0, -position);
       case AxisDirection.left:
-        return new Offset(_offset.pixels - child.size.width + size.width, 0.0);
+        return new Offset(position - child.size.width + size.width, 0.0);
       case AxisDirection.right:
-        return new Offset(-_offset.pixels, 0.0);
+        return new Offset(-position, 0.0);
     }
     return null;
   }
@@ -581,24 +583,9 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
         targetMainAxisExtent = bounds.width;
         break;
     }
+
     final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;
-    Rect targetRect;
-
-    switch (axisDirection) {
-      case AxisDirection.up:
-        targetRect = bounds.translate(0.0, -targetOffset);
-        break;
-      case AxisDirection.right:
-        targetRect = bounds.translate(-targetOffset, 0.0);
-        break;
-      case AxisDirection.down:
-        targetRect = bounds.translate(0.0, -targetOffset);
-        break;
-      case AxisDirection.left:
-        targetRect = bounds.translate(targetOffset, 0.0);
-        break;
-    }
-
+    final Rect targetRect = bounds.shift(_paintOffsetForPosition(targetOffset));
     return new RevealedOffset(offset: targetOffset, rect: targetRect);
   }
 

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -593,7 +593,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   @override
   void showOnScreen({RenderObject descendant, Rect rect}) {
     final Rect newRect = RenderViewportBase.showInViewport(
-      child: descendant,
+      descendant: descendant,
       viewport: this,
       offset: offset,
       rect: rect,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -590,16 +590,25 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   }
 
   @override
-  void showOnScreen({RenderObject descendant, Rect rect}) {
+  void showOnScreen({
+    RenderObject descendant,
+    Rect rect,
+    Duration duration: Duration.zero,
+    Curve curve: Curves.ease,
+  }) {
     final Rect newRect = RenderViewportBase.showInViewport(
       descendant: descendant,
       viewport: this,
       offset: offset,
       rect: rect,
+      duration: duration,
+      curve: curve,
     );
     super.showOnScreen(
       // Omitting `descendant` to get this viewport on screen.
       rect: newRect,
+      duration: duration,
+      curve: curve,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -605,7 +605,6 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
       curve: curve,
     );
     super.showOnScreen(
-      // Omitting `descendant` to get this viewport on screen.
       rect: newRect,
       duration: duration,
       curve: curve,

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -194,7 +194,7 @@ void main() {
 
   testWidgets('Nested Viewports showOnScreen', (WidgetTester tester) async {
     final List<List<Widget>> children = new List<List<Widget>>(10);
-    final List<ScrollController> controllersX = new List.generate(10, (int i) => new ScrollController(initialScrollOffset: 400.0));
+    final List<ScrollController> controllersX = new List<ScrollController>.generate(10, (int i) => new ScrollController(initialScrollOffset: 400.0));
     final ScrollController controllerY  = new ScrollController(initialScrollOffset: 400.0);
 
     /// Builds a gird:

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -331,6 +331,23 @@ void main() {
     await tester.pumpAndSettle();
     expect(controllersX[6].offset, 500.0);
     expect(controllerY.offset, 500.0);
+
+    controllersX[6].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and right of viewport with animations
+    tester.renderObject(find.byWidget(children[6][6], skipOffstage: false)).showOnScreen(duration: const Duration(seconds: 2));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.hasRunningAnimations, isTrue);
+    expect(controllersX[6].offset, greaterThan(400.0));
+    expect(controllersX[6].offset, lessThan(500.0));
+    expect(controllerY.offset, greaterThan(400.0));
+    expect(controllerY.offset, lessThan(500.0));
+    await tester.pumpAndSettle();
+    expect(controllersX[6].offset, 500.0);
+    expect(controllerY.offset, 500.0);
   });
 
   group('Nested viewports (same orientation) showOnScreen', () {

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1,0 +1,463 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
+    List<Widget> children;
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 300.0,
+            child: new ListView(
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              children: children = new List<Widget>.generate(20, (int i) {
+                return new Container(
+                  height: 100.0,
+                  width: 300.0,
+                  child: new Text('Tile $i'),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
+    List<Widget> children;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 300.0,
+            width: 200.0,
+            child: new ListView(
+              scrollDirection: Axis.horizontal,
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              children: children = new List<Widget>.generate(20, (int i) {
+                return new Container(
+                  height: 300.0,
+                  width: 100.0,
+                  child: new Text('Tile $i'),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - up', (WidgetTester tester) async {
+    List<Widget> children;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 300.0,
+            child: new ListView(
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              reverse: true,
+              children: children = new List<Widget>.generate(20, (int i) {
+                return new Container(
+                  height: 100.0,
+                  width: 300.0,
+                  child: new Text('Tile $i'),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 550.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 360.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
+    List<Widget> children;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 300.0,
+            width: 200.0,
+            child: new ListView(
+              scrollDirection: Axis.horizontal,
+              reverse: true,
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              children: children = new List<Widget>.generate(20, (int i) {
+                return new Container(
+                  height: 300.0,
+                  width: 100.0,
+                  child: new Text('Tile $i'),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 550.0);
+    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 360.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
+  });
+
+  testWidgets('Nested Viewports showOnScreen', (WidgetTester tester) async {
+    final List<List<Widget>> children = new List<List<Widget>>(10);
+    final List<ScrollController> controllersX = new List.generate(10, (int i) => new ScrollController(initialScrollOffset: 400.0));
+    final ScrollController controllerY  = new ScrollController(initialScrollOffset: 400.0);
+
+    /// Builds a gird:
+    ///
+    ///       <- x ->
+    ///   0 1 2 3 4 5 6 7 8 9
+    /// 0 c c c c c c c c c c
+    /// 1 c c c c c c c c c c
+    /// 2 c c c c c c c c c c
+    /// 3 c c c c c c c c c c  y
+    /// 4 c c c c v v c c c c
+    /// 5 c c c c v v c c c c
+    /// 6 c c c c c c c c c c
+    /// 7 c c c c c c c c c c
+    /// 8 c c c c c c c c c c
+    /// 9 c c c c c c c c c c
+    ///
+    /// Each c is a 100x100 container, v are containers visible in initial
+    /// viewport.
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 200.0,
+            child: new ListView(
+              controller: controllerY,
+              children: new List<Widget>.generate(10, (int y) {
+                return Container(
+                  height: 100.0,
+                  child: new ListView(
+                    scrollDirection: Axis.horizontal,
+                    controller: controllersX[y],
+                    children: children[y] = new List<Widget>.generate(10, (int x) {
+                      return new Container(
+                        height: 100.0,
+                        width: 100.0,
+                        child: new Text('$x,$y'),
+                      );
+                    }),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Already in viewport
+    tester.renderObject(find.byWidget(children[4][4], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[4].offset, 400.0);
+    expect(controllerY.offset, 400.0);
+
+    controllersX[4].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above viewport
+    tester.renderObject(find.byWidget(children[3][4], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[3].offset, 400.0);
+    expect(controllerY.offset, 300.0);
+
+    controllersX[3].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below viewport
+    tester.renderObject(find.byWidget(children[6][4], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[6].offset, 400.0);
+    expect(controllerY.offset, 500.0);
+
+    controllersX[6].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Left of viewport
+    tester.renderObject(find.byWidget(children[4][3], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[4].offset, 300.0);
+    expect(controllerY.offset, 400.0);
+
+    controllersX[4].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Right of viewport
+    tester.renderObject(find.byWidget(children[4][6], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[4].offset, 500.0);
+    expect(controllerY.offset, 400.0);
+
+    controllersX[4].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above and left of viewport
+    tester.renderObject(find.byWidget(children[3][3], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[3].offset, 300.0);
+    expect(controllerY.offset, 300.0);
+
+    controllersX[3].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and left of viewport
+    tester.renderObject(find.byWidget(children[6][3], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[6].offset, 300.0);
+    expect(controllerY.offset, 500.0);
+
+    controllersX[6].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above and right of viewport
+    tester.renderObject(find.byWidget(children[3][6], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[3].offset, 500.0);
+    expect(controllerY.offset, 300.0);
+
+    controllersX[3].jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and right of viewport
+    tester.renderObject(find.byWidget(children[6][6], skipOffstage: false)).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllersX[6].offset, 500.0);
+    expect(controllerY.offset, 500.0);
+  });
+
+  group('Nested viewports (same orientation) showOnScreen', () {
+    List<Widget> children;
+
+    Future<Null> buildNestedScroller({WidgetTester tester, ScrollController inner, ScrollController outer}) {
+      return tester.pumpWidget(
+        new Directionality(
+          textDirection: TextDirection.ltr,
+          child: new Center(
+            child: Container(
+              height: 200.0,
+              width: 300.0,
+              child: new ListView(
+                controller: outer,
+                children: <Widget>[
+                  new Container(
+                    height: 200.0,
+                  ),
+                  new Container(
+                    height: 200.0,
+                    width: 300.0,
+                    child: new ListView(
+                      controller: inner,
+                      children: children = new List<Widget>.generate(10, (int i) {
+                        return new Container(
+                          height: 100.0,
+                          width: 300.0,
+                          child: new Text('$i'),
+                        );
+                      }),
+                    ),
+                  ),
+                  new Container(
+                    height: 200.0,
+                  )
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('in view in inner, but not in outer', (WidgetTester tester) async {
+      final ScrollController inner = new ScrollController();
+      final ScrollController outer = new ScrollController();
+      await buildNestedScroller(
+        tester: tester,
+        inner: inner,
+        outer: outer,
+      );
+      expect(outer.offset, 0.0);
+      expect(inner.offset, 0.0);
+
+      tester.renderObject(find.byWidget(children[0], skipOffstage: false)).showOnScreen();
+      await tester.pumpAndSettle();
+      expect(inner.offset, 0.0);
+      expect(outer.offset, 100.0);
+    });
+
+    testWidgets('not in view of neither inner nor outer', (WidgetTester tester) async {
+      final ScrollController inner = new ScrollController();
+      final ScrollController outer = new ScrollController();
+      await buildNestedScroller(
+        tester: tester,
+        inner: inner,
+        outer: outer,
+      );
+      expect(outer.offset, 0.0);
+      expect(inner.offset, 0.0);
+
+      tester.renderObject(find.byWidget(children[4], skipOffstage: false)).showOnScreen();
+      await tester.pumpAndSettle();
+      expect(inner.offset, 300.0);
+      expect(outer.offset, 200.0);
+    });
+
+    testWidgets('in view in inner and outer', (WidgetTester tester) async {
+      final ScrollController inner = new ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = new ScrollController(initialScrollOffset: 200.0);
+      await buildNestedScroller(
+        tester: tester,
+        inner: inner,
+        outer: outer,
+      );
+      expect(outer.offset, 200.0);
+      expect(inner.offset, 200.0);
+
+      tester.renderObject(find.byWidget(children[2])).showOnScreen();
+      await tester.pumpAndSettle();
+      expect(outer.offset, 200.0);
+      expect(inner.offset, 200.0);
+    });
+
+    testWidgets('inner shown in outer, but item not visible', (WidgetTester tester) async {
+      final ScrollController inner = new ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = new ScrollController(initialScrollOffset: 200.0);
+      await buildNestedScroller(
+        tester: tester,
+        inner: inner,
+        outer: outer,
+      );
+      expect(outer.offset, 200.0);
+      expect(inner.offset, 200.0);
+
+      tester.renderObject(find.byWidget(children[5], skipOffstage: false)).showOnScreen();
+      await tester.pumpAndSettle();
+      expect(outer.offset, 200.0);
+      expect(inner.offset, 400.0);
+    });
+
+    testWidgets('inner half shown in outer, item only visible in inner', (WidgetTester tester) async {
+      final ScrollController inner = new ScrollController();
+      final ScrollController outer = new ScrollController(initialScrollOffset: 100.0);
+      await buildNestedScroller(
+        tester: tester,
+        inner: inner,
+        outer: outer,
+      );
+      expect(outer.offset, 100.0);
+      expect(inner.offset, 0.0);
+
+      tester.renderObject(find.byWidget(children[1])).showOnScreen();
+      await tester.pumpAndSettle();
+      expect(outer.offset, 200.0);
+      expect(inner.offset, 0.0);
+    });
+  });
+}

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -856,5 +856,14 @@ void main() {
     tester.renderObject(find.byWidget(innerChildren[9])).showOnScreen();
     await tester.pumpAndSettle();
     expect(controller.offset, 900.0);
+
+    tester.renderObject(find.byWidget(outerChildren[7])).showOnScreen(duration: const Duration(seconds: 2));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.hasRunningAnimations, isTrue);
+    expect(controller.offset, lessThan(900.0));
+    expect(controller.offset, greaterThan(700.0));
+    await tester.pumpAndSettle();
+    expect(controller.offset, 700.0);
   });
 }

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -743,4 +743,118 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     });
   });
+
+  testWidgets('ListWheelScrollView getOffsetToReveal', (WidgetTester tester) async {
+    List<Widget> outerChildren;
+    final List<Widget> innerChildren = new List<Widget>(10);
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 500.0,
+            width: 300.0,
+            child: new ListWheelScrollView(
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              itemExtent: 100.0,
+              children: outerChildren = new List<Widget>.generate(10, (int i) {
+                return new Container(
+                  child: new Center(
+                    child: innerChildren[i] = new Container(
+                      height: 50.0,
+                      width: 50.0,
+                      child: new Text('Item $i'),
+                    )
+                  ),
+                );
+              })
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderListWheelViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderListWheelViewport);
+
+    // direct child of viewport
+    RenderObject target = tester.renderObject(find.byWidget(outerChildren[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 200.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 200.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 240.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 240.0, 10.0, 10.0));
+
+    // descendant of viewport, not direct child
+    target = tester.renderObject(find.byWidget(innerChildren[5]));
+    revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(125.0, 225.0, 50.0, 50.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(125.0, 225.0, 50.0, 50.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(165.0, 265.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(165.0, 265.0, 10.0, 10.0));
+  });
+
+  testWidgets('ListWheelScrollView showOnScreen', (WidgetTester tester) async {
+    List<Widget> outerChildren;
+    final List<Widget> innerChildren = new List<Widget>(10);
+    ScrollController controller;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 500.0,
+            width: 300.0,
+            child: new ListWheelScrollView(
+                controller: controller = new ScrollController(initialScrollOffset: 300.0),
+                itemExtent: 100.0,
+                children:
+                outerChildren = new List<Widget>.generate(10, (int i) {
+                  return new Container(
+                    child: new Center(
+                        child: innerChildren[i] = new Container(
+                          height: 50.0,
+                          width: 50.0,
+                          child: new Text('Item $i'),
+                        )
+                    ),
+                  );
+                })
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.offset, 300.0);
+
+    tester.renderObject(find.byWidget(outerChildren[5])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controller.offset, 500.0);
+
+    tester.renderObject(find.byWidget(innerChildren[9])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controller.offset, 900.0);
+  });
 }

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -765,10 +765,10 @@ void main() {
                       height: 50.0,
                       width: 50.0,
                       child: new Text('Item $i'),
-                    )
+                    ),
                   ),
                 );
-              })
+              }),
             ),
           ),
         ),
@@ -827,20 +827,20 @@ void main() {
             height: 500.0,
             width: 300.0,
             child: new ListWheelScrollView(
-                controller: controller = new ScrollController(initialScrollOffset: 300.0),
-                itemExtent: 100.0,
-                children:
-                outerChildren = new List<Widget>.generate(10, (int i) {
-                  return new Container(
-                    child: new Center(
-                        child: innerChildren[i] = new Container(
-                          height: 50.0,
-                          width: 50.0,
-                          child: new Text('Item $i'),
-                        )
+              controller: controller = new ScrollController(initialScrollOffset: 300.0),
+              itemExtent: 100.0,
+              children:
+              outerChildren = new List<Widget>.generate(10, (int i) {
+                return new Container(
+                  child: new Center(
+                    child: innerChildren[i] = new Container(
+                      height: 50.0,
+                      width: 50.0,
+                      child: new Text('Item $i'),
                     ),
-                  );
-                })
+                  ),
+                );
+              }),
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -675,6 +675,23 @@ void main() {
     await tester.pumpAndSettle();
     expect(controllerX.offset, 500.0);
     expect(controllerY.offset, 500.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and right of viewport with animations
+    tester.renderObject(find.byWidget(children[6][6])).showOnScreen(duration: const Duration(seconds: 2));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.hasRunningAnimations, isTrue);
+    expect(controllerX.offset, greaterThan(400.0));
+    expect(controllerX.offset, lessThan(500.0));
+    expect(controllerY.offset, greaterThan(400.0));
+    expect(controllerY.offset, lessThan(500.0));
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 500.0);
+    expect(controllerY.offset, 500.0);
   });
 
   group('Nested SingleChildScrollView (same orientation) showOnScreen', () {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -5,6 +5,7 @@
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'semantics_tester.dart';
@@ -340,5 +341,345 @@ void main() {
     ));
 
     semantics.dispose();
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
+    List<Widget> children;
+    ScrollController controller;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 300.0,
+            child: new SingleChildScrollView(
+              controller: controller = new ScrollController(initialScrollOffset: 300.0),
+              child: new Column(
+                children: children = new List<Widget>.generate(20, (int i) {
+                  return new Container(
+                    height: 100.0,
+                    width: 300.0,
+                    child: new Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - up', (WidgetTester tester) async {
+    List<Widget> children;
+    ScrollController controller;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 300.0,
+            child: new SingleChildScrollView(
+              controller: controller = new ScrollController(initialScrollOffset: 300.0),
+              reverse: true,
+              child: new Column(
+                children: children = new List<Widget>.generate(20, (int i) {
+                  return new Container(
+                    height: 100.0,
+                    width: 300.0,
+                    child: new Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
+    List<Widget> children;
+    SingleChildScrollView scrollview;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 300.0,
+            width: 200.0,
+            child: scrollview = new SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              child: new Row(
+                children: children = new List<Widget>.generate(20, (int i) {
+                  return new Container(
+                    height: 300.0,
+                    width: 100.0,
+                    child: new Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
+    List<Widget> children;
+    SingleChildScrollView scrollview;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 300.0,
+            width: 200.0,
+            child: scrollview = new SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              reverse: true,
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              child: new Row(
+                children: children = new List<Widget>.generate(20, (int i) {
+                  return new Container(
+                    height: 300.0,
+                    width: 100.0,
+                    child: new Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
+  });
+
+  testWidgets('Nested SingleChildScrollView showOnScreen', (WidgetTester tester) async {
+    final List<List<Widget>> children = new List<List<Widget>>(10);
+    ScrollController controllerX;
+    ScrollController controllerY;
+
+    /// Builds a gird:
+    ///
+    ///       <- x ->
+    ///   0 1 2 3 4 5 6 7 8 9
+    /// 0 c c c c c c c c c c
+    /// 1 c c c c c c c c c c
+    /// 2 c c c c c c c c c c
+    /// 3 c c c c c c c c c c  y
+    /// 4 c c c c v v c c c c
+    /// 5 c c c c v v c c c c
+    /// 6 c c c c c c c c c c
+    /// 7 c c c c c c c c c c
+    /// 8 c c c c c c c c c c
+    /// 9 c c c c c c c c c c
+    ///
+    /// Each c is a 100x100 container, v are containers visible in initial
+    /// viewport.
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 200.0,
+            width: 200.0,
+            child: new SingleChildScrollView(
+              controller: controllerY = new ScrollController(initialScrollOffset: 400.0),
+              child: new SingleChildScrollView(
+                controller: controllerX = new ScrollController(initialScrollOffset: 400.0),
+                scrollDirection: Axis.horizontal,
+                child: new Column(
+                  children: new List<Widget>.generate(10, (int y) {
+                    return new Row(
+                      children: children[y] = new List<Widget>.generate(10, (int x) {
+                        return new Container(
+                          height: 100.0,
+                          width: 100.0,
+                        );
+                      })
+                    );
+                  }),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controllerX.offset, 400.0);
+    expect(controllerY.offset, 400.0);
+
+    // Already in viewport
+    tester.renderObject(find.byWidget(children[4][4])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 400.0);
+    expect(controllerY.offset, 400.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above viewport
+    tester.renderObject(find.byWidget(children[3][4])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 400.0);
+    expect(controllerY.offset, 300.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below viewport
+    tester.renderObject(find.byWidget(children[6][4])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 400.0);
+    expect(controllerY.offset, 500.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Left of viewport
+    tester.renderObject(find.byWidget(children[4][3])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 300.0);
+    expect(controllerY.offset, 400.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Right of viewport
+    tester.renderObject(find.byWidget(children[4][6])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 500.0);
+    expect(controllerY.offset, 400.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above and left of viewport
+    tester.renderObject(find.byWidget(children[3][3])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 300.0);
+    expect(controllerY.offset, 300.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and left of viewport
+    tester.renderObject(find.byWidget(children[6][3])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 300.0);
+    expect(controllerY.offset, 500.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Above and right of viewport
+    tester.renderObject(find.byWidget(children[3][6])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 500.0);
+    expect(controllerY.offset, 300.0);
+
+    controllerX.jumpTo(400.0);
+    controllerY.jumpTo(400.0);
+    await tester.pumpAndSettle();
+
+    // Below and right of viewport
+    tester.renderObject(find.byWidget(children[6][6])).showOnScreen();
+    await tester.pumpAndSettle();
+    expect(controllerX.offset, 500.0);
+    expect(controllerY.offset, 500.0);
   });
 }

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -437,6 +437,54 @@ void main() {
   });
 
   testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
+    List<Widget> children;
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.ltr,
+        child: new Center(
+          child: Container(
+            height: 300.0,
+            width: 200.0,
+            child: new SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              controller: new ScrollController(initialScrollOffset: 300.0),
+              child: new Row(
+                children: children = new List<Widget>.generate(20, (int i) {
+                  return new Container(
+                    height: 300.0,
+                    width: 100.0,
+                    child: new Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
+    expect(revealed.offset, 500.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0);
+    expect(revealed.offset, 400.0);
+    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
+
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 540.0);
+    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
+
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    expect(revealed.offset, 350.0);
+    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
+  });
+
+  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
     final List<Widget> children = new List<Widget>.generate(20, (int i) {
       return new Container(
         height: 300.0,
@@ -483,55 +531,6 @@ void main() {
     revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
-  });
-
-  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
-    List<Widget> children;
-
-    await tester.pumpWidget(
-      new Directionality(
-        textDirection: TextDirection.ltr,
-        child: new Center(
-          child: Container(
-            height: 300.0,
-            width: 200.0,
-            child: new SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              reverse: true,
-              controller: new ScrollController(initialScrollOffset: 300.0),
-              child: new Row(
-                children: children = new List<Widget>.generate(20, (int i) {
-                  return new Container(
-                    height: 300.0,
-                    width: 100.0,
-                    child: new Text('Tile $i'),
-                  );
-                }),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final RenderAbstractViewport viewport = tester.allRenderObjects.firstWhere((RenderObject r) => r is RenderAbstractViewport);
-
-    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
-    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
-    expect(revealed.offset, 500.0);
-    expect(revealed.rect, new Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
-
-    revealed = viewport.getOffsetToReveal(target, 1.0);
-    expect(revealed.offset, 400.0);
-    expect(revealed.rect, new Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
-
-    revealed = viewport.getOffsetToReveal(target, 0.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
-    expect(revealed.offset, 540.0);
-    expect(revealed.rect, new Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
-
-    revealed = viewport.getOffsetToReveal(target, 1.0, rect: new Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
-    expect(revealed.offset, 350.0);
-    expect(revealed.rect, new Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
   });
 
   testWidgets('Nested SingleChildScrollView showOnScreen', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -345,8 +345,6 @@ void main() {
 
   testWidgets('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
     List<Widget> children;
-    ScrollController controller;
-
     await tester.pumpWidget(
       new Directionality(
         textDirection: TextDirection.ltr,
@@ -355,7 +353,7 @@ void main() {
             height: 200.0,
             width: 300.0,
             child: new SingleChildScrollView(
-              controller: controller = new ScrollController(initialScrollOffset: 300.0),
+              controller: new ScrollController(initialScrollOffset: 300.0),
               child: new Column(
                 children: children = new List<Widget>.generate(20, (int i) {
                   return new Container(
@@ -392,7 +390,7 @@ void main() {
   });
 
   testWidgets('SingleChildScrollView getOffsetToReveal - up', (WidgetTester tester) async {
-    List<Widget> children = new List<Widget>.generate(20, (int i) {
+    final List<Widget> children = new List<Widget>.generate(20, (int i) {
       return new Container(
         height: 100.0,
         width: 300.0,
@@ -439,7 +437,7 @@ void main() {
   });
 
   testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
-    List<Widget> children = new List<Widget>.generate(20, (int i) {
+    final List<Widget> children = new List<Widget>.generate(20, (int i) {
       return new Container(
         height: 300.0,
         width: 100.0,
@@ -489,7 +487,6 @@ void main() {
 
   testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
     List<Widget> children;
-    SingleChildScrollView scrollview;
 
     await tester.pumpWidget(
       new Directionality(
@@ -498,7 +495,7 @@ void main() {
           child: Container(
             height: 300.0,
             width: 200.0,
-            child: scrollview = new SingleChildScrollView(
+            child: new SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               reverse: true,
               controller: new ScrollController(initialScrollOffset: 300.0),


### PR DESCRIPTION
New in this PR:
* Specify which part of a `RenderObject` should be shown on screen with `showOnScreen`.
* Support animations for bringing a `RenderObject` on screen with `showOnScreen`.
* Make `showOnScreen` work correctly in nested scroll views.
* Fix `showOnScreen` for `RenderObjects` that are larger than the viewport dimensions.
* Tests, tests, and more tests for the `showOnScreen` and `getOffsetToReveal` logic.
* Minor code clean-up and simplifications.
* Logic changes and bug fixes for `RenderListWheelViewport.getOffsetToReveal`.

This is in preparation for fixing https://github.com/flutter/flutter/issues/10826 (scroll text fields back into view when they have been covered by the appearing keyboard).

This PR contains minor breaking API changes:

* `RenderObject`
    old: `void showOnScreen([RenderObject child])`
    new: `void showOnScreen({RenderObject descendant, Rect rect, Duration duration, Curve curve})`
* `RenderAbstractViewport`
    old: `double getOffsetToReveal(RenderObject target, double alignment)`
    new: `RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect rect})`
* `RenderViewportBase`
    old: `static void showInViewport({RenderObject descendant, RenderAbstractViewport viewport, ViewportOffset offset})`
    new: `static Rect showInViewport({RenderObject descendant, Rect rect, RenderAbstractViewport viewport, ViewportOffset offset, Duration duration, Curve curve})`

It is expected that these APIs are almost never used directly by our clients and therefore the breaking nature of this change will not be an issue for them. This has been backed up by looking at the usage in a large corpus of Flutter code.