### PR TITLE
Fix type errors in iOS simulator discovery.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -58,10 +58,7 @@ class SimControl {
 
   /// Runs `simctl list --json` and returns the JSON of the corresponding
   /// [section].
-  ///
-  /// The return type depends on the [section] being listed but is usually
-  /// either a [Map] or a [List].
-  dynamic _list(SimControlListSection section) {
+  Map<String, dynamic> _list(SimControlListSection section) {
     // Sample output from `simctl list --json`:
     //
     // {
@@ -97,14 +94,18 @@ class SimControl {
     final Map<String, dynamic> devicesSection = _list(SimControlListSection.devices);
 
     for (String deviceCategory in devicesSection.keys) {
-      final List<Map<String, String>> devicesData = devicesSection[deviceCategory];
-
-      for (Map<String, String> data in devicesData) {
+      final List<dynamic> devicesData = devicesSection[deviceCategory];
+      for (Map<String, dynamic> data in devicesData.map(_castStringKeyedMap)) {
         devices.add(new SimDevice(deviceCategory, data));
       }
     }
 
     return devices;
+  }
+
+  Map<String, dynamic> _castStringKeyedMap(dynamic untyped) {
+    final Map<dynamic, dynamic> map = untyped;
+    return map.cast<String, dynamic>();
   }
 
   /// Returns all the connected simulator devices.
@@ -182,7 +183,7 @@ class SimDevice {
   SimDevice(this.category, this.data);
 
   final String category;
-  final Map<String, String> data;
+  final Map<String, dynamic> data;
 
   String get state => data['state'];
   String get availability => data['availability'];

--- a/packages/flutter_tools/test/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/ios/simulators_test.dart
@@ -329,4 +329,80 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
   });
+
+  group('SimControl', () {
+    const int mockPid = 123;
+    const String validSimControlOutput = '''
+{
+  "devices" : {
+    "watchOS 4.3" : [
+      {
+        "state" : "Shutdown",
+        "availability" : "(available)",
+        "name" : "Apple Watch - 38mm",
+        "udid" : "TEST-WATCH-UDID"
+      }
+    ],
+    "iOS 11.4" : [
+      {
+        "state" : "Booted",
+        "availability" : "(available)",
+        "name" : "iPhone 5s",
+        "udid" : "TEST-PHONE-UDID"
+      }
+    ],
+    "tvOS 11.4" : [
+      {
+        "state" : "Shutdown",
+        "availability" : "(available)",
+        "name" : "Apple TV",
+        "udid" : "TEST-TV-UDID"
+      }
+    ]
+  }
+}
+    ''';
+
+    MockProcessManager mockProcessManager;
+    SimControl simControl;
+
+    setUp(() {
+      mockProcessManager = new MockProcessManager();
+      when(mockProcessManager.runSync(any))
+          .thenReturn(new ProcessResult(mockPid, 0, validSimControlOutput, ''));
+
+      simControl = new SimControl();
+    });
+
+    testUsingContext('getDevices succeeds', () {
+      final List<SimDevice> devices = simControl.getDevices();
+
+      final SimDevice watch = devices[0];
+      expect(watch.category, 'watchOS 4.3');
+      expect(watch.state, 'Shutdown');
+      expect(watch.availability, '(available)');
+      expect(watch.name, 'Apple Watch - 38mm');
+      expect(watch.udid, 'TEST-WATCH-UDID');
+      expect(watch.isBooted, isFalse);
+
+      final SimDevice phone = devices[1];
+      expect(phone.category, 'iOS 11.4');
+      expect(phone.state, 'Booted');
+      expect(phone.availability, '(available)');
+      expect(phone.name, 'iPhone 5s');
+      expect(phone.udid, 'TEST-PHONE-UDID');
+      expect(phone.isBooted, isTrue);
+
+      final SimDevice tv = devices[2];
+      expect(tv.category, 'tvOS 11.4');
+      expect(tv.state, 'Shutdown');
+      expect(tv.availability, '(available)');
+      expect(tv.name, 'Apple TV');
+      expect(tv.udid, 'TEST-TV-UDID');
+      expect(tv.isBooted, isFalse);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      SimControl: () => simControl,
+    });
+  });
 }


### PR DESCRIPTION
I noticed this while playing around with Flutter on the latest VM internally.

The IntelliJ plugin was silently failing to discover my iOS simulators. It was due to this code hitting runtime type errors under `2.0.0-dev.66.0`:

```
type 'List<dynamic>' is not a subtype of type 'List<Map<String, String>>'
#0      SimControl.getDevices (package:flutter_tools/src/ios/simulators.dart:100:67)
```

I added a test that passes without the`simulators.dart` changes when run with `2.0.0-dev.63.0`, and fails with `2.0.0-dev.66.0`.

With the `simulators.dart` changes the test passes when run with either `2.0.0-dev.63.0` or `2.0.0-dev.66.0`.

This is due to the way the JSON is represented here as a `Map<String, dynamic>`. This code feels pretty loose with types in general and could probably be cleaned up a bit more, but I'm just looking to take the path of least resistance to getting the IntelliJ plugin's device discovery working again.