### PR TITLE
Fix disabled formfields trigger validation

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -71,7 +71,7 @@ class TextFormField extends FormField<String> {
     FormFieldSetter<String> onSaved,
     FormFieldValidator<String> validator,
     List<TextInputFormatter> inputFormatters,
-    bool enabled: true,
+    bool enabled = true,
     Brightness keyboardAppearance,
     EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
   }) : assert(initialValue == null || controller == null),

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -71,7 +71,7 @@ class TextFormField extends FormField<String> {
     FormFieldSetter<String> onSaved,
     FormFieldValidator<String> validator,
     List<TextInputFormatter> inputFormatters,
-    bool enabled,
+    bool enabled: true,
     Brightness keyboardAppearance,
     EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
   }) : assert(initialValue == null || controller == null),
@@ -90,6 +90,7 @@ class TextFormField extends FormField<String> {
     onSaved: onSaved,
     validator: validator,
     autovalidate: autovalidate,
+    enabled: enabled,
     builder: (FormFieldState<String> field) {
       final _TextFormFieldState state = field;
       final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -258,6 +258,10 @@ class FormField<T> extends StatefulWidget {
   final bool autovalidate;
 
   /// If true, indicates that the widget is enabled.
+  ///
+  /// Unless enabled, the widged is greyed out, does not accept focus,
+  /// performs no validation, does not save the value when the form
+  /// containing it is submitted.
   final bool enabled;
 
   @override
@@ -296,20 +300,23 @@ class FormFieldState<T> extends State<FormField<T>> {
     });
   }
 
-  /// Calls [FormField.validator] to set the [errorText]. Returns true if there
-  /// were no errors.
+  /// If [FormField.enabled] is true, calls [FormField.validator] to set the [errorText].
+  ///
+  /// Returns true if there were no errors.
   bool validate() {
-    setState(() {
-      _validate();
-    });
-    return !hasError;
+    if (widget.enabled) {
+      setState(() {
+        _validate();
+      });
+      return !hasError;
+    }
+    return true;
   }
 
   bool _validate() {
-    if (!widget.enabled)
-      _errorText = null;
-    else if (widget.validator != null)
+    if (widget.validator != null) {
       _errorText = widget.validator(_value);
+    }
     return !hasError;
   }
 
@@ -351,8 +358,9 @@ class FormFieldState<T> extends State<FormField<T>> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.autovalidate)
-      _validate();
+    if (widget.autovalidate) {
+      validate();
+    }
     Form.of(context)?._register(this);
     return widget.builder(this);
   }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -22,7 +22,7 @@ class Form extends StatefulWidget {
   const Form({
     Key key,
     @required this.child,
-    this.autovalidate: false,
+    this.autovalidate = false,
     this.onWillPop,
     this.onChanged,
   }) : assert(child != null),
@@ -227,7 +227,7 @@ class FormField<T> extends StatefulWidget {
     this.validator,
     this.initialValue,
     this.autovalidate = false,
-    this.enabled: true,
+    this.enabled = true,
   }) : assert(builder != null),
        super(key: key);
 

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -282,6 +282,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   bool get hasError => _errorText != null;
 
   /// Calls the [FormField]'s onSaved method with the current value.
+  /// If the [FormField]'s enabled is false, the method does nothing.
   void save() {
     if (widget.onSaved != null && widget.enabled)
       widget.onSaved(value);

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -257,7 +257,7 @@ class FormField<T> extends StatefulWidget {
   /// autovalidates, this value will be ignored.
   final bool autovalidate;
 
-  /// If true, indicates that the widget is enabled
+  /// If true, indicates that the widget is enabled.
   final bool enabled;
 
   @override

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -22,7 +22,7 @@ class Form extends StatefulWidget {
   const Form({
     Key key,
     @required this.child,
-    this.autovalidate = false,
+    this.autovalidate: false,
     this.onWillPop,
     this.onChanged,
   }) : assert(child != null),
@@ -227,6 +227,7 @@ class FormField<T> extends StatefulWidget {
     this.validator,
     this.initialValue,
     this.autovalidate = false,
+    this.enabled: true,
   }) : assert(builder != null),
        super(key: key);
 
@@ -256,6 +257,9 @@ class FormField<T> extends StatefulWidget {
   /// autovalidates, this value will be ignored.
   final bool autovalidate;
 
+  /// If true, indicates that the widget is enabled
+  final bool enabled;
+
   @override
   FormFieldState<T> createState() => FormFieldState<T>();
 }
@@ -279,7 +283,7 @@ class FormFieldState<T> extends State<FormField<T>> {
 
   /// Calls the [FormField]'s onSaved method with the current value.
   void save() {
-    if (widget.onSaved != null)
+    if (widget.onSaved != null && widget.enabled)
       widget.onSaved(value);
   }
 
@@ -301,7 +305,9 @@ class FormFieldState<T> extends State<FormField<T>> {
   }
 
   bool _validate() {
-    if (widget.validator != null)
+    if (!widget.enabled)
+      _errorText = null;
+    else if (widget.validator != null)
       _errorText = widget.validator(_value);
     return !hasError;
   }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -125,7 +125,7 @@ void main() {
             child: TextFormField(
               enabled: false,
               autovalidate: true,
-              validator: (String value) { _validateCalled++; return null; },
+              validator: (String value) { _validateCalled+=1; return null; },
             ),
           ),
         ),

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -119,10 +119,10 @@ void main() {
     int _validateCalled = 0;
 
     await tester.pumpWidget(
-      new MaterialApp(
-        home: new Material(
-          child: new Center(
-            child: new TextFormField(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
               enabled: false,
               autovalidate: true,
               validator: (String value) { _validateCalled++; return null; },

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -114,4 +114,28 @@ void main() {
     await tester.pump();
     expect(_validateCalled, 2);
   });
+
+  testWidgets('validate is not called if widget is disabled', (WidgetTester tester) async {
+    int _validateCalled = 0;
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Material(
+          child: new Center(
+            child: new TextFormField(
+              enabled: false,
+              autovalidate: true,
+              validator: (String value) { _validateCalled++; return null; },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(_validateCalled, 0);
+    await tester.showKeyboard(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), 'a');
+    await tester.pump();
+    expect(_validateCalled, 0);
+  });
 }


### PR DESCRIPTION
Hey,

Not sure if it's a bug or not, but I've discovered that FormFields' validate method is executed even if that field is disabled. This behavior prevents forms from submitting if you have disabled fields with validation on them.

P.S.

I've never done contributions on GitHub yet, so I hope I'm doing it right. I've read the contributing guide, but it hasn't made things easier to me :(