### PR TITLE
Removes trailing whitespace from source files.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -123,6 +123,13 @@ Future<Null> _analyzeRepo() async {
     options: <String>['--flutter-repo', '--watch', '--benchmark'],
   );
 
+  if (!Platform.isWindows) {
+    await _runCommand('grep',
+      <String>['--exclude-dir', '.pub-cache', '--exclude-dir', 'cache',  path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart')],
+      workingDirectory: flutterRoot,
+    );
+  }
+
   // Try an analysis against a big version of the gallery.
   await _runCommand(dart,
     <String>['--preview-dart-2', path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart')],

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -95,37 +95,6 @@ Future<Null> _verifyInternationalizations() async {
   print('Contents of $localizationsFile matches output of gen_localizations.dart script.');
 }
 
-Future<Null> _checkForTrailingSpaces() async {
-  if (!Platform.isWindows) {
-    print('Checking for trailing whitespace in source files.');
-    final List<String> fileTypes = <String>[
-      '*.dart', '*.cxx', '*.cpp', '*.cc', '*.c', '*.C', '*.h', '*.java', '*.mm', '*.m',
-    ];
-    final EvalResult changedFilesResult = await _evalCommand(
-      'git', <String>['diff', '-U0', '--no-color', '--name-only', 'master', '--'] + fileTypes,
-      workingDirectory: flutterRoot,
-    );
-    if (changedFilesResult.stdout == null) {
-      print('No Results for whitespace check.');
-      return;
-    }
-    final List<String> changedFiles = changedFilesResult.stdout.trim().split('\n');
-    if (changedFiles.isNotEmpty) {
-      await _runCommand('grep',
-        <String>[
-          '--line-number',
-          '--extended-regexp',
-          r'[[:space:]]+$',
-        ] + changedFiles,
-        workingDirectory: flutterRoot,
-        printOutput: false,
-        expectFailure: true, // Just means a non-zero exit code is expected.
-        expectedExitCode: 1, // Indicates that zero lines were found.
-      );
-    }
-  }
-}
-
 Future<Null> _analyzeRepo() async {
   await _verifyGeneratedPluginRegistrants(flutterRoot);
   await _verifyNoBadImportsInFlutter(flutterRoot);
@@ -153,8 +122,6 @@ Future<Null> _analyzeRepo() async {
   await _runFlutterAnalyze(flutterRoot,
     options: <String>['--flutter-repo', '--watch', '--benchmark'],
   );
-
-  await _checkForTrailingSpaces();
 
   // Try an analysis against a big version of the gallery.
   await _runCommand(dart,
@@ -364,7 +331,6 @@ Future<Null> _runCommand(String executable, List<String> arguments, {
   String workingDirectory,
   Map<String, String> environment,
   bool expectFailure = false,
-  int expectedExitCode,
   bool printOutput = true,
   bool skip = false,
   Duration timeout = _kLongTimeout,
@@ -397,7 +363,7 @@ Future<Null> _runCommand(String executable, List<String> arguments, {
     stderr.writeln('Process timed out after $timeout');
     return expectFailure ? 0 : 1;
   });
-  if ((exitCode == 0) == expectFailure || (expectedExitCode != null && exitCode != expectedExitCode)) {
+  if ((exitCode == 0) == expectFailure) {
     if (!printOutput) {
       stdout.writeln(utf8.decode((await savedStdout).expand((List<int> ints) => ints).toList()));
       stderr.writeln(utf8.decode((await savedStderr).expand((List<int> ints) => ints).toList()));

--- a/examples/flutter_view/ios/Runner/NativeViewController.h
+++ b/examples/flutter_view/ios/Runner/NativeViewController.h
@@ -11,7 +11,7 @@
 
 @end
 
-@interface NativeViewController: UIViewController 
+@interface NativeViewController: UIViewController
 @property (strong, nonatomic) id<NativeViewControllerDelegate> delegate;
 - (void) didReceiveIncrement;
 @end

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 /// Efficiently converts the response body of an [HttpClientResponse] into a [Uint8List].
-/// 
+///
 /// The future returned will forward all errors emitted by [response].
 Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response) {
   // response.contentLength is not trustworthy when GZIP is involved
@@ -28,6 +28,6 @@ Future<Uint8List> consolidateHttpClientResponseBytes(HttpClientResponse response
     }
     completer.complete(bytes);
   }, onError: completer.completeError, cancelOnError: true);
-  
+
   return completer.future;
 }

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -587,7 +587,7 @@ class _MaterialAppState extends State<MaterialApp> {
         },
       )
     );
-    
+
     assert(() {
       if (widget.debugShowMaterialGrid) {
         result = new GridPaper(

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -217,15 +217,15 @@ class AlertDialog extends StatelessWidget {
   /// from the [actions].
   final List<Widget> actions;
 
-  /// The semantic label of the dialog used by accessibility frameworks to 
+  /// The semantic label of the dialog used by accessibility frameworks to
   /// announce screen transitions when the dialog is opened and closed.
-  /// 
+  ///
   /// If this label is not provided, a semantic label will be infered from the
   /// [title] if it is not null.  If there is no title, the label will be taken
   /// from [MaterialLocalizations.alertDialogLabel].
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [SemanticsConfiguration.isRouteName], for a description of how this
   ///    value is used.
   final String semanticLabel;
@@ -475,15 +475,15 @@ class SimpleDialog extends StatelessWidget {
   /// the top padding ends up being 24 pixels.
   final EdgeInsetsGeometry contentPadding;
 
-  /// The semantic label of the dialog used by accessibility frameworks to 
+  /// The semantic label of the dialog used by accessibility frameworks to
   /// announce screen transitions when the dialog is opened and closed.
-  /// 
+  ///
   /// If this label is not provided, a semantic label will be infered from the
   /// [title] if it is not null.  If there is no title, the label will be taken
   /// from [MaterialLocalizations.dialogLabel].
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [SemanticsConfiguration.isRouteName], for a description of how this
   ///    value is used.
   final String semanticLabel;

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -144,19 +144,19 @@ abstract class MaterialLocalizations {
   /// user interaction with elements behind it.
   String get modalBarrierDismissLabel;
 
-  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a 
+  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a
   /// drawer widget is opened.
   String get drawerLabel;
- 
-  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a 
+
+  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a
   /// popup menu widget is opened.
   String get popupMenuLabel;
 
-  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a 
+  /// Label read out by accessibility tools (TalkBack or VoiceOver) when a
   /// dialog widget is opened.
   String get dialogLabel;
 
-  /// Label read out by accessibility tools (TalkBack or VoiceOver) when an 
+  /// Label read out by accessibility tools (TalkBack or VoiceOver) when an
   /// alert dialog widget is opened.
   String get alertDialogLabel;
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -688,12 +688,12 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 /// The `context` argument is used to look up the [Navigator] and [Theme] for
 /// the menu. It is only used when the method is called. Its corresponding
 /// widget can be safely removed from the tree before the popup menu is closed.
-/// 
-/// The `semanticLabel` argument is used by accessibility frameworks to 
-/// announce screen transitions when the menu is opened and closed. If this 
-/// label is not provided, it will default to 
+///
+/// The `semanticLabel` argument is used by accessibility frameworks to
+/// announce screen transitions when the menu is opened and closed. If this
+/// label is not provided, it will default to
 /// [MaterialLocalizations.popupMenuLabel].
-/// 
+///
 /// See also:
 ///
 ///  * [PopupMenuItem], a popup menu entry for a single value.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -280,9 +280,9 @@ class TextField extends StatefulWidget {
   final bool enabled;
 
   /// The appearance of the keyboard.
-  /// 
+  ///
   /// This setting is only honored on iOS devices.
-  /// 
+  ///
   /// If unset, defaults to the brightness of [ThemeData.primaryColorBrightness].
   final Brightness keyboardAppearance;
 

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -113,10 +113,10 @@ class TextTheme extends Diagnosticable {
   /// /// descendants, while leaving other ambient theme attributes alone.
   /// class TitleColorThemeCopy extends StatelessWidget {
   ///   TitleColorThemeCopy({Key key, this.child, this.titleColor}) : super(key: key);
-  /// 
+  ///
   ///   final Color titleColor;
   ///   final Widget child;
-  /// 
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     final ThemeData theme = Theme.of(context);
@@ -192,10 +192,10 @@ class TextTheme extends Diagnosticable {
   /// /// descendants, while leaving other ambient theme attributes alone.
   /// class TitleColorTheme extends StatelessWidget {
   ///   TitleColorTheme({Key key, this.child, this.titleColor}) : super(key: key);
-  /// 
+  ///
   ///   final Color titleColor;
   ///   final Widget child;
-  /// 
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -443,10 +443,10 @@ class LinearGradient extends Gradient {
 /// A normal radial gradient has a [center] and a [radius]. The [center] point
 /// corresponds to 0.0, and the ring at [radius] from the center corresponds
 /// to 1.0. These lengths are expressed in fractions, so that the same gradient
-/// can be reused with varying sized boxes without changing the parameters. 
+/// can be reused with varying sized boxes without changing the parameters.
 /// (This contrasts with [new ui.Gradient.radial], whose arguments are expressed
 /// in logical pixels.)
-/// 
+///
 /// It is also possible to create a two-point (or focal pointed) radial gradient
 /// (which is sometimes referred to as a two point conic gradient, but is not the
 /// same as a CSS conic gradient which corresponds to a [SweepGradient]). A [focal]
@@ -454,7 +454,7 @@ class LinearGradient extends Gradient {
 /// which will make the rendered gradient appear to be pointed or directed in the
 /// direction of the [focal] point. This is only important if [focal] and [center]
 /// are not equal or [focalRadius] > 0.0 (as this case is visually identical to a
-/// normal radial gradient).  One important case to avoid is having [focal] and 
+/// normal radial gradient).  One important case to avoid is having [focal] and
 /// [center] both resolve to [Offset.zero] when [focalRadius] > 0.0. In such a case,
 /// a valid shader cannot be created by the framework.
 ///
@@ -553,17 +553,17 @@ class RadialGradient extends Gradient {
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_clamp_radial.png)
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_mirror_radial.png)
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_repeated_radial.png)
-  /// 
+  ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_clamp_radialWithFocal.png)
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_mirror_radialWithFocal.png)
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/tile_mode_repeated_radialWithFocal.png)
   final TileMode tileMode;
 
   /// The focal point of the gradient.  If specified, the gradient will appear
-  /// to be focused along the vector from [center] to focal. 
-  /// 
+  /// to be focused along the vector from [center] to focal.
+  ///
   /// See [center] for a description of how the coordinates are mapped.
-  /// 
+  ///
   /// If this value is specified and [focalRadius] > 0.0, care should be taken
   /// to ensure that either this value or [center] will not both resolve to
   /// [Offset.zero], which would fail to create a valid gradient.
@@ -575,7 +575,7 @@ class RadialGradient extends Gradient {
   /// For example, if a radial gradient is painted on a box that is
   /// 100.0 pixels wide and 200.0 pixels tall, then a radius of 1.0
   /// will place the 1.0 stop at 100.0 pixels from the [focus].
-  /// 
+  ///
   /// If this value is specified and is greater than 0.0, either [focal] or
   /// [center] must not resolve to [Offset.zero], which would fail to create
   /// a valid gradient.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -50,7 +50,7 @@ const String _kColorForegroundWarning = 'Cannot provide both a color and a foreg
 /// [RichText] widget is explicitly given the ambient [DefaultTextStyle], since
 /// [RichText] does not do that automatically. The inner [TextStyle] objects are
 /// implicitly mixed with the parent [TextSpan]'s [TextSpan.style].
-/// 
+///
 /// If [color] is specified, [foreground] must be null and vice versa. [color] is
 /// treated as a shorthand for `new Paint()..color = color`.
 ///
@@ -260,10 +260,10 @@ class TextStyle extends Diagnosticable {
   final bool inherit;
 
   /// The color to use when painting the text.
-  /// 
+  ///
   /// If [foreground] is specified, this value must be null. The [color] property
   /// is shorthand for `new Paint()..color = color`.
-  ///   
+  ///
   /// In [merge], [apply], and [lerp], conflicts between [color] and [foreground]
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
@@ -331,15 +331,15 @@ class TextStyle extends Diagnosticable {
   /// styles are created with the same paint settings. Otherwise, each time it
   /// will appear like the style changed, which will result in unnecessary
   /// updates all the way through the framework.
-  /// 
+  ///
   /// If [color] is specified, this value must be null. The [color] property
   /// is shorthand for `new Paint()..color = color`.
-  /// 
+  ///
   /// In [merge], [apply], and [lerp], conflicts between [color] and [foreground]
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
-  final Paint foreground;  
-  
+  final Paint foreground;
+
   /// The paint drawn as a background for the text.
   ///
   /// The value should ideally be cached and reused each time if multiple text
@@ -372,7 +372,7 @@ class TextStyle extends Diagnosticable {
 
   /// Creates a copy of this text style but with the given fields replaced with
   /// the new values.
-  /// 
+  ///
   /// One of [color] or [foreground] must be null, and if this has [foreground]
   /// specified it will be given preference over any color parameter.
   TextStyle copyWith({
@@ -426,7 +426,7 @@ class TextStyle extends Diagnosticable {
   ///
   /// The non-numeric properties [color], [fontFamily], [decoration],
   /// [decorationColor] and [decorationStyle] are replaced with the new values.
-  /// 
+  ///
   /// [foreground] will be given preference over [color] if it is not null.
   ///
   /// The numeric properties are multiplied by the given factors and then
@@ -444,7 +444,7 @@ class TextStyle extends Diagnosticable {
   ///
   /// If the underlying values are null, then the corresponding factors and/or
   /// deltas must not be specified.
-  /// 
+  ///
   /// If [foreground] is specified on this object, then applying [color] here
   /// will have no effect.
   TextStyle apply({
@@ -520,7 +520,7 @@ class TextStyle extends Diagnosticable {
   /// inherit properties of this style.
   ///
   /// If the given text style is null, returns this text style.
-  /// 
+  ///
   /// One of [color] or [foreground] must be null, and if this or `other` has
   /// [foreground] specified it will be given preference over any color parameter.
   TextStyle merge(TextStyle other) {
@@ -571,7 +571,7 @@ class TextStyle extends Diagnosticable {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  /// 
+  ///
   /// If [foreground] is specified on either of `a` or `b`, both will be treated
   /// as if they have a [foreground] paint (creating a new [Paint] if necessary
   /// based on the [color] property).
@@ -645,7 +645,7 @@ class TextStyle extends Diagnosticable {
       height: ui.lerpDouble(a.height ?? b.height, b.height ?? a.height, t),
       locale: t < 0.5 ? a.locale : b.locale,
       foreground: (a.foreground != null || b.foreground != null)
-        ? t < 0.5 
+        ? t < 0.5
           ? a.foreground ?? (new Paint()..color = a.color)
           : b.foreground ?? (new Paint()..color = b.color)
         : null,

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -58,24 +58,24 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 ///   leader,
 ///   follower,
 /// }
-/// 
+///
 /// class FollowTheLeader extends MultiChildLayoutDelegate {
 ///   @override
 ///   void performLayout(Size size) {
 ///     Size leaderSize = Size.zero;
-/// 
+///
 ///     if (hasChild(_Slot.leader)) {
 ///       leaderSize = layoutChild(_Slot.leader, new BoxConstraints.loose(size));
 ///       positionChild(_Slot.leader, Offset.zero);
 ///     }
-/// 
+///
 ///     if (hasChild(_Slot.follower)) {
 ///       layoutChild(_Slot.follower, new BoxConstraints.tight(leaderSize));
 ///       positionChild(_Slot.follower, new Offset(size.width - leaderSize.width,
 ///           size.height - leaderSize.height));
 ///     }
 ///   }
-/// 
+///
 ///   @override
 ///   bool shouldRelayout(MultiChildLayoutDelegate oldDelegate) => false;
 /// }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -214,7 +214,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     final Offset bottom = new Offset(bounds.center.dx, bounds.center.dy - ui.window.padding.bottom / ui.window.devicePixelRatio);
     final SystemUiOverlayStyle upperOverlayStyle = layer.find<SystemUiOverlayStyle>(top);
     // Only android has a customizable system navigation bar.
-    SystemUiOverlayStyle lowerOverlayStyle; 
+    SystemUiOverlayStyle lowerOverlayStyle;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         lowerOverlayStyle = layer.find<SystemUiOverlayStyle>(bottom);

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -417,8 +417,8 @@ class SemanticsProperties extends DiagnosticableTree {
 
   /// If non-null, whether the node corresponds to the root of a subtree for
   /// which a route name should be announced.
-  /// 
-  /// Generally, this is set in combination with [explicitChildNodes], since 
+  ///
+  /// Generally, this is set in combination with [explicitChildNodes], since
   /// nodes with this flag are not considered focusable by Android or iOS.
   ///
   /// See also:
@@ -430,7 +430,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// If non-null, whether the node contains the semantic label for a route.
   ///
   /// See also:
-  /// 
+  ///
   ///  * [SemanticsFlag.namesRoute] for a description of how the name is used.
   final bool namesRoute;
 
@@ -2571,7 +2571,7 @@ class SemanticsConfiguration {
 
   /// Whether the semantics node is the root of a subtree for which values
   /// should be announced.
-  /// 
+  ///
   /// See also:
   ///  * [SemanticsFlag.scopesRoute], for a full description of route scoping.
   bool get scopesRoute => _hasFlag(SemanticsFlag.scopesRoute);
@@ -2580,7 +2580,7 @@ class SemanticsConfiguration {
   }
 
   /// Whether the semantics node contains the label of a route.
-  /// 
+  ///
   /// See also:
   ///  * [SemanticsFlag.namesRoute], for a full description of route naming.
   bool get namesRoute => _hasFlag(SemanticsFlag.namesRoute);

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -90,7 +90,7 @@ class AnnounceSemanticsEvent extends SemanticsEvent {
 }
 
 /// An event for a semantic announcement of a tooltip.
-/// 
+///
 /// This is only used by Android to announce tooltip values.
 class TooltipSemanticsEvent extends SemanticsEvent {
 

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -33,7 +33,7 @@ class SemanticsService {
   }
 
   /// Sends a semantic announcement of a tooltip.
-  /// 
+  ///
   /// Currently only honored on Android. The contents of [message] will be
   /// read by TalkBack.
   static Future<Null> tooltip(String message) async {

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -130,32 +130,32 @@ class SystemUiOverlayStyle {
   });
 
   /// The color of the system bottom navigation bar.
-  /// 
+  ///
   /// Only honored in Android versions O and greater.
   final Color systemNavigationBarColor;
 
   /// The color of the divider between the system's bottom navigation bar and the app's content.
-  /// 
+  ///
   /// Only honored in Android versions P and greater.
   final Color systemNavigationBarDividerColor;
 
   /// The brightness of the system navigation bar icons.
-  /// 
+  ///
   /// Only honored in Android versions O and greater.
   final Brightness systemNavigationBarIconBrightness;
 
   /// The color of top status bar.
-  /// 
+  ///
   /// Only honored in Android version M and greater.
   final Color statusBarColor;
 
   /// The brightness of top status bar.
-  /// 
+  ///
   /// Only honored in iOS.
   final Brightness statusBarBrightness;
 
   /// The brightness of the top status bar icons.
-  /// 
+  ///
   /// Only honored in Android version M and greater.
   final Brightness statusBarIconBrightness;
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -369,9 +369,9 @@ class TextInputConfiguration {
   final TextInputAction inputAction;
 
   /// The appearance of the keyboard.
-  /// 
+  ///
   /// This setting is only honored on iOS devices.
-  /// 
+  ///
   /// Defaults to [Brightness.light].
   final Brightness keyboardAppearance;
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4259,8 +4259,8 @@ class Flow extends MultiChildRenderObjectWidget {
 ///
 /// Consider using the [Text] widget to integrate with the [DefaultTextStyle]
 /// automatically. When all the text uses the same style, the default constructor
-/// is less verbose. The [Text.rich] constructor allows you to style multiple 
-/// spans with the default text style while still allowing specified styles per 
+/// is less verbose. The [Text.rich] constructor allows you to style multiple
+/// spans with the default text style while still allowing specified styles per
 /// span.
 ///
 /// ## Sample code

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -168,7 +168,7 @@ class Draggable<T> extends StatefulWidget {
 
   /// Whether the semantics of the [feedback] widget is ignored when building
   /// the semantics tree.
-  /// 
+  ///
   /// This value should be set to false when the [feedback] widget is intended
   /// to be the same object as the [child].  Placing a [GlobalKey] on this
   /// widget will ensure semantic focus is kept on the element as it moves in
@@ -656,7 +656,7 @@ class _DragAvatar<T> extends Drag {
   Offset _restrictAxis(Offset offset) {
     if (axis == null) {
       return offset;
-    } 
+    }
     if (axis == Axis.horizontal) {
       return new Offset(offset.dx, 0.0);
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -367,9 +367,9 @@ class EditableText extends StatefulWidget {
   final Radius cursorRadius;
 
   /// The appearance of the keyboard.
-  /// 
+  ///
   /// This setting is only honored on iOS devices.
-  /// 
+  ///
   /// Defaults to [Brightness.light].
   final Brightness keyboardAppearance;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2076,15 +2076,15 @@ class BuildOwner {
 
   /// Whether [_dirtyElements] need to be sorted again as a result of more
   /// elements becoming dirty during the build.
-  /// 
+  ///
   /// This is necessary to preserve the sort order defined by [Element._sort].
-  /// 
+  ///
   /// This field is set to null when [buildScope] is not actively rebuilding
   /// the widget tree.
   bool _dirtyElementsNeedsResorting;
 
   /// Whether [buildScope] is actively rebuilding the widget tree.
-  /// 
+  ///
   /// [scheduleBuildFor] should only be called when this value is true.
   bool get _debugIsInBuildScope => _dirtyElementsNeedsResorting != null;
 

--- a/packages/flutter/test/cupertino/slider_test.dart
+++ b/packages/flutter/test/cupertino/slider_test.dart
@@ -117,7 +117,7 @@ void main() {
     ));
 
     await _dragSlider(tester, sliderKey);
-    
+
     expect(numberOfTimesOnChangeStartIsCalled, equals(1));
 
     await tester.pump(); // No animation should start.
@@ -154,9 +154,9 @@ void main() {
         },
       ),
     ));
-    
+
     await _dragSlider(tester, sliderKey);
-    
+
     expect(numberOfTimesOnChangeEndIsCalled, equals(1));
 
     await tester.pump(); // No animation should start.
@@ -199,7 +199,7 @@ void main() {
     ));
 
     expect(value, equals(0.0));
-    
+
     final Offset topLeft = tester.getTopLeft(find.byKey(sliderKey));
     const double unit = CupertinoThumbPainter.radius;
     const double delta = 3.0 * unit;
@@ -210,7 +210,7 @@ void main() {
     expect(startValue, equals(0.0));
     expect(value, equals(finalValue));
     expect(endValue, equals(finalValue));
-    
+
     await tester.pump(); // No animation should start.
     // Check the transientCallbackCount before tearing down the widget to ensure
     // that no animation is running.
@@ -222,7 +222,7 @@ void main() {
     double value = 0.0;
     double startValue;
     double endValue;
-    
+
     await tester.pumpWidget(new Directionality(
       textDirection: TextDirection.rtl,
       child: new StatefulBuilder(
@@ -255,18 +255,18 @@ void main() {
     ));
 
     expect(value, equals(0.0));
-    
+
     final Offset bottomRight = tester.getBottomRight(find.byKey(sliderKey));
     const double unit = CupertinoThumbPainter.radius;
     const double delta = 3.0 * unit;
     await tester.dragFrom(bottomRight - const Offset(unit, unit), const Offset(-delta, 0.0));
-    
+
     final Size size = tester.getSize(find.byKey(sliderKey));
     final double finalValue = delta / (size.width - 2.0 * (8.0 + CupertinoThumbPainter.radius));
     expect(startValue, equals(0.0));
     expect(value, equals(finalValue));
     expect(endValue, equals(finalValue));
-    
+
     await tester.pump(); // No animation should start.
     // Check the transientCallbackCount before tearing down the widget to ensure
     // that no animation is running.

--- a/packages/flutter/test/foundation/licenses_test.dart
+++ b/packages/flutter/test/foundation/licenses_test.dart
@@ -34,10 +34,10 @@ G
  H
  H]
 \u0020\u0020
-IJ
-K
+I\u000cJ
+\u000cK
 K
-
+\u000c
 L
 L L
 L  L

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -133,7 +133,7 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
 
     await tester.pumpWidget(new MaterialApp(home: const Scaffold()));
-    
+
     expect(tester.binding.transientCallbackCount, 0);
 
     await tester.pumpWidget(new MaterialApp(home: const Scaffold(

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -251,9 +251,9 @@ void main() {
     );
 
     final RadialGradient actual = RadialGradient.lerp(testGradient1, testGradient2, 0.5);
-    
+
     expect(actual.focal, isNull);
-    
+
     expect(actual, const RadialGradient(
       center: const Alignment(0.0, -1.0),
       radius: 15.0,
@@ -322,7 +322,7 @@ void main() {
       ],
     ));
   });
-  
+
   test('SweepGradient lerp test', () {
     const SweepGradient testGradient1 = const SweepGradient(
       center: Alignment.topLeft,
@@ -409,9 +409,9 @@ void main() {
         const Color(0xff666666),
       ],
     );
-    
+
     final SweepGradient actual = testGradient.scale(0.5);
-    
+
     expect(actual, const SweepGradient(
       center: Alignment.topLeft,
       startAngle: 0.0,

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -252,7 +252,7 @@ void main() {
     expect(TextStyle.lerp(redTextStyle, bluePaintTextStyle, .25).color, isNull);
     expect(TextStyle.lerp(redTextStyle, bluePaintTextStyle, .25).foreground.color, red);
     expect(TextStyle.lerp(redTextStyle, bluePaintTextStyle, .75).foreground.color, blue);
-    
+
     expect(TextStyle.lerp(redPaintTextStyle, bluePaintTextStyle, .25).color, isNull);
     expect(TextStyle.lerp(redPaintTextStyle, bluePaintTextStyle, .25).foreground.color, red);
     expect(TextStyle.lerp(redPaintTextStyle, bluePaintTextStyle, .75).foreground.color, blue);

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -107,7 +107,7 @@ void main() {
   testWidgets('Ticker can be created before application unpauses', (WidgetTester tester) async {
     final ByteData pausedMessage = const StringCodec().encodeMessage('AppLifecycleState.paused');
     await BinaryMessages.handlePlatformMessage('flutter/lifecycle', pausedMessage, (_) {});
-    
+
     int tickCount = 0;
     void handleTick(Duration duration) {
       tickCount += 1;
@@ -126,7 +126,7 @@ void main() {
 
     final ByteData resumedMessage = const StringCodec().encodeMessage('AppLifecycleState.resumed');
     await BinaryMessages.handlePlatformMessage('flutter/lifecycle', resumedMessage, (_) {});
-    
+
     await tester.pump(const Duration(milliseconds: 10));
 
     expect(tickCount, equals(1));

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -73,7 +73,7 @@ class FakePlatformViewsController {
         code: 'error',
         message: 'Trying to dispose a platform view with unknown id: $id',
       );
-    
+
     _views.remove(id);
     return new Future<Null>.sync(() => null);
   }

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -715,7 +715,7 @@ void main() {
       expect(tester.getTopLeft(find.text('V')), thirdWidgetLocation);
     });
   });
- 
+
 
   testWidgets('Drag and drop - onDraggableCanceled not called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
@@ -1681,7 +1681,7 @@ void main() {
           ],
         ),
     ));
-    
+
     expect(semantics, hasSemantics(
       new TestSemantics.root(
         children: <TestSemantics>[
@@ -1741,7 +1741,7 @@ void main() {
     await tester.pump();
     await gesture.moveTo(secondLocation);
     await tester.pump();
-    
+
     expect(semantics, hasSemantics(
       new TestSemantics.root(
         children: <TestSemantics>[

--- a/packages/flutter/test/widgets/set_state_5_test.dart
+++ b/packages/flutter/test/widgets/set_state_5_test.dart
@@ -17,7 +17,7 @@ class BadWidgetState extends State<BadWidget> {
      _count = 1;
     });
   }
-  
+
   int _count = 0;
 
   @override

--- a/packages/flutter/test/widgets/spacer_test.dart
+++ b/packages/flutter/test/widgets/spacer_test.dart
@@ -52,7 +52,7 @@ void main() {
     expect(spacer4Rect.size.width, spacer3Rect.size.width * 2.0);
     expect(spacer4Rect.left, closeTo(10.0, 0.1));
   });
-  
+
   testWidgets('Spacer takes up space.', (WidgetTester tester) async {
     await tester.pumpWidget(new UnconstrainedBox(
       constrainedAxis: Axis.vertical,

--- a/packages/flutter_driver/lib/src/common/find.dart
+++ b/packages/flutter_driver/lib/src/common/find.dart
@@ -259,7 +259,7 @@ class ByType extends SerializableFinder {
 ///
 /// If the object returned by the finder does not have its own semantics node,
 /// then the semantics node of the first ancestor is returned instead.
-/// 
+///
 /// Throws an error if a finder returns multiple objects or if there are no
 /// semantics nodes.
 ///

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -573,10 +573,10 @@ class FlutterDriver {
 
   /// Retrieves the semantics node id for the object returned by `finder`, or
   /// the nearest ancestor with a semantics node.
-  /// 
+  ///
   /// Throws an error if `finder` returns multiple elements or a semantics
   /// node is not found.
-  /// 
+  ///
   /// Semantics must be enabled to use this method, either using a platform
   /// specific shell command or [setSemantics].
   Future<int> getSemanticsId(SerializableFinder finder, { Duration timeout = _kShortTimeout}) async {

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -63,7 +63,7 @@ class _DriverBinding extends BindingBase with ServicesBinding, SchedulerBinding,
 ///
 /// Optionally you can pass a [DataHandler] callback. It will be called if the
 /// test calls [FlutterDriver.requestData].
-/// 
+///
 /// `slienceErrors` will prevent exceptions from being logged. This is useful
 /// for tests where exceptions are expected. Defaults to false. Any errors
 /// will still be returned in the `response` field of the result json along

--- a/packages/flutter_driver/test/src/extension_test.dart
+++ b/packages/flutter_driver/test/src/extension_test.dart
@@ -81,10 +81,10 @@ void main() {
       final SemanticsHandle semantics = RendererBinding.instance.pipelineOwner.ensureSemantics();
       await tester.pumpWidget(
         const Text('hello', textDirection: TextDirection.ltr));
-      
+
       final Map<String, Object> arguments = new GetSemanticsId(new ByText('hello')).serialize();
       final GetSemanticsIdResult result = GetSemanticsIdResult.fromJson((await extension.call(arguments))['response']);
-  
+
       expect(result.id, 1);
       semantics.dispose();
     });
@@ -92,10 +92,10 @@ void main() {
     testWidgets('throws state error if no data is found', (WidgetTester tester) async {
       await tester.pumpWidget(
         const Text('hello', textDirection: TextDirection.ltr));
-      
+
       final Map<String, Object> arguments = new GetSemanticsId(new ByText('hello')).serialize();
       final Map<String, Object> response = await extension.call(arguments);
-  
+
       expect(response['isError'], true);
       expect(response['response'], contains('Bad state: No semantics data found'));
     });
@@ -111,10 +111,10 @@ void main() {
           ]),
         ),
       );
-      
+
       final Map<String, Object> arguments = new GetSemanticsId(new ByText('hello')).serialize();
       final Map<String, Object> response = await extension.call(arguments);
-  
+
       expect(response['isError'], true);
       expect(response['response'], contains('Bad state: Too many elements'));
       semantics.dispose();

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -616,7 +616,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   /// Attempts to find the [SemanticsData] of first result from `finder`.
-  /// 
+  ///
   /// If the object identified by the finder doesn't own it's semantic node,
   /// this will return the semantics data of the first ancestor with semantics
   /// data. The ancestor's semantic data will include the child's as well as

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -14,7 +14,7 @@ void main() {
       ));
       expect(find.text('test'), findsOneWidget);
     });
-  
+
     testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
       await tester.pumpWidget(_boilerplate(
         const Text.rich(

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -564,7 +564,7 @@ void main() {
           throwsA(isInstanceOf<StateError>()));
       semanticsHandle.dispose();
     });
-    
+
     testWidgets('Returns the correct SemanticsData', (WidgetTester tester) async {
       final SemanticsHandle semanticsHandle = tester.ensureSemantics();
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -70,7 +70,7 @@ String getEmulatorPath([AndroidSdk existingSdk]) {
 
 /// Locate the path for storing AVD emulator images. Returns null if none found.
 String getAvdPath() {
-  
+
   final List<String> searchPaths = <String>[
     platform.environment['ANDROID_AVD_HOME']
   ];

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -374,7 +374,7 @@ class AppDomain extends Domain {
         ipv6: ipv6,
       );
     }
-    
+
     return launch(
         runner,
         ({ Completer<DebugConnectionInfo> connectionInfoCompleter,

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -37,9 +37,9 @@ const String _kStackTraceFileField = 'DartError';
 const String _kStackTraceFilename = 'stacktrace_file';
 
 /// Sends crash reports to Google.
-/// 
+///
 /// There are two ways to override the behavior of this class:
-/// 
+///
 /// * Define a `FLUTTER_CRASH_SERVER_BASE_URL` environment variable that points
 ///   to a custom crash reporting server. This is useful if your development
 ///   environment is behind a firewall and unable to send crash reports to

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -20,7 +20,7 @@ const String noCertificatesInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
 No valid code signing certificates were found
 You can connect to your Apple Developer account by signing in with your Apple ID
-in Xcode and create an iOS Development Certificate as well as a Provisioning 
+in Xcode and create an iOS Development Certificate as well as a Provisioning
 Profile for your project by:
 $fixWithDevelopmentTeamInstruction
   5- Trust your newly created Development Certificate on your iOS device
@@ -37,12 +37,12 @@ Or run on an iOS simulator without code signing
 /// The user did iOS development but never on this project and/or device.
 const String noProvisioningProfileInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
-No Provisioning Profile was found for your project's Bundle Identifier or your 
-device. You can create a new Provisioning Profile for your project in Xcode for 
+No Provisioning Profile was found for your project's Bundle Identifier or your
+device. You can create a new Provisioning Profile for your project in Xcode for
 your team by:
 $fixWithDevelopmentTeamInstruction
 
-It's also possible that a previously installed app with the same Bundle 
+It's also possible that a previously installed app with the same Bundle
 Identifier was signed with a different certificate.
 
 For more information, please visit:
@@ -55,7 +55,7 @@ Or run on an iOS simulator without code signing
 /// Couldn't auto sign the app but can likely solved by retracing the signing flow in Xcode.
 const String noDevelopmentTeamInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
-Building a deployable iOS app requires a selected Development Team with a 
+Building a deployable iOS app requires a selected Development Team with a
 Provisioning Profile. Please ensure that a Development Team is selected by:
 $fixWithDevelopmentTeamInstruction
 
@@ -69,7 +69,7 @@ const String fixWithDevelopmentTeamInstruction = '''
        open ios/Runner.xcworkspace
   2- Select the 'Runner' project in the navigator then the 'Runner' target
      in the project settings
-  3- In the 'General' tab, make sure a 'Development Team' is selected. 
+  3- In the 'General' tab, make sure a 'Development Team' is selected.
      You may need to:
          - Log in with your Apple ID in Xcode first
          - Ensure you have a valid unique Bundle ID

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -20,7 +20,7 @@ const String noCertificatesInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
 No valid code signing certificates were found
 You can connect to your Apple Developer account by signing in with your Apple ID
-in Xcode and create an iOS Development Certificate as well as a Provisioning
+in Xcode and create an iOS Development Certificate as well as a Provisioning\u0020
 Profile for your project by:
 $fixWithDevelopmentTeamInstruction
   5- Trust your newly created Development Certificate on your iOS device
@@ -37,12 +37,12 @@ Or run on an iOS simulator without code signing
 /// The user did iOS development but never on this project and/or device.
 const String noProvisioningProfileInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
-No Provisioning Profile was found for your project's Bundle Identifier or your
-device. You can create a new Provisioning Profile for your project in Xcode for
+No Provisioning Profile was found for your project's Bundle Identifier or your\u0020
+device. You can create a new Provisioning Profile for your project in Xcode for\u0020
 your team by:
 $fixWithDevelopmentTeamInstruction
 
-It's also possible that a previously installed app with the same Bundle
+It's also possible that a previously installed app with the same Bundle\u0020
 Identifier was signed with a different certificate.
 
 For more information, please visit:
@@ -55,7 +55,7 @@ Or run on an iOS simulator without code signing
 /// Couldn't auto sign the app but can likely solved by retracing the signing flow in Xcode.
 const String noDevelopmentTeamInstruction = '''
 ════════════════════════════════════════════════════════════════════════════════
-Building a deployable iOS app requires a selected Development Team with a
+Building a deployable iOS app requires a selected Development Team with a\u0020
 Provisioning Profile. Please ensure that a Development Team is selected by:
 $fixWithDevelopmentTeamInstruction
 
@@ -69,7 +69,7 @@ const String fixWithDevelopmentTeamInstruction = '''
        open ios/Runner.xcworkspace
   2- Select the 'Runner' project in the navigator then the 'Runner' target
      in the project settings
-  3- In the 'General' tab, make sure a 'Development Team' is selected.
+  3- In the 'General' tab, make sure a 'Development Team' is selected.\u0020
      You may need to:
          - Log in with your Apple ID in Xcode first
          - Ensure you have a valid unique Bundle ID

--- a/packages/flutter_tools/test/cache_test.dart
+++ b/packages/flutter_tools/test/cache_test.dart
@@ -115,7 +115,7 @@ void main() {
 
 class MockFileSystem extends ForwardingFileSystem {
   MockFileSystem() : super(new MemoryFileSystem());
-    
+
   @override
   File file(dynamic path) {
     return new MockFile();

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -325,7 +325,7 @@ class VsCodeValidatorTestTargets extends VsCodeValidator {
   static final String validInstall = fs.path.join('test', 'data', 'vscode', 'application');
   static final String validExtensions = fs.path.join('test', 'data', 'vscode', 'extensions');
   static final String missingExtensions = fs.path.join('test', 'data', 'vscode', 'notExtensions');
-  VsCodeValidatorTestTargets._(String installDirectory, String extensionDirectory, {String edition}) 
+  VsCodeValidatorTestTargets._(String installDirectory, String extensionDirectory, {String edition})
     : super(new VsCode.fromDirectory(installDirectory, extensionDirectory, edition: edition));
 
   static VsCodeValidatorTestTargets get installedWithExtension =>

--- a/packages/flutter_tools/test/integration/flutter_attach.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach.dart
@@ -36,7 +36,7 @@ void main() {
     testUsingContext('can hot reload', () async {
       await _flutterRun.run(withDebugger: true);
       await _flutterAttach.attach(_flutterRun.vmServicePort);
-      
+
       await _flutterAttach.hotReload();
     });
   }, timeout: const Timeout.factor(3));

--- a/packages/flutter_tools/test/integration/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/basic_project.dart
@@ -19,9 +19,9 @@ class BasicProject extends TestProject {
   @override
   final String main = r'''
   import 'package:flutter/material.dart';
-  
+
   void main() => runApp(new MyApp());
-  
+
   class MyApp extends StatelessWidget {
     @override
     Widget build(BuildContext context) {

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -78,7 +78,7 @@ class FlutterTestDriver {
   Future<void> _setupProcess(List<String> args, {bool withDebugger = false}) async {
     final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
     _debugPrint('Spawning flutter $args in ${_projectFolder.path}');
-    
+
     const ProcessManager _processManager = const LocalProcessManager();
     _proc = await _processManager.start(
         <String>[flutterBin]
@@ -103,7 +103,7 @@ class FlutterTestDriver {
     // script).
     final Map<String, dynamic> connected = await _waitFor(event: 'daemon.connected');
     _procPid = connected['params']['pid'];
-    
+
     // Set this up now, but we don't wait it yet. We want to make sure we don't
     // miss it while waiting for debugPort below.
     final Future<Map<String, dynamic>> started = _waitFor(event: 'app.started',
@@ -126,7 +126,7 @@ class FlutterTestDriver {
 
       // Because we start paused, resume so the app is in a "running" state as
       // expected by tests. Tests will reload/restart as required if they need
-      // to hit breakpoints, etc. 
+      // to hit breakpoints, etc.
       await waitForPause();
       await resume(wait: false);
     }
@@ -266,7 +266,7 @@ class FlutterTestDriver {
         response.complete(json);
       }
     });
-    
+
     return _timeoutWithMessages(() => response.future,
             timeout: timeout,
             message: event != null
@@ -285,7 +285,7 @@ class FlutterTestDriver {
       messages.writeln('[+ ${ms.toString().padLeft(5)}] $m');
     }
     final StreamSubscription<String> sub = _allMessages.stream.listen(logMessage);
-    
+
     return f().timeout(timeout ?? defaultTimeout, onTimeout: () {
       logMessage('<timed out>');
       throw '$message\nReceived:\n${messages.toString()}';


### PR DESCRIPTION
There are only whitespace changes here, except for `packages/flutter/test/foundation/licenses_test.dart`, where I replace some raw whitespace (line feed) with their unicode equivalents.

I'm adding a presubmit check for this in #19412.