### PR TITLE
Fix both platform system chrome definitions

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -184,7 +184,7 @@ class ContactsDemoState extends State<ContactsDemo> {
             new SliverList(
               delegate: new SliverChildListDelegate(<Widget>[
                 new AnnotatedRegion<SystemUiOverlayStyle>(
-                  value: SystemUiOverlayStyle.light,
+                  value: SystemUiOverlayStyle.dark,
                   child: new _ContactCategory(
                     icon: Icons.call,
                     children: <Widget>[

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -402,7 +402,7 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
     }
     home = new AnnotatedRegion<SystemUiOverlayStyle>(
       child: home,
-      value: SystemUiOverlayStyle.dark
+      value: SystemUiOverlayStyle.light
     );
 
     return home;

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -478,8 +478,8 @@ class _AppBarState extends State<AppBar> {
     }
     final Brightness brightness = widget.brightness ?? themeData.primaryColorBrightness;
     final SystemUiOverlayStyle overlayStyle = brightness == Brightness.dark
-        ? SystemUiOverlayStyle.dark
-        : SystemUiOverlayStyle.light;
+        ? SystemUiOverlayStyle.light
+        : SystemUiOverlayStyle.dark;
 
     return new Semantics(
       container: true,

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -331,7 +331,7 @@ class SystemChrome {
 
   static SystemUiOverlayStyle _pendingStyle;
 
-  /// The last style the was set using [SystemChrome.setSystemUIOverlayStyle].
+  /// The last style that was set using [SystemChrome.setSystemUIOverlayStyle].
   @visibleForTesting
   static SystemUiOverlayStyle get latestStyle => _latestStyle;
   static SystemUiOverlayStyle _latestStyle;

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -100,23 +100,23 @@ class SystemUiOverlayStyle {
   /// System overlays should be drawn with a light color. Intended for
   /// applications with a dark background.
   static const SystemUiOverlayStyle light = const SystemUiOverlayStyle(
-    systemNavigationBarColor: const Color(0xFFFFFFFF),
-    systemNavigationBarDividerColor: null,
-    statusBarColor: null,
-    systemNavigationBarIconBrightness: Brightness.light,
-    statusBarIconBrightness: Brightness.light,
-    statusBarBrightness: Brightness.light,
-  );
-
-  /// System overlays should be drawn with a dark color. Intended for
-  /// applications with a light background.
-  static const SystemUiOverlayStyle dark = const SystemUiOverlayStyle(
     systemNavigationBarColor: const Color(0xFF000000),
     systemNavigationBarDividerColor: null,
     statusBarColor: null,
     systemNavigationBarIconBrightness: Brightness.dark,
     statusBarIconBrightness: Brightness.dark,
     statusBarBrightness: Brightness.dark,
+  );
+
+  /// System overlays should be drawn with a dark color. Intended for
+  /// applications with a light background.
+  static const SystemUiOverlayStyle dark = const SystemUiOverlayStyle(
+    systemNavigationBarColor: const Color(0xFFFFFFFF),
+    systemNavigationBarDividerColor: null,
+    statusBarColor: null,
+    systemNavigationBarIconBrightness: Brightness.light,
+    statusBarIconBrightness: Brightness.light,
+    statusBarBrightness: Brightness.light,
   );
 
   /// Creates a new [SystemUiOverlayStyle].

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -103,19 +103,19 @@ class SystemUiOverlayStyle {
     systemNavigationBarColor: const Color(0xFF000000),
     systemNavigationBarDividerColor: null,
     statusBarColor: null,
-    systemNavigationBarIconBrightness: Brightness.dark,
-    statusBarIconBrightness: Brightness.dark,
+    systemNavigationBarIconBrightness: Brightness.light,
+    statusBarIconBrightness: Brightness.light,
     statusBarBrightness: Brightness.dark,
   );
 
   /// System overlays should be drawn with a dark color. Intended for
   /// applications with a light background.
   static const SystemUiOverlayStyle dark = const SystemUiOverlayStyle(
-    systemNavigationBarColor: const Color(0xFFFFFFFF),
+    systemNavigationBarColor: const Color(0xFF000000),
     systemNavigationBarDividerColor: null,
     statusBarColor: null,
     systemNavigationBarIconBrightness: Brightness.light,
-    statusBarIconBrightness: Brightness.light,
+    statusBarIconBrightness: Brightness.dark,
     statusBarBrightness: Brightness.light,
   );
 
@@ -330,5 +330,9 @@ class SystemChrome {
   }
 
   static SystemUiOverlayStyle _pendingStyle;
+
+  /// The last style the was set using [SystemChrome.setSystemUIOverlayStyle].
+  @visibleForTesting
+  static SystemUiOverlayStyle get latestStyle => _latestStyle;
   static SystemUiOverlayStyle _latestStyle;
 }

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -103,8 +103,8 @@ class SystemUiOverlayStyle {
     systemNavigationBarColor: const Color(0xFFFFFFFF),
     systemNavigationBarDividerColor: null,
     statusBarColor: null,
-    systemNavigationBarIconBrightness: Brightness.dark,
-    statusBarIconBrightness: Brightness.dark,
+    systemNavigationBarIconBrightness: Brightness.light,
+    statusBarIconBrightness: Brightness.light,
     statusBarBrightness: Brightness.light,
   );
 
@@ -114,8 +114,8 @@ class SystemUiOverlayStyle {
     systemNavigationBarColor: const Color(0xFF000000),
     systemNavigationBarDividerColor: null,
     statusBarColor: null,
-    systemNavigationBarIconBrightness: Brightness.light,
-    statusBarIconBrightness: Brightness.light,
+    systemNavigationBarIconBrightness: Brightness.dark,
+    statusBarIconBrightness: Brightness.dark,
     statusBarBrightness: Brightness.dark,
   );
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
@@ -752,6 +753,47 @@ void main() {
     // is fixed.
     skip: !Platform.isLinux,
    );
+
+
+  testWidgets('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        onGenerateRoute: (RouteSettings settings) {
+          return new CupertinoPageRoute<void>(
+            settings: settings,
+            builder: (BuildContext context) {
+              return const CupertinoNavigationBar(
+                middle: const Text('Test'),
+                backgroundColor: const Color(0xFF000000),
+              );
+            },
+          );
+        },
+      ),
+    );
+    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
+  });
+
+  testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        onGenerateRoute: (RouteSettings settings) {
+          return new CupertinoPageRoute<void>(
+            settings: settings,
+            builder: (BuildContext context) {
+              return const CupertinoNavigationBar(
+                middle: const Text('Test'),
+                backgroundColor: const Color(0xFFFFFFFF),
+              );
+            },
+          );
+        },
+      ),
+    );
+    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
+  });
 }
 
 class _ExpectStyles extends StatelessWidget {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
@@ -1339,5 +1340,37 @@ void main() {
     ));
 
     semantics.dispose();
