### PR TITLE
Make HotRunner call pub get automatically if the pubspec is out of date.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -870,10 +870,6 @@ class _AppRunLogger extends Logger {
     bool expectSlowOperation = false,
     int progressIndicatorPadding = 52,
   }) {
-    // Ignore nested progresses; return a no-op status object.
-    if (_status != null)
-      return new Status();
-
     final int id = _nextProgressId++;
 
     _sendProgressEvent(<String, dynamic>{

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -9,6 +9,7 @@ import 'package:json_rpc_2/error_code.dart' as rpc_error_code;
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';
 
+import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
@@ -16,6 +17,7 @@ import 'base/utils.dart';
 import 'build_info.dart';
 import 'compile.dart';
 import 'dart/dependencies.dart';
+import 'dart/pub.dart';
 import 'device.dart';
 import 'globals.dart';
 import 'resident_runner.dart';
@@ -77,7 +79,7 @@ class HotRunner extends ResidentRunner {
     benchmarkData[name].add(value);
   }
 
-  bool _refreshDartDependencies() {
+  Future<bool> _refreshDartDependencies() async {
     if (!hotRunnerConfig.computeDartDependencies) {
       // Disabled.
       return true;
@@ -86,6 +88,22 @@ class HotRunner extends ResidentRunner {
       // Already computed.
       return true;
     }
+
+    try {
+      // Will return immediately if pubspec.yaml is up-to-date.
+      await pubGet(
+        context: PubContext.pubGet,
+        directory: projectRootPath,
+      );
+    } on ToolExit catch (error) {
+      printError(
+        'Unable to reload your application because "flutter packages get" failed to update '
+        'package dependencies.\n'
+        '$error'
+      );
+      return false;
+    }
+
     final DartDependencySetBuilder dartDependencySetBuilder =
         new DartDependencySetBuilder(mainPath, packagesFilePath);
     try {
@@ -230,7 +248,7 @@ class HotRunner extends ResidentRunner {
     }
 
     // Determine the Dart dependencies eagerly.
-    if (!_refreshDartDependencies()) {
+    if (!await _refreshDartDependencies()) {
       // Some kind of source level error or missing file in the Dart code.
       return 1;
     }
@@ -282,7 +300,7 @@ class HotRunner extends ResidentRunner {
   }
 
   Future<bool> _updateDevFS({ bool fullRestart = false }) async {
-    if (!_refreshDartDependencies()) {
+    if (!await _refreshDartDependencies()) {
       // Did not update DevFS because of a Dart source error.
       return false;
     }


### PR DESCRIPTION
This adds a call to 'pub get' if the pubspec.yaml is out of date wrt the .packages file when a hot reload is requested.

This PR is missing tests, however there is a dearth of tests for `HotRunner` because of the effort needed to set up an appropriate test environment. I'd like to fix that, but I think it's out of scope for this PR.

Fixes #15879