### PR TITLE
Change `onWIllPop` to return false in Cupertino Navigation Demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -46,7 +46,7 @@ class CupertinoNavigationDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return new WillPopScope(
       // Prevent swipe popping of this page. Use explicit exit buttons only.
-      onWillPop: () => new Future<bool>.value(true),
+      onWillPop: () => new Future<bool>.value(false),
       child: new CupertinoTabScaffold(
         tabBar: new CupertinoTabBar(
           items: const <BottomNavigationBarItem>[


### PR DESCRIPTION
I believe the comment above this line indicates it should prevent the back button from working on android when in the demo. Let me know if this is incorrect or you need anything else. 