### PR TITLE
Chevrons fade out completely on month picker scroll event

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -536,9 +536,9 @@ class _MonthPickerState extends State<MonthPicker> with SingleTickerProviderStat
 
     // Setup the fade animation for chevrons
     _chevronOpacityController = new AnimationController(
-      duration: const Duration(milliseconds: 500), vsync: this
+      duration: const Duration(milliseconds: 250), vsync: this
     );
-    _chevronOpacityAnimation = new Tween<double>(begin: 1.0, end: 0.5).animate(
+    _chevronOpacityAnimation = new Tween<double>(begin: 1.0, end: 0.0).animate(
       new CurvedAnimation(
         parent: _chevronOpacityController,
         curve: Curves.easeInOut,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -671,7 +671,7 @@ void _tests() {
     await gesture.moveBy(const Offset(50.0, 100.0));
     await tester.pumpAndSettle();
     for(RenderAnimatedOpacity renderer in chevronRenderers) {
-      expect(renderer.opacity.value, equals(0.5));
+      expect(renderer.opacity.value, equals(0.0));
       expect(renderer.opacity.status, equals(AnimationStatus.completed));
     }
 


### PR DESCRIPTION
Fades out chevrons in month picker completely when months are scrolled. Fix for #4138 