### PR TITLE
Add temporary debug prints to identify devicelab failures

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -128,8 +128,11 @@ Future<Map<String, double>> _readJsonResults(Process process) {
       process.kill(ProcessSignal.SIGINT); // flutter run doesn't quit automatically
       final String jsonOutput = jsonBuf.toString();
       try {
+        print('[DEBUG:DANTUP] Completing successfully');
         completer.complete(json.decode(jsonOutput));
+        print('[DEBUG:DANTUP] (done)');
       } catch (ex) {
+        print('[DEBUG:DANTUP] Decoding JSON failed ($ex). JSON string was: $jsonOutput');
         completer.completeError('Decoding JSON failed ($ex). JSON string was: $jsonOutput');
       }
       return;
@@ -145,6 +148,7 @@ Future<Map<String, double>> _readJsonResults(Process process) {
       stderrSub.cancel(),
     ]);
     if (!processWasKilledIntentionally && code != 0) {
+      print('[DEBUG:DANTUP] Completing with failure due to exit code=$code');
       completer.completeError('flutter run failed: exit code=$code');
     }
   });


### PR DESCRIPTION
This will be reverted after the tests have run. There's a failure in the device lab tests but we're not getting the output because the completion is failing (because the future is already completed). This just prints the exception that's occurring and also the other locations that are completing (so we know why it's trying to complete twice).