### PR TITLE
Enable extended FAB hero transition resizing

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -287,17 +287,12 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
 class _ChildOverflowBox extends SingleChildRenderObjectWidget {
   const _ChildOverflowBox({
     Key key,
-    this.alignment = Alignment.center,
     Widget child,
-  }) : assert(alignment != null),
-       super(key: key, child: child);
-
-  final AlignmentGeometry alignment;
+  }) : super(key: key, child: child);
 
   @override
   _RenderChildOverflowBox createRenderObject(BuildContext context) {
     return new _RenderChildOverflowBox(
-      alignment: alignment,
       textDirection: Directionality.of(context),
     );
   }
@@ -305,23 +300,15 @@ class _ChildOverflowBox extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, _RenderChildOverflowBox renderObject) {
     renderObject
-      ..alignment = alignment
       ..textDirection = Directionality.of(context);
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(new DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
   }
 }
 
 class _RenderChildOverflowBox extends RenderAligningShiftedBox {
   _RenderChildOverflowBox({
     RenderBox child,
-    AlignmentGeometry alignment = Alignment.center,
     TextDirection textDirection,
-  }) : super(child: child, alignment: alignment, textDirection: textDirection);
+  }) : super(child: child, alignment: Alignment.center, textDirection: textDirection);
 
   @override
   double computeMinIntrinsicWidth(double height) => 0.0;

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -344,5 +344,68 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('extended FAB hero transitions succeed', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/18782
 
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: new Scaffold(
+          floatingActionButton: new Builder(
+            builder: (BuildContext context) { // define context of Navigator.push()
+              return new FloatingActionButton.extended(
+                icon: const Icon(Icons.add),
+                label: const Text('A long FAB label'),
+                onPressed: () {
+                  Navigator.push(context, new MaterialPageRoute<void>(
+                    builder: (BuildContext context) {
+                      return new Scaffold(
+                        floatingActionButton: new FloatingActionButton.extended(
+                          icon: const Icon(Icons.add),
+                          label: const Text('X'),
+                          onPressed: () { },
+                        ),
+                        body: new Center(
+                          child: new RaisedButton(
+                            child: const Text('POP'),
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                          ),
+                        ),
+                      );
+                    },
+                  ));
+                },
+              );
+            },
+          ),
+          body: const Center(
+            child: const Text('Hello World'),
+          ),
+        ),
+      ),
+    );
+
+    final Finder longFAB = find.text('A long FAB label');
+    final Finder shortFAB = find.text('X');
+    final Finder helloWorld = find.text('Hello World');
+
+    expect(longFAB, findsOneWidget);
+    expect(shortFAB, findsNothing);
+    expect(helloWorld, findsOneWidget);
+
+    await tester.tap(longFAB);
+    await tester.pumpAndSettle();
+
+    expect(shortFAB, findsOneWidget);
+    expect(longFAB, findsNothing);
+
+    // Trigger a hero transition from shortFAB to longFAB.
+    await tester.tap(find.text('POP'));
+    await tester.pumpAndSettle();
+
+    expect(longFAB, findsOneWidget);
+    expect(shortFAB, findsNothing);
+    expect(helloWorld, findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/18782

All FAB's are heroes by default and extended FABs (new FloatingActionButton.extended) are built from a icon,label Row with MainAxisSize.min. So the widget of an extended FAB depends on the widths of its label and icon.

At the beginning of a hero-transition from an extended FAB with a short label like 'X' to one with a long label like 'I am a long FAB label', we try to size the long extended FAB to match the short one. This fails because MainAxisSize.min: the width of the underlying RenderFlex can't be smaller than the sum of the widths of the label and icon.

Added a _ChildOverflowBox widget whose size matches its child's size unless its constraints force it to be larger or smaller. The child is centered. Extended FABs wrap their Row with the _ChildOverflowBox  The result is clipped because the extended FAB's Row is enclosed by material shape.
