### PR TITLE
Checking for the end of the URL when finding the debugging address

### DIFF
--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -63,7 +63,7 @@ class ProtocolDiscovery {
     final int index = line.indexOf(_prefix + 'http://');
     if (index >= 0) {
       try {
-        uri = Uri.parse(line.substring(index + _prefix.length));
+        uri = Uri.parse(line.substring(index + _prefix.length, line.lastIndexOf('/')));
       } catch (error) {
         _stopScrapingLogs();
         _completer.completeError(error);


### PR DESCRIPTION
This pull request addresses #19618 by using `lastIndexOf` on the provided line to find the last slash in the URL. This will help it avoid anything that isn't an actual URL from the input. 

I'm still pretty new to Dart, so I am not sure if this is the best way to do this, but it has helped me continue using Flutter.