### PR TITLE
Make `ensureVersionFile` a `Future<void>` function.

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -87,7 +87,7 @@ class FlutterVersion {
   String get engineRevision => Cache.instance.engineRevision;
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
-  Future<Null> ensureVersionFile() {
+  Future<void> ensureVersionFile() {
     return fs.file(fs.path.join(Cache.flutterRoot, 'version')).writeAsString(_frameworkVersion);
   }
 


### PR DESCRIPTION
Ran into this:

_TypeError: type 'Future<File>' is not a subtype of type 'Future<Null>'

```
#0      FlutterVersion.ensureVersionFile (package:flutter_tools/src/version.dart:91:64)
#1      FlutterCommandRunner.runCommand.<anonymous closure> (package:flutter_tools/src/runner/flutter_command_runner.dart:295:39)
#2      _asyncThenWrapperHelper.<anonymous closure> (dart:async/runtime/libasync_patch.dart:77:64)
#3      _rootRunUnary (dart:async/zone.dart:1134:38)
#4      _CustomZone.runUnary (dart:async/zone.dart:1031:19)
#5      _FutureListener.handleValue (dart:async/future_impl.dart:129:18)
#6      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:638:45)
#7      Future._propagateToListeners (dart:async/future_impl.dart:667:32)
#8      Future._complete (dart:async/future_impl.dart:472:7)
#9      _SyncCompleter.complete (dart:async/future_impl.dart:51:12)
#10     _AsyncAwaitCompleter.complete (dart:async/runtime/libasync_patch.dart:28:18)
#11     Cache.lock (package:flutter_tools/src/cache.dart)
#12     _asyncThenWrapperHelper.<anonymous closure> (dart:async/runtime/libasync_patch.dart:77:64)
#13     _rootRunUnary (dart:async/zone.dart:1134:38)
#14     _CustomZone.runUnary (dart:async/zone.dart:1031:19)
#15     _FutureListener.handleValue (dart:async/future_impl.dart:129:18)
#16     Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:638:45)
#17     Future._propagateToListeners (dart:async/future_impl.dart:667:32)
#18     Future._completeWithValue (dart:async/future_impl.dart:482:5)
#19     Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:512:7)
#20     _rootRun (dart:async/zone.dart:1126:13)
#21     _CustomZone.run (dart:async/zone.dart:1023:19)
#22     _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:949:23)
#23     _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
#24     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
#25     _runPendingImmediateCallback (dart:isolate/runtime/libisolate_patch.dart:113:13)
#26     _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:166:5)
```

Easiest seems to be to just ignore the future value.
