### PR TITLE
Replace existing app if it already exists.

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test.dart
@@ -102,7 +102,7 @@ void main() {
 
       section('Installing $apkPath');
 
-      await device.adb(<String>['install', apkPath]);
+      await device.adb(<String>['install', '-r', apkPath]);
 
       try {
         section('Launching attach.');


### PR DESCRIPTION
The `flutter attach` test was failing because the Android device had
the app already installed.