### PR TITLE
Fix whitespace detector to handle deleted files.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ task:
     - bin\flutter.bat update-packages
     - git fetch origin master
   test_all_script: |
-    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD)..HEAD"
+    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD)..HEAD"
     bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
 
 task:
@@ -83,7 +83,7 @@ task:
     - bin\flutter.bat update-packages
     - git fetch origin master
   test_all_script: |
-    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD)..HEAD"
+    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD)..HEAD"
     bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
 
 task:
@@ -98,7 +98,7 @@ task:
     - bin/flutter update-packages
   test_all_script: |
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD)..HEAD"
+    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD)..HEAD"
     bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart
 
 task:
@@ -113,5 +113,5 @@ task:
     - bin/flutter update-packages
   test_all_script: |
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD)..HEAD"
+    export TEST_COMMIT_RANGE="$(git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD)..HEAD"
     bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -104,7 +104,7 @@ Future<Null> _checkForTrailingSpaces() async {
         ? Platform.environment['TEST_COMMIT_RANGE']
         : 'master..HEAD';
     final List<String> fileTypes = <String>[
-      '*.dart', '*.cxx', '*.cpp', '*.cc', '*.c', '*.C', '*.h', '*.java', '*.mm', '*.m',
+      '*.dart', '*.cxx', '*.cpp', '*.cc', '*.c', '*.C', '*.h', '*.java', '*.mm', '*.m', '.yml',
     ];
     final EvalResult changedFilesResult = await _evalCommand(
       'git', <String>['diff', '-U0', '--no-color', '--name-only', commitRange, '--'] + fileTypes,
@@ -116,9 +116,8 @@ Future<Null> _checkForTrailingSpaces() async {
     }
     // Only include files that actually exist, so that we don't try and grep for
     // nonexistent files (can occur when files are deleted or moved).
-    final List<String> changedFiles = changedFilesResult.stdout.trim().split('\n')
-        .where((String filename) {
-          return filename.trim().isNotEmpty && new File(filename).existsSync();
+    final List<String> changedFiles = changedFilesResult.stdout.split('\n').where((String filename) {
+      return new File(filename).existsSync();
     }).toList();
     if (changedFiles.isNotEmpty) {
       await _runCommand('grep',


### PR DESCRIPTION
The trailing whitespace detector wasn't handling file deletes very well (at all, really).

This filters the set of files grepped to only include files that exist.

Also, clarified the failure message to make it more obvious what the failure is when the grep finds results.