### PR TITLE
Bug Fix: release cache lock before use command `pub`

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -174,6 +174,7 @@ Future<Null> pub(List<String> arguments, {
 Future<Null> pubInteractively(List<String> arguments, {
   String directory,
 }) async {
+  Cache.releaseLockEarly();
   final int code = await runInteractively(
     _pubCommand(arguments),
     workingDirectory: directory,


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/14703