### PR TITLE
[frdb] Change to warning log on timeout.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -58,7 +58,7 @@ Future<json_rpc.Peer> _waitAndConnect(Uri uri) async {
         await new Future<Null>.delayed(_kReconnectAttemptInterval);
         return attemptConnection(uri);
       } else {
-        _log.severe('Connection to Fuchsia\'s Dart VM timed out at '
+        _log.warning('Connection to Fuchsia\'s Dart VM timed out at '
             '${uri.toString()}');
         rethrow;
       }


### PR DESCRIPTION
Before a severe log would be raised when timeout happens. Now that
testing connections requires potentially running into a timeout, this
will cause failures when there shouldn't be any.