### PR TITLE
[frdb] Fix JSON casting in RPC calls.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -123,8 +123,6 @@ class DartVm {
     final Map<String, dynamic> jsonVmRef =
         await invokeRpc('getVM', timeout: _kRpcTimeout);
     final List<IsolateRef> result = <IsolateRef>[];
-    // Grabs key within for-loop to prevent possible casting issues, as this key
-    // can return a `List<dynamic>` instead of `List<Map<String, dynamic>>`.
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
       final String name = jsonIsolate['name'];
       if (name.contains(pattern) && name.contains(new RegExp(r':main\(\)'))) {
@@ -165,8 +163,6 @@ class DartVm {
     final List<FlutterView> views = <FlutterView>[];
     final Map<String, dynamic> rpcResponse =
         await invokeRpc('_flutter.listViews', timeout: _kRpcTimeout);
-    // Grabs key within for-loop to prevent possible casting issues, as this key
-    // can return a `List<dynamic>` instead of `List<Map<String, dynamic>>`.
     for (Map<String, dynamic> jsonView in rpcResponse['views']) {
       final FlutterView flutterView = new FlutterView._fromJson(jsonView);
       if (flutterView != null) {

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -122,9 +122,10 @@ class DartVm {
   Future<List<IsolateRef>> getMainIsolatesByPattern(Pattern pattern) async {
     final Map<String, dynamic> jsonVmRef =
         await invokeRpc('getVM', timeout: _kRpcTimeout);
-    final List<Map<String, dynamic>> jsonIsolates = jsonVmRef['isolates'];
     final List<IsolateRef> result = <IsolateRef>[];
-    for (Map<String, dynamic> jsonIsolate in jsonIsolates) {
+    // Grabs key within for-loop to prevent possible casting issues, as this key
+    // can return a `List<dynamic>` instead of `List<Map<String, dynamic>>`.
+    for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
       final String name = jsonIsolate['name'];
       if (name.contains(pattern) && name.contains(new RegExp(r':main\(\)'))) {
         result.add(new IsolateRef._fromJson(jsonIsolate, this));
@@ -164,8 +165,9 @@ class DartVm {
     final List<FlutterView> views = <FlutterView>[];
     final Map<String, dynamic> rpcResponse =
         await invokeRpc('_flutter.listViews', timeout: _kRpcTimeout);
-    final List<Map<String, dynamic>> flutterViewsJson = rpcResponse['views'];
-    for (Map<String, dynamic> jsonView in flutterViewsJson) {
+    // Grabs key within for-loop to prevent possible casting issues, as this key
+    // can return a `List<dynamic>` instead of `List<Map<String, dynamic>>`.
+    for (Map<String, dynamic> jsonView in rpcResponse['views']) {
       final FlutterView flutterView = new FlutterView._fromJson(jsonView);
       if (flutterView != null) {
         views.add(flutterView);

--- a/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
@@ -108,6 +108,63 @@ void main() {
       expect(views[2].name, 'file://flutterBinary2');
     });
 
+    test('basic flutter view parsing with casting checks', () async {
+      final Map<String, dynamic> flutterViewCannedResponses = <String, dynamic>{
+        'views': <dynamic>[
+          <String, dynamic>{
+            'type': 'FlutterView',
+            'id': 'flutterView0',
+          },
+          <String, dynamic>{
+            'type': 'FlutterView',
+            'id': 'flutterView1',
+            'isolate': <String, dynamic>{
+              'type': '@Isolate',
+              'fixedId': 'true',
+              'id': 'isolates/1',
+              'name': 'file://flutterBinary1',
+              'number': '1',
+            },
+          },
+          <String, dynamic>{
+            'type': 'FlutterView',
+            'id': 'flutterView2',
+            'isolate': <String, dynamic>{
+              'type': '@Isolate',
+              'fixedId': 'true',
+              'id': 'isolates/2',
+              'name': 'file://flutterBinary2',
+              'number': '2',
+            },
+          },
+        ],
+      };
+
+      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+        when(mockPeer.sendRequest(
+                typed<String>(any), typed<Map<String, dynamic>>(any)))
+            .thenAnswer((_) => new Future<Map<String, dynamic>>(
+                () => flutterViewCannedResponses));
+        return new Future<json_rpc.Peer>(() => mockPeer);
+      }
+
+      fuchsiaVmServiceConnectionFunction = mockVmConnectionFunction;
+      final DartVm vm =
+          await DartVm.connect(Uri.parse('http://whatever.com/ws'));
+      expect(vm, isNot(null));
+      final List<FlutterView> views = await vm.getAllFlutterViews();
+      expect(views.length, 3);
+      // Check ID's as they cannot be null.
+      expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
+
+      // Verify names.
+      expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
+    });
+
     test('invalid flutter view missing ID', () async {
       final Map<String, dynamic> flutterViewCannedResponseMissingId =
           <String, dynamic>{
@@ -150,6 +207,50 @@ void main() {
 
       // Both views should be invalid as they were missing required fields.
       expect(failingFunction, throwsA(const isInstanceOf<RpcFormatError>()));
+    });
+
+    test('get isolates by pattern', () async {
+      final Map<String, dynamic> vmCannedResponse = <String, dynamic>{
+        'isolates': <dynamic>[
+          <String, dynamic>{
+            'type': '@Isolate',
+            'fixedId': 'true',
+            'id': 'isolates/1',
+            'name': 'file://thingThatWillNotMatch:main()',
+            'number': '1',
+          },
+          <String, dynamic>{
+            'type': '@Isolate',
+            'fixedId': 'true',
+            'id': 'isolates/1',
+            'name': 'file://flutterBinary1:main()',
+            'number': '2',
+          },
+          <String, dynamic>{
+            'type': '@Isolate',
+            'fixedId': 'true',
+            'id': 'isolates/2',
+            'name': 'file://flutterBinary2:main()',
+            'number': '3',
+          },
+        ],
+      };
+
+      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+        when(mockPeer.sendRequest(
+                typed<String>(any), typed<Map<String, dynamic>>(any)))
+            .thenAnswer((_) =>
+                new Future<Map<String, dynamic>>(() => vmCannedResponse));
+        return new Future<json_rpc.Peer>(() => mockPeer);
+      }
+
+      fuchsiaVmServiceConnectionFunction = mockVmConnectionFunction;
+      final DartVm vm =
+          await DartVm.connect(Uri.parse('http://whatever.com/ws'));
+      expect(vm, isNot(null));
+      final List<IsolateRef> isolates =
+          await vm.getMainIsolatesByPattern('flutterBinary');
+      expect(isolates.length, 2);
     });
 
     test('invalid flutter view missing ID', () async {


### PR DESCRIPTION
This prevents the error:

`type 'List<dynamic>' is not a subtype of type 'List<Map<String, dynamic>>' `

The test added fails when dart_vm.dart is reverted to `master`, and succeeds in
its current state.  This issue was run into while connecting to the
Dart VM.