### PR TITLE
Attempt to fix race in microbenchmark error handling code

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -115,7 +115,7 @@ Future<Map<String, double>> _readJsonResults(Process process) {
   final StreamSubscription<String> stdoutSub = process.stdout
       .transform(const Utf8Decoder())
       .transform(const LineSplitter())
-      .listen((String line) {
+      .listen((String line) async {
     print(line);
 
     if (line.contains(jsonStart)) {
@@ -141,9 +141,11 @@ Future<Map<String, double>> _readJsonResults(Process process) {
       jsonBuf.writeln(line.substring(line.indexOf(jsonPrefix) + jsonPrefix.length));
   });
 
-  process.exitCode.then<int>((int code) {
-    stdoutSub.cancel();
-    stderrSub.cancel();
+  process.exitCode.then<int>((int code) async {
+    await Future.wait<void>(<Future<void>>[
+      stdoutSub.cancel(),
+      stderrSub.cancel(),
+    ]);
     if (!processWasKilledIntentionally && code != 0) {
       completer.completeError('flutter run failed: exit code=$code');
     }

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -115,7 +115,7 @@ Future<Map<String, double>> _readJsonResults(Process process) {
   final StreamSubscription<String> stdoutSub = process.stdout
       .transform(const Utf8Decoder())
       .transform(const LineSplitter())
-      .listen((String line) async {
+      .listen((String line) {
     print(line);
 
     if (line.contains(jsonStart)) {


### PR DESCRIPTION
This is an attempt to fix an issue in the microbenchmarks where it seems like there is a race when a process exits after writing JSON. When the process quits we complete with an error, but then the stdout processing code parses the JSON and then tries to complete again.

Here we have an error when the JSON parsing code failed and called `completeError` but the completer was already completed (which presumably was due to the process exiting around the same time the JSON was printed).

I can't repro the issue locally and it's possible that this won't fix it (it may depend on whether the cancellation waits for the existing messages in the stream to be handled).

```
Running lib/gestures/velocity_tracker_bench.dart

Executing: /Users/flutter/.cocoon/flutter/dev/devicelab/../../bin/flutter run -v --profile -d ZY223TDZ45 --no-preview-dart-2 lib/gestures/velocity_tracker_bench.dart
Force quitting process:
command : /Users/flutter/.cocoon/flutter/dev/devicelab/../../bin/flutter run -v --profile -d ZY223TDZ45 --no-preview-dart-2 lib/gestures/velocity_tracker_bench.dart
  started : 2018-07-05 02:24:23.646671
  pid     : 92801
exitcode: -15
exitcode: -15
exitcode: -15
Task failed: flutter run failed: exit code=-15

Stack trace:
dart:async                                                   _Completer.completeError
package:flutter_devicelab/tasks/microbenchmarks.dart 146:17  _readJsonResults.
===== asynchronous gap ===========================
dart:async                                                   Future.then
package:flutter_devicelab/tasks/microbenchmarks.dart 142:20  _readJsonResults
package:flutter_devicelab/tasks/microbenchmarks.dart 53:22   createMicrobenchmarkTask.._runMicrobench._run
===== asynchronous gap ===========================
dart:async                                                   _asyncThenWrapperHelper
package:flutter_devicelab/tasks/microbenchmarks.dart 27:48   createMicrobenchmarkTask.._runMicrobench._run
package:flutter_devicelab/tasks/microbenchmarks.dart 55:18   createMicrobenchmarkTask.._runMicrobench
===== asynchronous gap ===========================
dart:async                                                   _asyncThenWrapperHelper
package:flutter_devicelab/tasks/microbenchmarks.dart 22:19   createMicrobenchmarkTask.
package:flutter_devicelab/framework/framework.dart 125:36    _TaskRunner._performTask.

Task execution finished
```

I don't think this is the only issue, because:

1) The fact that it's trying to `completeError` in the JSON handling suggests the JSON that was output could not be parsed (hopefully if this fixes the race, we'll at least get the real message now)

2) The `process.kill(sigint)` code does not seem to work in my testing.. I changed it to this:

```dart
process.exitCode.then<int>((int code) {
  print('PROCESS EXITED!!');
});
print('KILLING PROCESS');
process.kill(ProcessSignal.SIGINT); // flutter run doesn't quit automatically
await new Future<void>.delayed(const Duration(seconds: 20));
print('20 seconds later...');
await new Future<void>.delayed(const Duration(seconds: 20));
print('another 20 seconds later...');
```

and `PROCESS EXITED` was not output within those 40 seconds. I believe this may be because the shell (`flutter` is a shell script so runs inside a shell) is not passing on the `sigint` to the VM. Dart Code had some similar issues and I had to use the PID from the real VM process to terminate. We may need to revisit this.