### PR TITLE
Provide workaround for expression compilation frontend issue

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -253,6 +253,7 @@ class ResidentCompiler {
       '--incremental',
       '--strong',
       '--target=flutter',
+      '--initialize-from-dill=foo' // TODO(aam): remove once dartbug.com/33087 fixed
     ];
     if (outputPath != null) {
       command.addAll(<String>['--output-dill', outputPath]);


### PR DESCRIPTION
This disables attempt for frontend to initialize from kernel file since that breaks expression compilation. Underlying issue is tracked in https://github.com/dart-lang/sdk/issues/33087

cc @kmillikin