### PR TITLE
Added Samsung S9(+) to the list of known physical devices

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -38,6 +38,7 @@ const Map<String, _HardwareType> _knownHardware = const <String, _HardwareType>{
   'samsungexynos7870': _HardwareType.physical,
   'samsungexynos8890': _HardwareType.physical,
   'samsungexynos8895': _HardwareType.physical,
+  'samsungexynos9810': _HardwareType.physical,
 };
 
 class AndroidDevices extends PollingDeviceDiscovery {


### PR DESCRIPTION
This patch enables deploying the release version of apk to the Samsung Galaxy S9 with `flutter run --release`. The issue has already been mentioned in the [issue #18688](https://github.com/flutter/flutter/issues/18688).

The *flutter tools* cannot decide if the connected S9(+) is an emulator or a physical device so the Exynos 9810 processor needs to be whitelisted.

I have not added tests as in the existing set does not test particular devices. It just tests groups of them. I will gladly add the test if needed.