### PR TITLE
Users can modify the border color and width of input_decorator

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1594,7 +1594,11 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   double get _borderWeight {
     if (decoration.isCollapsed || decoration.border == InputBorder.none || !decoration.enabled)
       return 0.0;
-    return isFocused ? 2.0 : 1.0;
+    final double defaultWeight = isFocused ? 2.0 : 1.0;
+    if(decoration.border != null){
+      return decoration?.border?.borderSide?.width ?? defaultWeight;
+    }
+    return defaultWeight;
   }
 
   Color _getBorderColor(ThemeData themeData) {
@@ -1604,7 +1608,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       return themeData.disabledColor;
     }
     return decoration.errorText == null
-      ? _getActiveColor(themeData)
+      ? decoration?.border?.borderSide?.color ?? _getActiveColor(themeData)
       : themeData.errorColor;
   }
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1242,6 +1242,27 @@ void main() {
     expect(getBorderWeight(tester), 1.0);
   });
 
+
+  testWidgets('InputDecoration InputBorder borderSide color and width', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true, // label appears, vertically centered
+        // isFocused: false (default)
+        inputDecorationTheme: const InputDecorationTheme(
+          border: const OutlineInputBorder(borderSide:const BorderSide(color: Colors.red,width: 5.0) ),
+        ),
+      ),
+    );
+
+    // Overall height for this InputDecorator is 56dps. Layout is:
+    //   20 - top padding
+    //   16 - label (ahem font size 16dps)
+    //   20 - bottom padding
+    expect(getBorderWeight(tester), 5.0);
+    expect(getBorderColor(tester), Colors.red);
+  });
+
+
   testWidgets('InputDecorationTheme outline border, dense layout', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildInputDecorator(


### PR DESCRIPTION
In the process of using, I found that the InputDecorator's border color and width could not be modified. After finding the source code, the width of the code was only 2 or 1, and the color could only be read from the ThemeData. I modified this part of the code so that InputDecorator could read the values in the borderSide of the OutlineInputBorder or UnderlineInputBorder.