### PR TITLE
Avoid non-standard Gradle setup in Flutter module

### DIFF
--- a/packages/flutter_tools/templates/module/android/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/build.gradle.tmpl
@@ -18,14 +18,6 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
-subprojects {
-    project.buildDir = "${rootProject.buildDir}/android_gen"
-}
-subprojects {
-    project.evaluationDependsOn(':flutter')
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/packages/flutter_tools/templates/module/android/include_flutter.groovy.tmpl
+++ b/packages/flutter_tools/templates/module/android/include_flutter.groovy.tmpl
@@ -17,3 +17,13 @@ plugins.each { name, path ->
     gradle.include ":$name"
     gradle.project(":$name").projectDir = pluginDirectory
 }
+
+gradle.getGradle().projectsLoaded { g ->
+    g.rootProject.afterEvaluate { p ->
+        p.subprojects { sp ->
+            if (sp.name != 'flutter') {
+                sp.evaluationDependsOn(':flutter')
+            }
+        }
+    }
+}


### PR DESCRIPTION
Appears to become problematic with new functionality in Android Studio Gradle plugin 3.2.0, cf. https://github.com/flutter/flutter/issues/18939, https://github.com/flutter/flutter/issues/18940