### PR TITLE
Windows Dart SDK updater: Fall back to Invoke-WebRequest if downloading the Dart SDK via BITS fails

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -43,8 +43,15 @@ if (Test-Path $dartSdkPath) {
 }
 New-Item $dartSdkPath -force -type directory | Out-Null
 $dartSdkZip = "$cachePath\$dartZipName"
-Import-Module BitsTransfer
-Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
+
+Try {
+    Import-Module BitsTransfer
+    Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip
+}
+Catch {
+    Write-Host "Downloading the Dart SDK using the BITS service failed, retrying with WebRequest..."
+    Invoke-WebRequest -Uri $dartSdkUrl -OutFile $dartSdkZip
+}
 
 Write-Host "Unzipping Dart SDK..."
 If (Get-Command 7z -errorAction SilentlyContinue) {


### PR DESCRIPTION
Currently, the Dart SDK updater script for Windows uses `Start-BitsTransfer` which might fail due to a disabled BITS service etc.
We should provide some fallback mechanism using `Invoke-WebRequest`