### PR TITLE
Fix aot_snapshot_size_* benchmarks

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -228,6 +228,7 @@ class CompileTest {
     final List<String> options = <String>[
       'aot',
       '-v',
+      '--extra-gen-snapshot-options=--print_snapshot_sizes',
       '--release',
       '--no-pub',
       '--target-platform',
@@ -252,6 +253,9 @@ class CompileTest {
     final Map<String, dynamic> metrics = <String, dynamic>{};
     for (Match m in metricExpression.allMatches(compileLog)) {
       metrics[_sdkNameToMetricName(m.group(1))] = int.parse(m.group(2));
+    }
+    if (metrics.length != _kSdkNameToMetricNameMapping.length) {
+      throw 'Expected metrics: ${_kSdkNameToMetricNameMapping.keys}, but got: ${metrics.keys}.';
     }
     metrics['aot_snapshot_compile_millis'] = watch.elapsedMilliseconds;
 
@@ -326,19 +330,20 @@ class CompileTest {
     };
   }
 
-  static String _sdkNameToMetricName(String sdkName) {
-    const Map<String, String> kSdkNameToMetricNameMapping = const <String, String> {
-      'VMIsolate': 'aot_snapshot_size_vmisolate',
-      'Isolate': 'aot_snapshot_size_isolate',
-      'ReadOnlyData': 'aot_snapshot_size_rodata',
-      'Instructions': 'aot_snapshot_size_instructions',
-      'Total': 'aot_snapshot_size_total',
-    };
+  static const Map<String, String> _kSdkNameToMetricNameMapping = const <String, String> {
+    'VMIsolate': 'aot_snapshot_size_vmisolate',
+    'Isolate': 'aot_snapshot_size_isolate',
+    'ReadOnlyData': 'aot_snapshot_size_rodata',
+    'Instructions': 'aot_snapshot_size_instructions',
+    'Total': 'aot_snapshot_size_total',
+  };
 
-    if (!kSdkNameToMetricNameMapping.containsKey(sdkName))
+  static String _sdkNameToMetricName(String sdkName) {
+
+    if (!_kSdkNameToMetricNameMapping.containsKey(sdkName))
       throw 'Unrecognized SDK snapshot metric name: $sdkName';
 
-    return kSdkNameToMetricNameMapping[sdkName];
+    return _kSdkNameToMetricNameMapping[sdkName];
   }
 }
 


### PR DESCRIPTION
... and make sure they fail if they can't report the size.

This was broken in https://github.com/flutter/flutter/commit/d1cc8b6de82e3436d57f0d1c93b7689166028e31#r29384579. /cc @Hixie 