### PR TITLE
Handle malformed depfiles in Fingerprinter

### DIFF
--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -50,18 +50,18 @@ class Fingerprinter {
   }
 
   Future<bool> doesFingerprintMatch() async {
-    final File fingerprintFile = fs.file(fingerprintPath);
-    if (!fingerprintFile.existsSync())
-      return false;
-
-    if (!_depfilePaths.every(fs.isFileSync))
-      return false;
-
-    final List<String> paths = await _getPaths();
-    if (!paths.every(fs.isFileSync))
-      return false;
-
     try {
+      final File fingerprintFile = fs.file(fingerprintPath);
+      if (!fingerprintFile.existsSync())
+        return false;
+
+      if (!_depfilePaths.every(fs.isFileSync))
+        return false;
+
+      final List<String> paths = await _getPaths();
+      if (!paths.every(fs.isFileSync))
+        return false;
+
       final Fingerprint oldFingerprint = new Fingerprint.fromJson(await fingerprintFile.readAsString());
       final Fingerprint newFingerprint = await buildFingerprint();
       return oldFingerprint == newFingerprint;
@@ -153,6 +153,9 @@ class Fingerprint {
   // Ignore map entries here to avoid becoming inconsistent with equals
   // due to differences in map entry order.
   int get hashCode => hash2(_properties.length, _checksums.length);
+
+  @override
+  String toString() => '{checksums: $_checksums, properties: $_properties}';
 }
 
 final RegExp _separatorExpr = new RegExp(r'([^\\]) ');
@@ -171,6 +174,7 @@ Future<Set<String>> readDepfile(String depfilePath) async {
   // Depfile format:
   // outfile1 outfile2 : file1.dart file2.dart file3.dart
   final String contents = await fs.file(depfilePath).readAsString();
+
   final String dependencies = contents.split(': ')[1];
   return dependencies
       .replaceAllMapped(_separatorExpr, (Match match) => '${match.group(1)}\n')


### PR DESCRIPTION
Fingerprinter.doesFingerprintMatch() now returns false rather than
throwing if a depfile is malformed.