### PR TITLE
Update the documentation on BinaryCodec

### DIFF
--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -13,6 +13,10 @@ import 'message_codec.dart';
 ///
 /// On Android, messages will be represented using `java.nio.ByteBuffer`.
 /// On iOS, messages will be represented using `NSData`.
+///
+/// When sending outgoing messages from Android, be sure to use direct `ByteBuffer`
+/// as opposed to indirect. The `wrap()` API provides indirect buffers by default
+/// and you will get empty `ByteData` objects in Dart.
 class BinaryCodec implements MessageCodec<ByteData> {
   /// Creates a [MessageCodec] with unencoded binary messages represented using
   /// [ByteData].


### PR DESCRIPTION
Two clients have run into this in the past so adding a bit of documentation to make it clear. See https://github.com/flutter/flutter/issues/19849 for one example.