### PR TITLE
Flutter `emulator launch` crash running in dart-2-mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -72,7 +72,11 @@ class EmulatorsCommand extends FlutterCommand {
         await emulators.first.launch();
       }
       catch (e) {
-        printError(e);
+        if (e is String) {
+          printError(e);
+        } else {
+          rethrow;
+        }
       }
     }
   }

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -40,7 +40,8 @@ class IOSEmulator extends Emulator {
     Future<bool> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>['open']
           .followedBy(additionalArgs)
-          .followedBy(<String>['-a', getSimulatorPath()]);
+          .followedBy(<String>['-a', getSimulatorPath()])
+          .toList();
 
       final RunResult launchResult = await runAsync(args);
       if (launchResult.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../emulator.dart';

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -40,7 +40,7 @@ class IOSEmulator extends Emulator {
     Future<bool> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>['open']
           .followedBy(additionalArgs)
-          .followedBy(<String>['-a', getSimulatorPath()])
+          .followedBy(<String>['-a', xcode.getSimulatorPath()])
           .toList();
 
       final RunResult launchResult = await runAsync(args);
@@ -63,22 +63,10 @@ class IOSEmulator extends Emulator {
 
 /// Return the list of iOS Simulators (there can only be zero or one).
 List<IOSEmulator> getEmulators() {
-  final String simulatorPath = getSimulatorPath();
+  final String simulatorPath = xcode.getSimulatorPath();
   if (simulatorPath == null) {
     return <IOSEmulator>[];
   }
 
   return <IOSEmulator>[new IOSEmulator('apple_ios_simulator')];
-}
-
-String getSimulatorPath() {
-  if (xcode.xcodeSelectPath == null)
-    return null;
-  final List<String> searchPaths = <String>[
-    fs.path.join(xcode.xcodeSelectPath, 'Applications', 'Simulator.app'),
-  ];
-  return searchPaths.where((String p) => p != null).firstWhere(
-        (String p) => fs.directory(p).existsSync(),
-        orElse: () => null,
-      );
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -167,6 +167,18 @@ class Xcode {
   Future<RunResult> clang(List<String> args) {
     return runCheckedAsync(<String>['xcrun', 'clang']..addAll(args));
   }
+
+  String getSimulatorPath() {
+    if (xcodeSelectPath == null)
+      return null;
+    final List<String> searchPaths = <String>[
+      fs.path.join(xcodeSelectPath, 'Applications', 'Simulator.app'),
+    ];
+    return searchPaths.where((String p) => p != null).firstWhere(
+      (String p) => fs.directory(p).existsSync(),
+      orElse: () => null,
+    );
+  }
 }
 
 Future<XcodeBuildResult> buildXcodeProject({


### PR DESCRIPTION
This fixes a crash when running in Dart-2-mode because we were casting the result of `followedBy` (`Iterable<String>`) into a `List<String>`.

It also fixes some error handling here that assumed all errors thrown in `launch` were strings (simple errors to show to the user) and tried to print them. Now it will print simple strings to the user, but rethrow anything else (these are real crashes and should go up to the normal crash/log handling).

Fixes #19453.