### PR TITLE
Turn on MacOS tests on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,3 +50,17 @@ task:
     - bin\flutter.bat update-packages
   test_all_script:
     - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
+
+task:
+  name: tests-macos
+  env:
+    SHARD: tests
+  osx_instance:
+    image: high-sierra-xcode-9.4.1
+  git_fetch_script: git fetch origin
+  setup_script:
+    - bin/flutter config --no-analytics
+    - bin/flutter update-packages
+  test_all_script:
+    - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+    - bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart


### PR DESCRIPTION
Cirrus CI has macOS VMs, so this turns on an instance for tests so that we can evaluate if we can use Cirrus for all three platforms or not.