### PR TITLE
Make cleanup of flutter processes in tests more reliable

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -121,6 +121,7 @@ class ProcessSignal implements io.ProcessSignal {
   static const ProcessSignal SIGUSR1 = const _PosixProcessSignal._(io.ProcessSignal.SIGUSR1); // ignore: deprecated_member_use
   static const ProcessSignal SIGUSR2 = const _PosixProcessSignal._(io.ProcessSignal.SIGUSR2); // ignore: deprecated_member_use
   static const ProcessSignal SIGINT =  const ProcessSignal(io.ProcessSignal.SIGINT); // ignore: deprecated_member_use
+  static const ProcessSignal SIGKILL =  const ProcessSignal(io.ProcessSignal.SIGKILL); // ignore: deprecated_member_use
 
   final io.ProcessSignal _delegate;
 

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -116,12 +116,12 @@ class ProcessSignal implements io.ProcessSignal {
   @visibleForTesting
   const ProcessSignal(this._delegate);
 
-  static const ProcessSignal SIGWINCH = const _PosixProcessSignal._(io.ProcessSignal.SIGWINCH); // ignore: deprecated_member_use
-  static const ProcessSignal SIGTERM = const _PosixProcessSignal._(io.ProcessSignal.SIGTERM); // ignore: deprecated_member_use
-  static const ProcessSignal SIGUSR1 = const _PosixProcessSignal._(io.ProcessSignal.SIGUSR1); // ignore: deprecated_member_use
-  static const ProcessSignal SIGUSR2 = const _PosixProcessSignal._(io.ProcessSignal.SIGUSR2); // ignore: deprecated_member_use
-  static const ProcessSignal SIGINT =  const ProcessSignal(io.ProcessSignal.SIGINT); // ignore: deprecated_member_use
-  static const ProcessSignal SIGKILL =  const ProcessSignal(io.ProcessSignal.SIGKILL); // ignore: deprecated_member_use
+  static const ProcessSignal SIGWINCH = const _PosixProcessSignal._(io.ProcessSignal.sigwinch);
+  static const ProcessSignal SIGTERM = const _PosixProcessSignal._(io.ProcessSignal.sigterm);
+  static const ProcessSignal SIGUSR1 = const _PosixProcessSignal._(io.ProcessSignal.sigusr1);
+  static const ProcessSignal SIGUSR2 = const _PosixProcessSignal._(io.ProcessSignal.sigusr2);
+  static const ProcessSignal SIGINT =  const ProcessSignal(io.ProcessSignal.sigint);
+  static const ProcessSignal SIGKILL =  const ProcessSignal(io.ProcessSignal.sigkill);
 
   final io.ProcessSignal _delegate;
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -64,7 +64,7 @@ class FlutterTestDriver {
     _stdout.stream.listen(_debugPrint);
     _stderr.stream.listen(_debugPrint);
 
-    // Stash the PID so that we can terminate the VM more reliable than using
+    // Stash the PID so that we can terminate the VM more reliably than using
     // _proc.kill() (because _proc is a shell, because `flutter` is a shell
     // script).
     final Map<String, dynamic> connected = await _waitFor(event: 'daemon.connected');

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -124,7 +124,7 @@ class FlutterTestDriver {
       _debugPrint('Closing VM service');
       await vmService.close()
           .timeout(quitTimeout,
-              onTimeout: () => _debugPrint('VM Service did not quit within $quitTimeout'));
+              onTimeout: () { _debugPrint('VM Service did not quit within $quitTimeout'); });
     }
     if (_currentRunningAppId != null) {
       _debugPrint('Stopping app');
@@ -133,7 +133,7 @@ class FlutterTestDriver {
         <String, dynamic>{'appId': _currentRunningAppId}
       ).timeout(
         quitTimeout,
-        onTimeout: () => _debugPrint('app.stop did not return within $quitTimeout')
+        onTimeout: () { _debugPrint('app.stop did not return within $quitTimeout'); }
       );
       _currentRunningAppId = null;
     }

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -121,11 +121,13 @@ class FlutterTestDriver {
 
   Future<int> stop() async {
     if (vmService != null) {
+      _debugPrint('Closing VM service');
       await vmService.close()
           .timeout(quitTimeout,
               onTimeout: () => _debugPrint('VM Service did not quit within $quitTimeout'));
     }
     if (_currentRunningAppId != null) {
+      _debugPrint('Stopping app');
       await _sendRequest(
         'app.stop',
         <String, dynamic>{'appId': _currentRunningAppId}
@@ -135,6 +137,7 @@ class FlutterTestDriver {
       );
       _currentRunningAppId = null;
     }
+    _debugPrint('Waiting for process to end');
     return _proc.exitCode.timeout(quitTimeout, onTimeout: _killGracefully);
   }
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -20,10 +20,12 @@ import '../src/common.dart';
 const bool _printJsonAndStderr = false;
 const Duration defaultTimeout = const Duration(seconds: 20);
 const Duration appStartTimeout = const Duration(seconds: 60);
+const Duration quitTimeout = const Duration(seconds: 5);
 
 class FlutterTestDriver {
   Directory _projectFolder;
   Process _proc;
+  int _procPid;
   final StreamController<String> _stdout = new StreamController<String>.broadcast();
   final StreamController<String> _stderr = new StreamController<String>.broadcast();
   final StreamController<String> _allMessages = new StreamController<String>.broadcast();
@@ -62,6 +64,12 @@ class FlutterTestDriver {
     _stdout.stream.listen(_debugPrint);
     _stderr.stream.listen(_debugPrint);
 
+    // Stash the PID so that we can terminate the VM more reliable than using
+    // _proc.kill() (because _proc is a shell, because `flutter` is a shell
+    // script).
+    final Map<String, dynamic> connected = await _waitFor(event: 'daemon.connected');
+    _procPid = connected['params']['pid'];
+    
     // Set this up now, but we don't wait it yet. We want to make sure we don't
     // miss it while waiting for debugPort below.
     final Future<Map<String, dynamic>> started = _waitFor(event: 'app.started',
@@ -113,15 +121,34 @@ class FlutterTestDriver {
 
   Future<int> stop() async {
     if (vmService != null) {
-      await vmService.close();
+      await vmService.close()
+          .timeout(quitTimeout,
+              onTimeout: () => _debugPrint('VM Service did not quit within $quitTimeout'));
     }
     if (_currentRunningAppId != null) {
       await _sendRequest(
-          'app.stop',
-          <String, dynamic>{'appId': _currentRunningAppId}
+        'app.stop',
+        <String, dynamic>{'appId': _currentRunningAppId}
+      ).timeout(
+        quitTimeout,
+        onTimeout: () => _debugPrint('app.stop did not return within $quitTimeout')
       );
+      _currentRunningAppId = null;
     }
-    _currentRunningAppId = null;
+    return _proc.exitCode.timeout(quitTimeout, onTimeout: _killGracefully);
+  }
+
+  Future<int> _killGracefully() async {
+    if (_procPid == null)
+      return -1;
+    _debugPrint('Sending SIGINT to $_procPid..');
+    Process.killPid(_procPid);
+    return _proc.exitCode.timeout(quitTimeout, onTimeout: _killForcefully);
+  }
+
+  Future<int> _killForcefully() {
+    _debugPrint('Sending SIGTERM to $_procPid..');
+    Process.killPid(_procPid, ProcessSignal.SIGTERM);
     return _proc.exitCode;
   }
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -141,14 +141,14 @@ class FlutterTestDriver {
   Future<int> _killGracefully() async {
     if (_procPid == null)
       return -1;
-    _debugPrint('Sending SIGINT to $_procPid..');
+    _debugPrint('Sending SIGTERM to $_procPid..');
     Process.killPid(_procPid);
     return _proc.exitCode.timeout(quitTimeout, onTimeout: _killForcefully);
   }
 
   Future<int> _killForcefully() {
-    _debugPrint('Sending SIGTERM to $_procPid..');
-    Process.killPid(_procPid, ProcessSignal.SIGTERM);
+    _debugPrint('Sending SIGKILL to $_procPid..');
+    Process.killPid(_procPid, ProcessSignal.SIGKILL);
     return _proc.exitCode;
   }
 


### PR DESCRIPTION
I've sometimes seen `flutter` and `flutter_tester` processes hanging around while working on these tests. This changes adds some timeouts to the various things done in the cleanup code and gets progressively more aggressive with termination (first app.stop, then SIGINT, then SIGTERM) to try and eliminate the processes.

This may not catch all cases - if you Ctrl+C to terminate tests, the test framework will first try to allow the current test to complete and then run the cleanup, but it's possible to force terminate and the cleanup will be skipped (I guess this is the same for any process - SIGTERM doesn't allow processes to do any cleanup).

@gspencergoog I don't know if this fixes the instances you saw, but it seems to have fixed a few at least - I could leak some processes before this change and didn't managed with it. Do let me know if you have steps to leak any more though.