### PR TITLE
Eliminiate concurrent map key set modification

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -485,7 +485,7 @@ class DevFS {
       // that it is initiated by user key press).
       final List<String> invalidatedFiles = <String>[];
       final Set<Uri> filesUris = new Set<Uri>();
-      for (Uri uri in dirtyEntries.keys) {
+      for (Uri uri in dirtyEntries.keys.toList()) {
         if (!uri.path.startsWith(assetBuildDirPrefix)) {
           final DevFSContent content = dirtyEntries[uri];
           if (content is DevFSFileContent) {


### PR DESCRIPTION
Iterates over a copy of the dirty entries list rather than the original,
in order to avoid the potential for a concurrent modification exception
when fileUris are removed/added later in the loop.

This occurs when non-asset URIs (Dart sources) are listed in the dirty
set when --preview-dart-2 is enabled (the default).