### PR TITLE
Change from .first to .single to ensure our assumption is correct

### DIFF
--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -195,7 +195,7 @@ class FlutterTestDriver {
     // Currently these tests only have a single isolate. If this
     // ceases to be the case, this code will need changing.
     final VM vm = await vmService.getVM();
-    return await vm.isolates.first.load();
+    return await vm.isolates.single.load();
   }
 
   Future<void> addBreakpoint(String path, int line) async {


### PR DESCRIPTION
As suggested in a PR review after I'd merged it.