### PR TITLE
InheritedModel - an InheritedWidget for data models

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4034,7 +4034,7 @@ class ParentDataElement<T extends RenderObjectWidget> extends ProxyElement {
 }
 
 /// Used by [InheritedElement] to represent the aspects of its
-/// [InheritedWidget] that it depends on.
+/// [InheritedWidget] that will a dependent to be rebuilt.
 ///
 /// If [isGlobal] is true then a dependent widget should be rebuilt
 /// whenever the inherited widget it depends on changes.
@@ -4048,7 +4048,7 @@ class InheritedDependencies {
   /// Construct an InheritedDependencies object.
   const InheritedDependencies();
 
-  /// True then a dependent widget should be rebuilt whenever the inherited
+  /// If true then a dependent widget should be rebuilt whenever the inherited
   /// widget it depends on changes.
   ///
   /// This method returns true. Subclasses may return false because their

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3237,6 +3237,13 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   @override
   InheritedWidget inheritFromWidgetOfExactType(Type targetType, { Object aspect, InheritedElement target }) {
     assert(_debugCheckStateIsActiveForAncestorLookup());
+    assert(target == null || () {
+      // check that target is really an ancestor
+      Element ancestor = _parent;
+      while (ancestor != target && ancestor != null)
+        ancestor = ancestor._parent;
+      return ancestor == target;
+    }());
     final InheritedElement ancestor = target ?? (_inheritedWidgets == null ? null : _inheritedWidgets[targetType]);
     if (ancestor != null) {
       assert(ancestor is InheritedElement);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1821,6 +1821,7 @@ class InheritedModelElement<T> extends InheritedElement {
   // widget changes, regardless of which aspects have changed.
   void _addDependent(Element element, dynamic aspect) {
     if (aspect == null) {
+      // ignore: prefer_const_constructors
       _dependents[element] = new UnmodifiableSetView<T>.empty();
     } else if (_dependents[element] == null) {
       _dependents[element] = new HashSet<_AspectDependency<T>>.of(
@@ -1834,8 +1835,10 @@ class InheritedModelElement<T> extends InheritedElement {
   // The value of _dependents[dependent] is a Set<_AspectDependency>. Return a
   // new set that just contains the dependencies.
   Set<T> _getModelDependencies(Element dependent) {
-    if (_dependents[dependent].isEmpty)
+    if (_dependents[dependent].isEmpty) {
+      // ignore: prefer_const_constructors
       return new UnmodifiableSetView<T>.empty();
+    }
     return new HashSet<T>.of(
       _dependents[dependent].map((dynamic aspectDependencyValue) {
         final _AspectDependency<T> aspectDependency = aspectDependencyValue;
@@ -3560,6 +3563,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       // If we're ever called with aspect == null (the common case) then
       // InheritedElement.notifyClients will unconditionally rebuild all dependents.
       if (aspect == null) {
+        // ignore: prefer_const_constructors
         ancestor._dependents[this] = new UnmodifiableSetView<dynamic>.empty();
       } else {
         assert(ancestor is InheritedModelElement);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1705,7 +1705,7 @@ class _InactiveElements {
     try {
       elements.reversed.forEach(_unmount);
     } finally {
-      assert(_elements.isEmpty);
+       assert(_elements.isEmpty);
       _locked = false;
     }
   }
@@ -3245,13 +3245,15 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   InheritedWidget inheritFromElement(InheritedElement ancestor, { Object aspect }) {
     assert(ancestor != null);
     assert(() {
-      // check that ancestor really is an ancestor
+      if (_parent == null) {
+        // We're being deactivated, see deactivateChild()
+        return true;
+      }
       Element element = _parent;
       while (ancestor != element && element != null)
         element = element._parent;
       return ancestor == element;
     }());
-
     _dependencies ??= new HashSet<InheritedElement>();
     _dependencies.add(ancestor);
     ancestor.updateDependencies(this, aspect);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1584,9 +1584,9 @@ abstract class InheritedWidget extends ProxyWidget {
 /// will also be rebuilt, but only if there was a change in the model
 /// that corresponds to the token they provided.
 ///
-/// An inherited model converts tokens into "dependencies"
-/// with [getDependencyFor] (by default this method just
-/// returns the token). The inherited model's [updateShouldNotifyDependent]
+/// An inherited model converts tokens into "dependencies" of type `T`
+/// with [getDependencyFor]. By default this method just returns its
+/// `token` argument. The inherited model's [updateShouldNotifyDependent]
 /// method is tested for each dependent and its dependencies.
 ///
 /// Inherited widget descendants create a dependency on the inherited widget
@@ -1609,13 +1609,13 @@ abstract class InheritedWidget extends ProxyWidget {
 /// `foo` aspect of `MyModel`.
 ///
 /// The [updateShouldNotifyDependent] method decides if a change in the model
-/// warrants rebuilding the dependent (BuildContext). It must compare the old
+/// warrants rebuilding a dependent (BuildContext). It must compare the old
 /// and new [InheritedModel] widget configurations with a set of dependencies
 /// and decide if the model's changes correspond to any of the dependencies.
 ///
 /// For example:
 /// ```
-/// class ABCModel extends InheritedModel<String> {
+/// class ABModel extends InheritedModel<String> {
 ///   ABModel({ this.a, this.b, Widget child }) : super(child: child);
 ///
 ///   final int a;
@@ -1632,7 +1632,7 @@ abstract class InheritedWidget extends ProxyWidget {
 /// ```
 ///
 /// In the previous example the dependency checked by
-/// `updateShouldNotifyDependent` is just the token string passed to
+/// [updateShouldNotifyDependent] is just the token string passed to
 /// `inheritFromWidgetOfExactType`. Sometimes it's useful to have the
 /// model create a dependency object that's based on the token but takes
 /// the current state of the model into account. The [getDependencyFor]
@@ -1683,17 +1683,29 @@ abstract class InheritedWidget extends ProxyWidget {
 ///   // ...
 /// }
 /// ```
+///
+/// By default [InheritedWidget.updateShouldNotify] returns true. Subclasses
+/// can override it to quickly short circuit the update and skip calling
+/// [updateShouldNotifyDependent].
 abstract class InheritedModel<T> extends InheritedWidget {
   const InheritedModel({ Key key, Widget child }) : super(key: key, child: child);
 
   @override
   InheritedModelElement<T> createElement() => new InheritedModelElement<T>(this);
 
-  @protected
-  bool updateShouldNotifyDependent(covariant InheritedModel<T> oldWidget, Set<T> dependencies);
-
+  /// Returns a `T` that represents a dependency on this model.
+  ///
+  /// Returns [token] by default.
   @protected
   T getDependencyFor(dynamic token) => token;
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
+
+  /// Return true if the changes between this model and [oldWidget] match any
+  /// of the [dependencies].
+  @protected
+  bool updateShouldNotifyDependent(covariant InheritedModel<T> oldWidget, Set<T> dependencies);
 }
 
 // The dependency, produced by getDependencyFor(token), between an element and an

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1705,7 +1705,7 @@ class _InactiveElements {
     try {
       elements.reversed.forEach(_unmount);
     } finally {
-       assert(_elements.isEmpty);
+      assert(_elements.isEmpty);
       _locked = false;
     }
   }
@@ -1870,15 +1870,17 @@ abstract class BuildContext {
   /// render object is usually short.
   Size get size;
 
-  /// Registers this build context with [ancestor] such that when that when
+  /// Registers this build context with [ancestor] such that when
   /// [ancestor]'s widget changes this build context is rebuilt.
+  ///
+  /// Returns `ancestor.widget`.
   ///
   /// This method is rarely called directly. Most applications should use
   /// [inheritFromWidgetOfExactType], which calls this method after finding
   /// the appropriate [InheritedElement] ancestor.
   ///
   /// All of the qualifications about when [inheritFromWidgetOfExactType] can
-  /// be called, apply to this method as well.
+  /// be called apply to this method as well.
   InheritedWidget inheritFromElement(InheritedElement ancestor, { Object aspect });
 
   /// Obtains the nearest widget of the given type, which must be the type of a
@@ -1892,7 +1894,7 @@ abstract class BuildContext {
   ///
   /// This method should not be called from widget constructors or from
   /// [State.initState] methods, because those methods would not get called
-  /// again if the inherited value was to change. To ensure that the widget
+  /// again if the inherited value were to change. To ensure that the widget
   /// correctly updates itself when the inherited value changes, only call this
   /// (directly or indirectly) from build methods, layout and paint callbacks, or
   /// from [State.didChangeDependencies].
@@ -4100,6 +4102,8 @@ class InheritedElement extends ProxyElement {
   /// so that they can selectively rebuild dependents in
   /// [notifyDependents].
   ///
+  /// This method is typically only called in overrides of [updateDependencies].
+  ///
   /// See also:
   ///
   ///  * [updateDependencies], which is called each time a dependency is
@@ -4108,6 +4112,8 @@ class InheritedElement extends ProxyElement {
   ///    element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
   ///    dependencies value to decide if the dependent needs to be rebuilt.
+  ///  * [InheritedModel], which is an example of a class that uses this method
+  ///    to manage dependency values.
   @protected
   Object getDependencies(Element dependent) {
     return _dependents[dependent];
@@ -4117,11 +4123,13 @@ class InheritedElement extends ProxyElement {
   ///
   /// Each dependent element is mapped to a single object value
   /// which represents how the element depends on this
-  /// [InheritedElement]. This value is null by default and by default
-  /// dependent elements are rebuilt unconditionally.
+  /// [InheritedElement]. The [updateDependencies] method sets this value to
+  /// null by default so that dependent elements are rebuilt unconditionally.
   ///
   /// Subclasses can manage these values with [updateDependencies]
   /// so that they can selectively rebuild dependents in [notifyDependents].
+  ///
+  /// This method is typically only called in overrides of [updateDependencies].
   ///
   /// See also:
   ///
@@ -4131,6 +4139,8 @@ class InheritedElement extends ProxyElement {
   ///    element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
   ///    [getDependencies] value to decide if the dependent needs to be rebuilt.
+  ///  * [InheritedModel], which is an example of a class that uses this method
+  ///    to manage dependency values.
   @protected
   void setDependencies(Element dependent, Object value) {
     _dependents[dependent] = value;
@@ -4143,7 +4153,10 @@ class InheritedElement extends ProxyElement {
   /// [getDependencies].
   ///
   /// By default this method sets the inherited dependencies for [dependent]
-  /// to null. Subclasses can manage their own dependencies values so that they
+  /// to null. This only serves to record an unconditional dependency on
+  /// [dependent].
+  ///
+  /// Subclasses can manage their own dependencies values so that they
   /// can selectively rebuild dependents in [notifyDependents].
   ///
   /// See also:
@@ -4153,6 +4166,8 @@ class InheritedElement extends ProxyElement {
   ///  * [setDependencies], which sets the value for a dependent element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
   ///    dependencies value to decide if the dependent needs to be rebuilt.
+  ///  * [InheritedModel], which is an example of a class that uses this method
+  ///    to manage dependency values.
   @protected
   void updateDependencies(Element dependent, Object aspect) {
     setDependencies(dependent, null);
@@ -4164,6 +4179,16 @@ class InheritedElement extends ProxyElement {
   ///
   /// Subclasses can override this method to selectively call
   /// [didChangeDependencies] based on the value of [getDependencies].
+  ///
+  /// See also:
+  ///
+  ///  * [updateDependencies], which is called each time a dependency is
+  ///    created with [inheritFromWidgetOfExactType].
+  ///  * [getDependencies], which returns the current value for a dependent
+  ///    element.
+  ///  * [setDependencies], which sets the value for a dependent element.
+  ///  * [InheritedModel], which is an example of a class that uses this method
+  ///    to manage dependency values.
   @protected
   void notifyDependent(covariant InheritedWidget oldWidget, Element dependent) {
     dependent.didChangeDependencies();

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4072,7 +4072,7 @@ class InheritedElement extends ProxyElement {
   @override
   InheritedWidget get widget => super.widget;
 
-  final Map<Element, InheritedDependencies> _dependents = <Element, InheritedDependencies>{};
+  final Map<Element, InheritedDependencies> _dependents = new HashMap<Element, InheritedDependencies>();
 
   @override
   void _updateInheritance() {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4040,30 +4040,6 @@ class ParentDataElement<T extends RenderObjectWidget> extends ProxyElement {
   }
 }
 
-/// Used by [InheritedElement] to represent the aspects of its
-/// [InheritedWidget] that will cause a dependent to be rebuilt.
-///
-/// If [isUniversal] is true then a dependent widget should be rebuilt
-/// whenever the inherited widget it depends on changes.
-///
-/// See also:
-///
-///  * [InheritedModel] and [InheritedModelElement], whose implementations
-///    extends this class to provide a way for a widget to depend
-///    specific aspects of an inherited widget ancestor.
-class InheritedDependencies {
-  /// Construct an InheritedDependencies object.
-  const InheritedDependencies();
-
-  /// If true then a dependent widget should be rebuilt whenever the inherited
-  /// widget it depends on changes.
-  ///
-  /// This method returns true. Subclasses may return false because their
-  /// dependent widgets should be conditionally rebuilt, depending on
-  /// what aspect of the inherited widget changes.
-  bool get isUniversal => true;
-}
-
 /// An [Element] that uses an [InheritedWidget] as its configuration.
 class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
@@ -4072,7 +4048,7 @@ class InheritedElement extends ProxyElement {
   @override
   InheritedWidget get widget => super.widget;
 
-  final Map<Element, InheritedDependencies> _dependents = new HashMap<Element, InheritedDependencies>();
+  final Map<Element, Object> _dependents = new HashMap<Element, Object>();
 
   @override
   void _updateInheritance() {
@@ -4094,72 +4070,74 @@ class InheritedElement extends ProxyElement {
     super.debugDeactivated();
   }
 
-  /// Returns the [InheritedDependencies] value recorded for [dependent]
+  /// Returns the dependencies value recorded for [dependent]
   /// with [setDependencies].
   ///
-  /// Each dependent element is mapped to a single [InheritedDependencies]
-  /// object which represents how the element depends on this
-  /// [InheritedElement]. By default the inherited dependencies value has
-  /// [InheritedDependencies.isUniversal] true, which means that the dependent
-  /// element should be rebuilt whenever this inherited element changes.
+  /// Each dependent element is mapped to a single object value
+  /// which represents how the element depends on this
+  /// [InheritedElement]. This value is null by default and by default
+  /// dependent elements are rebuilt unconditionally.
+  ///
+  /// Subclasses can manage these values with [updateDependencies]
+  /// so that they can selectively rebuild dependents in
+  /// [notifyDependents].
   ///
   /// See also:
   ///
   ///  * [updateDependencies], which is called each time a dependency is
   ///    created with [inheritFromWidgetOfExactType].
-  ///  * [setDependencies], which sets [InheritedDependencies] for a dependent
+  ///  * [setDependencies], which sets dependencies value for a dependent
   ///    element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
-  ///    [InheritedDependencies] value to decide if the dependent needs
-  ///    to be rebuilt.
+  ///    dependencies value to decide if the dependent needs to be rebuilt.
   @protected
-  InheritedDependencies getDependencies(Element dependent) {
+  Object getDependencies(Element dependent) {
     return _dependents[dependent];
   }
 
-  /// Sets the [InheritedDependencies] value for [dependent].
+  /// Sets the value returned by [getDependencies] value for [dependent].
   ///
-  /// Each dependent element is mapped to a single [InheritedDependencies]
-  /// object which represents how the element depends on this
-  /// [InheritedElement]. By default the inherited dependencies value has
-  /// [InheritedDependencies.isUniversal] true, which means that the dependent
-  /// element should be rebuilt whenever this inherited element changes.
+  /// Each dependent element is mapped to a single object value
+  /// which represents how the element depends on this
+  /// [InheritedElement]. This value is null by default and by default
+  /// dependent elements are rebuilt unconditionally.
+  ///
+  /// Subclasses can manage these values with [updateDependencies]
+  /// so that they can selectively rebuild dependents in [notifyDependents].
   ///
   /// See also:
   ///
   ///  * [updateDependencies], which is called each time a dependency is
   ///    created with [inheritFromWidgetOfExactType].
-  ///  * [getDependencies], which returns the current [InheritedDependencies]
-  ///    for a dependent element.
+  ///  * [getDependencies], which returns the current value for a dependent
+  ///    element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
-  ///    [InheritedDependencies] value to decide if the dependent needs
-  ///    to be rebuilt.
+  ///    [getDependencies] value to decide if the dependent needs to be rebuilt.
   @protected
-  void setDependencies(Element dependent, InheritedDependencies value) {
+  void setDependencies(Element dependent, Object value) {
     _dependents[dependent] = value;
   }
 
   /// Called by [inheritFromWidgetOfExactType] when a new [dependent] is added.
   ///
-  /// Each dependent element is mapped to a single [InheritedDependencies]
-  /// object with [setDependencies]. This method can lookup the existing
-  /// dependencies with [getDependencies].
+  /// Each dependent element can be mapped to a single object value with
+  /// [setDependencies]. This method can lookup the existing dependencies with
+  /// [getDependencies].
   ///
   /// By default this method sets the inherited dependencies for [dependent]
-  /// to a value for which [InheritedDependencies.isUniversal] is true.
+  /// to null. Subclasses can manage their own dependencies values so that they
+  /// can selectively rebuild dependents in [notifyDependents].
   ///
   /// See also:
   ///
-  ///  * [getDependencies], which returns the current [InheritedDependencies]
-  ///    for a dependent element.
-  ///  * [setDependencies], which sets [InheritedDependencies] for a dependent
+  ///  * [getDependencies], which returns the current value for a dependent
   ///    element.
+  ///  * [setDependencies], which sets the value for a dependent element.
   ///  * [notifyDependent], which can be overridden to use a dependent's
-  ///    [InheritedDependencies] value to decide if the dependent needs
-  ///    to be rebuilt.
+  ///    dependencies value to decide if the dependent needs to be rebuilt.
   @protected
   void updateDependencies(Element dependent, Object aspect) {
-    setDependencies(dependent, const InheritedDependencies()); // isUniversal => true
+    setDependencies(dependent, null);
   }
 
   /// Called by [notifyClients] for each dependent.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:developer';
 
+import 'package:collection/collection.dart' show UnmodifiableSetView;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
@@ -44,9 +45,6 @@ export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpR
 /// widget's child be a widget such as [Row], [Column], or [Stack], which have a
 /// `children` property, and then provide the children to that widget.
 /// {@endtemplate}
-
-// TODO(hansmuller) - const UnmodifiableSetView<dynamic>.empty();
-final Set<dynamic> _kEmptySet = new HashSet<dynamic>();
 
 // KEYS
 
@@ -1820,7 +1818,7 @@ class InheritedModelElement<T> extends InheritedElement {
   // widget changes, regardless of which aspects have changed.
   void _addDependent(Element element, dynamic aspect) {
     if (aspect == null) {
-      _dependents[element] = new HashSet<T>(); // TBD _kEmptySet;
+      _dependents[element] = new UnmodifiableSetView<T>.empty();
     } else if (_dependents[element] == null) {
       _dependents[element] = new HashSet<_AspectDependency<T>>.of(
         <_AspectDependency<T>>[ _getAspectDependency(aspect) ]
@@ -1834,7 +1832,7 @@ class InheritedModelElement<T> extends InheritedElement {
   // new set that just contains the dependencies.
   Set<T> _getModelDependencies(Element dependent) {
     if (_dependents[dependent].isEmpty)
-      return new HashSet<T>(); // TBD  _kEmptySet;
+      return new UnmodifiableSetView<T>.empty();
     return new HashSet<T>.of(
       _dependents[dependent].map((dynamic aspectDependencyValue) {
         final _AspectDependency<T> aspectDependency = aspectDependencyValue;
@@ -3559,7 +3557,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       // If we're ever called with aspect == null (the common case) then
       // InheritedElement.notifyClients will unconditionally rebuild all dependents.
       if (aspect == null) {
-        ancestor._dependents[this] = _kEmptySet;
+        ancestor._dependents[this] = new UnmodifiableSetView<dynamic>.empty();
       } else {
         assert(ancestor is InheritedModelElement);
         final InheritedModelElement<dynamic> modelElement = ancestor;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1597,7 +1597,7 @@ abstract class InheritedWidget extends ProxyWidget {
 /// Typically the `inheritFrom` method is called from a model-specific
 /// static `of` method. For example:
 ///
-/// ```
+/// ```dart
 /// class MyModel extends InheritedModel<String> {
 ///   // ...
 ///   static MyModel of(BuildContext context, String dependency) {
@@ -1615,7 +1615,8 @@ abstract class InheritedWidget extends ProxyWidget {
 /// and decide if the model's changes correspond to any of the dependencies.
 ///
 /// For example:
-/// ```
+///
+/// ```dart
 /// class ABModel extends InheritedModel<String> {
 ///   ABModel({ this.a, this.b, Widget child }) : super(child: child);
 ///
@@ -1649,7 +1650,7 @@ abstract class InheritedWidget extends ProxyWidget {
 /// path dependency saves the value of the path so that
 /// `updateShouldNotifyDependent` can compare it with the current value.
 ///
-/// ```
+/// ```dart
 /// class IntegerTree {
 ///   int valueOf(String path) => _lookup(path);
 ///   // ...
@@ -1753,6 +1754,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
   /// a `context` dependency on the first model ancestor that has a non-null
   /// value for the specified path.
   ///
+  /// ```dart
   /// class IntegerModel extends InheritedModel<String> {
   ///   // ...
   ///   int valueOf(String path) => _model.valueOf(path);
@@ -1766,6 +1768,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
   ///     return value;
   ///   }
   /// }
+  /// ```
   ///
   /// If [aspect] and [visitor] are null this method is the same as:
   /// `context.inheritFromWidgetOfExactType(T)`.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4043,7 +4043,7 @@ class ParentDataElement<T extends RenderObjectWidget> extends ProxyElement {
 /// Used by [InheritedElement] to represent the aspects of its
 /// [InheritedWidget] that will cause a dependent to be rebuilt.
 ///
-/// If [isGlobal] is true then a dependent widget should be rebuilt
+/// If [isUniversal] is true then a dependent widget should be rebuilt
 /// whenever the inherited widget it depends on changes.
 ///
 /// See also:
@@ -4061,7 +4061,7 @@ class InheritedDependencies {
   /// This method returns true. Subclasses may return false because their
   /// dependent widgets should be conditionally rebuilt, depending on
   /// what aspect of the inherited widget changes.
-  bool get isGlobal => true;
+  bool get isUniversal => true;
 }
 
 /// An [Element] that uses an [InheritedWidget] as its configuration.
@@ -4100,7 +4100,7 @@ class InheritedElement extends ProxyElement {
   /// Each dependent element is mapped to a single [InheritedDependencies]
   /// object which represents how the element depends on this
   /// [InheritedElement]. By default the inherited dependencies value has
-  /// [InheritedDependencies.isGlobal] true, which means that the dependent
+  /// [InheritedDependencies.isUniversal] true, which means that the dependent
   /// element should be rebuilt whenever this inherited element changes.
   ///
   /// See also:
@@ -4122,7 +4122,7 @@ class InheritedElement extends ProxyElement {
   /// Each dependent element is mapped to a single [InheritedDependencies]
   /// object which represents how the element depends on this
   /// [InheritedElement]. By default the inherited dependencies value has
-  /// [InheritedDependencies.isGlobal] true, which means that the dependent
+  /// [InheritedDependencies.isUniversal] true, which means that the dependent
   /// element should be rebuilt whenever this inherited element changes.
   ///
   /// See also:
@@ -4146,7 +4146,7 @@ class InheritedElement extends ProxyElement {
   /// dependencies with [getDependencies].
   ///
   /// By default this method sets the inherited dependencies for [dependent]
-  /// to a value for which [InheritedDependencies.isGlobal] is true.
+  /// to a value for which [InheritedDependencies.isUniversal] is true.
   ///
   /// See also:
   ///
@@ -4159,7 +4159,7 @@ class InheritedElement extends ProxyElement {
   ///    to be rebuilt.
   @protected
   void updateDependencies(Element dependent, Object aspect) {
-    setDependencies(dependent, const InheritedDependencies()); // isGlobal => true
+    setDependencies(dependent, const InheritedDependencies()); // isUniversal => true
   }
 
   /// Called by [notifyClients] for each dependent.

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -209,7 +209,7 @@ class _Dependencies<T> extends InheritedDependencies {
   bool contains(T dependency) => values.contains(dependency);
 
   void add(T dependency) {
-    assert(isGlobal);
+    assert(!isGlobal);
     values.add(dependency);
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -174,18 +174,20 @@ class InheritedModelElement<T> extends InheritedElement {
   InheritedModel<T> get widget => super.widget;
 
   @override
-  InheritedDependencies updateDependencies(Element dependent, Object aspect) {
+  void updateDependencies(Element dependent, Object aspect) {
     final _Dependencies<T> dependencies = getDependencies(dependent);
     if (dependencies != null && dependencies.isGlobal)
-      return dependencies;
+      return;
 
-    if (aspect == null)
-      return new _Dependencies<T>(isGlobal: true);
-
-    assert(aspect is T);
-    if (dependencies == null)
-      return new _Dependencies<T>()..add(aspect);
-    return dependencies..add(aspect);
+    if (aspect == null) {
+      setDependencies(dependent, new _Dependencies<T>(isGlobal: true));
+    } else {
+      assert(aspect is T);
+      setDependencies(dependent, dependencies == null
+        ? (new _Dependencies<T>()..add(aspect))
+        : dependencies..add(aspect)
+      );
+    }
   }
 
   @override
@@ -207,6 +209,7 @@ class _Dependencies<T> extends InheritedDependencies {
   bool contains(T dependency) => values.contains(dependency);
 
   void add(T dependency) {
+    assert(isGlobal);
     values.add(dependency);
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -166,7 +166,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
       return null;
     final InheritedElement lastModel = models.last;
     for (InheritedElement model in models) {
-      final T value = context.inheritFromWidgetOfExactType(T, aspect: aspect, target: model);
+      final T value = context.inheritFromElement(model, aspect: aspect);
       if (model == lastModel)
         return value;
     }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -1,0 +1,212 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import 'framework.dart';
+
+/// An [InheritedWidget] that's intended to be used as the base class for data
+/// models which are scoped to a widget tree.
+///
+/// An inherited widget's dependents are unconditionally rebuilt when the
+/// inherited widget changes per [InheritedWidget.updateShouldNotify].
+/// Widgets that depend on an [InheritedModel] qualify their dependence
+/// with a value that indicates what "aspect" of the model they depend
+/// on. When the model is rebuilt, dependents will also be rebuilt, but
+/// only if there was a change in the model that corresponds to the aspect
+/// they provided.
+///
+/// The type parameter `T` is the type of the model aspect objects.
+///
+/// Widgets create a dependency on an [InheritedModel] with a static method:
+/// [InheritedModel.inheritFrom]. This method's `context` parameter
+/// defines the subtree that will be rebuilt when the model changes.
+/// Typically the `inheritFrom` method is called from a model-specific
+/// static `of` method. For example:
+///
+/// ```dart
+/// class MyModel extends InheritedModel<String> {
+///   // ...
+///   static MyModel of(BuildContext context, String dependency) {
+///     return InheritedModel.inheritFrom<MyModel>(context, aspect: dependency);
+///   }
+/// }
+/// ```
+///
+/// Calling `MyModel.of(context, 'foo')` means that `context` should only
+/// be rebuilt when the `foo` aspect of `MyModel` changes.
+///
+/// When the inherited model is rebuilt the [updateShouldNotify] and
+/// [updateShouldNotifyDependent] methods are used to decide what
+/// should be rebuilt.  If [updateShouldNotify] returns true, then the
+/// inherited model's [updateShouldNotifyDependent] method is tested for
+/// each dependent and the set of aspect objects it depends on.
+/// The [updateShouldNotifyDependent] method must compare the set of aspect
+/// dependencies with the changes in the model itself.
+///
+/// For example:
+///
+/// ```dart
+/// class ABModel extends InheritedModel<String> {
+///   ABModel({ this.a, this.b, Widget child }) : super(child: child);
+///
+///   final int a;
+///   final int b;
+///
+///   @override
+///   bool updateShouldNotify(ABCModel old) {
+///     return a != old.a || b != old.b;
+///   }
+///
+///   @override
+///   bool updateShouldNotifyDependent(ABCModel old, Set<String> dependencies) {
+///     return (a != old.a && dependencies.contains('a'))
+///         || (b != old.b && dependencies.contains('b'))
+///   }
+///
+///   // ...
+/// }
+/// ```
+///
+/// In the previous example the dependencies checked by
+/// [updateShouldNotifyDependent] are just the aspect strings passed to
+/// `inheritFromWidgetOfExactType`. They're represented as a [Set] because
+/// one Widget can depend on more than one aspect of the model.
+/// If a widget depends on the model but doesn't specify an aspect,
+/// then changes in the model will cause the widget to be rebuilt
+/// unconditionally.
+abstract class InheritedModel<T> extends InheritedWidget {
+  const InheritedModel({ Key key, Widget child }) : super(key: key, child: child);
+
+  @override
+  InheritedModelElement<T> createElement() => new InheritedModelElement<T>(this);
+
+  /// Return true if the changes between this model and [oldWidget] match any
+  /// of the [dependencies].
+  @protected
+  bool updateShouldNotifyDependent(
+    covariant InheritedModel<T> oldWidget, Set<T> dependencies);
+
+  // Return the first ancestor of context whose widget is type T and for which
+  // visitor(widget) returns false. If visitor is null then this function is the
+  // same as: context.ancestorInheritedElementForWidgetOfExactType(T).
+  static InheritedElement _findModel<T extends InheritedModel<Object>>(
+    BuildContext context,
+    bool visitor(T widget)
+  ) {
+    final InheritedElement model = context.ancestorInheritedElementForWidgetOfExactType(T);
+    if (model == null)
+      return null;
+
+    assert(model.widget is T);
+    final T modelWidget = model.widget;
+    if (visitor == null || !visitor(modelWidget))
+      return model;
+
+    Element modelParent;
+    model.visitAncestorElements((Element ancestor) {
+      modelParent = ancestor;
+      return false;
+    });
+    if (modelParent == null)
+      return null;
+    return _findModel<T>(modelParent, visitor);
+  }
+
+  /// Makes [context] dependent on the specified [aspect] of an [InheritedModel]
+  /// of type T.
+  ///
+  /// When the given [aspect] of the model changes, the context will be
+  /// rebuilt. The [updateShouldNotifyDependent] method must determine if a
+  /// change in the model widget corresponds to an `aspect` value.
+  ///
+  /// By default, the dependency created by this method targets the first
+  /// [InheritedModel] ancestor of type T. If [visitor] is specified then
+  /// it's the first [InheritedModel] ancestor of type T for which
+  /// [vistor] returns false. The vistor parameter can be used to create
+  /// models that override some values and delegate the rest to an
+  /// ancestor model.
+  ///
+  /// In the following example the model's static `valueOf` method returns the
+  /// first non-null value of `path`. By doing so the caller will have created
+  /// a `context` dependency on the first model ancestor that has a non-null
+  /// value for the specified path.
+  ///
+  /// ```dart
+  /// class IntegerModel extends InheritedModel<String> {
+  ///   // ...
+  ///   int valueOf(String path) => _model.valueOf(path);
+  ///
+  ///   static int valueOf(BuildContext context, String path) {
+  ///     int value;
+  ///     InheritedModel.inheritFrom<IntegerModel>(context,
+  ///       aspect: path,
+  ///       visitor: (IntegerModel widget) => (value = widget.valueOf(path)) == null,
+  ///     );
+  ///     return value;
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// If [aspect] and [visitor] are null this method is the same as:
+  /// `context.inheritFromWidgetOfExactType(T)`.
+  static T inheritFrom<T extends InheritedModel<Object>>(
+    BuildContext context, {
+    Object aspect,
+    bool visitor(T widget),
+  }) {
+    final InheritedElement model = _findModel<T>(context, visitor);
+    if (model != null)
+      return context.inheritFromWidgetOfExactType(T, aspect: aspect, target: model);
+    return null;
+  }
+}
+
+/// An [Element] that uses a [InheritedModel] as its configuration.
+class InheritedModelElement<T> extends InheritedElement {
+  /// Creates an element that uses the given widget as its configuration.
+  InheritedModelElement(InheritedModel<T> widget) : super(widget);
+
+  @override
+  InheritedModel<T> get widget => super.widget;
+
+  @override
+  InheritedDependencies updateDependencies(Element dependent, Object aspect) {
+    final _Dependencies<T> dependencies = getDependencies(dependent);
+    if (dependencies != null && dependencies.isGlobal)
+      return dependencies;
+
+    if (aspect == null)
+      return new _Dependencies<T>(isGlobal: true);
+
+    assert(aspect is T);
+    if (dependencies == null)
+      return new _Dependencies<T>()..add(aspect);
+    return dependencies..add(aspect);
+  }
+
+  @override
+  void notifyDependent(InheritedWidget oldWidget, Element dependent) {
+    final _Dependencies<T> dependencies = getDependencies(dependent);
+    if (dependencies.isGlobal || widget.updateShouldNotifyDependent(oldWidget, dependencies.values))
+      dependent.didChangeDependencies();
+  }
+}
+
+class _Dependencies<T> extends InheritedDependencies {
+  _Dependencies({ this.isGlobal = false });
+
+  @override
+  final bool isGlobal;
+
+  final Set<T> values = new HashSet<T>();
+
+  bool contains(T dependency) => values.contains(dependency);
+
+  void add(T dependency) {
+    values.add(dependency);
+  }
+}

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -105,7 +105,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
   /// all model aspects. This is typically done when a model can be used
   /// to "shadow" some aspects of an ancestor.
   @protected
-  bool isSupportedAspect(T aspect) => true;
+  bool isSupportedAspect(Object aspect) => true;
 
   // The [result] will be a list of all of context's type T ancestors concluding
   // with the one that supports the specified model [aspect].

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -118,8 +118,10 @@ abstract class InheritedModel<T> extends InheritedWidget {
   // with the one that supports the specified model [aspect].
   static Iterable<InheritedElement> _findModels<T extends InheritedModel<Object>>(BuildContext context, Object aspect) sync* {
     final InheritedElement model = context.ancestorInheritedElementForWidgetOfExactType(T);
-    if (model != null)
-      yield model;
+    if (model == null)
+      return;
+
+    yield(model);
 
     assert(model.widget is T);
     final T modelWidget = model.widget;
@@ -133,6 +135,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
     });
     if (modelParent == null)
       return;
+
     yield* _findModels<T>(modelParent, aspect);
   }
 
@@ -159,14 +162,13 @@ abstract class InheritedModel<T> extends InheritedWidget {
     // Rebuilding one of the intermediate models only causes its dependents
     // to be rebuilt if its aspects property changes (see _shouldNotify).
     final List<InheritedElement> models = _findModels<T>(context, aspect).toList();
-    if (models.isEmpty)
-      return null;
     final InheritedElement lastModel = models.last;
     for (InheritedElement model in models) {
       final T value = context.inheritFromElement(model, aspect: aspect);
       if (model == lastModel)
         return value;
     }
+
     assert(false);
     return null;
   }
@@ -190,6 +192,7 @@ class InheritedModelElement<T> extends InheritedElement {
       setDependencies(dependent, new HashSet<T>());
     } else {
       assert(aspect is T);
+      var foo = getDependencies(dependent);
       setDependencies(dependent, (dependencies ?? new HashSet<T>())..add(aspect));
     }
   }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -185,18 +185,17 @@ class InheritedModelElement<T> extends InheritedElement {
 
   @override
   void updateDependencies(Element dependent, Object aspect) {
-    final _Dependencies<T> dependencies = getDependencies(dependent);
-    if (dependencies != null && dependencies.isUniversal)
+    final Set<T> dependencies = getDependencies(dependent);
+    if (dependencies != null && dependencies.isEmpty)
       return;
 
     if (aspect == null) {
-      setDependencies(dependent, new _Dependencies<T>(isUniversal: true));
+      setDependencies(dependent, new HashSet<T>());
     } else {
       assert(aspect is T);
       setDependencies(dependent, dependencies == null
-        ? (new _Dependencies<T>()..add(aspect))
-        : dependencies..add(aspect)
-      );
+        ? (new HashSet<T>()..add(aspect))
+        : dependencies..add(aspect));
     }
   }
 
@@ -214,23 +213,11 @@ class InheritedModelElement<T> extends InheritedElement {
 
   @override
   void notifyDependent(InheritedModel<T> oldWidget, Element dependent) {
-    final _Dependencies<T> dependencies = getDependencies(dependent);
-    if (dependencies.isUniversal || _shouldNotify(oldWidget, dependent, dependencies.aspects))
+    final Set<T> dependencies = getDependencies(dependent);
+    if (dependencies == null)
+      return;
+    if (dependencies.isEmpty || _shouldNotify(oldWidget, dependent, dependencies))
       dependent.didChangeDependencies();
-  }
-}
-
-class _Dependencies<T> extends InheritedDependencies {
-  _Dependencies({ this.isUniversal = false });
-
-  @override
-  final bool isUniversal;
-
-  final Set<T> aspects = new HashSet<T>();
-
-  void add(T dependency) {
-    assert(!isUniversal);
-    aspects.add(dependency);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -8,11 +8,15 @@ import 'package:flutter/foundation.dart';
 
 import 'framework.dart';
 
-/// An [InheritedWidget] that's intended to be used as the base class for data
-/// models which are scoped to a widget tree.
+/// An [InheritedWidget] that's intended to be used as the base class for
+/// models whose dependents may only depend on one part or "aspect" of the
+/// overall model.
 ///
 /// An inherited widget's dependents are unconditionally rebuilt when the
 /// inherited widget changes per [InheritedWidget.updateShouldNotify].
+/// This widget is similar except that dependents aren't rebuilt
+/// unconditionally.
+///
 /// Widgets that depend on an [InheritedModel] qualify their dependence
 /// with a value that indicates what "aspect" of the model they depend
 /// on. When the model is rebuilt, dependents will also be rebuilt, but
@@ -38,7 +42,7 @@ import 'framework.dart';
 ///
 /// Calling `MyModel.of(context, 'foo')` means that `context` should only
 /// be rebuilt when the `foo` aspect of `MyModel` changes. If the aspect
-/// is null, then the the model supports all aspects.
+/// is null, then the model supports all aspects.
 ///
 /// When the inherited model is rebuilt the [updateShouldNotify] and
 /// [updateShouldNotifyDependent] methods are used to decide what

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -159,7 +159,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
     // Create a dependency on all of the type T ancestor models up until
     // a model is found whose aspects are null or contain the given aspect.
     // Rebuilding one of the intermediate models only causes its dependents
-    // to be rebuilt if its aspsects property changes (see _shouldNotify).
+    // to be rebuilt if its aspects property changes (see _shouldNotify).
     final List<InheritedElement> models = <InheritedElement>[];
     _findModels<T>(context, aspect, models);
     if (models.isEmpty)

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -46,6 +46,7 @@ export 'src/widgets/icon_theme_data.dart';
 export 'src/widgets/image.dart';
 export 'src/widgets/image_icon.dart';
 export 'src/widgets/implicit_animations.dart';
+export 'src/widgets/inherited_model.dart';
 export 'src/widgets/layout_builder.dart';
 export 'src/widgets/list_wheel_scroll_view.dart';
 export 'src/widgets/localizations.dart';

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  /*
   testWidgets('onSaved callback is called', (WidgetTester tester) async {
     final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
     String fieldValue;
@@ -392,7 +391,6 @@ void main() {
     expect(controller2.text, equals('Xyzzy'));
   });
 
-  */
   testWidgets('No crash when a TextFormField is removed from the tree', (WidgetTester tester) async {
     final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
     String fieldValue;

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
+  /*
   testWidgets('onSaved callback is called', (WidgetTester tester) async {
     final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
     String fieldValue;
@@ -391,6 +392,7 @@ void main() {
     expect(controller2.text, equals('Xyzzy'));
   });
 
+  */
   testWidgets('No crash when a TextFormField is removed from the tree', (WidgetTester tester) async {
     final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
     String fieldValue;

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -5,10 +5,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
+// See ShowABCField, ABCModel
+enum ShowABCFieldMode {
+  useOf, // Lookup the value to be displayed with ABCModel.of()
+  useValueOf, // Lookup the value to be displayed with ABCModel.valueOf()
+}
+
 // A simple "flat" InheritedModel: the data model is just 3 integer
 // valued fields: a, b, c.
 class ABCModel extends InheritedModel<String> {
-  ABCModel({
+  const ABCModel({
     Key key,
     this.a,
     this.b,
@@ -35,13 +41,32 @@ class ABCModel extends InheritedModel<String> {
   static ABCModel of(BuildContext context, { String fieldName }) {
     return InheritedModel.inheritFrom<ABCModel>(context, aspect: fieldName);
   }
+
+  // Returns the value of fieldName in the first ABCModel ancestor
+  // for which fieldName's value is non-null. Creates a dependency on
+  // on that ancestor: when the ancestor is rebuilt the given context
+  // will also be rebuit.
+  static int valueOf(BuildContext context, String fieldName) {
+    int value;
+    InheritedModel.inheritFrom<ABCModel>(
+      context,
+      aspect: fieldName,
+      visitor: (ABCModel widget) {
+        value = fieldName == 'a' ? widget.a : (fieldName == 'b' ? widget.b : widget.c);
+        return value == null;
+      }
+    );
+    return value;
+  }
 }
 
 class ShowABCField extends StatefulWidget {
-  ShowABCField({ Key key, this.fieldName }) : super(key: key);
+  const ShowABCField({ Key key, this.fieldName, this.mode = ShowABCFieldMode.useOf }) : super(key: key);
 
   final String fieldName;
+  final ShowABCFieldMode mode;
 
+  @override
   _ShowABCFieldState createState() => new _ShowABCFieldState();
 }
 
@@ -50,93 +75,94 @@ class _ShowABCFieldState extends State<ShowABCField> {
 
   @override
   Widget build(BuildContext context) {
-    final ABCModel abc = ABCModel.of(context, fieldName: widget.fieldName);
-    final int value = widget.fieldName == 'a' ? abc.a : (widget.fieldName == 'b' ? abc.b : abc.c);
+    int value;
+    switch (widget.mode) {
+      case ShowABCFieldMode.useOf:
+        final ABCModel abc = ABCModel.of(context, fieldName: widget.fieldName);
+        value = widget.fieldName == 'a' ? abc.a : (widget.fieldName == 'b' ? abc.b : abc.c);
+        break;
+      case ShowABCFieldMode.useValueOf:
+        value = ABCModel.valueOf(context, widget.fieldName);
+      break;
+    }
     return new Text('${widget.fieldName}: $value [${_buildCount++}]');
   }
 }
 
-class ABCPage extends StatefulWidget {
-  @override
-  _ABCPageState createState() => new _ABCPageState();
-}
-
-class _ABCPageState extends State<ABCPage> {
-  int _a = 0;
-  int _b = 1;
-  int _c = 2;
-
-  @override
-  Widget build(BuildContext context) {
-    final Widget showA = new ShowABCField(fieldName: 'a');
-    final Widget showB = new ShowABCField(fieldName: 'b');
-    final Widget showC = new ShowABCField(fieldName: 'c');
-
-    // Unconditionally depends on the ABCModel: rebuilt when any
-    // aspect of the model changes.
-    final Widget showABC = new Builder(
-      builder: (BuildContext context) {
-        final ABCModel abc = ABCModel.of(context);
-        return new Text('a: ${abc.a} b: ${abc.b} c: ${abc.c}');
-      }
-    );
-
-    return new Scaffold(
-      body: new StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return new ABCModel(
-            a: _a,
-            b: _b,
-            c: _c,
-            child: new Center(
-              child: new Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  showA,
-                  showB,
-                  showC,
-                  showABC,
-                  new RaisedButton(
-                    child: const Text('Increment a'),
-                    onPressed: () {
-                      // Rebuilds the ABCModel which triggers a rebuild
-                      // of showA because showA depends on the 'a' aspect
-                      // of the ABCModel.
-                      setState(() { _a += 1; });
-                    },
-                  ),
-                  new RaisedButton(
-                    child: const Text('Increment b'),
-                    onPressed: () {
-                      // Rebuilds the ABCModel which triggers a rebuild
-                      // of showB because showB depends on the 'b' aspect
-                      // of the ABCModel.
-                      setState(() { _b += 1; });
-                    },
-                  ),
-                  new RaisedButton(
-                    child: const Text('Increment c'),
-                    onPressed: () {
-                      // Rebuilds the ABCModel which triggers a rebuild
-                      // of showC because showC depends on the 'c' aspect
-                      // of the ABCModel.
-                      setState(() { _c += 1; });
-                    },
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
-      ),
-    );
-  }
-}
-
-
 void main() {
   testWidgets('InheritedModel flat ABCModel', (WidgetTester tester) async {
-    await tester.pumpWidget(new MaterialApp(home: new ABCPage()));
+    int _a = 0;
+    int _b = 1;
+    int _c = 2;
+
+    final Widget abcPage = new StatefulBuilder(
+      builder: (BuildContext context, StateSetter setState) {
+        const Widget showA = ShowABCField(fieldName: 'a');
+        const Widget showB = ShowABCField(fieldName: 'b');
+        const Widget showC = ShowABCField(fieldName: 'c');
+
+        // Unconditionally depends on the ABCModel: rebuilt when any
+        // aspect of the model changes.
+        final Widget showABC = new Builder(
+          builder: (BuildContext context) {
+            final ABCModel abc = ABCModel.of(context);
+            return new Text('a: ${abc.a} b: ${abc.b} c: ${abc.c}');
+          }
+        );
+
+        return new Scaffold(
+          body: new StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return new ABCModel(
+                a: _a,
+                b: _b,
+                c: _c,
+                child: new Center(
+                  child: new Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      showA,
+                      showB,
+                      showC,
+                      showABC,
+                      new RaisedButton(
+                        child: const Text('Increment a'),
+                        onPressed: () {
+                          // Rebuilds the ABCModel which triggers a rebuild
+                          // of showA because showA depends on the 'a' aspect
+                          // of the ABCModel.
+                          setState(() { _a += 1; });
+                        },
+                      ),
+                      new RaisedButton(
+                        child: const Text('Increment b'),
+                        onPressed: () {
+                          // Rebuilds the ABCModel which triggers a rebuild
+                          // of showB because showB depends on the 'b' aspect
+                          // of the ABCModel.
+                          setState(() { _b += 1; });
+                        },
+                      ),
+                      new RaisedButton(
+                        child: const Text('Increment c'),
+                        onPressed: () {
+                          // Rebuilds the ABCModel which triggers a rebuild
+                          // of showC because showC depends on the 'c' aspect
+                          // of the ABCModel.
+                          setState(() { _c += 1; });
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+
+    await tester.pumpWidget(new MaterialApp(home: abcPage));
 
     expect(find.text('a: 0 [0]'), findsOneWidget);
     expect(find.text('b: 1 [0]'), findsOneWidget);
@@ -178,5 +204,124 @@ void main() {
     expect(find.text('b: 2 [1]'), findsOneWidget);
     expect(find.text('c: 3 [1]'), findsOneWidget);
     expect(find.text('a: 2 b: 2 c: 3'), findsOneWidget);
+  });
+
+  testWidgets('InheritedModel flat ABCModel with shadowing', (WidgetTester tester) async {
+    int _a = 0;
+    int _b = 1;
+    int _c = 2;
+
+    // Same as in abcPage in the "InheritedModel flat ABCModel" test
+    // except:
+    // - ABCModel.valueOf() is used to look up the values for the showA, showB,
+    // and showC widgets (but not showABC which uses ABCModel.of()).
+    // - There are two ABCModels and the inner model's "a" property
+    // shadows (overrides) the outer model.
+    final Widget abcPage = new StatefulBuilder(
+      builder: (BuildContext context, StateSetter setState) {
+        const Widget showA = ShowABCField(fieldName: 'a', mode: ShowABCFieldMode.useValueOf);
+        const Widget showB = ShowABCField(fieldName: 'b', mode: ShowABCFieldMode.useValueOf);
+        const Widget showC = ShowABCField(fieldName: 'c', mode: ShowABCFieldMode.useValueOf);
+
+        // Unconditionally depends on the closest ABCModel ancestor.
+        // Which is the inner model, for which b,c are null.
+        final Widget showABC = new Builder(
+          builder: (BuildContext context) {
+            final ABCModel abc = ABCModel.of(context);
+            return new Text('a: ${abc.a} b: ${abc.b} c: ${abc.c}', style: Theme.of(context).textTheme.title);
+          }
+        );
+
+        return new Scaffold(
+          body: new StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return new ABCModel( // The "outer" model
+                a: _a,
+                b: _b,
+                c: _c,
+                child: new ABCModel( // The "inner" model
+                  a: 100 + _a, // Override the value of a
+                  b: null, // but not b, c
+                  c: null,
+                  child: new Center(
+                    child: new Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        showA,
+                        showB,
+                        showC,
+                        const SizedBox(height: 24.0),
+                        showABC,
+                        const SizedBox(height: 24.0),
+                        new RaisedButton(
+                          child: const Text('Increment a'),
+                          onPressed: () {
+                            setState(() { _a += 1; });
+                          },
+                        ),
+                        new RaisedButton(
+                          child: const Text('Increment b'),
+                          onPressed: () {
+                            setState(() { _b += 1; });
+                          },
+                        ),
+                        new RaisedButton(
+                          child: const Text('Increment c'),
+                          onPressed: () {
+                            setState(() { _c += 1; });
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+
+    await tester.pumpWidget(new MaterialApp(home: abcPage));
+    expect(find.text('a: 100 [0]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 100 b: null c: null'), findsOneWidget);
+
+    await tester.tap(find.text('Increment a'));
+    await tester.pumpAndSettle();
+    // Verify that field 'a' was incremented, but only the showA
+    // and showABC widgets were rebuilt.
+    expect(find.text('a: 101 [1]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 101 b: null c: null'), findsOneWidget);
+
+    await tester.tap(find.text('Increment a'));
+    await tester.pumpAndSettle();
+    // Verify that field 'a' was incremented, but only the showA
+    // and showABC widgets were rebuilt.
+    expect(find.text('a: 102 [2]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 102 b: null c: null'), findsOneWidget);
+
+    // Verify that field 'b' was incremented, but only the showB
+    // and showABC widgets were rebuilt.
+    await tester.tap(find.text('Increment b'));
+    await tester.pumpAndSettle();
+    expect(find.text('a: 102 [2]'), findsOneWidget);
+    expect(find.text('b: 2 [1]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 102 b: null c: null'), findsOneWidget);
+
+    // Verify that field 'c' was incremented, but only the showC
+    // and showABC widgets were rebuilt.
+    await tester.tap(find.text('Increment c'));
+    await tester.pumpAndSettle();
+    expect(find.text('a: 102 [2]'), findsOneWidget);
+    expect(find.text('b: 2 [1]'), findsOneWidget);
+    expect(find.text('c: 3 [1]'), findsOneWidget);
+    expect(find.text('a: 102 b: null c: null'), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -1,0 +1,182 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+// A simple "flat" InheritedModel: the data model is just 3 integer
+// valued fields: a, b, c.
+class ABCModel extends InheritedModel<String> {
+  ABCModel({
+    Key key,
+    this.a,
+    this.b,
+    this.c,
+    Widget child,
+  }) : super(key: key, child: child);
+
+  final int a;
+  final int b;
+  final int c;
+
+  @override
+  bool updateShouldNotify(ABCModel old) {
+    return a != old.a || b != old.b || c != old.c;
+  }
+
+  @override
+  bool updateShouldNotifyDependent(ABCModel old, Set<String> dependencies) {
+    return (a != old.a && dependencies.contains('a'))
+        || (b != old.b && dependencies.contains('b'))
+        || (c != old.c && dependencies.contains('c'));
+  }
+
+  static ABCModel of(BuildContext context, { String fieldName }) {
+    return InheritedModel.inheritFrom<ABCModel>(context, aspect: fieldName);
+  }
+}
+
+class ShowABCField extends StatefulWidget {
+  ShowABCField({ Key key, this.fieldName }) : super(key: key);
+
+  final String fieldName;
+
+  _ShowABCFieldState createState() => new _ShowABCFieldState();
+}
+
+class _ShowABCFieldState extends State<ShowABCField> {
+  int _buildCount = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final ABCModel abc = ABCModel.of(context, fieldName: widget.fieldName);
+    final int value = widget.fieldName == 'a' ? abc.a : (widget.fieldName == 'b' ? abc.b : abc.c);
+    return new Text('${widget.fieldName}: $value [${_buildCount++}]');
+  }
+}
+
+class ABCPage extends StatefulWidget {
+  @override
+  _ABCPageState createState() => new _ABCPageState();
+}
+
+class _ABCPageState extends State<ABCPage> {
+  int _a = 0;
+  int _b = 1;
+  int _c = 2;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget showA = new ShowABCField(fieldName: 'a');
+    final Widget showB = new ShowABCField(fieldName: 'b');
+    final Widget showC = new ShowABCField(fieldName: 'c');
+
+    // Unconditionally depends on the ABCModel: rebuilt when any
+    // aspect of the model changes.
+    final Widget showABC = new Builder(
+      builder: (BuildContext context) {
+        final ABCModel abc = ABCModel.of(context);
+        return new Text('a: ${abc.a} b: ${abc.b} c: ${abc.c}');
+      }
+    );
+
+    return new Scaffold(
+      body: new StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return new ABCModel(
+            a: _a,
+            b: _b,
+            c: _c,
+            child: new Center(
+              child: new Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  showA,
+                  showB,
+                  showC,
+                  showABC,
+                  new RaisedButton(
+                    child: const Text('Increment a'),
+                    onPressed: () {
+                      // Rebuilds the ABCModel which triggers a rebuild
+                      // of showA because showA depends on the 'a' aspect
+                      // of the ABCModel.
+                      setState(() { _a += 1; });
+                    },
+                  ),
+                  new RaisedButton(
+                    child: const Text('Increment b'),
+                    onPressed: () {
+                      // Rebuilds the ABCModel which triggers a rebuild
+                      // of showB because showB depends on the 'b' aspect
+                      // of the ABCModel.
+                      setState(() { _b += 1; });
+                    },
+                  ),
+                  new RaisedButton(
+                    child: const Text('Increment c'),
+                    onPressed: () {
+                      // Rebuilds the ABCModel which triggers a rebuild
+                      // of showC because showC depends on the 'c' aspect
+                      // of the ABCModel.
+                      setState(() { _c += 1; });
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+
+void main() {
+  testWidgets('InheritedModel flat ABCModel', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(home: new ABCPage()));
+
+    expect(find.text('a: 0 [0]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 0 b: 1 c: 2'), findsOneWidget);
+
+    await tester.tap(find.text('Increment a'));
+    await tester.pumpAndSettle();
+    // Verify that field 'a' was incremented, but only the showA
+    // and showABC widgets were rebuilt.
+    expect(find.text('a: 1 [1]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 1 b: 1 c: 2'), findsOneWidget);
+
+    // Verify that field 'a' was incremented, but only the showA
+    // and showABC widgets were rebuilt.
+    await tester.tap(find.text('Increment a'));
+    await tester.pumpAndSettle();
+    expect(find.text('a: 2 [2]'), findsOneWidget);
+    expect(find.text('b: 1 [0]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 2 b: 1 c: 2'), findsOneWidget);
+
+    // Verify that field 'b' was incremented, but only the showB
+    // and showABC widgets were rebuilt.
+    await tester.tap(find.text('Increment b'));
+    await tester.pumpAndSettle();
+    expect(find.text('a: 2 [2]'), findsOneWidget);
+    expect(find.text('b: 2 [1]'), findsOneWidget);
+    expect(find.text('c: 2 [0]'), findsOneWidget);
+    expect(find.text('a: 2 b: 2 c: 2'), findsOneWidget);
+
+    // Verify that field 'c' was incremented, but only the showC
+    // and showABC widgets were rebuilt.
+    await tester.tap(find.text('Increment c'));
+    await tester.pumpAndSettle();
+    expect(find.text('a: 2 [2]'), findsOneWidget);
+    expect(find.text('b: 2 [1]'), findsOneWidget);
+    expect(find.text('c: 3 [1]'), findsOneWidget);
+    expect(find.text('a: 2 b: 2 c: 3'), findsOneWidget);
+  });
+}

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -31,7 +31,7 @@ class ABCModel extends InheritedModel<String> {
   final Set<String> aspects;
 
   @override
-  bool isSupportedAspect(String aspect) {
+  bool isSupportedAspect(Object aspect) {
     return aspect == null || aspects == null || aspects.contains(aspect);
   }
 


### PR DESCRIPTION
An `InheritedModel` is an InheritedWidget that's intended to be used as the base class for data models which are scoped to a widget tree.

A sample app that demonstrates defining a simple InheritedModel: https://gist.github.com/HansMuller/b947e76c34d941397989eaab537d45ca
