### PR TITLE
fix test for segmented control

### DIFF
--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -925,6 +925,6 @@ void main() {
     await tester.startGesture(center);
     await tester.pumpAndSettle();
 
-    expect(find.byType(RepaintBoundary), matchesGoldenFile('segmented_control_test.1.0.png'));
+    await expectLater(find.byType(RepaintBoundary), matchesGoldenFile('segmented_control_test.1.0.png'));
   });
 }


### PR DESCRIPTION
cc @nataliesampsell 

The current test intermittently fails because it's not awaited on the golden file comparison.  It'd done right a few lines above, just making this one consistent.