### PR TITLE
Fix CupertinoSwitch accessibility

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
@@ -26,42 +26,51 @@ class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
         child: new Column(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: <Widget>[
-            new Column(
-              children: <Widget>[
-                new CupertinoSwitch(
-                  value: _switchValue,
-                  onChanged: (bool value) {
-                    setState(() {
-                      _switchValue = value;
-                    });
-                  },
-                ),
-                const Text(
-                  'Active'
-                ),
-              ],
+            new Semantics(
+              container: true,
+              child: new Column(
+                children: <Widget>[
+                  new CupertinoSwitch(
+                    value: _switchValue,
+                    onChanged: (bool value) {
+                      setState(() {
+                        _switchValue = value;
+                      });
+                    },
+                  ),
+                  const Text(
+                    'Active'
+                  ),
+                ],
+              ),
             ),
-            new Column(
-              children: const <Widget>[
-                const CupertinoSwitch(
-                  value: true,
-                  onChanged: null,
-                ),
-                const Text(
-                  'Disabled'
-                ),
-              ],
+            new Semantics(
+              container: true,
+              child: new Column(
+                children: const <Widget>[
+                  const CupertinoSwitch(
+                    value: true,
+                    onChanged: null,
+                  ),
+                  const Text(
+                    'Disabled'
+                  ),
+                ],
+              ),
             ),
-            new Column(
-              children: const <Widget>[
-                const CupertinoSwitch(
-                  value: false,
-                  onChanged: null,
-                ),
-                const Text(
-                  'Disabled'
-                ),
-              ],
+            new Semantics(
+              container: true,
+              child: new Column(
+                children: const <Widget>[
+                  const CupertinoSwitch(
+                    value: false,
+                    onChanged: null,
+                  ),
+                  const Text(
+                    'Disabled'
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -380,10 +380,11 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
 
-    config.isSemanticBoundary = isInteractive;
     if (isInteractive)
       config.onTap = _handleTap;
-    config.isChecked = _value;
+
+    config.isEnabled = isInteractive;
+    config.isToggled = _value;
   }
 
   final CupertinoThumbPainter _thumbPainter = new CupertinoThumbPainter();


### PR DESCRIPTION
Removed the semantic boundary since in iOS, switches can be part of UITableViewCells etc