### PR TITLE
Make Gradle script support Flutter-as-lib

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -53,7 +53,7 @@ class FlutterPlugin implements Plugin<Project> {
 
     private String resolveProperty(Project project, String name, String defaultValue) {
         if (localProperties == null) {
-            localProperties = readPropertiesIfExist(project.rootProject.file("local.properties"))
+            localProperties = readPropertiesIfExist(new File(project.projectDir.parentFile, "local.properties"))
         }
         String result
         if (project.hasProperty(name)) {
@@ -107,8 +107,8 @@ class FlutterPlugin implements Plugin<Project> {
             localEngineSrcPath = engineOut.parentFile.parent
 
             project.dependencies {
-                if (project.getConfigurations().findByName("implementation")) {
-                    implementation project.files(flutterJar)
+                if (project.getConfigurations().findByName("api")) {
+                    api project.files(flutterJar)
                 } else {
                     compile project.files(flutterJar)
                 }
@@ -146,16 +146,16 @@ class FlutterPlugin implements Plugin<Project> {
                     into "lib/x86_64"
                 }
             }
-            // Add flutter.jar dependencies to all <buildType>Implementation configurations, including custom ones
+            // Add flutter.jar dependencies to all <buildType>Api configurations, including custom ones
             // added after applying the Flutter plugin.
-            project.android.buildTypes.each { addFlutterJarImplementationDependency(project, it) }
-            project.android.buildTypes.whenObjectAdded { addFlutterJarImplementationDependency(project, it) }
+            project.android.buildTypes.each { addFlutterJarApiDependency(project, it) }
+            project.android.buildTypes.whenObjectAdded { addFlutterJarApiDependency(project, it) }
         }
 
         project.extensions.create("flutter", FlutterExtension)
         project.afterEvaluate this.&addFlutterTask
 
-        File pluginsFile = new File(project.rootProject.projectDir.parentFile, '.flutter-plugins')
+        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
         Properties plugins = readPropertiesIfExist(pluginsFile)
 
         plugins.each { name, _ ->
@@ -199,15 +199,15 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     /**
-     * Adds suitable flutter.jar implementation dependencies to the specified buildType.
+     * Adds suitable flutter.jar api dependencies to the specified buildType.
      *
      * Note: The BuildType DSL type is not public, and is therefore omitted from the signature.
      */
-    private void addFlutterJarImplementationDependency(Project project, buildType) {
+    private void addFlutterJarApiDependency(Project project, buildType) {
         project.dependencies {
             String configuration;
-            if (project.getConfigurations().findByName("implementation")) {
-                configuration = buildType.name + "Implementation";
+            if (project.getConfigurations().findByName("api")) {
+                configuration = buildType.name + "Api";
             } else {
                 configuration = buildType.name + "Compile";
             }


### PR DESCRIPTION
For add2app scenarios, we want to include Flutter as a library module, not a stand-alone app. To make this work with Gradle, we need to
* Refer to `android/local.properties` and `.flutter_plugins` relative to the Flutter sub-project, not relative to the root project of the host app (which could be located anywhere).
* Re-export `flutter.jar` from the Flutter module so that it is available to the host app. This means the Gradle dependency from the module to `flutter.jar` must be `api`, not `implementation`.