### PR TITLE
[frdp] Use 'true' instead of 'date' for dummy ssh tunnel command

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -558,7 +558,7 @@ class _SshPortForwarder implements PortForwarder {
     }
     final String targetAddress =
         isIpV6 && interface.isNotEmpty ? '$address%$interface' : address;
-    const String dummyRemoteCommand = 'date';
+    const String dummyRemoteCommand = 'true';
     command.addAll(<String>[
       '-nNT',
       '-f',


### PR DESCRIPTION
'date' doesn't end up in every build, but 'true' appears to exist a bit more reliably.