### PR TITLE
Add image stream error handling mechanism

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -150,7 +150,7 @@ class ImageStream extends Diagnosticable {
   }
 
   /// Stop listening for new concrete [ImageInfo] objects and errors from
-  /// its associated [ImageErrorListener].
+  /// the `listener`'s associated [ImageErrorListener].
   void removeListener(ImageListener listener) {
     if (_completer != null)
       return _completer.removeListener(listener);

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -312,11 +312,12 @@ abstract class ImageStreamCompleter extends Diagnosticable {
     );
 
     // Many listeners can have the same error listener. De-duplicate.
-    final Set<ImageErrorListener> localErrorListeners =
+    final List<ImageErrorListener> localErrorListeners =
         _listeners.map<ImageErrorListener>(
           (_ImageListenerPair listenerPair) => listenerPair.errorListener
-        ).toSet()
-            ..remove(null);
+        ).where(
+          (ImageErrorListener errorListener) => errorListener != null
+        ).toList();
 
     if (localErrorListeners.isEmpty) {
       FlutterError.reportError(_currentError);

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -136,7 +136,7 @@ class ImageStream extends Diagnosticable {
   /// a paint.
   void addListener(ImageListener listener, { ImageErrorListener onError }) {
     if (_completer != null)
-      return _completer.addListener(listener);
+      return _completer.addListener(listener, onError: onError);
     _listeners ??= <ImageListener, ImageErrorListener>{};
     _listeners[listener] = onError;
   }
@@ -217,6 +217,19 @@ abstract class ImageStreamCompleter extends Diagnosticable {
           stack: stack,
         );
       }
+    }
+    if (_currentError != null && onError != null) {
+      try {
+          onError(_currentError.exception, _currentError.stack);
+        } catch (exception, stack) {
+          reportError(
+            context: 'by a synchronously-called image error listener',
+            exception: exception,
+            stack: stack,
+            // Error listeners themselves failed. Don't feed back to listeners.
+            skipListeners: true,
+          );
+        }
     }
   }
 

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -123,12 +123,12 @@ class ImageStream extends Diagnosticable {
     if (_listeners != null) {
       final List<_ImageListenerPair> initialListeners = _listeners;
       _listeners = null;
-      initialListeners.forEach((_ImageListenerPair listenerPair) {
+      for (_ImageListenerPair listenerPair in initialListeners) {
         _completer.addListener(
           listenerPair.listener,
           onError: listenerPair.errorListener,
         );
-      });
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -65,15 +65,17 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
 /// The [BuildContext] and [Size] are used to select an image configuration
 /// (see [createLocalImageConfiguration]).
 ///
+/// The `onError` argument can be used to manually handle errors while precaching.
+///
 /// See also:
 ///
 ///   * [ImageCache], which holds images that may be reused.
 Future<Null> precacheImage(
   ImageProvider provider,
   BuildContext context, {
-    Size size,
-    ImageErrorListener onError,
-  }) {
+  Size size,
+  ImageErrorListener onError,
+}) {
   final ImageConfiguration config = createLocalImageConfiguration(context, size: size);
   final Completer<Null> completer = new Completer<Null>();
   final ImageStream stream = provider.resolve(config);

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -151,288 +151,322 @@ void main() {
     expect(emittedImages, equals(<ImageInfo>[new ImageInfo(image: frame.image)]));
   });
 
-   testWidgets('ImageStream emits frames (animated images)', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('ImageStream emits frames (animated images)', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final List<ImageInfo> emittedImages = <ImageInfo>[];
-     imageStream.addListener((ImageInfo image, bool synchronousCall) {
-       emittedImages.add(image);
-     });
+    final List<ImageInfo> emittedImages = <ImageInfo>[];
+    imageStream.addListener((ImageInfo image, bool synchronousCall) {
+      emittedImages.add(image);
+    });
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle();
-     // We are waiting for the next animation tick, so at this point no frames
-     // should have been emitted.
-     expect(emittedImages.length, 0);
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle();
+    // We are waiting for the next animation tick, so at this point no frames
+    // should have been emitted.
+    expect(emittedImages.length, 0);
 
-     await tester.pump();
-     expect(emittedImages, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
+    await tester.pump();
+    expect(emittedImages, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
 
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
-     mockCodec.completeNextFrame(frame2);
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    mockCodec.completeNextFrame(frame2);
 
-     await tester.pump(const Duration(milliseconds: 100));
-     // The duration for the current frame was 200ms, so we don't emit the next
-     // frame yet even though it is ready.
-     expect(emittedImages.length, 1);
+    await tester.pump(const Duration(milliseconds: 100));
+    // The duration for the current frame was 200ms, so we don't emit the next
+    // frame yet even though it is ready.
+    expect(emittedImages.length, 1);
 
-     await tester.pump(const Duration(milliseconds: 100));
-     expect(emittedImages, equals(<ImageInfo>[
-       new ImageInfo(image: frame1.image),
-       new ImageInfo(image: frame2.image),
-     ]));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(emittedImages, equals(<ImageInfo>[
+      new ImageInfo(image: frame1.image),
+      new ImageInfo(image: frame2.image),
+    ]));
 
-     // Let the pending timer for the next frame to complete so we can cleanly
-     // quit the test without pending timers.
-     await tester.pump(const Duration(milliseconds: 400));
-   });
+    // Let the pending timer for the next frame to complete so we can cleanly
+    // quit the test without pending timers.
+    await tester.pump(const Duration(milliseconds: 400));
+  });
 
-   testWidgets('animation wraps back', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('animation wraps back', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final List<ImageInfo> emittedImages = <ImageInfo>[];
-     imageStream.addListener((ImageInfo image, bool synchronousCall) {
-       emittedImages.add(image);
-     });
+    final List<ImageInfo> emittedImages = <ImageInfo>[];
+    imageStream.addListener((ImageInfo image, bool synchronousCall) {
+      emittedImages.add(image);
+    });
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
-     mockCodec.completeNextFrame(frame2);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(const Duration(milliseconds: 400)); // emit 3rd frame
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
+    mockCodec.completeNextFrame(frame2);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(const Duration(milliseconds: 400)); // emit 3rd frame
 
-     expect(emittedImages, equals(<ImageInfo>[
-       new ImageInfo(image: frame1.image),
-       new ImageInfo(image: frame2.image),
-       new ImageInfo(image: frame1.image),
-     ]));
+    expect(emittedImages, equals(<ImageInfo>[
+      new ImageInfo(image: frame1.image),
+      new ImageInfo(image: frame2.image),
+      new ImageInfo(image: frame1.image),
+    ]));
 
-     // Let the pending timer for the next frame to complete so we can cleanly
-     // quit the test without pending timers.
-     await tester.pump(const Duration(milliseconds: 200));
-   });
+    // Let the pending timer for the next frame to complete so we can cleanly
+    // quit the test without pending timers.
+    await tester.pump(const Duration(milliseconds: 200));
+  });
 
