### PR TITLE
Fix Dart 2 issue in `flutter doctor`'s VS Code detection

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -182,7 +182,7 @@ class VsCode {
     if (!fs.isFileSync(packageJsonPath))
       return null;
     final String jsonString = fs.file(packageJsonPath).readAsStringSync();
-    final Map<String, String> jsonObject = json.decode(jsonString);
+    final Map<String, dynamic> jsonObject = json.decode(jsonString);
     return jsonObject['version'];
   }
 }


### PR DESCRIPTION
Fixes #18995; a crash if you run doctor with `--preview-dart-2` passed to the VM.

I presume this is the correct fix. json.decode returns a `Map<String, dynamic>` not `String, String` so this fixes this. However, the signature for `decode` actually just says `dynamic` and this changes still feels slightly weird because I'm still assuming the value is a `String`.