### PR TITLE
add semantic event to request focus

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -133,3 +133,19 @@ class TapSemanticEvent extends SemanticsEvent {
   @override
   Map<String, dynamic> getDataMap() => const <String, dynamic>{};
 }
+
+
+/// Requests semantic focus from the platform.
+///
+/// This should only be used in rare cases where an action needs to trigger
+/// movement of semantic focus that would be difficult for a user to perform.
+/// For example, dismissing a [SnackBar] widget may send accessibility focus
+/// back to the widget which triggered it.
+class RequestSemanticFocusEvent extends SemanticsEvent {
+
+  /// Constructs an event that requests semantic focus from the platform.
+  const RequestSemanticFocusEvent() : super('focus');
+
+  @override
+  Map<String, dynamic> getDataMap() => const <String, dynamic>{};
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/18641

Sometimes we may need to imperatively move the semantic focus, this is the framework implementation.  There is no engine impl yet, but in theory we can submit this first since it is non breaking