### PR TITLE
Include stdout/stderr in failure messages for devicelab's tests

### DIFF
--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -26,13 +26,10 @@ void main() {
     }
 
     Future<void> expectScriptResult(List<String> testNames, int expectedExitCode) async {
-      String _indent(String msg) {
-        return '    ' + msg.replaceAll('\n', '\n    ').trim();
-      }
       final ProcessResult result = await runScript(testNames);
       expect(result.exitCode, expectedExitCode,
-          reason: '[ stderr from test process ]\n\n${_indent(result.stderr)}\n\n[ end of stderr ]'
-          '\n\n[ stdout from test process ]\n\n${_indent(result.stdout)}\n\n[ end of stdout ]');
+          reason: '[ stderr from test process ]\n\n${result.stderr}\n\n[ end of stderr ]'
+          '\n\n[ stdout from test process ]\n\n${result.stdout}\n\n[ end of stdout ]');
     }
 
     test('exits with code 0 when succeeds', () async {

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -31,9 +31,8 @@ void main() {
       }
       final ProcessResult result = await runScript(testNames);
       expect(result.exitCode, expectedExitCode,
-          reason: 'Exit code was ${result.exitCode} (expected $expectedExitCode)\n\n'
-          '[ stderr from test process ]\n\n${_indent(result.stderr)}\n\n[ end of stderr ]\n\n'
-          '[ stdout from test process ]\n\n${_indent(result.stdout)}\n\n[ end of stdout ]');
+          reason: '[ stderr from test process ]\n\n${_indent(result.stderr)}\n\n[ end of stderr ]'
+          '\n\n[ stdout from test process ]\n\n${_indent(result.stdout)}\n\n[ end of stdout ]');
     }
 
     test('exits with code 0 when succeeds', () async {

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -13,7 +13,7 @@ void main() {
   const ProcessManager processManager = const LocalProcessManager();
 
   group('run.dart script', () {
-    Future<int> runScript(List<String> testNames) async {
+    Future<ProcessResult> runScript(List<String> testNames) async {
       final List<String> options = <String>['bin/run.dart'];
       for (String testName in testNames) {
         options..addAll(<String>['-t', testName]);
@@ -22,39 +22,49 @@ void main() {
       final ProcessResult scriptProcess = processManager.runSync(
         <String>[dart]..addAll(options)
       );
-      return scriptProcess.exitCode;
+      return scriptProcess;
+    }
+
+    Future<void> expectScriptResult(List<String> testNames, int expectedExitCode) async {
+      String _indent(String msg) {
+        return '    ' + msg.replaceAll('\n', '\n    ').trim();
+      }
+      final ProcessResult result = await runScript(testNames);
+      expect(result.exitCode, expectedExitCode,
+          reason: 'Exit code was ${result.exitCode} (expected $expectedExitCode)\n\n'
+          '[ stderr from test process ]\n\n${_indent(result.stderr)}\n\n[ end of stderr ]\n\n'
+          '[ stdout from test process ]\n\n${_indent(result.stdout)}\n\n[ end of stdout ]');
     }
 
     test('exits with code 0 when succeeds', () async {
-      expect(await runScript(<String>['smoke_test_success']), 0);
+      await expectScriptResult(<String>['smoke_test_success'], 0);
     });
 
     test('accepts file paths', () async {
-      expect(await runScript(<String>['bin/tasks/smoke_test_success.dart']), 0);
+      await expectScriptResult(<String>['bin/tasks/smoke_test_success.dart'], 0);
     });
 
     test('rejects invalid file paths', () async {
-      expect(await runScript(<String>['lib/framework/adb.dart']), 1);
+      await expectScriptResult(<String>['lib/framework/adb.dart'], 1);
     });
 
     test('exits with code 1 when task throws', () async {
-      expect(await runScript(<String>['smoke_test_throws']), 1);
+      await expectScriptResult(<String>['smoke_test_throws'], 1);
     });
 
     test('exits with code 1 when fails', () async {
-      expect(await runScript(<String>['smoke_test_failure']), 1);
+      await expectScriptResult(<String>['smoke_test_failure'], 1);
     });
 
     test('exits with code 1 when fails to connect', () async {
-      expect(await runScript(<String>['smoke_test_setup_failure']), 1);
+      await expectScriptResult(<String>['smoke_test_setup_failure'], 1);
     }, skip: true); // https://github.com/flutter/flutter/issues/5901
 
     test('exits with code 1 when results are mixed', () async {
-      expect(
-        await runScript(<String>[
+      await expectScriptResult(<String>[
           'smoke_test_failure',
           'smoke_test_success',
-        ]),
+        ],
         1,
       );
     });


### PR DESCRIPTION
Sometimes some of these tests unexpectedly fail with a non-zero exit code. This ensures stdout/stderr is included in the test failure message when this happens so that we can track down the issue.

Before:

```
00:01 +0 -2: run.dart script accepts file paths [E]                                                                                                            
  Expected: <0>
    Actual: <1>
  
  package:test              expect
  test/run_test.dart 33:7   main.<fn>.expectScriptResult
  ===== asynchronous gap ===========================
  dart:async                _AsyncAwaitCompleter.completeError
  test/run_test.dart        main.<fn>.expectScriptResult
  ===== asynchronous gap ===========================
  dart:async                _asyncThenWrapperHelper
  test/run_test.dart 28:89  main.<fn>.expectScriptResult
  test/run_test.dart 43:31  main.<fn>.<fn>

```

After:

```
00:01 +0 -2: run.dart script accepts file paths [E]                                                                                                            
  Expected: <0>
    Actual: <1>
  [ stderr from test process ]

  [ end of stderr ]
  
  [ stdout from test process ]
  
      ═════════════════╡ ••• Running task "smoke_test_success" ••• ╞══════════════════
      
      
      Executing: /Users/dantup/Dev/Google/flutter/dev/devicelab/../../bin/cache/dart-sdk/bin/dart --enable-vm-service=0 --no-pause-isolates-on-exit bin/tasks/smoke_test_success.dart
      RegExp: pattern=Observatory listening on (\S+:(\d+)/\S*)$ flags=
      Instance of '_RegExpMatch'
      [smoke_test_success] [STDOUT] Observatory listening on http://127.0.0.1:65284/
      exitcode: 0
      Task result:
      {
        "success": false,
        "reason": "fake error"
      }
      
      
      ═════════════════╡ ••• Finished task "smoke_test_success" ••• ╞═════════════════
  
  [ end of stdout ]
  
  package:test              expect
  test/run_test.dart 33:7   main.<fn>.expectScriptResult
  ===== asynchronous gap ===========================
  dart:async                _AsyncAwaitCompleter.completeError
  test/run_test.dart        main.<fn>.expectScriptResult
  ===== asynchronous gap ===========================
  dart:async                _asyncThenWrapperHelper
  test/run_test.dart 28:89  main.<fn>.expectScriptResult
  test/run_test.dart 43:31  main.<fn>.<fn>
```