### PR TITLE
Upgrade node on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
       - fonts-droid
 language: node_js
 node_js:
-  - "6"
+  - "8"
 git:
   # We rely on git tags for determining the version.
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
       - fonts-droid
 language: node_js
 node_js:
-  - "8"
+  - "8.1"
 git:
   # We rely on git tags for determining the version.
   depth: false

--- a/dev/bots/travis_install.sh
+++ b/dev/bots/travis_install.sh
@@ -18,8 +18,8 @@ function retry {
   return 0
 }
 
-if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  gem install coveralls-lcov
-  gem install bundler
+#if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+#  gem install coveralls-lcov
+#  gem install bundler
   retry 5 npm install -g firebase-tools@">=3.6.1 <3.7.0"
-fi
+#fi

--- a/dev/bots/travis_install.sh
+++ b/dev/bots/travis_install.sh
@@ -18,8 +18,8 @@ function retry {
   return 0
 }
 
-#if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-#  gem install coveralls-lcov
-#  gem install bundler
+if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  gem install coveralls-lcov
+  gem install bundler
   retry 5 npm install -g firebase-tools@">=3.6.1 <3.7.0"
-#fi
+fi


### PR DESCRIPTION
This upgrades Node (and with it, NPM) to the latest LTS version. Hopefully it may resolve some of the hangs we see when installing firebase-tools in the Travis script (used for deploying docs). I've already put a `retry` script around that, but it only helps in the cases where we get errors (eg. npm network wobbles) and not the case where it just hangs and Travis eventually kills it.

As far as I can tell, nodejs/npm are only used in two places:

1. A line in travis/install that installs firebase-tools
2. A call to `firebase deploy` in the docs script which only runs for certain branches and not in PRs

To test `1`, I removed the condition around it and let it run on my own Travis branch. Unsurprisingly it didn't fail, but all it does it installs the package!

Testing `2` isn't really possible without me deploying docs (and couldn't be done from a PR branch since it won't have access to the secret env variables); however I think the risk is low since if it's broken it's likely a `firebase-tools` bug and lots of people are probably using this version of nodejs in the wild.

(cc @mit-mit - you last upgraded the NodeJS version, so you may have a better opinion on the risk of this)