-   testWidgets('animation doesnt repeat more than specified', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = 0;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('animation doesnt repeat more than specified', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = 0;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final List<ImageInfo> emittedImages = <ImageInfo>[];
-     imageStream.addListener((ImageInfo image, bool synchronousCall) {
-       emittedImages.add(image);
-     });
+    final List<ImageInfo> emittedImages = <ImageInfo>[];
+    imageStream.addListener((ImageInfo image, bool synchronousCall) {
+      emittedImages.add(image);
+    });
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
-     mockCodec.completeNextFrame(frame2);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
-     mockCodec.completeNextFrame(frame1);
-     // allow another frame to complete (but we shouldn't be asking for it as
-     // this animation should not repeat.
-     await tester.idle();
-     await tester.pump(const Duration(milliseconds: 400));
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
+    mockCodec.completeNextFrame(frame2);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
+    mockCodec.completeNextFrame(frame1);
+    // allow another frame to complete (but we shouldn't be asking for it as
+    // this animation should not repeat.
+    await tester.idle();
+    await tester.pump(const Duration(milliseconds: 400));
 
-     expect(emittedImages, equals(<ImageInfo>[
-       new ImageInfo(image: frame1.image),
-       new ImageInfo(image: frame2.image),
-     ]));
-   });
+    expect(emittedImages, equals(<ImageInfo>[
+      new ImageInfo(image: frame1.image),
+      new ImageInfo(image: frame2.image),
+    ]));
+  });
 
