### PR TITLE
Adjust Cupertino controls's APIs to match Material

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -50,6 +50,7 @@ class CupertinoButton extends StatefulWidget {
     @required this.child,
     this.padding,
     this.color,
+    this.disabledColor,
     this.minSize = 44.0,
     this.pressedOpacity = 0.1,
     this.borderRadius = const BorderRadius.all(const Radius.circular(8.0)),
@@ -70,6 +71,14 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// Defaults to null which produces a button with no background or border.
   final Color color;
+
+  /// The color of the button's background when the button is disabled.
+  ///
+  /// Ignored if the [CupertinoButton] doesn't also have a [color].
+  ///
+  /// Defaults to a standard iOS disabled color when [color] is specified and
+  /// [disabledColor] is null.
+  final Color disabledColor;
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///
@@ -216,7 +225,7 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
               decoration: new BoxDecoration(
                 borderRadius: widget.borderRadius,
                 color: backgroundColor != null && !enabled
-                  ? _kDisabledBackground
+                  ? widget.disabledColor ?? _kDisabledBackground
                   : backgroundColor,
               ),
               child: new Padding(

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -57,7 +57,7 @@ class CupertinoSlider extends StatefulWidget {
     this.min = 0.0,
     this.max = 1.0,
     this.divisions,
-    this.activeColor = CupertinoColors.activeBlue,
+    this.activeColor,
   }) : assert(value != null),
        assert(min != null),
        assert(max != null),
@@ -95,7 +95,7 @@ class CupertinoSlider extends StatefulWidget {
   ///   },
   /// )
   /// ```
-  /// 
+  ///
   /// See also:
   ///
   ///  * [onChangeStart] for a callback that is called when the user starts
@@ -185,6 +185,8 @@ class CupertinoSlider extends StatefulWidget {
   final int divisions;
 
   /// The color to use for the portion of the slider that has been selected.
+  ///
+  /// Defaults to [CupertinoColors.activeBlue].
   final Color activeColor;
 
   @override
@@ -223,7 +225,7 @@ class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderSt
     return new _CupertinoSliderRenderObjectWidget(
       value: (widget.value - widget.min) / (widget.max - widget.min),
       divisions: widget.divisions,
-      activeColor: widget.activeColor,
+      activeColor: widget.activeColor ?? CupertinoColors.activeBlue,
       onChanged: widget.onChanged != null ? _handleChanged : null,
       onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
       onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -51,7 +51,7 @@ class CupertinoSwitch extends StatefulWidget {
     Key key,
     @required this.value,
     @required this.onChanged,
-    this.activeColor = CupertinoColors.activeGreen,
+    this.activeColor,
   }) : super(key: key);
 
   /// Whether this switch is on or off.
@@ -82,6 +82,8 @@ class CupertinoSwitch extends StatefulWidget {
   final ValueChanged<bool> onChanged;
 
   /// The color to use when this switch is on.
+  ///
+  /// Defaults to [CupertinoColors.activeGreen].
   final Color activeColor;
 
   @override
@@ -100,7 +102,7 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   Widget build(BuildContext context) {
     return new _CupertinoSwitchRenderObjectWidget(
       value: widget.value,
-      activeColor: widget.activeColor,
+      activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
       onChanged: widget.onChanged,
       vsync: this,
     );

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -198,6 +198,34 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('Can specify colors', (WidgetTester tester) async {
+    await tester.pumpWidget(boilerplate(child: new CupertinoButton(
+      child: const Text('Skeuomorph me'),
+      color: const Color(0x0000FF),
+      disabledColor: const Color(0x00FF00),
+      onPressed: () { },
+    )));
+
+    BoxDecoration boxDecoration = tester.widget<DecoratedBox>(
+        find.widgetWithText(DecoratedBox, 'Skeuomorph me')
+      ).decoration;
+
+    expect(boxDecoration.color, const Color(0x0000FF));
+
+    await tester.pumpWidget(boilerplate(child: const CupertinoButton(
+      child: const Text('Skeuomorph me'),
+      color: const Color(0x0000FF),
+      disabledColor: const Color(0x00FF00),
+      onPressed: null,
+    )));
+
+    boxDecoration = tester.widget<DecoratedBox>(
+        find.widgetWithText(DecoratedBox, 'Skeuomorph me')
+      ).decoration;
+
+    expect(boxDecoration.color, const Color(0x00FF00));
+  });
 }
 
 Widget boilerplate({ Widget child }) {


### PR DESCRIPTION
Extract a few changes from #17823 that should be done either way to match Cupertino controls' defaulting mechanisms to be more consistent with their Material counterparts.