### PR TITLE
Fix misplaced quote in update_packages.dart

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -130,7 +130,7 @@ class UpdatePackagesCommand extends FlutterCommand {
           // we need to run update-packages to recapture the transitive deps.
           printError(
             'Warning: pubspec in ${directory.path} has invalid dependencies. '
-            'Please run "flutter update-packages" --force-upgrade to update them correctly.'
+            'Please run "flutter update-packages --force-upgrade" to update them correctly.'
           );
           needsUpdate = true;
         } else {


### PR DESCRIPTION
This quote was misplaced, so copy/pasting would fail.