### PR TITLE
Fix copy/paste error in test

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -90,7 +90,7 @@ void main() {
     test('can evaluate complex expressions in top level function', () async {
       await _flutter.run(withDebugger: true);
       await breakInTopLevelFunction(_flutter);
-      await evaluateTrivialExpressions();
+      await evaluateComplexExpressions();
     });
 
     test('can evaluate complex expressions in build method', () async {


### PR DESCRIPTION
This test was calling the wrong method making it a duplicate of a test further up and this method wasn't being tested in a top level function.