### PR TITLE
Add `--machine` support for `flutter attach`

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -10,7 +10,7 @@ flutter daemon
 
 It runs a persistent, JSON-RPC based server to communicate with devices. IDEs and other tools can start the flutter tool in this mode and get device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
 
-A set of `flutter daemon` commands/events are also exposed via `flutter run --machine` which allows IDEs and tools to launch flutter applications and interact to send commands like Hot Reload. The command and events that are available in this mode are documented at the bottom of this document.
+A set of `flutter daemon` commands/events are also exposed via `flutter run --machine` and `flutter attach --machine` which allow IDEs and tools to launch and attach to flutter applications and interact to send commands like Hot Reload. The command and events that are available in these modes are documented at the bottom of this document.
 
 ## Protocol
 
@@ -182,9 +182,9 @@ The returned `params` will contain:
 - `emulatorName` - the name of the emulator created; this will have been auto-generated if you did not supply one
 - `error` - when `success`=`false`, a message explaining why the creation of the emulator failed
 
-## Flutter Run --machine
+## 'flutter run --machine' and 'flutter attach --machine' 
 
-When running `flutter run --machine` the following subset of the daemon is available:
+When running `flutter run --machine` or `flutter attach --machine` the following subset of the daemon is available:
 
 ### daemon domain
 
@@ -219,5 +219,6 @@ See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter
 
 ## Changelog
 
+- 0.4.1: Added `flutter attach --machine`
 - 0.4.0: Added `emulator.create` command
 - 0.3.0: Added `daemon.connected` event at startup

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -103,12 +103,9 @@ class AttachCommand extends FlutterCommand {
         observatoryDiscovery = new ProtocolDiscovery.observatory(
             device.getLogReader(),
             portForwarder: device.portForwarder);
-        // TODO(dantup): Do we need to send something via the daemon in --machine
-        // mode or should clients assume that we're waiting until they get the
-        // app.started event?
-        if (daemon == null)
-          printStatus('Listening.');
+        printStatus('Waiting for a connection from Flutter on ${device.name}...');
         observatoryUri = await observatoryDiscovery.uri;
+        printStatus('Done.');
       } finally {
         await observatoryDiscovery?.cancel();
       }

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -4,12 +4,11 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/commands/daemon.dart';
-
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/io.dart';
 import '../cache.dart';
