### PR TITLE
Add IJ module definitions for modules

### DIFF
--- a/packages/flutter_tools/templates/module/common/.idea/libraries/Dart_SDK.xml.tmpl
+++ b/packages/flutter_tools/templates/module/common/.idea/libraries/Dart_SDK.xml.tmpl
@@ -1,0 +1,19 @@
+<component name="libraryTable">
+  <library name="Dart SDK">
+    <CLASSES>
+      <root url="file://{{{dartSdk}}}/lib/async" />
+      <root url="file://{{{dartSdk}}}/lib/collection" />
+      <root url="file://{{{dartSdk}}}/lib/convert" />
+      <root url="file://{{{dartSdk}}}/lib/core" />
+      <root url="file://{{{dartSdk}}}/lib/developer" />
+      <root url="file://{{{dartSdk}}}/lib/html" />
+      <root url="file://{{{dartSdk}}}/lib/io" />
+      <root url="file://{{{dartSdk}}}/lib/isolate" />
+      <root url="file://{{{dartSdk}}}/lib/math" />
+      <root url="file://{{{dartSdk}}}/lib/mirrors" />
+      <root url="file://{{{dartSdk}}}/lib/typed_data" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/packages/flutter_tools/templates/module/common/.idea/libraries/Flutter_for_Android.xml.tmpl
+++ b/packages/flutter_tools/templates/module/common/.idea/libraries/Flutter_for_Android.xml.tmpl
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Flutter for Android">
+    <CLASSES>
+      <root url="jar://{{{androidFlutterJar}}}!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/packages/flutter_tools/templates/module/common/.idea/modules.xml.tmpl
+++ b/packages/flutter_tools/templates/module/common/.idea/modules.xml.tmpl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/{{projectName}}.iml" filepath="$PROJECT_DIR$/{{projectName}}.iml" />
+      <module fileurl="file://$PROJECT_DIR$/{{projectName}}_android.iml" filepath="$PROJECT_DIR$/{{projectName}}_android.iml" />
+    </modules>
+  </component>
+</project>

--- a/packages/flutter_tools/templates/module/common/.idea/workspace.xml.tmpl
+++ b/packages/flutter_tools/templates/module/common/.idea/workspace.xml.tmpl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="FileEditorManager">
+    <leaf>
+      <file leaf-file-name="main.dart" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/lib/main.dart">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="0">
+              <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="ToolWindowManager">
+    <editor active="true" />
+    <layout>
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+    </layout>
+  </component>
+  <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+    </navigator>
+    <panes>
+      <pane id="ProjectPane">
+        <option name="show-excluded-files" value="false" />
+      </pane>
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="dart.analysis.tool.window.force.activate" value="true" />
+    <property name="show.migrate.to.gradle.popup" value="false" />
+  </component>
+</project>

--- a/packages/flutter_tools/templates/module/common/projectName.iml.tmpl
+++ b/packages/flutter_tools/templates/module/common/projectName.iml.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/packages/flutter_tools/templates/module/common/projectName_android.iml.tmpl
+++ b/packages/flutter_tools/templates/module/common/projectName_android.iml.tmpl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_APT" value="/.android/gen" />
+        <option name="GEN_FOLDER_RELATIVE_PATH_AIDL" value="/.android/gen" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/.android/AndroidManifest.xml" />
+        <option name="RES_FOLDER_RELATIVE_PATH" value="/.android/res" />
+        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/.android/assets" />
+        <option name="LIBS_FOLDER_RELATIVE_PATH" value="/.android/libs" />
+        <option name="PROGUARD_LOGS_FOLDER_RELATIVE_PATH" value="/.android/proguard_logs" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/.android">
+      <sourceFolder url="file://$MODULE_DIR$/.android/Flutter/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/.android/gen" isTestSource="false" generated="true" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API {{androidSdkVersion}} Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Flutter for Android" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
I tried to do the IJ configuration for Flutter modules in IJ so we wouldn't need these files. It isn't working, so let's do it the old way. These files are adapted from the 'app' template files with adjustments for path differences.

@devoncarew @pq 