### PR TITLE
do not display character counter when decoration is dense

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1746,7 +1746,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       errorMaxLines: decoration.errorMaxLines,
     );
 
-    final Widget counter = decoration.counterText == null ? null :
+    final Widget counter = (decoration.counterText == null || decorationIsDense) ? null :
       new Text(
         decoration.counterText,
         style: _getHelperStyle(themeData).merge(decoration.counterStyle),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2250,4 +2250,34 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
+  testWidgets('TextField decoration has no counter text when isDense is true', (WidgetTester tester) async{
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: TextField(
+          decoration: InputDecoration(
+            counterText: 'test',
+            isDense: false,
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('test'), findsOneWidget);
+
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: TextField(
+          decoration: InputDecoration(
+            counterText: 'test',
+            isDense: true,
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('test'), findsNothing);
+  });
+
 }


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/14716

cc @HansMuller - not sure if this is something that changed recently.  If so, we should close the bug, otherwise we should just fix it