### PR TITLE
Increase size of checkbox, switch, and radio button to 48 by 48

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -200,7 +200,7 @@ class _RenderCheckbox extends RenderToggleable {
         activeColor: activeColor,
         inactiveColor: inactiveColor,
         onChanged: onChanged,
-        size: const Size(2 * kRadialReactionRadius, 2 * kRadialReactionRadius),
+        size: const Size(2 * kRadialReactionRadius + 8.0, 2 * kRadialReactionRadius + 8.0),
         vsync: vsync,
       );
 

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -179,7 +179,7 @@ class _RenderRadio extends RenderToggleable {
     activeColor: activeColor,
     inactiveColor: inactiveColor,
     onChanged: onChanged,
-    size: const Size(2 * kRadialReactionRadius, 2 * kRadialReactionRadius),
+    size: const Size(2 * kRadialReactionRadius + 8.0, 2 * kRadialReactionRadius + 8.0),
     vsync: vsync,
   );
 

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -223,7 +223,7 @@ const double _kTrackWidth = 33.0;
 const double _kTrackRadius = _kTrackHeight / 2.0;
 const double _kThumbRadius = 10.0;
 const double _kSwitchWidth = _kTrackWidth - 2 * _kTrackRadius + 2 * kRadialReactionRadius;
-const double _kSwitchHeight = 2 * kRadialReactionRadius;
+const double _kSwitchHeight = 2 * kRadialReactionRadius + 8.0;
 
 class _RenderSwitch extends RenderToggleable {
   _RenderSwitch({

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -16,7 +16,7 @@ void main() {
     debugResetSemanticsIdCounter();
   });
 
-  testWidgets('Checkbox size is 40x40', (WidgetTester tester) async {
+  testWidgets('Checkbox size is 48x48', (WidgetTester tester) async {
     await tester.pumpWidget(
       new Material(
         child: new Center(
@@ -28,7 +28,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(Checkbox)), const Size(40.0, 40.0));
+    expect(tester.getSize(find.byType(Checkbox)), const Size(48.0, 48.0));
   });
 
   testWidgets('CheckBox semantics', (WidgetTester tester) async {

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(log, isEmpty);
   });
 
-  testWidgets('Radio size is 40x40', (WidgetTester tester) async {
+  testWidgets('Radio size is 48x48', (WidgetTester tester) async {
     final Key key = new UniqueKey();
 
     await tester.pumpWidget(
@@ -80,7 +80,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key)), const Size(40.0, 40.0));
+    expect(tester.getSize(find.byKey(key)), const Size(48.0, 48.0));
   });
 
 


### PR DESCRIPTION
Conform to android a11y scanner and 48 by 48 tap target recommendation.