### PR TITLE
Update devicelab test with new message prefix

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test.dart
@@ -31,7 +31,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
       .listen((String line) {
     print('attach:stdout: $line');
     stdout.add(line);
-    if (line.contains('Listening') && onListening != null) {
+    if (line.contains('Waiting') && onListening != null) {
       listening.complete(onListening());
     }
     if (line.contains('To quit, press "q".'))


### PR DESCRIPTION
While working on attach, I changed the message output while waiting for an app to connect but didn't catch this.