### PR TITLE
Hide flutter_gallery's option page if it's closed

### DIFF
--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -282,11 +282,11 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
             ),
           ),
           new Expanded(
-            child: new _TappableWhileStatusIs(
-              AnimationStatus.dismissed,
-              controller: _controller,
+            child: new Visibility(
               child: widget.backLayer,
-            ),
+              visible: _controller.status != AnimationStatus.completed,
+              maintainState: true,
+            )
           ),
         ],
       ),


### PR DESCRIPTION
This improves the flutter_gallery's transition test performance by ~10% on my Nexus5X (from 18ms to 16ms).

Previously, the option page will always be rendered, and then completely occluded later by the front page.

I wonder if we need some mechanism to detect such occlusion in framework or engine to improve the performance in general.