### PR TITLE
Check video widget is mounted on call to setState

### DIFF
--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -151,7 +151,8 @@ class _VideoPlayPauseState extends State<VideoPlayPause> {
 
   _VideoPlayPauseState() {
     listener = () {
-      setState(() {});
+      if (mounted)
+        setState(() {});
     };
   }
 
@@ -374,7 +375,8 @@ class _VideoDemoState extends State<VideoDemo>
       controller.play();
       await connectedCompleter.future;
       await controller.initialize();
-      setState(() {});
+      if (mounted)
+        setState(() {});
     }
 
     initController(butterflyController);


### PR DESCRIPTION
When setState() calls occur asynchronously, it's possible that the
Futures on which they're waiting don't complete until the widget is
removed. To avoid this, we check the widget is mounted before calling
setState().

Fixes a devicelab test failure in test_driver/transitions_perf.dart