### PR TITLE
Skip integration tests that use flutter-tester on Windows

### DIFF
--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:test/test.dart';
 
 import 'test_data/basic_project.dart';

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -43,5 +43,6 @@ void main() {
       await new Future<void>.delayed(requiredLifespan);
       expect(_flutter.hasExited, equals(false));
     });
-  }, timeout: const Timeout.factor(3));
+    // Skip on Windows due to https://github.com/flutter/flutter/issues/17833
+  }, timeout: const Timeout.factor(3), skip: platform.isWindows);
 }


### PR DESCRIPTION
flutter-tester on Windows is known to be broken. I will un-skip all of these once a fix for flutter-tester lands on Windows.