### PR TITLE
Prepare for upgrading video player in Gallery to newest version

### DIFF
--- a/examples/flutter_gallery/android/app/build.gradle
+++ b/examples/flutter_gallery/android/app/build.gradle
@@ -64,7 +64,7 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   string_scanner: 1.0.2
   url_launcher: 3.0.0
   cupertino_icons: 0.1.2
-  video_player: 0.6.0
+  video_player: 0.5.1
 
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets: 0.1.4

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   string_scanner: 1.0.2
   url_launcher: 3.0.0
   cupertino_icons: 0.1.2
-  video_player: 0.5.1
+  video_player: 0.6.0
 
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets: 0.1.4


### PR DESCRIPTION
Version 0.6.0 of `video_player` plugin uses `ExoPlayer` instead of `MediaPlayer` on Android. The new dependency on `ExoPlayer` Java packages necessitates down-grading the Android test dependencies of `flutter_gallery` for compatibility with `ExoPlayer` transitive deps. Not down-grading caused the build error and roll-back of https://github.com/flutter/flutter/pull/18471