### PR TITLE
Ensure errors launching emulators are exposed to the daemon

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -11,7 +11,6 @@ import '../android/android_workflow.dart';
 import '../base/file_system.dart';
 import '../base/process.dart';
 import '../emulator.dart';
-import '../globals.dart';
 import 'android_sdk.dart';
 
 class AndroidEmulators extends EmulatorDiscovery {
@@ -41,22 +40,20 @@ class AndroidEmulator extends Emulator {
   String get label => _properties['avd.ini.displayname'];
 
   @override
-  Future<bool> launch() async {
-    final Future<bool> launchResult =
+  Future<void> launch() async {
+    final Future<void> launchResult =
         runAsync(<String>[getEmulatorPath(), '-avd', id])
             .then((RunResult runResult) {
               if (runResult.exitCode != 0) {
-                printError('$runResult');
-                return false;
+                throw '$runResult';
               }
-              return true;
             });
     // emulator continues running on a successful launch so if we
     // haven't quit within 3 seconds we assume that's a success and just
     // return.
-    return Future.any<bool>(<Future<bool>>[
+    return Future.any<void>(<Future<void>>[
       launchResult,
-      new Future<void>.delayed(const Duration(seconds: 3)).then((_) => true)
+      new Future<void>.delayed(const Duration(seconds: 3))
     ]);
   }
 }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -49,7 +49,7 @@ class EmulatorsCommand extends FlutterCommand {
     }
   }
 
-  Future<Null> _launchEmulator(String id) async {
+  Future<void> _launchEmulator(String id) async {
     final List<Emulator> emulators =
         await emulatorManager.getEmulatorsMatching(id);
 
@@ -61,11 +61,16 @@ class EmulatorsCommand extends FlutterCommand {
         "More than one emulator matches '$id':",
       );
     } else {
+      try {
       await emulators.first.launch();
+      }
+      catch (e) {
+        printError(e);
+      }
     }
   }
 
-  Future<Null> _listEmulators(String searchText) async {
+  Future<void> _listEmulators(String searchText) async {
     final List<Emulator> emulators = searchText == null
         ? await emulatorManager.getAllAvailableEmulators()
         : await emulatorManager.getEmulatorsMatching(searchText);

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -62,7 +62,7 @@ class EmulatorsCommand extends FlutterCommand {
       );
     } else {
       try {
-      await emulators.first.launch();
+        await emulators.first.launch();
       }
       catch (e) {
         printError(e);

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -95,7 +95,7 @@ abstract class Emulator {
     return id == other.id;
   }
 
-  Future<bool> launch();
+  Future<void> launch();
 
   @override
   String toString() => name;

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -36,8 +36,8 @@ class IOSEmulator extends Emulator {
   String get label => null;
 
   @override
-  Future<bool> launch() async {
-    Future<bool> launchSimulator(List<String> additionalArgs) async {
+  Future<void> launch() async {
+    Future<void> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>['open']
           .followedBy(additionalArgs)
           .followedBy(<String>['-a', getSimulatorPath()]);

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -62,7 +62,7 @@ class _MockEmulator extends Emulator {
   final String label;
 
   @override
-  Future<bool> launch() {
+  Future<void> launch() {
     throw new UnimplementedError('Not implemented in Mock');
   }
 }


### PR DESCRIPTION
The original emulator code used `printError` when an error occurred launching an emulator. This worked fine from the CLI but in the daemon it means the response came back successful and then we got a `logMessage` with the error. This means editors believed the launch worked (Dart Code ends up sitting around waiting for an emulator to connect) and there was an unrelated error.

This code pushes the `printError` up to the command so that the daemon error handling code will return the error correctly.