### PR TITLE
Handle attempted caching of failed network image better

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -143,7 +143,7 @@ class ImageCache {
     result = loader();
     void listener(ImageInfo info, bool syncCall) {
       // Images that fail to load don't contribute to cache size.
-      final int imageSize = info.image == null ? 0 : info.image.height * info.image.width * 4;
+      final int imageSize = info?.image == null ? 0 : info.image.height * info.image.width * 4;
       final _CachedImage image = new _CachedImage(result, imageSize);
       // If the image is bigger than the maximum cache size, and the cache size
       // is not zero, then increase the cache size to the size of the image plus


### PR DESCRIPTION
If either image or image.info is null, treat it as an image of size zero.

Fixes https://github.com/flutter/flutter/issues/19766