### PR TITLE
Rebuilding BottomNavigationBar when items.length changes

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -304,7 +304,7 @@ class _BottomNavigationTile extends StatelessWidget {
 
 class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerProviderStateMixin {
   List<AnimationController> _controllers = <AnimationController>[];
-  List<CurvedAnimation> _animations = <CurvedAnimation>[];
+  List<CurvedAnimation> _animations;
 
   // A queue of color splashes currently being animated.
   final Queue<_Circle> _circles = new Queue<_Circle>();

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -303,8 +303,8 @@ class _BottomNavigationTile extends StatelessWidget {
 }
 
 class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerProviderStateMixin {
-  List<AnimationController> _controllers;
-  List<CurvedAnimation> _animations;
+  List<AnimationController> _controllers = <AnimationController>[];
+  List<CurvedAnimation> _animations = <CurvedAnimation>[];
 
   // A queue of color splashes currently being animated.
   final Queue<_Circle> _circles = new Queue<_Circle>();
@@ -315,9 +315,13 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
 
   static final Tween<double> _flexTween = new Tween<double>(begin: 1.0, end: 1.5);
 
-  @override
-  void initState() {
-    super.initState();
+  void _resetState() {
+    for (AnimationController controller in _controllers)
+      controller.dispose();
+    for (_Circle circle in _circles)
+      circle.dispose();
+    _circles.clear();
+
     _controllers = new List<AnimationController>.generate(widget.items.length, (int index) {
       return new AnimationController(
         duration: kThemeAnimationDuration,
@@ -333,6 +337,12 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     });
     _controllers[widget.currentIndex].value = 1.0;
     _backgroundColor = widget.items[widget.currentIndex].backgroundColor;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _resetState();
   }
 
   void _rebuild() {
@@ -385,6 +395,13 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
   @override
   void didUpdateWidget(BottomNavigationBar oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    // No animated segue if the length of the items list changes.
+    if (widget.items.length != oldWidget.items.length) {
+      _resetState();
+      return;
+    }
+
     if (widget.currentIndex != oldWidget.currentIndex) {
       switch (widget.type) {
         case BottomNavigationBarType.fixed:

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -602,6 +602,44 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('BottomNavigationBar handles items.length changes', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/10322
+
+    Widget buildFrame(int itemCount) {
+      return new MaterialApp(
+        home: new Scaffold(
+          bottomNavigationBar: new BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            currentIndex: 0,
+            items: new List<BottomNavigationBarItem>.generate(itemCount, (int itemIndex) {
+              return new BottomNavigationBarItem(
+                icon: const Icon(Icons.android),
+                title: new Text('item $itemIndex'),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(3));
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('item 2'), findsOneWidget);
+    expect(find.text('item 3'), findsNothing);
+
+    await tester.pumpWidget(buildFrame(4));
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('item 2'), findsOneWidget);
+    expect(find.text('item 3'), findsOneWidget);
+
+    await tester.pumpWidget(buildFrame(2));
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('item 2'), findsNothing);
+    expect(find.text('item 3'), findsNothing);
+  });
 }
 
 Widget boilerplate({ Widget bottomNavigationBar, @required TextDirection textDirection }) {


### PR DESCRIPTION
If the length of the items list changes, just reset the navigation bar's internal state. 

Fixes: https://github.com/flutter/flutter/issues/14466
Fixes: https://github.com/flutter/flutter/issues/19125
Fixes: https://github.com/flutter/flutter/issues/10322

