### PR TITLE
Fix use of Future<void> as a Future<bool>

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -57,7 +57,6 @@ class IOSEmulator extends Emulator {
     // Run again to force it to Foreground (using -n doesn't force existing
     // devices to the foreground)
     await launchSimulator(<String>[]);
-    return;
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -37,7 +37,7 @@ class IOSEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    Future<void> launchSimulator(List<String> additionalArgs) async {
+    Future<bool> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>['open']
           .followedBy(additionalArgs)
           .followedBy(<String>['-a', getSimulatorPath()]);
@@ -53,7 +53,7 @@ class IOSEmulator extends Emulator {
     // First run with `-n` to force a device to boot if there isn't already one
     if (!await launchSimulator(<String>['-n']))
       return false;
-    
+
     // Run again to force it to Foreground (using -n doesn't force existing
     // devices to the foreground)
     return launchSimulator(<String>[]);

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -52,11 +52,12 @@ class IOSEmulator extends Emulator {
 
     // First run with `-n` to force a device to boot if there isn't already one
     if (!await launchSimulator(<String>['-n']))
-      return false;
+      return;
 
     // Run again to force it to Foreground (using -n doesn't force existing
     // devices to the foreground)
-    return launchSimulator(<String>[]);
+    await launchSimulator(<String>[]);
+    return;
   }
 }
 


### PR DESCRIPTION
Small fix, using `void` as a bool.

This is unfortunately not being caught right now: https://github.com/dart-lang/sdk/issues/33629 .