### PR TITLE
[WIP] improve order of text field semantic label

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -710,6 +710,26 @@ class _RenderDecoration extends RenderBox {
     _children.forEach(visitor);
   }
 
+  // Do not visit the hint, helper, counter, or error text for semantics.
+  // Instead we add them in a semantics node ancestor.
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    if (icon != null)
+      visitor(icon);
+    if (input != null)
+      visitor(input);
+    if (prefixIcon != null)
+      visitor(prefixIcon);
+    if (suffixIcon != null)
+      visitor(suffixIcon);
+    if (prefix != null)
+      visitor(prefix);
+    if (suffix != null)
+      visitor(suffix);
+    if (container != null)
+      visitor(container);
+  }
+
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
     final List<DiagnosticsNode> value = <DiagnosticsNode>[];
@@ -1608,6 +1628,25 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       : themeData.errorColor;
   }
 
+  String _getSemanticLabel() {
+    final StringBuffer buffer = new StringBuffer();
+    if (widget.isFocused && widget.decoration.hintText != null)
+      buffer.write(widget.decoration.hintText);
+    else if (!widget.isFocused  && widget.decoration.helperText != null)
+      buffer.write(widget.decoration.helperText);
+    if (widget.decoration.errorText != null) {
+      if (buffer.isNotEmpty)
+        buffer.write(' ');
+      buffer.write(widget.decoration.errorText);
+    }
+    if (widget.decoration.counterText != null) {
+      if (buffer.isNotEmpty)
+        buffer.write(' ');
+      buffer.write(widget.decoration.counterText);
+    }
+    return buffer.toString();
+  }
+
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
@@ -1780,28 +1819,31 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
         : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
     }
-    return new _Decorator(
-      decoration: new _Decoration(
-        contentPadding: contentPadding,
-        isCollapsed: decoration.isCollapsed,
-        floatingLabelHeight: floatingLabelHeight,
-        floatingLabelProgress: _floatingLabelController.value,
-        border: decoration.border,
-        borderGap: _borderGap,
-        icon: icon,
-        input: widget.child,
-        label: label,
-        hint: hint,
-        prefix: prefix,
-        suffix: suffix,
-        prefixIcon: prefixIcon,
-        suffixIcon: suffixIcon,
-        helperError: helperError,
-        counter: counter,
-        container: container,
+    return new Semantics(
+      label: _getSemanticLabel(),
+      child: new _Decorator(
+        decoration: new _Decoration(
+          contentPadding: contentPadding,
+          isCollapsed: decoration.isCollapsed,
+          floatingLabelHeight: floatingLabelHeight,
+          floatingLabelProgress: _floatingLabelController.value,
+          border: decoration.border,
+          borderGap: _borderGap,
+          icon: icon,
+          input: widget.child,
+          label: label,
+          hint: hint,
+          prefix: prefix,
+          suffix: suffix,
+          prefixIcon: prefixIcon,
+          suffixIcon: suffixIcon,
+          helperError: helperError,
+          counter: counter,
+          container: container,
+        ),
+        textDirection: textDirection,
+        textBaseline: textBaseline,
       ),
-      textDirection: textDirection,
-      textBaseline: textBaseline,
     );
   }
 }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -559,17 +559,16 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     );
 
     if (widget.decoration != null) {
-      final Listenable listenable = new Listenable.merge(<Listenable>[focusNode, controller]);
-      child = AnimatedBuilder(
-        animation: listenable,
+      child = new AnimatedBuilder(
+        animation: new Listenable.merge(<Listenable>[ focusNode, controller ]),
         builder: (BuildContext context, Widget child) {
           return new InputDecorator(
-              decoration: _getEffectiveDecoration(),
-              baseStyle: widget.style,
-              textAlign: widget.textAlign,
-              isFocused: focusNode.hasFocus,
-              isEmpty: controller.value.text.isEmpty,
-              child: child,
+            decoration: _getEffectiveDecoration(),
+            baseStyle: widget.style,
+            textAlign: widget.textAlign,
+            isFocused: focusNode.hasFocus,
+            isEmpty: controller.value.text.isEmpty,
+            child: child,
           );
         },
         child: child,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -559,16 +559,17 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     );
 
     if (widget.decoration != null) {
-      child = new AnimatedBuilder(
-        animation: new Listenable.merge(<Listenable>[ focusNode, controller ]),
+      final Listenable listenable = new Listenable.merge(<Listenable>[focusNode, controller]);
+      child = AnimatedBuilder(
+        animation: listenable,
         builder: (BuildContext context, Widget child) {
           return new InputDecorator(
-            decoration: _getEffectiveDecoration(),
-            baseStyle: widget.style,
-            textAlign: widget.textAlign,
-            isFocused: focusNode.hasFocus,
-            isEmpty: controller.value.text.isEmpty,
-            child: child,
+              decoration: _getEffectiveDecoration(),
+              baseStyle: widget.style,
+              textAlign: widget.textAlign,
+              isFocused: focusNode.hasFocus,
+              isEmpty: controller.value.text.isEmpty,
+              child: child,
           );
         },
         child: child,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3782,13 +3782,13 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   }
 
   /// The handlers and supported [CustomSemanticsAction]s for this node.
-  /// 
+  ///
   /// These handlers are called whenever the user performs the associated
   /// custom accessibility action from a special platform menu. Providing any
   /// custom actions here also adds [SemanticsAction.customAction] to the node.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///   * [CustomSemanticsAction], for an explaination of custom actions.
   Map<CustomSemanticsAction, VoidCallback> get customSemanticsActions => _customSemanticsActions;
   Map<CustomSemanticsAction, VoidCallback> _customSemanticsActions;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2184,4 +2184,68 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
+  testWidgets('TextField semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final TextEditingController controller = new TextEditingController();
+    final Key key = new UniqueKey();
+
+    await tester.pumpWidget(
+      overlay(
+        child: new TextField(
+          key: key,
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: 'hint',
+            helperText: 'helper',
+            counterText: 'counter',
+            errorText: 'error',
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(
+          label: 'helper error counter',
+          id: 1,
+          textDirection: TextDirection.ltr,
+          actions: <SemanticsAction>[
+            SemanticsAction.tap,
+          ],
+          flags: <SemanticsFlag>[
+            SemanticsFlag.isTextField,
+          ],
+        ),
+      ],
+    ), ignoreTransform: true, ignoreRect: true));
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    expect(semantics, hasSemantics(new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(
+          label: 'hint error counter',
+          id: 1,
+          textDirection: TextDirection.ltr,
+          textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
+          actions: <SemanticsAction>[
+            SemanticsAction.tap,
+            SemanticsAction.setSelection,
+            SemanticsAction.paste,
+          ],
+          flags: <SemanticsFlag>[
+            SemanticsFlag.isTextField,
+            SemanticsFlag.isFocused,
+          ],
+        ),
+      ],
+    ), ignoreTransform: true, ignoreRect: true));
+
+    controller.text = 'hello';
+    await tester.pump();
+    semantics.dispose();
+  });
+
 }


### PR DESCRIPTION
Also ensures that the hint text continues to contribute semantics even when it is covered by text.
TextField hint is announced on focus.

Fixes #16673