### PR TITLE
Fix async matching against golden image

### DIFF
--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -925,6 +925,6 @@ void main() {
     await tester.startGesture(center);
     await tester.pumpAndSettle();
 
-    expect(find.byType(RepaintBoundary), matchesGoldenFile('segmented_control_test.1.0.png'));
+    await expectLater(find.byType(RepaintBoundary), matchesGoldenFile('segmented_control_test.1.0.png'));
   });
 }


### PR DESCRIPTION
Currently causes CI failure. Adjusted code to comply with [documented usage](https://github.com/flutter/flutter/blob/master/packages/flutter_test/lib/src/matchers.dart#L263), hoping that helps.