### PR TITLE
expose PathOperation

### DIFF
--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -21,6 +21,7 @@ export 'dart:ui' show
   PaintingStyle,
   Path,
   PathFillType,
+  PathOperation,
   Radius,
   RRect,
   RSTransform,


### PR DESCRIPTION
Right now, if you want to use `Path.combine`, you have to add an import of `dart:ui` specifically for that (and I haven't seen any helpful hints in IDEs assisting with that discovery).

This ensures that if a user has imported anything from the framework that brings them `Path` also brings them `PathOperation`, which is used by `Path.combine` to expose path ops.