### PR TITLE
Allow disabling DropDownButton with optional hint for disabled state

### DIFF
--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/rendering.dart';
 import '../widgets/semantics_tester.dart';
 
 const List<String> menuItems = <String>['one', 'two', 'three', 'four'];
+final ValueChanged<String> onChanged = (_) {};
 
 final Type dropdownButtonType = DropdownButton<String>(
   onChanged: (_) { },
@@ -26,6 +27,7 @@ Widget buildFrame({
   bool isDense = false,
   bool isExpanded = false,
   Widget hint,
+  Widget disabledHint,
   List<String> items = menuItems,
   Alignment alignment = Alignment.center,
   TextDirection textDirection = TextDirection.ltr,
@@ -40,10 +42,11 @@ Widget buildFrame({
             key: buttonKey,
             value: value,
             hint: hint,
+            disabledHint: disabledHint,
             onChanged: onChanged,
             isDense: isDense,
             isExpanded: isExpanded,
-            items: items.map<DropdownMenuItem<String>>((String item) {
+            items: items == null ? null : items.map<DropdownMenuItem<String>>((String item) {
               return DropdownMenuItem<String>(
                 key: ValueKey<String>(item),
                 value: item,
@@ -115,7 +118,7 @@ bool sameGeometry(RenderBox box1, RenderBox box2) {
 void main() {
   testWidgets('Default dropdown golden', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
-    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two');
+    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two', onChanged: onChanged);
     await tester.pumpWidget(build());
     final Finder buttonFinder = find.byKey(buttonKey);
     assert(tester.renderObject(buttonFinder).attached);
@@ -128,7 +131,7 @@ void main() {
 
   testWidgets('Expanded dropdown golden', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
-    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two', isExpanded: true);
+    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two', isExpanded: true, onChanged: onChanged);
     await tester.pumpWidget(build());
     final Finder buttonFinder = find.byKey(buttonKey);
     assert(tester.renderObject(buttonFinder).attached);
@@ -326,7 +329,7 @@ void main() {
       final Key buttonKey = UniqueKey();
       const String value = 'two';
 
-      Widget build() => buildFrame(buttonKey: buttonKey, value: value, textDirection: textDirection);
+      Widget build() => buildFrame(buttonKey: buttonKey, value: value, textDirection: textDirection, onChanged: onChanged);
 
       await tester.pumpWidget(build());
       final RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
@@ -371,7 +374,7 @@ void main() {
   testWidgets('Arrow icon aligns with the edge of button when expanded', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two', isExpanded: true);
+    Widget build() => buildFrame(buttonKey: buttonKey, value: 'two', isExpanded: true, onChanged: onChanged);
 
     await tester.pumpWidget(build());
     final RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
@@ -389,7 +392,7 @@ void main() {
     final Key buttonKey = UniqueKey();
     const String value = 'two';
 
-    Widget build() => buildFrame(buttonKey: buttonKey, value: value, isDense: true);
+    Widget build() => buildFrame(buttonKey: buttonKey, value: value, isDense: true, onChanged: onChanged);
 
     await tester.pumpWidget(build());
     final RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
@@ -428,7 +431,8 @@ void main() {
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       value: null, // nothing selected
-      items: List<String>.generate(/*length=*/ 100, (int index) => index.toString())
+      items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
+      onChanged: onChanged,
     ));
     await tester.tap(find.byKey(buttonKey));
     await tester.pump();
@@ -455,7 +459,8 @@ void main() {
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       value: '50',
-      items: List<String>.generate(/*length=*/ 100, (int index) => index.toString())
+      items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
+      onChanged: onChanged,
     ));
     final RenderBox buttonBox = tester.renderObject(find.byKey(buttonKey));
     await tester.tap(find.byKey(buttonKey));
@@ -477,7 +482,7 @@ void main() {
     final Key buttonKey = UniqueKey();
     String value;
 
-    Widget build() => buildFrame(buttonKey: buttonKey, value: value);
+    Widget build() => buildFrame(buttonKey: buttonKey, value: value, onChanged: onChanged);
 
     await tester.pumpWidget(build());
     final RenderBox buttonBoxNullValue = tester.renderObject(find.byKey(buttonKey));
@@ -594,19 +599,19 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topLeft, value: menuItems.last)
+      buildFrame(alignment: Alignment.topLeft, value: menuItems.last, onChanged: onChanged)
     );
     expect(menuRect.topLeft, Offset.zero);
     expect(menuRect.topRight, Offset(menuRect.width, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topCenter, value: menuItems.last)
+      buildFrame(alignment: Alignment.topCenter, value: menuItems.last, onChanged: onChanged)
     );
     expect(menuRect.topLeft, Offset(buttonRect.left, 0.0));
     expect(menuRect.topRight, Offset(buttonRect.right, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topRight, value: menuItems.last)
+      buildFrame(alignment: Alignment.topRight, value: menuItems.last, onChanged: onChanged)
     );
     expect(menuRect.topLeft, Offset(800.0 - menuRect.width, 0.0));
     expect(menuRect.topRight, const Offset(800.0, 0.0));
@@ -616,19 +621,19 @@ void main() {
     // is selected) and shifted horizontally so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.centerLeft, value: menuItems.first)
+      buildFrame(alignment: Alignment.centerLeft, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.topLeft, Offset(0.0, buttonRect.top));
     expect(menuRect.topRight, Offset(menuRect.width, buttonRect.top));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.center, value: menuItems.first)
+      buildFrame(alignment: Alignment.center, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.topLeft, buttonRect.topLeft);
     expect(menuRect.topRight, buttonRect.topRight);
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.centerRight, value: menuItems.first)
+      buildFrame(alignment: Alignment.centerRight, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.topLeft, Offset(800.0 - menuRect.width, buttonRect.top));
     expect(menuRect.topRight, Offset(800.0, buttonRect.top));
@@ -638,26 +643,26 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomLeft, value: menuItems.first)
+      buildFrame(alignment: Alignment.bottomLeft, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.bottomLeft, const Offset(0.0, 600.0));
     expect(menuRect.bottomRight, Offset(menuRect.width, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomCenter, value: menuItems.first)
+      buildFrame(alignment: Alignment.bottomCenter, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.bottomLeft, Offset(buttonRect.left, 600.0));
     expect(menuRect.bottomRight, Offset(buttonRect.right, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomRight, value: menuItems.first)
+      buildFrame(alignment: Alignment.bottomRight, value: menuItems.first, onChanged: onChanged)
     );
     expect(menuRect.bottomLeft, Offset(800.0 - menuRect.width, 600.0));
     expect(menuRect.bottomRight, const Offset(800.0, 600.0));
   });
 
   testWidgets('Dropdown menus are dismissed on screen orientation changes', (WidgetTester tester) async {
-    await tester.pumpWidget(buildFrame());
+    await tester.pumpWidget(buildFrame(onChanged: onChanged));
     await tester.tap(find.byType(dropdownButtonType));
     await tester.pumpAndSettle();
     expect(find.byType(ListView), findsOneWidget);
@@ -670,7 +675,7 @@ void main() {
 
   testWidgets('Semantics Tree contains only selected element', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
-    await tester.pumpWidget(buildFrame(items: menuItems));
+    await tester.pumpWidget(buildFrame(items: menuItems, onChanged: onChanged));
 
     expect(semantics, isNot(includesNodeWith(label: menuItems[0])));
     expect(semantics, includesNodeWith(label: menuItems[1]));
@@ -702,7 +707,7 @@ void main() {
       buttonKey: key,
       value: 'three',
       items: menuItems,
-      onChanged: null,
+      onChanged: onChanged,
       hint: const Text('test'),
     ));
 
@@ -722,6 +727,7 @@ void main() {
       buttonKey: key,
       value: null,
       items: menuItems,
+      onChanged: onChanged,
     ));
     await tester.tap(find.byKey(key));
     await tester.pumpAndSettle();
@@ -776,6 +782,42 @@ void main() {
       ],
     ), ignoreId: true, ignoreRect: true, ignoreTransform: true));
     semantics.dispose();
+  });
+
+  testWidgets('disabledHint displays on empty items or onChanged', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+
+    Widget build({List<String> items, ValueChanged<String> onChanged}) => buildFrame(
+      items: items,
+      onChanged: onChanged,
+      buttonKey: buttonKey, value: null,
+      hint: const Text('enabled'),
+      disabledHint: const Text('disabled'));
+
+    // [disabledHint] should display when [items] is null
+    await tester.pumpWidget(build(items: null, onChanged: onChanged));
+    expect(find.text('enabled'), findsNothing);
+    expect(find.text('disabled'), findsOneWidget);
+
+    // [disabledHint] should display when [items] is an empty list.
+    await tester.pumpWidget(build(items: <String>[], onChanged: onChanged));
+    expect(find.text('enabled'), findsNothing);
+    expect(find.text('disabled'), findsOneWidget);
+
+    // [disabledHint] should display when [onChanged] is null
+    await tester.pumpWidget(build(items: menuItems, onChanged: null));
+    expect(find.text('enabled'), findsNothing);
+    expect(find.text('disabled'), findsOneWidget);
+    final RenderBox disabledHintBox = tester.renderObject(find.byKey(buttonKey));
+
+    // A Dropdown button with a disabled hint should be the same size as a
+    // one with a regular enabled hint.
+    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
+    expect(find.text('disabled'), findsNothing);
+    expect(find.text('enabled'), findsOneWidget);
+    final RenderBox enabledHintBox = tester.renderObject(find.byKey(buttonKey));
+    expect(enabledHintBox.localToGlobal(Offset.zero), equals(disabledHintBox.localToGlobal(Offset.zero)));
+    expect(enabledHintBox.size, equals(disabledHintBox.size));
   });
 
   testWidgets('Dropdown in middle showing middle item', (WidgetTester tester) async {


### PR DESCRIPTION
A quite common pattern in App that allows to filter Data, is selecting properties in multiple DropDownButtons where the available properties for the next DropDownbutton are only avaliable and dependending  on the value selected with the upper DropDownButton.
Currently it was not possible to disable a DropDownButton if you had no data ready for its items.. Therefore I make this PR.

I tried if it is possible to pass null or an empty List for `items` but both threw exceptions and did not disabling tapping on the button.

Now if you pass null for `items`it will disable the button and draw the down arrow in a lighter color.
 
Additionally you can provide an optional `hintDisabled' widget which will be displayed instead of `hint` if the button is disabled like here:

![image](https://user-images.githubusercontent.com/16635729/41601376-9481af7c-73d8-11e8-871b-23014287394f.png)

by updating `items` with a valid list it automatically get:

![image](https://user-images.githubusercontent.com/16635729/41603447-407e77fc-73dd-11e8-99c0-b847a1cfc3a6.png)


If no `hintDisabled` is provided `hint`will be displayed in disabled state too.