### PR TITLE
Remove redundant check for platform.isLinux.

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -121,14 +121,6 @@ class CoverageCollector extends TestWatcher {
 
     const String baseCoverageData = 'coverage/lcov.base.info';
     if (mergeCoverageData) {
-      if (!platform.isLinux) {
-        printError(
-          'Merging coverage data is supported only on Linux because it '
-          'requires the "lcov" tool.'
-        );
-        return false;
-      }
-
       if (!fs.isFileSync(baseCoverageData)) {
         printError('Missing "$baseCoverageData". Unable to merge coverage data.');
         return false;


### PR DESCRIPTION
We don't actually care if we're on linux, we care only if the lcov
tool is available. We check for that explicitly just below.
Additionally there is code below which indicates that lcov is available
for macOS. Before this change that code would never execute.