### PR TITLE
Fix gitignore in Flutter module template

### DIFF
--- a/packages/flutter_tools/templates/module/common/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/module/common/.gitignore.tmpl
@@ -36,5 +36,6 @@ Icon?
 .tags*
 
 build/
-android_gen/
+.android/
+.ios/
 .flutter-plugins


### PR DESCRIPTION
Flutter module projects should gitignore their generated platform-specific code.