### PR TITLE
add onLongPressUp gesture which is fired when a long-press ends

### DIFF
--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -27,6 +27,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
 
   /// Called when a long-press is recognized.
   GestureLongPressCallback onLongPress;
+  
   /// Called when long-press is recognized and the pointer stops to contact the screen
   GestureLongPressUpCallback onLongPressUp;
 

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -11,6 +11,9 @@ import 'recognizer.dart';
 /// same location for a long period of time.
 typedef void GestureLongPressCallback();
 
+/// Signature for when the pointer ends to contat the same location for a long period of time on the screen
+typedef void GestureLongPressUpCallback();
+
 /// Recognizes when the user has pressed down at the same location for a long
 /// period of time.
 class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
@@ -19,20 +22,35 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// Consider assigning the [onLongPress] callback after creating this object.
   LongPressGestureRecognizer({ Object debugOwner }) : super(deadline: kLongPressTimeout, debugOwner: debugOwner);
 
+  //is a flag which is used to determine if the longPress action happened
+  bool _longPressAccepted = false;
+
   /// Called when a long-press is recognized.
   GestureLongPressCallback onLongPress;
+  /// Called when long-press is recognized and the pointer stops to contact the screen
+  GestureLongPressUpCallback onLongPressUp;
 
   @override
   void didExceedDeadline() {
     resolve(GestureDisposition.accepted);
+    _longPressAccepted = true;
     if (onLongPress != null)
       invokeCallback<void>('onLongPress', onLongPress);
   }
 
   @override
   void handlePrimaryPointer(PointerEvent event) {
-    if (event is PointerUpEvent)
-      resolve(GestureDisposition.rejected);
+    if (event is PointerUpEvent) {
+      /// only accept the event if the pointer is for a longer period of a time on the screen
+      /// and the onLongPressUp event is registered
+      if( _longPressAccepted == true && onLongPressUp != null ) {
+        _longPressAccepted= false;
+        resolve(GestureDisposition.accepted);
+        invokeCallback<void>('onLongPressUp', onLongPressUp);
+      } else {
+        resolve(GestureDisposition.rejected);
+      }
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -11,7 +11,7 @@ import 'recognizer.dart';
 /// same location for a long period of time.
 typedef void GestureLongPressCallback();
 
-/// Signature for when the pointer ends to contat the same location for a long period of time on the screen
+/// Signature for when a pointer stops to contacting the screen after a long period of time
 typedef void GestureLongPressUpCallback();
 
 /// Recognizes when the user has pressed down at the same location for a long
@@ -20,37 +20,40 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// Creates a long-press gesture recognizer.
   ///
   /// Consider assigning the [onLongPress] callback after creating this object.
-  LongPressGestureRecognizer({ Object debugOwner }) : super(deadline: kLongPressTimeout, debugOwner: debugOwner);
+  LongPressGestureRecognizer({ Object debugOwner })
+      : super(deadline: kLongPressTimeout, debugOwner: debugOwner);
 
-  //is a flag which is used to determine if the longPress action happened
   bool _longPressAccepted = false;
 
-  /// Called when a long-press is recognized.
+  /// Called when the pointer stops contacting the screen after the long-press gesture has been recognized.
   GestureLongPressCallback onLongPress;
-  
-  /// Called when long-press is recognized and the pointer stops to contact the screen
+
+  /// Called when the pointer stops contacting the screen after the long-press gesture has been recognized
   GestureLongPressUpCallback onLongPressUp;
 
   @override
   void didExceedDeadline() {
     resolve(GestureDisposition.accepted);
     _longPressAccepted = true;
-    if (onLongPress != null)
+    if (onLongPress != null) {
       invokeCallback<void>('onLongPress', onLongPress);
+    }
   }
 
   @override
   void handlePrimaryPointer(PointerEvent event) {
     if (event is PointerUpEvent) {
-      /// only accept the event if the pointer is for a longer period of a time on the screen
-      /// and the onLongPressUp event is registered
-      if( _longPressAccepted == true && onLongPressUp != null ) {
-        _longPressAccepted= false;
-        resolve(GestureDisposition.accepted);
+      if (_longPressAccepted == true && onLongPressUp != null) {
+        _longPressAccepted = false;
         invokeCallback<void>('onLongPressUp', onLongPressUp);
       } else {
         resolve(GestureDisposition.rejected);
       }
+    }
+
+    else if (event is PointerDownEvent) {
+      // the first touch, initialize the  flag with false
+      _longPressAccepted = false;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -150,6 +150,7 @@ class GestureDetector extends StatelessWidget {
     this.onTapCancel,
     this.onDoubleTap,
     this.onLongPress,
+    this.onLongPressUp,
     this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
@@ -223,6 +224,10 @@ class GestureDetector extends StatelessWidget {
   /// A pointer has remained in contact with the screen at the same location for
   /// a long period of time.
   final GestureLongPressCallback onLongPress;
+
+  /// A pointer has left the contact with the screen at the same location after
+  /// a long period of time.
+  final GestureLongPressUpCallback onLongPressUp;
 
   /// A pointer has contacted the screen and might begin to move vertically.
   final GestureDragDownCallback onVerticalDragDown;
@@ -330,12 +335,13 @@ class GestureDetector extends StatelessWidget {
       );
     }
 
-    if (onLongPress != null) {
+    if (onLongPress != null || onLongPressUp !=null) {
       gestures[LongPressGestureRecognizer] = new GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
         () => new LongPressGestureRecognizer(debugOwner: this),
         (LongPressGestureRecognizer instance) {
           instance
-            ..onLongPress = onLongPress;
+            ..onLongPress = onLongPress
+            ..onLongPressUp = onLongPressUp;
         },
       );
     }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -225,8 +225,7 @@ class GestureDetector extends StatelessWidget {
   /// a long period of time.
   final GestureLongPressCallback onLongPress;
 
-  /// A pointer has left the contact with the screen at the same location after
-  /// a long period of time.
+  /// A pointer that has triggered a long-press has stopped contacting the screen.
   final GestureLongPressUpCallback onLongPressUp;
 
   /// A pointer has contacted the screen and might begin to move vertically.


### PR DESCRIPTION
a new gesture event (onLongPressUp) which is fired when a pointer stops contacting the same location for a long period on the screen.
