### PR TITLE
adjust declared types to work with dart 2 typing at runtime

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -150,7 +150,8 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         final Iterable<Directory> directories = fs
             .directory(path)
             .listSync()
-            .where((FileSystemEntity e) => e is Directory);
+            .where((FileSystemEntity e) => e is Directory)
+            .cast<Directory>();
         for (Directory directory in directories) {
           final String name = directory.basename;
           // An exact match, or something like 'Android Studio 3.0 Preview.app'.

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -10,6 +10,7 @@ import 'package:yaml/yaml.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/platform.dart';
+import 'base/utils.dart';
 import 'build_info.dart';
 import 'cache.dart';
 import 'dart/package_map.dart';
@@ -268,20 +269,21 @@ Map<String, dynamic> _readMaterialFontsManifest() {
   final String fontsPath = fs.path.join(fs.path.absolute(Cache.flutterRoot),
       'packages', 'flutter_tools', 'schema', 'material_fonts.yaml');
 
-  return loadYaml(fs.file(fontsPath).readAsStringSync());
+  return castStringKeyedMap(loadYaml(fs.file(fontsPath).readAsStringSync()));
 }
 
 final Map<String, dynamic> _materialFontsManifest = _readMaterialFontsManifest();
 
 List<Map<String, dynamic>> _getMaterialFonts(String fontSet) {
-  return _materialFontsManifest[fontSet];
+  final List<dynamic> fontsList = _materialFontsManifest[fontSet];
+  return fontsList?.map(castStringKeyedMap)?.toList();
 }
 
 List<_Asset> _getMaterialAssets(String fontSet) {
   final List<_Asset> result = <_Asset>[];
 
   for (Map<String, dynamic> family in _getMaterialFonts(fontSet)) {
-    for (Map<String, dynamic> font in family['fonts']) {
+    for (Map<dynamic, dynamic> font in family['fonts']) {
       final Uri entryUri = fs.path.toUri(font['asset']);
       result.add(new _Asset(
         baseDir: fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -276,7 +276,7 @@ final Map<String, dynamic> _materialFontsManifest = _readMaterialFontsManifest()
 
 List<Map<String, dynamic>> _getMaterialFonts(String fontSet) {
   final List<dynamic> fontsList = _materialFontsManifest[fontSet];
-  return fontsList?.map(castStringKeyedMap)?.toList();
+  return fontsList?.map<Map<String, dynamic>>(castStringKeyedMap)?.toList();
 }
 
 List<_Asset> _getMaterialAssets(String fontSet) {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -231,6 +231,13 @@ class Uuid {
       value.toRadixString(16).padLeft(count, '0');
 }
 
+/// Given a data structure which is a Map of String to dynamic values, return
+/// the same structure (`Map<String, dynamic>`) with the correct runtime types.
+Map<String, dynamic> castStringKeyedMap(dynamic untyped) {
+  final Map<dynamic, dynamic> map = untyped;
+  return map.cast<String, dynamic>();
+}
+
 Clock get clock => context[Clock];
 
 typedef Future<Null> AsyncCallback();

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -139,8 +139,8 @@ class AnalysisServer {
     final String file = issueInfo['file'];
     final List<dynamic> errorsList = issueInfo['errors'];
     final List<AnalysisError> errors = errorsList
-        .map(castStringKeyedMap)
-        .map((Map<String, dynamic> json) => new AnalysisError(json))
+        .map<Map<String, dynamic>>(castStringKeyedMap)
+        .map<AnalysisError>((Map<String, dynamic> json) => new AnalysisError(json))
         .toList();
     if (!_errorsController.isClosed)
       _errorsController.add(new FileAnalysisErrors(file, errors));

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -10,6 +10,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/platform.dart';
 import '../base/process_manager.dart';
+import '../base/utils.dart';
 import '../globals.dart';
 
 class AnalysisServer {
@@ -136,7 +137,9 @@ class AnalysisServer {
   void _handleAnalysisIssues(Map<String, dynamic> issueInfo) {
     // {"event":"analysis.errors","params":{"file":"/Users/.../lib/main.dart","errors":[]}}
     final String file = issueInfo['file'];
-    final List<AnalysisError> errors = issueInfo['errors']
+    final List<dynamic> errorsList = issueInfo['errors'];
+    final List<AnalysisError> errors = errorsList
+        .map(castStringKeyedMap)
         .map((Map<String, dynamic> json) => new AnalysisError(json))
         .toList();
     if (!_errorsController.isClosed)

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -121,7 +121,7 @@ class FlutterManifest {
     final List<dynamic> fontList = _flutterDescriptor['fonts'];
     return fontList == null
         ? const <Map<String, dynamic>>[]
-        : fontList.map(castStringKeyedMap).toList();
+        : fontList.map<Map<String, dynamic>>(castStringKeyedMap).toList();
   }
 
   List<Uri> get assets {
@@ -129,7 +129,11 @@ class FlutterManifest {
     if (assets == null) {
       return const <Uri>[];
     }
-    return assets.cast<String>().map(Uri.encodeFull)?.map(Uri.parse)?.toList();
+    return assets
+        .cast<String>()
+        .map<String>(Uri.encodeFull)
+        ?.map<Uri>(Uri.parse)
+        ?.toList();
   }
 
   List<Font> _fonts;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -395,7 +395,7 @@ Future<XcodeBuildResult> buildXcodeProject({
             '-allowProvisioningUpdates',
             '-allowProvisioningDeviceRegistration',
           ].contains(buildCommand);
-        }),
+        }).toList(),
     workingDirectory: app.appDirectory,
   ));
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -14,6 +14,7 @@ import '../base/io.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../bundle.dart' as bundle;
 import '../device.dart';
@@ -95,17 +96,12 @@ class SimControl {
 
     for (String deviceCategory in devicesSection.keys) {
       final List<dynamic> devicesData = devicesSection[deviceCategory];
-      for (Map<String, dynamic> data in devicesData.map(_castStringKeyedMap)) {
+      for (Map<String, dynamic> data in devicesData.map(castStringKeyedMap)) {
         devices.add(new SimDevice(deviceCategory, data));
       }
     }
 
     return devices;
-  }
-
-  Map<String, dynamic> _castStringKeyedMap(dynamic untyped) {
-    final Map<dynamic, dynamic> map = untyped;
-    return map.cast<String, dynamic>();
   }
 
   /// Returns all the connected simulator devices.
@@ -123,23 +119,23 @@ class SimControl {
     ]);
   }
 
-  Future<Null> install(String deviceId, String appPath) {
+  Future<RunResult> install(String deviceId, String appPath) {
     return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'install', deviceId, appPath]);
   }
 
-  Future<Null> uninstall(String deviceId, String appId) {
+  Future<RunResult> uninstall(String deviceId, String appId) {
     return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'uninstall', deviceId, appId]);
   }
 
-  Future<Null> launch(String deviceId, String appIdentifier, [List<String> launchArgs]) {
+  Future<RunResult> launch(String deviceId, String appIdentifier, [List<String> launchArgs]) {
     final List<String> args = <String>[_xcrunPath, 'simctl', 'launch', deviceId, appIdentifier];
     if (launchArgs != null)
       args.addAll(launchArgs);
     return runCheckedAsync(args);
   }
 
-  Future<void> takeScreenshot(String deviceId, String outputPath) {
-    return runCheckedAsync(<String>[_xcrunPath, 'simctl', 'io', deviceId, 'screenshot', outputPath]);
+  Future<void> takeScreenshot(String deviceId, String outputPath) async {
+    await runCheckedAsync(<String>[_xcrunPath, 'simctl', 'io', deviceId, 'screenshot', outputPath]);
   }
 }
 
@@ -350,7 +346,7 @@ class IOSSimulator extends Device {
     return criteria.reduce((bool a, bool b) => a && b);
   }
 
-  Future<Null> _setupUpdatedApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
+  Future<void> _setupUpdatedApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
     await _sideloadUpdatedAssetsForInstalledApplicationBundle(app, buildInfo, mainPath);
 
     if (!await _applicationIsInstalledAndRunning(app))

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -353,7 +353,7 @@ class IOSSimulator extends Device {
       return _buildAndInstallApplicationBundle(app, buildInfo, mainPath, usesTerminalUi);
   }
 
-  Future<Null> _buildAndInstallApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
+  Future<void> _buildAndInstallApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
     // Step 1: Build the Xcode project.
     // The build mode for the simulator is always debug.
 
@@ -385,7 +385,7 @@ class IOSSimulator extends Device {
     await SimControl.instance.install(id, fs.path.absolute(bundle.path));
   }
 
-  Future<Null> _sideloadUpdatedAssetsForInstalledApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath) {
+  Future<void> _sideloadUpdatedAssetsForInstalledApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath) {
     // When running in previewDart2 mode, we still need to run compiler to
     // produce kernel file for the application.
     return bundle.build(

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -96,7 +96,7 @@ class SimControl {
 
     for (String deviceCategory in devicesSection.keys) {
       final List<dynamic> devicesData = devicesSection[deviceCategory];
-      for (Map<String, dynamic> data in devicesData.map(castStringKeyedMap)) {
+      for (Map<String, dynamic> data in devicesData.map<Map<String, dynamic>>(castStringKeyedMap)) {
         devices.add(new SimDevice(deviceCategory, data));
       }
     }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -388,7 +388,7 @@ class VersionCheckStamp {
     return const VersionCheckStamp();
   }
 
-  static VersionCheckStamp fromJson(Map<String, String> jsonObject) {
+  static VersionCheckStamp fromJson(Map<String, dynamic> jsonObject) {
     DateTime readDateTime(String property) {
       return jsonObject.containsKey(property)
           ? DateTime.parse(jsonObject[property])

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -17,6 +17,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/io.dart' as io;
+import 'base/utils.dart';
 import 'globals.dart';
 import 'vmservice_record_replay.dart';
 
@@ -256,7 +257,10 @@ class VMService {
 
   /// Whether our connection to the VM service has been closed;
   bool get isClosed => _peer.isClosed;
-  Future<Null> get done => _peer.done;
+
+  Future<Null> get done async {
+    await _peer.done;
+  }
 
   // Events
   Future<Stream<ServiceEvent>> get onDebugEvent => onEvent('Debug');
@@ -284,7 +288,7 @@ class VMService {
     Map<String, dynamic> params,
   ) {
     return Future.any(<Future<Map<String, dynamic>>>[
-      _peer.sendRequest(method, params),
+      _peer.sendRequest(method, params).then(castStringKeyedMap),
       _connectionError.future,
     ]);
   }
@@ -334,8 +338,8 @@ class VMService {
   }
 
   /// Reloads the VM.
-  Future<VM> getVM() {
-    return _vm.reload();
+  Future<VM> getVM() async {
+    return await _vm.reload();
   }
 
   Future<Null> waitForViews({int attempts = 5, int attemptSeconds = 1}) async {
@@ -683,7 +687,7 @@ class VM extends ServiceObjectOwner {
     _embedder = map['_embedder'];
 
     // Remove any isolates which are now dead from the isolate cache.
-    _removeDeadIsolates(map['isolates']);
+    _removeDeadIsolates(map['isolates'].cast<Isolate>());
   }
 
   final Map<String, ServiceObject> _cache = <String,ServiceObject>{};
@@ -851,7 +855,7 @@ class VM extends ServiceObjectOwner {
   }
 
   /// Invoke the RPC and return a [ServiceObject] response.
-  Future<ServiceObject> invokeRpc(String method, {
+  Future<T> invokeRpc<T extends ServiceObject>(String method, {
     Map<String, dynamic> params = const <String, dynamic>{},
     Duration timeout,
   }) async {
@@ -922,13 +926,13 @@ class VM extends ServiceObjectOwner {
                                Uri packages,
                                Uri assetsDirectory) {
     // TODO(goderbauer): Transfer Uri (instead of file path) when remote end supports it.
-    return invokeRpc('_flutter.runInView',
-                    params: <String, dynamic> {
-                      'viewId': viewId,
-                      'mainScript': main.toFilePath(windows: false),
-                      'packagesFile': packages.toFilePath(windows: false),
-                      'assetDirectory': assetsDirectory.toFilePath(windows: false)
-                    });
+    return invokeRpc<ServiceMap>('_flutter.runInView',
+      params: <String, dynamic> {
+        'viewId': viewId,
+        'mainScript': main.toFilePath(windows: false),
+        'packagesFile': packages.toFilePath(windows: false),
+        'assetDirectory': assetsDirectory.toFilePath(windows: false)
+    });
   }
 
   Future<Map<String, dynamic>> clearVMTimeline() {
@@ -1324,7 +1328,7 @@ class Isolate extends ServiceObjectOwner {
   }
 
   Future<String> flutterPlatformOverride([String platform]) async {
-    final Map<String, String> result = await invokeFlutterExtensionRpcRaw(
+    final Map<String, dynamic> result = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.platformOverride',
       params: platform != null ? <String, dynamic>{ 'value': platform } : <String, String>{},
       timeout: const Duration(seconds: 5),

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -288,7 +288,7 @@ class VMService {
     Map<String, dynamic> params,
   ) {
     return Future.any(<Future<Map<String, dynamic>>>[
-      _peer.sendRequest(method, params).then(castStringKeyedMap),
+      _peer.sendRequest(method, params).then<Map<String, dynamic>>(castStringKeyedMap),
       _connectionError.future,
     ]);
   }


### PR DESCRIPTION
Fix several issues when running flutter_tools in --preview-dart-2:

- fix declared return types to address strong mode at runtime errors
- `cast()` data structures parsed from json so that the types at runtime match what we expect
- add generic types to some methods to allow the types to flow through a method call

We'll need to change the flutter_tools tests over to running in `--preview-dart-2` in order to keep the code dart 2 safe, but we're not quite ready to do that (our test suite is reparsed for each individual test - the test suite takes 40-50 minutes to run).
