### PR TITLE
Add saveLayer back if there's an overflowShader

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -355,7 +355,13 @@ class RenderParagraph extends RenderBox {
 
     if (_hasVisualOverflow) {
       final Rect bounds = offset & size;
+      if (_overflowShader != null) {
+        // This layer limits what the shader below blends with to be just the text
+        // (as opposed to the text and its background).
+        canvas.saveLayer(bounds, new Paint());
+      } else {
         canvas.save();
+      }
       canvas.clipRect(bounds);
     }
     _textPainter.paint(canvas, offset);


### PR DESCRIPTION
This should fix https://github.com/flutter/flutter/issues/18729

I'll try to figure out how to remove the saveLayer without affecting the correctness later.