### PR TITLE
Fix the gradle templates so that they default to values rather than throw

### DIFF
--- a/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-java.tmpl/app/build.gradle.tmpl
@@ -13,12 +13,12 @@ if (flutterRoot == null) {
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
-    throw new GradleException("versionCode not found. Define flutter.versionCode in the local.properties file.")
+    flutterVersionCode = '1'
 }
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    throw new GradleException("versionName not found. Define flutter.versionName in the local.properties file.")
+    flutterVersionName = '1.0'
 }
 
 apply plugin: 'com.android.application'

--- a/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/create/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -13,12 +13,12 @@ if (flutterRoot == null) {
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
-    throw new GradleException("versionCode not found. Define flutter.versionCode in the local.properties file.")
+    flutterVersionCode = '1'
 }
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    throw new GradleException("versionName not found. Define flutter.versionName in the local.properties file.")
+    flutterVersionName = '1.0'
 }
 
 apply plugin: 'com.android.application'

--- a/packages/flutter_tools/templates/module/android/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/Flutter.tmpl/build.gradle.tmpl
@@ -15,12 +15,12 @@ if (flutterRoot == null) {
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
-    throw new GradleException("versionCode not found. Define flutter.versionCode in the local.properties file.")
+    flutterVersionCode = '1'
 }
 
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
-    throw new GradleException("versionName not found. Define flutter.versionName in the local.properties file.")
+    flutterVersionName = '1.0'
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
When createing a new project, the build fails with an error similar to:

```
versionCode not found. Define flutter.versionCode in the local.properties file.
```

This puts developers in the untenable situation of having to edit a file with local paths, but being unable to check it in.

Fixes https://github.com/flutter/flutter/issues/18983.