### PR TITLE
Adding a setup function for hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -27,6 +27,11 @@ class HotRunnerConfig {
   bool computeDartDependencies = true;
   /// Should the hot runner assume that the minimal Dart dependencies do not change?
   bool stableDartDependencies = false;
+  /// A hook for implementations to perform any necessary initialization prior
+  /// to a hot restart. Should return true if the hot restart should continue.
+  Future<bool> setupHotRestart() async {
+    return true;
+  }
 }
 
 HotRunnerConfig get hotRunnerConfig => context[HotRunnerConfig];
@@ -477,6 +482,10 @@ class HotRunner extends ResidentRunner {
       );
       try {
         final Stopwatch timer = new Stopwatch()..start();
+        if (!(await hotRunnerConfig.setupHotRestart())) {
+          status.cancel();
+          return new OperationResult(1, 'setupHotRestart failed');
+        }
         await _restartFromSources();
         timer.stop();
         status.cancel();

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -80,8 +80,6 @@ dev_dependencies:
   collection: 1.14.6
   mockito: 3.0.0-beta
   file_testing: 2.0.0
-  flutter_test:
-    sdk: flutter
 
 dartdoc:
   # Exclude this package from the hosted API docs.

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -80,6 +80,8 @@ dev_dependencies:
   collection: 1.14.6
   mockito: 3.0.0-beta
   file_testing: 2.0.0
+  flutter_test:
+    sdk: flutter
 
 dartdoc:
   # Exclude this package from the hosted API docs.

--- a/packages/flutter_tools/test/hot_test.dart
+++ b/packages/flutter_tools/test/hot_test.dart
@@ -2,7 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'src/context.dart';
@@ -83,4 +88,49 @@ void main() {
       }), true);
     });
   });
+
+  group('hotRestart', () {
+    FlutterDevice device;
+
+    setUp(() {
+      device = new FlutterDevice(new MockDevice(),
+          previewDart2: false, trackWidgetCreation: false);
+    });
+
+    testUsingContext('no setup', () async {
+      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+          true);
+    });
+
+    testUsingContext('setup function succeeds', () async {
+      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+          true);
+    }, overrides: <Type, Generator>{
+      HotRunnerConfig: () => new TestHotRunnerConfig(true),
+    });
+
+    testUsingContext('setup function fails', () async {
+      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+          false);
+    }, overrides: <Type, Generator>{
+      HotRunnerConfig: () => new TestHotRunnerConfig(false),
+    });
+  });
+}
+
+class MockDevice extends Mock implements Device {
+  MockDevice() {
+    when(isSupported()).thenReturn(true);
+  }
+}
+
+class TestHotRunnerConfig extends HotRunnerConfig {
+  bool _successfulSetup;
+
+  TestHotRunnerConfig(this._successfulSetup);
+
+  @override
+  Future<bool> setupHotRestart() async {
+    return _successfulSetup;
+  }
 }

--- a/packages/flutter_tools/test/hot_test.dart
+++ b/packages/flutter_tools/test/hot_test.dart
@@ -90,27 +90,27 @@ void main() {
   });
 
   group('hotRestart', () {
-    FlutterDevice device;
+    final List<FlutterDevice> devices = <FlutterDevice>[];
 
     setUp(() {
-      device = new FlutterDevice(new MockDevice(),
-          previewDart2: false, trackWidgetCreation: false);
+      devices.add(new FlutterDevice(new MockDevice(),
+          previewDart2: false, trackWidgetCreation: false));
     });
 
     testUsingContext('no setup', () async {
-      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+      expect((await new HotRunner(devices).restart(fullRestart: true)).isOk,
           true);
     });
 
     testUsingContext('setup function succeeds', () async {
-      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+      expect((await new HotRunner(devices).restart(fullRestart: true)).isOk,
           true);
     }, overrides: <Type, Generator>{
       HotRunnerConfig: () => new TestHotRunnerConfig(true),
     });
 
     testUsingContext('setup function fails', () async {
-      expect((await new HotRunner([device]).restart(fullRestart: true)).isOk,
+      expect((await new HotRunner(devices).restart(fullRestart: true)).isOk,
           false);
     }, overrides: <Type, Generator>{
       HotRunnerConfig: () => new TestHotRunnerConfig(false),

--- a/packages/flutter_tools/test/hot_test.dart
+++ b/packages/flutter_tools/test/hot_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -106,14 +107,14 @@ void main() {
       expect((await new HotRunner(devices).restart(fullRestart: true)).isOk,
           true);
     }, overrides: <Type, Generator>{
-      HotRunnerConfig: () => new TestHotRunnerConfig(true),
+      HotRunnerConfig: () => new TestHotRunnerConfig(successfulSetup: true),
     });
 
     testUsingContext('setup function fails', () async {
       expect((await new HotRunner(devices).restart(fullRestart: true)).isOk,
           false);
     }, overrides: <Type, Generator>{
-      HotRunnerConfig: () => new TestHotRunnerConfig(false),
+      HotRunnerConfig: () => new TestHotRunnerConfig(successfulSetup: false),
     });
   });
 }
@@ -125,12 +126,12 @@ class MockDevice extends Mock implements Device {
 }
 
 class TestHotRunnerConfig extends HotRunnerConfig {
-  bool _successfulSetup;
+  bool successfulSetup;
 
-  TestHotRunnerConfig(this._successfulSetup);
+  TestHotRunnerConfig({@required this.successfulSetup});
 
   @override
   Future<bool> setupHotRestart() async {
-    return _successfulSetup;
+    return successfulSetup;
   }
 }


### PR DESCRIPTION
Implementors can override this to perform any necessary initialization before a restart is started.