+  });
+
+  testWidgets('AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
+    final ThemeData darkTheme = new ThemeData.dark();
+    await tester.pumpWidget(new MaterialApp(
+      theme: darkTheme,
+      home: Scaffold(
+        appBar: new AppBar(title: const Text('test'))
+      ),
+    ));
+
+    expect(darkTheme.primaryColorBrightness, Brightness.dark);
+    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
+      statusBarBrightness: Brightness.dark,
+      statusBarIconBrightness: Brightness.light,
+    ));
+  });
+
+  testWidgets('AppBar draws a dark system bar for a light background', (WidgetTester tester) async {
+    final ThemeData lightTheme = new ThemeData(primaryColor: Colors.white);
+    await tester.pumpWidget(new MaterialApp(
+      theme: lightTheme,
+      home: Scaffold(
+        appBar: new AppBar(title: const Text('test'))
+      ),
+    ));
+
+    expect(lightTheme.primaryColorBrightness, Brightness.light);
+    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
+      statusBarBrightness: Brightness.light,
+      statusBarIconBrightness: Brightness.dark,
+    ));
   });
 }


### PR DESCRIPTION
These got out of sync when I created them, since there is some confusion between drawing with or for a dark color and how the flags behave

Doesn't require https://github.com/flutter/engine/pull/5609/files first, but that will allow me to swap all values to be consistent.