### PR TITLE
Teach drag start behaviors to DragGestureRecognizer

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -172,12 +172,11 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         )));
       }
       if (delta != Offset.zero && onUpdate != null) {
-        final Offset deltaForDetails = _getDeltaForDetails(delta);
         invokeCallback<void>('onUpdate', () => onUpdate(DragUpdateDetails(
           sourceTimeStamp: timestamp,
-          delta: deltaForDetails,
+          delta: _getDeltaForDetails(delta),
           primaryDelta: _getPrimaryValueFromOffset(delta),
-          globalPosition: _initialPosition + deltaForDetails,
+          globalPosition: _initialPosition + delta,
         )));
       }
     }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -181,15 +181,13 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       _state = _DragState.accepted;
       final Offset delta = _pendingDragOffset;
       final Duration timestamp = _lastPendingEventTimestamp;
-      Offset startPosition;
       Offset updateDelta;
       switch (dragStartBehavior) {
         case DragStartBehavior.start:
-          startPosition = _initialPosition + delta;
+          _initialPosition += delta;
           updateDelta = Offset.zero;
           break;
         case DragStartBehavior.down:
-          startPosition = _initialPosition;
           updateDelta = _getDeltaForDetails(delta);
           break;
       }
@@ -198,7 +196,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       if (onStart != null) {
         invokeCallback<void>('onStart', () => onStart(DragStartDetails(
           sourceTimeStamp: timestamp,
-          globalPosition: startPosition,
+          globalPosition: _initialPosition,
         )));
       }
       if (updateDelta != Offset.zero && onUpdate != null) {
@@ -206,7 +204,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
           sourceTimeStamp: timestamp,
           delta: updateDelta,
           primaryDelta: _getPrimaryValueFromOffset(updateDelta),
-          globalPosition: startPosition + delta,
+          globalPosition: _initialPosition + delta,
         )));
       }
     }

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -165,6 +165,90 @@ void main() {
     drag.dispose();
   });
 
+  testGesture('Should report most recent point to onStart by default', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer();
+    final VerticalDragGestureRecognizer competingDrag = VerticalDragGestureRecognizer();
+
+    Offset positionAtOnStart;
+    drag.onStart = (DragStartDetails details) {
+      positionAtOnStart = details.globalPosition;
+    };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    drag.addPointer(down);
+    competingDrag.addPointer(down);
+    tester.closeArena(5);
+    tester.route(down);
+
+    tester.route(pointer.move(const Offset(30.0, 0.0)));
+    drag.dispose();
+    competingDrag.dispose();
+
+    expect(positionAtOnStart, const Offset(30.0, 00.0));
+  });
+
+  testGesture('Should report most recent point to onStart with a start configuration', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag =
+        HorizontalDragGestureRecognizer(dragStartBehavior: DragStartBehavior.start);
+    final VerticalDragGestureRecognizer competingDrag = VerticalDragGestureRecognizer();
+
+    Offset positionAtOnStart;
+    drag.onStart = (DragStartDetails details) {
+      positionAtOnStart = details.globalPosition;
+    };
+    Offset updateOffset;
+    drag.onUpdate = (DragUpdateDetails details) {
+      updateOffset = details.globalPosition;
+    };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    drag.addPointer(down);
+    competingDrag.addPointer(down);
+    tester.closeArena(5);
+    tester.route(down);
+
+    tester.route(pointer.move(const Offset(30.0, 0.0)));
+    drag.dispose();
+    competingDrag.dispose();
+
+    expect(positionAtOnStart, const Offset(30.0, 0.0));
+    expect(updateOffset, null);
+  });
+
+  testGesture('Should report initial down point to onStart with a down configuration', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag =
+        HorizontalDragGestureRecognizer(dragStartBehavior: DragStartBehavior.down);
+    final VerticalDragGestureRecognizer competingDrag = VerticalDragGestureRecognizer();
+
+    Offset positionAtOnStart;
+    drag.onStart = (DragStartDetails details) {
+      positionAtOnStart = details.globalPosition;
+    };
+    Offset updateOffset;
+    Offset updateDelta;
+    drag.onUpdate = (DragUpdateDetails details) {
+      updateOffset = details.globalPosition;
+      updateDelta = details.delta;
+    };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    drag.addPointer(down);
+    competingDrag.addPointer(down);
+    tester.closeArena(5);
+    tester.route(down);
+
+    tester.route(pointer.move(const Offset(30.0, 0.0)));
+    drag.dispose();
+    competingDrag.dispose();
+
+    expect(positionAtOnStart, const Offset(10.0, 10.0));
+    expect(updateOffset, const Offset(30.0, 0.0));
+    expect(updateDelta, const Offset(20.0, 0.0));
+  });
+
   testGesture('Drag with multiple pointers', (GestureTester tester) {
     final HorizontalDragGestureRecognizer drag1 = HorizontalDragGestureRecognizer();
     final VerticalDragGestureRecognizer drag2 = VerticalDragGestureRecognizer();

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -58,8 +58,7 @@ void main() {
     tester.route(pointer.move(const Offset(20.0, 30.0))); // moved 10 horizontally and 20 vertically which is 22 total
     expect(didStartPan, isTrue); // 22 > 18
     didStartPan = false;
-    expect(updatedScrollDelta, const Offset(10.0, 20.0));
-    updatedScrollDelta = null;
+    expect(updatedScrollDelta, null);
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
@@ -249,9 +248,11 @@ void main() {
     expect(updateDelta, const Offset(20.0, 0.0));
   });
 
-  testGesture('Drag with multiple pointers', (GestureTester tester) {
-    final HorizontalDragGestureRecognizer drag1 = HorizontalDragGestureRecognizer();
-    final VerticalDragGestureRecognizer drag2 = VerticalDragGestureRecognizer();
+   testGesture('Drag with multiple pointers in down behavior', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag1 =
+        HorizontalDragGestureRecognizer(dragStartBehavior: DragStartBehavior.down);
+    final VerticalDragGestureRecognizer drag2 =
+        VerticalDragGestureRecognizer(dragStartBehavior: DragStartBehavior.down);
 
     final List<String> log = <String>[];
     drag1.onDown = (_) { log.add('drag1-down'); };


### PR DESCRIPTION
DragGestureRecognizer used to always pass the down point that was initially touched. With this change its behavior become configurable, and onStart can be given either the initial down point, or the point touched at the time onStart is invoked.

This currently doesn't have platform-specific logic since I am only aware of the behavior in Android (from issue #18249).

cc @Hixie