### PR TITLE
Update state of BottomNavigationBar if background updates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Dan Field <dfield@gmail.com>
 Noah Groß <gross@ngsger.de>
 Victor Choueiri <victor@ctrlanddev.com>
 Lukasz Piliszczuk <lukasz@intheloup.io>
+Nathan Samson <nathan@nathansamson.be>

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -413,6 +413,12 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
       _controllers[oldWidget.currentIndex].reverse();
       _controllers[widget.currentIndex].forward();
     }
+
+    if (widget.items[widget.currentIndex].backgroundColor != _backgroundColor) {
+      setState(() {
+        _backgroundColor = widget.items[widget.currentIndex].backgroundColor;
+      });
+    }
   }
 
   List<Widget> _createTiles() {


### PR DESCRIPTION
This tracks the backgroundColor of the selected item  and updates the widget accordingly.

Note that I do not fully understand why we need to keep track of the `_backgroundColor` (and use `widget.items[widget.currentIndex].backgroundColor` directly...

Fixes #19653 