### PR TITLE
Ensure timeouts in flutter_tools integration tests include all messages received

### DIFF
--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -150,8 +150,8 @@ class FlutterTestDriver {
     final VM vm = await vmService.getVM();
     final VMIsolate isolate = await vm.isolates.first.load();
     debugPrint('Waiting for isolate to pause');
-    await isolate.waitUntilPaused()
-        .timeout(defaultTimeout, onTimeout: () => throw 'Isolate did not pause');
+    await _timeoutWithMessages<dynamic>(isolate.waitUntilPaused(),
+        message: 'Isolate did not pause');
     return isolate.load();
   }
 
@@ -164,8 +164,8 @@ class FlutterTestDriver {
     final VM vm = await vmService.getVM();
     final VMIsolate isolate = await vm.isolates.first.load();
     debugPrint('Sending resume ($step)');
-    await isolate.resume(step: step)
-        .timeout(defaultTimeout, onTimeout: () => throw 'Isolate did not respond to resume ($step)');
+    await _timeoutWithMessages<dynamic>(isolate.resume(step: step),
+        message: 'Isolate did not respond to resume ($step)');
     return wait ? waitForPause() : null;
   }
 
@@ -185,8 +185,8 @@ class FlutterTestDriver {
 
   Future<VMInstanceRef> evaluateExpression(String expression) async {
     final VMFrame topFrame = await getTopStackFrame();
-    return topFrame.evaluate(expression)
-        .timeout(defaultTimeout, onTimeout: () => throw 'Timed out evaluating expression ($expression)');
+    return _timeoutWithMessages(topFrame.evaluate(expression),
+        message: 'Timed out evaluating expression ($expression)');
   }
 
   Future<VMFrame> getTopStackFrame() async {

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -209,8 +209,13 @@ class FlutterTestDriver {
     // Capture output to a buffer so if we don't get the repsonse we want we can show
     // the output that did arrive in the timeout error.
     final StringBuffer messages = new StringBuffer();
-    _stdout.stream.listen(messages.writeln);
-    _stderr.stream.listen(messages.writeln);
+    final DateTime start = new DateTime.now();
+    void logMessage(String m) {
+      final int ms = new DateTime.now().difference(start).inMilliseconds;
+      messages.writeln('[+ ${ms.toString().padLeft(5)}] $m');
+    }
+    _stdout.stream.listen(logMessage);
+    _stderr.stream.listen(logMessage);
 
     final Completer<Map<String, dynamic>> response = new Completer<Map<String, dynamic>>();
     final StreamSubscription<String> sub = _stdout.stream.listen((String line) {


### PR DESCRIPTION
These integration tests had a bunch of places doing `.timeout()` on futures, but didn't give much info when they timed out.

This creates a `_timeoutWithMessages` method that will log all messages (stdin, stdout and stderr for the `flutter run` process and also the input/output to VM service protocol) in the timeout message.

Also increases the app start timeout slightly because I saw a [failure](https://travis-ci.org/flutter/flutter/jobs/402340869) where the `app.started` event hadn't come through within the original default (20 seconds) and I hope it was just a bit slow on the CI rather than broken.