### PR TITLE
increase cache size if image is loaded that is larger than max size

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -145,6 +145,12 @@ class ImageCache {
       // Images that fail to load don't contribute to cache size.
       final int imageSize = info.image == null ? 0 : info.image.height * info.image.width * 4;
       final _CachedImage image = new _CachedImage(result, imageSize);
+      // If the image is bigger than the maximum cache size, and the cache size
+      // is not zero, then increase the cache size to the size of the image plus
+      // some change.
+      if (maximumSizeBytes > 0 && imageSize > maximumSizeBytes) {
+        _maximumSizeBytes = imageSize + 1000;
+      }
       _currentSizeBytes += imageSize;
       _pendingImages.remove(key);
       _cache[key] = image;

--- a/packages/flutter/test/painting/image_cache_test.dart
+++ b/packages/flutter/test/painting/image_cache_test.dart
@@ -118,5 +118,15 @@ void main() {
       expect(imageCache.currentSize, 1);
       expect(imageCache.currentSizeBytes, 256);
     });
+
+    test('Increases cache size if an image is loaded that is larger then the maximum size', () async {
+      const TestImage testImage = const TestImage(width: 8, height: 8);
+
+      imageCache.maximumSizeBytes = 1;
+      await extractOneFrame(const TestImageProvider(1, 1, image: testImage).resolve(ImageConfiguration.empty));
+      expect(imageCache.currentSize, 1);
+      expect(imageCache.currentSizeBytes, 256);
+      expect(imageCache.maximumSizeBytes, 256 + 1000);
+    });
   });
 }


### PR DESCRIPTION
unless cache size is explicitly set to zero