### PR TITLE
Add process output for flutter_tester test and unskip

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -97,15 +97,20 @@ class MyApp extends StatelessWidget {
 }
 ''');
 
+      // Capture process output so that if the process quits we can print the
+      // stdout/stderr in the error.
+      final StringBuffer logs = new StringBuffer();
+      device.getLogReader().logLines.listen(logs.write);
+
       final LaunchResult result = await start(mainPath);
 
       expect(result.started, isTrue);
       expect(result.observatoryUri, isNotNull);
 
       await new Future<void>.delayed(const Duration(seconds: 3));
-      expect(device.isRunning, true);
+      expect(device.isRunning, true, reason: 'Device did not remain running.\n\n$logs'.trim());
 
       expect(await device.stopApp(null), isTrue);
-    }, skip: true);
+    });
   });
 }

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -107,6 +107,11 @@ class MyApp extends StatelessWidget {
       expect(result.started, isTrue);
       expect(result.observatoryUri, isNotNull);
 
+      // This test has been seen to fail on mac_bot because the process did not keep running.
+      // Capturing stdout/stderr has been added subsequently to try and track this down.
+      // If you're ivnestigating this test failing in the future, feel free to
+      // mark is as skip (it's not currently critical) and notifiy dantup@ to look at the logs.
+
       await new Future<void>.delayed(const Duration(seconds: 3));
       expect(device.isRunning, true, reason: 'Device did not remain running.\n\n$logs'.trim());
 


### PR DESCRIPTION
Take 2 (3?)!

I'm trying this again. I believe the original failure was flake - it passed everywhere except mac_bot, and it subsequently passed on mac_bot just before I reverted it (the failure was another flaky test!) so I'd really like to see it fail with the stdout/stderr logging.

If the test fails again, I will re-mark it as skip (and hopefully investigate a fix if there was anything useful logged). If it passes, I'm going to leave it in until it flakes again and hopefully we'll get some output. I've added a comment to the test so if this happens and someone else ends up investigating it's clearer what's happened.