### PR TITLE
Increase verbosity on bots during setup and other minor cleanup

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -89,10 +89,12 @@ function upgrade_flutter () {
     rm -f "$FLUTTER_ROOT/version"
     touch "$FLUTTER_ROOT/bin/cache/.dartignore"
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
+    VERBOSITY=--verbosity=error
 
     echo Building flutter tool...
     if [[ "$TRAVIS" == "true" ]] || [[ "$BOT" == "true" ]] || [[ "$CONTINUOUS_INTEGRATION" == "true" ]] || [[ "$CHROME_HEADLESS" == "1" ]] || [[ "$APPVEYOR" == "true" ]] || [[ "$CI" == "true" ]]; then
       PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
+      VERBOSITY=--verbosity=all
     fi
     export PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_install"
 
@@ -102,7 +104,7 @@ function upgrade_flutter () {
 
     while : ; do
       cd "$FLUTTER_TOOLS_DIR"
-      "$PUB" upgrade --verbosity=error --no-packages-dir && break
+      "$PUB" upgrade $VERBOSITY --no-packages-dir && break
       echo Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds...
       sleep 5
     done

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -113,11 +113,12 @@ GOTO :after_subroutine
   :do_snapshot
     IF EXIST "%FLUTTER_ROOT%\version" DEL "%FLUTTER_ROOT%\version"
     ECHO: > "%cache_dir%\.dartignore"
-    ECHO Updating flutter tool...
+    ECHO Building flutter tool...
     PUSHD "%flutter_tools_dir%"
 
     REM Makes changes to PUB_ENVIRONMENT only visible to commands within SETLOCAL/ENDLOCAL
     SETLOCAL
+      SET VERBOSITY=--verbosity=error
       IF "%TRAVIS%" == "true" GOTO on_bot
       IF "%BOT%" == "true" GOTO on_bot
       IF "%CONTINUOUS_INTEGRATION%" == "true" GOTO on_bot
@@ -127,13 +128,14 @@ GOTO :after_subroutine
       GOTO not_on_bot
       :on_bot
         SET PUB_ENVIRONMENT=%PUB_ENVIRONMENT%:flutter_bot
+        SET VERBOSITY=--verbosity=all
       :not_on_bot
       SET PUB_ENVIRONMENT=%PUB_ENVIRONMENT%:flutter_install
       IF "%PUB_CACHE%" == "" (
-       IF EXIST "%pub_cache_path%" SET PUB_CACHE=%pub_cache_path%
+        IF EXIST "%pub_cache_path%" SET PUB_CACHE=%pub_cache_path%
       )
       :retry_pub_upgrade
-      CALL "%pub%" upgrade --verbosity=error --no-packages-dir
+      CALL "%pub%" upgrade %VERBOSITY% --no-packages-dir
       IF "%ERRORLEVEL%" NEQ "0" (
         ECHO Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds...
         timeout /t 5 /nobreak

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -686,6 +686,13 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///
 /// Only works if it's the child of a [Stack].
 ///
+/// This widget is a good choice if the _size_ of the child would end up
+/// changing as a result of this animation. If the size is intended to remain
+/// the same, with only the _position_ changing over time, then consider
+/// [SlideTransition] instead. [SlideTransition] only triggers a repaint each
+/// frame of the animation, whereas [AnimatedPositioned] will trigger a relayout
+/// as well.
+///
 /// See also:
 ///
 ///  * [AnimatedPositionedDirectional], which adapts to the ambient
@@ -828,10 +835,17 @@ class _AnimatedPositionedState extends AnimatedWidgetBaseState<AnimatedPositione
 ///
 /// Only works if it's the child of a [Stack].
 ///
+/// This widget is a good choice if the _size_ of the child would end up
+/// changing as a result of this animation. If the size is intended to remain
+/// the same, with only the _position_ changing over time, then consider
+/// [SlideTransition] instead. [SlideTransition] only triggers a repaint each
+/// frame of the animation, whereas [AnimatedPositionedDirectional] will trigger
+/// a relayout as well. ([SlideTransition] is also text-direction-aware.)
+///
 /// See also:
 ///
 ///  * [AnimatedPositioned], which specifies the widget's position visually (the
-///  * same as this widget, but for animating [Positioned]).
+///    same as this widget, but for animating [Positioned]).
 class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its position implicitly.
   ///

--- a/packages/flutter/test/scheduler/scheduler_tester.dart
+++ b/packages/flutter/test/scheduler/scheduler_tester.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/scheduler.dart';
 
-@Deprecated('animation_tester is not compatible with dart:async')
+@Deprecated('scheduler_tester is not compatible with dart:async')
 class Future { } // so that people can't import us and dart:async
 
 void tick(Duration duration) {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -605,14 +605,16 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   ///
   /// Will throw an error if there is no back button in the page.
   Future<void> pageBack() async {
-    Finder backButton = find.byTooltip('Back');
-    if (backButton.evaluate().isEmpty) {
-      backButton = find.widgetWithIcon(CupertinoButton, CupertinoIcons.back);
-    }
+    return TestAsyncUtils.guard(() async {
+      Finder backButton = find.byTooltip('Back');
+      if (backButton.evaluate().isEmpty) {
+        backButton = find.widgetWithIcon(CupertinoButton, CupertinoIcons.back);
+      }
 
-    expect(backButton, findsOneWidget, reason: 'One back button expected on screen');
+      expectSync(backButton, findsOneWidget, reason: 'One back button expected on screen');
 
-    await tap(backButton);
+      await tap(backButton);
+    });
   }
 
   /// Attempts to find the [SemanticsData] of first result from `finder`.


### PR DESCRIPTION
The verbosity change is to help track down timeouts that currently look like:

```
C:\Windows\Temp\flutter sdk>call bin\flutter.bat config --no-analytics
Checking Dart SDK version...
Downloading Dart SDK from Flutter engine c5a63d28bf3735569c8187753bc490d8351a8363...
Unzipping Dart SDK...
Updating flutter tool...
```