### PR TITLE
Fix shlock errors due to flutter is installed on an exFAT Volume on MacOS

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -79,7 +79,9 @@ function upgrade_flutter () {
   if hash flock 2>/dev/null; then
     flock 3 2>/dev/null || true
   elif hash shlock 2>/dev/null; then
-    FLUTTER_UPGRADE_LOCK="$FLUTTER_ROOT/bin/cache/.upgrade_lock"
+    # FLUTTER_UPGRADE_LOCK="$FLUTTER_ROOT/bin/cache/.upgrade_lock"
+    FLUTTER_UPGRADE_LOCK="$HOME/flutter.upgrade_lock"
+    
     while ! shlock -f "$FLUTTER_UPGRADE_LOCK" -p $$ ; do sleep .1 ; done
     trap _rmlock EXIT
   fi


### PR DESCRIPTION
shlock seems not supporting mounted exFAT Volume on MacOS (v10.13.5) well. Thus if FLUTTER_HOME is on one of these volumes, flutter gets stuck at shlock errors. Moving the upgrade lock file under $HOME fixes the issue. I'd think it would make better sense to make $HOME/.flutter a directory and put  these files under it. But as of now, .flutter is an info file. 