### PR TITLE
Use binary name to locate .packages file on Fuchsia

### DIFF
--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -326,17 +326,19 @@ class FuchsiaReloadCommand extends FlutterCommand {
     if (!_fileExists(_target))
       throwToolExit('Couldn\'t find application entry point at $_target.');
 
-    final String packagesFileName = '${_projectName}_dart_library.packages';
-    _dotPackagesPath = '$_buildDir/dartlang/gen/$_projectRoot/$packagesFileName';
-    if (!_fileExists(_dotPackagesPath))
-      throwToolExit('Couldn\'t find .packages file at $_dotPackagesPath.');
-
     final String nameOverride = argResults['name-override'];
     if (nameOverride == null) {
       _binaryName = _projectName;
     } else {
       _binaryName = nameOverride;
     }
+
+    // When there's an override of the on-device binary name, use that name
+    // to locate the .packages file.
+    final String packagesFileName = '${_binaryName}_dart_library.packages';
+    _dotPackagesPath = '$_buildDir/dartlang/gen/$_projectRoot/$packagesFileName';
+    if (!_fileExists(_dotPackagesPath))
+      throwToolExit('Couldn\'t find .packages file at $_dotPackagesPath.');
 
     final String isolateNumber = argResults['isolate-number'];
     if (isolateNumber == null) {


### PR DESCRIPTION
The topaz/examples/ui/hello_material project builds multiple mods, e.g. hello_material_jit, hello_material_aot, etc. To hot reload the hello_material_jit mod using the flutter tool you have to issue the following command:

flutter fuchsia_reload -b ~/fuchsia/out/x64 -a 192.168.42.47 -g //topaz/examples/ui/hello_material:hello_material -t main.dart -n hello_material_jit

where you override the default name of the on-device binary. However flutter tool still uses the project name for the .packages file. The above command fails because the tool cannot locate hello_material_dart_library.packages when it should instead look for hello_material_jit_dart_library.packages. This cl changes the flutter tool to use the override name (if supplied) to find the .packages file.