### PR TITLE
update Text finder to convert Text.rich to plain text for comparison

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -476,7 +476,9 @@ class _TextFinder extends MatchFinder {
   bool matches(Element candidate) {
     if (candidate.widget is Text) {
       final Text textWidget = candidate.widget;
-      return textWidget.data == text;
+      if (textWidget.data != null)
+        return textWidget.data == text;
+      return textWidget.textSpan.toPlainText() == text;
     } else if (candidate.widget is EditableText) {
       final EditableText editable = candidate.widget;
       return editable.controller.text == text;

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -7,6 +7,28 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('text', () {
+    testWidgets('finds Text widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+        const Text('test'),
+      ));
+      expect(find.text('test'), findsOneWidget);
+    });
+  
+    testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+        const Text.rich(
+          TextSpan(text: 't', children: <TextSpan>[
+            const TextSpan(text: 'e'),
+            const TextSpan(text: 'st'),
+          ]
+        ),
+      )));
+
+      expect(find.text('test'), findsOneWidget);
+    });
+  });
+
   group('hitTestable', () {
     testWidgets('excludes non-hit-testable widgets', (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
Allows users to find widgets constructed with `Text.rich` using the text finder.

Fixes https://github.com/flutter/flutter/issues/19267