### PR TITLE
Add Windows support to defaultTargetPlatform

### DIFF
--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -34,7 +34,7 @@ TargetPlatform get defaultTargetPlatform {
   TargetPlatform result;
   if (Platform.isIOS || Platform.isMacOS) {
     result = TargetPlatform.iOS;
-  } else if (Platform.isAndroid || Platform.isLinux) {
+  } else if (Platform.isAndroid || Platform.isLinux || Platform.isWindows) {
     result = TargetPlatform.android;
   } else if (Platform.operatingSystem == 'fuchsia') {
     result = TargetPlatform.fuchsia;


### PR DESCRIPTION
A significant amonut of code uses defaultTargetPlatform, so it's
currently impossible to run most apps on Windows. This adds a mapping
from Windows as a host to Android as a target, paralleling the
macOS->iOS and Linux->Android mappings.

This allows more use of Windows as a host platform (e.g., for testing,
as in issue #17768).