### PR TITLE
Remove saveLayer after clip from dart

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -235,8 +235,6 @@ class PaintingContext {
     _canvas = null;
   }
 
-  static final Paint _defaultPaint = new Paint();
-
   /// Hints that the painting in the current layer is complex and would benefit
   /// from caching.
   ///
@@ -351,11 +349,9 @@ class PaintingContext {
     } else {
       canvas
         ..save()
-        ..clipRRect(offsetClipRRect)
-        ..saveLayer(offsetBounds, _defaultPaint);
+        ..clipRRect(offsetClipRRect);
       painter(this, offset);
       canvas
-        ..restore()
         ..restore();
     }
   }
@@ -380,11 +376,9 @@ class PaintingContext {
     } else {
       canvas
         ..save()
-        ..clipPath(clipPath.shift(offset))
-        ..saveLayer(bounds.shift(offset), _defaultPaint);
+        ..clipPath(clipPath.shift(offset));
       painter(this, offset);
       canvas
-        ..restore()
         ..restore();
     }
   }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -355,13 +355,7 @@ class RenderParagraph extends RenderBox {
 
     if (_hasVisualOverflow) {
       final Rect bounds = offset & size;
-      if (_overflowShader != null) {
-        // This layer limits what the shader below blends with to be just the text
-        // (as opposed to the text and its background).
-        canvas.saveLayer(bounds, new Paint());
-      } else {
         canvas.save();
-      }
       canvas.clipRect(bounds);
     }
     _textPainter.paint(canvas, offset);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1487,7 +1487,6 @@ abstract class _RenderPhysicalModelBase<T> extends _RenderCustomClip<T> {
     markNeedsPaint();
   }
 
-  static final Paint _defaultPaint = new Paint();
   static final Paint _transparentPaint = new Paint()..color = const Color(0x00000000);
 
   // On Fuchsia, the system compositor is responsible for drawing shadows
@@ -1642,17 +1641,7 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
         canvas.drawRRect(offsetRRect, new Paint()..color = color);
         canvas.save();
         canvas.clipRRect(offsetRRect);
-        // We only use a new layer for non-rectangular clips, on the basis that
-        // rectangular clips won't need antialiasing. This is not really
-        // correct, because if we're e.g. rotated, rectangles will also be
-        // aliased. Unfortunately, it's too much of a performance win to err on
-        // the side of correctness here.
-        // TODO(ianh): Find a better solution.
-        if (!offsetRRect.isRect)
-          canvas.saveLayer(offsetBounds, _RenderPhysicalModelBase._defaultPaint);
         super.paint(context, offset);
-        if (!offsetRRect.isRect)
-          canvas.restore();
         canvas.restore();
         assert(context.canvas == canvas, 'canvas changed even though needsCompositing was false');
       }
@@ -1763,10 +1752,8 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
           );
         }
         canvas.drawPath(offsetPath, new Paint()..color = color..style = PaintingStyle.fill);
-        canvas.saveLayer(offsetBounds, _RenderPhysicalModelBase._defaultPaint);
         canvas.clipPath(offsetPath);
         super.paint(context, offset);
-        canvas.restore();
         assert(context.canvas == canvas, 'canvas changed even though needsCompositing was false');
       }
     }


### PR DESCRIPTION
This is a follow up on https://github.com/flutter/engine/pull/5420
and https://github.com/flutter/flutter/issues/18057

Note that our raster cache will most likely cache the SkPicture so
this should NOT have a big performance impact by itself. We'll
only get a small speedup before raster cache kicks in.

Once the raster cache is disabled, we can see that complex_layout
scroll speedups from 11ms/frame to 9ms/frame. With raster cache,
it's about 8ms/frame. (All on my Nexus 5X).

For flutter_gallery transition test, we get a big speedup from 38.5ms/frame
to 17.5ms/frame without raster cache. With raster cache and this PR,
it's about 15.5ms/frame.

So with this PR, the raster cache becomes much less important
at least for our own benchmarks.