### PR TITLE
Add integration tests to ensure flutter run does not quit at startup

### DIFF
--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:test/test.dart';
+
+import 'test_data/basic_project.dart';
+import 'test_driver.dart';
+
+BasicProject _project = new BasicProject();
+FlutterTestDriver _flutter;
+
+const Duration requiredLifespan = Duration(seconds: 5);
+
+void main() {
+  group('flutter run', () {
+    setUp(() async {
+      final Directory tempDir = await fs.systemTempDirectory.createTemp('test_app');
+      await _project.setUpIn(tempDir);
+      _flutter = new FlutterTestDriver(tempDir);
+    });
+
+    tearDown(() async {
+      try {
+        await _flutter.stop();
+        _project.cleanup();
+      } catch (e) {
+        // Don't fail tests if we failed to clean up temp folder.
+      }
+    });
+
+    test('does not terminate', () async {
+      await _flutter.run();
+      await new Future<void>.delayed(requiredLifespan);
+      expect(_flutter.hasExited, equals(false));
+    });
+
+    test('does not terminate when a debugger is attached', () async {
+      await _flutter.run(withDebugger: true);
+      await new Future<void>.delayed(requiredLifespan);
+      expect(_flutter.hasExited, equals(false));
+    });
+
+    test('does not terminate when a debugger is attached and pause-on-exceptions', () async {
+      await _flutter.run(withDebugger: true, pauseOnExceptions: true);
+      await new Future<void>.delayed(requiredLifespan);
+      expect(_flutter.hasExited, equals(false));
+    });
+  }, timeout: const Timeout.factor(3));
+}

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -14,6 +14,9 @@ import 'test_driver.dart';
 BasicProject _project = new BasicProject();
 FlutterTestDriver _flutter;
 
+/// This duration is arbitrary but is ideally:
+/// a) long enough to ensure that if the app is crashing at startup, we notice
+/// b) as short as possible, to avoid inflating build times
 const Duration requiredLifespan = Duration(seconds: 5);
 
 void main() {
@@ -25,18 +28,8 @@ void main() {
     });
 
     tearDown(() async {
-      try {
-        await _flutter.stop();
-        _project.cleanup();
-      } catch (e) {
-        // Don't fail tests if we failed to clean up temp folder.
-      }
-    });
-
-    test('does not terminate', () async {
-      await _flutter.run();
-      await new Future<void>.delayed(requiredLifespan);
-      expect(_flutter.hasExited, equals(false));
+      await _flutter.stop();
+      _project.cleanup();
     });
 
     test('does not terminate when a debugger is attached', () async {

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -54,9 +54,6 @@ class FlutterTestDriver {
     return msg;
   }
 
-  // TODO(dantup): Is there a better way than spawning a proc? This breaks debugging..
-  // However, there's a lot of logic inside RunCommand that wouldn't be good
-  // to duplicate here.
   Future<void> run({bool withDebugger = false, bool pauseOnExceptions = false}) async {
     await _setupProcess(<String>[
         'run',

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -192,6 +192,8 @@ class FlutterTestDriver {
   }
 
   Future<VMIsolate> getFlutterIsolate() async {
+    // Currently these tests only have a single isolate. If this
+    // ceases to be the case, this code will need changing.
     final VM vm = await vmService.getVM();
     return await vm.isolates.first.load();
   }

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -34,12 +34,14 @@ class FlutterTestDriver {
   String _currentRunningAppId;
   Uri _vmServiceWsUri;
   int _vmServicePort;
+  bool _hasExited = false;
 
   FlutterTestDriver(this._projectFolder);
 
   VMServiceClient vmService;
   String get lastErrorInfo => _errorBuffer.toString();
   int get vmServicePort => _vmServicePort;
+  bool get hasExited => _hasExited;
 
   String _debugPrint(String msg) {
     const int maxLength = 500;
@@ -55,16 +57,16 @@ class FlutterTestDriver {
   // TODO(dantup): Is there a better way than spawning a proc? This breaks debugging..
   // However, there's a lot of logic inside RunCommand that wouldn't be good
   // to duplicate here.
-  Future<void> run({bool withDebugger = false}) async {
+  Future<void> run({bool withDebugger = false, bool pauseOnExceptions = false}) async {
     await _setupProcess(<String>[
         'run',
         '--machine',
         '-d',
         'flutter-tester',
-    ], withDebugger: withDebugger);
+    ], withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions);
   }
 
-  Future<void> attach(int port, {bool withDebugger = false}) async {
+  Future<void> attach(int port, {bool withDebugger = false, bool pauseOnExceptions = false}) async {
     await _setupProcess(<String>[
         'attach',
         '--machine',
@@ -72,10 +74,10 @@ class FlutterTestDriver {
         'flutter-tester',
         '--debug-port',
         '$port',
-    ], withDebugger: withDebugger);
+    ], withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions);
   }
 
-  Future<void> _setupProcess(List<String> args, {bool withDebugger = false}) async {
+  Future<void> _setupProcess(List<String> args, {bool withDebugger = false, bool pauseOnExceptions = false}) async {
     final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
     _debugPrint('Spawning flutter $args in ${_projectFolder.path}');
 
@@ -88,6 +90,7 @@ class FlutterTestDriver {
         workingDirectory: _projectFolder.path,
         environment: <String, String>{'FLUTTER_TEST': 'true'});
 
+    _proc.exitCode.then((_) => _hasExited = true);
     _transformToLines(_proc.stdout).listen((String line) => _stdout.add(line));
     _transformToLines(_proc.stderr).listen((String line) => _stderr.add(line));
 
@@ -128,6 +131,9 @@ class FlutterTestDriver {
       // expected by tests. Tests will reload/restart as required if they need
       // to hit breakpoints, etc.
       await waitForPause();
+      if (pauseOnExceptions) {
+        await (await getFlutterIsolate()).setExceptionPauseMode(VMExceptionPauseMode.unhandled);
+      }
       await resume(wait: false);
     }
 
@@ -188,9 +194,13 @@ class FlutterTestDriver {
     return _proc.exitCode;
   }
 
-  Future<void> addBreakpoint(String path, int line) async {
+  Future<VMIsolate> getFlutterIsolate() async {
     final VM vm = await vmService.getVM();
-    final VMIsolate isolate = await vm.isolates.first.load();
+    return await vm.isolates.first.load();
+  }
+
+  Future<void> addBreakpoint(String path, int line) async {
+    final VMIsolate isolate = await getFlutterIsolate();
     _debugPrint('Sending breakpoint for $path:$line');
     await isolate.addBreakpoint(path, line);
   }


### PR DESCRIPTION
~~**These tests require https://github.com/dart-lang/vm_service_client/pull/38 to be merged and rolled into flutter before they can be landed. CI builds will fail until this happens.**~~

~~Even with that change, the final test here fails on current master which I believe is due to https://github.com/flutter/flutter/issues/19379. Applying the PR to e22f99743b4f0bea4a9b8e7703ce5ffbfda37a04 results in all passing.~~

`vm_service_client` changes landed and updated, and the above PR was merged too. This should be good to go now.