### PR TITLE
Default SnackBar duration is below Material Spec's minimum #19003

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -23,7 +23,7 @@ const Color _kSnackBackground = const Color(0xFF323232);
 // TODO(ianh): Implement the Tablet version of snackbar if we're "on a tablet".
 
 const Duration _kSnackBarTransitionDuration = const Duration(milliseconds: 250);
-const Duration _kSnackBarDisplayDuration = const Duration(milliseconds: 1500);
+const Duration _kSnackBarDisplayDuration = const Duration(milliseconds: 4000);
 const Curve _snackBarHeightCurve = Curves.fastOutSlowIn;
 const Curve _snackBarFadeCurve = const Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
 


### PR DESCRIPTION
PR for this issue https://github.com/flutter/flutter/issues/19003

Changed Material Snackbar default duration to 4 seconds as per Material Design Spec.