### PR TITLE
Change material RefreshIndictor.onRefresh signature from Future<Null> to Future<void>

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Tetsuhiro Ueda <najeira@gmail.com>
 Dan Field <dfield@gmail.com>
 Noah Groß <gross@ngsger.de>
 Victor Choueiri <victor@ctrlanddev.com>
+Lukasz Piliszczuk <lukasz@intheloup.io>

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -32,7 +32,7 @@ const Duration _kIndicatorScaleDuration = const Duration(milliseconds: 200);
 /// finished.
 ///
 /// Used by [RefreshIndicator.onRefresh].
-typedef Future<Null> RefreshCallback();
+typedef Future<void> RefreshCallback();
 
 // The state machine moves through these modes only when the scrollable
 // identified by scrollableKey has been scrolled to its min or max limit.
@@ -146,7 +146,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   Animation<Color> _valueColor;
 
   _RefreshIndicatorMode _mode;
-  Future<Null> _pendingRefreshFuture;
+  Future<void> _pendingRefreshFuture;
   bool _isIndicatorAtTop;
   double _dragOffset;
 
@@ -297,7 +297,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   // Stop showing the refresh indicator.
-  Future<Null> _dismiss(_RefreshIndicatorMode newMode) async {
+  Future<void> _dismiss(_RefreshIndicatorMode newMode) async {
     // This can only be called from _show() when refreshing and
     // _handleScrollNotification in response to a ScrollEndNotification or
     // direction change.
@@ -327,7 +327,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   void _show() {
     assert(_mode != _RefreshIndicatorMode.refresh);
     assert(_mode != _RefreshIndicatorMode.snap);
-    final Completer<Null> completer = new Completer<Null>();
+    final Completer<void> completer = new Completer<void>();
     _pendingRefreshFuture = completer.future;
     _mode = _RefreshIndicatorMode.snap;
     _positionController
@@ -340,7 +340,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
             _mode = _RefreshIndicatorMode.refresh;
           });
 
-          final Future<Null> refreshResult = widget.onRefresh();
+          final Future<void> refreshResult = widget.onRefresh();
           assert(() {
             if (refreshResult == null)
               FlutterError.reportError(new FlutterErrorDetails(
@@ -381,7 +381,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   /// When initiated in this manner, the refresh indicator is independent of any
   /// actual scroll view. It defaults to showing the indicator at the top. To
   /// show it at the bottom, set `atTop` to false.
-  Future<Null> show({ bool atTop = true }) {
+  Future<void> show({ bool atTop = true }) {
     if (_mode != _RefreshIndicatorMode.refresh &&
         _mode != _RefreshIndicatorMode.snap) {
       if (_mode == null)

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -10,14 +10,14 @@ import 'package:flutter/material.dart';
 
 bool refreshCalled = false;
 
-Future<Null> refresh() {
+Future<void> refresh() {
   refreshCalled = true;
-  return new Future<Null>.value();
+  return new Future<void>.value();
 }
 
-Future<Null> holdRefresh() {
+Future<void> holdRefresh() {
   refreshCalled = true;
-  return new Completer<Null>().future;
+  return new Completer<void>().future;
 }
 
 void main() {
@@ -248,7 +248,7 @@ void main() {
     bool completed = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed = true; });
+      .then<void>((_) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -260,7 +260,7 @@ void main() {
     refreshCalled = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed = true; });
+      .then<void>((_) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -291,7 +291,7 @@ void main() {
     bool completed = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed = true; });
+      .then<void>((_) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -303,7 +303,7 @@ void main() {
     refreshCalled = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed = true; });
+      .then<void>((_) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -335,11 +335,11 @@ void main() {
     bool completed1 = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed1 = true; });
+      .then<void>((_) { completed1 = true; });
     bool completed2 = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<Null>((Null value) { completed2 = true; });
+      .then<void>((_) { completed2 = true; });
     await tester.pump();
     expect(completed1, false);
     expect(completed2, false);

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -248,7 +248,7 @@ void main() {
     bool completed = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed = true; });
+      .then<void>((void value) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -260,7 +260,7 @@ void main() {
     refreshCalled = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed = true; });
+      .then<void>((void value) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -291,7 +291,7 @@ void main() {
     bool completed = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed = true; });
+      .then<void>((void value) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -303,7 +303,7 @@ void main() {
     refreshCalled = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed = true; });
+      .then<void>((void value) { completed = true; });
     await tester.pump();
     expect(completed, false);
     await tester.pump(const Duration(seconds: 1));
@@ -335,11 +335,11 @@ void main() {
     bool completed1 = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed1 = true; });
+      .then<void>((void value) { completed1 = true; });
     bool completed2 = false;
     tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator))
       .show()
-      .then<void>((_) { completed2 = true; });
+      .then<void>((void value) { completed2 = true; });
     await tester.pump();
     expect(completed1, false);
     expect(completed2, false);


### PR DESCRIPTION
1. Make `RefreshIndictor.onRefresh` signature consistent with `CupertinoRefreshControl`, the equivalent widget when matching iOS platform. It allows to assign the same method for handling the refresh callback whether you start by implementing `RefreshIndictor` or `CupertinoRefreshControl`;
2. My understanding is since dart 2.0 the preferred way to describe a future returning no value is `Future<void>`;
3. No breaking changes because `Future<void> f = Future<Null>.value()` is valid.