### PR TITLE
Revert "Make initialSemanticsTreeCreation less sensitive to GC timing…

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/semantics_perf.dart
+++ b/dev/benchmarks/complex_layout/test_driver/semantics_perf.dart
@@ -5,16 +5,7 @@
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:complex_layout/main.dart' as app;
 
-// Avoid sensitivity to GC timing.
-dynamic provokeSemispaceGrowth() {
-  dynamic tree(int n) {
-    return n == 0 ? null : <dynamic>[tree(n - 1), tree(n - 1)];
-  }
-  return tree(16);  // 2^16 * 6 words ~= 1.5 MB
-}
-
 void main() {
-  provokeSemispaceGrowth();
   enableFlutterDriverExtension();
   app.main();
 }


### PR DESCRIPTION
…. (#19491)"

This reverts commit 3840719987c4b42e7b8a5557c3b47de73bae400f.

Bug: https://github.com/flutter/flutter/issues/19435