### PR TITLE
Revert "Add process output for flutter_tester test and unskip"

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -94,20 +94,15 @@ class MyApp extends StatelessWidget {
 }
 ''');
 
-      // Capture process output so that if the process quits we can print the
-      // stdout/stderr in the error.
-      final StringBuffer logs = new StringBuffer();
-      device.getLogReader().logLines.listen(logs.write);
-
       final LaunchResult result = await start(mainPath);
 
       expect(result.started, isTrue);
       expect(result.observatoryUri, isNotNull);
 
       await new Future<void>.delayed(const Duration(seconds: 3));
-      expect(device.isRunning, true, reason: 'Device did not remain running.\n\n$logs'.trim());
+      expect(device.isRunning, true);
 
       expect(await device.stopApp(null), isTrue);
-    });
+    }, skip: true);
   });
 }


### PR DESCRIPTION
This is to revert flutter/flutter#18868 if it fails (we suspect it will, but it has some additional logging in which might reveal why - since it doesn't fail anywhere except `mac_bot`).

I won't land it until after that changeset has built (and failed) on `mac_bot`. If it doesn't fail, then I'll just abort this PR and we'll have to wait until it fails to see if the log contains the info.