+import '../commands/daemon.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../protocol_discovery.dart';

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -138,7 +138,8 @@ class AttachCommand extends FlutterCommand {
         await hotRunner.attach();
       }
     } finally {
-      device.portForwarder.forwardedPorts.forEach(device.portForwarder.unforward);
+      final List<ForwardedPort> ports = device.portForwarder.forwardedPorts.toList();
+      ports.forEach(device.portForwarder.unforward);
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -90,8 +90,7 @@ class AttachCommand extends FlutterCommand {
     final int devicePort = observatoryPort;
 
     final Daemon daemon = argResults['machine']
-      ? new Daemon(
-            stdinCommandStream, stdoutCommandResponse,
+      ? new Daemon(stdinCommandStream, stdoutCommandResponse,
             notifyingLogger: new NotifyingLogger(), logToStdout: true)
       : null;
 
@@ -100,8 +99,9 @@ class AttachCommand extends FlutterCommand {
       ProtocolDiscovery observatoryDiscovery;
       try {
         observatoryDiscovery = new ProtocolDiscovery.observatory(
-            device.getLogReader(),
-            portForwarder: device.portForwarder);
+          device.getLogReader(),
+          portForwarder: device.portForwarder,
+        );
         printStatus('Waiting for a connection from Flutter on ${device.name}...');
         observatoryUri = await observatoryDiscovery.uri;
         printStatus('Done.');
@@ -113,14 +113,14 @@ class AttachCommand extends FlutterCommand {
       observatoryUri = Uri.parse('http://$ipv4Loopback:$localPort/');
     }
     try {
-      final FlutterDevice flutterDevice =
-          new FlutterDevice(device, trackWidgetCreation: false, previewDart2: argResults['preview-dart-2']);
+      final FlutterDevice flutterDevice = new FlutterDevice(device,
+          trackWidgetCreation: false, previewDart2: argResults['preview-dart-2']);
       flutterDevice.observatoryUris = <Uri>[ observatoryUri ];
       final HotRunner hotRunner = new HotRunner(
         <FlutterDevice>[flutterDevice],
         debuggingOptions: new DebuggingOptions.enabled(getBuildInfo()),
         packagesFilePath: globalResults['packages'],
-        usesTerminalUI: daemon == null
+        usesTerminalUI: daemon == null,
       );
 
       if (daemon != null) {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -377,11 +377,8 @@ class AppDomain extends Domain {
     
     return launch(
         runner,
-        ({
-          Completer<DebugConnectionInfo> connectionInfoCompleter,
-          Completer<void> appStartedCompleter
-        }) =>
-            runner.run(
+        ({ Completer<DebugConnectionInfo> connectionInfoCompleter,
+            Completer<void> appStartedCompleter }) => runner.run(
                 connectionInfoCompleter: connectionInfoCompleter,
                 appStartedCompleter: appStartedCompleter,
                 route: route),

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -28,7 +28,7 @@ import '../runner/flutter_command.dart';
 import '../tester/flutter_tester.dart';
 import '../vmservice.dart';
 
-const String protocolVersion = '0.4.0';
+const String protocolVersion = '0.4.1';
 
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -369,8 +369,26 @@ class AppDomain extends Domain {
         ipv6: ipv6,
       );
     }
+    
+    return launch(runner, runner.run, device, projectDirectory, enableHotReload,
+        options, route, cwd);
+  }
 
-    final AppInstance app = new AppInstance(_getNewAppId(), runner: runner, logToStdout: daemon.logToStdout);
+  Future<AppInstance> launch(
+      ResidentRunner runner,
+      Function({
+        Completer<DebugConnectionInfo> connectionInfoCompleter,
+        Completer<Null> appStartedCompleter,
+        String route
+      }) run,
+      Device device,
+      String projectDirectory,
+      bool enableHotReload,
+      DebuggingOptions options,
+      String route,
+      Directory cwd) async {
+    final AppInstance app = new AppInstance(_getNewAppId(),
+        runner: runner, logToStdout: daemon.logToStdout);
     _apps.add(app);
     _sendAppEvent(app, 'start', <String, dynamic>{
       'deviceId': device.id,
@@ -403,7 +421,7 @@ class AppDomain extends Domain {
 
     await app._runInZone<Null>(this, () async {
       try {
-        await runner.run(
+        await run(
           connectionInfoCompleter: connectionInfoCompleter,
           appStartedCompleter: appStartedCompleter,
           route: route,
@@ -419,7 +437,6 @@ class AppDomain extends Domain {
         _apps.remove(app);
       }
     });
-
     return app;
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -391,7 +391,7 @@ class RunCommand extends RunCommandBase {
     // need to know about analytics.
     //
     // Do not add more operations to the future.
-    final Completer<Null> appStartedTimeRecorder = new Completer<Null>.sync();
+    final Completer<void> appStartedTimeRecorder = new Completer<void>.sync();
     // This callback can't throw.
     appStartedTimeRecorder.future.then( // ignore: unawaited_futures
       (_) { appStartedTime = clock.now(); }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -467,7 +467,7 @@ abstract class ResidentRunner {
   /// Start the app and keep the process running during its lifetime.
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<Null> appStartedCompleter,
+    Completer<void> appStartedCompleter,
     String route,
     bool shouldBuild = true
   });

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -35,7 +35,7 @@ class ColdRunner extends ResidentRunner {
   @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<Null> appStartedCompleter,
+    Completer<void> appStartedCompleter,
     String route,
     bool shouldBuild = true
   }) async {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -235,7 +235,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<Null> appStartedCompleter,
+    Completer<void> appStartedCompleter,
     String route,
     bool shouldBuild = true
   }) async {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -149,7 +149,7 @@ class HotRunner extends ResidentRunner {
 
   Future<int> attach({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<Null> appStartedCompleter,
+    Completer<void> appStartedCompleter,
     String viewFilter,
   }) async {
     try {

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -44,6 +44,7 @@ class FlutterTesterDevice extends Device {
   FlutterTesterDevice(String deviceId) : super(deviceId);
 
   Process _process;
+  final DevicePortForwarder _portForwarder = new _NoopPortForwarder();
 
   @override
   Future<bool> get isLocalEmulator async => false;
@@ -52,7 +53,7 @@ class FlutterTesterDevice extends Device {
   String get name => 'Flutter test device';
 
   @override
-  DevicePortForwarder get portForwarder => null;
+  DevicePortForwarder get portForwarder => _portForwarder;
 
   @override
   Future<String> get sdkNameAndVersion async {
@@ -232,4 +233,22 @@ class _FlutterTesterDeviceLogReader extends DeviceLogReader {
   String get name => 'flutter tester log reader';
 
   void addLine(String line) => _logLinesController.add(line);
+}
+
+/// A fake port forwarder that doesn't do anything. Used by flutter tester
+/// where the VM is running on the same machine and does not need ports forwarding.
+class _NoopPortForwarder extends DevicePortForwarder {
+  @override
+  Future<int> forward(int devicePort, {int hostPort}) {
+    if (hostPort != null && hostPort != devicePort)
+      throw 'Forwarding to a different port is not supported by flutter tester';
+    return new Future<int>.value(devicePort);
+  }
+
+  // TODO: implement forwardedPorts
+  @override
+  List<ForwardedPort> get forwardedPorts => <ForwardedPort>[];
+
+  @override
+  Future<Null> unforward(ForwardedPort forwardedPort) => null;
 }

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -245,7 +245,6 @@ class _NoopPortForwarder extends DevicePortForwarder {
     return new Future<int>.value(devicePort);
   }
 
-  // TODO: implement forwardedPorts
   @override
   List<ForwardedPort> get forwardedPorts => <ForwardedPort>[];
 

--- a/packages/flutter_tools/test/integration/flutter_attach.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach.dart
@@ -2,34 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:test/test.dart';
 
 import '../src/context.dart';
+import 'test_data/basic_project.dart';
 import 'test_driver.dart';
-import 'test_utils.dart';
 
-Directory _tempDir;
 FlutterTestDriver _flutterRun, _flutterAttach;
+BasicProject _project = new BasicProject();
 
 void main() {
 
   setUp(() async {
-    _tempDir = await fs.systemTempDirectory.createTemp('test_app');
-    await _setupSampleProject();
-    _flutterRun = new FlutterTestDriver(_tempDir);
-    _flutterAttach = new FlutterTestDriver(_tempDir);
+    final Directory tempDir = await fs.systemTempDirectory.createTemp('test_app');
+    await _project.setUpIn(tempDir);
+    _flutterRun = new FlutterTestDriver(tempDir);
+    _flutterAttach = new FlutterTestDriver(tempDir);
   });
 
   tearDown(() async {
     try {
       await _flutterRun.stop();
       await _flutterAttach.stop();
-      _tempDir?.deleteSync(recursive: true);
-      _tempDir = null;
+      _project.cleanup();
     } catch (e) {
       // Don't fail tests if we failed to clean up temp folder.
     }
@@ -43,34 +40,4 @@ void main() {
       await _flutterAttach.hotReload();
     });
   }, timeout: const Timeout.factor(3));
-}
-
-// TODO: Rebase on other PRs with better sample projects (class-based) before
-// landing...
-Future<void> _setupSampleProject() async {
-  writePubspec(_tempDir.path);
-  writePackages(_tempDir.path);
-  await getPackages(_tempDir.path);
-  
-  final String mainPath = fs.path.join(_tempDir.path, 'lib', 'main.dart');
-  writeFile(mainPath, r'''
-  import 'package:flutter/material.dart';
-  
-  void main() => runApp(new MyApp());
-  
-  class MyApp extends StatelessWidget {
-    @override
-    Widget build(BuildContext context) {
-      topLevelFunction();
-      return new MaterialApp(
-  title: 'Flutter Demo',
-  home: new Container(),
-      );
-    }
-  }
-
-  topLevelFunction() {
-    print("test");
-  }
-  ''');
 }

--- a/packages/flutter_tools/test/integration/flutter_attach.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach.dart
@@ -1,0 +1,76 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:test/test.dart';
+
+import '../src/context.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+Directory _tempDir;
+FlutterTestDriver _flutterRun, _flutterAttach;
+
+void main() {
+
+  setUp(() async {
+    _tempDir = await fs.systemTempDirectory.createTemp('test_app');
+    await _setupSampleProject();
+    _flutterRun = new FlutterTestDriver(_tempDir);
+    _flutterAttach = new FlutterTestDriver(_tempDir);
+  });
+
+  tearDown(() async {
+    try {
+      await _flutterRun.stop();
+      await _flutterAttach.stop();
+      _tempDir?.deleteSync(recursive: true);
+      _tempDir = null;
+    } catch (e) {
+      // Don't fail tests if we failed to clean up temp folder.
+    }
+  });
+
+  group('attached process', () {
+    testUsingContext('can hot reload', () async {
+      await _flutterRun.run(withDebugger: true);
+      await _flutterAttach.attach(_flutterRun.vmServicePort);
+      
+      await _flutterAttach.hotReload();
+    });
+  }, timeout: const Timeout.factor(3));
+}
+
+// TODO: Rebase on other PRs with better sample projects (class-based) before
+// landing...
+Future<void> _setupSampleProject() async {
+  writePubspec(_tempDir.path);
+  writePackages(_tempDir.path);
+  await getPackages(_tempDir.path);
+  
+  final String mainPath = fs.path.join(_tempDir.path, 'lib', 'main.dart');
+  writeFile(mainPath, r'''
+  import 'package:flutter/material.dart';
+  
+  void main() => runApp(new MyApp());
+  
+  class MyApp extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      topLevelFunction();
+      return new MaterialApp(
+  title: 'Flutter Demo',
+  home: new Container(),
+      );
+    }
+  }
+
+  topLevelFunction() {
+    print("test");
+  }
+  ''');
+}

--- a/packages/flutter_tools/test/resident_runner_test.dart
+++ b/packages/flutter_tools/test/resident_runner_test.dart
@@ -36,7 +36,7 @@ class TestRunner extends ResidentRunner {
   @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
-    Completer<dynamic> appStartedCompleter,
+    Completer<void> appStartedCompleter,
     String route,
     bool shouldBuild = true,
   }) => null;

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -79,7 +79,7 @@ void main() {
       expect(device.id, 'flutter-tester');
       expect(await device.isLocalEmulator, isFalse);
       expect(device.name, 'Flutter test device');
-      expect(device.portForwarder, isNull);
+      expect(device.portForwarder, isNot(isNull));
       expect(await device.targetPlatform, TargetPlatform.tester);
 
       expect(await device.installApp(null), isTrue);


### PR DESCRIPTION
I've split some of the code out of `startApp` in `Daemon` into a new method (`launch`) so that it can be reused by `attach` (this handles sending app.start messages, etc.) and changed `AttachCommand` to create a `Daemon` when run in `--machine`  mode (similar to how `RunCommand` does for `flutter run --machine`).

I also bumped the daemon protocol version so that clients can detect whether `flutter attach --machine` is supported (though note, you'll need to have spawned some other type of daemon in order to have received the protocol version - probably this is no problem because editors will spawn the device daemon well before the user tries to attach).

Tests are still outstanding; but I wanted to get feedback (and allow this to be tried out - I have a working implementation in Dart Code I'll make a preview build of soon). I'd like to build the tests using the new integration test driver I was working on (#18865 and #18878) so that they can be run on all builds/PRs instead of just devicelab.

Fixes #19045.