### PR TITLE
Upgrade dartdoc to 0.20.2.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -22,7 +22,7 @@ if [ -d "$FLUTTER_PUB_CACHE" ]; then
 fi
 
 # Install dartdoc.
-bin/cache/dart-sdk/bin/pub global activate dartdoc 0.20.1
+bin/cache/dart-sdk/bin/pub global activate dartdoc 0.20.2
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Upgrades dartdoc to 0.20.2. This has changes in dependencies and minor tweaks for Dart 2.0.  The included bugfix impacts only Angular; flutter document generation is not changed.

Release notes:
https://github.com/dart-lang/dartdoc/releases/tag/v0.20.2