### PR TITLE
Let the Kernel FE know whether it's building for a release VM.

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -391,6 +391,7 @@ class AOTSnapshotter {
       aot: true,
       entryPointsJsonFiles: entryPointsJsonFiles,
       trackWidgetCreation: false,
+      target_product_vm: buildMode == BuildMode.release
     );
 
     // Write path to frontend_server, since things need to be re-generated when that changes.

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -391,7 +391,7 @@ class AOTSnapshotter {
       aot: true,
       entryPointsJsonFiles: entryPointsJsonFiles,
       trackWidgetCreation: false,
-      target_product_vm: buildMode == BuildMode.release,
+      targetProductVm: buildMode == BuildMode.release,
     );
 
     // Write path to frontend_server, since things need to be re-generated when that changes.

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -391,7 +391,7 @@ class AOTSnapshotter {
       aot: true,
       entryPointsJsonFiles: entryPointsJsonFiles,
       trackWidgetCreation: false,
-      target_product_vm: buildMode == BuildMode.release
+      target_product_vm: buildMode == BuildMode.release,
     );
 
     // Write path to frontend_server, since things need to be re-generated when that changes.

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -84,7 +84,7 @@ class KernelCompiler {
     String packagesPath,
     List<String> fileSystemRoots,
     String fileSystemScheme,
-    bool target_product_vm = false
+    bool target_product_vm = false,
   }) async {
     final String frontendServer = artifacts.getArtifactPath(
       Artifact.frontendServerSnapshotForEngineDartSdk

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -84,6 +84,7 @@ class KernelCompiler {
     String packagesPath,
     List<String> fileSystemRoots,
     String fileSystemScheme,
+    bool target_product_vm = false
   }) async {
     final String frontendServer = artifacts.getArtifactPath(
       Artifact.frontendServerSnapshotForEngineDartSdk
@@ -133,6 +134,9 @@ class KernelCompiler {
     if (aot) {
       command.add('--aot');
       command.add('--tfa');
+    }
+    if (target_product_vm) {
+      command.add('-Ddart.vm.product=true');
     }
     if (entryPointsJsonFiles != null) {
       for (String entryPointsJson in entryPointsJsonFiles) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -84,7 +84,7 @@ class KernelCompiler {
     String packagesPath,
     List<String> fileSystemRoots,
     String fileSystemScheme,
-    bool target_product_vm = false,
+    bool targetProductVm = false,
   }) async {
     final String frontendServer = artifacts.getArtifactPath(
       Artifact.frontendServerSnapshotForEngineDartSdk
@@ -135,7 +135,7 @@ class KernelCompiler {
       command.add('--aot');
       command.add('--tfa');
     }
-    if (target_product_vm) {
+    if (targetProductVm) {
       command.add('-Ddart.vm.product=true');
     }
     if (entryPointsJsonFiles != null) {


### PR DESCRIPTION
 This is needed for the constants transformation. Once this is resolved, the `vmservice_io` library is
tree-shaken out of compiled code for release builds, resulting in a 10-15% code size decrease.