### PR TITLE
Set FLUTTER_TEST when spawning flutter_tester

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -150,7 +150,10 @@ class FlutterTesterDevice extends Device {
       printTrace(command.join(' '));
 
       _isRunning = true;
-      _process = await processManager.start(command);
+      _process = await processManager.start(command,
+      environment: <String, String>{
+        'FLUTTER_TEST': 'true',
+      });
       _process.exitCode.then((_) => _isRunning = false);
       _process.stdout
           .transform(utf8.decoder)


### PR DESCRIPTION
In the flutter_tester integration tests, I was logging stdout/stderr to debug some issues and noticed on Windows the sample app throws (same as I saw in Dart Code's tests and raised https://github.com/flutter/flutter/issues/17768) so I think this should be set here too?