### PR TITLE
Update CONTRIBUTING.md to suggest Android Studio and fix Mac command …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Things you will need
 
  * Linux, Mac OS X, or Windows
  * git (used for source version control).
- * An IDE. We recommend [IntelliJ with the Flutter plugin](https://flutter.io/intellij-ide/).
+ * An IDE. We recommend [Android Studio with the Flutter plugin](https://flutter.io/using-ide/).
  * An ssh client (used to authenticate with GitHub).
  * Python (used by some of our tools).
  * The Android platform tools (see [Issue #55](https://github.com/flutter/flutter/issues/55)
@@ -37,7 +37,7 @@ Things you will need
    _If you're also working on the Flutter engine, you can use the
    copy of the Android platform tools in
    `.../engine/src/third_party/android_tools/sdk/platform-tools`._
-   - Mac: `brew install android-platform-tools`
+   - Mac: `brew cask install android-platform-tools`
    - Linux: `sudo apt-get install android-tools-adb`
 
 Getting the code and configuring your environment


### PR DESCRIPTION
…to install android-platform-tools.

With the previous instructions you get the following error on Mac:
```
brew install android-platform-tools
Error: No available formula with the name "android-platform-tools" 
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install android-platform-tools
````