### PR TITLE
[frdb] Add support for env connection variable.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -175,9 +175,15 @@ class FuchsiaRemoteConnection {
   /// successfully (that being the outgoing interface of your machine, not the
   /// interface on the target machine).
   ///
-  /// Attempts to `address` via the environment variable `FUCHSIA_DEVICE_URL` in
-  /// the event that the argument is not passed. If `address` is not supplied,
-  /// `interface` is also ignored.
+  /// Attempts to set `address` via the environment variable
+  /// `FUCHSIA_DEVICE_URL` in the event that the argument is not passed.
+  /// If `address` is not supplied, `interface` is also ignored, as the format
+  /// is expected to contain the interface as well (in the event that it is
+  /// link-local), like the following:
+  ///
+  /// ```
+  /// fe80::1%eth0
+  /// ```
   ///
   /// In the event that `FUCHSIA_SSH_CONFIG` is set in the environment, that
   /// will be used when `sshConfigPath` isn't supplied.

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -13,11 +13,9 @@ import 'common/network.dart';
 import 'dart/dart_vm.dart';
 import 'runners/ssh_command_runner.dart';
 
-final String _ipv4Loopback =
-    InternetAddress.LOOPBACK_IP_V4.address; // ignore: deprecated_member_use
+final String _ipv4Loopback = InternetAddress.loopbackIPv4.address;
 
-final String _ipv6Loopback =
-    InternetAddress.LOOPBACK_IP_V6.address; // ignore: deprecated_member_use
+final String _ipv6Loopback = InternetAddress.loopbackIPv6.address;
 
 const ProcessManager _processManager = const LocalProcessManager();
 
@@ -60,7 +58,7 @@ class FuchsiaRemoteConnectionError extends Error {
 
   @override
   String toString() {
-    return '$FuchsiaRemoteConnectionError: $message\n${super.stackTrace}';
+    return '$FuchsiaRemoteConnectionError: $message';
   }
 }
 

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -13,9 +13,11 @@ import 'common/network.dart';
 import 'dart/dart_vm.dart';
 import 'runners/ssh_command_runner.dart';
 
-final String _ipv4Loopback = InternetAddress.LOOPBACK_IP_V4.address; // ignore: deprecated_member_use
+final String _ipv4Loopback =
+    InternetAddress.LOOPBACK_IP_V4.address; // ignore: deprecated_member_use
 
-final String _ipv6Loopback = InternetAddress.LOOPBACK_IP_V6.address; // ignore: deprecated_member_use
+final String _ipv6Loopback =
+    InternetAddress.LOOPBACK_IP_V6.address; // ignore: deprecated_member_use
 
 const ProcessManager _processManager = const LocalProcessManager();
 
@@ -45,6 +47,21 @@ PortForwardingFunction fuchsiaPortForwardingFunction = _SshPortForwarder.start;
 /// implementation.
 void restoreFuchsiaPortForwardingFunction() {
   fuchsiaPortForwardingFunction = _SshPortForwarder.start;
+}
+
+/// A general error raised when something fails within a
+/// [FuchsiaRemoteConnection].
+class FuchsiaRemoteConnectionError extends Error {
+  /// Basic constructor outlining the reason for the failure in `message`.
+  FuchsiaRemoteConnectionError(this.message);
+
+  /// The reason for the failure.
+  final String message;
+
+  @override
+  String toString() {
+    return '$FuchsiaRemoteConnectionError: $message\n${super.stackTrace}';
+  }
 }
 
 /// An enum specifying a Dart VM's state.
@@ -157,11 +174,32 @@ class FuchsiaRemoteConnection {
   /// then `interface` will probably need to be set in order to connect
   /// successfully (that being the outgoing interface of your machine, not the
   /// interface on the target machine).
-  static Future<FuchsiaRemoteConnection> connect(
-    String address, [
+  ///
+  /// Attempts to `address` via the environment variable `FUCHSIA_DEVICE_URL` in
+  /// the event that the argument is not passed. If `address` is not supplied,
+  /// `interface` is also ignored.
+  ///
+  /// In the event that `FUCHSIA_SSH_CONFIG` is set in the environment, that
+  /// will be used when `sshConfigPath` isn't supplied.
+  static Future<FuchsiaRemoteConnection> connect([
+    String address,
     String interface = '',
     String sshConfigPath,
   ]) async {
+    address ??= Platform.environment['FUCHSIA_DEVICE_URL'];
+    sshConfigPath ??= Platform.environment['FUCHSIA_SSH_CONFIG'];
+    if (address == null) {
+      throw new FuchsiaRemoteConnectionError(
+          'No address supplied, and \$FUCHSIA_DEVICE_URL not found.');
+    }
+    const String interfaceDelimiter = '%';
+    if (address.contains(interfaceDelimiter)) {
+      final List<String> addressAndInterface =
+          address.split(interfaceDelimiter);
+      address = addressAndInterface[0];
+      interface = addressAndInterface[1];
+    }
+
     return await FuchsiaRemoteConnection.connectWithSshCommandRunner(
       new SshCommandRunner(
         address: address,


### PR DESCRIPTION
Similar to the flutter driver, now the fuchsia_remote_debug_protocol can
connect via an environment variable. This can also be used to point to
the SSH config location.

This makes it so that tests written using the FRDB do not have to write
extra information about where their device is on the network.