### PR TITLE
Fix 'are there any views available' check

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -636,7 +636,7 @@ abstract class ResidentRunner {
           compileExpression: compileExpression);
       await device.getVMs();
       await device.waitForViews();
-      if (device.views == null)
+      if (device.views.isEmpty)
         printStatus('No Flutter views available on ${device.device.name}');
       else
         viewFound = true;


### PR DESCRIPTION
`device.views` can never be null, it can be empty however.