### PR TITLE
Add process output for flutter_tester test and unskip

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -94,15 +94,20 @@ class MyApp extends StatelessWidget {
 }
 ''');
 
+      // Capture process output so that if the process quits we can print the
+      // stdout/stderr in the error.
+      final StringBuffer logs = new StringBuffer();
+      device.getLogReader().logLines.listen(logs.write);
+
       final LaunchResult result = await start(mainPath);
 
       expect(result.started, isTrue);
       expect(result.observatoryUri, isNotNull);
 
       await new Future<void>.delayed(const Duration(seconds: 3));
-      expect(device.isRunning, true);
+      expect(device.isRunning, true, reason: 'Device did not remain running.\n\n$logs'.trim());
 
       expect(await device.stopApp(null), isTrue);
-    }, skip: true);
+    });
   });
 }


### PR DESCRIPTION
This test failed after I commit my "new tests" (which slightly refactored this code, but not in any way I can imagine would cause the failure). It failed because flutter_tester didn't remain alive (a bug we'd had previously, and specifically added this test for), however only on `mac_bot`; bot on Travis, AppVeyor or locally. I marked it as skip to get the build green, but I'd like to get to the bottom of it.

This test adds any stdout/stderr to the error message in case there are clues there (maybe it crashed?), however the only way to test this out is probably to merge and let it run on `mac_bot` again (this means merging something that will probably break the build, and then reverting it once it's run).

@devoncarew 