### PR TITLE
Add some options to format subcommand

### DIFF
--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -10,6 +10,15 @@ import '../dart/sdk.dart';
 import '../runner/flutter_command.dart';
 
 class FormatCommand extends FlutterCommand {
+  FormatCommand() {
+    argParser.addFlag('dry-run',
+      abbr: 'n',
+      help: 'Show which files would be modified but make no changes.',
+      defaultsTo: false,
+      negatable: false,
+    );
+  }
+
   @override
   final String name = 'format';
 
@@ -36,7 +45,8 @@ class FormatCommand extends FlutterCommand {
     }
 
     final String dartfmt = sdkBinaryName('dartfmt');
-    final List<String> cmd = <String>[dartfmt, '-w']..addAll(argResults.rest);
+
+    final List<String> cmd = <String>[dartfmt, argResults['dry-run'] ? '-n' : '-w']..addAll(argResults.rest);
     final int result = await runCommandAndStreamOutput(cmd);
     if (result != 0)
       throwToolExit('Formatting failed: $result', exitCode: result);

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -22,6 +22,12 @@ class FormatCommand extends FlutterCommand {
       defaultsTo: false,
       negatable: false,
     );
+    argParser.addFlag('machine',
+      abbr: 'm',
+      help: 'Produce machine-readable JSON output.',
+      defaultsTo: false,
+      negatable: false,
+    );
   }
 
   @override
@@ -50,12 +56,22 @@ class FormatCommand extends FlutterCommand {
     }
 
     final String dartfmt = sdkBinaryName('dartfmt');
+    final List<String> cmd = <String>[dartfmt];
 
-    final List<String> cmd = <String>[
-      dartfmt, argResults['dry-run'] ? '-n' : '-w'];
+    if (argResults['dry-run']) {
+      cmd.add('-n');
+    }
+    if (argResults['machine']) {
+      cmd.add('-m');
+    }
+    if (!argResults['dry-run'] && !argResults['machine']) {
+      cmd.add('-w');
+    }
+
     if (argResults['set-exit-if-changed']) {
       cmd.add('--set-exit-if-changed');
     }
+
     cmd..addAll(argResults.rest);
 
     final int result = await runCommandAndStreamOutput(cmd);

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -17,6 +17,11 @@ class FormatCommand extends FlutterCommand {
       defaultsTo: false,
       negatable: false,
     );
+    argParser.addFlag('set-exit-if-changed',
+      help: 'Return exit code 1 if there are any formatting changes.',
+      defaultsTo: false,
+      negatable: false,
+    );
   }
 
   @override
@@ -46,7 +51,13 @@ class FormatCommand extends FlutterCommand {
 
     final String dartfmt = sdkBinaryName('dartfmt');
 
-    final List<String> cmd = <String>[dartfmt, argResults['dry-run'] ? '-n' : '-w']..addAll(argResults.rest);
+    final List<String> cmd = <String>[
+      dartfmt, argResults['dry-run'] ? '-n' : '-w'];
+    if (argResults['set-exit-if-changed']) {
+      cmd.add('--set-exit-if-changed');
+    }
+    cmd..addAll(argResults.rest);
+
     final int result = await runCommandAndStreamOutput(cmd);
     if (result != 0)
       throwToolExit('Formatting failed: $result', exitCode: result);

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -56,25 +56,25 @@ class FormatCommand extends FlutterCommand {
     }
 
     final String dartfmt = sdkBinaryName('dartfmt');
-    final List<String> cmd = <String>[dartfmt];
+    final List<String> command = <String>[dartfmt];
 
     if (argResults['dry-run']) {
-      cmd.add('-n');
+      command.add('-n');
     }
     if (argResults['machine']) {
-      cmd.add('-m');
+      command.add('-m');
     }
     if (!argResults['dry-run'] && !argResults['machine']) {
-      cmd.add('-w');
+      command.add('-w');
     }
 
     if (argResults['set-exit-if-changed']) {
-      cmd.add('--set-exit-if-changed');
+      command.add('--set-exit-if-changed');
     }
 
-    cmd..addAll(argResults.rest);
+    command..addAll(argResults.rest);
 
-    final int result = await runCommandAndStreamOutput(cmd);
+    final int result = await runCommandAndStreamOutput(command);
     if (result != 0)
       throwToolExit('Formatting failed: $result', exitCode: result);
   }

--- a/packages/flutter_tools/test/commands/format_test.dart
+++ b/packages/flutter_tools/test/commands/format_test.dart
@@ -38,5 +38,42 @@ void main() {
       final String formatted = srcFile.readAsStringSync();
       expect(formatted, original);
     });
+
+    testUsingContext('dry-run', () async {
+      final String projectPath = await createProject(temp);
+
+      final File srcFile = fs.file(
+          fs.path.join(projectPath, 'lib', 'main.dart'));
+      final String nonFormatted = srcFile.readAsStringSync().replaceFirst(
+          'main()', 'main(  )');
+      srcFile.writeAsStringSync(nonFormatted);
+
+      final FormatCommand command = new FormatCommand();
+      final CommandRunner<Null> runner = createTestCommandRunner(command);
+      await runner.run(<String>['format', '--dry-run', srcFile.path]);
+
+      final String shouldNotFormatted = srcFile.readAsStringSync();
+      expect(shouldNotFormatted, nonFormatted);
+    });
+
+    testUsingContext('dry-run with set-exit-if-changed', () async {
+      final String projectPath = await createProject(temp);
+
+      final File srcFile = fs.file(
+          fs.path.join(projectPath, 'lib', 'main.dart'));
+      final String nonFormatted = srcFile.readAsStringSync().replaceFirst(
+          'main()', 'main(  )');
+      srcFile.writeAsStringSync(nonFormatted);
+
+      final FormatCommand command = new FormatCommand();
+      final CommandRunner<Null> runner = createTestCommandRunner(command);
+
+      expect(runner.run(<String>[
+        'format', '--dry-run', '--set-exit-if-changed', srcFile.path
+      ]), throwsException);
+
+      final String shouldNotFormatted = srcFile.readAsStringSync();
+      expect(shouldNotFormatted, nonFormatted);
+    });
   });
 }


### PR DESCRIPTION
This pull-request introduces some options to `flutter format` subcommand.

- `--dry-run`, `-n`
- `--set-exit-if-changes`
- `--machine`, `-m`

These options are passed through to `dartfmt` command.

This patch is related to #12797.