### PR TITLE
Don't be case-sensitive when checking for extension

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -35,7 +35,7 @@ class VsCode {
         .listSync()
         .where((FileSystemEntity d) => d is Directory)
         .where(
-            (FileSystemEntity d) => d.basename.startsWith(extensionIdentifier));
+            (FileSystemEntity d) => d.basename.toLowerCase().startsWith(extensionIdentifier.toLowerCase()));
 
     if (extensionDirs.isNotEmpty) {
       final FileSystemEntity extensionDir = extensionDirs.first;

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -30,12 +30,13 @@ class VsCode {
     }
 
     // Check for presence of extension.
+    final String extensionIdentifierLower = extensionIdentifier.toLowerCase();
     final Iterable<FileSystemEntity> extensionDirs = fs
         .directory(extensionDirectory)
         .listSync()
         .where((FileSystemEntity d) => d is Directory)
         .where(
-            (FileSystemEntity d) => d.basename.toLowerCase().startsWith(extensionIdentifier.toLowerCase()));
+            (FileSystemEntity d) => d.basename.toLowerCase().startsWith(extensionIdentifierLower));
 
     if (extensionDirs.isNotEmpty) {
       final FileSystemEntity extensionDir = extensionDirs.first;

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -10,7 +10,7 @@ import 'vscode.dart';
 
 class VsCodeValidator extends DoctorValidator {
   static const String extensionMarketplaceUrl =
-    'https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter';
+    'https://marketplace.visualstudio.com/items?itemName=${VsCode.extensionIdentifier}';
   final VsCode _vsCode;
 
   VsCodeValidator(this._vsCode) : super(_vsCode.productName);


### PR DESCRIPTION
Seems like VS Code may have started using lowercase extension folders recently (our identifier is `Dart-Code.flutter` but now the folder is named `dart-code.flutter`), so thi smakes the check not sensitive to casing.