### PR TITLE
Look up breakpoints rather than relying on magic numbers

### DIFF
--- a/packages/flutter_tools/test/integration/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/basic_project.dart
@@ -26,7 +26,7 @@ class BasicProject extends TestProject {
     @override
     Widget build(BuildContext context) {
       topLevelFunction();
-      return new MaterialApp(
+      return new MaterialApp( // BREAKPOINT
         title: 'Flutter Demo',
         home: new Container(),
       );
@@ -34,18 +34,13 @@ class BasicProject extends TestProject {
   }
 
   topLevelFunction() {
-    print("test");
+    print("topLevelFunction"); // 2 BREAKPOINT
   }
   ''';
 
-  @override
-  String get breakpointFile => buildMethodBreakpointFile;
-  @override
-  int get breakpointLine => buildMethodBreakpointLine;
-
-  String get buildMethodBreakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
-  int get buildMethodBreakpointLine => 9;
+  String get buildMethodBreakpointFile => breakpointFile;
+  int get buildMethodBreakpointLine => breakpointLine;
 
   String get topLevelFunctionBreakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
-  int get topLevelFunctionBreakpointLine => 17;
+  int get topLevelFunctionBreakpointLine => lineContaining(main, '// 2 BREAKPOINT');
 }

--- a/packages/flutter_tools/test/integration/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/basic_project.dart
@@ -34,7 +34,7 @@ class BasicProject extends TestProject {
   }
 
   topLevelFunction() {
-    print("topLevelFunction"); // 2 BREAKPOINT
+    print("topLevelFunction"); // TOP LEVEL BREAKPOINT
   }
   ''';
 
@@ -42,5 +42,5 @@ class BasicProject extends TestProject {
   int get buildMethodBreakpointLine => breakpointLine;
 
   String get topLevelFunctionBreakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
-  int get topLevelFunctionBreakpointLine => lineContaining(main, '// 2 BREAKPOINT');
+  int get topLevelFunctionBreakpointLine => lineContaining(main, '// TOP LEVEL BREAKPOINT');
 }

--- a/packages/flutter_tools/test/integration/test_data/test_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/test_project.dart
@@ -16,8 +16,8 @@ abstract class TestProject {
   String get main;
 
   // Valid locations for a breakpoint for tests that just need to break somewhere.
-  String get breakpointFile;
-  int get breakpointLine;
+  String get breakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
+  int get breakpointLine => lineContaining(main, '// BREAKPOINT');
 
   Future<void> setUpIn(Directory dir) async {
     this.dir = dir;
@@ -28,5 +28,12 @@ abstract class TestProject {
 
   void cleanup() {
     dir?.deleteSync(recursive: true);
+  }
+
+  int lineContaining(String contents, String search) {
+    final int index = contents.split('\n').indexWhere((String l) => l.contains(search));
+    if (index == -1)
+      throw new Exception("Did not find '$search' inside the file");
+    return index;
   }
 }


### PR DESCRIPTION
This changes the breakpoints in some integration tests from being hard-coded numbers to being searches in the code for comments. This makes it easier to maintain them if the code changes (these tests are mostly currently skipped due to intermittent issues, and while investigating them I noticed that something has changed that made the old numbers in correct).

It also makes a minor editor to the print based on https://github.com/flutter/flutter/issues/19542#issuecomment-407297993 which may help understand why the test is intermittently failing.