### PR TITLE
Mark flutter_attach_test flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -274,6 +274,7 @@ tasks:
       Tests the `flutter attach` command.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   # iOS on-device tests
 


### PR DESCRIPTION
Introduced in d248725e1509603551fc4e70e532c190743cd4ab, but has been red
since landing. Marking flaky rather than reverting since it's the only
failure.