### PR TITLE
Ensure we have the Java binary on PATH when invoking avdmanager

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -466,6 +466,8 @@ class AndroidSdk {
   }
 
   Map<String, String> _sdkManagerEnv;
+  /// Returns an environment with the Java folder added to PATH for use in calling
+  /// Java-based Android SDK commands such as sdkmanager and avdmanager.
   Map<String, String> get sdkManagerEnv {
     if (_sdkManagerEnv == null) {
       // If we can locate Java, then add it to the path used to run the Android SDK manager.

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -114,7 +114,8 @@ class EmulatorManager {
       '-k', sdkId,
       '-d', device
     ];
-    final ProcessResult runResult = processManager.runSync(args);
+    final ProcessResult runResult = processManager.runSync(args,
+        environment: androidSdk?.sdkManagerEnv);
     return new CreateEmulatorResult(
       name,
       success: runResult.exitCode == 0,
@@ -134,7 +135,8 @@ class EmulatorManager {
       'device',
       '-c'
     ];
-    final ProcessResult runResult = processManager.runSync(args);
+    final ProcessResult runResult = processManager.runSync(args,
+        environment: androidSdk?.sdkManagerEnv);
     if (runResult.exitCode != 0)
       return null;
 
@@ -159,7 +161,8 @@ class EmulatorManager {
       'avd',
       '-n', 'temp',
     ];
-    final ProcessResult runResult = processManager.runSync(args);
+    final ProcessResult runResult = processManager.runSync(args,
+        environment: androidSdk?.sdkManagerEnv);
 
     // Get the list of IDs that match our criteria
     final List<String> availableIDs = runResult.stderr


### PR DESCRIPTION
This applies a fix we have for SdkManager to AvdManager so we force Java into `PATH` (see https://github.com/flutter/flutter/issues/13379#issuecomment-400984667).

@mit-mit Are you able to pull this branch and confirm if it works (it's not quite what you tested with JAVA_HOME but it made sense to reuse this fix than add something new).