### PR TITLE
Use ThemeData's platform for app bar behavior

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -379,11 +379,11 @@ class _AppBarState extends State<AppBar> {
     Widget title = widget.title;
     if (title != null) {
       bool namesRoute;
-      switch (defaultTargetPlatform) {
+      switch (themeData.platform) {
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
-           namesRoute = true;
-           break;
+          namesRoute = true;
+          break;
         case TargetPlatform.iOS:
           break;
       }


### PR DESCRIPTION
The app bar uses ThemeData.platform in one case, and
defaultTargetPlatform in another. This makes it consistent in using the
target platform in ThemeData, honoring any override that may have been
set at the application level.