### PR TITLE
Change HttpStatus.ok to HttpStatus.OK

### DIFF
--- a/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
+++ b/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
@@ -59,7 +59,7 @@ class Upload {
         ..add(content);
 
       final HttpClientResponse response = await request.close().timeout(timeLimit);
-      if (response.statusCode == HttpStatus.ok) {
+      if (response.statusCode == HttpStatus.OK) {
         logMessage('Saved $name');
         await response.drain<Null>();
       } else {
@@ -67,7 +67,7 @@ class Upload {
         logMessage('Request to save "$name" (length ${content.length}) failed with status ${response.statusCode}, will retry');
         logMessage(await response.transform(utf8.decoder).join());
       }
-      return response.statusCode == HttpStatus.ok;
+      return response.statusCode == HttpStatus.OK;
     } on TimeoutException catch (_) {
       logMessage('Request to save "$name" (length ${content.length}) timed out, will retry');
       return false;

--- a/dev/manual_tests/test/mock_image_http.dart
+++ b/dev/manual_tests/test/mock_image_http.dart
@@ -15,7 +15,7 @@ MockHttpClient createMockImageHttpClient(SecurityContext _) {
   when(request.headers).thenReturn(headers);
   when(request.close()).thenAnswer((_) => new Future<HttpClientResponse>.value(response));
   when(response.contentLength).thenReturn(kTransparentImage.length);
-  when(response.statusCode).thenReturn(HttpStatus.ok);
+  when(response.statusCode).thenReturn(HttpStatus.OK);
   when(response.listen(typed(any))).thenAnswer((Invocation invocation) {
     final void Function(List<int>) onData = invocation.positionalArguments[0];
     final void Function() onDone = invocation.namedArguments[#onDone];

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -486,7 +486,7 @@ class NetworkImage extends ImageProvider<NetworkImage> {
       request.headers.add(name, value);
     });
     final HttpClientResponse response = await request.close();
-    if (response.statusCode != HttpStatus.ok)
+    if (response.statusCode != HttpStatus.OK)
       throw new Exception('HTTP request failed, statusCode: ${response?.statusCode}, $resolved');
 
     final Uint8List bytes = await consolidateHttpClientResponseBytes(response);

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -115,7 +115,7 @@ class NetworkAssetBundle extends AssetBundle {
   Future<ByteData> load(String key) async {
     final HttpClientRequest request = await _httpClient.getUrl(_urlFromKey(key));
     final HttpClientResponse response = await request.close();
-    if (response.statusCode != HttpStatus.ok)
+    if (response.statusCode != HttpStatus.OK)
       throw new FlutterError(
         'Unable to load asset: $key\n'
         'HTTP status code: ${response.statusCode}'

--- a/packages/flutter/test/widgets/image_headers_test.dart
+++ b/packages/flutter/test/widgets/image_headers_test.dart
@@ -31,7 +31,7 @@ void main() {
       when(request.headers).thenReturn(headers);
       when(request.close()).thenAnswer((_) => new Future<HttpClientResponse>.value(response));
       when(response.contentLength).thenReturn(kTransparentImage.length);
-      when(response.statusCode).thenReturn(HttpStatus.ok);
+      when(response.statusCode).thenReturn(HttpStatus.OK);
       when(response.listen(typed(any))).thenAnswer((Invocation invocation) {
         final void Function(List<int>) onData = invocation.positionalArguments[0];
         final void Function() onDone = invocation.namedArguments[#onDone];


### PR DESCRIPTION
Greg Spencer:

The HttpStatus.ok was renamed from HttpStatus.OK with the most recent
engine roll (which brought in 0.62 of Dart, which changed that enum
name).