### PR TITLE
Make initialSemanticsTreeCreation less sensitive to GC timing.

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/semantics_perf.dart
+++ b/dev/benchmarks/complex_layout/test_driver/semantics_perf.dart
@@ -5,7 +5,16 @@
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:complex_layout/main.dart' as app;
 
+// Avoid sensitivity to GC timing.
+dynamic provokeSemispaceGrowth() {
+  dynamic tree(int n) {
+    return n == 0 ? null : <dynamic>[tree(n - 1), tree(n - 1)];
+  }
+  return tree(16);  // 2^16 * 6 words ~= 1.5 MB
+}
+
 void main() {
+  provokeSemispaceGrowth();
   enableFlutterDriverExtension();
   app.main();
 }


### PR DESCRIPTION
Bug: https://github.com/flutter/flutter/issues/19435