### PR TITLE
[WIP] Make build folder device-specific

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -56,7 +56,7 @@ Future<Null> run(List<String> args) async {
   Cache.flutterRoot = platform.environment['FLUTTER_ROOT'];
 
   final String assetDir = argResults[_kOptionAsset];
-  final AssetBundle assets = await buildAssets(
+  final AssetBundle assets = await buildAssets(/* deviceId??? */
     manifestPath: argResults[_kOptionManifest] ?? defaultManifestPath,
     assetDirPath: assetDir,
     packagesPath: argResults[_kOptionPackages],

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -352,6 +352,7 @@ class AndroidDevice extends Device {
     String route,
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
+    String deviceId,
     bool prebuiltApplication = false,
     bool applicationNeedsRebuild = false,
     bool usesTerminalUi = true,
@@ -380,7 +381,7 @@ class AndroidDevice extends Device {
       );
       // Package has been built, so we can get the updated application ID and
       // activity name from the .apk.
-      package = await AndroidApk.fromCurrentDirectory();
+      package = await AndroidApk.fromCurrentDirectory(deviceId);
     }
 
     printTrace("Stopping app '${package.name}' on $name.");

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -90,10 +90,11 @@ class _ManifestAssetBundle implements AssetBundle {
     String manifestPath = defaultManifestPath,
     String assetDirPath,
     String packagesPath,
+    String deviceId,
     bool includeDefaultFonts = true,
     bool reportLicensedPackages = false
   }) async {
-    assetDirPath ??= getAssetBuildDirectory();
+    assetDirPath ??= getAssetBuildDirectory(deviceId);
     packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
     FlutterManifest flutterManifest;
     try {
@@ -125,7 +126,7 @@ class _ManifestAssetBundle implements AssetBundle {
       packageMap,
       flutterManifest,
       assetBasePath,
-      excludeDirs: <String>[assetDirPath, getBuildDirectory()]
+      excludeDirs: <String>[assetDirPath, getBuildDirectory(deviceId)]
     );
 
     if (assetVariants == null)

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -262,11 +262,14 @@ HostPlatform getCurrentHostPlatform() {
 }
 
 /// Returns the top-level build output directory.
-String getBuildDirectory() {
+/// null is a valid device ID for the parent folder, but it's positional
+/// so that you have to explicitly pass it to avoid accidentally getting
+/// the global folder.
+String getBuildDirectory(String deviceId) {
   // TODO(johnmccutchan): Stop calling this function as part of setting
   // up command line argument processing.
   if (context == null || config == null)
-    return 'build';
+    return deviceId == null ? 'build' : fs.path.join('build', deviceId);
 
   final String buildDir = config.getValue('build-dir') ?? 'build';
   if (fs.path.isAbsolute(buildDir)) {
@@ -277,28 +280,28 @@ String getBuildDirectory() {
 }
 
 /// Returns the Android build output directory.
-String getAndroidBuildDirectory() {
+String getAndroidBuildDirectory(String deviceId) {
   // TODO(cbracken) move to android subdir.
-  return getBuildDirectory();
+  return getBuildDirectory(deviceId);
 }
 
 /// Returns the AOT build output directory.
 String getAotBuildDirectory() {
-  return fs.path.join(getBuildDirectory(), 'aot');
+  return fs.path.join(getBuildDirectory(null), 'aot');
 }
 
 /// Returns the asset build output directory.
-String getAssetBuildDirectory() {
-  return fs.path.join(getBuildDirectory(), 'flutter_assets');
+String getAssetBuildDirectory(String deviceId) {
+  return fs.path.join(getBuildDirectory(deviceId), 'flutter_assets');
 }
 
 /// Returns the iOS build output directory.
-String getIosBuildDirectory() {
-  return fs.path.join(getBuildDirectory(), 'ios');
+String getIosBuildDirectory(String deviceId) {
+  return fs.path.join(getBuildDirectory(deviceId), 'ios');
 }
 
 /// Returns directory used by incremental compiler (IKG - incremental kernel
 /// generator) to store cached intermediate state.
-String getIncrementalCompilerByteStoreDirectory() {
-  return fs.path.join(getBuildDirectory(), 'ikg_byte_store');
+String getIncrementalCompilerByteStoreDirectory(String deviceId) {
+  return fs.path.join(getBuildDirectory(deviceId), 'ikg_byte_store');
 }

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -123,7 +123,7 @@ Future<void> build({
   }
 
   final AssetBundle assets = await buildAssets(
-    /* deviceId???, */
+    deviceId,
     manifestPath: manifestPath,
     assetDirPath: assetDirPath,
     packagesPath: packagesPath,

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -21,9 +21,9 @@ class BuildBundleCommand extends BuildSubCommand {
       ..addOption('asset-base', help: 'Ignored. Will be removed.', hide: !verboseHelp)
       ..addOption('manifest', defaultsTo: defaultManifestPath)
       ..addOption('private-key', defaultsTo: defaultPrivateKeyPath)
-      ..addOption('snapshot', defaultsTo: defaultSnapshotPath)
-      ..addOption('depfile', defaultsTo: defaultDepfilePath)
-      ..addOption('kernel-file', defaultsTo: defaultApplicationKernelPath)
+      ..addOption('snapshot', defaultsTo: getDefaultSnapshotPath(/* deviceId??? */))
+      ..addOption('depfile', defaultsTo: getDefaultDepfilePath(/* deviceId??? */))
+      ..addOption('kernel-file', defaultsTo: getDefaultApplicationKernelPath(/* deviceId??? */))
       ..addFlag('preview-dart-2',
         defaultsTo: true,
         hide: !verboseHelp,
@@ -51,7 +51,7 @@ class BuildBundleCommand extends BuildSubCommand {
         splitCommas: true,
         hide: true,
       )
-      ..addOption('asset-dir', defaultsTo: getAssetBuildDirectory())
+      ..addOption('asset-dir', defaultsTo: getAssetBuildDirectory(null))
       ..addFlag('report-licensed-packages',
         help: 'Whether to report the names of all the packages that are included '
               'in the application\'s LICENSE file.',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -60,7 +60,7 @@ class BuildIOSCommand extends BuildSubCommand {
     if (getCurrentHostPlatform() != HostPlatform.darwin_x64)
       throwToolExit('Building for iOS is only supported on the Mac.');
 
-    final BuildableIOSApp app = await applicationPackages.getPackageForPlatform(TargetPlatform.ios);
+    final BuildableIOSApp app = await applicationPackages.getPackageForPlatform(TargetPlatform.ios, /* deviceId??? */);
 
     if (app == null)
       throwToolExit('Application not configured for iOS');

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -23,7 +23,8 @@ class CleanCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final Directory buildDir = fs.directory(getBuildDirectory());
+    // Pass null as deviceID as we want the parent folder to clean all
+    final Directory buildDir = fs.directory(getBuildDirectory(null));
     printStatus("Deleting '${buildDir.path}${fs.path.separator}'.");
 
     if (!buildDir.existsSync())

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -235,7 +235,7 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
 
   printTrace('Installing application package.');
   final ApplicationPackage package = await command.applicationPackages
-      .getPackageForPlatform(await command.device.targetPlatform);
+      .getPackageForPlatform(await command.device.targetPlatform, command.device.id);
   if (await command.device.isAppInstalled(package))
     await command.device.uninstallApp(package);
   await command.device.installApp(package);
@@ -313,7 +313,7 @@ void restoreAppStopper() {
 
 Future<bool> _stopApp(DriveCommand command) async {
   printTrace('Stopping application.');
-  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(await command.device.targetPlatform);
+  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(await command.device.targetPlatform, command.device.id);
   final bool stopped = await command.device.stopApp(package);
   await command._deviceLogSubscription?.cancel();
   return stopped;

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -34,7 +34,7 @@ class InstallCommand extends FlutterCommand {
 
   @override
   Future<Null> runCommand() async {
-    final ApplicationPackage package = await applicationPackages.getPackageForPlatform(await device.targetPlatform);
+    final ApplicationPackage package = await applicationPackages.getPackageForPlatform(await device.targetPlatform, device.id);
 
     Cache.releaseLockEarly();
 

--- a/packages/flutter_tools/lib/src/commands/stop.dart
+++ b/packages/flutter_tools/lib/src/commands/stop.dart
@@ -35,7 +35,7 @@ class StopCommand extends FlutterCommand {
   @override
   Future<Null> runCommand() async {
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    final ApplicationPackage app = await applicationPackages.getPackageForPlatform(targetPlatform);
+    final ApplicationPackage app = await applicationPackages.getPackageForPlatform(targetPlatform, device.id);
     if (app == null) {
       final String platformName = getNameForTargetPlatform(targetPlatform);
       throwToolExit('No Flutter application for $platformName found in the current directory.');

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -120,14 +120,14 @@ class IOSDevice extends Device {
   @override
   Future<bool> installApp(ApplicationPackage app) async {
     final IOSApp iosApp = app;
-    final Directory bundle = fs.directory(iosApp.deviceBundlePath);
+    final Directory bundle = fs.directory(iosApp.getDeviceBundlePath(id));
     if (!bundle.existsSync()) {
       printError('Could not find application bundle at ${bundle.path}; have you run "flutter build ios"?');
       return false;
     }
 
     try {
-      await runCheckedAsync(<String>[_installerPath, '-i', iosApp.deviceBundlePath]);
+      await runCheckedAsync(<String>[_installerPath, '-i', iosApp.getDeviceBundlePath(id)]);
       return true;
     } catch (e) {
       return false;
@@ -184,7 +184,7 @@ class IOSDevice extends Device {
 
     // Step 2: Check that the application exists at the specified path.
     final IOSApp iosApp = package;
-    final Directory bundle = fs.directory(iosApp.deviceBundlePath);
+    final Directory bundle = fs.directory(iosApp.getDeviceBundlePath(id));
     if (!bundle.existsSync()) {
       printError('Could not find the built application bundle at ${bundle.path}.');
       return new LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -254,7 +254,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     // If the Xcode project, Podfile, or Generated.xcconfig have changed since
     // last run, pods should be updated.
     final Fingerprinter fingerprinter = new Fingerprinter(
-      fingerprintPath: fs.path.join(getIosBuildDirectory(), 'pod_inputs.fingerprint'),
+      fingerprintPath: fs.path.join(getIosBuildDirectory(/* deviceId??? */), 'pod_inputs.fingerprint'),
       paths: <String>[
         _getPbxProjPath(app.appDirectory),
         fs.path.join(iosPath, 'Podfile'),
@@ -302,7 +302,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       buildCommands.addAll(<String>[
         '-workspace', fs.path.basename(entity.path),
         '-scheme', scheme,
-        'BUILD_DIR=${fs.path.absolute(getIosBuildDirectory())}',
+        'BUILD_DIR=${fs.path.absolute(getIosBuildDirectory(/* deviceId??? */))}',
       ]);
       break;
     }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -223,7 +223,7 @@ class IOSSimulator extends Device {
   Future<bool> installApp(ApplicationPackage app) async {
     try {
       final IOSApp iosApp = app;
-      await SimControl.instance.install(id, iosApp.simulatorBundlePath);
+      await SimControl.instance.install(id, iosApp.getSimulatorBundlePath(id));
       return true;
     } catch (e) {
       return false;
@@ -380,7 +380,7 @@ class IOSSimulator extends Device {
 
     // Step 2: Assert that the Xcode project was successfully built.
     final IOSApp iosApp = app;
-    final Directory bundle = fs.directory(iosApp.simulatorBundlePath);
+    final Directory bundle = fs.directory(iosApp.getSimulatorBundlePath(id));
     final bool bundleExists = bundle.existsSync();
     if (!bundleExists)
       throwToolExit('Could not find the built application bundle at ${bundle.path}.');

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -77,9 +77,9 @@ Future<void> updateGeneratedXcodeProperties({
   localsBuffer.writeln('FLUTTER_BUILD_MODE=${buildInfo.modeName}');
 
   // The build outputs directory, relative to FLUTTER_APPLICATION_PATH.
-  localsBuffer.writeln('FLUTTER_BUILD_DIR=${getBuildDirectory()}');
+  localsBuffer.writeln('FLUTTER_BUILD_DIR=${getBuildDirectory(/* deviceId??? */)}');
 
-  localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
+  localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory(/* deviceId??? */)}');
 
   localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=${flutterFrameworkDir(buildInfo.mode)}');
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -158,7 +158,7 @@ class FlutterDevice {
 
   Future<Null> resetAssetDirectory() async {
     final Uri deviceAssetsDirectoryUri = devFS.baseUri.resolveUri(
-        fs.path.toUri(getAssetBuildDirectory()));
+        fs.path.toUri(getAssetBuildDirectory(device.id)));
     assert(deviceAssetsDirectoryUri != null);
     await Future.wait(views.map(
       (FlutterView view) => view.setAssetDirectory(deviceAssetsDirectoryUri)
@@ -271,6 +271,7 @@ class FlutterDevice {
     final TargetPlatform targetPlatform = await device.targetPlatform;
     package = await getApplicationPackageForPlatform(
       targetPlatform,
+      device.id,
       applicationBinary: hotRunner.applicationBinary
     );
 
@@ -321,6 +322,7 @@ class FlutterDevice {
     final TargetPlatform targetPlatform = await device.targetPlatform;
     package = await getApplicationPackageForPlatform(
       targetPlatform,
+      device.id,
       applicationBinary: coldRunner.applicationBinary
     );
 
@@ -389,6 +391,7 @@ class FlutterDevice {
     int bytes = 0;
     try {
       bytes = await devFS.update(
+        device.id,
         mainPath: mainPath,
         target: target,
         bundle: bundle,

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -88,7 +88,7 @@ class ColdRunner extends ResidentRunner {
       if (device.vmServices != null && device.vmServices.isNotEmpty) {
         printStatus('Downloading startup trace info for ${device.device.name}');
         try {
-          await downloadStartupTrace(device.vmServices.first);
+          await downloadStartupTrace(device.vmServices.first, device.device.id);
         } catch (error) {
           printError('Error downloading startup trace: $error');
           return 2;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -359,7 +359,7 @@ class HotRunner extends ResidentRunner {
         fs.path.toUri(entryUri));
       final Uri devicePackagesUri = device.devFS.baseUri.resolve('.packages');
       final Uri deviceAssetsDirectoryUri = device.devFS.baseUri.resolveUri(
-        fs.path.toUri(getAssetBuildDirectory()));
+        fs.path.toUri(getAssetBuildDirectory(device.device.id)));
       await _launchInView(device,
                           deviceEntryUri,
                           devicePackagesUri,

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -127,8 +127,8 @@ class FlutterTesterDevice extends Device {
     }
 
     // Build assets and perform initial compilation.
-    final String assetDirPath = getAssetBuildDirectory();
-    final String applicationKernelFilePath = bundle.defaultApplicationKernelPath;
+    final String assetDirPath = getAssetBuildDirectory(id);
+    final String applicationKernelFilePath = bundle.getDefaultApplicationKernelPath(id);
     await bundle.build(
       mainPath: mainPath,
       assetDirPath: assetDirPath,

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -74,8 +74,8 @@ class Tracing {
 
 /// Download the startup trace information from the given observatory client and
 /// store it to build/start_up_info.json.
-Future<Null> downloadStartupTrace(VMService observatory) async {
-  final String traceInfoFilePath = fs.path.join(getBuildDirectory(), 'start_up_info.json');
+Future<Null> downloadStartupTrace(VMService observatory, String deviceId) async {
+  final String traceInfoFilePath = fs.path.join(getBuildDirectory(deviceId), 'start_up_info.json');
   final File traceInfoFile = fs.file(traceInfoFilePath);
 
   // Delete old startup data, if any.


### PR DESCRIPTION
This code does not compile... there are around 12 places where we don't have a device ID (and probably cannot get one). It's mainly for discussion around #18566.

@devoncarew I made `getBuildDirectory` require a device ID, and added it to the sigs of all callers (as a positional arg, so you cannot accidentally omit it). I followed it all the way up to somewhere I could get a device ID.

There are a few places I explicitly passed null:

  1. the `clean` command - we want that to clean the parent folder
  2. the AOT build folder - I figured we'd never have a device ID here because we're building a release build

There are about 12 places left that do not compile because we don't have access to a device ID. I do not know whether these contexts can have device IDs. For ex., some of them are things like writing a variable into an Xcode project file; which seems like it should be device-agnostic; but I don't know what this variable is used for to know how to deal with this.

It's possible that some of these build folders do not need to be device-specific and that might fix some of these. There are also some places calling these methods that are as default values (eg. BuildBundleCommand's options)... passing `null` here would likely result in some other code later on reading that value and getting the "wrong" (general build, not device-specific) folder.