### PR TITLE
Clean up startProgress logic.

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -13,6 +13,8 @@ import 'utils.dart';
 
 const int kDefaultStatusPadding = 59;
 
+typedef void VoidCallback();
+
 abstract class Logger {
   bool get isVerbose => false;
 
@@ -53,8 +55,6 @@ abstract class Logger {
   });
 }
 
-typedef void _FinishCallback();
-
 class StdoutLogger extends Logger {
 
   Status _status;
@@ -66,7 +66,6 @@ class StdoutLogger extends Logger {
   void printError(String message, { StackTrace stackTrace, bool emphasis = false }) {
     _status?.cancel();
     _status = null;
-
     if (emphasis)
       message = terminal.bolden(message);
     stderr.writeln(message);
@@ -109,15 +108,24 @@ class StdoutLogger extends Logger {
   }) {
     if (_status != null) {
       // Ignore nested progresses; return a no-op status object.
-      return new Status()..start();
+      return new Status(onFinish: _clearStatus)..start();
     }
     if (terminal.supportsColor) {
-      _status = new AnsiStatus(message, expectSlowOperation, () { _status = null; }, progressIndicatorPadding)..start();
+      _status = new AnsiStatus(
+        message: message,
+        expectSlowOperation: expectSlowOperation,
+        padding: progressIndicatorPadding,
+        onFinish: _clearStatus,
+      )..start();
     } else {
       printStatus(message);
-      _status = new Status()..start();
+      _status = new Status(onFinish: _clearStatus)..start();
     }
     return _status;
+  }
+
+  void _clearStatus() {
+    _status = null;
   }
 }
 
@@ -180,7 +188,7 @@ class BufferLogger extends Logger {
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     printStatus(message);
-    return new Status();
+    return new Status()..start();
   }
 
   /// Clears all buffers.
@@ -230,7 +238,9 @@ class VerboseLogger extends Logger {
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     printStatus(message);
-    return new Status();
+    return new Status(onFinish: () {
+      printTrace('$message (completed)');
+    })..start();
   }
 
   void _emit(_LogType type, String message, [StackTrace stackTrace]) {
@@ -275,75 +285,91 @@ enum _LogType {
 /// A [Status] class begins when start is called, and may produce progress
 /// information asynchronously.
 ///
-/// When stop is called, summary information supported by this class is printed.
-/// If cancel is called, no summary information is displayed.
-/// The base class displays nothing at all.
+/// The [Status] class itself never has any output.
+///
+/// The [AnsiSpinner] subclass shows a spinner, and replaces it with a single
+/// space character when stopped or canceled.
+///
+/// The [AnsiStatus] subclass shows a spinner, and replaces it with timing
+/// information when stopped. When canceled, the information isn't shown. In
+/// either case, a newline is printed.
+///
+/// Generally, consider `logger.startProgress` instead of directly creating
+/// a [Status] or one of its subclasses.
 class Status {
-  Status();
+  Status({ this.onFinish });
+
+  /// A straight [Status] or an [AnsiSpinner] (depending on whether the
+  /// terminal is fancy enough), already started.
+  factory Status.withSpinner({ VoidCallback onFinish }) {
+    if (terminal.supportsColor)
+      return new AnsiSpinner(onFinish: onFinish)..start();
+    return new Status(onFinish: onFinish)..start();
+  }
+
+  final VoidCallback onFinish;
 
   bool _isStarted = false;
 
-  factory Status.withSpinner() {
-    if (terminal.supportsColor)
-      return new AnsiSpinner()..start();
-    return new Status()..start();
-  }
-
-  /// Display summary information for this spinner; called by [stop].
-  void summaryInformation() {}
-
-  /// Call to start spinning.  Call this method via super at the beginning
-  /// of a subclass [start] method.
+  /// Call to start spinning.
   void start() {
+    assert(!_isStarted);
     _isStarted = true;
   }
 
-  /// Call to stop spinning and delete the spinner.  Print summary information,
-  /// if applicable to the spinner.
+  /// Call to stop spinning after success.
   void stop() {
-    if (_isStarted) {
-      cancel();
-      summaryInformation();
-    }
+    assert(_isStarted);
+    _isStarted = false;
+    if (onFinish != null)
+      onFinish();
   }
 
-  /// Call to cancel the spinner without printing any summary output.  Call
-  /// this method via super at the end of a subclass [cancel] method.
+  /// Call to cancel the spinner after failure or cancelation.
   void cancel() {
+    assert(_isStarted);
     _isStarted = false;
+    if (onFinish != null)
+      onFinish();
   }
 }
 
 /// An [AnsiSpinner] is a simple animation that does nothing but implement an
-/// ASCII spinner.  When stopped or canceled, the animation erases itself.
+/// ASCII spinner. When stopped or canceled, the animation erases itself.
 class AnsiSpinner extends Status {
+  AnsiSpinner({ VoidCallback onFinish }) : super(onFinish: onFinish);
+
   int ticks = 0;
   Timer timer;
 
-  static final List<String> _progress = <String>['-', r'\', '|', r'/'];
+  static final List<String> _progress = <String>[r'-', r'\', r'|', r'/'];
 
-  void _callback(Timer _) {
+  void _callback(Timer timer) {
     stdout.write('\b${_progress[ticks++ % _progress.length]}');
   }
 
   @override
   void start() {
     super.start();
+    assert(timer == null);
     stdout.write(' ');
-    _callback(null);
     timer = new Timer.periodic(const Duration(milliseconds: 100), _callback);
+    _callback(timer);
   }
 
   @override
-  /// Clears the spinner.  After cancel, the cursor will be one space right
-  /// of where it was when [start] was called (assuming no other input).
+  void stop() {
+    assert(timer.isActive);
+    timer.cancel();
+    stdout.write('\b \b');
+    super.stop();
+  }
+
+  @override
   void cancel() {
-    if (timer?.isActive == true) {
-      timer.cancel();
-      // Many terminals do not interpret backspace as deleting a character,
-      // but rather just moving the cursor back one.
-      stdout.write('\b \b');
-    }
+    assert(timer.isActive);
+    timer.cancel();
+    stdout.write('\b \b');
     super.cancel();
   }
 }
@@ -353,59 +379,50 @@ class AnsiSpinner extends Status {
 /// On [stop], will additionally print out summary information in
 /// milliseconds if [expectSlowOperation] is false, as seconds otherwise.
 class AnsiStatus extends AnsiSpinner {
-  AnsiStatus(this.message, this.expectSlowOperation, this.onFinish, this.padding);
+  AnsiStatus({
+    this.message,
+    this.expectSlowOperation,
+    this.padding,
+    VoidCallback onFinish,
+  }) : super(onFinish: onFinish);
 
   final String message;
   final bool expectSlowOperation;
-  final _FinishCallback onFinish;
   final int padding;
 
   Stopwatch stopwatch;
-  bool _finished = false;
 
   @override
-  /// Writes [message] to [stdout] with padding, then begins spinning.
   void start() {
     stopwatch = new Stopwatch()..start();
     stdout.write('${message.padRight(padding)}     ');
-    assert(!_finished);
     super.start();
   }
 
   @override
-  /// Calls onFinish.
   void stop() {
-    if (!_finished) {
-      onFinish();
-      _finished = true;
-      super.cancel();
-      summaryInformation();
-    }
+    super.stop();
+    writeSummaryInformation();
+    stdout.write('\n');
   }
 
   @override
+  void cancel() {
+    super.cancel();
+    stdout.write('\n');
+  }
+
   /// Backs up 4 characters and prints a (minimum) 5 character padded time.  If
   /// [expectSlowOperation] is true, the time is in seconds; otherwise,
   /// milliseconds.  Only backs up 4 characters because [super.cancel] backs
   /// up one.
   ///
   /// Example: '\b\b\b\b 0.5s', '\b\b\b\b150ms', '\b\b\b\b1600ms'
-  void summaryInformation() {
+  void writeSummaryInformation() {
     if (expectSlowOperation) {
-      stdout.writeln('\b\b\b\b${getElapsedAsSeconds(stopwatch.elapsed).padLeft(5)}');
+      stdout.write('\b\b\b\b${getElapsedAsSeconds(stopwatch.elapsed).padLeft(5)}');
     } else {
-      stdout.writeln('\b\b\b\b${getElapsedAsMilliseconds(stopwatch.elapsed).padLeft(5)}');
-    }
-  }
-
-  @override
-  /// Calls [onFinish].
-  void cancel() {
-    if (!_finished) {
-      onFinish();
-      _finished = true;
-      super.cancel();
-      stdout.write('\n');
+      stdout.write('\b\b\b\b${getElapsedAsMilliseconds(stopwatch.elapsed).padLeft(5)}');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -295,11 +295,15 @@ abstract class CachedArtifact {
     return _withDownloadFile('${flattenNameSubdirs(url)}', (File tempFile) async {
       if (!verifier(tempFile)) {
         final Status status = logger.startProgress(message, expectSlowOperation: true);
-        await _downloadFile(url, tempFile).then<Null>((_) {
+        try {
+          await _downloadFile(url, tempFile);
           status.stop();
-        }).whenComplete(status.cancel);
+        } catch (exception) {
+          status.cancel();
+          rethrow;
+        }
       } else {
-        logger.printStatus('$message(cached)');
+        logger.printTrace('$message (cached)');
       }
       _ensureExists(location);
       extractor(tempFile, location);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -901,7 +901,14 @@ class _AppRunLogger extends Logger {
       'message': message,
     });
 
-    _status = new _AppLoggerStatus(this, id, progressId);
+    _status = new Status(onFinish: () {
+      _status = null;
+      _sendProgressEvent(<String, dynamic>{
+        'id': id.toString(),
+        'progressId': progressId,
+        'finished': true
+      });
+    });
     return _status;
   }
 
@@ -921,37 +928,6 @@ class _AppRunLogger extends Logger {
       printStatus('event sent after app closed: $event');
     else
       domain._sendAppEvent(app, 'progress', event);
-  }
-}
-
-class _AppLoggerStatus extends Status {
-  _AppLoggerStatus(this.logger, this.id, this.progressId);
-
-  final _AppRunLogger logger;
-  final int id;
-  final String progressId;
-
-  @override
-  void start() {}
-
-  @override
-  void stop() {
-    logger._status = null;
-    _sendFinished();
-  }
-
-  @override
-  void cancel() {
-    logger._status = null;
-    _sendFinished();
-  }
-
-  void _sendFinished() {
-    logger._sendProgressEvent(<String, dynamic>{
-      'id': id.toString(),
-      'progressId': progressId,
-      'finished': true
-    });
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -84,7 +84,10 @@ class UpdatePackagesCommand extends FlutterCommand {
   final bool hidden;
 
   Future<Null> _downloadCoverageData() async {
-    final Status status = logger.startProgress('Downloading lcov data for package:flutter...', expectSlowOperation: true);
+    final Status status = logger.startProgress(
+      'Downloading lcov data for package:flutter...',
+      expectSlowOperation: true,
+    );
     final String urlBase = platform.environment['FLUTTER_STORAGE_BASE_URL'] ?? 'https://storage.googleapis.com';
     final List<int> data = await fetchUrl(Uri.parse('$urlBase/flutter_infra/flutter/coverage/lcov.info'));
     final String coverageDir = fs.path.join(Cache.flutterRoot, 'packages/flutter/coverage');

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -109,8 +109,10 @@ Future<Null> pubGet({
         failureMessage: 'pub $command failed',
         retry: true,
       );
-    } finally {
       status.stop();
+    } catch (exception) {
+      status.cancel();
+      rethrow;
     }
   }
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -145,9 +145,13 @@ class Doctor {
     for (ValidatorTask validatorTask in startValidatorTasks()) {
       final DoctorValidator validator = validatorTask.validator;
       final Status status = new Status.withSpinner();
-      await (validatorTask.result).then<void>((_) {
-        status.stop();
-      }).whenComplete(status.cancel);
+      try {
+        await validatorTask.result;
+      } catch (exception) {
+        status.cancel();
+        rethrow;
+      }
+      status.stop();
 
       final ValidationResult result = await validatorTask.result;
       if (result.type == ValidationType.missing) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -299,7 +299,6 @@ class IOSDevice extends Device {
         bundlePath: bundle.path,
         launchArguments: launchArguments,
       );
-      installStatus.stop();
     } else {
       // Debugging is enabled, look for the observatory server port post launch.
       printTrace('Debugging is enabled, connecting to observatory');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -385,7 +385,7 @@ class FlutterDevice {
   }) async {
     final Status devFSStatus = logger.startProgress(
       'Syncing files to device ${device.name}...',
-      expectSlowOperation: true
+      expectSlowOperation: true,
     );
     int bytes = 0;
     try {
@@ -554,8 +554,9 @@ abstract class ResidentRunner {
           for (FlutterView view in device.views)
             await view.uiIsolate.flutterDebugAllowBanner(false);
         } catch (error) {
-          status.stop();
+          status.cancel();
           printError('Error communicating with Flutter on the device: $error');
+          return;
         }
       }
       try {
@@ -566,8 +567,9 @@ abstract class ResidentRunner {
             for (FlutterView view in device.views)
               await view.uiIsolate.flutterDebugAllowBanner(true);
           } catch (error) {
-            status.stop();
+            status.cancel();
             printError('Error communicating with Flutter on the device: $error');
+            return;
           }
         }
       }
@@ -575,7 +577,7 @@ abstract class ResidentRunner {
       status.stop();
       printStatus('Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).');
     } catch (error) {
-      status.stop();
+      status.cancel();
       printError('Error taking screenshot: $error');
     }
   }

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:test/test.dart';
@@ -40,23 +41,27 @@ void main() {
       mockStdio = new MockStdio();
       ansiSpinner = new AnsiSpinner();
       called = 0;
-      ansiStatus = new AnsiStatus('Hello world', true, () => called++, 20);
+      ansiStatus = new AnsiStatus(
+        message: 'Hello world',
+        expectSlowOperation: true,
+        padding: 20,
+        onFinish: () => called++,
+      );
     });
 
     List<String> outputLines() => mockStdio.writtenToStdout.join('').split('\n');
 
-    Future<void> doWhile(bool doThis()) async {
-      return Future.doWhile(() async {
-        // Future.doWhile() isn't enough by itself, because the VM never gets
-        // around to scheduling the other tasks for some reason.
-        await new Future<void>.delayed(const Duration(milliseconds: 0));
-        return doThis();
+    Future<void> doWhileAsync(bool doThis()) async {
+      return Future.doWhile(() {
+        // We want to let other tasks run at the same time, so we schedule these
+        // using a timer rather than a microtask.
+        return Future<bool>.delayed(Duration.zero, doThis);
       });
     }
 
     testUsingContext('AnsiSpinner works', () async {
       ansiSpinner.start();
-      await doWhile(() => ansiSpinner.ticks < 10);
+      await doWhileAsync(() => ansiSpinner.ticks < 10);
       List<String> lines = outputLines();
       expect(lines[0], startsWith(' \b-\b\\\b|\b/\b-\b\\\b|\b/'));
       expect(lines[0].endsWith('\n'), isFalse);
@@ -66,44 +71,37 @@ void main() {
       expect(lines[0], endsWith('\b \b'));
       expect(lines.length, equals(1));
 
-      // Verify that stopping multiple times doesn't clear multiple times.
-      ansiSpinner.stop();
-      lines = outputLines();
-      expect(lines[0].endsWith('\b \b '), isFalse);
-      expect(lines.length, equals(1));
-      ansiSpinner.cancel();
-      lines = outputLines();
-      expect(lines[0].endsWith('\b \b '), isFalse);
-      expect(lines.length, equals(1));
+      // Verify that stopping or canceling multiple times throws.
+      expect(() { ansiSpinner.stop(); }, throwsA(const isInstanceOf<AssertionError>()));
+      expect(() { ansiSpinner.cancel(); }, throwsA(const isInstanceOf<AssertionError>()));
     }, overrides: <Type, Generator>{Stdio: () => mockStdio});
 
     testUsingContext('AnsiStatus works when cancelled', () async {
       ansiStatus.start();
-      await doWhile(() => ansiStatus.ticks < 10);
+      await doWhileAsync(() => ansiStatus.ticks < 10);
       List<String> lines = outputLines();
       expect(lines[0], startsWith('Hello world               \b-\b\\\b|\b/\b-\b\\\b|\b/\b-'));
-      expect(lines[0].endsWith('\n'), isFalse);
       expect(lines.length, equals(1));
+      expect(lines[0].endsWith('\n'), isFalse);
+
+      // Verify a cancel does _not_ print the time and prints a newline.
       ansiStatus.cancel();
       lines = outputLines();
+      final List<Match> matches = secondDigits.allMatches(lines[0]).toList();
+      expect(matches, isEmpty);
       expect(lines[0], endsWith('\b \b'));
-      expect(lines.length, equals(2));
       expect(called, equals(1));
-      ansiStatus.cancel();
-      lines = outputLines();
-      expect(lines[0].endsWith('\b \b\b \b'), isFalse);
       expect(lines.length, equals(2));
-      expect(called, equals(1));
-      ansiStatus.stop();
-      lines = outputLines();
-      expect(lines[0].endsWith('\b \b\b \b'), isFalse);
-      expect(lines.length, equals(2));
-      expect(called, equals(1));
+      expect(lines[1], equals(''));
+
+      // Verify that stopping or canceling multiple times throws.
+      expect(() { ansiStatus.cancel(); }, throwsA(const isInstanceOf<AssertionError>()));
+      expect(() { ansiStatus.stop(); }, throwsA(const isInstanceOf<AssertionError>()));
     }, overrides: <Type, Generator>{Stdio: () => mockStdio});
 
     testUsingContext('AnsiStatus works when stopped', () async {
       ansiStatus.start();
-      await doWhile(() => ansiStatus.ticks < 10);
+      await doWhileAsync(() => ansiStatus.ticks < 10);
       List<String> lines = outputLines();
       expect(lines[0], startsWith('Hello world               \b-\b\\\b|\b/\b-\b\\\b|\b/\b-'));
       expect(lines.length, equals(1));
@@ -111,55 +109,55 @@ void main() {
       // Verify a stop prints the time.
       ansiStatus.stop();
       lines = outputLines();
-      List<Match> matches = secondDigits.allMatches(lines[0]).toList();
+      final List<Match> matches = secondDigits.allMatches(lines[0]).toList();
       expect(matches, isNotNull);
       expect(matches, hasLength(1));
-      Match  match = matches.first;
+      final Match match = matches.first;
       expect(lines[0], endsWith(match.group(0)));
-      final String initialTime = match.group(0);
       expect(called, equals(1));
       expect(lines.length, equals(2));
       expect(lines[1], equals(''));
 
-      // Verify stopping more than once generates no additional output.
-      ansiStatus.stop();
-      lines = outputLines();
-      matches = secondDigits.allMatches(lines[0]).toList();
-      expect(matches, hasLength(1));
-      match = matches.first;
-      expect(lines[0], endsWith(initialTime));
-      expect(called, equals(1));
-      expect(lines.length, equals(2));
-      expect(lines[1], equals(''));
+      // Verify that stopping or canceling multiple times throws.
+      expect(() { ansiStatus.stop(); }, throwsA(const isInstanceOf<AssertionError>()));
+      expect(() { ansiStatus.cancel(); }, throwsA(const isInstanceOf<AssertionError>()));
     }, overrides: <Type, Generator>{Stdio: () => mockStdio});
 
-    testUsingContext('AnsiStatus works when cancelled', () async {
-      ansiStatus.start();
-      await doWhile(() => ansiStatus.ticks < 10);
-      List<String> lines = outputLines();
-      expect(lines[0], startsWith('Hello world               \b-\b\\\b|\b/\b-\b\\\b|\b/\b-'));
-      expect(lines.length, equals(1));
+    testUsingContext('sequential startProgress calls with StdoutLogger', () async {
+      context[Logger].startProgress('AAA')..stop();
+      context[Logger].startProgress('BBB')..stop();
+      expect(outputLines(), <String>[
+        'AAA',
+        'BBB',
+        '',
+      ]);
+    }, overrides: <Type, Generator>{
+      Stdio: () => mockStdio,
+      Logger: () => new StdoutLogger(),
+    });
 
-      // Verify a cancel does _not_ print the time and prints a newline.
-      ansiStatus.cancel();
-      lines = outputLines();
-      List<Match> matches = secondDigits.allMatches(lines[0]).toList();
-      expect(matches, isEmpty);
-      expect(lines[0], endsWith('\b \b'));
-      expect(called, equals(1));
-      // TODO(jcollins-g): Consider having status objects print the newline
-      // when canceled, or never printing a newline at all.
-      expect(lines.length, equals(2));
+    testUsingContext('sequential startProgress calls with VerboseLogger and StdoutLogger', () async {
+      context[Logger].startProgress('AAA')..stop();
+      context[Logger].startProgress('BBB')..stop();
+      expect(outputLines(), <String>[
+        '[        ] AAA',
+        '[        ] AAA (completed)',
+        '[        ] BBB',
+        '[        ] BBB (completed)',
+        ''
+      ]);
+    }, overrides: <Type, Generator>{
+      Stdio: () => mockStdio,
+      Logger: () => new VerboseLogger(new StdoutLogger()),
+    });
 
-      // Verifying calling stop after cancel doesn't print anything weird.
-      ansiStatus.stop();
-      lines = outputLines();
-      matches = secondDigits.allMatches(lines[0]).toList();
-      expect(matches, isEmpty);
-      expect(lines[0], endsWith('\b \b'));
-      expect(called, equals(1));
-      expect(lines[0], isNot(endsWith('\b \b\b \b')));
-      expect(lines.length, equals(2));
-    }, overrides: <Type, Generator>{Stdio: () => mockStdio});
+    testUsingContext('sequential startProgress calls with BufferLogger', () async {
+      context[Logger].startProgress('AAA')..stop();
+      context[Logger].startProgress('BBB')..stop();
+      final BufferLogger logger = context[Logger];
+      expect(logger.statusText, 'AAA\nBBB\n');
+    }, overrides: <Type, Generator>{
+      Logger: () => new BufferLogger(),
+    });
   });
 }


### PR DESCRIPTION
Disallow calling stop() or cancel() multiple times. This means that
when you use startProgress you have to more carefully think about what
exactly is going on.

Properly cancel startProgress in non-ANSI situations, so that
back-to-back startProgress calls all render to the console.