### PR TITLE
Show Search button on keyboard for search widget

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -412,11 +412,11 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
         textTheme: theme.primaryTextTheme,
         brightness: theme.primaryColorBrightness,
         leading: widget.delegate.buildLeading(context),
-        // TODO(goderbauer): Show the search key (instead of enter) on keyboard, https://github.com/flutter/flutter/issues/17525
         title: new TextField(
           controller: queryTextController,
           focusNode: widget.delegate._focusNode,
           style: theme.textTheme.title,
+          textInputAction: TextInputAction.search,
           onSubmitted: (String _) {
             widget.delegate.showResults(context);
           },

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -17,7 +17,7 @@ import 'material.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
-export 'package:flutter/services.dart' show TextInputType;
+export 'package:flutter/services.dart' show TextInputType, TextInputAction;
 
 /// A material design text field.
 ///

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -463,6 +463,20 @@ void main() {
     expect(nestedSearchResults, <String>[null]);
     expect(selectedResults, <String>['Result Foo']);
   });
+
+  testWidgets('keyboard show search button', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = new _TestSearchDelegate();
+
+    await tester.pumpWidget(new TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    await tester.showKeyboard(find.byType(TextField));
+
+    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.search.toString());
+  });
 }
 
 class TestHomePage extends StatelessWidget {


### PR DESCRIPTION
Also:
 * Export `TextInputAction` from `text_field.dart` to parallel `TextInputType`.

Requires https://github.com/flutter/flutter/pull/19011 to be submitted.