### PR TITLE
Avoid repeating microbenchmark

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -74,8 +74,6 @@ TaskFunction createMicrobenchmarkTask() {
     addDart1Results(await _runMicrobench(
         'lib/stocks/layout_bench.dart', previewDart2: false));
     addDart1Results(await _runMicrobench(
-        'lib/stocks/layout_bench.dart', previewDart2: false));
-    addDart1Results(await _runMicrobench(
         'lib/stocks/build_bench.dart', previewDart2: false));
     addDart1Results(await _runMicrobench(
         'lib/gestures/velocity_tracker_bench.dart', previewDart2: false));


### PR DESCRIPTION
We currently execute one of the Dart 1 microbenchmarks twice in a row, only to ignore one of the results. It appears related to recent test flakiness (see log below).
```
[   +1 ms] Latest build already installed.
[        ] Moto G 4 startApp
[   +2 ms] /Volumes/DevicelabAndroid/sdk/platform-tools/adb -s ZY2245H6ZS shell am start -a android.intent.action.RUN -f 0x20000000 --ez enable-background-compilation true --ez enable-dart-profiling true com.yourcompany.microbenchmarks/io.flutter.app.FlutterActivity
[ +974 ms] Starting: Intent { act=android.intent.action.RUN flg=0x20000000 cmp=com.yourcompany.microbenchmarks/io.flutter.app.FlutterActivity (has extras) }
[        ] Waiting for observatory port to be available...
[+17607 ms] I/flutter (18415): ================ RESULTS ================
[   +1 ms] I/flutter (18415): :::JSON::: {"stock_layout_iteration":3683.8005893909626}
[+27047 ms] I/flutter (18415): ================ RESULTS ================
[        ] I/flutter (18415): :::JSON::: {"stock_layout_iteration":3683.8005893909626}
[        ] I/flutter (18415): ================ FORMATTED ==============
Task failed: Bad state: Future already completed

Stack trace:
dart:async                                                   _Completer.completeError
package:flutter_devicelab/tasks/microbenchmarks.dart 135:19  _readJsonResults.
===== asynchronous gap ===========================
dart:async                                                   _BoundSinkStream.listen
package:flutter_devicelab/tasks/microbenchmarks.dart 118:8   _readJsonResults
package:flutter_devicelab/tasks/microbenchmarks.dart 53:22   createMicrobenchmarkTask.._runMicrobench._run
===== asynchronous gap ===========================
dart:async                                                   _asyncThenWrapperHelper
package:flutter_devicelab/tasks/microbenchmarks.dart 27:48   createMicrobenchmarkTask.._runMicrobench._run
package:flutter_devicelab/tasks/microbenchmarks.dart 55:18   createMicrobenchmarkTask.._runMicrobench
===== asynchronous gap ===========================
dart:async                                                   _asyncThenWrapperHelper
package:flutter_devicelab/tasks/microbenchmarks.dart 22:19   createMicrobenchmarkTask.
package:flutter_devicelab/framework/framework.dart 125:36    _TaskRunner._performTask.

[        ] I/flutter (18415): Stock layout: 3683.8 µs per iteration
[        ] I/flutter (18415): ================ FORMATTED ==============
[        ] I/flutter (18415): Stock layout: 3683.8 µs per iteration
```