-   testWidgets('frames are only decoded when there are active listeners', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('frames are only decoded when there are active listeners', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
-     imageStream.addListener(listener);
+    final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
+    imageStream.addListener(listener);
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
-     mockCodec.completeNextFrame(frame2);
-     imageStream.removeListener(listener);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(const Duration(milliseconds: 400)); // emit 2nd frame.
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
+    mockCodec.completeNextFrame(frame2);
+    imageStream.removeListener(listener);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(const Duration(milliseconds: 400)); // emit 2nd frame.
 
-     // Decoding of the 3rd frame should not start as there are no registered
-     // listeners to the stream
-     expect(mockCodec.numFramesAsked, 2);
+    // Decoding of the 3rd frame should not start as there are no registered
+    // listeners to the stream
+    expect(mockCodec.numFramesAsked, 2);
 
-     imageStream.addListener(listener);
-     await tester.idle(); // let nextFrameFuture complete
-     expect(mockCodec.numFramesAsked, 3);
-   });
+    imageStream.addListener(listener);
+    await tester.idle(); // let nextFrameFuture complete
+    expect(mockCodec.numFramesAsked, 3);
+  });
 
-   testWidgets('multiple stream listeners', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('multiple stream listeners', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final List<ImageInfo> emittedImages1 = <ImageInfo>[];
-     final ImageListener listener1 = (ImageInfo image, bool synchronousCall) {
-       emittedImages1.add(image);
-     };
-     final List<ImageInfo> emittedImages2 = <ImageInfo>[];
-     final ImageListener listener2 = (ImageInfo image, bool synchronousCall) {
-       emittedImages2.add(image);
-     };
-     imageStream.addListener(listener1);
-     imageStream.addListener(listener2);
+    final List<ImageInfo> emittedImages1 = <ImageInfo>[];
+    final ImageListener listener1 = (ImageInfo image, bool synchronousCall) {
+      emittedImages1.add(image);
+    };
+    final List<ImageInfo> emittedImages2 = <ImageInfo>[];
+    final ImageListener listener2 = (ImageInfo image, bool synchronousCall) {
+      emittedImages2.add(image);
+    };
+    imageStream.addListener(listener1);
+    imageStream.addListener(listener2);
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
-     expect(emittedImages1, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
-     expect(emittedImages2, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
+    expect(emittedImages1, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
+    expect(emittedImages2, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
 
-     mockCodec.completeNextFrame(frame2);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // next app frame will schedule a timer.
-     imageStream.removeListener(listener1);
+    mockCodec.completeNextFrame(frame2);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // next app frame will schedule a timer.
+    imageStream.removeListener(listener1);
 
-     await tester.pump(const Duration(milliseconds: 400)); // emit 2nd frame.
-     expect(emittedImages1, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
-     expect(emittedImages2, equals(<ImageInfo>[
-       new ImageInfo(image: frame1.image),
-       new ImageInfo(image: frame2.image),
-     ]));
-   });
+    await tester.pump(const Duration(milliseconds: 400)); // emit 2nd frame.
+    expect(emittedImages1, equals(<ImageInfo>[new ImageInfo(image: frame1.image)]));
+    expect(emittedImages2, equals(<ImageInfo>[
+      new ImageInfo(image: frame1.image),
+      new ImageInfo(image: frame2.image),
+    ]));
+  });
 
-   testWidgets('timer is canceled when listeners are removed', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('timer is canceled when listeners are removed', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
-     imageStream.addListener(listener);
+    final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
+    imageStream.addListener(listener);
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
 
-     mockCodec.completeNextFrame(frame2);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump();
+    mockCodec.completeNextFrame(frame2);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump();
 
-     imageStream.removeListener(listener);
-     // The test framework will fail this if there are pending timers at this
-     // point.
-   });
+    imageStream.removeListener(listener);
+    // The test framework will fail this if there are pending timers at this
+    // point.
+  });
 
-   testWidgets('timeDilation affects animation frame timers', (WidgetTester tester) async {
-     final MockCodec mockCodec = new MockCodec();
-     mockCodec.frameCount = 2;
-     mockCodec.repetitionCount = -1;
-     final Completer<Codec> codecCompleter = new Completer<Codec>();
+  testWidgets('timeDilation affects animation frame timers', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 2;
+    mockCodec.repetitionCount = -1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
 
-     final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
-       codec: codecCompleter.future,
-       scale: 1.0,
-     );
+    final ImageStreamCompleter imageStream = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
 
-     final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
-     imageStream.addListener(listener);
+    final ImageListener listener = (ImageInfo image, bool synchronousCall) {};
+    imageStream.addListener(listener);
 
-     codecCompleter.complete(mockCodec);
-     await tester.idle();
+    codecCompleter.complete(mockCodec);
+    await tester.idle();
 
-     final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
-     final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
+    final FrameInfo frame1 = new FakeFrameInfo(20, 10, const Duration(milliseconds: 200));
+    final FrameInfo frame2 = new FakeFrameInfo(200, 100, const Duration(milliseconds: 400));
 
-     mockCodec.completeNextFrame(frame1);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // first animation frame shows on first app frame.
+    mockCodec.completeNextFrame(frame1);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // first animation frame shows on first app frame.
 
-     timeDilation = 2.0;
-     mockCodec.completeNextFrame(frame2);
-     await tester.idle(); // let nextFrameFuture complete
-     await tester.pump(); // schedule next app frame
-     await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
-     // Decoding of the 3rd frame should not start after 200 ms, as time is
-     // dilated by a factor of 2.
-     expect(mockCodec.numFramesAsked, 2);
-     await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
-     expect(mockCodec.numFramesAsked, 3);
+    timeDilation = 2.0;
+    mockCodec.completeNextFrame(frame2);
+    await tester.idle(); // let nextFrameFuture complete
+    await tester.pump(); // schedule next app frame
+    await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
+    // Decoding of the 3rd frame should not start after 200 ms, as time is
+    // dilated by a factor of 2.
+    expect(mockCodec.numFramesAsked, 2);
+    await tester.pump(const Duration(milliseconds: 200)); // emit 2nd frame.
+    expect(mockCodec.numFramesAsked, 3);
+  });
 
-   });
+  testWidgets('error handlers can intercept errors', (WidgetTester tester) async {
+    final MockCodec mockCodec = new MockCodec();
+    mockCodec.frameCount = 1;
+    final Completer<Codec> codecCompleter = new Completer<Codec>();
+
+    final ImageStreamCompleter streamUnderTest = new MultiFrameImageStreamCompleter(
+      codec: codecCompleter.future,
+      scale: 1.0,
+    );
+
+    dynamic capturedException;
+    final ImageErrorListener errorListener = (dynamic exception, StackTrace stackTrace) {
+      capturedException = exception;
+    };
+
+    streamUnderTest.addListener(
+      (ImageInfo image, bool synchronousCall) {},
+      onError: errorListener,
+    );
+
+    codecCompleter.complete(mockCodec);
+    // MultiFrameImageStreamCompleter only sets an error handler for the next
+    // frame future after the codec future has completed.
+    // Idling here lets the MultiFrameImageStreamCompleter advance and set the
+    // error handler for the nextFrame future.
+    await tester.idle();
+
+    mockCodec.failNextFrame('frame completion error');
+    await tester.idle();
+
+    // No exception is passed up.
+    expect(tester.takeException(), isNull);
+    expect(capturedException, 'frame completion error');
+  });
 }

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -529,11 +529,11 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 }
 
 class TestImageStreamCompleter extends ImageStreamCompleter {
-  final List<ImageListener> listeners = <ImageListener> [];
+  final Map<ImageListener, ImageErrorListener> listeners = <ImageListener, ImageErrorListener> {};
 
   @override
-  void addListener(ImageListener listener) {
-    listeners.add(listener);
+  void addListener(ImageListener listener, { ImageErrorListener onError }) {
+    listeners[listener] = onError;
   }
 
   @override

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -449,7 +449,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Duplicate error listener is called once', (WidgetTester tester) async {
+  testWidgets('Duplicate error listeners are all called', (WidgetTester tester) async {
     dynamic capturedException;
     StackTrace capturedStackTrace;
     ImageInfo capturedImage;
@@ -489,8 +489,7 @@ void main() {
     // The image stream error handler should have the original exception.
     expect(capturedException, testException);
     expect(capturedStackTrace, testStack);
-    // Error listener registered twice but should be called once.
-    expect(errorListenerCalled, 1);
+    expect(errorListenerCalled, 2);
     // If there is an error listener, there should be no FlutterError reported.
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
Fixes #18255, fixes #18238

Consolidates various flutter error reporting sites. Make them all interceptable by a error listener first.