### PR TITLE
Move collectCoverageData into CoverageCollector so it can be re-used.

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -8,6 +8,10 @@ import 'package:coverage/coverage.dart' as coverage;
 
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/os.dart';
+import '../base/platform.dart';
+import '../base/process_manager.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
 
@@ -98,5 +102,63 @@ class CoverageCollector extends TestWatcher {
     final String result = await formatter.format(_globalHitmap);
     _globalHitmap = null;
     return result;
+  }
+
+  Future<bool> collectCoverageData(String coveragePath, { bool mergeCoverageData = false }) async {
+    final Status status = logger.startProgress('Collecting coverage information...');
+    final String coverageData = await finalizeCoverage(
+      timeout: const Duration(seconds: 30),
+    );
+    status.stop();
+    printTrace('coverage information collection complete');
+    if (coverageData == null)
+      return false;
+
+    final File coverageFile = fs.file(coveragePath)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(coverageData, flush: true);
+    printTrace('wrote coverage data to $coveragePath (size=${coverageData.length})');
+
+    const String baseCoverageData = 'coverage/lcov.base.info';
+    if (mergeCoverageData) {
+      if (!platform.isLinux) {
+        printError(
+          'Merging coverage data is supported only on Linux because it '
+          'requires the "lcov" tool.'
+        );
+        return false;
+      }
+
+      if (!fs.isFileSync(baseCoverageData)) {
+        printError('Missing "$baseCoverageData". Unable to merge coverage data.');
+        return false;
+      }
+
+      if (os.which('lcov') == null) {
+        String installMessage = 'Please install lcov.';
+        if (platform.isLinux)
+          installMessage = 'Consider running "sudo apt-get install lcov".';
+        else if (platform.isMacOS)
+          installMessage = 'Consider running "brew install lcov".';
+        printError('Missing "lcov" tool. Unable to merge coverage data.\n$installMessage');
+        return false;
+      }
+
+      final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_tools');
+      try {
+        final File sourceFile = coverageFile.copySync(fs.path.join(tempDir.path, 'lcov.source.info'));
+        final ProcessResult result = processManager.runSync(<String>[
+          'lcov',
+          '--add-tracefile', baseCoverageData,
+          '--add-tracefile', sourceFile.path,
+          '--output-file', coverageFile.path,
+        ]);
+        if (result.exitCode != 0)
+          return false;
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    }
+    return true;
   }
 }


### PR DESCRIPTION
This will let us re-use that code from fuchsia_tester.dart.
Tested by running the stocks example tests with coverage collection before and after.
.lcov files are identical.