### PR TITLE
Cleanup in localizations code

### DIFF
--- a/dev/tools/gen_date_localizations.dart
+++ b/dev/tools/gen_date_localizations.dart
@@ -6,7 +6,8 @@
 /// package for the subset of locales supported by the flutter_localizations
 /// package.
 ///
-/// The extracted data is written into packages/flutter_localizations/lib/src/l10n/date_localizations.dart.
+/// The extracted data is written into:
+///   packages/flutter_localizations/lib/src/l10n/date_localizations.dart
 ///
 /// ## Usage
 ///
@@ -89,7 +90,7 @@ Future<Null> main(List<String> rawArgs) async {
   });
   buffer.writeln('};');
 
-  // Note: code that uses datePatterns expects it to contain values of type
+  // Code that uses datePatterns expects it to contain values of type
   // Map<String, String> not Map<String, dynamic>.
   buffer.writeln('const Map<String, Map<String, String>> datePatterns = const <String, Map<String, String>> {');
   patternFiles.forEach((String locale, File data) {

--- a/dev/tools/localizations_utils.dart
+++ b/dev/tools/localizations_utils.dart
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart' as argslib;
 import 'package:meta/meta.dart';
 
 void exitWithError(String errorMessage) {
-  if (errorMessage == null)
-    return;
-  stderr.writeln('Fatal Error: $errorMessage');
+  assert(errorMessage != null);
+  stderr.writeln('fatal: $errorMessage');
   exit(1);
 }
 
@@ -23,6 +24,13 @@ void checkCwdIsRepoRoot(String commandName) {
       'current working directory is: ${Directory.current.path}'
     );
   }
+}
+
+String camelCase(String locale) {
+  return locale
+    .split('_')
+    .map((String part) => part.substring(0, 1).toUpperCase() + part.substring(1).toLowerCase())
+    .join('');
 }
 
 GeneratorOptions parseArgs(List<String> rawArgs) {
@@ -44,4 +52,91 @@ class GeneratorOptions {
   });
 
   final bool writeToFile;
+}
+
+const String registry = 'https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry';
+
+// See also //master/tools/gen_locale.dart in the engine repo.
+Map<String, List<String>> _parseSection(String section) {
+  final Map<String, List<String>> result = <String, List<String>>{};
+  List<String> lastHeading;
+  for (String line in section.split('\n')) {
+    if (line == '')
+      continue;
+    if (line.startsWith('  ')) {
+      lastHeading[lastHeading.length - 1] = '${lastHeading.last}${line.substring(1)}';
+      continue;
+    }
+    final int colon = line.indexOf(':');
+    if (colon <= 0)
+      throw 'not sure how to deal with "$line"';
+    final String name = line.substring(0, colon);
+    final String value = line.substring(colon + 2);
+    lastHeading = result.putIfAbsent(name, () => <String>[]);
+    result[name].add(value);
+  }
+  return result;
+}
+
+final Map<String, String> _languages = <String, String>{};
+final Map<String, String> _regions = <String, String>{};
+final Map<String, String> _scripts = <String, String>{};
+const String kProvincePrefix = ', Province of ';
+const String kParentheticalPrefix = ' (';
+
+/// Prepares the data for the [describeLocale] method below.
+///
+/// The data is obtained from the official IANA registry.
+Future<void> precacheLanguageAndRegionTags() async {
+  final HttpClient client = new HttpClient();
+  final HttpClientRequest request = await client.getUrl(Uri.parse(registry));
+  final HttpClientResponse response = await request.close();
+  final String body = (await response.transform(utf8.decoder).toList()).join('');
+  client.close(force: true);
+  final List<Map<String, List<String>>> sections = body.split('%%').skip(1).map<Map<String, List<String>>>(_parseSection).toList();
+  for (Map<String, List<String>> section in sections) {
+    assert(section.containsKey('Type'), section.toString());
+    final String type = section['Type'].single;
+    if (type == 'language' || type == 'region' || type == 'script') {
+      assert(section.containsKey('Subtag') && section.containsKey('Description'), section.toString());
+      final String subtag = section['Subtag'].single;
+      String description = section['Description'].join(' ');
+      if (description.startsWith('United '))
+        description = 'the $description';
+      if (description.contains(kParentheticalPrefix))
+        description = description.substring(0, description.indexOf(kParentheticalPrefix));
+      if (description.contains(kProvincePrefix))
+        description = description.substring(0, description.indexOf(kProvincePrefix));
+      if (description.endsWith(' Republic'))
+        description = 'the $description';
+      switch (type) {
+        case 'language':
+          _languages[subtag] = description;
+          break;
+        case 'region':
+          _regions[subtag] = description;
+          break;
+        case 'script':
+          _scripts[subtag] = description;
+          break;
+      }
+    }
+  }
+}
+
+String describeLocale(String tag) {
+  final List<String> subtags = tag.split('_');
+  assert(subtags.isNotEmpty);
+  assert(_languages.containsKey(subtags[0]));
+  final String language = _languages[subtags[0]];
+  if (subtags.length >= 2) {
+    final String region = _regions[subtags[1]];
+    final String script = _scripts[subtags[1]];
+    assert(region != null || script != null);
+    if (region != null)
+      return '$language, as used in $region';
+    if (script != null)
+      return '$language, using the $script script';
+  }
+  return '$language';
 }

--- a/dev/tools/localizations_validator.dart
+++ b/dev/tools/localizations_validator.dart
@@ -5,6 +5,18 @@
 import 'dart:convert' show json;
 import 'dart:io';
 
+// The first suffix in kPluralSuffixes must be "Other". "Other" is special
+// because it's the only one that is required.
+const List<String> kPluralSuffixes = <String>['Other', 'Zero', 'One', 'Two', 'Few', 'Many'];
+final RegExp kPluralRegexp = new RegExp(r'(\w*)(' + kPluralSuffixes.skip(1).join(r'|') + r')$');
+
+class ValidationError implements Exception {
+  ValidationError(this. message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
 /// Sanity checking of the @foo metadata in the English translations,
 /// material_en.arb.
 ///
@@ -14,13 +26,13 @@ import 'dart:io';
 /// - Each @foo resource must have a Map value with a String valued
 ///   description entry.
 ///
-/// Returns an error message upon failure, null on success.
-String validateEnglishLocalizations(File file) {
+/// Throws an exception upon failure.
+void validateEnglishLocalizations(File file) {
   final StringBuffer errorMessages = new StringBuffer();
 
   if (!file.existsSync()) {
     errorMessages.writeln('English localizations do not exist: $file');
-    return errorMessages.toString();
+    throw new ValidationError(errorMessages.toString());
   }
 
   final Map<String, dynamic> bundle = json.decode(file.readAsStringSync());
@@ -36,7 +48,7 @@ String validateEnglishLocalizations(File file) {
       final int suffixIndex = resourceId.indexOf(suffix);
       return suffixIndex != -1 && bundle['@${resourceId.substring(0, suffixIndex)}'] != null;
     }
-    if (<String>['Zero', 'One', 'Two', 'Few', 'Many', 'Other'].any(checkPluralResource))
+    if (kPluralSuffixes.any(checkPluralResource))
       continue;
 
     errorMessages.writeln('A value was not specified for @$resourceId');
@@ -70,7 +82,8 @@ String validateEnglishLocalizations(File file) {
     }
   }
 
-  return errorMessages.isEmpty ? null : errorMessages.toString();
+  if (errorMessages.isNotEmpty)
+    throw new ValidationError(errorMessages.toString());
 }
 
 /// Enforces the following invariants in our localizations:
@@ -81,8 +94,8 @@ String validateEnglishLocalizations(File file) {
 /// Uses "en" localizations as the canonical source of locale keys that other
 /// locales are compared against.
 ///
-/// If validation fails, return an error message, otherwise return null.
-String validateLocalizations(
+/// If validation fails, throws an exception.
+void validateLocalizations(
   Map<String, Map<String, String>> localeToResources,
   Map<String, Map<String, dynamic>> localeToAttributes,
 ) {
@@ -99,12 +112,9 @@ String validateLocalizations(
     // Many languages require only a subset of these variations, so we do not
     // require them so long as the "Other" variation exists.
     bool isPluralVariation(String key) {
-      final RegExp pluralRegexp = new RegExp(r'(\w*)(Zero|One|Two|Few|Many)$');
-      final Match pluralMatch = pluralRegexp.firstMatch(key);
-
+      final Match pluralMatch = kPluralRegexp.firstMatch(key);
       if (pluralMatch == null)
         return false;
-
       final String prefix = pluralMatch[1];
       return resources.containsKey('${prefix}Other');
     }
@@ -151,7 +161,6 @@ String validateLocalizations(
           ..writeln('  "notUsed": "Sindhi time format does not use a.m. indicator"')
           ..writeln('}');
     }
-    return errorMessages.toString();
+    throw new ValidationError(errorMessages.toString());
   }
-  return null;
 }

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -134,7 +134,8 @@ Iterable<String> debugWordWrap(String message, int width, { String wrapIndent = 
         if ((index - startForLengthCalculations > width) || (index == message.length)) {
           // we are over the width line, so break
           if ((index - startForLengthCalculations <= width) || (lastWordEnd == null)) {
-            // we should use this point, before either it doesn't actually go over the end (last line), or it does, but there was no earlier break point
+            // we should use this point, because either it doesn't actually go over the
+            // end (last line), or it does, but there was no earlier break point
             lastWordEnd = index;
           }
           if (addPrefix) {

--- a/packages/flutter_localizations/lib/flutter_localizations.dart
+++ b/packages/flutter_localizations/lib/flutter_localizations.dart
@@ -5,5 +5,6 @@
 /// Localizations for the Flutter library
 library flutter_localizations;
 
-export 'src/material_localizations.dart' show GlobalMaterialLocalizations;
-export 'src/widgets_localizations.dart' show GlobalWidgetsLocalizations;
+export 'src/l10n/localizations.dart';
+export 'src/material_localizations.dart';
+export 'src/widgets_localizations.dart';

--- a/packages/flutter_localizations/lib/src/l10n/README.md
+++ b/packages/flutter_localizations/lib/src/l10n/README.md
@@ -68,7 +68,8 @@ contain translations for the same set of resource IDs as
 For each resource ID defined for English in material_en.arb, there is
 an additional resource with an '@' prefix. These '@' resources are not
 used by the material library at run time, they just exist to inform
-translators about how the value will be used.
+translators about how the value will be used, and to inform the code
+generator about what code to write.
 
 ```dart
 "cancelButtonLabel": "CANCEL",
@@ -130,9 +131,11 @@ help define an app's text theme and time picker layout respectively.
 
 The value of `timeOfDayFormat` defines how a time picker displayed by
 [showTimePicker()](https://docs.flutter.io/flutter/material/showTimePicker.html)
-formats and lays out its time controls. The value of `timeOfDayFormat` must be
-a string that matches one of the formats defined by
-https://docs.flutter.io/flutter/material/TimeOfDayFormat-class.html.
+formats and lays out its time controls. The value of `timeOfDayFormat`
+must be a string that matches one of the formats defined by
+<https://docs.flutter.io/flutter/material/TimeOfDayFormat-class.html>.
+It is converted to an enum value because the `material_en.arb` file
+has this value labeled as `"x-flutter-type": "icuShortTimePattern"`.
 
 The value of `scriptCategory` is based on the
 [Language categories reference](https://material.io/go/design-typography#typography-language-categories-reference)

--- a/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
@@ -7668,9 +7668,9 @@ const Map<String, dynamic> dateSymbols = <String, dynamic>{
     ],
     'AMPMS': <dynamic>[r'''AM''', r'''PM'''],
     'DATEFORMATS': <dynamic>[
-      r'''EEEE, MMMM d, y''',
-      r'''MMMM d, y''',
-      r'''MMM d, y''',
+      r'''EEEE، d MMMM، y''',
+      r'''d MMMM، y''',
+      r'''d MMM، y''',
       r'''d/M/yy'''
     ],
     'TIMEFORMATS': <dynamic>[
@@ -9994,7 +9994,7 @@ const Map<String, Map<String, String>> datePatterns =
     'MMMd': r'''d MMM''',
     'MMMEd': r'''EEE، d MMM''',
     'MMMM': r'''LLLL''',
-    'MMMMd': r'''MMMM d''',
+    'MMMMd': r'''d MMMM''',
     'MMMMEEEEd': r'''EEEE، d MMMM''',
     'QQQ': r'''QQQ''',
     'QQQQ': r'''QQQQ''',
@@ -10006,8 +10006,8 @@ const Map<String, Map<String, String>> datePatterns =
     'yMMMd': r'''d MMM، y''',
     'yMMMEd': r'''EEE، d MMM، y''',
     'yMMMM': r'''MMMM y''',
-    'yMMMMd': r'''MMMM d, y''',
-    'yMMMMEEEEd': r'''EEEE, MMMM d, y''',
+    'yMMMMd': r'''d MMMM، y''',
+    'yMMMMEEEEd': r'''EEEE، d MMMM، y''',
     'yQQQ': r'''QQQ y''',
     'yQQQQ': r'''QQQQ y''',
     'H': r'''HH''',

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -2,2948 +2,9580 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This file has been automatically generated.  Please do not edit it manually.
+// This file has been automatically generated. Please do not edit it manually.
 // To regenerate the file, use:
 // dart dev/tools/gen_localizations.dart --overwrite
 
-// The TranslationBundle subclasses defined here encode all of the translations
-// found in the flutter_localizations/lib/src/l10n/*.arb files.
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' as intl;
+
+import '../material_localizations.dart';
+
+// The classes defined here encode all of the translations found in the
+// `flutter_localizations/lib/src/l10n/*.arb` files.
 //
-// The [MaterialLocalizations] class uses the (generated)
-// translationBundleForLocale() function to look up a const TranslationBundle
-// instance for a locale.
-
-// ignore_for_file: public_member_api_docs
-
-import 'dart:ui' show Locale;
-
-class TranslationBundle {
-  const TranslationBundle(this.parent);
-  final TranslationBundle parent;
-  String get selectedRowCountTitleOne => parent?.selectedRowCountTitleOne;
-  String get selectedRowCountTitleZero => parent?.selectedRowCountTitleZero;
-  String get selectedRowCountTitleTwo => parent?.selectedRowCountTitleTwo;
-  String get selectedRowCountTitleFew => parent?.selectedRowCountTitleFew;
-  String get selectedRowCountTitleMany => parent?.selectedRowCountTitleMany;
-  String get scriptCategory => parent?.scriptCategory;
-  String get timeOfDayFormat => parent?.timeOfDayFormat;
-  String get openAppDrawerTooltip => parent?.openAppDrawerTooltip;
-  String get backButtonTooltip => parent?.backButtonTooltip;
-  String get closeButtonTooltip => parent?.closeButtonTooltip;
-  String get deleteButtonTooltip => parent?.deleteButtonTooltip;
-  String get nextMonthTooltip => parent?.nextMonthTooltip;
-  String get previousMonthTooltip => parent?.previousMonthTooltip;
-  String get nextPageTooltip => parent?.nextPageTooltip;
-  String get previousPageTooltip => parent?.previousPageTooltip;
-  String get showMenuTooltip => parent?.showMenuTooltip;
-  String get aboutListTileTitle => parent?.aboutListTileTitle;
-  String get licensesPageTitle => parent?.licensesPageTitle;
-  String get pageRowsInfoTitle => parent?.pageRowsInfoTitle;
-  String get pageRowsInfoTitleApproximate => parent?.pageRowsInfoTitleApproximate;
-  String get rowsPerPageTitle => parent?.rowsPerPageTitle;
-  String get tabLabel => parent?.tabLabel;
-  String get selectedRowCountTitleOther => parent?.selectedRowCountTitleOther;
-  String get cancelButtonLabel => parent?.cancelButtonLabel;
-  String get closeButtonLabel => parent?.closeButtonLabel;
-  String get continueButtonLabel => parent?.continueButtonLabel;
-  String get copyButtonLabel => parent?.copyButtonLabel;
-  String get cutButtonLabel => parent?.cutButtonLabel;
-  String get okButtonLabel => parent?.okButtonLabel;
-  String get pasteButtonLabel => parent?.pasteButtonLabel;
-  String get selectAllButtonLabel => parent?.selectAllButtonLabel;
-  String get viewLicensesButtonLabel => parent?.viewLicensesButtonLabel;
-  String get anteMeridiemAbbreviation => parent?.anteMeridiemAbbreviation;
-  String get postMeridiemAbbreviation => parent?.postMeridiemAbbreviation;
-  String get timePickerHourModeAnnouncement => parent?.timePickerHourModeAnnouncement;
-  String get timePickerMinuteModeAnnouncement => parent?.timePickerMinuteModeAnnouncement;
-  String get signedInLabel => parent?.signedInLabel;
-  String get hideAccountsLabel => parent?.hideAccountsLabel;
-  String get showAccountsLabel => parent?.showAccountsLabel;
-  String get modalBarrierDismissLabel => parent?.modalBarrierDismissLabel;
-  String get drawerLabel => parent?.drawerLabel;
-  String get popupMenuLabel => parent?.popupMenuLabel;
-  String get dialogLabel => parent?.dialogLabel;
-  String get alertDialogLabel => parent?.alertDialogLabel;
-  String get searchFieldLabel => parent?.searchFieldLabel;
-}
-
-// ignore: camel_case_types
-class _Bundle_ar extends TranslationBundle {
-  const _Bundle_ar() : super(null);
-  @override String get selectedRowCountTitleOne => r'تم اختيار عنصر واحد';
-  @override String get selectedRowCountTitleZero => r'لم يتم اختيار أي عنصر';
-  @override String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
-  @override String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
-  @override String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get openAppDrawerTooltip => r'فتح قائمة التنقل';
-  @override String get backButtonTooltip => r'رجوع';
-  @override String get closeButtonTooltip => r'إغلاق';
-  @override String get deleteButtonTooltip => r'حذف';
-  @override String get nextMonthTooltip => r'الشهر التالي';
-  @override String get previousMonthTooltip => r'الشهر السابق';
-  @override String get nextPageTooltip => r'الصفحة التالية';
-  @override String get previousPageTooltip => r'الصفحة السابقة';
-  @override String get showMenuTooltip => r'عرض القائمة';
-  @override String get aboutListTileTitle => r'حول "$applicationName"';
-  @override String get licensesPageTitle => r'التراخيص';
-  @override String get pageRowsInfoTitle => r'من $firstRow إلى $lastRow من إجمالي $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا';
-  @override String get rowsPerPageTitle => r'عدد الصفوف في الصفحة:';
-  @override String get tabLabel => r'علامة التبويب $tabIndex من $tabCount';
-  @override String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
-  @override String get cancelButtonLabel => r'إلغاء';
-  @override String get closeButtonLabel => r'إغلاق';
-  @override String get continueButtonLabel => r'متابعة';
-  @override String get copyButtonLabel => r'نسخ';
-  @override String get cutButtonLabel => r'قص';
-  @override String get okButtonLabel => r'حسنًا';
-  @override String get pasteButtonLabel => r'لصق';
-  @override String get selectAllButtonLabel => r'اختيار الكل';
-  @override String get viewLicensesButtonLabel => r'الاطّلاع على التراخيص';
-  @override String get anteMeridiemAbbreviation => r'ص';
-  @override String get postMeridiemAbbreviation => r'م';
-  @override String get timePickerHourModeAnnouncement => r'اختيار الساعات';
-  @override String get timePickerMinuteModeAnnouncement => r'اختيار الدقائق';
-  @override String get signedInLabel => r'تم تسجيل الدخول';
-  @override String get hideAccountsLabel => r'إخفاء الحسابات';
-  @override String get showAccountsLabel => r'إظهار الحسابات';
-  @override String get modalBarrierDismissLabel => r'رفض';
-  @override String get drawerLabel => r'قائمة تنقل';
-  @override String get popupMenuLabel => r'قائمة منبثقة';
-  @override String get dialogLabel => r'مربع حوار';
-  @override String get alertDialogLabel => r'مربع حوار التنبيه';
-  @override String get searchFieldLabel => r'بحث';
-}
-
-// ignore: camel_case_types
-class _Bundle_bg extends TranslationBundle {
-  const _Bundle_bg() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Отваряне на менюто за навигация';
-  @override String get backButtonTooltip => r'Назад';
-  @override String get closeButtonTooltip => r'Затваряне';
-  @override String get deleteButtonTooltip => r'Изтриване';
-  @override String get nextMonthTooltip => r'Следващият месец';
-  @override String get previousMonthTooltip => r'Предишният месец';
-  @override String get nextPageTooltip => r'Следващата страница';
-  @override String get previousPageTooltip => r'Предишната страница';
-  @override String get showMenuTooltip => r'Показване на менюто';
-  @override String get aboutListTileTitle => r'Всичко за $applicationName';
-  @override String get licensesPageTitle => r'Лицензи';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow от $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow от около $rowCount';
-  @override String get rowsPerPageTitle => r'Редове на страница:';
-  @override String get tabLabel => r'Раздел $tabIndex от $tabCount';
-  @override String get selectedRowCountTitleOne => r'Избран е 1 елемент';
-  @override String get selectedRowCountTitleOther => r'Избрани са $selectedRowCount елемента';
-  @override String get cancelButtonLabel => r'ОТКАЗ';
-  @override String get closeButtonLabel => r'ЗАТВАРЯНЕ';
-  @override String get continueButtonLabel => r'НАПРЕД';
-  @override String get copyButtonLabel => r'КОПИРАНЕ';
-  @override String get cutButtonLabel => r'ИЗРЯЗВАНЕ';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'ПОСТАВЯНЕ';
-  @override String get selectAllButtonLabel => r'ИЗБИРАНЕ НА ВСИЧКО';
-  @override String get viewLicensesButtonLabel => r'ПРЕГЛЕД НА ЛИЦЕНЗИТЕ';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Избиране на часове';
-  @override String get timePickerMinuteModeAnnouncement => r'Избиране на минути';
-  @override String get modalBarrierDismissLabel => r'Отхвърляне';
-  @override String get signedInLabel => r'В профила си сте';
-  @override String get hideAccountsLabel => r'Скриване на профилите';
-  @override String get showAccountsLabel => r'Показване на профилите';
-  @override String get drawerLabel => r'Меню за навигация';
-  @override String get popupMenuLabel => r'Изскачащо меню';
-  @override String get dialogLabel => r'Диалогов прозорец';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_bs extends TranslationBundle {
-  const _Bundle_bs() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
-  @override String get openAppDrawerTooltip => r'Otvaranje izbornika za navigaciju';
-  @override String get backButtonTooltip => r'Natrag';
-  @override String get closeButtonTooltip => r'Zatvaranje';
-  @override String get deleteButtonTooltip => r'Brisanje';
-  @override String get nextMonthTooltip => r'Sljedeći mjesec';
-  @override String get previousMonthTooltip => r'Prethodni mjesec';
-  @override String get nextPageTooltip => r'Sljedeća stranica';
-  @override String get previousPageTooltip => r'Prethodna stranica';
-  @override String get showMenuTooltip => r'Prikaz izbornika';
-  @override String get aboutListTileTitle => r'O aplikaciji $applicationName';
-  @override String get licensesPageTitle => r'Licence';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow od $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow od otprilike $rowCount';
-  @override String get rowsPerPageTitle => r'Redaka po stranici:';
-  @override String get tabLabel => r'Kartica $tabIndex od $tabCount';
-  @override String get selectedRowCountTitleOne => r'Odabrana je jedna stavka';
-  @override String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
-  @override String get cancelButtonLabel => r'ODUSTANI';
-  @override String get closeButtonLabel => r'ZATVORI';
-  @override String get continueButtonLabel => r'NASTAVI';
-  @override String get copyButtonLabel => r'KOPIRAJ';
-  @override String get cutButtonLabel => r'IZREŽI';
-  @override String get okButtonLabel => r'U REDU';
-  @override String get pasteButtonLabel => r'ZALIJEPI';
-  @override String get selectAllButtonLabel => r'ODABERI SVE';
-  @override String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
-  @override String get anteMeridiemAbbreviation => r'prijepodne';
-  @override String get postMeridiemAbbreviation => r'popodne';
-  @override String get timePickerHourModeAnnouncement => r'Odaberite sate';
-  @override String get timePickerMinuteModeAnnouncement => r'Odaberite minute';
-  @override String get modalBarrierDismissLabel => r'Odbaci';
-  @override String get signedInLabel => r'Prijavljeni korisnik';
-  @override String get hideAccountsLabel => r'Sakrijte račune';
-  @override String get showAccountsLabel => r'Prikažite račune';
-  @override String get drawerLabel => r'Navigacijski izbornik';
-  @override String get popupMenuLabel => r'Skočni izbornik';
-  @override String get dialogLabel => r'Dijalog';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_ca extends TranslationBundle {
-  const _Bundle_ca() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Obre el menú de navegació';
-  @override String get backButtonTooltip => r'Enrere';
-  @override String get closeButtonTooltip => r'Tanca';
-  @override String get deleteButtonTooltip => r'Suprimeix';
-  @override String get nextMonthTooltip => r'Mes següent';
-  @override String get previousMonthTooltip => r'Mes anterior';
-  @override String get nextPageTooltip => r'Pàgina següent';
-  @override String get previousPageTooltip => r'Pàgina anterior';
-  @override String get showMenuTooltip => r'Mostra el menú';
-  @override String get aboutListTileTitle => r'Sobre $applicationName';
-  @override String get licensesPageTitle => r'Llicències';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow d' "'" r'aproximadament $rowCount';
-  @override String get rowsPerPageTitle => r'Files per pàgina:';
-  @override String get tabLabel => r'Pestanya $tabIndex de $tabCount';
-  @override String get selectedRowCountTitleOne => r'S' "'" r'ha seleccionat 1 element';
-  @override String get selectedRowCountTitleOther => r'S' "'" r'han seleccionat $selectedRowCount elements';
-  @override String get cancelButtonLabel => r'CANCEL·LA';
-  @override String get closeButtonLabel => r'TANCA';
-  @override String get continueButtonLabel => r'CONTINUA';
-  @override String get copyButtonLabel => r'COPIA';
-  @override String get cutButtonLabel => r'RETALLA';
-  @override String get okButtonLabel => r'D' "'" r'ACORD';
-  @override String get pasteButtonLabel => r'ENGANXA';
-  @override String get selectAllButtonLabel => r'SELECCIONA-HO TOT';
-  @override String get viewLicensesButtonLabel => r'MOSTRA LES LLICÈNCIES';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Selecciona les hores';
-  @override String get timePickerMinuteModeAnnouncement => r'Selecciona els minuts';
-  @override String get modalBarrierDismissLabel => r'Ignora';
-  @override String get signedInLabel => r'Sessió iniciada';
-  @override String get hideAccountsLabel => r'Amaga els comptes';
-  @override String get showAccountsLabel => r'Mostra els comptes';
-  @override String get drawerLabel => r'Menú de navegació';
-  @override String get popupMenuLabel => r'Menú emergent';
-  @override String get dialogLabel => r'Diàleg';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_cs extends TranslationBundle {
-  const _Bundle_cs() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Jsou vybrány $selectedRowCount položky';
-  @override String get selectedRowCountTitleMany => r'Je vybráno $selectedRowCount položky';
-  @override String get openAppDrawerTooltip => r'Otevřít navigační nabídku';
-  @override String get backButtonTooltip => r'Zpět';
-  @override String get closeButtonTooltip => r'Zavřít';
-  @override String get deleteButtonTooltip => r'Smazat';
-  @override String get nextMonthTooltip => r'Další měsíc';
-  @override String get previousMonthTooltip => r'Předchozí měsíc';
-  @override String get nextPageTooltip => r'Další stránka';
-  @override String get previousPageTooltip => r'Předchozí stránka';
-  @override String get showMenuTooltip => r'Zobrazit nabídku';
-  @override String get aboutListTileTitle => r'O aplikaci $applicationName';
-  @override String get licensesPageTitle => r'Licence';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow z $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow z asi $rowCount';
-  @override String get rowsPerPageTitle => r'Počet řádků na stránku:';
-  @override String get tabLabel => r'Karta $tabIndex z $tabCount';
-  @override String get selectedRowCountTitleOne => r'Je vybrána 1 položka';
-  @override String get selectedRowCountTitleOther => r'Je vybráno $selectedRowCount položek';
-  @override String get cancelButtonLabel => r'ZRUŠIT';
-  @override String get closeButtonLabel => r'ZAVŘÍT';
-  @override String get continueButtonLabel => r'POKRAČOVAT';
-  @override String get copyButtonLabel => r'KOPÍROVAT';
-  @override String get cutButtonLabel => r'VYJMOUT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'VLOŽIT';
-  @override String get selectAllButtonLabel => r'VYBRAT VŠE';
-  @override String get viewLicensesButtonLabel => r'ZOBRAZIT LICENCE';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Vyberte hodiny';
-  @override String get timePickerMinuteModeAnnouncement => r'Vyberte minuty';
-  @override String get modalBarrierDismissLabel => r'Zavřít';
-  @override String get signedInLabel => r'Uživatel přihlášen';
-  @override String get hideAccountsLabel => r'Skrýt účty';
-  @override String get showAccountsLabel => r'Zobrazit účty';
-  @override String get drawerLabel => r'Navigační nabídka';
-  @override String get popupMenuLabel => r'Vyskakovací nabídka';
-  @override String get dialogLabel => r'Dialogové okno';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_da extends TranslationBundle {
-  const _Bundle_da() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Åbn navigationsmenuen';
-  @override String get backButtonTooltip => r'Tilbage';
-  @override String get closeButtonTooltip => r'Luk';
-  @override String get deleteButtonTooltip => r'Slet';
-  @override String get nextMonthTooltip => r'Næste måned';
-  @override String get previousMonthTooltip => r'Forrige måned';
-  @override String get nextPageTooltip => r'Næste side';
-  @override String get previousPageTooltip => r'Forrige side';
-  @override String get showMenuTooltip => r'Vis menu';
-  @override String get aboutListTileTitle => r'Om $applicationName';
-  @override String get licensesPageTitle => r'Licenser';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow af $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow af ca. $rowCount';
-  @override String get rowsPerPageTitle => r'Rækker pr. side:';
-  @override String get tabLabel => r'Fane $tabIndex af $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 element er valgt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
-  @override String get cancelButtonLabel => r'ANNULLER';
-  @override String get closeButtonLabel => r'LUK';
-  @override String get continueButtonLabel => r'FORTSÆT';
-  @override String get copyButtonLabel => r'KOPIÉR';
-  @override String get cutButtonLabel => r'KLIP';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'SÆT IND';
-  @override String get selectAllButtonLabel => r'VÆLG ALLE';
-  @override String get viewLicensesButtonLabel => r'SE LICENSER';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Vælg timer';
-  @override String get timePickerMinuteModeAnnouncement => r'Vælg minutter';
-  @override String get modalBarrierDismissLabel => r'Afvis';
-  @override String get signedInLabel => r'Logget ind';
-  @override String get hideAccountsLabel => r'Skjul konti';
-  @override String get showAccountsLabel => r'Vis konti';
-  @override String get drawerLabel => r'Navigationsmenu';
-  @override String get popupMenuLabel => r'Pop op-menu';
-  @override String get dialogLabel => r'Dialogboks';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_de extends TranslationBundle {
-  const _Bundle_de() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
-  @override String get backButtonTooltip => r'Zurück';
-  @override String get closeButtonTooltip => r'Schließen';
-  @override String get deleteButtonTooltip => r'Löschen';
-  @override String get nextMonthTooltip => r'Nächster Monat';
-  @override String get previousMonthTooltip => r'Vorheriger Monat';
-  @override String get nextPageTooltip => r'Nächste Seite';
-  @override String get previousPageTooltip => r'Vorherige Seite';
-  @override String get showMenuTooltip => r'Menü anzeigen';
-  @override String get aboutListTileTitle => r'Über $applicationName';
-  @override String get licensesPageTitle => r'Lizenzen';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
-  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
-  @override String get tabLabel => r'Tab $tabIndex von $tabCount';
-  @override String get selectedRowCountTitleZero => r'Keine Objekte ausgewählt';
-  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
-  @override String get cancelButtonLabel => r'ABBRECHEN';
-  @override String get closeButtonLabel => r'SCHLIEẞEN';
-  @override String get continueButtonLabel => r'WEITER';
-  @override String get copyButtonLabel => r'KOPIEREN';
-  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'EINFÜGEN';
-  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
-  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
-  @override String get anteMeridiemAbbreviation => r'VORM.';
-  @override String get postMeridiemAbbreviation => r'NACHM.';
-  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
-  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
-  @override String get signedInLabel => r'Angemeldet';
-  @override String get hideAccountsLabel => r'Konten ausblenden';
-  @override String get showAccountsLabel => r'Konten anzeigen';
-  @override String get modalBarrierDismissLabel => r'Schließen';
-  @override String get drawerLabel => r'Navigationsmenü';
-  @override String get popupMenuLabel => r'Pop-up-Menü';
-  @override String get dialogLabel => r'Dialogfeld';
-  @override String get alertDialogLabel => r'Aufmerksam';
-  @override String get searchFieldLabel => r'Suchen';
-}
-
-// ignore: camel_case_types
-class _Bundle_el extends TranslationBundle {
-  const _Bundle_el() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Άνοιγμα μενού πλοήγησης';
-  @override String get backButtonTooltip => r'Πίσω';
-  @override String get closeButtonTooltip => r'Κλείσιμο';
-  @override String get deleteButtonTooltip => r'Διαγραφή';
-  @override String get nextMonthTooltip => r'Επόμενος μήνας';
-  @override String get previousMonthTooltip => r'Προηγούμενος μήνας';
-  @override String get nextPageTooltip => r'Επόμενη σελίδα';
-  @override String get previousPageTooltip => r'Προηγούμενη σελίδα';
-  @override String get showMenuTooltip => r'Εμφάνιση μενού';
-  @override String get aboutListTileTitle => r'Σχετικά με την εφαρμογή $applicationName';
-  @override String get licensesPageTitle => r'Άδειες';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow από $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow από περίπου $rowCount';
-  @override String get rowsPerPageTitle => r'Σειρές ανά σελίδα:';
-  @override String get tabLabel => r'Καρτέλα $tabIndex από $tabCount';
-  @override String get selectedRowCountTitleOne => r'Επιλέχθηκε 1 στοιχείο';
-  @override String get selectedRowCountTitleOther => r'Επιλέχθηκαν $selectedRowCount στοιχεία';
-  @override String get cancelButtonLabel => r'ΑΚΥΡΩΣΗ';
-  @override String get closeButtonLabel => r'ΚΛΕΙΣΙΜΟ';
-  @override String get continueButtonLabel => r'ΣΥΝΕΧΕΙΑ';
-  @override String get copyButtonLabel => r'ΑΝΤΙΓΡΑΦΗ';
-  @override String get cutButtonLabel => r'ΑΠΟΚΟΠΗ';
-  @override String get okButtonLabel => r'ΟΚ';
-  @override String get pasteButtonLabel => r'ΕΠΙΚΟΛΛΗΣΗ';
-  @override String get selectAllButtonLabel => r'ΕΠΙΛΟΓΗ ΟΛΩΝ';
-  @override String get viewLicensesButtonLabel => r'ΠΡΟΒΟΛΗ ΑΔΕΙΩΝ';
-  @override String get anteMeridiemAbbreviation => r'π.μ.';
-  @override String get postMeridiemAbbreviation => r'μ.μ.';
-  @override String get timePickerHourModeAnnouncement => r'Επιλογή ωρών';
-  @override String get timePickerMinuteModeAnnouncement => r'Επιλογή λεπτών';
-  @override String get modalBarrierDismissLabel => r'Παράβλεψη';
-  @override String get signedInLabel => r'Σε σύνδεση';
-  @override String get hideAccountsLabel => r'Απόκρυψη λογαριασμών';
-  @override String get showAccountsLabel => r'Εμφάνιση λογαριασμών';
-  @override String get drawerLabel => r'Μενού πλοήγησης';
-  @override String get popupMenuLabel => r'Αναδυόμενο μενού';
-  @override String get dialogLabel => r'Παράθυρο διαλόγου';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_en extends TranslationBundle {
-  const _Bundle_en() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get openAppDrawerTooltip => r'Open navigation menu';
-  @override String get backButtonTooltip => r'Back';
-  @override String get closeButtonTooltip => r'Close';
-  @override String get deleteButtonTooltip => r'Delete';
-  @override String get nextMonthTooltip => r'Next month';
-  @override String get previousMonthTooltip => r'Previous month';
-  @override String get nextPageTooltip => r'Next page';
-  @override String get previousPageTooltip => r'Previous page';
-  @override String get showMenuTooltip => r'Show menu';
-  @override String get aboutListTileTitle => r'About $applicationName';
-  @override String get licensesPageTitle => r'Licenses';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow of $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow of about $rowCount';
-  @override String get rowsPerPageTitle => r'Rows per page:';
-  @override String get tabLabel => r'Tab $tabIndex of $tabCount';
-  @override String get selectedRowCountTitleZero => r'No items selected';
-  @override String get selectedRowCountTitleOne => r'1 item selected';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
-  @override String get cancelButtonLabel => r'CANCEL';
-  @override String get closeButtonLabel => r'CLOSE';
-  @override String get continueButtonLabel => r'CONTINUE';
-  @override String get copyButtonLabel => r'COPY';
-  @override String get cutButtonLabel => r'CUT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'PASTE';
-  @override String get selectAllButtonLabel => r'SELECT ALL';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENSES';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Select hours';
-  @override String get timePickerMinuteModeAnnouncement => r'Select minutes';
-  @override String get modalBarrierDismissLabel => r'Dismiss';
-  @override String get signedInLabel => r'Signed in';
-  @override String get hideAccountsLabel => r'Hide accounts';
-  @override String get showAccountsLabel => r'Show accounts';
-  @override String get drawerLabel => r'Navigation menu';
-  @override String get popupMenuLabel => r'Popup menu';
-  @override String get dialogLabel => r'Dialog';
-  @override String get alertDialogLabel => r'Alert';
-  @override String get searchFieldLabel => r'Search';
-}
-
-// ignore: camel_case_types
-class _Bundle_es extends TranslationBundle {
-  const _Bundle_es() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get openAppDrawerTooltip => r'Abrir el menú de navegación';
-  @override String get backButtonTooltip => r'Atrás';
-  @override String get closeButtonTooltip => r'Cerrar';
-  @override String get deleteButtonTooltip => r'Eliminar';
-  @override String get nextMonthTooltip => r'Mes siguiente';
-  @override String get previousMonthTooltip => r'Mes anterior';
-  @override String get nextPageTooltip => r'Página siguiente';
-  @override String get previousPageTooltip => r'Página anterior';
-  @override String get showMenuTooltip => r'Mostrar menú';
-  @override String get aboutListTileTitle => r'Sobre $applicationName';
-  @override String get licensesPageTitle => r'Licencias';
-  @override String get pageRowsInfoTitle => r'$firstRow‑$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow‑$lastRow de aproximadamente $rowCount';
-  @override String get rowsPerPageTitle => r'Filas por página:';
-  @override String get tabLabel => r'Pestaña $tabIndex de $tabCount';
-  @override String get selectedRowCountTitleZero => r'No se han seleccionado elementos';
-  @override String get selectedRowCountTitleOne => r'1 elemento seleccionado';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementos seleccionados';
-  @override String get cancelButtonLabel => r'CANCELAR';
-  @override String get closeButtonLabel => r'CERRAR';
-  @override String get continueButtonLabel => r'CONTINUAR';
-  @override String get copyButtonLabel => r'COPIAR';
-  @override String get cutButtonLabel => r'CORTAR';
-  @override String get okButtonLabel => r'ACEPTAR';
-  @override String get pasteButtonLabel => r'PEGAR';
-  @override String get selectAllButtonLabel => r'SELECCIONAR TODO';
-  @override String get viewLicensesButtonLabel => r'VER LICENCIAS';
-  @override String get anteMeridiemAbbreviation => r'A.M.';
-  @override String get postMeridiemAbbreviation => r'P.M.';
-  @override String get timePickerHourModeAnnouncement => r'Seleccionar horas';
-  @override String get timePickerMinuteModeAnnouncement => r'Seleccionar minutos';
-  @override String get signedInLabel => r'Sesión iniciada';
-  @override String get hideAccountsLabel => r'Ocultar cuentas';
-  @override String get showAccountsLabel => r'Mostrar cuentas';
-  @override String get modalBarrierDismissLabel => r'Ignorar';
-  @override String get drawerLabel => r'Menú de navegación';
-  @override String get popupMenuLabel => r'Menú emergente';
-  @override String get dialogLabel => r'Cuadro de diálogo';
-  @override String get alertDialogLabel => r'Alerta';
-  @override String get searchFieldLabel => r'Buscar';
-}
-
-// ignore: camel_case_types
-class _Bundle_et extends TranslationBundle {
-  const _Bundle_et() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Ava navigeerimismenüü';
-  @override String get backButtonTooltip => r'Tagasi';
-  @override String get closeButtonTooltip => r'Sule';
-  @override String get deleteButtonTooltip => r'Kustuta';
-  @override String get nextMonthTooltip => r'Järgmine kuu';
-  @override String get previousMonthTooltip => r'Eelmine kuu';
-  @override String get nextPageTooltip => r'Järgmine leht';
-  @override String get previousPageTooltip => r'Eelmine leht';
-  @override String get showMenuTooltip => r'Kuva menüü';
-  @override String get aboutListTileTitle => r'Teave rakenduse $applicationName kohta';
-  @override String get licensesPageTitle => r'Litsentsid';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow $rowCount-st';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow umbes $rowCount-st';
-  @override String get rowsPerPageTitle => r'Ridu lehe kohta:';
-  @override String get tabLabel => r'$tabIndex. vahekaart $tabCount-st';
-  @override String get selectedRowCountTitleOne => r'Valitud on 1 üksus';
-  @override String get selectedRowCountTitleOther => r'Valitud on $selectedRowCount üksust';
-  @override String get cancelButtonLabel => r'TÜHISTA';
-  @override String get closeButtonLabel => r'SULE';
-  @override String get continueButtonLabel => r'JÄTKA';
-  @override String get copyButtonLabel => r'KOPEERI';
-  @override String get cutButtonLabel => r'LÕIKA';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'KLEEBI';
-  @override String get selectAllButtonLabel => r'VALI KÕIK';
-  @override String get viewLicensesButtonLabel => r'KUVA LITSENTSID';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Tundide valimine';
-  @override String get timePickerMinuteModeAnnouncement => r'Minutite valimine';
-  @override String get modalBarrierDismissLabel => r'Loobu';
-  @override String get signedInLabel => r'Sisse logitud';
-  @override String get hideAccountsLabel => r'Peida kontod';
-  @override String get showAccountsLabel => r'Kuva kontod';
-  @override String get drawerLabel => r'Navigeerimismenüü';
-  @override String get popupMenuLabel => r'Hüpikmenüü';
-  @override String get dialogLabel => r'Dialoog';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_fa extends TranslationBundle {
-  const _Bundle_fa() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get selectedRowCountTitleOne => r'۱ مورد انتخاب شد';
-  @override String get openAppDrawerTooltip => r'باز کردن منوی پیمایش';
-  @override String get backButtonTooltip => r'برگشت';
-  @override String get closeButtonTooltip => r'بستن';
-  @override String get deleteButtonTooltip => r'حذف';
-  @override String get nextMonthTooltip => r'ماه بعد';
-  @override String get previousMonthTooltip => r'ماه قبل';
-  @override String get nextPageTooltip => r'صفحه بعد';
-  @override String get previousPageTooltip => r'صفحه قبل';
-  @override String get showMenuTooltip => r'نمایش منو';
-  @override String get aboutListTileTitle => r'درباره $applicationName';
-  @override String get licensesPageTitle => r'مجوزها';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow از حدود $rowCount';
-  @override String get rowsPerPageTitle => r'ردیف در هر صفحه:';
-  @override String get tabLabel => r'برگه $tabIndex از $tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount مورد انتخاب شدند';
-  @override String get cancelButtonLabel => r'لغو';
-  @override String get closeButtonLabel => r'بستن';
-  @override String get continueButtonLabel => r'ادامه';
-  @override String get copyButtonLabel => r'کپی';
-  @override String get cutButtonLabel => r'برش';
-  @override String get okButtonLabel => r'تأیید';
-  @override String get pasteButtonLabel => r'جای‌گذاری';
-  @override String get selectAllButtonLabel => r'انتخاب همه';
-  @override String get viewLicensesButtonLabel => r'مشاهده مجوزها';
-  @override String get anteMeridiemAbbreviation => r'ق.ظ.';
-  @override String get postMeridiemAbbreviation => r'ب.ظ.';
-  @override String get timePickerHourModeAnnouncement => r'انتخاب ساعت';
-  @override String get timePickerMinuteModeAnnouncement => r'انتخاب دقیقه';
-  @override String get signedInLabel => r'واردشده به سیستم';
-  @override String get hideAccountsLabel => r'پنهان کردن حساب‌ها';
-  @override String get showAccountsLabel => r'نشان دادن حساب‌ها';
-  @override String get modalBarrierDismissLabel => r'نپذیرفتن';
-  @override String get drawerLabel => r'منوی پیمایش';
-  @override String get popupMenuLabel => r'منوی بازشو';
-  @override String get dialogLabel => r'کادر گفتگو';
-  @override String get alertDialogLabel => r'هشدار';
-  @override String get searchFieldLabel => r'جستجو کردن';
-}
-
-// ignore: camel_case_types
-class _Bundle_fi extends TranslationBundle {
-  const _Bundle_fi() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Avaa navigointivalikko';
-  @override String get backButtonTooltip => r'Takaisin';
-  @override String get closeButtonTooltip => r'Sulje';
-  @override String get deleteButtonTooltip => r'Poista';
-  @override String get nextMonthTooltip => r'Seuraava kuukausi';
-  @override String get previousMonthTooltip => r'Edellinen kuukausi';
-  @override String get nextPageTooltip => r'Seuraava sivu';
-  @override String get previousPageTooltip => r'Edellinen sivu';
-  @override String get showMenuTooltip => r'Näytä valikko';
-  @override String get aboutListTileTitle => r'Tietoja sovelluksesta $applicationName';
-  @override String get licensesPageTitle => r'Lisenssit';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow/$rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow/~$rowCount';
-  @override String get rowsPerPageTitle => r'Riviä/sivu:';
-  @override String get tabLabel => r'Välilehti $tabIndex/$tabCount';
-  @override String get selectedRowCountTitleOne => r'1 kohde valittu';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount kohdetta valittu';
-  @override String get cancelButtonLabel => r'PERUUTA';
-  @override String get closeButtonLabel => r'SULJE';
-  @override String get continueButtonLabel => r'JATKA';
-  @override String get copyButtonLabel => r'COPY';
-  @override String get cutButtonLabel => r'LEIKKAA';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'LIITÄ';
-  @override String get selectAllButtonLabel => r'VALITSE KAIKKI';
-  @override String get viewLicensesButtonLabel => r'NÄYTÄ KÄYTTÖOIKEUDET';
-  @override String get anteMeridiemAbbreviation => r'ap';
-  @override String get postMeridiemAbbreviation => r'ip';
-  @override String get timePickerHourModeAnnouncement => r'Valitse tunnit';
-  @override String get timePickerMinuteModeAnnouncement => r'Valitse minuutit';
-  @override String get modalBarrierDismissLabel => r'Ohita';
-  @override String get signedInLabel => r'Kirjautunut sisään';
-  @override String get hideAccountsLabel => r'Piilota tilit';
-  @override String get showAccountsLabel => r'Näytä tilit';
-  @override String get drawerLabel => r'Navigointivalikko';
-  @override String get popupMenuLabel => r'Ponnahdusvalikko';
-  @override String get dialogLabel => r'Valintaikkuna';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_fil extends TranslationBundle {
-  const _Bundle_fil() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Buksan ang menu ng navigation';
-  @override String get backButtonTooltip => r'Bumalik';
-  @override String get closeButtonTooltip => r'Isara';
-  @override String get deleteButtonTooltip => r'I-delete';
-  @override String get nextMonthTooltip => r'Susunod na buwan';
-  @override String get previousMonthTooltip => r'Nakaraang buwan';
-  @override String get nextPageTooltip => r'Susunod na page';
-  @override String get previousPageTooltip => r'Nakaraang page';
-  @override String get showMenuTooltip => r'Ipakita ang menu';
-  @override String get aboutListTileTitle => r'Tungkol sa $applicationName';
-  @override String get licensesPageTitle => r'Mga Lisensya';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow ng $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow ng humigit kumulang $rowCount';
-  @override String get rowsPerPageTitle => r'Mga row bawat page:';
-  @override String get tabLabel => r'Tab $tabIndex ng $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 item ang napili';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
-  @override String get cancelButtonLabel => r'KANSELAHIN';
-  @override String get closeButtonLabel => r'ISARA';
-  @override String get continueButtonLabel => r'MAGPATULOY';
-  @override String get copyButtonLabel => r'KOPYAHIN';
-  @override String get cutButtonLabel => r'I-CUT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'I-PASTE';
-  @override String get selectAllButtonLabel => r'PILIIN LAHAT';
-  @override String get viewLicensesButtonLabel => r'TINGNAN ANG MGA LISENSYA';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Pumili ng mga oras';
-  @override String get timePickerMinuteModeAnnouncement => r'Pumili ng mga minuto';
-  @override String get modalBarrierDismissLabel => r'I-dismiss';
-  @override String get signedInLabel => r'Naka-sign in';
-  @override String get hideAccountsLabel => r'Itago ang mga account';
-  @override String get showAccountsLabel => r'Ipakita ang mga account';
-  @override String get drawerLabel => r'Menu ng navigation';
-  @override String get popupMenuLabel => r'Popup na menu';
-  @override String get dialogLabel => r'Dialog';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_fr extends TranslationBundle {
-  const _Bundle_fr() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Ouvrir le menu de navigation';
-  @override String get backButtonTooltip => r'Retour';
-  @override String get closeButtonTooltip => r'Fermer';
-  @override String get deleteButtonTooltip => r'Supprimer';
-  @override String get nextMonthTooltip => r'Mois suivant';
-  @override String get previousMonthTooltip => r'Mois précédent';
-  @override String get nextPageTooltip => r'Page suivante';
-  @override String get previousPageTooltip => r'Page précédente';
-  @override String get showMenuTooltip => r'Afficher le menu';
-  @override String get aboutListTileTitle => r'À propos de $applicationName';
-  @override String get licensesPageTitle => r'Licences';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow sur $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow sur environ $rowCount';
-  @override String get rowsPerPageTitle => r'Lignes par page :';
-  @override String get tabLabel => r'Onglet $tabIndex sur $tabCount';
-  @override String get selectedRowCountTitleZero => r'Aucun élément sélectionné';
-  @override String get selectedRowCountTitleOne => r'1 élément sélectionné';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount éléments sélectionnés';
-  @override String get cancelButtonLabel => r'ANNULER';
-  @override String get closeButtonLabel => r'FERMER';
-  @override String get continueButtonLabel => r'CONTINUER';
-  @override String get copyButtonLabel => r'COPIER';
-  @override String get cutButtonLabel => r'COUPER';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'COLLER';
-  @override String get selectAllButtonLabel => r'TOUT SÉLECTIONNER';
-  @override String get viewLicensesButtonLabel => r'AFFICHER LES LICENCES';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Sélectionner une heure';
-  @override String get timePickerMinuteModeAnnouncement => r'Sélectionner des minutes';
-  @override String get signedInLabel => r'Connecté';
-  @override String get hideAccountsLabel => r'Masquer les comptes';
-  @override String get showAccountsLabel => r'Afficher les comptes';
-  @override String get modalBarrierDismissLabel => r'Ignorer';
-  @override String get drawerLabel => r'Menu de navigation';
-  @override String get popupMenuLabel => r'Menu contextuel';
-  @override String get dialogLabel => r'Boîte de dialogue';
-  @override String get alertDialogLabel => r'Alerte';
-  @override String get searchFieldLabel => r'Chercher';
-}
-
-// ignore: camel_case_types
-class _Bundle_gsw extends TranslationBundle {
-  const _Bundle_gsw() : super(null);
-  @override String get tabLabel => r'Tab $tabIndex von $tabCount';
-  @override String get showAccountsLabel => r'Konten anzeigen';
-  @override String get hideAccountsLabel => r'Konten ausblenden';
-  @override String get signedInLabel => r'Angemeldet';
-  @override String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
-  @override String get timePickerHourModeAnnouncement => r'Stunden auswählen';
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
-  @override String get backButtonTooltip => r'Zurück';
-  @override String get closeButtonTooltip => r'Schließen';
-  @override String get deleteButtonTooltip => r'Löschen';
-  @override String get nextMonthTooltip => r'Nächster Monat';
-  @override String get previousMonthTooltip => r'Vorheriger Monat';
-  @override String get nextPageTooltip => r'Nächste Seite';
-  @override String get previousPageTooltip => r'Vorherige Seite';
-  @override String get showMenuTooltip => r'Menü anzeigen';
-  @override String get aboutListTileTitle => r'Über $applicationName';
-  @override String get licensesPageTitle => r'Lizenzen';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow von $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow von etwa $rowCount';
-  @override String get rowsPerPageTitle => r'Zeilen pro Seite:';
-  @override String get selectedRowCountTitleOne => r'1 Element ausgewählt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
-  @override String get cancelButtonLabel => r'ABBRECHEN';
-  @override String get closeButtonLabel => r'SCHLIEẞEN';
-  @override String get continueButtonLabel => r'WEITER';
-  @override String get copyButtonLabel => r'KOPIEREN';
-  @override String get cutButtonLabel => r'AUSSCHNEIDEN';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'EINFÜGEN';
-  @override String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
-  @override String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
-  @override String get anteMeridiemAbbreviation => r'VORM.';
-  @override String get postMeridiemAbbreviation => r'NACHM.';
-  @override String get modalBarrierDismissLabel => r'Schließen';
-  @override String get drawerLabel => r'Navigationsmenü';
-  @override String get popupMenuLabel => r'Pop-up-Menü';
-  @override String get dialogLabel => r'Dialogfeld';
-  @override String get alertDialogLabel => r'Aufmerksam';
-  @override String get searchFieldLabel => r'Suchen';
-}
-
-// ignore: camel_case_types
-class _Bundle_he extends TranslationBundle {
-  const _Bundle_he() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get selectedRowCountTitleOne => r'פריט אחד נבחר';
-  @override String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
-  @override String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
-  @override String get openAppDrawerTooltip => r'פתיחה של תפריט הניווט';
-  @override String get backButtonTooltip => r'הקודם';
-  @override String get closeButtonTooltip => r'סגירה';
-  @override String get deleteButtonTooltip => r'מחיקה';
-  @override String get nextMonthTooltip => r'החודש הבא';
-  @override String get previousMonthTooltip => r'החודש הקודם';
-  @override String get nextPageTooltip => r'הדף הבא';
-  @override String get previousPageTooltip => r'הדף הקודם';
-  @override String get showMenuTooltip => r'הצגת התפריט';
-  @override String get aboutListTileTitle => r'מידע על $applicationName';
-  @override String get licensesPageTitle => r'רישיונות';
-  @override String get pageRowsInfoTitle => r'$lastRow–$firstRow מתוך $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$lastRow–$firstRow מתוך כ-$rowCount';
-  @override String get rowsPerPageTitle => r'שורות בכל דף:';
-  @override String get tabLabel => r'כרטיסייה $tabIndex מתוך $tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
-  @override String get cancelButtonLabel => r'ביטול';
-  @override String get closeButtonLabel => r'סגירה';
-  @override String get continueButtonLabel => r'המשך';
-  @override String get copyButtonLabel => r'העתקה';
-  @override String get cutButtonLabel => r'גזירה';
-  @override String get okButtonLabel => r'אישור';
-  @override String get pasteButtonLabel => r'הדבקה';
-  @override String get selectAllButtonLabel => r'בחירת הכול';
-  @override String get viewLicensesButtonLabel => r'הצגת הרישיונות';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'בחירת שעות';
-  @override String get timePickerMinuteModeAnnouncement => r'בחירת דקות';
-  @override String get signedInLabel => r'מחובר';
-  @override String get hideAccountsLabel => r'הסתרת החשבונות';
-  @override String get showAccountsLabel => r'הצגת החשבונות';
-  @override String get modalBarrierDismissLabel => r'סגירה';
-  @override String get drawerLabel => r'תפריט ניווט';
-  @override String get popupMenuLabel => r'תפריט קופץ';
-  @override String get dialogLabel => r'תיבת דו-שיח';
-  @override String get alertDialogLabel => r'עֵרָנִי';
-  @override String get searchFieldLabel => r'לחפש';
-}
-
-// ignore: camel_case_types
-class _Bundle_hi extends TranslationBundle {
-  const _Bundle_hi() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'ah:mm';
-  @override String get openAppDrawerTooltip => r'नेविगेशन मेन्यू खोलें';
-  @override String get backButtonTooltip => r'वापस जाएं';
-  @override String get closeButtonTooltip => r'बंद करें';
-  @override String get deleteButtonTooltip => r'मिटाएं';
-  @override String get nextMonthTooltip => r'अगला महीना';
-  @override String get previousMonthTooltip => r'पिछला महीना';
-  @override String get nextPageTooltip => r'अगला पेज';
-  @override String get previousPageTooltip => r'पिछला पेज';
-  @override String get showMenuTooltip => r'मेन्यू दिखाएं';
-  @override String get aboutListTileTitle => r'$applicationName के बारे में जानकारी';
-  @override String get licensesPageTitle => r'लाइसेंस';
-  @override String get pageRowsInfoTitle => r'$rowCount का $firstRow–$lastRow';
-  @override String get pageRowsInfoTitleApproximate => r'$rowCount में से करीब $firstRow–$lastRow';
-  @override String get rowsPerPageTitle => r'हर पेज में पंक्तियों की संख्या:';
-  @override String get tabLabel => r'$tabCount का टैब $tabIndex';
-  @override String get selectedRowCountTitleOne => r'1 चीज़ चुनी गई';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount चीज़ें चुनी गईं';
-  @override String get cancelButtonLabel => r'रद्द करें';
-  @override String get closeButtonLabel => r'बंद करें';
-  @override String get continueButtonLabel => r'जारी रखें';
-  @override String get copyButtonLabel => r'कॉपी करें';
-  @override String get cutButtonLabel => r'कट करें';
-  @override String get okButtonLabel => r'ठीक है';
-  @override String get pasteButtonLabel => r'चिपकाएं';
-  @override String get selectAllButtonLabel => r'सभी चुनें';
-  @override String get viewLicensesButtonLabel => r'लाइसेंस देखें';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'घंटे के हिसाब से समय चुनें';
-  @override String get timePickerMinuteModeAnnouncement => r'मिनट के हिसाब से समय चुनें';
-  @override String get modalBarrierDismissLabel => r'खारिज करें';
-  @override String get signedInLabel => r'साइन इन किया हुआ है';
-  @override String get hideAccountsLabel => r'खाते छिपाएं';
-  @override String get showAccountsLabel => r'खाते दिखाएं';
-  @override String get drawerLabel => r'नेविगेशन मेन्यू';
-  @override String get popupMenuLabel => r'पॉपअप मेन्यू';
-  @override String get dialogLabel => r'संवाद';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_hr extends TranslationBundle {
-  const _Bundle_hr() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
-  @override String get openAppDrawerTooltip => r'Otvaranje izbornika za navigaciju';
-  @override String get backButtonTooltip => r'Natrag';
-  @override String get closeButtonTooltip => r'Zatvaranje';
-  @override String get deleteButtonTooltip => r'Brisanje';
-  @override String get nextMonthTooltip => r'Sljedeći mjesec';
-  @override String get previousMonthTooltip => r'Prethodni mjesec';
-  @override String get nextPageTooltip => r'Sljedeća stranica';
-  @override String get previousPageTooltip => r'Prethodna stranica';
-  @override String get showMenuTooltip => r'Prikaz izbornika';
-  @override String get aboutListTileTitle => r'O aplikaciji $applicationName';
-  @override String get licensesPageTitle => r'Licence';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow od $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow od otprilike $rowCount';
-  @override String get rowsPerPageTitle => r'Redaka po stranici:';
-  @override String get tabLabel => r'Kartica $tabIndex od $tabCount';
-  @override String get selectedRowCountTitleOne => r'Odabrana je jedna stavka';
-  @override String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
-  @override String get cancelButtonLabel => r'ODUSTANI';
-  @override String get closeButtonLabel => r'ZATVORI';
-  @override String get continueButtonLabel => r'NASTAVI';
-  @override String get copyButtonLabel => r'KOPIRAJ';
-  @override String get cutButtonLabel => r'IZREŽI';
-  @override String get okButtonLabel => r'U REDU';
-  @override String get pasteButtonLabel => r'ZALIJEPI';
-  @override String get selectAllButtonLabel => r'ODABERI SVE';
-  @override String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
-  @override String get anteMeridiemAbbreviation => r'prijepodne';
-  @override String get postMeridiemAbbreviation => r'popodne';
-  @override String get timePickerHourModeAnnouncement => r'Odaberite sate';
-  @override String get timePickerMinuteModeAnnouncement => r'Odaberite minute';
-  @override String get modalBarrierDismissLabel => r'Odbaci';
-  @override String get signedInLabel => r'Prijavljeni korisnik';
-  @override String get hideAccountsLabel => r'Sakrijte račune';
-  @override String get showAccountsLabel => r'Prikažite račune';
-  @override String get drawerLabel => r'Navigacijski izbornik';
-  @override String get popupMenuLabel => r'Skočni izbornik';
-  @override String get dialogLabel => r'Dijalog';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_hu extends TranslationBundle {
-  const _Bundle_hu() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigációs menü megnyitása';
-  @override String get backButtonTooltip => r'Vissza';
-  @override String get closeButtonTooltip => r'Bezárás';
-  @override String get deleteButtonTooltip => r'Törlés';
-  @override String get nextMonthTooltip => r'Következő hónap';
-  @override String get previousMonthTooltip => r'Előző hónap';
-  @override String get nextPageTooltip => r'Következő oldal';
-  @override String get previousPageTooltip => r'Előző oldal';
-  @override String get showMenuTooltip => r'Menü megjelenítése';
-  @override String get aboutListTileTitle => r'A(z) $applicationName névjegye';
-  @override String get licensesPageTitle => r'Licencek';
-  @override String get pageRowsInfoTitle => r'$rowCount/$firstRow–$lastRow.';
-  @override String get pageRowsInfoTitleApproximate => r'Körülbelül $rowCount/$firstRow–$lastRow.';
-  @override String get rowsPerPageTitle => r'Oldalankénti sorszám:';
-  @override String get tabLabel => r'$tabCount/$tabIndex. lap';
-  @override String get selectedRowCountTitleOne => r'1 elem kiválasztva';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elem kiválasztva';
-  @override String get cancelButtonLabel => r'MÉGSE';
-  @override String get closeButtonLabel => r'BEZÁRÁS';
-  @override String get continueButtonLabel => r'TOVÁBB';
-  @override String get copyButtonLabel => r'MÁSOLÁS';
-  @override String get cutButtonLabel => r'KIVÁGÁS';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'BEILLESZTÉS';
-  @override String get selectAllButtonLabel => r'AZ ÖSSZES KIJELÖLÉSE';
-  @override String get viewLicensesButtonLabel => r'LICENCEK MEGTEKINTÉSE';
-  @override String get anteMeridiemAbbreviation => r'de.';
-  @override String get postMeridiemAbbreviation => r'du.';
-  @override String get timePickerHourModeAnnouncement => r'Óra kiválasztása';
-  @override String get timePickerMinuteModeAnnouncement => r'Perc kiválasztása';
-  @override String get modalBarrierDismissLabel => r'Elvetés';
-  @override String get signedInLabel => r'Bejelentkezve';
-  @override String get hideAccountsLabel => r'Fiókok elrejtése';
-  @override String get showAccountsLabel => r'Fiókok megjelenítése';
-  @override String get drawerLabel => r'Navigációs menü';
-  @override String get popupMenuLabel => r'Előugró menü';
-  @override String get dialogLabel => r'Párbeszédablak';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_id extends TranslationBundle {
-  const _Bundle_id() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Buka menu navigasi';
-  @override String get backButtonTooltip => r'Kembali';
-  @override String get closeButtonTooltip => r'Tutup';
-  @override String get deleteButtonTooltip => r'Hapus';
-  @override String get nextMonthTooltip => r'Bulan berikutnya';
-  @override String get previousMonthTooltip => r'Bulan sebelumnya';
-  @override String get nextPageTooltip => r'Halaman berikutnya';
-  @override String get previousPageTooltip => r'Halaman sebelumnya';
-  @override String get showMenuTooltip => r'Tampilkan menu';
-  @override String get aboutListTileTitle => r'Tentang $applicationName';
-  @override String get licensesPageTitle => r'Lisensi';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow dari $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow dari kira-kira $rowCount';
-  @override String get rowsPerPageTitle => r'Baris per halaman:';
-  @override String get tabLabel => r'Tab $tabIndex dari $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 item dipilih';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
-  @override String get cancelButtonLabel => r'BATAL';
-  @override String get closeButtonLabel => r'TUTUP';
-  @override String get continueButtonLabel => r'LANJUTKAN';
-  @override String get copyButtonLabel => r'SALIN';
-  @override String get cutButtonLabel => r'POTONG';
-  @override String get okButtonLabel => r'Oke';
-  @override String get pasteButtonLabel => r'TEMPEL';
-  @override String get selectAllButtonLabel => r'PILIH SEMUA';
-  @override String get viewLicensesButtonLabel => r'LIHAT LISENSI';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Pilih jam';
-  @override String get timePickerMinuteModeAnnouncement => r'Pilih menit';
-  @override String get modalBarrierDismissLabel => r'Tutup';
-  @override String get signedInLabel => r'Telah login';
-  @override String get hideAccountsLabel => r'Sembunyikan akun';
-  @override String get showAccountsLabel => r'Tampilkan akun';
-  @override String get drawerLabel => r'Menu navigasi';
-  @override String get popupMenuLabel => r'Menu pop-up';
-  @override String get dialogLabel => r'Dialog';
-  @override String get alertDialogLabel => r'Waspada';
-  @override String get searchFieldLabel => r'Pencarian';
-}
-
-// ignore: camel_case_types
-class _Bundle_it extends TranslationBundle {
-  const _Bundle_it() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleOne => r'1 elemento selezionato';
-  @override String get openAppDrawerTooltip => r'Apri il menu di navigazione';
-  @override String get backButtonTooltip => r'Indietro';
-  @override String get closeButtonTooltip => r'Chiudi';
-  @override String get deleteButtonTooltip => r'Elimina';
-  @override String get nextMonthTooltip => r'Mese successivo';
-  @override String get previousMonthTooltip => r'Mese precedente';
-  @override String get nextPageTooltip => r'Pagina successiva';
-  @override String get previousPageTooltip => r'Pagina precedente';
-  @override String get showMenuTooltip => r'Mostra il menu';
-  @override String get aboutListTileTitle => r'Informazioni su $applicationName';
-  @override String get licensesPageTitle => r'Licenze';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow di $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow di circa $rowCount';
-  @override String get rowsPerPageTitle => r'Righe per pagina:';
-  @override String get tabLabel => r'Scheda $tabIndex di $tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
-  @override String get cancelButtonLabel => r'ANNULLA';
-  @override String get closeButtonLabel => r'CHIUDI';
-  @override String get continueButtonLabel => r'CONTINUA';
-  @override String get copyButtonLabel => r'COPIA';
-  @override String get cutButtonLabel => r'TAGLIA';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'INCOLLA';
-  @override String get selectAllButtonLabel => r'SELEZIONA TUTTO';
-  @override String get viewLicensesButtonLabel => r'VISUALIZZA LICENZE';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Seleziona le ore';
-  @override String get timePickerMinuteModeAnnouncement => r'Seleziona i minuti';
-  @override String get signedInLabel => r'Connesso';
-  @override String get hideAccountsLabel => r'Nascondi account';
-  @override String get showAccountsLabel => r'Mostra account';
-  @override String get modalBarrierDismissLabel => r'Ignora';
-  @override String get drawerLabel => r'Menu di navigazione';
-  @override String get popupMenuLabel => r'Menu popup';
-  @override String get dialogLabel => r'Finestra di dialogo';
-  @override String get alertDialogLabel => r'Mettere in guardia';
-  @override String get searchFieldLabel => r'Ricerca';
-}
-
-// ignore: camel_case_types
-class _Bundle_ja extends TranslationBundle {
-  const _Bundle_ja() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get selectedRowCountTitleOne => r'1 件のアイテムを選択中';
-  @override String get openAppDrawerTooltip => r'ナビゲーション メニューを開く';
-  @override String get backButtonTooltip => r'戻る';
-  @override String get closeButtonTooltip => r'閉じる';
-  @override String get deleteButtonTooltip => r'削除';
-  @override String get nextMonthTooltip => r'来月';
-  @override String get previousMonthTooltip => r'前月';
-  @override String get nextPageTooltip => r'次のページ';
-  @override String get previousPageTooltip => r'前のページ';
-  @override String get showMenuTooltip => r'メニューを表示';
-  @override String get aboutListTileTitle => r'$applicationName について';
-  @override String get licensesPageTitle => r'ライセンス';
-  @override String get pageRowsInfoTitle => r'$firstRow - $lastRow 行（合計 $rowCount 行）';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow 行（合計約 $rowCount 行）';
-  @override String get rowsPerPageTitle => r'ページあたりの行数:';
-  @override String get tabLabel => r'タブ: $tabIndex/$tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount 件のアイテムを選択中';
-  @override String get cancelButtonLabel => r'キャンセル';
-  @override String get closeButtonLabel => r'閉じる';
-  @override String get continueButtonLabel => r'続行';
-  @override String get copyButtonLabel => r'コピー';
-  @override String get cutButtonLabel => r'切り取り';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'貼り付け';
-  @override String get selectAllButtonLabel => r'すべて選択';
-  @override String get viewLicensesButtonLabel => r'ライセンスを表示';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'時間を選択';
-  @override String get timePickerMinuteModeAnnouncement => r'分を選択';
-  @override String get signedInLabel => r'ログイン中';
-  @override String get hideAccountsLabel => r'アカウントを非表示';
-  @override String get showAccountsLabel => r'アカウントを表示';
-  @override String get modalBarrierDismissLabel => r'閉じる';
-  @override String get drawerLabel => r'ナビゲーション メニュー';
-  @override String get popupMenuLabel => r'ポップアップ メニュー';
-  @override String get dialogLabel => r'ダイアログ';
-  @override String get alertDialogLabel => r'アラート';
-  @override String get searchFieldLabel => r'サーチ';
-}
-
-// ignore: camel_case_types
-class _Bundle_ko extends TranslationBundle {
-  const _Bundle_ko() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'a h:mm';
-  @override String get openAppDrawerTooltip => r'탐색 메뉴 열기';
-  @override String get backButtonTooltip => r'뒤로';
-  @override String get closeButtonTooltip => r'닫기';
-  @override String get deleteButtonTooltip => r'삭제';
-  @override String get nextMonthTooltip => r'다음 달';
-  @override String get previousMonthTooltip => r'지난달';
-  @override String get nextPageTooltip => r'다음 페이지';
-  @override String get previousPageTooltip => r'이전 페이지';
-  @override String get showMenuTooltip => r'메뉴 표시';
-  @override String get aboutListTileTitle => r'$applicationName 정보';
-  @override String get licensesPageTitle => r'라이선스';
-  @override String get pageRowsInfoTitle => r'$rowCount행 중 $firstRow~$lastRow행';
-  @override String get pageRowsInfoTitleApproximate => r'약 $rowCount행 중 $firstRow~$lastRow행';
-  @override String get rowsPerPageTitle => r'페이지당 행 수:';
-  @override String get tabLabel => r'탭 $tabCount개 중 $tabIndex번째';
-  @override String get selectedRowCountTitleOne => r'항목 1개 선택됨';
-  @override String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
-  @override String get cancelButtonLabel => r'취소';
-  @override String get closeButtonLabel => r'닫기';
-  @override String get continueButtonLabel => r'계속';
-  @override String get copyButtonLabel => r'복사';
-  @override String get cutButtonLabel => r'잘라내기';
-  @override String get okButtonLabel => r'확인';
-  @override String get pasteButtonLabel => r'붙여넣기';
-  @override String get selectAllButtonLabel => r'전체 선택';
-  @override String get viewLicensesButtonLabel => r'라이선스 보기';
-  @override String get anteMeridiemAbbreviation => r'오전';
-  @override String get postMeridiemAbbreviation => r'오후';
-  @override String get timePickerHourModeAnnouncement => r'시간 선택';
-  @override String get timePickerMinuteModeAnnouncement => r'분 선택';
-  @override String get signedInLabel => r'로그인됨';
-  @override String get hideAccountsLabel => r'계정 숨기기';
-  @override String get showAccountsLabel => r'계정 표시';
-  @override String get modalBarrierDismissLabel => r'닫기';
-  @override String get drawerLabel => r'탐색 메뉴';
-  @override String get popupMenuLabel => r'팝업 메뉴';
-  @override String get dialogLabel => r'대화상자';
-  @override String get alertDialogLabel => r'경보';
-  @override String get searchFieldLabel => r'수색';
-}
-
-// ignore: camel_case_types
-class _Bundle_lt extends TranslationBundle {
-  const _Bundle_lt() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Pasirinkti $selectedRowCount elementai';
-  @override String get selectedRowCountTitleMany => r'Pasirinkta $selectedRowCount elemento';
-  @override String get openAppDrawerTooltip => r'Atidaryti naršymo meniu';
-  @override String get backButtonTooltip => r'Atgal';
-  @override String get closeButtonTooltip => r'Uždaryti';
-  @override String get deleteButtonTooltip => r'Ištrinti';
-  @override String get nextMonthTooltip => r'Kitas mėnuo';
-  @override String get previousMonthTooltip => r'Ankstesnis mėnuo';
-  @override String get nextPageTooltip => r'Kitas puslapis';
-  @override String get previousPageTooltip => r'Ankstesnis puslapis';
-  @override String get showMenuTooltip => r'Rodyti meniu';
-  @override String get aboutListTileTitle => r'Apie „$applicationName“';
-  @override String get licensesPageTitle => r'Licencijos';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow iš $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow iš maždaug $rowCount';
-  @override String get rowsPerPageTitle => r'Eilučių puslapyje:';
-  @override String get tabLabel => r'$tabIndex skirtukas iš $tabCount';
-  @override String get selectedRowCountTitleOne => r'Pasirinktas 1 elementas';
-  @override String get selectedRowCountTitleOther => r'Pasirinkta $selectedRowCount elementų';
-  @override String get cancelButtonLabel => r'ATŠAUKTI';
-  @override String get closeButtonLabel => r'UŽDARYTI';
-  @override String get continueButtonLabel => r'TĘSTI';
-  @override String get copyButtonLabel => r'KOPIJUOTI';
-  @override String get cutButtonLabel => r'IŠKIRPTI';
-  @override String get okButtonLabel => r'GERAI';
-  @override String get pasteButtonLabel => r'ĮKLIJUOTI';
-  @override String get selectAllButtonLabel => r'PASIRINKTI VISKĄ';
-  @override String get viewLicensesButtonLabel => r'PERŽIŪRĖTI LICENCIJAS';
-  @override String get anteMeridiemAbbreviation => r'priešpiet';
-  @override String get postMeridiemAbbreviation => r'popiet';
-  @override String get timePickerHourModeAnnouncement => r'Pasirinkite valandas';
-  @override String get timePickerMinuteModeAnnouncement => r'Pasirinkite minutes';
-  @override String get modalBarrierDismissLabel => r'Atsisakyti';
-  @override String get signedInLabel => r'Prisijungta';
-  @override String get hideAccountsLabel => r'Slėpti paskyras';
-  @override String get showAccountsLabel => r'Rodyti paskyras';
-  @override String get drawerLabel => r'Naršymo meniu';
-  @override String get popupMenuLabel => r'Iššokantysis meniu';
-  @override String get dialogLabel => r'Dialogo langas';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_lv extends TranslationBundle {
-  const _Bundle_lv() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Atvērt navigācijas izvēlni';
-  @override String get backButtonTooltip => r'Atpakaļ';
-  @override String get closeButtonTooltip => r'Aizvērt';
-  @override String get deleteButtonTooltip => r'Dzēst';
-  @override String get nextMonthTooltip => r'Nākamais mēnesis';
-  @override String get previousMonthTooltip => r'Iepriekšējais mēnesis';
-  @override String get nextPageTooltip => r'Nākamā lapa';
-  @override String get previousPageTooltip => r'Iepriekšējā lapa';
-  @override String get showMenuTooltip => r'Rādīt izvēlni';
-  @override String get aboutListTileTitle => r'Par $applicationName';
-  @override String get licensesPageTitle => r'Licences';
-  @override String get pageRowsInfoTitle => r'$firstRow.–$lastRow. no $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow.–$lastRow. no aptuveni $rowCount';
-  @override String get rowsPerPageTitle => r'Rindas lapā:';
-  @override String get tabLabel => r'$tabIndex. cilne no $tabCount';
-  @override String get selectedRowCountTitleZero => r'Nav atlasītu vienumu';
-  @override String get selectedRowCountTitleOne => r'Atlasīts 1 vienums';
-  @override String get selectedRowCountTitleOther => r'Atlasīti $selectedRowCount vienumi';
-  @override String get cancelButtonLabel => r'ATCELT';
-  @override String get closeButtonLabel => r'AIZVĒRT';
-  @override String get continueButtonLabel => r'TURPINĀT';
-  @override String get copyButtonLabel => r'KOPĒT';
-  @override String get cutButtonLabel => r'IZGRIEZT';
-  @override String get okButtonLabel => r'LABI';
-  @override String get pasteButtonLabel => r'IELĪMĒT';
-  @override String get selectAllButtonLabel => r'ATLASĪT VISU';
-  @override String get viewLicensesButtonLabel => r'SKATĪT LICENCES';
-  @override String get anteMeridiemAbbreviation => r'priekšpusdienā';
-  @override String get postMeridiemAbbreviation => r'pēcpusdienā';
-  @override String get timePickerHourModeAnnouncement => r'Atlasiet stundas';
-  @override String get timePickerMinuteModeAnnouncement => r'Atlasiet minūtes';
-  @override String get modalBarrierDismissLabel => r'Nerādīt';
-  @override String get signedInLabel => r'Esat pierakstījies';
-  @override String get hideAccountsLabel => r'Slēpt kontus';
-  @override String get showAccountsLabel => r'Rādīt kontus';
-  @override String get drawerLabel => r'Navigācijas izvēlne';
-  @override String get popupMenuLabel => r'Uznirstošā izvēlne';
-  @override String get dialogLabel => r'Dialoglodziņš';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_ms extends TranslationBundle {
-  const _Bundle_ms() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get openAppDrawerTooltip => r'Buka menu navigasi';
-  @override String get backButtonTooltip => r'Kembali';
-  @override String get closeButtonTooltip => r'Tutup';
-  @override String get deleteButtonTooltip => r'Padam';
-  @override String get nextMonthTooltip => r'Bulan depan';
-  @override String get previousMonthTooltip => r'Bulan sebelumnya';
-  @override String get nextPageTooltip => r'Halaman seterusnya';
-  @override String get previousPageTooltip => r'Halaman sebelumnya';
-  @override String get showMenuTooltip => r'Tunjukkan menu';
-  @override String get aboutListTileTitle => r'Perihal $applicationName';
-  @override String get licensesPageTitle => r'Lesen';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow dari $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow dari kira-kira $rowCount';
-  @override String get rowsPerPageTitle => r'Baris setiap halaman:';
-  @override String get tabLabel => r'Tab $tabIndex dari $tabCount';
-  @override String get selectedRowCountTitleZero => r'Tiada item dipilih';
-  @override String get selectedRowCountTitleOne => r'1 item dipilih';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
-  @override String get cancelButtonLabel => r'BATAL';
-  @override String get closeButtonLabel => r'TUTUP';
-  @override String get continueButtonLabel => r'TERUSKAN';
-  @override String get copyButtonLabel => r'SALIN';
-  @override String get cutButtonLabel => r'POTONG';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'TAMPAL';
-  @override String get selectAllButtonLabel => r'PILIH SEMUA';
-  @override String get viewLicensesButtonLabel => r'LIHAT LESEN';
-  @override String get anteMeridiemAbbreviation => r'PG';
-  @override String get postMeridiemAbbreviation => r'PTG';
-  @override String get timePickerHourModeAnnouncement => r'Pilih jam';
-  @override String get timePickerMinuteModeAnnouncement => r'Pilih minit';
-  @override String get modalBarrierDismissLabel => r'Tolak';
-  @override String get signedInLabel => r'Dilog masuk';
-  @override String get hideAccountsLabel => r'Sembunyikan akaun';
-  @override String get showAccountsLabel => r'Tunjukkan akaun';
-  @override String get drawerLabel => r'Menu navigasi';
-  @override String get popupMenuLabel => r'Menu pop timbul';
-  @override String get dialogLabel => r'Dialog';
-  @override String get alertDialogLabel => r'Amaran';
-  @override String get searchFieldLabel => r'Carian';
-}
-
-// ignore: camel_case_types
-class _Bundle_nb extends TranslationBundle {
-  const _Bundle_nb() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Åpne navigasjonsmenyen';
-  @override String get backButtonTooltip => r'Tilbake';
-  @override String get closeButtonTooltip => r'Lukk';
-  @override String get deleteButtonTooltip => r'Slett';
-  @override String get nextMonthTooltip => r'Neste måned';
-  @override String get previousMonthTooltip => r'Forrige måned';
-  @override String get nextPageTooltip => r'Neste side';
-  @override String get previousPageTooltip => r'Forrige side';
-  @override String get showMenuTooltip => r'Vis meny';
-  @override String get aboutListTileTitle => r'Om $applicationName';
-  @override String get licensesPageTitle => r'Lisenser';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow av $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow av omtrent $rowCount';
-  @override String get rowsPerPageTitle => r'Rader per side:';
-  @override String get tabLabel => r'Fane $tabIndex av $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 element er valgt';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
-  @override String get cancelButtonLabel => r'AVBRYT';
-  @override String get closeButtonLabel => r'LUKK';
-  @override String get continueButtonLabel => r'FORTSETT';
-  @override String get copyButtonLabel => r'KOPIÉR';
-  @override String get cutButtonLabel => r'KLIPP UT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'LIM INN';
-  @override String get selectAllButtonLabel => r'VELG ALLE';
-  @override String get viewLicensesButtonLabel => r'SE LISENSER';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Angi timer';
-  @override String get timePickerMinuteModeAnnouncement => r'Angi minutter';
-  @override String get modalBarrierDismissLabel => r'Avvis';
-  @override String get signedInLabel => r'Pålogget';
-  @override String get hideAccountsLabel => r'Skjul kontoer';
-  @override String get showAccountsLabel => r'Vis kontoer';
-  @override String get drawerLabel => r'Navigasjonsmeny';
-  @override String get popupMenuLabel => r'Forgrunnsmeny';
-  @override String get dialogLabel => r'Dialogboks';
-  @override String get alertDialogLabel => r'Varsling';
-  @override String get searchFieldLabel => r'Søke';
-}
-
-// ignore: camel_case_types
-class _Bundle_nl extends TranslationBundle {
-  const _Bundle_nl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Navigatiemenu openen';
-  @override String get backButtonTooltip => r'Terug';
-  @override String get closeButtonTooltip => r'Sluiten';
-  @override String get deleteButtonTooltip => r'Verwijderen';
-  @override String get nextMonthTooltip => r'Volgende maand';
-  @override String get previousMonthTooltip => r'Vorige maand';
-  @override String get nextPageTooltip => r'Volgende pagina';
-  @override String get previousPageTooltip => r'Vorige pagina';
-  @override String get showMenuTooltip => r'Menu weergeven';
-  @override String get aboutListTileTitle => r'Over $applicationName';
-  @override String get licensesPageTitle => r'Licenties';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow van $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow van ongeveer $rowCount';
-  @override String get rowsPerPageTitle => r'Rijen per pagina:';
-  @override String get tabLabel => r'Tabblad $tabIndex van $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 item geselecteerd';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
-  @override String get cancelButtonLabel => r'ANNULEREN';
-  @override String get closeButtonLabel => r'SLUITEN';
-  @override String get continueButtonLabel => r'DOORGAAN';
-  @override String get copyButtonLabel => r'KOPIËREN';
-  @override String get cutButtonLabel => r'KNIPPEN';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'PLAKKEN';
-  @override String get selectAllButtonLabel => r'ALLES SELECTEREN';
-  @override String get viewLicensesButtonLabel => r'LICENTIES BEKIJKEN';
-  @override String get anteMeridiemAbbreviation => r'am';
-  @override String get postMeridiemAbbreviation => r'pm';
-  @override String get timePickerHourModeAnnouncement => r'Uren selecteren';
-  @override String get timePickerMinuteModeAnnouncement => r'Minuten selecteren';
-  @override String get signedInLabel => r'Ingelogd';
-  @override String get hideAccountsLabel => r'Accounts verbergen';
-  @override String get showAccountsLabel => r'Accounts weergeven';
-  @override String get modalBarrierDismissLabel => r'Sluiten';
-  @override String get drawerLabel => r'Navigatiemenu';
-  @override String get popupMenuLabel => r'Pop-upmenu';
-  @override String get dialogLabel => r'Dialoogvenster';
-  @override String get alertDialogLabel => r'Alarm';
-  @override String get searchFieldLabel => r'Zoeken';
-}
-
-// ignore: camel_case_types
-class _Bundle_pl extends TranslationBundle {
-  const _Bundle_pl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
-  @override String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
-  @override String get openAppDrawerTooltip => r'Otwórz menu nawigacyjne';
-  @override String get backButtonTooltip => r'Wstecz';
-  @override String get closeButtonTooltip => r'Zamknij';
-  @override String get deleteButtonTooltip => r'Usuń';
-  @override String get nextMonthTooltip => r'Następny miesiąc';
-  @override String get previousMonthTooltip => r'Poprzedni miesiąc';
-  @override String get nextPageTooltip => r'Następna strona';
-  @override String get previousPageTooltip => r'Poprzednia strona';
-  @override String get showMenuTooltip => r'Pokaż menu';
-  @override String get aboutListTileTitle => r'$applicationName – informacje';
-  @override String get licensesPageTitle => r'Licencje';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow z $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow z około $rowCount';
-  @override String get rowsPerPageTitle => r'Wiersze na stronie:';
-  @override String get tabLabel => r'Karta $tabIndex z $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 wybrany element';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount wybranego elementu';
-  @override String get cancelButtonLabel => r'ANULUJ';
-  @override String get closeButtonLabel => r'ZAMKNIJ';
-  @override String get continueButtonLabel => r'DALEJ';
-  @override String get copyButtonLabel => r'KOPIUJ';
-  @override String get cutButtonLabel => r'WYTNIJ';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'WKLEJ';
-  @override String get selectAllButtonLabel => r'ZAZNACZ WSZYSTKO';
-  @override String get viewLicensesButtonLabel => r'WYŚWIETL LICENCJE';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Wybierz godziny';
-  @override String get timePickerMinuteModeAnnouncement => r'Wybierz minuty';
-  @override String get signedInLabel => r'Zalogowani użytkownicy';
-  @override String get hideAccountsLabel => r'Ukryj konta';
-  @override String get showAccountsLabel => r'Pokaż konta';
-  @override String get modalBarrierDismissLabel => r'Zamknij';
-  @override String get drawerLabel => r'Menu nawigacyjne';
-  @override String get popupMenuLabel => r'Wyskakujące menu';
-  @override String get dialogLabel => r'Okno dialogowe';
-  @override String get alertDialogLabel => r'Alarm';
-  @override String get searchFieldLabel => r'Szukaj';
-}
-
-// ignore: camel_case_types
-class _Bundle_ps extends TranslationBundle {
-  const _Bundle_ps() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'د پرانیستی نیینګ مینو';
-  @override String get backButtonTooltip => r'شاته';
-  @override String get closeButtonTooltip => r'بنده';
-  @override String get deleteButtonTooltip => r'';
-  @override String get nextMonthTooltip => r'بله میاشت';
-  @override String get previousMonthTooltip => r'تیره میاشت';
-  @override String get nextPageTooltip => r'بله پاڼه';
-  @override String get previousPageTooltip => r'مخکینی مخ';
-  @override String get showMenuTooltip => r'غورنۍ ښودل';
-  @override String get aboutListTileTitle => r'د $applicationName په اړه';
-  @override String get licensesPageTitle => r'جوازونه';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow د $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow څخه $rowCount د';
-  @override String get rowsPerPageTitle => r'د هرې پاڼې پاڼې:';
-  @override String get tabLabel => r'$tabIndex د $tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
-  @override String get cancelButtonLabel => r'لغوه کول';
-  @override String get closeButtonLabel => r'تړل';
-  @override String get continueButtonLabel => r'منځپانګې';
-  @override String get copyButtonLabel => r'کاپی';
-  @override String get cutButtonLabel => r'کم کړئ';
-  @override String get okButtonLabel => r'سمه ده';
-  @override String get pasteButtonLabel => r'پیټ کړئ';
-  @override String get selectAllButtonLabel => r'غوره کړئ';
-  @override String get viewLicensesButtonLabel => r'لیدلس وګورئ';
-  @override String get timePickerHourModeAnnouncement => r'وختونه وټاکئ';
-  @override String get timePickerMinuteModeAnnouncement => r'منې غوره کړئ';
-  @override String get signedInLabel => r'ننوتل';
-  @override String get hideAccountsLabel => r'حسابونه پټ کړئ';
-  @override String get showAccountsLabel => r'حسابونه ښکاره کړئ';
-  @override String get modalBarrierDismissLabel => r'رد کړه';
-  @override String get drawerLabel => r'د نیویگیشن مینو';
-  @override String get popupMenuLabel => r'د پاپ اپ مینو';
-  @override String get dialogLabel => r'خبرې اترې';
-  @override String get alertDialogLabel => r'خبرتیا';
-  @override String get searchFieldLabel => r'لټون';
-}
-
-// ignore: camel_case_types
-class _Bundle_pt extends TranslationBundle {
-  const _Bundle_pt() : super(null);
-  @override String get anteMeridiemAbbreviation => r'Manhã';
-  @override String get selectedRowCountTitleOne => r'1 item selecionado';
-  @override String get postMeridiemAbbreviation => r'Tarde/noite';
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Abrir menu de navegação';
-  @override String get backButtonTooltip => r'Voltar';
-  @override String get closeButtonTooltip => r'Fechar';
-  @override String get deleteButtonTooltip => r'Excluir';
-  @override String get nextMonthTooltip => r'Próximo mês';
-  @override String get previousMonthTooltip => r'Mês anterior';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get previousPageTooltip => r'Página anterior';
-  @override String get showMenuTooltip => r'Mostrar menu';
-  @override String get aboutListTileTitle => r'Sobre o app $applicationName';
-  @override String get licensesPageTitle => r'Licenças';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow de aproximadamente $rowCount';
-  @override String get rowsPerPageTitle => r'Linhas por página:';
-  @override String get tabLabel => r'Guia $tabIndex de $tabCount';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
-  @override String get cancelButtonLabel => r'CANCELAR';
-  @override String get closeButtonLabel => r'FECHAR';
-  @override String get continueButtonLabel => r'CONTINUAR';
-  @override String get copyButtonLabel => r'COPIAR';
-  @override String get cutButtonLabel => r'RECORTAR';
-  @override String get okButtonLabel => r'Ok';
-  @override String get pasteButtonLabel => r'COLAR';
-  @override String get selectAllButtonLabel => r'SELECIONAR TUDO';
-  @override String get viewLicensesButtonLabel => r'VER LICENÇAS';
-  @override String get timePickerHourModeAnnouncement => r'Selecione as horas';
-  @override String get timePickerMinuteModeAnnouncement => r'Selecione os minutos';
-  @override String get signedInLabel => r'Conectado a';
-  @override String get hideAccountsLabel => r'Ocultar contas';
-  @override String get showAccountsLabel => r'Mostrar contas';
-  @override String get modalBarrierDismissLabel => r'Dispensar';
-  @override String get drawerLabel => r'Menu de navegação';
-  @override String get popupMenuLabel => r'Menu pop-up';
-  @override String get dialogLabel => r'Caixa de diálogo';
-  @override String get alertDialogLabel => r'Alerta';
-  @override String get searchFieldLabel => r'Pesquisa';
-}
-
-// ignore: camel_case_types
-class _Bundle_ro extends TranslationBundle {
-  const _Bundle_ro() : super(null);
-  @override String get selectedRowCountTitleFew => r'$selectedRowCount articole selectate';
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Deschideți meniul de navigare';
-  @override String get backButtonTooltip => r'Înapoi';
-  @override String get closeButtonTooltip => r'Închideți';
-  @override String get deleteButtonTooltip => r'Ștergeți';
-  @override String get nextMonthTooltip => r'Luna viitoare';
-  @override String get previousMonthTooltip => r'Luna trecută';
-  @override String get nextPageTooltip => r'Pagina următoare';
-  @override String get previousPageTooltip => r'Pagina anterioară';
-  @override String get showMenuTooltip => r'Afișați meniul';
-  @override String get aboutListTileTitle => r'Despre $applicationName';
-  @override String get licensesPageTitle => r'Licențe';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow din $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow din aproximativ $rowCount';
-  @override String get rowsPerPageTitle => r'Rânduri pe pagină:';
-  @override String get tabLabel => r'Fila $tabIndex din $tabCount';
-  @override String get selectedRowCountTitleZero => r'Nu există elemente selectate';
-  @override String get selectedRowCountTitleOne => r'Un articol selectat';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount de articole selectate';
-  @override String get cancelButtonLabel => r'ANULAȚI';
-  @override String get closeButtonLabel => r'ÎNCHIDEȚI';
-  @override String get continueButtonLabel => r'CONTINUAȚI';
-  @override String get copyButtonLabel => r'COPIAȚI';
-  @override String get cutButtonLabel => r'DECUPAȚI';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'INSERAȚI';
-  @override String get selectAllButtonLabel => r'SELECTAȚI TOATE';
-  @override String get viewLicensesButtonLabel => r'VEDEȚI LICENȚELE';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get timePickerHourModeAnnouncement => r'Selectați orele';
-  @override String get timePickerMinuteModeAnnouncement => r'Selectați minutele';
-  @override String get signedInLabel => r'V-ați conectat';
-  @override String get hideAccountsLabel => r'Ascundeți conturile';
-  @override String get showAccountsLabel => r'Afișați conturile';
-  @override String get modalBarrierDismissLabel => r'Închideți';
-  @override String get drawerLabel => r'Meniu de navigare';
-  @override String get popupMenuLabel => r'Meniu pop-up';
-  @override String get dialogLabel => r'Casetă de dialog';
-  @override String get alertDialogLabel => r'Alerta';
-  @override String get searchFieldLabel => r'Căutare';
-}
-
-// ignore: camel_case_types
-class _Bundle_ru extends TranslationBundle {
-  const _Bundle_ru() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'H:mm';
-  @override String get selectedRowCountTitleFew => r'Выбрано $selectedRowCount объекта';
-  @override String get selectedRowCountTitleMany => r'Выбрано $selectedRowCount объектов';
-  @override String get openAppDrawerTooltip => r'Открыть меню навигации';
-  @override String get backButtonTooltip => r'Назад';
-  @override String get closeButtonTooltip => r'Закрыть';
-  @override String get deleteButtonTooltip => r'Удалить';
-  @override String get nextMonthTooltip => r'Следующий месяц';
-  @override String get previousMonthTooltip => r'Предыдущий месяц';
-  @override String get nextPageTooltip => r'Следующая страница';
-  @override String get previousPageTooltip => r'Предыдущая страница';
-  @override String get showMenuTooltip => r'Показать меню';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow из $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow из примерно $rowCount';
-  @override String get rowsPerPageTitle => r'Строк на странице:';
-  @override String get tabLabel => r'Вкладка $tabIndex из $tabCount';
-  @override String get aboutListTileTitle => r'$applicationName: сведения';
-  @override String get licensesPageTitle => r'Лицензии';
-  @override String get selectedRowCountTitleZero => r'Строки не выбраны';
-  @override String get selectedRowCountTitleOne => r'Выбран 1 объект';
-  @override String get selectedRowCountTitleOther => r'Выбрано $selectedRowCount объекта';
-  @override String get cancelButtonLabel => r'ОТМЕНА';
-  @override String get closeButtonLabel => r'ЗАКРЫТЬ';
-  @override String get continueButtonLabel => r'ПРОДОЛЖИТЬ';
-  @override String get copyButtonLabel => r'КОПИРОВАТЬ';
-  @override String get cutButtonLabel => r'ВЫРЕЗАТЬ';
-  @override String get okButtonLabel => r'ОК';
-  @override String get pasteButtonLabel => r'ВСТАВИТЬ';
-  @override String get selectAllButtonLabel => r'ВЫБРАТЬ ВСЕ';
-  @override String get viewLicensesButtonLabel => r'ЛИЦЕНЗИИ';
-  @override String get anteMeridiemAbbreviation => r'АМ';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Выберите часы';
-  @override String get timePickerMinuteModeAnnouncement => r'Выберите минуты';
-  @override String get signedInLabel => r'Вход выполнен';
-  @override String get hideAccountsLabel => r'Скрыть аккаунты';
-  @override String get showAccountsLabel => r'Показать аккаунты';
-  @override String get modalBarrierDismissLabel => r'Закрыть';
-  @override String get drawerLabel => r'Меню навигации';
-  @override String get popupMenuLabel => r'Всплывающее меню';
-  @override String get dialogLabel => r'Диалоговое окно';
-  @override String get alertDialogLabel => r'бдительный';
-  @override String get searchFieldLabel => r'Поиск';
-}
-
-// ignore: camel_case_types
-class _Bundle_sk extends TranslationBundle {
-  const _Bundle_sk() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'$selectedRowCount vybraté položky';
-  @override String get selectedRowCountTitleMany => r'$selectedRowCount items selected';
-  @override String get openAppDrawerTooltip => r'Otvoriť navigačnú ponuku';
-  @override String get backButtonTooltip => r'Späť';
-  @override String get closeButtonTooltip => r'Zavrieť';
-  @override String get deleteButtonTooltip => r'Odstrániť';
-  @override String get nextMonthTooltip => r'Budúci mesiac';
-  @override String get previousMonthTooltip => r'Predošlý mesiac';
-  @override String get nextPageTooltip => r'Ďalšia strana';
-  @override String get previousPageTooltip => r'Predchádzajúca stránka';
-  @override String get showMenuTooltip => r'Zobraziť ponuku';
-  @override String get aboutListTileTitle => r'$applicationName – informácie';
-  @override String get licensesPageTitle => r'Licencie';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow z $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow z približne $rowCount';
-  @override String get rowsPerPageTitle => r'Počet riadkov na stránku:';
-  @override String get tabLabel => r'Karta $tabIndex z $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 vybratá položka';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount vybratých položiek';
-  @override String get cancelButtonLabel => r'ZRUŠIŤ';
-  @override String get closeButtonLabel => r'ZAVRIEŤ';
-  @override String get continueButtonLabel => r'POKRAČOVAŤ';
-  @override String get copyButtonLabel => r'KOPÍROVAŤ';
-  @override String get cutButtonLabel => r'VYSTRIHNÚŤ';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'PRILEPIŤ';
-  @override String get selectAllButtonLabel => r'VYBRAŤ VŠETKO';
-  @override String get viewLicensesButtonLabel => r'ZOBRAZIŤ LICENCIE';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Vybrať hodiny';
-  @override String get timePickerMinuteModeAnnouncement => r'Vybrať minúty';
-  @override String get modalBarrierDismissLabel => r'Odmietnuť';
-  @override String get signedInLabel => r'Prihlásili ste sa';
-  @override String get hideAccountsLabel => r'Skryť účty';
-  @override String get showAccountsLabel => r'Zobraziť účty';
-  @override String get drawerLabel => r'Navigačná ponuka';
-  @override String get popupMenuLabel => r'Kontextová ponuka';
-  @override String get dialogLabel => r'Dialógové okno';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_sl extends TranslationBundle {
-  const _Bundle_sl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleTwo => r'Izbrana sta $selectedRowCount elementa';
-  @override String get selectedRowCountTitleFew => r'Izbrani so $selectedRowCount elementi';
-  @override String get openAppDrawerTooltip => r'Odpiranje menija za krmarjenje';
-  @override String get backButtonTooltip => r'Nazaj';
-  @override String get closeButtonTooltip => r'Zapiranje';
-  @override String get deleteButtonTooltip => r'Brisanje';
-  @override String get nextMonthTooltip => r'Naslednji mesec';
-  @override String get previousMonthTooltip => r'Prejšnji mesec';
-  @override String get nextPageTooltip => r'Naslednja stran';
-  @override String get previousPageTooltip => r'Prejšnja stran';
-  @override String get showMenuTooltip => r'Prikaz menija';
-  @override String get aboutListTileTitle => r'O aplikaciji $applicationName';
-  @override String get licensesPageTitle => r'Licence';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow od $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow od približno $rowCount';
-  @override String get rowsPerPageTitle => r'Vrstice na stran:';
-  @override String get tabLabel => r'Zavihek $tabIndex od $tabCount';
-  @override String get selectedRowCountTitleOne => r'Izbran je 1 element';
-  @override String get selectedRowCountTitleOther => r'Izbranih je $selectedRowCount elementov';
-  @override String get cancelButtonLabel => r'PREKLIČI';
-  @override String get closeButtonLabel => r'ZAPRI';
-  @override String get continueButtonLabel => r'NAPREJ';
-  @override String get copyButtonLabel => r'KOPIRAJ';
-  @override String get cutButtonLabel => r'IZREŽI';
-  @override String get okButtonLabel => r'V REDU';
-  @override String get pasteButtonLabel => r'PRILEPI';
-  @override String get selectAllButtonLabel => r'IZBERI VSE';
-  @override String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
-  @override String get anteMeridiemAbbreviation => r'DOP.';
-  @override String get postMeridiemAbbreviation => r'POP.';
-  @override String get timePickerHourModeAnnouncement => r'Izberite ure';
-  @override String get timePickerMinuteModeAnnouncement => r'Izberite minute';
-  @override String get modalBarrierDismissLabel => r'Opusti';
-  @override String get signedInLabel => r'Prijavljen';
-  @override String get hideAccountsLabel => r'Skrivanje računov';
-  @override String get showAccountsLabel => r'Prikaz računov';
-  @override String get drawerLabel => r'Meni za krmarjenje';
-  @override String get popupMenuLabel => r'Pojavni meni';
-  @override String get dialogLabel => r'Pogovorno okno';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_sr extends TranslationBundle {
-  const _Bundle_sr() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Изабране су $selectedRowCount ставке';
-  @override String get openAppDrawerTooltip => r'Отворите мени за навигацију';
-  @override String get backButtonTooltip => r'Назад';
-  @override String get closeButtonTooltip => r'Затворите';
-  @override String get deleteButtonTooltip => r'Избришите';
-  @override String get nextMonthTooltip => r'Следећи месец';
-  @override String get previousMonthTooltip => r'Претходни месец';
-  @override String get nextPageTooltip => r'Следећа страница';
-  @override String get previousPageTooltip => r'Претходна страница';
-  @override String get showMenuTooltip => r'Прикажи мени';
-  @override String get aboutListTileTitle => r'О апликацији $applicationName';
-  @override String get licensesPageTitle => r'Лиценце';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow oд $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow oд приближно $rowCount';
-  @override String get rowsPerPageTitle => r'Редова по страници:';
-  @override String get tabLabel => r'$tabIndex. картица од $tabCount';
-  @override String get selectedRowCountTitleOne => r'Изабрана је 1 ставка';
-  @override String get selectedRowCountTitleOther => r'Изабрано је $selectedRowCount ставки';
-  @override String get cancelButtonLabel => r'ОТКАЖИ';
-  @override String get closeButtonLabel => r'ЗАТВОРИ';
-  @override String get continueButtonLabel => r'НАСТАВИ';
-  @override String get copyButtonLabel => r'КОПИРАЈ';
-  @override String get cutButtonLabel => r'ИСЕЦИ';
-  @override String get okButtonLabel => r'Потврди';
-  @override String get pasteButtonLabel => r'НАЛЕПИ';
-  @override String get selectAllButtonLabel => r'ИЗАБЕРИ СВЕ';
-  @override String get viewLicensesButtonLabel => r'ПРИКАЖИ ЛИЦЕНЦЕ';
-  @override String get anteMeridiemAbbreviation => r'пре подне';
-  @override String get postMeridiemAbbreviation => r'по подне';
-  @override String get timePickerHourModeAnnouncement => r'Изаберите сате';
-  @override String get timePickerMinuteModeAnnouncement => r'Изаберите минуте';
-  @override String get modalBarrierDismissLabel => r'Одбаци';
-  @override String get signedInLabel => r'Пријављени сте';
-  @override String get hideAccountsLabel => r'Сакриј налоге';
-  @override String get showAccountsLabel => r'Прикажи налоге';
-  @override String get drawerLabel => r'Мени за навигацију';
-  @override String get popupMenuLabel => r'Искачући мени';
-  @override String get dialogLabel => r'Дијалог';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_sv extends TranslationBundle {
-  const _Bundle_sv() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Öppna navigeringsmenyn';
-  @override String get backButtonTooltip => r'Tillbaka';
-  @override String get closeButtonTooltip => r'Stäng';
-  @override String get deleteButtonTooltip => r'Radera';
-  @override String get nextMonthTooltip => r'Nästa månad';
-  @override String get previousMonthTooltip => r'Föregående månad';
-  @override String get nextPageTooltip => r'Nästa sida';
-  @override String get previousPageTooltip => r'Föregående sida';
-  @override String get showMenuTooltip => r'Visa meny';
-  @override String get aboutListTileTitle => r'Om $applicationName';
-  @override String get licensesPageTitle => r'Licenser';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow av $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow av ungefär $rowCount';
-  @override String get rowsPerPageTitle => r'Rader per sida:';
-  @override String get tabLabel => r'Flik $tabIndex av $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 objekt har markerats';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount objekt har markerats';
-  @override String get cancelButtonLabel => r'AVBRYT';
-  @override String get closeButtonLabel => r'STÄNG';
-  @override String get continueButtonLabel => r'FORTSÄTT';
-  @override String get copyButtonLabel => r'KOPIERA';
-  @override String get cutButtonLabel => r'KLIPP UT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'KLISTRA IN';
-  @override String get selectAllButtonLabel => r'MARKERA ALLA';
-  @override String get viewLicensesButtonLabel => r'VISA LICENSER';
-  @override String get anteMeridiemAbbreviation => r'FM';
-  @override String get postMeridiemAbbreviation => r'EM';
-  @override String get timePickerHourModeAnnouncement => r'Välj timmar';
-  @override String get timePickerMinuteModeAnnouncement => r'Välj minuter';
-  @override String get modalBarrierDismissLabel => r'Stäng';
-  @override String get signedInLabel => r'Inloggad';
-  @override String get hideAccountsLabel => r'Dölj konton';
-  @override String get showAccountsLabel => r'Visa konton';
-  @override String get drawerLabel => r'Navigeringsmeny';
-  @override String get popupMenuLabel => r'Popup-meny';
-  @override String get dialogLabel => r'Dialogruta';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_th extends TranslationBundle {
-  const _Bundle_th() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'ah:mm';
-  @override String get openAppDrawerTooltip => r'เปิดเมนูการนำทาง';
-  @override String get backButtonTooltip => r'กลับ';
-  @override String get closeButtonTooltip => r'ปิด';
-  @override String get deleteButtonTooltip => r'ลบ';
-  @override String get nextMonthTooltip => r'เดือนหน้า';
-  @override String get previousMonthTooltip => r'เดือนที่แล้ว';
-  @override String get nextPageTooltip => r'หน้าถัดไป';
-  @override String get previousPageTooltip => r'หน้าก่อน';
-  @override String get showMenuTooltip => r'แสดงเมนู';
-  @override String get aboutListTileTitle => r'เกี่ยวกับ $applicationName';
-  @override String get licensesPageTitle => r'ใบอนุญาต';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow จาก $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow จากประมาณ $rowCount';
-  @override String get rowsPerPageTitle => r'แถวต่อหน้า:';
-  @override String get tabLabel => r'แท็บที่ $tabIndex จาก $tabCount';
-  @override String get selectedRowCountTitleOne => r'เลือกแล้ว 1 รายการ';
-  @override String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
-  @override String get cancelButtonLabel => r'ยกเลิก';
-  @override String get closeButtonLabel => r'ปิด';
-  @override String get continueButtonLabel => r'ต่อไป';
-  @override String get copyButtonLabel => r'คัดลอก';
-  @override String get cutButtonLabel => r'ตัด';
-  @override String get okButtonLabel => r'ตกลง';
-  @override String get pasteButtonLabel => r'วาง';
-  @override String get selectAllButtonLabel => r'เลือกทั้งหมด';
-  @override String get viewLicensesButtonLabel => r'ดูใบอนุญาต';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'เลือกชั่วโมง';
-  @override String get timePickerMinuteModeAnnouncement => r'เลือกนาที';
-  @override String get signedInLabel => r'ลงชื่อเข้าใช้';
-  @override String get hideAccountsLabel => r'ซ่อนบัญชี';
-  @override String get showAccountsLabel => r'แสดงบัญชี';
-  @override String get modalBarrierDismissLabel => r'ปิด';
-  @override String get drawerLabel => r'เมนูการนำทาง';
-  @override String get popupMenuLabel => r'เมนูป๊อปอัป';
-  @override String get dialogLabel => r'กล่องโต้ตอบ';
-  @override String get alertDialogLabel => r'เตือนภัย';
-  @override String get searchFieldLabel => r'ค้นหา';
-}
-
-// ignore: camel_case_types
-class _Bundle_tl extends TranslationBundle {
-  const _Bundle_tl() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Buksan ang menu ng navigation';
-  @override String get backButtonTooltip => r'Bumalik';
-  @override String get closeButtonTooltip => r'Isara';
-  @override String get deleteButtonTooltip => r'I-delete';
-  @override String get nextMonthTooltip => r'Susunod na buwan';
-  @override String get previousMonthTooltip => r'Nakaraang buwan';
-  @override String get nextPageTooltip => r'Susunod na page';
-  @override String get previousPageTooltip => r'Nakaraang page';
-  @override String get showMenuTooltip => r'Ipakita ang menu';
-  @override String get aboutListTileTitle => r'Tungkol sa $applicationName';
-  @override String get licensesPageTitle => r'Mga Lisensya';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow ng $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow ng humigit kumulang $rowCount';
-  @override String get rowsPerPageTitle => r'Mga row bawat page:';
-  @override String get tabLabel => r'Tab $tabIndex ng $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 item ang napili';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
-  @override String get cancelButtonLabel => r'KANSELAHIN';
-  @override String get closeButtonLabel => r'ISARA';
-  @override String get continueButtonLabel => r'MAGPATULOY';
-  @override String get copyButtonLabel => r'KOPYAHIN';
-  @override String get cutButtonLabel => r'I-CUT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'I-PASTE';
-  @override String get selectAllButtonLabel => r'PILIIN LAHAT';
-  @override String get viewLicensesButtonLabel => r'TINGNAN ANG MGA LISENSYA';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'Pumili ng mga oras';
-  @override String get timePickerMinuteModeAnnouncement => r'Pumili ng mga minuto';
-  @override String get modalBarrierDismissLabel => r'I-dismiss';
-  @override String get signedInLabel => r'Naka-sign in';
-  @override String get hideAccountsLabel => r'Itago ang mga account';
-  @override String get showAccountsLabel => r'Ipakita ang mga account';
-  @override String get drawerLabel => r'Menu ng navigation';
-  @override String get popupMenuLabel => r'Popup na menu';
-  @override String get dialogLabel => r'Dialog';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_tr extends TranslationBundle {
-  const _Bundle_tr() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Gezinme menüsünü aç';
-  @override String get backButtonTooltip => r'Geri';
-  @override String get closeButtonTooltip => r'Kapat';
-  @override String get deleteButtonTooltip => r'Sil';
-  @override String get nextMonthTooltip => r'Gelecek ay';
-  @override String get previousMonthTooltip => r'Önceki ay';
-  @override String get nextPageTooltip => r'Sonraki sayfa';
-  @override String get previousPageTooltip => r'Önceki sayfa';
-  @override String get showMenuTooltip => r'Menüyü göster';
-  @override String get aboutListTileTitle => r'$applicationName Hakkında';
-  @override String get licensesPageTitle => r'Lisanslar';
-  @override String get pageRowsInfoTitle => r'$firstRow-$lastRow / $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow-$lastRow / $rowCount';
-  @override String get rowsPerPageTitle => r'Sayfa başına satır sayısı:';
-  @override String get tabLabel => r'Sekme $tabIndex / $tabCount';
-  @override String get selectedRowCountTitleOne => r'1 öğe seçildi';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
-  @override String get cancelButtonLabel => r'İPTAL';
-  @override String get closeButtonLabel => r'KAPAT';
-  @override String get continueButtonLabel => r'DEVAM';
-  @override String get copyButtonLabel => r'KOPYALA';
-  @override String get cutButtonLabel => r'KES';
-  @override String get okButtonLabel => r'Tamam';
-  @override String get pasteButtonLabel => r'YAPIŞTIR';
-  @override String get selectAllButtonLabel => r'TÜMÜNÜ SEÇ';
-  @override String get viewLicensesButtonLabel => r'LİSANLARI GÖSTER';
-  @override String get anteMeridiemAbbreviation => r'ÖÖ';
-  @override String get postMeridiemAbbreviation => r'ÖS';
-  @override String get timePickerHourModeAnnouncement => r'Saati seçin';
-  @override String get timePickerMinuteModeAnnouncement => r'Dakikayı seçin';
-  @override String get signedInLabel => r'Oturum açıldı';
-  @override String get hideAccountsLabel => r'Hesapları gizle';
-  @override String get showAccountsLabel => r'Hesapları göster';
-  @override String get modalBarrierDismissLabel => r'Kapat';
-  @override String get drawerLabel => r'Gezinme menüsü';
-  @override String get popupMenuLabel => r'Popup menü';
-  @override String get dialogLabel => r'İletişim kutusu';
-  @override String get alertDialogLabel => r'Alarm';
-  @override String get searchFieldLabel => r'Arama';
-}
-
-// ignore: camel_case_types
-class _Bundle_uk extends TranslationBundle {
-  const _Bundle_uk() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get selectedRowCountTitleFew => r'Вибрано $selectedRowCount елементи';
-  @override String get selectedRowCountTitleMany => r'Вибрано $selectedRowCount елементів';
-  @override String get openAppDrawerTooltip => r'Відкрити меню навігації';
-  @override String get backButtonTooltip => r'Назад';
-  @override String get closeButtonTooltip => r'Закрити';
-  @override String get deleteButtonTooltip => r'Видалити';
-  @override String get nextMonthTooltip => r'Наступний місяць';
-  @override String get previousMonthTooltip => r'Попередній місяць';
-  @override String get nextPageTooltip => r'Наступна сторінка';
-  @override String get previousPageTooltip => r'Попередня сторінка';
-  @override String get showMenuTooltip => r'Показати меню';
-  @override String get aboutListTileTitle => r'Про додаток $applicationName';
-  @override String get licensesPageTitle => r'Ліцензії';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow з $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow з приблизно $rowCount';
-  @override String get rowsPerPageTitle => r'Рядків на сторінці:';
-  @override String get tabLabel => r'Вкладка $tabIndex з $tabCount';
-  @override String get selectedRowCountTitleOne => r'Вибрано 1 елемент';
-  @override String get selectedRowCountTitleOther => r'Вибрано $selectedRowCount елемента';
-  @override String get cancelButtonLabel => r'СКАСУВАТИ';
-  @override String get closeButtonLabel => r'ЗАКРИТИ';
-  @override String get continueButtonLabel => r'ПРОДОВЖИТИ';
-  @override String get copyButtonLabel => r'КОПІЮВАТИ';
-  @override String get cutButtonLabel => r'ВИРІЗАТИ';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'ВСТАВИТИ';
-  @override String get selectAllButtonLabel => r'ВИБРАТИ ВСІ';
-  @override String get viewLicensesButtonLabel => r'ПЕРЕГЛЯНУТИ ЛІЦЕНЗІЇ';
-  @override String get anteMeridiemAbbreviation => r'дп';
-  @override String get postMeridiemAbbreviation => r'пп';
-  @override String get timePickerHourModeAnnouncement => r'Виберіть години';
-  @override String get timePickerMinuteModeAnnouncement => r'Виберіть хвилини';
-  @override String get modalBarrierDismissLabel => r'Усунути';
-  @override String get signedInLabel => r'Ви ввійшли';
-  @override String get hideAccountsLabel => r'Сховати облікові записи';
-  @override String get showAccountsLabel => r'Показати облікові записи';
-  @override String get drawerLabel => r'Меню навігації';
-  @override String get popupMenuLabel => r'Спливаюче меню';
-  @override String get dialogLabel => r'Вікно';
-  @override String get alertDialogLabel => r'TBD';
-  @override String get searchFieldLabel => r'TBD';
-}
-
-// ignore: camel_case_types
-class _Bundle_ur extends TranslationBundle {
-  const _Bundle_ur() : super(null);
-  @override String get scriptCategory => r'tall';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get selectedRowCountTitleOne => r'1 آئٹم منتخب کیا گیا';
-  @override String get openAppDrawerTooltip => r'نیویگیشن مینو کھولیں';
-  @override String get backButtonTooltip => r'پیچھے';
-  @override String get closeButtonTooltip => r'بند کریں';
-  @override String get deleteButtonTooltip => r'حذف کریں';
-  @override String get nextMonthTooltip => r'اگلا مہینہ';
-  @override String get previousMonthTooltip => r'پچھلا مہینہ';
-  @override String get nextPageTooltip => r'اگلا صفحہ';
-  @override String get previousPageTooltip => r'گزشتہ صفحہ';
-  @override String get showMenuTooltip => r'مینو دکھائیں';
-  @override String get aboutListTileTitle => r'$applicationName کے بارے میں';
-  @override String get licensesPageTitle => r'لائسنسز';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow از $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow $rowCount میں سے تقریباً';
-  @override String get rowsPerPageTitle => r'قطاریں فی صفحہ:';
-  @override String get tabLabel => r'$tabCount میں سے $tabIndex ٹیب';
-  @override String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
-  @override String get cancelButtonLabel => r'منسوخ کریں';
-  @override String get closeButtonLabel => r'بند کریں';
-  @override String get continueButtonLabel => r'جاری رکھیں';
-  @override String get copyButtonLabel => r'کاپی کریں';
-  @override String get cutButtonLabel => r'کٹ کریں';
-  @override String get okButtonLabel => r'ٹھیک ہے';
-  @override String get pasteButtonLabel => r'پیسٹ کریں';
-  @override String get selectAllButtonLabel => r'سبھی منتخب کریں';
-  @override String get viewLicensesButtonLabel => r'لائسنسز دیکھیں';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get timePickerHourModeAnnouncement => r'گھنٹے منتخب کریں';
-  @override String get timePickerMinuteModeAnnouncement => r'منٹ منتخب کریں';
-  @override String get signedInLabel => r'سائن ان کردہ ہے';
-  @override String get hideAccountsLabel => r'اکاؤنٹس چھپائیں';
-  @override String get showAccountsLabel => r'اکاؤنٹس دکھائیں';
-  @override String get modalBarrierDismissLabel => r'برخاست کریں';
-  @override String get drawerLabel => r'نیویگیشن مینو';
-  @override String get popupMenuLabel => r'پاپ اپ مینو';
-  @override String get dialogLabel => r'ڈائلاگ';
-  @override String get alertDialogLabel => r'انتباہ';
-  @override String get searchFieldLabel => r'تلاش کریں';
-}
-
-// ignore: camel_case_types
-class _Bundle_vi extends TranslationBundle {
-  const _Bundle_vi() : super(null);
-  @override String get scriptCategory => r'English-like';
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get openAppDrawerTooltip => r'Mở menu di chuyển';
-  @override String get backButtonTooltip => r'Quay lại';
-  @override String get closeButtonTooltip => r'Đóng';
-  @override String get deleteButtonTooltip => r'Xóa';
-  @override String get nextMonthTooltip => r'Tháng sau';
-  @override String get previousMonthTooltip => r'Tháng trước';
-  @override String get nextPageTooltip => r'Trang tiếp theo';
-  @override String get previousPageTooltip => r'Trang trước';
-  @override String get showMenuTooltip => r'Hiển thị menu';
-  @override String get aboutListTileTitle => r'Giới thiệu về $applicationName';
-  @override String get licensesPageTitle => r'Giấy phép';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow trong tổng số $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow trong tổng số khoảng $rowCount';
-  @override String get rowsPerPageTitle => r'Số hàng mỗi trang:';
-  @override String get tabLabel => r'Tab $tabIndex trong tổng số $tabCount';
-  @override String get selectedRowCountTitleOne => r'Đã chọn 1 mục';
-  @override String get selectedRowCountTitleOther => r'Đã chọn $selectedRowCount mục';
-  @override String get cancelButtonLabel => r'HỦY';
-  @override String get closeButtonLabel => r'ĐÓNG';
-  @override String get continueButtonLabel => r'TIẾP TỤC';
-  @override String get copyButtonLabel => r'SAO CHÉP';
-  @override String get cutButtonLabel => r'CẮT';
-  @override String get okButtonLabel => r'OK';
-  @override String get pasteButtonLabel => r'DÁN';
-  @override String get selectAllButtonLabel => r'CHỌN TẤT CẢ';
-  @override String get viewLicensesButtonLabel => r'XEM GIẤY PHÉP';
-  @override String get anteMeridiemAbbreviation => r'SÁNG';
-  @override String get postMeridiemAbbreviation => r'CHIỀU';
-  @override String get timePickerHourModeAnnouncement => r'Chọn giờ';
-  @override String get timePickerMinuteModeAnnouncement => r'Chọn phút';
-  @override String get modalBarrierDismissLabel => r'Bỏ qua';
-  @override String get signedInLabel => r'Đã đăng nhập';
-  @override String get hideAccountsLabel => r'Ẩn tài khoản';
-  @override String get showAccountsLabel => r'Hiển thị tài khoản';
-  @override String get drawerLabel => r'Menu di chuyển';
-  @override String get popupMenuLabel => r'Menu bật lên';
-  @override String get dialogLabel => r'Hộp thoại';
-  @override String get alertDialogLabel => r'Hộp thoại';
-  @override String get searchFieldLabel => r'Tìm kiếm';
-}
-
-// ignore: camel_case_types
-class _Bundle_zh extends TranslationBundle {
-  const _Bundle_zh() : super(null);
-  @override String get scriptCategory => r'dense';
-  @override String get timeOfDayFormat => r'ah:mm';
-  @override String get selectedRowCountTitleOne => r'已选择 1 项内容';
-  @override String get openAppDrawerTooltip => r'打开导航菜单';
-  @override String get backButtonTooltip => r'返回';
-  @override String get nextPageTooltip => r'下一页';
-  @override String get previousPageTooltip => r'上一页';
-  @override String get showMenuTooltip => r'显示菜单';
-  @override String get aboutListTileTitle => r'关于$applicationName';
-  @override String get licensesPageTitle => r'许可';
-  @override String get pageRowsInfoTitle => r'第 $firstRow-$lastRow 行（共 $rowCount 行）';
-  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow-$lastRow 行（共约 $rowCount 行）';
-  @override String get rowsPerPageTitle => r'每页行数：';
-  @override String get tabLabel => r'第 $tabIndex 个标签，共 $tabCount 个';
-  @override String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
-  @override String get cancelButtonLabel => r'取消';
-  @override String get continueButtonLabel => r'继续';
-  @override String get closeButtonLabel => r'关闭';
-  @override String get copyButtonLabel => r'复制';
-  @override String get cutButtonLabel => r'剪切';
-  @override String get okButtonLabel => r'确定';
-  @override String get pasteButtonLabel => r'粘贴';
-  @override String get selectAllButtonLabel => r'全选';
-  @override String get viewLicensesButtonLabel => r'查看许可';
-  @override String get closeButtonTooltip => r'关闭';
-  @override String get deleteButtonTooltip => r'删除';
-  @override String get nextMonthTooltip => r'下个月';
-  @override String get previousMonthTooltip => r'上个月';
-  @override String get anteMeridiemAbbreviation => r'上午';
-  @override String get postMeridiemAbbreviation => r'下午';
-  @override String get timePickerHourModeAnnouncement => r'选择小时';
-  @override String get timePickerMinuteModeAnnouncement => r'选择分钟';
-  @override String get signedInLabel => r'已登录';
-  @override String get hideAccountsLabel => r'隐藏帐号';
-  @override String get showAccountsLabel => r'显示帐号';
-  @override String get modalBarrierDismissLabel => r'关闭';
-  @override String get drawerLabel => r'导航菜单';
-  @override String get popupMenuLabel => r'弹出菜单';
-  @override String get dialogLabel => r'对话框';
-  @override String get alertDialogLabel => r'警报';
-  @override String get searchFieldLabel => r'搜索';
-}
-
-// ignore: camel_case_types
-class _Bundle_de_CH extends TranslationBundle {
-  const _Bundle_de_CH() : super(const _Bundle_de());
-  @override String get closeButtonTooltip => r'Schliessen';
-  @override String get modalBarrierDismissLabel => r'Schliessen';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_AU extends TranslationBundle {
-  const _Bundle_en_AU() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_CA extends TranslationBundle {
-  const _Bundle_en_CA() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_GB extends TranslationBundle {
-  const _Bundle_en_GB() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_IE extends TranslationBundle {
-  const _Bundle_en_IE() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_IN extends TranslationBundle {
-  const _Bundle_en_IN() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_SG extends TranslationBundle {
-  const _Bundle_en_SG() : super(const _Bundle_en());
-  @override String get licensesPageTitle => r'Licences';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_en_ZA extends TranslationBundle {
-  const _Bundle_en_ZA() : super(const _Bundle_en());
-  @override String get timeOfDayFormat => r'HH:mm';
-  @override String get viewLicensesButtonLabel => r'VIEW LICENCES';
-  @override String get licensesPageTitle => r'Licences';
-  @override String get popupMenuLabel => r'Pop-up menu';
-  @override String get dialogLabel => r'Dialogue';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_419 extends TranslationBundle {
-  const _Bundle_es_419() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_AR extends TranslationBundle {
-  const _Bundle_es_AR() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_BO extends TranslationBundle {
-  const _Bundle_es_BO() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_CL extends TranslationBundle {
-  const _Bundle_es_CL() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_CO extends TranslationBundle {
-  const _Bundle_es_CO() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_CR extends TranslationBundle {
-  const _Bundle_es_CR() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_DO extends TranslationBundle {
-  const _Bundle_es_DO() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_EC extends TranslationBundle {
-  const _Bundle_es_EC() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_GT extends TranslationBundle {
-  const _Bundle_es_GT() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_HN extends TranslationBundle {
-  const _Bundle_es_HN() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_MX extends TranslationBundle {
-  const _Bundle_es_MX() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_NI extends TranslationBundle {
-  const _Bundle_es_NI() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_PA extends TranslationBundle {
-  const _Bundle_es_PA() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_PE extends TranslationBundle {
-  const _Bundle_es_PE() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_PR extends TranslationBundle {
-  const _Bundle_es_PR() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_PY extends TranslationBundle {
-  const _Bundle_es_PY() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_SV extends TranslationBundle {
-  const _Bundle_es_SV() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_US extends TranslationBundle {
-  const _Bundle_es_US() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get timeOfDayFormat => r'h:mm a';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_UY extends TranslationBundle {
-  const _Bundle_es_UY() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_es_VE extends TranslationBundle {
-  const _Bundle_es_VE() : super(const _Bundle_es());
-  @override String get modalBarrierDismissLabel => r'Descartar';
-  @override String get signedInLabel => r'Cuenta con la que accediste';
-  @override String get openAppDrawerTooltip => r'Abrir menú de navegación';
-  @override String get deleteButtonTooltip => r'Borrar';
-  @override String get nextMonthTooltip => r'Próximo mes';
-  @override String get nextPageTooltip => r'Próxima página';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow–$lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow–$lastRow de aproximadamente $rowCount';
-  @override String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
-  @override String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
-  @override String get anteMeridiemAbbreviation => r'a.m.';
-  @override String get postMeridiemAbbreviation => r'p.m.';
-  @override String get dialogLabel => r'Diálogo';
-}
-
-// ignore: camel_case_types
-class _Bundle_fr_CA extends TranslationBundle {
-  const _Bundle_fr_CA() : super(const _Bundle_fr());
-  @override String get timeOfDayFormat => r'HH ' "'" r'h' "'" r' mm';
-}
-
-// ignore: camel_case_types
-class _Bundle_pt_PT extends TranslationBundle {
-  const _Bundle_pt_PT() : super(const _Bundle_pt());
-  @override String get tabLabel => r'Separador $tabIndex de $tabCount';
-  @override String get signedInLabel => r'Com sessão iniciada';
-  @override String get timePickerMinuteModeAnnouncement => r'Selecionar minutos';
-  @override String get timePickerHourModeAnnouncement => r'Selecionar horas';
-  @override String get deleteButtonTooltip => r'Eliminar';
-  @override String get nextMonthTooltip => r'Mês seguinte';
-  @override String get nextPageTooltip => r'Página seguinte';
-  @override String get aboutListTileTitle => r'Acerca de $applicationName';
-  @override String get pageRowsInfoTitle => r'$firstRow a $lastRow de $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow a $lastRow de cerca de $rowCount';
-  @override String get cutButtonLabel => r'CORTAR';
-  @override String get okButtonLabel => r'OK';
-  @override String get anteMeridiemAbbreviation => r'AM';
-  @override String get postMeridiemAbbreviation => r'PM';
-  @override String get modalBarrierDismissLabel => r'Ignorar';
-}
-
-// ignore: camel_case_types
-class _Bundle_sr_Latn extends TranslationBundle {
-  const _Bundle_sr_Latn() : super(const _Bundle_sr());
-  @override String get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
-  @override String get openAppDrawerTooltip => r'Otvorite meni za navigaciju';
-  @override String get backButtonTooltip => r'Nazad';
-  @override String get closeButtonTooltip => r'Zatvorite';
-  @override String get deleteButtonTooltip => r'Izbrišite';
-  @override String get nextMonthTooltip => r'Sledeći mesec';
-  @override String get previousMonthTooltip => r'Prethodni mesec';
-  @override String get nextPageTooltip => r'Sledeća stranica';
-  @override String get previousPageTooltip => r'Prethodna stranica';
-  @override String get showMenuTooltip => r'Prikaži meni';
-  @override String get aboutListTileTitle => r'O aplikaciji $applicationName';
-  @override String get licensesPageTitle => r'Licence';
-  @override String get pageRowsInfoTitle => r'$firstRow – $lastRow od $rowCount';
-  @override String get pageRowsInfoTitleApproximate => r'$firstRow – $lastRow od približno $rowCount';
-  @override String get rowsPerPageTitle => r'Redova po stranici:';
-  @override String get tabLabel => r'$tabIndex. kartica od $tabCount';
-  @override String get selectedRowCountTitleOne => r'Izabrana je 1 stavka';
-  @override String get selectedRowCountTitleOther => r'Izabrano je $selectedRowCount stavki';
-  @override String get cancelButtonLabel => r'OTKAŽI';
-  @override String get closeButtonLabel => r'ZATVORI';
-  @override String get continueButtonLabel => r'NASTAVI';
-  @override String get copyButtonLabel => r'KOPIRAJ';
-  @override String get cutButtonLabel => r'ISECI';
-  @override String get okButtonLabel => r'Potvrdi';
-  @override String get pasteButtonLabel => r'NALEPI';
-  @override String get selectAllButtonLabel => r'IZABERI SVE';
-  @override String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
-  @override String get anteMeridiemAbbreviation => r'pre podne';
-  @override String get postMeridiemAbbreviation => r'po podne';
-  @override String get timePickerHourModeAnnouncement => r'Izaberite sate';
-  @override String get timePickerMinuteModeAnnouncement => r'Izaberite minute';
-  @override String get modalBarrierDismissLabel => r'Odbaci';
-  @override String get signedInLabel => r'Prijavljeni ste';
-  @override String get hideAccountsLabel => r'Sakrij naloge';
-  @override String get showAccountsLabel => r'Prikaži naloge';
-  @override String get drawerLabel => r'Meni za navigaciju';
-  @override String get popupMenuLabel => r'Iskačući meni';
-  @override String get dialogLabel => r'Dijalog';
-}
-
-// ignore: camel_case_types
-class _Bundle_zh_HK extends TranslationBundle {
-  const _Bundle_zh_HK() : super(const _Bundle_zh());
-  @override String get tabLabel => r'第 $tabIndex 個分頁 (共 $tabCount 個)';
-  @override String get showAccountsLabel => r'顯示帳戶';
-  @override String get modalBarrierDismissLabel => r'關閉';
-  @override String get hideAccountsLabel => r'隱藏帳戶';
-  @override String get signedInLabel => r'已登入帳戶';
-  @override String get openAppDrawerTooltip => r'開啟導覽選單';
-  @override String get closeButtonTooltip => r'關閉';
-  @override String get deleteButtonTooltip => r'刪除';
-  @override String get nextMonthTooltip => r'下個月';
-  @override String get previousMonthTooltip => r'上個月';
-  @override String get nextPageTooltip => r'下一頁';
-  @override String get previousPageTooltip => r'上一頁';
-  @override String get showMenuTooltip => r'顯示選單';
-  @override String get aboutListTileTitle => r'關於「$applicationName」';
-  @override String get licensesPageTitle => r'授權';
-  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
-  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
-  @override String get rowsPerPageTitle => r'每頁列數：';
-  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
-  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
-  @override String get closeButtonLabel => r'關閉';
-  @override String get continueButtonLabel => r'繼續';
-  @override String get copyButtonLabel => r'複製';
-  @override String get cutButtonLabel => r'剪下';
-  @override String get okButtonLabel => r'確定';
-  @override String get pasteButtonLabel => r'貼上';
-  @override String get selectAllButtonLabel => r'全選';
-  @override String get viewLicensesButtonLabel => r'查看授權';
-  @override String get timePickerHourModeAnnouncement => r'選取小時數';
-  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
-  @override String get drawerLabel => r'導覽選單';
-  @override String get popupMenuLabel => r'彈出式選單';
-  @override String get dialogLabel => r'對話方塊';
-}
-
-// ignore: camel_case_types
-class _Bundle_zh_TW extends TranslationBundle {
-  const _Bundle_zh_TW() : super(const _Bundle_zh());
-  @override String get tabLabel => r'第 $tabIndex 個分頁 (共 $tabCount 個)';
-  @override String get showAccountsLabel => r'顯示帳戶';
-  @override String get modalBarrierDismissLabel => r'關閉';
-  @override String get hideAccountsLabel => r'隱藏帳戶';
-  @override String get signedInLabel => r'已登入帳戶';
-  @override String get openAppDrawerTooltip => r'開啟導覽選單';
-  @override String get closeButtonTooltip => r'關閉';
-  @override String get deleteButtonTooltip => r'刪除';
-  @override String get nextMonthTooltip => r'下個月';
-  @override String get previousMonthTooltip => r'上個月';
-  @override String get nextPageTooltip => r'下一頁';
-  @override String get previousPageTooltip => r'上一頁';
-  @override String get showMenuTooltip => r'顯示選單';
-  @override String get aboutListTileTitle => r'關於「$applicationName」';
-  @override String get licensesPageTitle => r'授權';
-  @override String get pageRowsInfoTitle => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
-  @override String get pageRowsInfoTitleApproximate => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
-  @override String get rowsPerPageTitle => r'每頁列數：';
-  @override String get selectedRowCountTitleOne => r'已選取 1 個項目';
-  @override String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
-  @override String get closeButtonLabel => r'關閉';
-  @override String get continueButtonLabel => r'繼續';
-  @override String get copyButtonLabel => r'複製';
-  @override String get cutButtonLabel => r'剪下';
-  @override String get okButtonLabel => r'確定';
-  @override String get pasteButtonLabel => r'貼上';
-  @override String get selectAllButtonLabel => r'全選';
-  @override String get viewLicensesButtonLabel => r'查看授權';
-  @override String get timePickerHourModeAnnouncement => r'選取小時數';
-  @override String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
-  @override String get drawerLabel => r'導覽選單';
-  @override String get popupMenuLabel => r'彈出式選單';
-  @override String get dialogLabel => r'對話方塊';
-}
-
-TranslationBundle translationBundleForLocale(Locale locale) {
+// These classes are constructed by the [getTranslation] method at the bottom of
+// this file, and used by the [_MaterialLocalizationsDelegate.load] method defined
+// in `flutter_localizations/lib/src/material_localizations.dart`.
+
+/// The translations for Arabic (`ar`).
+class MaterialLocalizationAr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Arabic.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationAr({
+    String localeName = 'ar',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'حول "$applicationName"';
+
+  @override
+  String get alertDialogLabel => r'مربع حوار التنبيه';
+
+  @override
+  String get anteMeridiemAbbreviation => r'ص';
+
+  @override
+  String get backButtonTooltip => r'رجوع';
+
+  @override
+  String get cancelButtonLabel => r'إلغاء';
+
+  @override
+  String get closeButtonLabel => r'إغلاق';
+
+  @override
+  String get closeButtonTooltip => r'إغلاق';
+
+  @override
+  String get continueButtonLabel => r'متابعة';
+
+  @override
+  String get copyButtonLabel => r'نسخ';
+
+  @override
+  String get cutButtonLabel => r'قص';
+
+  @override
+  String get deleteButtonTooltip => r'حذف';
+
+  @override
+  String get dialogLabel => r'مربع حوار';
+
+  @override
+  String get drawerLabel => r'قائمة تنقل';
+
+  @override
+  String get hideAccountsLabel => r'إخفاء الحسابات';
+
+  @override
+  String get licensesPageTitle => r'التراخيص';
+
+  @override
+  String get modalBarrierDismissLabel => r'رفض';
+
+  @override
+  String get nextMonthTooltip => r'الشهر التالي';
+
+  @override
+  String get nextPageTooltip => r'الصفحة التالية';
+
+  @override
+  String get okButtonLabel => r'حسنًا';
+
+  @override
+  String get openAppDrawerTooltip => r'فتح قائمة التنقل';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'من $firstRow إلى $lastRow من إجمالي $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'من $firstRow إلى $lastRow من إجمالي $rowCount تقريبًا';
+
+  @override
+  String get pasteButtonLabel => r'لصق';
+
+  @override
+  String get popupMenuLabel => r'قائمة منبثقة';
+
+  @override
+  String get postMeridiemAbbreviation => r'م';
+
+  @override
+  String get previousMonthTooltip => r'الشهر السابق';
+
+  @override
+  String get previousPageTooltip => r'الصفحة السابقة';
+
+  @override
+  String get rowsPerPageTitle => r'عدد الصفوف في الصفحة:';
+
+  @override
+  String get scriptCategory => r'tall';
+
+  @override
+  String get searchFieldLabel => r'بحث';
+
+  @override
+  String get selectAllButtonLabel => r'اختيار الكل';
+
+  @override
+  String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
+
+  @override
+  String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
+
+  @override
+  String get selectedRowCountTitleOne => r'تم اختيار عنصر واحد';
+
+  @override
+  String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
+
+  @override
+  String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
+
+  @override
+  String get selectedRowCountTitleZero => r'لم يتم اختيار أي عنصر';
+
+  @override
+  String get showAccountsLabel => r'إظهار الحسابات';
+
+  @override
+  String get showMenuTooltip => r'عرض القائمة';
+
+  @override
+  String get signedInLabel => r'تم تسجيل الدخول';
+
+  @override
+  String get tabLabelRaw => r'علامة التبويب $tabIndex من $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'اختيار الساعات';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'اختيار الدقائق';
+
+  @override
+  String get viewLicensesButtonLabel => r'الاطّلاع على التراخيص';
+}
+
+/// The translations for Bulgarian (`bg`).
+class MaterialLocalizationBg extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Bulgarian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationBg({
+    String localeName = 'bg',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Всичко за $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Назад';
+
+  @override
+  String get cancelButtonLabel => r'ОТКАЗ';
+
+  @override
+  String get closeButtonLabel => r'ЗАТВАРЯНЕ';
+
+  @override
+  String get closeButtonTooltip => r'Затваряне';
+
+  @override
+  String get continueButtonLabel => r'НАПРЕД';
+
+  @override
+  String get copyButtonLabel => r'КОПИРАНЕ';
+
+  @override
+  String get cutButtonLabel => r'ИЗРЯЗВАНЕ';
+
+  @override
+  String get deleteButtonTooltip => r'Изтриване';
+
+  @override
+  String get dialogLabel => r'Диалогов прозорец';
+
+  @override
+  String get drawerLabel => r'Меню за навигация';
+
+  @override
+  String get hideAccountsLabel => r'Скриване на профилите';
+
+  @override
+  String get licensesPageTitle => r'Лицензи';
+
+  @override
+  String get modalBarrierDismissLabel => r'Отхвърляне';
+
+  @override
+  String get nextMonthTooltip => r'Следващият месец';
+
+  @override
+  String get nextPageTooltip => r'Следващата страница';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Отваряне на менюто за навигация';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow от $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow от около $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ПОСТАВЯНЕ';
+
+  @override
+  String get popupMenuLabel => r'Изскачащо меню';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Предишният месец';
+
+  @override
+  String get previousPageTooltip => r'Предишната страница';
+
+  @override
+  String get rowsPerPageTitle => r'Редове на страница:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ИЗБИРАНЕ НА ВСИЧКО';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Избран е 1 елемент';
+
+  @override
+  String get selectedRowCountTitleOther => r'Избрани са $selectedRowCount елемента';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Показване на профилите';
+
+  @override
+  String get showMenuTooltip => r'Показване на менюто';
+
+  @override
+  String get signedInLabel => r'В профила си сте';
+
+  @override
+  String get tabLabelRaw => r'Раздел $tabIndex от $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Избиране на часове';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Избиране на минути';
+
+  @override
+  String get viewLicensesButtonLabel => r'ПРЕГЛЕД НА ЛИЦЕНЗИТЕ';
+}
+
+/// The translations for Bosnian (`bs`).
+class MaterialLocalizationBs extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Bosnian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationBs({
+    String localeName = 'bs',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'O aplikaciji $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'prijepodne';
+
+  @override
+  String get backButtonTooltip => r'Natrag';
+
+  @override
+  String get cancelButtonLabel => r'ODUSTANI';
+
+  @override
+  String get closeButtonLabel => r'ZATVORI';
+
+  @override
+  String get closeButtonTooltip => r'Zatvaranje';
+
+  @override
+  String get continueButtonLabel => r'NASTAVI';
+
+  @override
+  String get copyButtonLabel => r'KOPIRAJ';
+
+  @override
+  String get cutButtonLabel => r'IZREŽI';
+
+  @override
+  String get deleteButtonTooltip => r'Brisanje';
+
+  @override
+  String get dialogLabel => r'Dijalog';
+
+  @override
+  String get drawerLabel => r'Navigacijski izbornik';
+
+  @override
+  String get hideAccountsLabel => r'Sakrijte račune';
+
+  @override
+  String get licensesPageTitle => r'Licence';
+
+  @override
+  String get modalBarrierDismissLabel => r'Odbaci';
+
+  @override
+  String get nextMonthTooltip => r'Sljedeći mjesec';
+
+  @override
+  String get nextPageTooltip => r'Sljedeća stranica';
+
+  @override
+  String get okButtonLabel => r'U REDU';
+
+  @override
+  String get openAppDrawerTooltip => r'Otvaranje izbornika za navigaciju';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow od $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow od otprilike $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ZALIJEPI';
+
+  @override
+  String get popupMenuLabel => r'Skočni izbornik';
+
+  @override
+  String get postMeridiemAbbreviation => r'popodne';
+
+  @override
+  String get previousMonthTooltip => r'Prethodni mjesec';
+
+  @override
+  String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get rowsPerPageTitle => r'Redaka po stranici:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ODABERI SVE';
+
+  @override
+  String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Odabrana je jedna stavka';
+
+  @override
+  String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Prikažite račune';
+
+  @override
+  String get showMenuTooltip => r'Prikaz izbornika';
+
+  @override
+  String get signedInLabel => r'Prijavljeni korisnik';
+
+  @override
+  String get tabLabelRaw => r'Kartica $tabIndex od $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Odaberite sate';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Odaberite minute';
+
+  @override
+  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
+}
+
+/// The translations for Catalan Valencian (`ca`).
+class MaterialLocalizationCa extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Catalan Valencian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationCa({
+    String localeName = 'ca',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Sobre $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Enrere';
+
+  @override
+  String get cancelButtonLabel => r'CANCEL·LA';
+
+  @override
+  String get closeButtonLabel => r'TANCA';
+
+  @override
+  String get closeButtonTooltip => r'Tanca';
+
+  @override
+  String get continueButtonLabel => r'CONTINUA';
+
+  @override
+  String get copyButtonLabel => r'COPIA';
+
+  @override
+  String get cutButtonLabel => r'RETALLA';
+
+  @override
+  String get deleteButtonTooltip => r'Suprimeix';
+
+  @override
+  String get dialogLabel => r'Diàleg';
+
+  @override
+  String get drawerLabel => r'Menú de navegació';
+
+  @override
+  String get hideAccountsLabel => r'Amaga els comptes';
+
+  @override
+  String get licensesPageTitle => r'Llicències';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ignora';
+
+  @override
+  String get nextMonthTooltip => r'Mes següent';
+
+  @override
+  String get nextPageTooltip => r'Pàgina següent';
+
+  @override
+  String get okButtonLabel => r'D' "'" r'ACORD';
+
+  @override
+  String get openAppDrawerTooltip => r'Obre el menú de navegació';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow d' "'" r'aproximadament $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ENGANXA';
+
+  @override
+  String get popupMenuLabel => r'Menú emergent';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Mes anterior';
+
+  @override
+  String get previousPageTooltip => r'Pàgina anterior';
+
+  @override
+  String get rowsPerPageTitle => r'Files per pàgina:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'SELECCIONA-HO TOT';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'S' "'" r'ha seleccionat 1 element';
+
+  @override
+  String get selectedRowCountTitleOther => r'S' "'" r'han seleccionat $selectedRowCount elements';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Mostra els comptes';
+
+  @override
+  String get showMenuTooltip => r'Mostra el menú';
+
+  @override
+  String get signedInLabel => r'Sessió iniciada';
+
+  @override
+  String get tabLabelRaw => r'Pestanya $tabIndex de $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Selecciona les hores';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Selecciona els minuts';
+
+  @override
+  String get viewLicensesButtonLabel => r'MOSTRA LES LLICÈNCIES';
+}
+
+/// The translations for Czech (`cs`).
+class MaterialLocalizationCs extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Czech.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationCs({
+    String localeName = 'cs',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'O aplikaci $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Zpět';
+
+  @override
+  String get cancelButtonLabel => r'ZRUŠIT';
+
+  @override
+  String get closeButtonLabel => r'ZAVŘÍT';
+
+  @override
+  String get closeButtonTooltip => r'Zavřít';
+
+  @override
+  String get continueButtonLabel => r'POKRAČOVAT';
+
+  @override
+  String get copyButtonLabel => r'KOPÍROVAT';
+
+  @override
+  String get cutButtonLabel => r'VYJMOUT';
+
+  @override
+  String get deleteButtonTooltip => r'Smazat';
+
+  @override
+  String get dialogLabel => r'Dialogové okno';
+
+  @override
+  String get drawerLabel => r'Navigační nabídka';
+
+  @override
+  String get hideAccountsLabel => r'Skrýt účty';
+
+  @override
+  String get licensesPageTitle => r'Licence';
+
+  @override
+  String get modalBarrierDismissLabel => r'Zavřít';
+
+  @override
+  String get nextMonthTooltip => r'Další měsíc';
+
+  @override
+  String get nextPageTooltip => r'Další stránka';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Otevřít navigační nabídku';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow z $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow z asi $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'VLOŽIT';
+
+  @override
+  String get popupMenuLabel => r'Vyskakovací nabídka';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Předchozí měsíc';
+
+  @override
+  String get previousPageTooltip => r'Předchozí stránka';
+
+  @override
+  String get rowsPerPageTitle => r'Počet řádků na stránku:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'VYBRAT VŠE';
+
+  @override
+  String get selectedRowCountTitleFew => r'Jsou vybrány $selectedRowCount položky';
+
+  @override
+  String get selectedRowCountTitleMany => r'Je vybráno $selectedRowCount položky';
+
+  @override
+  String get selectedRowCountTitleOne => r'Je vybrána 1 položka';
+
+  @override
+  String get selectedRowCountTitleOther => r'Je vybráno $selectedRowCount položek';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Zobrazit účty';
+
+  @override
+  String get showMenuTooltip => r'Zobrazit nabídku';
+
+  @override
+  String get signedInLabel => r'Uživatel přihlášen';
+
+  @override
+  String get tabLabelRaw => r'Karta $tabIndex z $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Vyberte hodiny';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Vyberte minuty';
+
+  @override
+  String get viewLicensesButtonLabel => r'ZOBRAZIT LICENCE';
+}
+
+/// The translations for Danish (`da`).
+class MaterialLocalizationDa extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Danish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationDa({
+    String localeName = 'da',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Om $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Tilbage';
+
+  @override
+  String get cancelButtonLabel => r'ANNULLER';
+
+  @override
+  String get closeButtonLabel => r'LUK';
+
+  @override
+  String get closeButtonTooltip => r'Luk';
+
+  @override
+  String get continueButtonLabel => r'FORTSÆT';
+
+  @override
+  String get copyButtonLabel => r'KOPIÉR';
+
+  @override
+  String get cutButtonLabel => r'KLIP';
+
+  @override
+  String get deleteButtonTooltip => r'Slet';
+
+  @override
+  String get dialogLabel => r'Dialogboks';
+
+  @override
+  String get drawerLabel => r'Navigationsmenu';
+
+  @override
+  String get hideAccountsLabel => r'Skjul konti';
+
+  @override
+  String get licensesPageTitle => r'Licenser';
+
+  @override
+  String get modalBarrierDismissLabel => r'Afvis';
+
+  @override
+  String get nextMonthTooltip => r'Næste måned';
+
+  @override
+  String get nextPageTooltip => r'Næste side';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Åbn navigationsmenuen';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow af $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow af ca. $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'SÆT IND';
+
+  @override
+  String get popupMenuLabel => r'Pop op-menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Forrige måned';
+
+  @override
+  String get previousPageTooltip => r'Forrige side';
+
+  @override
+  String get rowsPerPageTitle => r'Rækker pr. side:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'VÆLG ALLE';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 element er valgt';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Vis konti';
+
+  @override
+  String get showMenuTooltip => r'Vis menu';
+
+  @override
+  String get signedInLabel => r'Logget ind';
+
+  @override
+  String get tabLabelRaw => r'Fane $tabIndex af $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Vælg timer';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Vælg minutter';
+
+  @override
+  String get viewLicensesButtonLabel => r'SE LICENSER';
+}
+
+/// The translations for German (`de`).
+class MaterialLocalizationDe extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for German.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationDe({
+    String localeName = 'de',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Über $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Aufmerksam';
+
+  @override
+  String get anteMeridiemAbbreviation => r'VORM.';
+
+  @override
+  String get backButtonTooltip => r'Zurück';
+
+  @override
+  String get cancelButtonLabel => r'ABBRECHEN';
+
+  @override
+  String get closeButtonLabel => r'SCHLIEẞEN';
+
+  @override
+  String get closeButtonTooltip => r'Schließen';
+
+  @override
+  String get continueButtonLabel => r'WEITER';
+
+  @override
+  String get copyButtonLabel => r'KOPIEREN';
+
+  @override
+  String get cutButtonLabel => r'AUSSCHNEIDEN';
+
+  @override
+  String get deleteButtonTooltip => r'Löschen';
+
+  @override
+  String get dialogLabel => r'Dialogfeld';
+
+  @override
+  String get drawerLabel => r'Navigationsmenü';
+
+  @override
+  String get hideAccountsLabel => r'Konten ausblenden';
+
+  @override
+  String get licensesPageTitle => r'Lizenzen';
+
+  @override
+  String get modalBarrierDismissLabel => r'Schließen';
+
+  @override
+  String get nextMonthTooltip => r'Nächster Monat';
+
+  @override
+  String get nextPageTooltip => r'Nächste Seite';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow von $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow von etwa $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'EINFÜGEN';
+
+  @override
+  String get popupMenuLabel => r'Pop-up-Menü';
+
+  @override
+  String get postMeridiemAbbreviation => r'NACHM.';
+
+  @override
+  String get previousMonthTooltip => r'Vorheriger Monat';
+
+  @override
+  String get previousPageTooltip => r'Vorherige Seite';
+
+  @override
+  String get rowsPerPageTitle => r'Zeilen pro Seite:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Suchen';
+
+  @override
+  String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 Element ausgewählt';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Keine Objekte ausgewählt';
+
+  @override
+  String get showAccountsLabel => r'Konten anzeigen';
+
+  @override
+  String get showMenuTooltip => r'Menü anzeigen';
+
+  @override
+  String get signedInLabel => r'Angemeldet';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex von $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Stunden auswählen';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
+
+  @override
+  String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
+}
+
+/// The translations for German, as used in Switzerland (`de_CH`).
+class MaterialLocalizationDeCh extends MaterialLocalizationDe {
+  /// Create an instance of the translation bundle for German, as used in Switzerland.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationDeCh({
+    String localeName = 'de_CH',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get closeButtonTooltip => r'Schliessen';
+
+  @override
+  String get modalBarrierDismissLabel => r'Schliessen';
+}
+
+/// The translations for Modern Greek (`el`).
+class MaterialLocalizationEl extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Modern Greek.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEl({
+    String localeName = 'el',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Σχετικά με την εφαρμογή $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'π.μ.';
+
+  @override
+  String get backButtonTooltip => r'Πίσω';
+
+  @override
+  String get cancelButtonLabel => r'ΑΚΥΡΩΣΗ';
+
+  @override
+  String get closeButtonLabel => r'ΚΛΕΙΣΙΜΟ';
+
+  @override
+  String get closeButtonTooltip => r'Κλείσιμο';
+
+  @override
+  String get continueButtonLabel => r'ΣΥΝΕΧΕΙΑ';
+
+  @override
+  String get copyButtonLabel => r'ΑΝΤΙΓΡΑΦΗ';
+
+  @override
+  String get cutButtonLabel => r'ΑΠΟΚΟΠΗ';
+
+  @override
+  String get deleteButtonTooltip => r'Διαγραφή';
+
+  @override
+  String get dialogLabel => r'Παράθυρο διαλόγου';
+
+  @override
+  String get drawerLabel => r'Μενού πλοήγησης';
+
+  @override
+  String get hideAccountsLabel => r'Απόκρυψη λογαριασμών';
+
+  @override
+  String get licensesPageTitle => r'Άδειες';
+
+  @override
+  String get modalBarrierDismissLabel => r'Παράβλεψη';
+
+  @override
+  String get nextMonthTooltip => r'Επόμενος μήνας';
+
+  @override
+  String get nextPageTooltip => r'Επόμενη σελίδα';
+
+  @override
+  String get okButtonLabel => r'ΟΚ';
+
+  @override
+  String get openAppDrawerTooltip => r'Άνοιγμα μενού πλοήγησης';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow από $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow από περίπου $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ΕΠΙΚΟΛΛΗΣΗ';
+
+  @override
+  String get popupMenuLabel => r'Αναδυόμενο μενού';
+
+  @override
+  String get postMeridiemAbbreviation => r'μ.μ.';
+
+  @override
+  String get previousMonthTooltip => r'Προηγούμενος μήνας';
+
+  @override
+  String get previousPageTooltip => r'Προηγούμενη σελίδα';
+
+  @override
+  String get rowsPerPageTitle => r'Σειρές ανά σελίδα:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ΕΠΙΛΟΓΗ ΟΛΩΝ';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Επιλέχθηκε 1 στοιχείο';
+
+  @override
+  String get selectedRowCountTitleOther => r'Επιλέχθηκαν $selectedRowCount στοιχεία';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Εμφάνιση λογαριασμών';
+
+  @override
+  String get showMenuTooltip => r'Εμφάνιση μενού';
+
+  @override
+  String get signedInLabel => r'Σε σύνδεση';
+
+  @override
+  String get tabLabelRaw => r'Καρτέλα $tabIndex από $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Επιλογή ωρών';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Επιλογή λεπτών';
+
+  @override
+  String get viewLicensesButtonLabel => r'ΠΡΟΒΟΛΗ ΑΔΕΙΩΝ';
+}
+
+/// The translations for English (`en`).
+class MaterialLocalizationEn extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for English.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEn({
+    String localeName = 'en',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'About $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alert';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Back';
+
+  @override
+  String get cancelButtonLabel => r'CANCEL';
+
+  @override
+  String get closeButtonLabel => r'CLOSE';
+
+  @override
+  String get closeButtonTooltip => r'Close';
+
+  @override
+  String get continueButtonLabel => r'CONTINUE';
+
+  @override
+  String get copyButtonLabel => r'COPY';
+
+  @override
+  String get cutButtonLabel => r'CUT';
+
+  @override
+  String get deleteButtonTooltip => r'Delete';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Navigation menu';
+
+  @override
+  String get hideAccountsLabel => r'Hide accounts';
+
+  @override
+  String get licensesPageTitle => r'Licenses';
+
+  @override
+  String get modalBarrierDismissLabel => r'Dismiss';
+
+  @override
+  String get nextMonthTooltip => r'Next month';
+
+  @override
+  String get nextPageTooltip => r'Next page';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Open navigation menu';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow of $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow of about $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PASTE';
+
+  @override
+  String get popupMenuLabel => r'Popup menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Previous month';
+
+  @override
+  String get previousPageTooltip => r'Previous page';
+
+  @override
+  String get rowsPerPageTitle => r'Rows per page:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Search';
+
+  @override
+  String get selectAllButtonLabel => r'SELECT ALL';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item selected';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'No items selected';
+
+  @override
+  String get showAccountsLabel => r'Show accounts';
+
+  @override
+  String get showMenuTooltip => r'Show menu';
+
+  @override
+  String get signedInLabel => r'Signed in';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex of $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Select hours';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Select minutes';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENSES';
+}
+
+/// The translations for English, as used in Australia (`en_AU`).
+class MaterialLocalizationEnAu extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in Australia.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnAu({
+    String localeName = 'en_AU',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in Canada (`en_CA`).
+class MaterialLocalizationEnCa extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in Canada.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnCa({
+    String localeName = 'en_CA',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in the United Kingdom (`en_GB`).
+class MaterialLocalizationEnGb extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in the United Kingdom.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnGb({
+    String localeName = 'en_GB',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in Ireland (`en_IE`).
+class MaterialLocalizationEnIe extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in Ireland.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnIe({
+    String localeName = 'en_IE',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in India (`en_IN`).
+class MaterialLocalizationEnIn extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in India.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnIn({
+    String localeName = 'en_IN',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in Singapore (`en_SG`).
+class MaterialLocalizationEnSg extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in Singapore.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnSg({
+    String localeName = 'en_SG',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for English, as used in South Africa (`en_ZA`).
+class MaterialLocalizationEnZa extends MaterialLocalizationEn {
+  /// Create an instance of the translation bundle for English, as used in South Africa.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEnZa({
+    String localeName = 'en_ZA',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENCES';
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get popupMenuLabel => r'Pop-up menu';
+
+  @override
+  String get dialogLabel => r'Dialogue';
+}
+
+/// The translations for Spanish Castilian (`es`).
+class MaterialLocalizationEs extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Spanish Castilian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEs({
+    String localeName = 'es',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Sobre $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alerta';
+
+  @override
+  String get anteMeridiemAbbreviation => r'A.M.';
+
+  @override
+  String get backButtonTooltip => r'Atrás';
+
+  @override
+  String get cancelButtonLabel => r'CANCELAR';
+
+  @override
+  String get closeButtonLabel => r'CERRAR';
+
+  @override
+  String get closeButtonTooltip => r'Cerrar';
+
+  @override
+  String get continueButtonLabel => r'CONTINUAR';
+
+  @override
+  String get copyButtonLabel => r'COPIAR';
+
+  @override
+  String get cutButtonLabel => r'CORTAR';
+
+  @override
+  String get deleteButtonTooltip => r'Eliminar';
+
+  @override
+  String get dialogLabel => r'Cuadro de diálogo';
+
+  @override
+  String get drawerLabel => r'Menú de navegación';
+
+  @override
+  String get hideAccountsLabel => r'Ocultar cuentas';
+
+  @override
+  String get licensesPageTitle => r'Licencias';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ignorar';
+
+  @override
+  String get nextMonthTooltip => r'Mes siguiente';
+
+  @override
+  String get nextPageTooltip => r'Página siguiente';
+
+  @override
+  String get okButtonLabel => r'ACEPTAR';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir el menú de navegación';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow‑$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow‑$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PEGAR';
+
+  @override
+  String get popupMenuLabel => r'Menú emergente';
+
+  @override
+  String get postMeridiemAbbreviation => r'P.M.';
+
+  @override
+  String get previousMonthTooltip => r'Mes anterior';
+
+  @override
+  String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get rowsPerPageTitle => r'Filas por página:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Buscar';
+
+  @override
+  String get selectAllButtonLabel => r'SELECCIONAR TODO';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 elemento seleccionado';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount elementos seleccionados';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'No se han seleccionado elementos';
+
+  @override
+  String get showAccountsLabel => r'Mostrar cuentas';
+
+  @override
+  String get showMenuTooltip => r'Mostrar menú';
+
+  @override
+  String get signedInLabel => r'Sesión iniciada';
+
+  @override
+  String get tabLabelRaw => r'Pestaña $tabIndex de $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.H_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Seleccionar horas';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Seleccionar minutos';
+
+  @override
+  String get viewLicensesButtonLabel => r'VER LICENCIAS';
+}
+
+/// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).
+class MaterialLocalizationEs419 extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Latin America and the Caribbean.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEs419({
+    String localeName = 'es_419',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Argentina (`es_AR`).
+class MaterialLocalizationEsAr extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Argentina.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsAr({
+    String localeName = 'es_AR',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Bolivia (`es_BO`).
+class MaterialLocalizationEsBo extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Bolivia.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsBo({
+    String localeName = 'es_BO',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Chile (`es_CL`).
+class MaterialLocalizationEsCl extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Chile.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsCl({
+    String localeName = 'es_CL',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Colombia (`es_CO`).
+class MaterialLocalizationEsCo extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Colombia.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsCo({
+    String localeName = 'es_CO',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Costa Rica (`es_CR`).
+class MaterialLocalizationEsCr extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Costa Rica.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsCr({
+    String localeName = 'es_CR',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in the Dominican Republic (`es_DO`).
+class MaterialLocalizationEsDo extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in the Dominican Republic.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsDo({
+    String localeName = 'es_DO',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Ecuador (`es_EC`).
+class MaterialLocalizationEsEc extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Ecuador.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsEc({
+    String localeName = 'es_EC',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Guatemala (`es_GT`).
+class MaterialLocalizationEsGt extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Guatemala.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsGt({
+    String localeName = 'es_GT',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Honduras (`es_HN`).
+class MaterialLocalizationEsHn extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Honduras.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsHn({
+    String localeName = 'es_HN',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Mexico (`es_MX`).
+class MaterialLocalizationEsMx extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Mexico.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsMx({
+    String localeName = 'es_MX',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Nicaragua (`es_NI`).
+class MaterialLocalizationEsNi extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Nicaragua.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsNi({
+    String localeName = 'es_NI',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Panama (`es_PA`).
+class MaterialLocalizationEsPa extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Panama.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsPa({
+    String localeName = 'es_PA',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Peru (`es_PE`).
+class MaterialLocalizationEsPe extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Peru.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsPe({
+    String localeName = 'es_PE',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Puerto Rico (`es_PR`).
+class MaterialLocalizationEsPr extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Puerto Rico.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsPr({
+    String localeName = 'es_PR',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Paraguay (`es_PY`).
+class MaterialLocalizationEsPy extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Paraguay.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsPy({
+    String localeName = 'es_PY',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in El Salvador (`es_SV`).
+class MaterialLocalizationEsSv extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in El Salvador.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsSv({
+    String localeName = 'es_SV',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in the United States (`es_US`).
+class MaterialLocalizationEsUs extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in the United States.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsUs({
+    String localeName = 'es_US',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Uruguay (`es_UY`).
+class MaterialLocalizationEsUy extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Uruguay.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsUy({
+    String localeName = 'es_UY',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Spanish Castilian, as used in Venezuela (`es_VE`).
+class MaterialLocalizationEsVe extends MaterialLocalizationEs {
+  /// Create an instance of the translation bundle for Spanish Castilian, as used in Venezuela.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEsVe({
+    String localeName = 'es_VE',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get modalBarrierDismissLabel => r'Descartar';
+
+  @override
+  String get signedInLabel => r'Cuenta con la que accediste';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menú de navegación';
+
+  @override
+  String get deleteButtonTooltip => r'Borrar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mes';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Se seleccionó 1 elemento';
+
+  @override
+  String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get dialogLabel => r'Diálogo';
+}
+
+/// The translations for Estonian (`et`).
+class MaterialLocalizationEt extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Estonian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationEt({
+    String localeName = 'et',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Teave rakenduse $applicationName kohta';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Tagasi';
+
+  @override
+  String get cancelButtonLabel => r'TÜHISTA';
+
+  @override
+  String get closeButtonLabel => r'SULE';
+
+  @override
+  String get closeButtonTooltip => r'Sule';
+
+  @override
+  String get continueButtonLabel => r'JÄTKA';
+
+  @override
+  String get copyButtonLabel => r'KOPEERI';
+
+  @override
+  String get cutButtonLabel => r'LÕIKA';
+
+  @override
+  String get deleteButtonTooltip => r'Kustuta';
+
+  @override
+  String get dialogLabel => r'Dialoog';
+
+  @override
+  String get drawerLabel => r'Navigeerimismenüü';
+
+  @override
+  String get hideAccountsLabel => r'Peida kontod';
+
+  @override
+  String get licensesPageTitle => r'Litsentsid';
+
+  @override
+  String get modalBarrierDismissLabel => r'Loobu';
+
+  @override
+  String get nextMonthTooltip => r'Järgmine kuu';
+
+  @override
+  String get nextPageTooltip => r'Järgmine leht';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Ava navigeerimismenüü';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow $rowCount-st';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow umbes $rowCount-st';
+
+  @override
+  String get pasteButtonLabel => r'KLEEBI';
+
+  @override
+  String get popupMenuLabel => r'Hüpikmenüü';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Eelmine kuu';
+
+  @override
+  String get previousPageTooltip => r'Eelmine leht';
+
+  @override
+  String get rowsPerPageTitle => r'Ridu lehe kohta:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'VALI KÕIK';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Valitud on 1 üksus';
+
+  @override
+  String get selectedRowCountTitleOther => r'Valitud on $selectedRowCount üksust';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Kuva kontod';
+
+  @override
+  String get showMenuTooltip => r'Kuva menüü';
+
+  @override
+  String get signedInLabel => r'Sisse logitud';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex. vahekaart $tabCount-st';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Tundide valimine';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Minutite valimine';
+
+  @override
+  String get viewLicensesButtonLabel => r'KUVA LITSENTSID';
+}
+
+/// The translations for Persian (`fa`).
+class MaterialLocalizationFa extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Persian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationFa({
+    String localeName = 'fa',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'درباره $applicationName';
+
+  @override
+  String get alertDialogLabel => r'هشدار';
+
+  @override
+  String get anteMeridiemAbbreviation => r'ق.ظ.';
+
+  @override
+  String get backButtonTooltip => r'برگشت';
+
+  @override
+  String get cancelButtonLabel => r'لغو';
+
+  @override
+  String get closeButtonLabel => r'بستن';
+
+  @override
+  String get closeButtonTooltip => r'بستن';
+
+  @override
+  String get continueButtonLabel => r'ادامه';
+
+  @override
+  String get copyButtonLabel => r'کپی';
+
+  @override
+  String get cutButtonLabel => r'برش';
+
+  @override
+  String get deleteButtonTooltip => r'حذف';
+
+  @override
+  String get dialogLabel => r'کادر گفتگو';
+
+  @override
+  String get drawerLabel => r'منوی پیمایش';
+
+  @override
+  String get hideAccountsLabel => r'پنهان کردن حساب‌ها';
+
+  @override
+  String get licensesPageTitle => r'مجوزها';
+
+  @override
+  String get modalBarrierDismissLabel => r'نپذیرفتن';
+
+  @override
+  String get nextMonthTooltip => r'ماه بعد';
+
+  @override
+  String get nextPageTooltip => r'صفحه بعد';
+
+  @override
+  String get okButtonLabel => r'تأیید';
+
+  @override
+  String get openAppDrawerTooltip => r'باز کردن منوی پیمایش';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow از $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow از حدود $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'جای‌گذاری';
+
+  @override
+  String get popupMenuLabel => r'منوی بازشو';
+
+  @override
+  String get postMeridiemAbbreviation => r'ب.ظ.';
+
+  @override
+  String get previousMonthTooltip => r'ماه قبل';
+
+  @override
+  String get previousPageTooltip => r'صفحه قبل';
+
+  @override
+  String get rowsPerPageTitle => r'ردیف در هر صفحه:';
+
+  @override
+  String get scriptCategory => r'tall';
+
+  @override
+  String get searchFieldLabel => r'جستجو کردن';
+
+  @override
+  String get selectAllButtonLabel => r'انتخاب همه';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'۱ مورد انتخاب شد';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount مورد انتخاب شدند';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'نشان دادن حساب‌ها';
+
+  @override
+  String get showMenuTooltip => r'نمایش منو';
+
+  @override
+  String get signedInLabel => r'واردشده به سیستم';
+
+  @override
+  String get tabLabelRaw => r'برگه $tabIndex از $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.H_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'انتخاب ساعت';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'انتخاب دقیقه';
+
+  @override
+  String get viewLicensesButtonLabel => r'مشاهده مجوزها';
+}
+
+/// The translations for Finnish (`fi`).
+class MaterialLocalizationFi extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Finnish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationFi({
+    String localeName = 'fi',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Tietoja sovelluksesta $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'ap';
+
+  @override
+  String get backButtonTooltip => r'Takaisin';
+
+  @override
+  String get cancelButtonLabel => r'PERUUTA';
+
+  @override
+  String get closeButtonLabel => r'SULJE';
+
+  @override
+  String get closeButtonTooltip => r'Sulje';
+
+  @override
+  String get continueButtonLabel => r'JATKA';
+
+  @override
+  String get copyButtonLabel => r'COPY';
+
+  @override
+  String get cutButtonLabel => r'LEIKKAA';
+
+  @override
+  String get deleteButtonTooltip => r'Poista';
+
+  @override
+  String get dialogLabel => r'Valintaikkuna';
+
+  @override
+  String get drawerLabel => r'Navigointivalikko';
+
+  @override
+  String get hideAccountsLabel => r'Piilota tilit';
+
+  @override
+  String get licensesPageTitle => r'Lisenssit';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ohita';
+
+  @override
+  String get nextMonthTooltip => r'Seuraava kuukausi';
+
+  @override
+  String get nextPageTooltip => r'Seuraava sivu';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Avaa navigointivalikko';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow/$rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow/~$rowCount';
+
+  @override
+  String get pasteButtonLabel => r'LIITÄ';
+
+  @override
+  String get popupMenuLabel => r'Ponnahdusvalikko';
+
+  @override
+  String get postMeridiemAbbreviation => r'ip';
+
+  @override
+  String get previousMonthTooltip => r'Edellinen kuukausi';
+
+  @override
+  String get previousPageTooltip => r'Edellinen sivu';
+
+  @override
+  String get rowsPerPageTitle => r'Riviä/sivu:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'VALITSE KAIKKI';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 kohde valittu';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount kohdetta valittu';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Näytä tilit';
+
+  @override
+  String get showMenuTooltip => r'Näytä valikko';
+
+  @override
+  String get signedInLabel => r'Kirjautunut sisään';
+
+  @override
+  String get tabLabelRaw => r'Välilehti $tabIndex/$tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Valitse tunnit';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Valitse minuutit';
+
+  @override
+  String get viewLicensesButtonLabel => r'NÄYTÄ KÄYTTÖOIKEUDET';
+}
+
+/// The translations for Filipino Pilipino (`fil`).
+class MaterialLocalizationFil extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Filipino Pilipino.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationFil({
+    String localeName = 'fil',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Tungkol sa $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Bumalik';
+
+  @override
+  String get cancelButtonLabel => r'KANSELAHIN';
+
+  @override
+  String get closeButtonLabel => r'ISARA';
+
+  @override
+  String get closeButtonTooltip => r'Isara';
+
+  @override
+  String get continueButtonLabel => r'MAGPATULOY';
+
+  @override
+  String get copyButtonLabel => r'KOPYAHIN';
+
+  @override
+  String get cutButtonLabel => r'I-CUT';
+
+  @override
+  String get deleteButtonTooltip => r'I-delete';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Menu ng navigation';
+
+  @override
+  String get hideAccountsLabel => r'Itago ang mga account';
+
+  @override
+  String get licensesPageTitle => r'Mga Lisensya';
+
+  @override
+  String get modalBarrierDismissLabel => r'I-dismiss';
+
+  @override
+  String get nextMonthTooltip => r'Susunod na buwan';
+
+  @override
+  String get nextPageTooltip => r'Susunod na page';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Buksan ang menu ng navigation';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow ng $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow ng humigit kumulang $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'I-PASTE';
+
+  @override
+  String get popupMenuLabel => r'Popup na menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Nakaraang buwan';
+
+  @override
+  String get previousPageTooltip => r'Nakaraang page';
+
+  @override
+  String get rowsPerPageTitle => r'Mga row bawat page:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'PILIIN LAHAT';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item ang napili';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Ipakita ang mga account';
+
+  @override
+  String get showMenuTooltip => r'Ipakita ang menu';
+
+  @override
+  String get signedInLabel => r'Naka-sign in';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex ng $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Pumili ng mga oras';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Pumili ng mga minuto';
+
+  @override
+  String get viewLicensesButtonLabel => r'TINGNAN ANG MGA LISENSYA';
+}
+
+/// The translations for French (`fr`).
+class MaterialLocalizationFr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for French.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationFr({
+    String localeName = 'fr',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'À propos de $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alerte';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Retour';
+
+  @override
+  String get cancelButtonLabel => r'ANNULER';
+
+  @override
+  String get closeButtonLabel => r'FERMER';
+
+  @override
+  String get closeButtonTooltip => r'Fermer';
+
+  @override
+  String get continueButtonLabel => r'CONTINUER';
+
+  @override
+  String get copyButtonLabel => r'COPIER';
+
+  @override
+  String get cutButtonLabel => r'COUPER';
+
+  @override
+  String get deleteButtonTooltip => r'Supprimer';
+
+  @override
+  String get dialogLabel => r'Boîte de dialogue';
+
+  @override
+  String get drawerLabel => r'Menu de navigation';
+
+  @override
+  String get hideAccountsLabel => r'Masquer les comptes';
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ignorer';
+
+  @override
+  String get nextMonthTooltip => r'Mois suivant';
+
+  @override
+  String get nextPageTooltip => r'Page suivante';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Ouvrir le menu de navigation';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow sur $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow sur environ $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'COLLER';
+
+  @override
+  String get popupMenuLabel => r'Menu contextuel';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Mois précédent';
+
+  @override
+  String get previousPageTooltip => r'Page précédente';
+
+  @override
+  String get rowsPerPageTitle => r'Lignes par page :';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Chercher';
+
+  @override
+  String get selectAllButtonLabel => r'TOUT SÉLECTIONNER';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 élément sélectionné';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount éléments sélectionnés';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Aucun élément sélectionné';
+
+  @override
+  String get showAccountsLabel => r'Afficher les comptes';
+
+  @override
+  String get showMenuTooltip => r'Afficher le menu';
+
+  @override
+  String get signedInLabel => r'Connecté';
+
+  @override
+  String get tabLabelRaw => r'Onglet $tabIndex sur $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Sélectionner une heure';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Sélectionner des minutes';
+
+  @override
+  String get viewLicensesButtonLabel => r'AFFICHER LES LICENCES';
+}
+
+/// The translations for French, as used in Canada (`fr_CA`).
+class MaterialLocalizationFrCa extends MaterialLocalizationFr {
+  /// Create an instance of the translation bundle for French, as used in Canada.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationFrCa({
+    String localeName = 'fr_CA',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.frenchCanadian;
+}
+
+/// The translations for Swiss German Alemannic Alsatian (`gsw`).
+class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Swiss German Alemannic Alsatian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationGsw({
+    String localeName = 'gsw',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Über $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Aufmerksam';
+
+  @override
+  String get anteMeridiemAbbreviation => r'VORM.';
+
+  @override
+  String get backButtonTooltip => r'Zurück';
+
+  @override
+  String get cancelButtonLabel => r'ABBRECHEN';
+
+  @override
+  String get closeButtonLabel => r'SCHLIEẞEN';
+
+  @override
+  String get closeButtonTooltip => r'Schließen';
+
+  @override
+  String get continueButtonLabel => r'WEITER';
+
+  @override
+  String get copyButtonLabel => r'KOPIEREN';
+
+  @override
+  String get cutButtonLabel => r'AUSSCHNEIDEN';
+
+  @override
+  String get deleteButtonTooltip => r'Löschen';
+
+  @override
+  String get dialogLabel => r'Dialogfeld';
+
+  @override
+  String get drawerLabel => r'Navigationsmenü';
+
+  @override
+  String get hideAccountsLabel => r'Konten ausblenden';
+
+  @override
+  String get licensesPageTitle => r'Lizenzen';
+
+  @override
+  String get modalBarrierDismissLabel => r'Schließen';
+
+  @override
+  String get nextMonthTooltip => r'Nächster Monat';
+
+  @override
+  String get nextPageTooltip => r'Nächste Seite';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Navigationsmenü öffnen';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow von $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow von etwa $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'EINFÜGEN';
+
+  @override
+  String get popupMenuLabel => r'Pop-up-Menü';
+
+  @override
+  String get postMeridiemAbbreviation => r'NACHM.';
+
+  @override
+  String get previousMonthTooltip => r'Vorheriger Monat';
+
+  @override
+  String get previousPageTooltip => r'Vorherige Seite';
+
+  @override
+  String get rowsPerPageTitle => r'Zeilen pro Seite:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Suchen';
+
+  @override
+  String get selectAllButtonLabel => r'ALLE AUSWÄHLEN';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 Element ausgewählt';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Konten anzeigen';
+
+  @override
+  String get showMenuTooltip => r'Menü anzeigen';
+
+  @override
+  String get signedInLabel => r'Angemeldet';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex von $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Stunden auswählen';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Minuten auswählen';
+
+  @override
+  String get viewLicensesButtonLabel => r'LIZENZEN ANZEIGEN';
+}
+
+/// The translations for Hebrew (`he`).
+class MaterialLocalizationHe extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Hebrew.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationHe({
+    String localeName = 'he',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'מידע על $applicationName';
+
+  @override
+  String get alertDialogLabel => r'עֵרָנִי';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'הקודם';
+
+  @override
+  String get cancelButtonLabel => r'ביטול';
+
+  @override
+  String get closeButtonLabel => r'סגירה';
+
+  @override
+  String get closeButtonTooltip => r'סגירה';
+
+  @override
+  String get continueButtonLabel => r'המשך';
+
+  @override
+  String get copyButtonLabel => r'העתקה';
+
+  @override
+  String get cutButtonLabel => r'גזירה';
+
+  @override
+  String get deleteButtonTooltip => r'מחיקה';
+
+  @override
+  String get dialogLabel => r'תיבת דו-שיח';
+
+  @override
+  String get drawerLabel => r'תפריט ניווט';
+
+  @override
+  String get hideAccountsLabel => r'הסתרת החשבונות';
+
+  @override
+  String get licensesPageTitle => r'רישיונות';
+
+  @override
+  String get modalBarrierDismissLabel => r'סגירה';
+
+  @override
+  String get nextMonthTooltip => r'החודש הבא';
+
+  @override
+  String get nextPageTooltip => r'הדף הבא';
+
+  @override
+  String get okButtonLabel => r'אישור';
+
+  @override
+  String get openAppDrawerTooltip => r'פתיחה של תפריט הניווט';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$lastRow–$firstRow מתוך $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$lastRow–$firstRow מתוך כ-$rowCount';
+
+  @override
+  String get pasteButtonLabel => r'הדבקה';
+
+  @override
+  String get popupMenuLabel => r'תפריט קופץ';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'החודש הקודם';
+
+  @override
+  String get previousPageTooltip => r'הדף הקודם';
+
+  @override
+  String get rowsPerPageTitle => r'שורות בכל דף:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'לחפש';
+
+  @override
+  String get selectAllButtonLabel => r'בחירת הכול';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
+
+  @override
+  String get selectedRowCountTitleOne => r'פריט אחד נבחר';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
+
+  @override
+  String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'הצגת החשבונות';
+
+  @override
+  String get showMenuTooltip => r'הצגת התפריט';
+
+  @override
+  String get signedInLabel => r'מחובר';
+
+  @override
+  String get tabLabelRaw => r'כרטיסייה $tabIndex מתוך $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.H_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'בחירת שעות';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'בחירת דקות';
+
+  @override
+  String get viewLicensesButtonLabel => r'הצגת הרישיונות';
+}
+
+/// The translations for Hindi (`hi`).
+class MaterialLocalizationHi extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Hindi.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationHi({
+    String localeName = 'hi',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName के बारे में जानकारी';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'वापस जाएं';
+
+  @override
+  String get cancelButtonLabel => r'रद्द करें';
+
+  @override
+  String get closeButtonLabel => r'बंद करें';
+
+  @override
+  String get closeButtonTooltip => r'बंद करें';
+
+  @override
+  String get continueButtonLabel => r'जारी रखें';
+
+  @override
+  String get copyButtonLabel => r'कॉपी करें';
+
+  @override
+  String get cutButtonLabel => r'कट करें';
+
+  @override
+  String get deleteButtonTooltip => r'मिटाएं';
+
+  @override
+  String get dialogLabel => r'संवाद';
+
+  @override
+  String get drawerLabel => r'नेविगेशन मेन्यू';
+
+  @override
+  String get hideAccountsLabel => r'खाते छिपाएं';
+
+  @override
+  String get licensesPageTitle => r'लाइसेंस';
+
+  @override
+  String get modalBarrierDismissLabel => r'खारिज करें';
+
+  @override
+  String get nextMonthTooltip => r'अगला महीना';
+
+  @override
+  String get nextPageTooltip => r'अगला पेज';
+
+  @override
+  String get okButtonLabel => r'ठीक है';
+
+  @override
+  String get openAppDrawerTooltip => r'नेविगेशन मेन्यू खोलें';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$rowCount का $firstRow–$lastRow';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$rowCount में से करीब $firstRow–$lastRow';
+
+  @override
+  String get pasteButtonLabel => r'चिपकाएं';
+
+  @override
+  String get popupMenuLabel => r'पॉपअप मेन्यू';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'पिछला महीना';
+
+  @override
+  String get previousPageTooltip => r'पिछला पेज';
+
+  @override
+  String get rowsPerPageTitle => r'हर पेज में पंक्तियों की संख्या:';
+
+  @override
+  String get scriptCategory => r'dense';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'सभी चुनें';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 चीज़ चुनी गई';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount चीज़ें चुनी गईं';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'खाते दिखाएं';
+
+  @override
+  String get showMenuTooltip => r'मेन्यू दिखाएं';
+
+  @override
+  String get signedInLabel => r'साइन इन किया हुआ है';
+
+  @override
+  String get tabLabelRaw => r'$tabCount का टैब $tabIndex';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.a_space_h_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'घंटे के हिसाब से समय चुनें';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'मिनट के हिसाब से समय चुनें';
+
+  @override
+  String get viewLicensesButtonLabel => r'लाइसेंस देखें';
+}
+
+/// The translations for Croatian (`hr`).
+class MaterialLocalizationHr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Croatian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationHr({
+    String localeName = 'hr',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'O aplikaciji $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'prijepodne';
+
+  @override
+  String get backButtonTooltip => r'Natrag';
+
+  @override
+  String get cancelButtonLabel => r'ODUSTANI';
+
+  @override
+  String get closeButtonLabel => r'ZATVORI';
+
+  @override
+  String get closeButtonTooltip => r'Zatvaranje';
+
+  @override
+  String get continueButtonLabel => r'NASTAVI';
+
+  @override
+  String get copyButtonLabel => r'KOPIRAJ';
+
+  @override
+  String get cutButtonLabel => r'IZREŽI';
+
+  @override
+  String get deleteButtonTooltip => r'Brisanje';
+
+  @override
+  String get dialogLabel => r'Dijalog';
+
+  @override
+  String get drawerLabel => r'Navigacijski izbornik';
+
+  @override
+  String get hideAccountsLabel => r'Sakrijte račune';
+
+  @override
+  String get licensesPageTitle => r'Licence';
+
+  @override
+  String get modalBarrierDismissLabel => r'Odbaci';
+
+  @override
+  String get nextMonthTooltip => r'Sljedeći mjesec';
+
+  @override
+  String get nextPageTooltip => r'Sljedeća stranica';
+
+  @override
+  String get okButtonLabel => r'U REDU';
+
+  @override
+  String get openAppDrawerTooltip => r'Otvaranje izbornika za navigaciju';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow od $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow od otprilike $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ZALIJEPI';
+
+  @override
+  String get popupMenuLabel => r'Skočni izbornik';
+
+  @override
+  String get postMeridiemAbbreviation => r'popodne';
+
+  @override
+  String get previousMonthTooltip => r'Prethodni mjesec';
+
+  @override
+  String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get rowsPerPageTitle => r'Redaka po stranici:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ODABERI SVE';
+
+  @override
+  String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Odabrana je jedna stavka';
+
+  @override
+  String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Prikažite račune';
+
+  @override
+  String get showMenuTooltip => r'Prikaz izbornika';
+
+  @override
+  String get signedInLabel => r'Prijavljeni korisnik';
+
+  @override
+  String get tabLabelRaw => r'Kartica $tabIndex od $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Odaberite sate';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Odaberite minute';
+
+  @override
+  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
+}
+
+/// The translations for Hungarian (`hu`).
+class MaterialLocalizationHu extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Hungarian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationHu({
+    String localeName = 'hu',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'A(z) $applicationName névjegye';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'de.';
+
+  @override
+  String get backButtonTooltip => r'Vissza';
+
+  @override
+  String get cancelButtonLabel => r'MÉGSE';
+
+  @override
+  String get closeButtonLabel => r'BEZÁRÁS';
+
+  @override
+  String get closeButtonTooltip => r'Bezárás';
+
+  @override
+  String get continueButtonLabel => r'TOVÁBB';
+
+  @override
+  String get copyButtonLabel => r'MÁSOLÁS';
+
+  @override
+  String get cutButtonLabel => r'KIVÁGÁS';
+
+  @override
+  String get deleteButtonTooltip => r'Törlés';
+
+  @override
+  String get dialogLabel => r'Párbeszédablak';
+
+  @override
+  String get drawerLabel => r'Navigációs menü';
+
+  @override
+  String get hideAccountsLabel => r'Fiókok elrejtése';
+
+  @override
+  String get licensesPageTitle => r'Licencek';
+
+  @override
+  String get modalBarrierDismissLabel => r'Elvetés';
+
+  @override
+  String get nextMonthTooltip => r'Következő hónap';
+
+  @override
+  String get nextPageTooltip => r'Következő oldal';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Navigációs menü megnyitása';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$rowCount/$firstRow–$lastRow.';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'Körülbelül $rowCount/$firstRow–$lastRow.';
+
+  @override
+  String get pasteButtonLabel => r'BEILLESZTÉS';
+
+  @override
+  String get popupMenuLabel => r'Előugró menü';
+
+  @override
+  String get postMeridiemAbbreviation => r'du.';
+
+  @override
+  String get previousMonthTooltip => r'Előző hónap';
+
+  @override
+  String get previousPageTooltip => r'Előző oldal';
+
+  @override
+  String get rowsPerPageTitle => r'Oldalankénti sorszám:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'AZ ÖSSZES KIJELÖLÉSE';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 elem kiválasztva';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount elem kiválasztva';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Fiókok megjelenítése';
+
+  @override
+  String get showMenuTooltip => r'Menü megjelenítése';
+
+  @override
+  String get signedInLabel => r'Bejelentkezve';
+
+  @override
+  String get tabLabelRaw => r'$tabCount/$tabIndex. lap';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Óra kiválasztása';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Perc kiválasztása';
+
+  @override
+  String get viewLicensesButtonLabel => r'LICENCEK MEGTEKINTÉSE';
+}
+
+/// The translations for Indonesian (`id`).
+class MaterialLocalizationId extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Indonesian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationId({
+    String localeName = 'id',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Tentang $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Waspada';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Kembali';
+
+  @override
+  String get cancelButtonLabel => r'BATAL';
+
+  @override
+  String get closeButtonLabel => r'TUTUP';
+
+  @override
+  String get closeButtonTooltip => r'Tutup';
+
+  @override
+  String get continueButtonLabel => r'LANJUTKAN';
+
+  @override
+  String get copyButtonLabel => r'SALIN';
+
+  @override
+  String get cutButtonLabel => r'POTONG';
+
+  @override
+  String get deleteButtonTooltip => r'Hapus';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Menu navigasi';
+
+  @override
+  String get hideAccountsLabel => r'Sembunyikan akun';
+
+  @override
+  String get licensesPageTitle => r'Lisensi';
+
+  @override
+  String get modalBarrierDismissLabel => r'Tutup';
+
+  @override
+  String get nextMonthTooltip => r'Bulan berikutnya';
+
+  @override
+  String get nextPageTooltip => r'Halaman berikutnya';
+
+  @override
+  String get okButtonLabel => r'Oke';
+
+  @override
+  String get openAppDrawerTooltip => r'Buka menu navigasi';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow dari $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow dari kira-kira $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'TEMPEL';
+
+  @override
+  String get popupMenuLabel => r'Menu pop-up';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Bulan sebelumnya';
+
+  @override
+  String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get rowsPerPageTitle => r'Baris per halaman:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Pencarian';
+
+  @override
+  String get selectAllButtonLabel => r'PILIH SEMUA';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item dipilih';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Tampilkan akun';
+
+  @override
+  String get showMenuTooltip => r'Tampilkan menu';
+
+  @override
+  String get signedInLabel => r'Telah login';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex dari $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Pilih jam';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Pilih menit';
+
+  @override
+  String get viewLicensesButtonLabel => r'LIHAT LISENSI';
+}
+
+/// The translations for Italian (`it`).
+class MaterialLocalizationIt extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Italian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationIt({
+    String localeName = 'it',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Informazioni su $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Mettere in guardia';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Indietro';
+
+  @override
+  String get cancelButtonLabel => r'ANNULLA';
+
+  @override
+  String get closeButtonLabel => r'CHIUDI';
+
+  @override
+  String get closeButtonTooltip => r'Chiudi';
+
+  @override
+  String get continueButtonLabel => r'CONTINUA';
+
+  @override
+  String get copyButtonLabel => r'COPIA';
+
+  @override
+  String get cutButtonLabel => r'TAGLIA';
+
+  @override
+  String get deleteButtonTooltip => r'Elimina';
+
+  @override
+  String get dialogLabel => r'Finestra di dialogo';
+
+  @override
+  String get drawerLabel => r'Menu di navigazione';
+
+  @override
+  String get hideAccountsLabel => r'Nascondi account';
+
+  @override
+  String get licensesPageTitle => r'Licenze';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ignora';
+
+  @override
+  String get nextMonthTooltip => r'Mese successivo';
+
+  @override
+  String get nextPageTooltip => r'Pagina successiva';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Apri il menu di navigazione';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow di $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow di circa $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'INCOLLA';
+
+  @override
+  String get popupMenuLabel => r'Menu popup';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Mese precedente';
+
+  @override
+  String get previousPageTooltip => r'Pagina precedente';
+
+  @override
+  String get rowsPerPageTitle => r'Righe per pagina:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Ricerca';
+
+  @override
+  String get selectAllButtonLabel => r'SELEZIONA TUTTO';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 elemento selezionato';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Mostra account';
+
+  @override
+  String get showMenuTooltip => r'Mostra il menu';
+
+  @override
+  String get signedInLabel => r'Connesso';
+
+  @override
+  String get tabLabelRaw => r'Scheda $tabIndex di $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Seleziona le ore';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Seleziona i minuti';
+
+  @override
+  String get viewLicensesButtonLabel => r'VISUALIZZA LICENZE';
+}
+
+/// The translations for Japanese (`ja`).
+class MaterialLocalizationJa extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Japanese.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationJa({
+    String localeName = 'ja',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName について';
+
+  @override
+  String get alertDialogLabel => r'アラート';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'戻る';
+
+  @override
+  String get cancelButtonLabel => r'キャンセル';
+
+  @override
+  String get closeButtonLabel => r'閉じる';
+
+  @override
+  String get closeButtonTooltip => r'閉じる';
+
+  @override
+  String get continueButtonLabel => r'続行';
+
+  @override
+  String get copyButtonLabel => r'コピー';
+
+  @override
+  String get cutButtonLabel => r'切り取り';
+
+  @override
+  String get deleteButtonTooltip => r'削除';
+
+  @override
+  String get dialogLabel => r'ダイアログ';
+
+  @override
+  String get drawerLabel => r'ナビゲーション メニュー';
+
+  @override
+  String get hideAccountsLabel => r'アカウントを非表示';
+
+  @override
+  String get licensesPageTitle => r'ライセンス';
+
+  @override
+  String get modalBarrierDismissLabel => r'閉じる';
+
+  @override
+  String get nextMonthTooltip => r'来月';
+
+  @override
+  String get nextPageTooltip => r'次のページ';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'ナビゲーション メニューを開く';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow - $lastRow 行（合計 $rowCount 行）';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow 行（合計約 $rowCount 行）';
+
+  @override
+  String get pasteButtonLabel => r'貼り付け';
+
+  @override
+  String get popupMenuLabel => r'ポップアップ メニュー';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'前月';
+
+  @override
+  String get previousPageTooltip => r'前のページ';
+
+  @override
+  String get rowsPerPageTitle => r'ページあたりの行数:';
+
+  @override
+  String get scriptCategory => r'dense';
+
+  @override
+  String get searchFieldLabel => r'サーチ';
+
+  @override
+  String get selectAllButtonLabel => r'すべて選択';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 件のアイテムを選択中';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount 件のアイテムを選択中';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'アカウントを表示';
+
+  @override
+  String get showMenuTooltip => r'メニューを表示';
+
+  @override
+  String get signedInLabel => r'ログイン中';
+
+  @override
+  String get tabLabelRaw => r'タブ: $tabIndex/$tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.H_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'時間を選択';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'分を選択';
+
+  @override
+  String get viewLicensesButtonLabel => r'ライセンスを表示';
+}
+
+/// The translations for Korean (`ko`).
+class MaterialLocalizationKo extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Korean.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationKo({
+    String localeName = 'ko',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName 정보';
+
+  @override
+  String get alertDialogLabel => r'경보';
+
+  @override
+  String get anteMeridiemAbbreviation => r'오전';
+
+  @override
+  String get backButtonTooltip => r'뒤로';
+
+  @override
+  String get cancelButtonLabel => r'취소';
+
+  @override
+  String get closeButtonLabel => r'닫기';
+
+  @override
+  String get closeButtonTooltip => r'닫기';
+
+  @override
+  String get continueButtonLabel => r'계속';
+
+  @override
+  String get copyButtonLabel => r'복사';
+
+  @override
+  String get cutButtonLabel => r'잘라내기';
+
+  @override
+  String get deleteButtonTooltip => r'삭제';
+
+  @override
+  String get dialogLabel => r'대화상자';
+
+  @override
+  String get drawerLabel => r'탐색 메뉴';
+
+  @override
+  String get hideAccountsLabel => r'계정 숨기기';
+
+  @override
+  String get licensesPageTitle => r'라이선스';
+
+  @override
+  String get modalBarrierDismissLabel => r'닫기';
+
+  @override
+  String get nextMonthTooltip => r'다음 달';
+
+  @override
+  String get nextPageTooltip => r'다음 페이지';
+
+  @override
+  String get okButtonLabel => r'확인';
+
+  @override
+  String get openAppDrawerTooltip => r'탐색 메뉴 열기';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$rowCount행 중 $firstRow~$lastRow행';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'약 $rowCount행 중 $firstRow~$lastRow행';
+
+  @override
+  String get pasteButtonLabel => r'붙여넣기';
+
+  @override
+  String get popupMenuLabel => r'팝업 메뉴';
+
+  @override
+  String get postMeridiemAbbreviation => r'오후';
+
+  @override
+  String get previousMonthTooltip => r'지난달';
+
+  @override
+  String get previousPageTooltip => r'이전 페이지';
+
+  @override
+  String get rowsPerPageTitle => r'페이지당 행 수:';
+
+  @override
+  String get scriptCategory => r'dense';
+
+  @override
+  String get searchFieldLabel => r'수색';
+
+  @override
+  String get selectAllButtonLabel => r'전체 선택';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'항목 1개 선택됨';
+
+  @override
+  String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'계정 표시';
+
+  @override
+  String get showMenuTooltip => r'메뉴 표시';
+
+  @override
+  String get signedInLabel => r'로그인됨';
+
+  @override
+  String get tabLabelRaw => r'탭 $tabCount개 중 $tabIndex번째';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.a_space_h_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'시간 선택';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'분 선택';
+
+  @override
+  String get viewLicensesButtonLabel => r'라이선스 보기';
+}
+
+/// The translations for Lithuanian (`lt`).
+class MaterialLocalizationLt extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Lithuanian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationLt({
+    String localeName = 'lt',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Apie „$applicationName“';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'priešpiet';
+
+  @override
+  String get backButtonTooltip => r'Atgal';
+
+  @override
+  String get cancelButtonLabel => r'ATŠAUKTI';
+
+  @override
+  String get closeButtonLabel => r'UŽDARYTI';
+
+  @override
+  String get closeButtonTooltip => r'Uždaryti';
+
+  @override
+  String get continueButtonLabel => r'TĘSTI';
+
+  @override
+  String get copyButtonLabel => r'KOPIJUOTI';
+
+  @override
+  String get cutButtonLabel => r'IŠKIRPTI';
+
+  @override
+  String get deleteButtonTooltip => r'Ištrinti';
+
+  @override
+  String get dialogLabel => r'Dialogo langas';
+
+  @override
+  String get drawerLabel => r'Naršymo meniu';
+
+  @override
+  String get hideAccountsLabel => r'Slėpti paskyras';
+
+  @override
+  String get licensesPageTitle => r'Licencijos';
+
+  @override
+  String get modalBarrierDismissLabel => r'Atsisakyti';
+
+  @override
+  String get nextMonthTooltip => r'Kitas mėnuo';
+
+  @override
+  String get nextPageTooltip => r'Kitas puslapis';
+
+  @override
+  String get okButtonLabel => r'GERAI';
+
+  @override
+  String get openAppDrawerTooltip => r'Atidaryti naršymo meniu';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow iš $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow iš maždaug $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ĮKLIJUOTI';
+
+  @override
+  String get popupMenuLabel => r'Iššokantysis meniu';
+
+  @override
+  String get postMeridiemAbbreviation => r'popiet';
+
+  @override
+  String get previousMonthTooltip => r'Ankstesnis mėnuo';
+
+  @override
+  String get previousPageTooltip => r'Ankstesnis puslapis';
+
+  @override
+  String get rowsPerPageTitle => r'Eilučių puslapyje:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'PASIRINKTI VISKĄ';
+
+  @override
+  String get selectedRowCountTitleFew => r'Pasirinkti $selectedRowCount elementai';
+
+  @override
+  String get selectedRowCountTitleMany => r'Pasirinkta $selectedRowCount elemento';
+
+  @override
+  String get selectedRowCountTitleOne => r'Pasirinktas 1 elementas';
+
+  @override
+  String get selectedRowCountTitleOther => r'Pasirinkta $selectedRowCount elementų';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Rodyti paskyras';
+
+  @override
+  String get showMenuTooltip => r'Rodyti meniu';
+
+  @override
+  String get signedInLabel => r'Prisijungta';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex skirtukas iš $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Pasirinkite valandas';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Pasirinkite minutes';
+
+  @override
+  String get viewLicensesButtonLabel => r'PERŽIŪRĖTI LICENCIJAS';
+}
+
+/// The translations for Latvian (`lv`).
+class MaterialLocalizationLv extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Latvian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationLv({
+    String localeName = 'lv',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Par $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'priekšpusdienā';
+
+  @override
+  String get backButtonTooltip => r'Atpakaļ';
+
+  @override
+  String get cancelButtonLabel => r'ATCELT';
+
+  @override
+  String get closeButtonLabel => r'AIZVĒRT';
+
+  @override
+  String get closeButtonTooltip => r'Aizvērt';
+
+  @override
+  String get continueButtonLabel => r'TURPINĀT';
+
+  @override
+  String get copyButtonLabel => r'KOPĒT';
+
+  @override
+  String get cutButtonLabel => r'IZGRIEZT';
+
+  @override
+  String get deleteButtonTooltip => r'Dzēst';
+
+  @override
+  String get dialogLabel => r'Dialoglodziņš';
+
+  @override
+  String get drawerLabel => r'Navigācijas izvēlne';
+
+  @override
+  String get hideAccountsLabel => r'Slēpt kontus';
+
+  @override
+  String get licensesPageTitle => r'Licences';
+
+  @override
+  String get modalBarrierDismissLabel => r'Nerādīt';
+
+  @override
+  String get nextMonthTooltip => r'Nākamais mēnesis';
+
+  @override
+  String get nextPageTooltip => r'Nākamā lapa';
+
+  @override
+  String get okButtonLabel => r'LABI';
+
+  @override
+  String get openAppDrawerTooltip => r'Atvērt navigācijas izvēlni';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow.–$lastRow. no $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow.–$lastRow. no aptuveni $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'IELĪMĒT';
+
+  @override
+  String get popupMenuLabel => r'Uznirstošā izvēlne';
+
+  @override
+  String get postMeridiemAbbreviation => r'pēcpusdienā';
+
+  @override
+  String get previousMonthTooltip => r'Iepriekšējais mēnesis';
+
+  @override
+  String get previousPageTooltip => r'Iepriekšējā lapa';
+
+  @override
+  String get rowsPerPageTitle => r'Rindas lapā:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ATLASĪT VISU';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Atlasīts 1 vienums';
+
+  @override
+  String get selectedRowCountTitleOther => r'Atlasīti $selectedRowCount vienumi';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Nav atlasītu vienumu';
+
+  @override
+  String get showAccountsLabel => r'Rādīt kontus';
+
+  @override
+  String get showMenuTooltip => r'Rādīt izvēlni';
+
+  @override
+  String get signedInLabel => r'Esat pierakstījies';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex. cilne no $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Atlasiet stundas';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Atlasiet minūtes';
+
+  @override
+  String get viewLicensesButtonLabel => r'SKATĪT LICENCES';
+}
+
+/// The translations for Malay (`ms`).
+class MaterialLocalizationMs extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Malay.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationMs({
+    String localeName = 'ms',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Perihal $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Amaran';
+
+  @override
+  String get anteMeridiemAbbreviation => r'PG';
+
+  @override
+  String get backButtonTooltip => r'Kembali';
+
+  @override
+  String get cancelButtonLabel => r'BATAL';
+
+  @override
+  String get closeButtonLabel => r'TUTUP';
+
+  @override
+  String get closeButtonTooltip => r'Tutup';
+
+  @override
+  String get continueButtonLabel => r'TERUSKAN';
+
+  @override
+  String get copyButtonLabel => r'SALIN';
+
+  @override
+  String get cutButtonLabel => r'POTONG';
+
+  @override
+  String get deleteButtonTooltip => r'Padam';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Menu navigasi';
+
+  @override
+  String get hideAccountsLabel => r'Sembunyikan akaun';
+
+  @override
+  String get licensesPageTitle => r'Lesen';
+
+  @override
+  String get modalBarrierDismissLabel => r'Tolak';
+
+  @override
+  String get nextMonthTooltip => r'Bulan depan';
+
+  @override
+  String get nextPageTooltip => r'Halaman seterusnya';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Buka menu navigasi';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow dari $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow dari kira-kira $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'TAMPAL';
+
+  @override
+  String get popupMenuLabel => r'Menu pop timbul';
+
+  @override
+  String get postMeridiemAbbreviation => r'PTG';
+
+  @override
+  String get previousMonthTooltip => r'Bulan sebelumnya';
+
+  @override
+  String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get rowsPerPageTitle => r'Baris setiap halaman:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Carian';
+
+  @override
+  String get selectAllButtonLabel => r'PILIH SEMUA';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item dipilih';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Tiada item dipilih';
+
+  @override
+  String get showAccountsLabel => r'Tunjukkan akaun';
+
+  @override
+  String get showMenuTooltip => r'Tunjukkan menu';
+
+  @override
+  String get signedInLabel => r'Dilog masuk';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex dari $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Pilih jam';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Pilih minit';
+
+  @override
+  String get viewLicensesButtonLabel => r'LIHAT LESEN';
+}
+
+/// The translations for Norwegian Bokmål (`nb`).
+class MaterialLocalizationNb extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Norwegian Bokmål.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationNb({
+    String localeName = 'nb',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Om $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Varsling';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Tilbake';
+
+  @override
+  String get cancelButtonLabel => r'AVBRYT';
+
+  @override
+  String get closeButtonLabel => r'LUKK';
+
+  @override
+  String get closeButtonTooltip => r'Lukk';
+
+  @override
+  String get continueButtonLabel => r'FORTSETT';
+
+  @override
+  String get copyButtonLabel => r'KOPIÉR';
+
+  @override
+  String get cutButtonLabel => r'KLIPP UT';
+
+  @override
+  String get deleteButtonTooltip => r'Slett';
+
+  @override
+  String get dialogLabel => r'Dialogboks';
+
+  @override
+  String get drawerLabel => r'Navigasjonsmeny';
+
+  @override
+  String get hideAccountsLabel => r'Skjul kontoer';
+
+  @override
+  String get licensesPageTitle => r'Lisenser';
+
+  @override
+  String get modalBarrierDismissLabel => r'Avvis';
+
+  @override
+  String get nextMonthTooltip => r'Neste måned';
+
+  @override
+  String get nextPageTooltip => r'Neste side';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Åpne navigasjonsmenyen';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow av $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow av omtrent $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'LIM INN';
+
+  @override
+  String get popupMenuLabel => r'Forgrunnsmeny';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Forrige måned';
+
+  @override
+  String get previousPageTooltip => r'Forrige side';
+
+  @override
+  String get rowsPerPageTitle => r'Rader per side:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Søke';
+
+  @override
+  String get selectAllButtonLabel => r'VELG ALLE';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 element er valgt';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Vis kontoer';
+
+  @override
+  String get showMenuTooltip => r'Vis meny';
+
+  @override
+  String get signedInLabel => r'Pålogget';
+
+  @override
+  String get tabLabelRaw => r'Fane $tabIndex av $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Angi timer';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Angi minutter';
+
+  @override
+  String get viewLicensesButtonLabel => r'SE LISENSER';
+}
+
+/// The translations for Dutch Flemish (`nl`).
+class MaterialLocalizationNl extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Dutch Flemish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationNl({
+    String localeName = 'nl',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Over $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alarm';
+
+  @override
+  String get anteMeridiemAbbreviation => r'am';
+
+  @override
+  String get backButtonTooltip => r'Terug';
+
+  @override
+  String get cancelButtonLabel => r'ANNULEREN';
+
+  @override
+  String get closeButtonLabel => r'SLUITEN';
+
+  @override
+  String get closeButtonTooltip => r'Sluiten';
+
+  @override
+  String get continueButtonLabel => r'DOORGAAN';
+
+  @override
+  String get copyButtonLabel => r'KOPIËREN';
+
+  @override
+  String get cutButtonLabel => r'KNIPPEN';
+
+  @override
+  String get deleteButtonTooltip => r'Verwijderen';
+
+  @override
+  String get dialogLabel => r'Dialoogvenster';
+
+  @override
+  String get drawerLabel => r'Navigatiemenu';
+
+  @override
+  String get hideAccountsLabel => r'Accounts verbergen';
+
+  @override
+  String get licensesPageTitle => r'Licenties';
+
+  @override
+  String get modalBarrierDismissLabel => r'Sluiten';
+
+  @override
+  String get nextMonthTooltip => r'Volgende maand';
+
+  @override
+  String get nextPageTooltip => r'Volgende pagina';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Navigatiemenu openen';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow van $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow van ongeveer $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PLAKKEN';
+
+  @override
+  String get popupMenuLabel => r'Pop-upmenu';
+
+  @override
+  String get postMeridiemAbbreviation => r'pm';
+
+  @override
+  String get previousMonthTooltip => r'Vorige maand';
+
+  @override
+  String get previousPageTooltip => r'Vorige pagina';
+
+  @override
+  String get rowsPerPageTitle => r'Rijen per pagina:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Zoeken';
+
+  @override
+  String get selectAllButtonLabel => r'ALLES SELECTEREN';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item geselecteerd';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Accounts weergeven';
+
+  @override
+  String get showMenuTooltip => r'Menu weergeven';
+
+  @override
+  String get signedInLabel => r'Ingelogd';
+
+  @override
+  String get tabLabelRaw => r'Tabblad $tabIndex van $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Uren selecteren';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Minuten selecteren';
+
+  @override
+  String get viewLicensesButtonLabel => r'LICENTIES BEKIJKEN';
+}
+
+/// The translations for Polish (`pl`).
+class MaterialLocalizationPl extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Polish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationPl({
+    String localeName = 'pl',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName – informacje';
+
+  @override
+  String get alertDialogLabel => r'Alarm';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Wstecz';
+
+  @override
+  String get cancelButtonLabel => r'ANULUJ';
+
+  @override
+  String get closeButtonLabel => r'ZAMKNIJ';
+
+  @override
+  String get closeButtonTooltip => r'Zamknij';
+
+  @override
+  String get continueButtonLabel => r'DALEJ';
+
+  @override
+  String get copyButtonLabel => r'KOPIUJ';
+
+  @override
+  String get cutButtonLabel => r'WYTNIJ';
+
+  @override
+  String get deleteButtonTooltip => r'Usuń';
+
+  @override
+  String get dialogLabel => r'Okno dialogowe';
+
+  @override
+  String get drawerLabel => r'Menu nawigacyjne';
+
+  @override
+  String get hideAccountsLabel => r'Ukryj konta';
+
+  @override
+  String get licensesPageTitle => r'Licencje';
+
+  @override
+  String get modalBarrierDismissLabel => r'Zamknij';
+
+  @override
+  String get nextMonthTooltip => r'Następny miesiąc';
+
+  @override
+  String get nextPageTooltip => r'Następna strona';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Otwórz menu nawigacyjne';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow z $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow z około $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'WKLEJ';
+
+  @override
+  String get popupMenuLabel => r'Wyskakujące menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Poprzedni miesiąc';
+
+  @override
+  String get previousPageTooltip => r'Poprzednia strona';
+
+  @override
+  String get rowsPerPageTitle => r'Wiersze na stronie:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Szukaj';
+
+  @override
+  String get selectAllButtonLabel => r'ZAZNACZ WSZYSTKO';
+
+  @override
+  String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
+
+  @override
+  String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
+
+  @override
+  String get selectedRowCountTitleOne => r'1 wybrany element';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount wybranego elementu';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Pokaż konta';
+
+  @override
+  String get showMenuTooltip => r'Pokaż menu';
+
+  @override
+  String get signedInLabel => r'Zalogowani użytkownicy';
+
+  @override
+  String get tabLabelRaw => r'Karta $tabIndex z $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Wybierz godziny';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Wybierz minuty';
+
+  @override
+  String get viewLicensesButtonLabel => r'WYŚWIETL LICENCJE';
+}
+
+/// The translations for Pushto Pashto (`ps`).
+class MaterialLocalizationPs extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Pushto Pashto.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationPs({
+    String localeName = 'ps',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'د $applicationName په اړه';
+
+  @override
+  String get alertDialogLabel => r'خبرتیا';
+
+  @override
+  String get anteMeridiemAbbreviation => null;
+
+  @override
+  String get backButtonTooltip => r'شاته';
+
+  @override
+  String get cancelButtonLabel => r'لغوه کول';
+
+  @override
+  String get closeButtonLabel => r'تړل';
+
+  @override
+  String get closeButtonTooltip => r'بنده';
+
+  @override
+  String get continueButtonLabel => r'منځپانګې';
+
+  @override
+  String get copyButtonLabel => r'کاپی';
+
+  @override
+  String get cutButtonLabel => r'کم کړئ';
+
+  @override
+  String get deleteButtonTooltip => r'';
+
+  @override
+  String get dialogLabel => r'خبرې اترې';
+
+  @override
+  String get drawerLabel => r'د نیویگیشن مینو';
+
+  @override
+  String get hideAccountsLabel => r'حسابونه پټ کړئ';
+
+  @override
+  String get licensesPageTitle => r'جوازونه';
+
+  @override
+  String get modalBarrierDismissLabel => r'رد کړه';
+
+  @override
+  String get nextMonthTooltip => r'بله میاشت';
+
+  @override
+  String get nextPageTooltip => r'بله پاڼه';
+
+  @override
+  String get okButtonLabel => r'سمه ده';
+
+  @override
+  String get openAppDrawerTooltip => r'د پرانیستی نیینګ مینو';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow د $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow څخه $rowCount د';
+
+  @override
+  String get pasteButtonLabel => r'پیټ کړئ';
+
+  @override
+  String get popupMenuLabel => r'د پاپ اپ مینو';
+
+  @override
+  String get postMeridiemAbbreviation => null;
+
+  @override
+  String get previousMonthTooltip => r'تیره میاشت';
+
+  @override
+  String get previousPageTooltip => r'مخکینی مخ';
+
+  @override
+  String get rowsPerPageTitle => r'د هرې پاڼې پاڼې:';
+
+  @override
+  String get scriptCategory => r'tall';
+
+  @override
+  String get searchFieldLabel => r'لټون';
+
+  @override
+  String get selectAllButtonLabel => r'غوره کړئ';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => null;
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'حسابونه ښکاره کړئ';
+
+  @override
+  String get showMenuTooltip => r'غورنۍ ښودل';
+
+  @override
+  String get signedInLabel => r'ننوتل';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex د $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'وختونه وټاکئ';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'منې غوره کړئ';
+
+  @override
+  String get viewLicensesButtonLabel => r'لیدلس وګورئ';
+}
+
+/// The translations for Portuguese (`pt`).
+class MaterialLocalizationPt extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Portuguese.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationPt({
+    String localeName = 'pt',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Sobre o app $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alerta';
+
+  @override
+  String get anteMeridiemAbbreviation => r'Manhã';
+
+  @override
+  String get backButtonTooltip => r'Voltar';
+
+  @override
+  String get cancelButtonLabel => r'CANCELAR';
+
+  @override
+  String get closeButtonLabel => r'FECHAR';
+
+  @override
+  String get closeButtonTooltip => r'Fechar';
+
+  @override
+  String get continueButtonLabel => r'CONTINUAR';
+
+  @override
+  String get copyButtonLabel => r'COPIAR';
+
+  @override
+  String get cutButtonLabel => r'RECORTAR';
+
+  @override
+  String get deleteButtonTooltip => r'Excluir';
+
+  @override
+  String get dialogLabel => r'Caixa de diálogo';
+
+  @override
+  String get drawerLabel => r'Menu de navegação';
+
+  @override
+  String get hideAccountsLabel => r'Ocultar contas';
+
+  @override
+  String get licensesPageTitle => r'Licenças';
+
+  @override
+  String get modalBarrierDismissLabel => r'Dispensar';
+
+  @override
+  String get nextMonthTooltip => r'Próximo mês';
+
+  @override
+  String get nextPageTooltip => r'Próxima página';
+
+  @override
+  String get okButtonLabel => r'Ok';
+
+  @override
+  String get openAppDrawerTooltip => r'Abrir menu de navegação';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow de aproximadamente $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'COLAR';
+
+  @override
+  String get popupMenuLabel => r'Menu pop-up';
+
+  @override
+  String get postMeridiemAbbreviation => r'Tarde/noite';
+
+  @override
+  String get previousMonthTooltip => r'Mês anterior';
+
+  @override
+  String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get rowsPerPageTitle => r'Linhas por página:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Pesquisa';
+
+  @override
+  String get selectAllButtonLabel => r'SELECIONAR TUDO';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item selecionado';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Mostrar contas';
+
+  @override
+  String get showMenuTooltip => r'Mostrar menu';
+
+  @override
+  String get signedInLabel => r'Conectado a';
+
+  @override
+  String get tabLabelRaw => r'Guia $tabIndex de $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Selecione as horas';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Selecione os minutos';
+
+  @override
+  String get viewLicensesButtonLabel => r'VER LICENÇAS';
+}
+
+/// The translations for Portuguese, as used in Portugal (`pt_PT`).
+class MaterialLocalizationPtPt extends MaterialLocalizationPt {
+  /// Create an instance of the translation bundle for Portuguese, as used in Portugal.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationPtPt({
+    String localeName = 'pt_PT',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get tabLabelRaw => r'Separador $tabIndex de $tabCount';
+
+  @override
+  String get signedInLabel => r'Com sessão iniciada';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Selecionar minutos';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Selecionar horas';
+
+  @override
+  String get deleteButtonTooltip => r'Eliminar';
+
+  @override
+  String get nextMonthTooltip => r'Mês seguinte';
+
+  @override
+  String get nextPageTooltip => r'Página seguinte';
+
+  @override
+  String get aboutListTileTitleRaw => r'Acerca de $applicationName';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow a $lastRow de $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow a $lastRow de cerca de $rowCount';
+
+  @override
+  String get cutButtonLabel => r'CORTAR';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get modalBarrierDismissLabel => r'Ignorar';
+}
+
+/// The translations for Romanian Moldavian Moldovan (`ro`).
+class MaterialLocalizationRo extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Romanian Moldavian Moldovan.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationRo({
+    String localeName = 'ro',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Despre $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alerta';
+
+  @override
+  String get anteMeridiemAbbreviation => r'a.m.';
+
+  @override
+  String get backButtonTooltip => r'Înapoi';
+
+  @override
+  String get cancelButtonLabel => r'ANULAȚI';
+
+  @override
+  String get closeButtonLabel => r'ÎNCHIDEȚI';
+
+  @override
+  String get closeButtonTooltip => r'Închideți';
+
+  @override
+  String get continueButtonLabel => r'CONTINUAȚI';
+
+  @override
+  String get copyButtonLabel => r'COPIAȚI';
+
+  @override
+  String get cutButtonLabel => r'DECUPAȚI';
+
+  @override
+  String get deleteButtonTooltip => r'Ștergeți';
+
+  @override
+  String get dialogLabel => r'Casetă de dialog';
+
+  @override
+  String get drawerLabel => r'Meniu de navigare';
+
+  @override
+  String get hideAccountsLabel => r'Ascundeți conturile';
+
+  @override
+  String get licensesPageTitle => r'Licențe';
+
+  @override
+  String get modalBarrierDismissLabel => r'Închideți';
+
+  @override
+  String get nextMonthTooltip => r'Luna viitoare';
+
+  @override
+  String get nextPageTooltip => r'Pagina următoare';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Deschideți meniul de navigare';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow din $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow din aproximativ $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'INSERAȚI';
+
+  @override
+  String get popupMenuLabel => r'Meniu pop-up';
+
+  @override
+  String get postMeridiemAbbreviation => r'p.m.';
+
+  @override
+  String get previousMonthTooltip => r'Luna trecută';
+
+  @override
+  String get previousPageTooltip => r'Pagina anterioară';
+
+  @override
+  String get rowsPerPageTitle => r'Rânduri pe pagină:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Căutare';
+
+  @override
+  String get selectAllButtonLabel => r'SELECTAȚI TOATE';
+
+  @override
+  String get selectedRowCountTitleFew => r'$selectedRowCount articole selectate';
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Un articol selectat';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount de articole selectate';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Nu există elemente selectate';
+
+  @override
+  String get showAccountsLabel => r'Afișați conturile';
+
+  @override
+  String get showMenuTooltip => r'Afișați meniul';
+
+  @override
+  String get signedInLabel => r'V-ați conectat';
+
+  @override
+  String get tabLabelRaw => r'Fila $tabIndex din $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Selectați orele';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Selectați minutele';
+
+  @override
+  String get viewLicensesButtonLabel => r'VEDEȚI LICENȚELE';
+}
+
+/// The translations for Russian (`ru`).
+class MaterialLocalizationRu extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Russian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationRu({
+    String localeName = 'ru',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName: сведения';
+
+  @override
+  String get alertDialogLabel => r'бдительный';
+
+  @override
+  String get anteMeridiemAbbreviation => r'АМ';
+
+  @override
+  String get backButtonTooltip => r'Назад';
+
+  @override
+  String get cancelButtonLabel => r'ОТМЕНА';
+
+  @override
+  String get closeButtonLabel => r'ЗАКРЫТЬ';
+
+  @override
+  String get closeButtonTooltip => r'Закрыть';
+
+  @override
+  String get continueButtonLabel => r'ПРОДОЛЖИТЬ';
+
+  @override
+  String get copyButtonLabel => r'КОПИРОВАТЬ';
+
+  @override
+  String get cutButtonLabel => r'ВЫРЕЗАТЬ';
+
+  @override
+  String get deleteButtonTooltip => r'Удалить';
+
+  @override
+  String get dialogLabel => r'Диалоговое окно';
+
+  @override
+  String get drawerLabel => r'Меню навигации';
+
+  @override
+  String get hideAccountsLabel => r'Скрыть аккаунты';
+
+  @override
+  String get licensesPageTitle => r'Лицензии';
+
+  @override
+  String get modalBarrierDismissLabel => r'Закрыть';
+
+  @override
+  String get nextMonthTooltip => r'Следующий месяц';
+
+  @override
+  String get nextPageTooltip => r'Следующая страница';
+
+  @override
+  String get okButtonLabel => r'ОК';
+
+  @override
+  String get openAppDrawerTooltip => r'Открыть меню навигации';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow из $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow из примерно $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ВСТАВИТЬ';
+
+  @override
+  String get popupMenuLabel => r'Всплывающее меню';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Предыдущий месяц';
+
+  @override
+  String get previousPageTooltip => r'Предыдущая страница';
+
+  @override
+  String get rowsPerPageTitle => r'Строк на странице:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Поиск';
+
+  @override
+  String get selectAllButtonLabel => r'ВЫБРАТЬ ВСЕ';
+
+  @override
+  String get selectedRowCountTitleFew => r'Выбрано $selectedRowCount объекта';
+
+  @override
+  String get selectedRowCountTitleMany => r'Выбрано $selectedRowCount объектов';
+
+  @override
+  String get selectedRowCountTitleOne => r'Выбран 1 объект';
+
+  @override
+  String get selectedRowCountTitleOther => r'Выбрано $selectedRowCount объекта';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'Строки не выбраны';
+
+  @override
+  String get showAccountsLabel => r'Показать аккаунты';
+
+  @override
+  String get showMenuTooltip => r'Показать меню';
+
+  @override
+  String get signedInLabel => r'Вход выполнен';
+
+  @override
+  String get tabLabelRaw => r'Вкладка $tabIndex из $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.H_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Выберите часы';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Выберите минуты';
+
+  @override
+  String get viewLicensesButtonLabel => r'ЛИЦЕНЗИИ';
+}
+
+/// The translations for Slovak (`sk`).
+class MaterialLocalizationSk extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Slovak.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationSk({
+    String localeName = 'sk',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName – informácie';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Späť';
+
+  @override
+  String get cancelButtonLabel => r'ZRUŠIŤ';
+
+  @override
+  String get closeButtonLabel => r'ZAVRIEŤ';
+
+  @override
+  String get closeButtonTooltip => r'Zavrieť';
+
+  @override
+  String get continueButtonLabel => r'POKRAČOVAŤ';
+
+  @override
+  String get copyButtonLabel => r'KOPÍROVAŤ';
+
+  @override
+  String get cutButtonLabel => r'VYSTRIHNÚŤ';
+
+  @override
+  String get deleteButtonTooltip => r'Odstrániť';
+
+  @override
+  String get dialogLabel => r'Dialógové okno';
+
+  @override
+  String get drawerLabel => r'Navigačná ponuka';
+
+  @override
+  String get hideAccountsLabel => r'Skryť účty';
+
+  @override
+  String get licensesPageTitle => r'Licencie';
+
+  @override
+  String get modalBarrierDismissLabel => r'Odmietnuť';
+
+  @override
+  String get nextMonthTooltip => r'Budúci mesiac';
+
+  @override
+  String get nextPageTooltip => r'Ďalšia strana';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Otvoriť navigačnú ponuku';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow z $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow z približne $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PRILEPIŤ';
+
+  @override
+  String get popupMenuLabel => r'Kontextová ponuka';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Predošlý mesiac';
+
+  @override
+  String get previousPageTooltip => r'Predchádzajúca stránka';
+
+  @override
+  String get rowsPerPageTitle => r'Počet riadkov na stránku:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'VYBRAŤ VŠETKO';
+
+  @override
+  String get selectedRowCountTitleFew => r'$selectedRowCount vybraté položky';
+
+  @override
+  String get selectedRowCountTitleMany => r'$selectedRowCount items selected';
+
+  @override
+  String get selectedRowCountTitleOne => r'1 vybratá položka';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount vybratých položiek';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Zobraziť účty';
+
+  @override
+  String get showMenuTooltip => r'Zobraziť ponuku';
+
+  @override
+  String get signedInLabel => r'Prihlásili ste sa';
+
+  @override
+  String get tabLabelRaw => r'Karta $tabIndex z $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Vybrať hodiny';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Vybrať minúty';
+
+  @override
+  String get viewLicensesButtonLabel => r'ZOBRAZIŤ LICENCIE';
+}
+
+/// The translations for Slovenian (`sl`).
+class MaterialLocalizationSl extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Slovenian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationSl({
+    String localeName = 'sl',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'O aplikaciji $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'DOP.';
+
+  @override
+  String get backButtonTooltip => r'Nazaj';
+
+  @override
+  String get cancelButtonLabel => r'PREKLIČI';
+
+  @override
+  String get closeButtonLabel => r'ZAPRI';
+
+  @override
+  String get closeButtonTooltip => r'Zapiranje';
+
+  @override
+  String get continueButtonLabel => r'NAPREJ';
+
+  @override
+  String get copyButtonLabel => r'KOPIRAJ';
+
+  @override
+  String get cutButtonLabel => r'IZREŽI';
+
+  @override
+  String get deleteButtonTooltip => r'Brisanje';
+
+  @override
+  String get dialogLabel => r'Pogovorno okno';
+
+  @override
+  String get drawerLabel => r'Meni za krmarjenje';
+
+  @override
+  String get hideAccountsLabel => r'Skrivanje računov';
+
+  @override
+  String get licensesPageTitle => r'Licence';
+
+  @override
+  String get modalBarrierDismissLabel => r'Opusti';
+
+  @override
+  String get nextMonthTooltip => r'Naslednji mesec';
+
+  @override
+  String get nextPageTooltip => r'Naslednja stran';
+
+  @override
+  String get okButtonLabel => r'V REDU';
+
+  @override
+  String get openAppDrawerTooltip => r'Odpiranje menija za krmarjenje';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow od $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow od približno $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PRILEPI';
+
+  @override
+  String get popupMenuLabel => r'Pojavni meni';
+
+  @override
+  String get postMeridiemAbbreviation => r'POP.';
+
+  @override
+  String get previousMonthTooltip => r'Prejšnji mesec';
+
+  @override
+  String get previousPageTooltip => r'Prejšnja stran';
+
+  @override
+  String get rowsPerPageTitle => r'Vrstice na stran:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'IZBERI VSE';
+
+  @override
+  String get selectedRowCountTitleFew => r'Izbrani so $selectedRowCount elementi';
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Izbran je 1 element';
+
+  @override
+  String get selectedRowCountTitleOther => r'Izbranih je $selectedRowCount elementov';
+
+  @override
+  String get selectedRowCountTitleTwo => r'Izbrana sta $selectedRowCount elementa';
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Prikaz računov';
+
+  @override
+  String get showMenuTooltip => r'Prikaz menija';
+
+  @override
+  String get signedInLabel => r'Prijavljen';
+
+  @override
+  String get tabLabelRaw => r'Zavihek $tabIndex od $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Izberite ure';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Izberite minute';
+
+  @override
+  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
+}
+
+/// The translations for Serbian (`sr`).
+class MaterialLocalizationSr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Serbian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationSr({
+    String localeName = 'sr',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'О апликацији $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'пре подне';
+
+  @override
+  String get backButtonTooltip => r'Назад';
+
+  @override
+  String get cancelButtonLabel => r'ОТКАЖИ';
+
+  @override
+  String get closeButtonLabel => r'ЗАТВОРИ';
+
+  @override
+  String get closeButtonTooltip => r'Затворите';
+
+  @override
+  String get continueButtonLabel => r'НАСТАВИ';
+
+  @override
+  String get copyButtonLabel => r'КОПИРАЈ';
+
+  @override
+  String get cutButtonLabel => r'ИСЕЦИ';
+
+  @override
+  String get deleteButtonTooltip => r'Избришите';
+
+  @override
+  String get dialogLabel => r'Дијалог';
+
+  @override
+  String get drawerLabel => r'Мени за навигацију';
+
+  @override
+  String get hideAccountsLabel => r'Сакриј налоге';
+
+  @override
+  String get licensesPageTitle => r'Лиценце';
+
+  @override
+  String get modalBarrierDismissLabel => r'Одбаци';
+
+  @override
+  String get nextMonthTooltip => r'Следећи месец';
+
+  @override
+  String get nextPageTooltip => r'Следећа страница';
+
+  @override
+  String get okButtonLabel => r'Потврди';
+
+  @override
+  String get openAppDrawerTooltip => r'Отворите мени за навигацију';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow oд $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow oд приближно $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'НАЛЕПИ';
+
+  @override
+  String get popupMenuLabel => r'Искачући мени';
+
+  @override
+  String get postMeridiemAbbreviation => r'по подне';
+
+  @override
+  String get previousMonthTooltip => r'Претходни месец';
+
+  @override
+  String get previousPageTooltip => r'Претходна страница';
+
+  @override
+  String get rowsPerPageTitle => r'Редова по страници:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ИЗАБЕРИ СВЕ';
+
+  @override
+  String get selectedRowCountTitleFew => r'Изабране су $selectedRowCount ставке';
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Изабрана је 1 ставка';
+
+  @override
+  String get selectedRowCountTitleOther => r'Изабрано је $selectedRowCount ставки';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Прикажи налоге';
+
+  @override
+  String get showMenuTooltip => r'Прикажи мени';
+
+  @override
+  String get signedInLabel => r'Пријављени сте';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex. картица од $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Изаберите сате';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Изаберите минуте';
+
+  @override
+  String get viewLicensesButtonLabel => r'ПРИКАЖИ ЛИЦЕНЦЕ';
+}
+
+/// The translations for Serbian, using the Latin script (`sr_Latn`).
+class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
+  /// Create an instance of the translation bundle for Serbian, using the Latin script.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationSrLatn({
+    String localeName = 'sr_Latn',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
+
+  @override
+  String get openAppDrawerTooltip => r'Otvorite meni za navigaciju';
+
+  @override
+  String get backButtonTooltip => r'Nazad';
+
+  @override
+  String get closeButtonTooltip => r'Zatvorite';
+
+  @override
+  String get deleteButtonTooltip => r'Izbrišite';
+
+  @override
+  String get nextMonthTooltip => r'Sledeći mesec';
+
+  @override
+  String get previousMonthTooltip => r'Prethodni mesec';
+
+  @override
+  String get nextPageTooltip => r'Sledeća stranica';
+
+  @override
+  String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get showMenuTooltip => r'Prikaži meni';
+
+  @override
+  String get aboutListTileTitleRaw => r'O aplikaciji $applicationName';
+
+  @override
+  String get licensesPageTitle => r'Licence';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow od $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow od približno $rowCount';
+
+  @override
+  String get rowsPerPageTitle => r'Redova po stranici:';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex. kartica od $tabCount';
+
+  @override
+  String get selectedRowCountTitleOne => r'Izabrana je 1 stavka';
+
+  @override
+  String get selectedRowCountTitleOther => r'Izabrano je $selectedRowCount stavki';
+
+  @override
+  String get cancelButtonLabel => r'OTKAŽI';
+
+  @override
+  String get closeButtonLabel => r'ZATVORI';
+
+  @override
+  String get continueButtonLabel => r'NASTAVI';
+
+  @override
+  String get copyButtonLabel => r'KOPIRAJ';
+
+  @override
+  String get cutButtonLabel => r'ISECI';
+
+  @override
+  String get okButtonLabel => r'Potvrdi';
+
+  @override
+  String get pasteButtonLabel => r'NALEPI';
+
+  @override
+  String get selectAllButtonLabel => r'IZABERI SVE';
+
+  @override
+  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
+
+  @override
+  String get anteMeridiemAbbreviation => r'pre podne';
+
+  @override
+  String get postMeridiemAbbreviation => r'po podne';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Izaberite sate';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Izaberite minute';
+
+  @override
+  String get modalBarrierDismissLabel => r'Odbaci';
+
+  @override
+  String get signedInLabel => r'Prijavljeni ste';
+
+  @override
+  String get hideAccountsLabel => r'Sakrij naloge';
+
+  @override
+  String get showAccountsLabel => r'Prikaži naloge';
+
+  @override
+  String get drawerLabel => r'Meni za navigaciju';
+
+  @override
+  String get popupMenuLabel => r'Iskačući meni';
+
+  @override
+  String get dialogLabel => r'Dijalog';
+}
+
+/// The translations for Swedish (`sv`).
+class MaterialLocalizationSv extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Swedish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationSv({
+    String localeName = 'sv',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Om $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'FM';
+
+  @override
+  String get backButtonTooltip => r'Tillbaka';
+
+  @override
+  String get cancelButtonLabel => r'AVBRYT';
+
+  @override
+  String get closeButtonLabel => r'STÄNG';
+
+  @override
+  String get closeButtonTooltip => r'Stäng';
+
+  @override
+  String get continueButtonLabel => r'FORTSÄTT';
+
+  @override
+  String get copyButtonLabel => r'KOPIERA';
+
+  @override
+  String get cutButtonLabel => r'KLIPP UT';
+
+  @override
+  String get deleteButtonTooltip => r'Radera';
+
+  @override
+  String get dialogLabel => r'Dialogruta';
+
+  @override
+  String get drawerLabel => r'Navigeringsmeny';
+
+  @override
+  String get hideAccountsLabel => r'Dölj konton';
+
+  @override
+  String get licensesPageTitle => r'Licenser';
+
+  @override
+  String get modalBarrierDismissLabel => r'Stäng';
+
+  @override
+  String get nextMonthTooltip => r'Nästa månad';
+
+  @override
+  String get nextPageTooltip => r'Nästa sida';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Öppna navigeringsmenyn';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow av $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow av ungefär $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'KLISTRA IN';
+
+  @override
+  String get popupMenuLabel => r'Popup-meny';
+
+  @override
+  String get postMeridiemAbbreviation => r'EM';
+
+  @override
+  String get previousMonthTooltip => r'Föregående månad';
+
+  @override
+  String get previousPageTooltip => r'Föregående sida';
+
+  @override
+  String get rowsPerPageTitle => r'Rader per sida:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'MARKERA ALLA';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 objekt har markerats';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount objekt har markerats';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Visa konton';
+
+  @override
+  String get showMenuTooltip => r'Visa meny';
+
+  @override
+  String get signedInLabel => r'Inloggad';
+
+  @override
+  String get tabLabelRaw => r'Flik $tabIndex av $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Välj timmar';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Välj minuter';
+
+  @override
+  String get viewLicensesButtonLabel => r'VISA LICENSER';
+}
+
+/// The translations for Thai (`th`).
+class MaterialLocalizationTh extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Thai.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationTh({
+    String localeName = 'th',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'เกี่ยวกับ $applicationName';
+
+  @override
+  String get alertDialogLabel => r'เตือนภัย';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'กลับ';
+
+  @override
+  String get cancelButtonLabel => r'ยกเลิก';
+
+  @override
+  String get closeButtonLabel => r'ปิด';
+
+  @override
+  String get closeButtonTooltip => r'ปิด';
+
+  @override
+  String get continueButtonLabel => r'ต่อไป';
+
+  @override
+  String get copyButtonLabel => r'คัดลอก';
+
+  @override
+  String get cutButtonLabel => r'ตัด';
+
+  @override
+  String get deleteButtonTooltip => r'ลบ';
+
+  @override
+  String get dialogLabel => r'กล่องโต้ตอบ';
+
+  @override
+  String get drawerLabel => r'เมนูการนำทาง';
+
+  @override
+  String get hideAccountsLabel => r'ซ่อนบัญชี';
+
+  @override
+  String get licensesPageTitle => r'ใบอนุญาต';
+
+  @override
+  String get modalBarrierDismissLabel => r'ปิด';
+
+  @override
+  String get nextMonthTooltip => r'เดือนหน้า';
+
+  @override
+  String get nextPageTooltip => r'หน้าถัดไป';
+
+  @override
+  String get okButtonLabel => r'ตกลง';
+
+  @override
+  String get openAppDrawerTooltip => r'เปิดเมนูการนำทาง';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow จาก $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow จากประมาณ $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'วาง';
+
+  @override
+  String get popupMenuLabel => r'เมนูป๊อปอัป';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'เดือนที่แล้ว';
+
+  @override
+  String get previousPageTooltip => r'หน้าก่อน';
+
+  @override
+  String get rowsPerPageTitle => r'แถวต่อหน้า:';
+
+  @override
+  String get scriptCategory => r'tall';
+
+  @override
+  String get searchFieldLabel => r'ค้นหา';
+
+  @override
+  String get selectAllButtonLabel => r'เลือกทั้งหมด';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'เลือกแล้ว 1 รายการ';
+
+  @override
+  String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'แสดงบัญชี';
+
+  @override
+  String get showMenuTooltip => r'แสดงเมนู';
+
+  @override
+  String get signedInLabel => r'ลงชื่อเข้าใช้';
+
+  @override
+  String get tabLabelRaw => r'แท็บที่ $tabIndex จาก $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.a_space_h_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'เลือกชั่วโมง';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'เลือกนาที';
+
+  @override
+  String get viewLicensesButtonLabel => r'ดูใบอนุญาต';
+}
+
+/// The translations for Tagalog (`tl`).
+class MaterialLocalizationTl extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Tagalog.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationTl({
+    String localeName = 'tl',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Tungkol sa $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Bumalik';
+
+  @override
+  String get cancelButtonLabel => r'KANSELAHIN';
+
+  @override
+  String get closeButtonLabel => r'ISARA';
+
+  @override
+  String get closeButtonTooltip => r'Isara';
+
+  @override
+  String get continueButtonLabel => r'MAGPATULOY';
+
+  @override
+  String get copyButtonLabel => r'KOPYAHIN';
+
+  @override
+  String get cutButtonLabel => r'I-CUT';
+
+  @override
+  String get deleteButtonTooltip => r'I-delete';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Menu ng navigation';
+
+  @override
+  String get hideAccountsLabel => r'Itago ang mga account';
+
+  @override
+  String get licensesPageTitle => r'Mga Lisensya';
+
+  @override
+  String get modalBarrierDismissLabel => r'I-dismiss';
+
+  @override
+  String get nextMonthTooltip => r'Susunod na buwan';
+
+  @override
+  String get nextPageTooltip => r'Susunod na page';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Buksan ang menu ng navigation';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow ng $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow ng humigit kumulang $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'I-PASTE';
+
+  @override
+  String get popupMenuLabel => r'Popup na menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Nakaraang buwan';
+
+  @override
+  String get previousPageTooltip => r'Nakaraang page';
+
+  @override
+  String get rowsPerPageTitle => r'Mga row bawat page:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'PILIIN LAHAT';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item ang napili';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Ipakita ang mga account';
+
+  @override
+  String get showMenuTooltip => r'Ipakita ang menu';
+
+  @override
+  String get signedInLabel => r'Naka-sign in';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex ng $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Pumili ng mga oras';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Pumili ng mga minuto';
+
+  @override
+  String get viewLicensesButtonLabel => r'TINGNAN ANG MGA LISENSYA';
+}
+
+/// The translations for Turkish (`tr`).
+class MaterialLocalizationTr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Turkish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationTr({
+    String localeName = 'tr',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName Hakkında';
+
+  @override
+  String get alertDialogLabel => r'Alarm';
+
+  @override
+  String get anteMeridiemAbbreviation => r'ÖÖ';
+
+  @override
+  String get backButtonTooltip => r'Geri';
+
+  @override
+  String get cancelButtonLabel => r'İPTAL';
+
+  @override
+  String get closeButtonLabel => r'KAPAT';
+
+  @override
+  String get closeButtonTooltip => r'Kapat';
+
+  @override
+  String get continueButtonLabel => r'DEVAM';
+
+  @override
+  String get copyButtonLabel => r'KOPYALA';
+
+  @override
+  String get cutButtonLabel => r'KES';
+
+  @override
+  String get deleteButtonTooltip => r'Sil';
+
+  @override
+  String get dialogLabel => r'İletişim kutusu';
+
+  @override
+  String get drawerLabel => r'Gezinme menüsü';
+
+  @override
+  String get hideAccountsLabel => r'Hesapları gizle';
+
+  @override
+  String get licensesPageTitle => r'Lisanslar';
+
+  @override
+  String get modalBarrierDismissLabel => r'Kapat';
+
+  @override
+  String get nextMonthTooltip => r'Gelecek ay';
+
+  @override
+  String get nextPageTooltip => r'Sonraki sayfa';
+
+  @override
+  String get okButtonLabel => r'Tamam';
+
+  @override
+  String get openAppDrawerTooltip => r'Gezinme menüsünü aç';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow-$lastRow / $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow-$lastRow / $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'YAPIŞTIR';
+
+  @override
+  String get popupMenuLabel => r'Popup menü';
+
+  @override
+  String get postMeridiemAbbreviation => r'ÖS';
+
+  @override
+  String get previousMonthTooltip => r'Önceki ay';
+
+  @override
+  String get previousPageTooltip => r'Önceki sayfa';
+
+  @override
+  String get rowsPerPageTitle => r'Sayfa başına satır sayısı:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Arama';
+
+  @override
+  String get selectAllButtonLabel => r'TÜMÜNÜ SEÇ';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 öğe seçildi';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Hesapları göster';
+
+  @override
+  String get showMenuTooltip => r'Menüyü göster';
+
+  @override
+  String get signedInLabel => r'Oturum açıldı';
+
+  @override
+  String get tabLabelRaw => r'Sekme $tabIndex / $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Saati seçin';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Dakikayı seçin';
+
+  @override
+  String get viewLicensesButtonLabel => r'LİSANLARI GÖSTER';
+}
+
+/// The translations for Ukrainian (`uk`).
+class MaterialLocalizationUk extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Ukrainian.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationUk({
+    String localeName = 'uk',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Про додаток $applicationName';
+
+  @override
+  String get alertDialogLabel => r'TBD';
+
+  @override
+  String get anteMeridiemAbbreviation => r'дп';
+
+  @override
+  String get backButtonTooltip => r'Назад';
+
+  @override
+  String get cancelButtonLabel => r'СКАСУВАТИ';
+
+  @override
+  String get closeButtonLabel => r'ЗАКРИТИ';
+
+  @override
+  String get closeButtonTooltip => r'Закрити';
+
+  @override
+  String get continueButtonLabel => r'ПРОДОВЖИТИ';
+
+  @override
+  String get copyButtonLabel => r'КОПІЮВАТИ';
+
+  @override
+  String get cutButtonLabel => r'ВИРІЗАТИ';
+
+  @override
+  String get deleteButtonTooltip => r'Видалити';
+
+  @override
+  String get dialogLabel => r'Вікно';
+
+  @override
+  String get drawerLabel => r'Меню навігації';
+
+  @override
+  String get hideAccountsLabel => r'Сховати облікові записи';
+
+  @override
+  String get licensesPageTitle => r'Ліцензії';
+
+  @override
+  String get modalBarrierDismissLabel => r'Усунути';
+
+  @override
+  String get nextMonthTooltip => r'Наступний місяць';
+
+  @override
+  String get nextPageTooltip => r'Наступна сторінка';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Відкрити меню навігації';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow з $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow з приблизно $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'ВСТАВИТИ';
+
+  @override
+  String get popupMenuLabel => r'Спливаюче меню';
+
+  @override
+  String get postMeridiemAbbreviation => r'пп';
+
+  @override
+  String get previousMonthTooltip => r'Попередній місяць';
+
+  @override
+  String get previousPageTooltip => r'Попередня сторінка';
+
+  @override
+  String get rowsPerPageTitle => r'Рядків на сторінці:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'TBD';
+
+  @override
+  String get selectAllButtonLabel => r'ВИБРАТИ ВСІ';
+
+  @override
+  String get selectedRowCountTitleFew => r'Вибрано $selectedRowCount елементи';
+
+  @override
+  String get selectedRowCountTitleMany => r'Вибрано $selectedRowCount елементів';
+
+  @override
+  String get selectedRowCountTitleOne => r'Вибрано 1 елемент';
+
+  @override
+  String get selectedRowCountTitleOther => r'Вибрано $selectedRowCount елемента';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Показати облікові записи';
+
+  @override
+  String get showMenuTooltip => r'Показати меню';
+
+  @override
+  String get signedInLabel => r'Ви ввійшли';
+
+  @override
+  String get tabLabelRaw => r'Вкладка $tabIndex з $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Виберіть години';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Виберіть хвилини';
+
+  @override
+  String get viewLicensesButtonLabel => r'ПЕРЕГЛЯНУТИ ЛІЦЕНЗІЇ';
+}
+
+/// The translations for Urdu (`ur`).
+class MaterialLocalizationUr extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Urdu.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationUr({
+    String localeName = 'ur',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'$applicationName کے بارے میں';
+
+  @override
+  String get alertDialogLabel => r'انتباہ';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'پیچھے';
+
+  @override
+  String get cancelButtonLabel => r'منسوخ کریں';
+
+  @override
+  String get closeButtonLabel => r'بند کریں';
+
+  @override
+  String get closeButtonTooltip => r'بند کریں';
+
+  @override
+  String get continueButtonLabel => r'جاری رکھیں';
+
+  @override
+  String get copyButtonLabel => r'کاپی کریں';
+
+  @override
+  String get cutButtonLabel => r'کٹ کریں';
+
+  @override
+  String get deleteButtonTooltip => r'حذف کریں';
+
+  @override
+  String get dialogLabel => r'ڈائلاگ';
+
+  @override
+  String get drawerLabel => r'نیویگیشن مینو';
+
+  @override
+  String get hideAccountsLabel => r'اکاؤنٹس چھپائیں';
+
+  @override
+  String get licensesPageTitle => r'لائسنسز';
+
+  @override
+  String get modalBarrierDismissLabel => r'برخاست کریں';
+
+  @override
+  String get nextMonthTooltip => r'اگلا مہینہ';
+
+  @override
+  String get nextPageTooltip => r'اگلا صفحہ';
+
+  @override
+  String get okButtonLabel => r'ٹھیک ہے';
+
+  @override
+  String get openAppDrawerTooltip => r'نیویگیشن مینو کھولیں';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow از $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow $rowCount میں سے تقریباً';
+
+  @override
+  String get pasteButtonLabel => r'پیسٹ کریں';
+
+  @override
+  String get popupMenuLabel => r'پاپ اپ مینو';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'پچھلا مہینہ';
+
+  @override
+  String get previousPageTooltip => r'گزشتہ صفحہ';
+
+  @override
+  String get rowsPerPageTitle => r'قطاریں فی صفحہ:';
+
+  @override
+  String get scriptCategory => r'tall';
+
+  @override
+  String get searchFieldLabel => r'تلاش کریں';
+
+  @override
+  String get selectAllButtonLabel => r'سبھی منتخب کریں';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 آئٹم منتخب کیا گیا';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'اکاؤنٹس دکھائیں';
+
+  @override
+  String get showMenuTooltip => r'مینو دکھائیں';
+
+  @override
+  String get signedInLabel => r'سائن ان کردہ ہے';
+
+  @override
+  String get tabLabelRaw => r'$tabCount میں سے $tabIndex ٹیب';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'گھنٹے منتخب کریں';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'منٹ منتخب کریں';
+
+  @override
+  String get viewLicensesButtonLabel => r'لائسنسز دیکھیں';
+}
+
+/// The translations for Vietnamese (`vi`).
+class MaterialLocalizationVi extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Vietnamese.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationVi({
+    String localeName = 'vi',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'Giới thiệu về $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Hộp thoại';
+
+  @override
+  String get anteMeridiemAbbreviation => r'SÁNG';
+
+  @override
+  String get backButtonTooltip => r'Quay lại';
+
+  @override
+  String get cancelButtonLabel => r'HỦY';
+
+  @override
+  String get closeButtonLabel => r'ĐÓNG';
+
+  @override
+  String get closeButtonTooltip => r'Đóng';
+
+  @override
+  String get continueButtonLabel => r'TIẾP TỤC';
+
+  @override
+  String get copyButtonLabel => r'SAO CHÉP';
+
+  @override
+  String get cutButtonLabel => r'CẮT';
+
+  @override
+  String get deleteButtonTooltip => r'Xóa';
+
+  @override
+  String get dialogLabel => r'Hộp thoại';
+
+  @override
+  String get drawerLabel => r'Menu di chuyển';
+
+  @override
+  String get hideAccountsLabel => r'Ẩn tài khoản';
+
+  @override
+  String get licensesPageTitle => r'Giấy phép';
+
+  @override
+  String get modalBarrierDismissLabel => r'Bỏ qua';
+
+  @override
+  String get nextMonthTooltip => r'Tháng sau';
+
+  @override
+  String get nextPageTooltip => r'Trang tiếp theo';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Mở menu di chuyển';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow trong tổng số $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow trong tổng số khoảng $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'DÁN';
+
+  @override
+  String get popupMenuLabel => r'Menu bật lên';
+
+  @override
+  String get postMeridiemAbbreviation => r'CHIỀU';
+
+  @override
+  String get previousMonthTooltip => r'Tháng trước';
+
+  @override
+  String get previousPageTooltip => r'Trang trước';
+
+  @override
+  String get rowsPerPageTitle => r'Số hàng mỗi trang:';
+
+  @override
+  String get scriptCategory => r'English-like';
+
+  @override
+  String get searchFieldLabel => r'Tìm kiếm';
+
+  @override
+  String get selectAllButtonLabel => r'CHỌN TẤT CẢ';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'Đã chọn 1 mục';
+
+  @override
+  String get selectedRowCountTitleOther => r'Đã chọn $selectedRowCount mục';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'Hiển thị tài khoản';
+
+  @override
+  String get showMenuTooltip => r'Hiển thị menu';
+
+  @override
+  String get signedInLabel => r'Đã đăng nhập';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex trong tổng số $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Chọn giờ';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Chọn phút';
+
+  @override
+  String get viewLicensesButtonLabel => r'XEM GIẤY PHÉP';
+}
+
+/// The translations for Chinese (`zh`).
+class MaterialLocalizationZh extends GlobalMaterialLocalizations {
+  /// Create an instance of the translation bundle for Chinese.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationZh({
+    String localeName = 'zh',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'关于$applicationName';
+
+  @override
+  String get alertDialogLabel => r'警报';
+
+  @override
+  String get anteMeridiemAbbreviation => r'上午';
+
+  @override
+  String get backButtonTooltip => r'返回';
+
+  @override
+  String get cancelButtonLabel => r'取消';
+
+  @override
+  String get closeButtonLabel => r'关闭';
+
+  @override
+  String get closeButtonTooltip => r'关闭';
+
+  @override
+  String get continueButtonLabel => r'继续';
+
+  @override
+  String get copyButtonLabel => r'复制';
+
+  @override
+  String get cutButtonLabel => r'剪切';
+
+  @override
+  String get deleteButtonTooltip => r'删除';
+
+  @override
+  String get dialogLabel => r'对话框';
+
+  @override
+  String get drawerLabel => r'导航菜单';
+
+  @override
+  String get hideAccountsLabel => r'隐藏帐号';
+
+  @override
+  String get licensesPageTitle => r'许可';
+
+  @override
+  String get modalBarrierDismissLabel => r'关闭';
+
+  @override
+  String get nextMonthTooltip => r'下个月';
+
+  @override
+  String get nextPageTooltip => r'下一页';
+
+  @override
+  String get okButtonLabel => r'确定';
+
+  @override
+  String get openAppDrawerTooltip => r'打开导航菜单';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'第 $firstRow-$lastRow 行（共 $rowCount 行）';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'第 $firstRow-$lastRow 行（共约 $rowCount 行）';
+
+  @override
+  String get pasteButtonLabel => r'粘贴';
+
+  @override
+  String get popupMenuLabel => r'弹出菜单';
+
+  @override
+  String get postMeridiemAbbreviation => r'下午';
+
+  @override
+  String get previousMonthTooltip => r'上个月';
+
+  @override
+  String get previousPageTooltip => r'上一页';
+
+  @override
+  String get rowsPerPageTitle => r'每页行数：';
+
+  @override
+  String get scriptCategory => r'dense';
+
+  @override
+  String get searchFieldLabel => r'搜索';
+
+  @override
+  String get selectAllButtonLabel => r'全选';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'已选择 1 项内容';
+
+  @override
+  String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => null;
+
+  @override
+  String get showAccountsLabel => r'显示帐号';
+
+  @override
+  String get showMenuTooltip => r'显示菜单';
+
+  @override
+  String get signedInLabel => r'已登录';
+
+  @override
+  String get tabLabelRaw => r'第 $tabIndex 个标签，共 $tabCount 个';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.a_space_h_colon_mm;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'选择小时';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'选择分钟';
+
+  @override
+  String get viewLicensesButtonLabel => r'查看许可';
+}
+
+/// The translations for Chinese, as used in Hong Kong (`zh_HK`).
+class MaterialLocalizationZhHk extends MaterialLocalizationZh {
+  /// Create an instance of the translation bundle for Chinese, as used in Hong Kong.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationZhHk({
+    String localeName = 'zh_HK',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get tabLabelRaw => r'第 $tabIndex 個分頁 (共 $tabCount 個)';
+
+  @override
+  String get showAccountsLabel => r'顯示帳戶';
+
+  @override
+  String get modalBarrierDismissLabel => r'關閉';
+
+  @override
+  String get hideAccountsLabel => r'隱藏帳戶';
+
+  @override
+  String get signedInLabel => r'已登入帳戶';
+
+  @override
+  String get openAppDrawerTooltip => r'開啟導覽選單';
+
+  @override
+  String get closeButtonTooltip => r'關閉';
+
+  @override
+  String get deleteButtonTooltip => r'刪除';
+
+  @override
+  String get nextMonthTooltip => r'下個月';
+
+  @override
+  String get previousMonthTooltip => r'上個月';
+
+  @override
+  String get nextPageTooltip => r'下一頁';
+
+  @override
+  String get previousPageTooltip => r'上一頁';
+
+  @override
+  String get showMenuTooltip => r'顯示選單';
+
+  @override
+  String get aboutListTileTitleRaw => r'關於「$applicationName」';
+
+  @override
+  String get licensesPageTitle => r'授權';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
+
+  @override
+  String get rowsPerPageTitle => r'每頁列數：';
+
+  @override
+  String get selectedRowCountTitleOne => r'已選取 1 個項目';
+
+  @override
+  String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+
+  @override
+  String get closeButtonLabel => r'關閉';
+
+  @override
+  String get continueButtonLabel => r'繼續';
+
+  @override
+  String get copyButtonLabel => r'複製';
+
+  @override
+  String get cutButtonLabel => r'剪下';
+
+  @override
+  String get okButtonLabel => r'確定';
+
+  @override
+  String get pasteButtonLabel => r'貼上';
+
+  @override
+  String get selectAllButtonLabel => r'全選';
+
+  @override
+  String get viewLicensesButtonLabel => r'查看授權';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'選取小時數';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
+
+  @override
+  String get drawerLabel => r'導覽選單';
+
+  @override
+  String get popupMenuLabel => r'彈出式選單';
+
+  @override
+  String get dialogLabel => r'對話方塊';
+}
+
+/// The translations for Chinese, as used in Taiwan (`zh_TW`).
+class MaterialLocalizationZhTw extends MaterialLocalizationZh {
+  /// Create an instance of the translation bundle for Chinese, as used in Taiwan.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
+  const MaterialLocalizationZhTw({
+    String localeName = 'zh_TW',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get tabLabelRaw => r'第 $tabIndex 個分頁 (共 $tabCount 個)';
+
+  @override
+  String get showAccountsLabel => r'顯示帳戶';
+
+  @override
+  String get modalBarrierDismissLabel => r'關閉';
+
+  @override
+  String get hideAccountsLabel => r'隱藏帳戶';
+
+  @override
+  String get signedInLabel => r'已登入帳戶';
+
+  @override
+  String get openAppDrawerTooltip => r'開啟導覽選單';
+
+  @override
+  String get closeButtonTooltip => r'關閉';
+
+  @override
+  String get deleteButtonTooltip => r'刪除';
+
+  @override
+  String get nextMonthTooltip => r'下個月';
+
+  @override
+  String get previousMonthTooltip => r'上個月';
+
+  @override
+  String get nextPageTooltip => r'下一頁';
+
+  @override
+  String get previousPageTooltip => r'上一頁';
+
+  @override
+  String get showMenuTooltip => r'顯示選單';
+
+  @override
+  String get aboutListTileTitleRaw => r'關於「$applicationName」';
+
+  @override
+  String get licensesPageTitle => r'授權';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'第 $firstRow - $lastRow 列 (總共 $rowCount 列)';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'第 $firstRow - $lastRow 列 (總共約 $rowCount 列)';
+
+  @override
+  String get rowsPerPageTitle => r'每頁列數：';
+
+  @override
+  String get selectedRowCountTitleOne => r'已選取 1 個項目';
+
+  @override
+  String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+
+  @override
+  String get closeButtonLabel => r'關閉';
+
+  @override
+  String get continueButtonLabel => r'繼續';
+
+  @override
+  String get copyButtonLabel => r'複製';
+
+  @override
+  String get cutButtonLabel => r'剪下';
+
+  @override
+  String get okButtonLabel => r'確定';
+
+  @override
+  String get pasteButtonLabel => r'貼上';
+
+  @override
+  String get selectAllButtonLabel => r'全選';
+
+  @override
+  String get viewLicensesButtonLabel => r'查看授權';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'選取小時數';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'選取分鐘數';
+
+  @override
+  String get drawerLabel => r'導覽選單';
+
+  @override
+  String get popupMenuLabel => r'彈出式選單';
+
+  @override
+  String get dialogLabel => r'對話方塊';
+}
+
+/// The set of supported languages, as language code strings.
+///
+/// The [GlobalMaterialLocalizations.delegate] can generate localizations for
+/// any [Locale] with a language code from this set, regardless of the region.
+/// Some regions have specific support (e.g. `de` covers all forms of German,
+/// but there is support for `de-CH` specifically to override some of the
+/// translations for Switzerland).
+///
+/// See also:
+///
+///  * [getTranslation], whose documentation describes these values.
+final Set<String> kSupportedLanguages = new HashSet<String>.from(const <String>[
+  'ar', // Arabic
+  'bg', // Bulgarian
+  'bs', // Bosnian
+  'ca', // Catalan Valencian
+  'cs', // Czech
+  'da', // Danish
+  'de', // German
+  'el', // Modern Greek
+  'en', // English
+  'es', // Spanish Castilian
+  'et', // Estonian
+  'fa', // Persian
+  'fi', // Finnish
+  'fil', // Filipino Pilipino
+  'fr', // French
+  'gsw', // Swiss German Alemannic Alsatian
+  'he', // Hebrew
+  'hi', // Hindi
+  'hr', // Croatian
+  'hu', // Hungarian
+  'id', // Indonesian
+  'it', // Italian
+  'ja', // Japanese
+  'ko', // Korean
+  'lt', // Lithuanian
+  'lv', // Latvian
+  'ms', // Malay
+  'nb', // Norwegian Bokmål
+  'nl', // Dutch Flemish
+  'pl', // Polish
+  'ps', // Pushto Pashto
+  'pt', // Portuguese
+  'ro', // Romanian Moldavian Moldovan
+  'ru', // Russian
+  'sk', // Slovak
+  'sl', // Slovenian
+  'sr', // Serbian
+  'sv', // Swedish
+  'th', // Thai
+  'tl', // Tagalog
+  'tr', // Turkish
+  'uk', // Ukrainian
+  'ur', // Urdu
+  'vi', // Vietnamese
+  'zh', // Chinese
+]);
+
+/// Creates a [GlobalMaterialLocalizations] instance for the given `locale`.
+///
+/// All of the function's arguments except `locale` will be passed to the [new
+/// GlobalMaterialLocalizations] constructor. (The `localeName` argument of that
+/// constructor is specified by the actual subclass constructor by this
+/// function.)
+///
+/// The following locales are supported by this package:
+///
+/// {@template flutter.localizations.languages}
+///  * `ar` - Arabic
+///  * `bg` - Bulgarian
+///  * `bs` - Bosnian
+///  * `ca` - Catalan Valencian
+///  * `cs` - Czech
+///  * `da` - Danish
+///  * `de` - German (plus one variant)
+///  * `el` - Modern Greek
+///  * `en` - English (plus 7 variants)
+///  * `es` - Spanish Castilian (plus 20 variants)
+///  * `et` - Estonian
+///  * `fa` - Persian
+///  * `fi` - Finnish
+///  * `fil` - Filipino Pilipino
+///  * `fr` - French (plus one variant)
+///  * `gsw` - Swiss German Alemannic Alsatian
+///  * `he` - Hebrew
+///  * `hi` - Hindi
+///  * `hr` - Croatian
+///  * `hu` - Hungarian
+///  * `id` - Indonesian
+///  * `it` - Italian
+///  * `ja` - Japanese
+///  * `ko` - Korean
+///  * `lt` - Lithuanian
+///  * `lv` - Latvian
+///  * `ms` - Malay
+///  * `nb` - Norwegian Bokmål
+///  * `nl` - Dutch Flemish
+///  * `pl` - Polish
+///  * `ps` - Pushto Pashto
+///  * `pt` - Portuguese (plus one variant)
+///  * `ro` - Romanian Moldavian Moldovan
+///  * `ru` - Russian
+///  * `sk` - Slovak
+///  * `sl` - Slovenian
+///  * `sr` - Serbian (plus one variant)
+///  * `sv` - Swedish
+///  * `th` - Thai
+///  * `tl` - Tagalog
+///  * `tr` - Turkish
+///  * `uk` - Ukrainian
+///  * `ur` - Urdu
+///  * `vi` - Vietnamese
+///  * `zh` - Chinese (plus 2 variants)
+/// {@endtemplate}
+///
+/// Generally speaking, this method is only intended to be used by
+/// [GlobalMaterialLocalizations.delegate].
+GlobalMaterialLocalizations getTranslation(
+  Locale locale,
+  intl.DateFormat fullYearFormat,
+  intl.DateFormat mediumDateFormat,
+  intl.DateFormat longDateFormat,
+  intl.DateFormat yearMonthFormat,
+  intl.NumberFormat decimalFormat,
+  intl.NumberFormat twoDigitZeroPaddedFormat,
+) {
   switch (locale.languageCode) {
     case 'ar':
-      return const _Bundle_ar();
+      return new MaterialLocalizationAr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'bg':
-      return const _Bundle_bg();
+      return new MaterialLocalizationBg(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'bs':
-      return const _Bundle_bs();
+      return new MaterialLocalizationBs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ca':
-      return const _Bundle_ca();
+      return new MaterialLocalizationCa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'cs':
-      return const _Bundle_cs();
+      return new MaterialLocalizationCs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'da':
-      return const _Bundle_da();
+      return new MaterialLocalizationDa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'de': {
-      switch (locale.toString()) {
-        case 'de_CH':
-          return const _Bundle_de_CH();
+      switch (locale.countryCode) {
+        case 'CH':
+          return new MaterialLocalizationDeCh(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_de();
+      return new MaterialLocalizationDe(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'el':
-      return const _Bundle_el();
+      return new MaterialLocalizationEl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'en': {
-      switch (locale.toString()) {
-        case 'en_AU':
-          return const _Bundle_en_AU();
-        case 'en_CA':
-          return const _Bundle_en_CA();
-        case 'en_GB':
-          return const _Bundle_en_GB();
-        case 'en_IE':
-          return const _Bundle_en_IE();
-        case 'en_IN':
-          return const _Bundle_en_IN();
-        case 'en_SG':
-          return const _Bundle_en_SG();
-        case 'en_ZA':
-          return const _Bundle_en_ZA();
+      switch (locale.countryCode) {
+        case 'AU':
+          return new MaterialLocalizationEnAu(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'CA':
+          return new MaterialLocalizationEnCa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'GB':
+          return new MaterialLocalizationEnGb(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'IE':
+          return new MaterialLocalizationEnIe(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'IN':
+          return new MaterialLocalizationEnIn(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'SG':
+          return new MaterialLocalizationEnSg(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'ZA':
+          return new MaterialLocalizationEnZa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_en();
+      return new MaterialLocalizationEn(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'es': {
-      switch (locale.toString()) {
-        case 'es_419':
-          return const _Bundle_es_419();
-        case 'es_AR':
-          return const _Bundle_es_AR();
-        case 'es_BO':
-          return const _Bundle_es_BO();
-        case 'es_CL':
-          return const _Bundle_es_CL();
-        case 'es_CO':
-          return const _Bundle_es_CO();
-        case 'es_CR':
-          return const _Bundle_es_CR();
-        case 'es_DO':
-          return const _Bundle_es_DO();
-        case 'es_EC':
-          return const _Bundle_es_EC();
-        case 'es_GT':
-          return const _Bundle_es_GT();
-        case 'es_HN':
-          return const _Bundle_es_HN();
-        case 'es_MX':
-          return const _Bundle_es_MX();
-        case 'es_NI':
-          return const _Bundle_es_NI();
-        case 'es_PA':
-          return const _Bundle_es_PA();
-        case 'es_PE':
-          return const _Bundle_es_PE();
-        case 'es_PR':
-          return const _Bundle_es_PR();
-        case 'es_PY':
-          return const _Bundle_es_PY();
-        case 'es_SV':
-          return const _Bundle_es_SV();
-        case 'es_US':
-          return const _Bundle_es_US();
-        case 'es_UY':
-          return const _Bundle_es_UY();
-        case 'es_VE':
-          return const _Bundle_es_VE();
+      switch (locale.countryCode) {
+        case '419':
+          return new MaterialLocalizationEs419(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'AR':
+          return new MaterialLocalizationEsAr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'BO':
+          return new MaterialLocalizationEsBo(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'CL':
+          return new MaterialLocalizationEsCl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'CO':
+          return new MaterialLocalizationEsCo(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'CR':
+          return new MaterialLocalizationEsCr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'DO':
+          return new MaterialLocalizationEsDo(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'EC':
+          return new MaterialLocalizationEsEc(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'GT':
+          return new MaterialLocalizationEsGt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'HN':
+          return new MaterialLocalizationEsHn(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'MX':
+          return new MaterialLocalizationEsMx(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'NI':
+          return new MaterialLocalizationEsNi(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'PA':
+          return new MaterialLocalizationEsPa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'PE':
+          return new MaterialLocalizationEsPe(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'PR':
+          return new MaterialLocalizationEsPr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'PY':
+          return new MaterialLocalizationEsPy(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'SV':
+          return new MaterialLocalizationEsSv(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'US':
+          return new MaterialLocalizationEsUs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'UY':
+          return new MaterialLocalizationEsUy(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'VE':
+          return new MaterialLocalizationEsVe(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_es();
+      return new MaterialLocalizationEs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'et':
-      return const _Bundle_et();
+      return new MaterialLocalizationEt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'fa':
-      return const _Bundle_fa();
+      return new MaterialLocalizationFa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'fi':
-      return const _Bundle_fi();
+      return new MaterialLocalizationFi(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'fil':
-      return const _Bundle_fil();
+      return new MaterialLocalizationFil(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'fr': {
-      switch (locale.toString()) {
-        case 'fr_CA':
-          return const _Bundle_fr_CA();
+      switch (locale.countryCode) {
+        case 'CA':
+          return new MaterialLocalizationFrCa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_fr();
+      return new MaterialLocalizationFr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'gsw':
-      return const _Bundle_gsw();
+      return new MaterialLocalizationGsw(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'he':
-      return const _Bundle_he();
+      return new MaterialLocalizationHe(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'hi':
-      return const _Bundle_hi();
+      return new MaterialLocalizationHi(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'hr':
-      return const _Bundle_hr();
+      return new MaterialLocalizationHr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'hu':
-      return const _Bundle_hu();
+      return new MaterialLocalizationHu(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'id':
-      return const _Bundle_id();
+      return new MaterialLocalizationId(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'it':
-      return const _Bundle_it();
+      return new MaterialLocalizationIt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ja':
-      return const _Bundle_ja();
+      return new MaterialLocalizationJa(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ko':
-      return const _Bundle_ko();
+      return new MaterialLocalizationKo(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'lt':
-      return const _Bundle_lt();
+      return new MaterialLocalizationLt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'lv':
-      return const _Bundle_lv();
+      return new MaterialLocalizationLv(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ms':
-      return const _Bundle_ms();
+      return new MaterialLocalizationMs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'nb':
-      return const _Bundle_nb();
+      return new MaterialLocalizationNb(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'nl':
-      return const _Bundle_nl();
+      return new MaterialLocalizationNl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'pl':
-      return const _Bundle_pl();
+      return new MaterialLocalizationPl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ps':
-      return const _Bundle_ps();
+      return new MaterialLocalizationPs(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'pt': {
-      switch (locale.toString()) {
-        case 'pt_PT':
-          return const _Bundle_pt_PT();
+      switch (locale.countryCode) {
+        case 'PT':
+          return new MaterialLocalizationPtPt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_pt();
+      return new MaterialLocalizationPt(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'ro':
-      return const _Bundle_ro();
+      return new MaterialLocalizationRo(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ru':
-      return const _Bundle_ru();
+      return new MaterialLocalizationRu(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'sk':
-      return const _Bundle_sk();
+      return new MaterialLocalizationSk(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'sl':
-      return const _Bundle_sl();
+      return new MaterialLocalizationSl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'sr': {
-      switch (locale.toString()) {
-        case 'sr_Latn':
-          return const _Bundle_sr_Latn();
+      switch (locale.countryCode) {
+        case 'Latn':
+          return new MaterialLocalizationSrLatn(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_sr();
+      return new MaterialLocalizationSr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
     case 'sv':
-      return const _Bundle_sv();
+      return new MaterialLocalizationSv(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'th':
-      return const _Bundle_th();
+      return new MaterialLocalizationTh(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'tl':
-      return const _Bundle_tl();
+      return new MaterialLocalizationTl(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'tr':
-      return const _Bundle_tr();
+      return new MaterialLocalizationTr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'uk':
-      return const _Bundle_uk();
+      return new MaterialLocalizationUk(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'ur':
-      return const _Bundle_ur();
+      return new MaterialLocalizationUr(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'vi':
-      return const _Bundle_vi();
+      return new MaterialLocalizationVi(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     case 'zh': {
-      switch (locale.toString()) {
-        case 'zh_HK':
-          return const _Bundle_zh_HK();
-        case 'zh_TW':
-          return const _Bundle_zh_TW();
+      switch (locale.countryCode) {
+        case 'HK':
+          return new MaterialLocalizationZhHk(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
+        case 'TW':
+          return new MaterialLocalizationZhTw(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
       }
-      return const _Bundle_zh();
+      return new MaterialLocalizationZh(fullYearFormat: fullYearFormat, mediumDateFormat: mediumDateFormat, longDateFormat: longDateFormat, yearMonthFormat: yearMonthFormat, decimalFormat: decimalFormat, twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat);
     }
   }
-  return const TranslationBundle(null);
+  assert(false, 'getTranslation() called for unsupported locale "$locale"');
+  return null;
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -6,7 +6,8 @@
 
   "timeOfDayFormat": "h:mm a",
   "@timeOfDayFormat": {
-    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US"
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
   },
 
   "openAppDrawerTooltip": "Open navigation menu",

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -11,14 +11,25 @@ import 'package:intl/date_symbols.dart' as intl;
 import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
 import 'l10n/date_localizations.dart' as date_localizations;
 
-import 'l10n/localizations.dart' show TranslationBundle, translationBundleForLocale;
+import 'l10n/localizations.dart';
 import 'widgets_localizations.dart';
 
 // Watch out: the supported locales list in the doc comment below must be kept
 // in sync with the list we test, see test/translations_test.dart, and of course
 // the actual list of supported locales in _MaterialLocalizationsDelegate.
 
-/// Localized strings for the material widgets.
+/// Implementation of localized strings for the material widgets using the
+/// `intl` package for date and time formatting.
+///
+/// ## Supported languages
+///
+/// This class supports locales with the following [Locale.languageCode]s:
+///
+/// {@macro flutter.localizations.languages}
+///
+/// This list is available programatically via [kSupportedLanguages].
+///
+/// ## Sample code
 ///
 /// To include the localizations provided by this class in a [MaterialApp],
 /// add [GlobalMaterialLocalizations.delegates] to
@@ -29,133 +40,87 @@ import 'widgets_localizations.dart';
 /// new MaterialApp(
 ///   localizationsDelegates: GlobalMaterialLocalizations.delegates,
 ///   supportedLocales: [
-///     const Locale('en', 'US'), // English
-///     const Locale('he', 'IL'), // Hebrew
+///     const Locale('en', 'US'), // American English
+///     const Locale('he', 'IL'), // Israeli Hebrew
 ///     // ...
 ///   ],
 ///   // ...
 /// )
 /// ```
 ///
-/// This class supports locales with the following [Locale.languageCode]s:
+/// ## Overriding translations
 ///
-///   * ar - Arabic
-///   * bg - Bulgarian
-///   * bs - Bosnian
-///   * ca - Catalan
-///   * cs - Czech
-///   * da - Danish
-///   * de - German
-///   * el - Greek
-///   * en - English
-///   * es - Spanish
-///   * et - Estonian
-///   * fa - Farsi
-///   * fi - Finnish
-///   * fil - Fillipino
-///   * fr - French
-///   * gsw - Swiss German
-///   * hi - Hindi
-///   * he - Hebrew
-///   * hr - Croatian
-///   * hu - Hungarian
-///   * id - Indonesian
-///   * it - Italian
-///   * ja - Japanese
-///   * ko - Korean
-///   * lv - Latvian
-///   * lt - Lithuanian
-///   * ms - Malay
-///   * nl - Dutch
-///   * nb - Norwegian
-///   * pl - Polish
-///   * ps - Pashto
-///   * pt - Portuguese
-///   * ro - Romanian
-///   * ru - Russian
-///   * sk - Slovak
-///   * sl - Slovenian
-///   * sr - Serbian
-///   * sv - Swedish
-///   * tl - Tagalog
-///   * th - Thai
-///   * tr - Turkish
-///   * uk - Ukranian
-///   * ur - Urdu
-///   * vi - Vietnamese
-///   * zh - Simplified Chinese
+/// To create a translation that's similar to an existing language's translation
+/// but has slightly different strings, subclass the relevant translation
+/// directly and then create a [LocalizationsDelegate<MaterialLocalizations>]
+/// subclass to define how to load it.
+///
+/// Avoid subclassing an unrelated language (for example, subclassing
+/// [MaterialLocalizationEn] and then passing a non-English `localeName` to the
+/// constructor). Doing so will cause confusion for locale-specific behaviors;
+/// in particular, translations that use the `localeName` for determining how to
+/// pluralize will end up doing invalid things. Subclassing an existing
+/// language's translations is only suitable for making small changes to the
+/// existing strings. For providing a new language entirely, implement
+/// [MaterialLocalizations] directly.
 ///
 /// See also:
 ///
 ///  * The Flutter Internationalization Tutorial,
 ///    <https://flutter.io/tutorials/internationalization/>.
 ///  * [DefaultMaterialLocalizations], which only provides US English translations.
-class GlobalMaterialLocalizations implements MaterialLocalizations {
-  /// Constructs an object that defines the material widgets' localized strings
+abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
+  /// Initializes an object that defines the material widgets' localized strings
   /// for the given `locale`.
   ///
-  /// [LocalizationsDelegate] implementations typically call the static [load]
-  /// function, rather than constructing this class directly.
-  GlobalMaterialLocalizations(this.locale)
-      : assert(locale != null),
-        _localeName = _computeLocaleName(locale) {
-    _loadDateIntlDataIfNotLoaded();
-
-    _translationBundle = translationBundleForLocale(locale);
-    assert(_translationBundle != null);
-
-    if (intl.DateFormat.localeExists(_localeName)) {
-      _fullYearFormat = new intl.DateFormat.y(_localeName);
-      _mediumDateFormat = new intl.DateFormat.MMMEd(_localeName);
-      _longDateFormat = new intl.DateFormat.yMMMMEEEEd(_localeName);
-      _yearMonthFormat = new intl.DateFormat.yMMMM(_localeName);
-    } else if (intl.DateFormat.localeExists(locale.languageCode)) {
-      _fullYearFormat = new intl.DateFormat.y(locale.languageCode);
-      _mediumDateFormat = new intl.DateFormat.MMMEd(locale.languageCode);
-      _longDateFormat = new intl.DateFormat.yMMMMEEEEd(locale.languageCode);
-      _yearMonthFormat = new intl.DateFormat.yMMMM(locale.languageCode);
-    } else {
-      _fullYearFormat = new intl.DateFormat.y();
-      _mediumDateFormat = new intl.DateFormat.MMMEd();
-      _longDateFormat = new intl.DateFormat.yMMMMEEEEd();
-      _yearMonthFormat = new intl.DateFormat.yMMMM();
-    }
-
-    if (intl.NumberFormat.localeExists(_localeName)) {
-      _decimalFormat = new intl.NumberFormat.decimalPattern(_localeName);
-      _twoDigitZeroPaddedFormat = new intl.NumberFormat('00', _localeName);
-    } else if (intl.NumberFormat.localeExists(locale.languageCode)) {
-      _decimalFormat = new intl.NumberFormat.decimalPattern(locale.languageCode);
-      _twoDigitZeroPaddedFormat = new intl.NumberFormat('00', locale.languageCode);
-    } else {
-      _decimalFormat = new intl.NumberFormat.decimalPattern();
-      _twoDigitZeroPaddedFormat = new intl.NumberFormat('00');
-    }
-  }
-
-  /// The locale for which the values of this class's localized resources
-  /// have been translated.
-  final Locale locale;
+  /// The arguments are used for further runtime localization of data,
+  /// specifically for selecting plurals, date and time formatting, and number
+  /// formatting. They correspond to the following values:
+  ///
+  ///  1. The string that would be returned by [Intl.canonicalizedLocale] for
+  ///     the locale.
+  ///  2. The [intl.DateFormat] for [formatYear].
+  ///  3. The [intl.DateFormat] for [formatMediumDate].
+  ///  4. The [intl.DateFormat] for [formatFullDate].
+  ///  5. The [intl.DateFormat] for [formatMonthYear].
+  ///  6. The [NumberFormat] for [formatDecimal] (also used by [formatHour] and
+  ///     [formatTimeOfDay] when [timeOfDayFormat] doesn't use [HourFormat.HH]).
+  ///  7. The [NumberFormat] for [formatHour] and the hour part of
+  ///     [formatTimeOfDay] when [timeOfDayFormat] uses [HourFormat.HH], and for
+  ///     [formatMinute] and the minute part of [formatTimeOfDay].
+  ///
+  /// The [narrowWeekdays] and [firstDayOfWeekIndex] properties use the values
+  /// from the [intl.DateFormat] used by [formatFullDate].
+  const GlobalMaterialLocalizations({
+    @required String localeName,
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : assert(localeName != null),
+       this._localeName = localeName,
+       assert(fullYearFormat != null),
+       this._fullYearFormat = fullYearFormat,
+       assert(mediumDateFormat != null),
+       this._mediumDateFormat = mediumDateFormat,
+       assert(longDateFormat != null),
+       this._longDateFormat = longDateFormat,
+       assert(yearMonthFormat != null),
+       this._yearMonthFormat = yearMonthFormat,
+       assert(decimalFormat != null),
+       this._decimalFormat = decimalFormat,
+       assert(twoDigitZeroPaddedFormat != null),
+       this._twoDigitZeroPaddedFormat = twoDigitZeroPaddedFormat;
 
   final String _localeName;
-
-  TranslationBundle _translationBundle;
-
-  intl.NumberFormat _decimalFormat;
-
-  intl.NumberFormat _twoDigitZeroPaddedFormat;
-
-  intl.DateFormat _fullYearFormat;
-
-  intl.DateFormat _mediumDateFormat;
-
-  intl.DateFormat _longDateFormat;
-
-  intl.DateFormat _yearMonthFormat;
-
-  static String _computeLocaleName(Locale locale) {
-    return intl.Intl.canonicalizedLocale(locale.toString());
-  }
+  final intl.DateFormat _fullYearFormat;
+  final intl.DateFormat _mediumDateFormat;
+  final intl.DateFormat _longDateFormat;
+  final intl.DateFormat _yearMonthFormat;
+  final intl.NumberFormat _decimalFormat;
+  final intl.NumberFormat _twoDigitZeroPaddedFormat;
 
   @override
   String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat = false }) {
@@ -198,11 +163,11 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   @override
   List<String> get narrowWeekdays {
-    return _fullYearFormat.dateSymbols.NARROWWEEKDAYS;
+    return _longDateFormat.dateSymbols.NARROWWEEKDAYS;
   }
 
   @override
-  int get firstDayOfWeekIndex => (_fullYearFormat.dateSymbols.FIRSTDAYOFWEEK + 1) % 7;
+  int get firstDayOfWeekIndex => (_longDateFormat.dateSymbols.FIRSTDAYOFWEEK + 1) % 7;
 
   @override
   String formatDecimal(int number) {
@@ -234,7 +199,6 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
       case TimeOfDayFormat.frenchCanadian:
         return '$hour h $minute';
     }
-
     return null;
   }
 
@@ -248,152 +212,162 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
     return null;
   }
 
-  @override
-  String get openAppDrawerTooltip => _translationBundle.openAppDrawerTooltip;
-
-  @override
-  String get backButtonTooltip => _translationBundle.backButtonTooltip;
-
-  @override
-  String get closeButtonTooltip => _translationBundle.closeButtonTooltip;
-
-  @override
-  String get deleteButtonTooltip => _translationBundle.deleteButtonTooltip;
-
-  @override
-  String get nextMonthTooltip => _translationBundle.nextMonthTooltip;
-
-  @override
-  String get previousMonthTooltip => _translationBundle.previousMonthTooltip;
-
-  @override
-  String get nextPageTooltip => _translationBundle.nextPageTooltip;
-
-  @override
-  String get previousPageTooltip => _translationBundle.previousPageTooltip;
-
-  @override
-  String get showMenuTooltip => _translationBundle.showMenuTooltip;
-
-  @override
-  String get drawerLabel => _translationBundle.alertDialogLabel;
-
-  @override
-  String get popupMenuLabel => _translationBundle.popupMenuLabel;
-
-  @override
-  String get dialogLabel => _translationBundle.dialogLabel;
-
-  @override
-  String get alertDialogLabel => _translationBundle.alertDialogLabel;
-
-  @override
-  String get searchFieldLabel => _translationBundle.searchFieldLabel;
+  /// The raw version of [aboutListTileTitle], with `$applicationName` verbatim
+  /// in the string.
+  @protected
+  String get aboutListTileTitleRaw;
 
   @override
   String aboutListTileTitle(String applicationName) {
-    final String text = _translationBundle.aboutListTileTitle;
+    final String text = aboutListTileTitleRaw;
     return text.replaceFirst(r'$applicationName', applicationName);
   }
 
-  @override
-  String get licensesPageTitle => _translationBundle.licensesPageTitle;
+  /// The raw version of [pageRowsInfoTitle], with `$firstRow`, `$lastRow`' and
+  /// `$rowCount` verbatim in the string, for the case where the value is
+  /// approximate.
+  @protected
+  String get pageRowsInfoTitleApproximateRaw;
+
+  /// The raw version of [pageRowsInfoTitle], with `$firstRow`, `$lastRow`' and
+  /// `$rowCount` verbatim in the string, for the case where the value is
+  /// precise.
+  @protected
+  String get pageRowsInfoTitleRaw;
 
   @override
   String pageRowsInfoTitle(int firstRow, int lastRow, int rowCount, bool rowCountIsApproximate) {
-    String text = rowCountIsApproximate ? _translationBundle.pageRowsInfoTitleApproximate : null;
-    text ??= _translationBundle.pageRowsInfoTitle;
-    assert(text != null, 'A $locale localization was not found for pageRowsInfoTitle or pageRowsInfoTitleApproximate');
-    // TODO(hansmuller): this could be more efficient.
+    String text = rowCountIsApproximate ? pageRowsInfoTitleApproximateRaw : null;
+    text ??= pageRowsInfoTitleRaw;
+    assert(text != null, 'A $_localeName localization was not found for pageRowsInfoTitle or pageRowsInfoTitleApproximate');
     return text
       .replaceFirst(r'$firstRow', formatDecimal(firstRow))
       .replaceFirst(r'$lastRow', formatDecimal(lastRow))
       .replaceFirst(r'$rowCount', formatDecimal(rowCount));
   }
 
-  @override
-  String get rowsPerPageTitle => _translationBundle.rowsPerPageTitle;
+  /// The raw version of [tabLabel], with `$tabIndex` and `$tabCount` verbatim
+  /// in the string.
+  @protected
+  String get tabLabelRaw;
 
   @override
   String tabLabel({int tabIndex, int tabCount}) {
     assert(tabIndex >= 1);
     assert(tabCount >= 1);
-    final String template = _translationBundle.tabLabel;
+    final String template = tabLabelRaw;
     return template
       .replaceFirst(r'$tabIndex', formatDecimal(tabIndex))
       .replaceFirst(r'$tabCount', formatDecimal(tabCount));
   }
 
+  /// The "zero" form of [selectedRowCountTitle].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  ///  * [selectedRowCountTitleOther], the "other" form
+  @protected
+  String get selectedRowCountTitleZero => null;
+
+  /// The "one" form of [selectedRowCountTitle].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  ///  * [selectedRowCountTitleOther], the "other" form
+  @protected
+  String get selectedRowCountTitleOne => null;
+
+  /// The "two" form of [selectedRowCountTitle].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  ///  * [selectedRowCountTitleOther], the "other" form
+  @protected
+  String get selectedRowCountTitleTwo => null;
+
+  /// The "few" form of [selectedRowCountTitle].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  ///  * [selectedRowCountTitleOther], the "other" form
+  @protected
+  String get selectedRowCountTitleFew => null;
+
+  /// The "many" form of [selectedRowCountTitle].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleOther], the "other" form
+  @protected
+  String get selectedRowCountTitleMany => null;
+
+  /// The "other" form of [selectedRowCountTitle].
+  ///
+  /// This form is required.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  @protected
+  String get selectedRowCountTitleOther;
+
   @override
   String selectedRowCountTitle(int selectedRowCount) {
-    // TODO(hmuller): the rules for mapping from an integer value to
-    // "one" or "two" etc. are locale specific and an additional "few" category
-    // is needed. See http://cldr.unicode.org/index/cldr-spec/plural-rules
-    String text;
-    if (selectedRowCount == 0)
-      text = _translationBundle.selectedRowCountTitleZero;
-    else if (selectedRowCount == 1)
-      text = _translationBundle.selectedRowCountTitleOne;
-    else if (selectedRowCount == 2)
-      text = _translationBundle.selectedRowCountTitleTwo;
-    else if (selectedRowCount > 2)
-      text = _translationBundle.selectedRowCountTitleMany;
-    text ??= _translationBundle.selectedRowCountTitleOther;
-    assert(text != null);
-
-    return text.replaceFirst(r'$selectedRowCount', formatDecimal(selectedRowCount));
+    return intl.Intl.plural(
+      selectedRowCount,
+      zero: selectedRowCountTitleZero,
+      one: selectedRowCountTitleOne,
+      two: selectedRowCountTitleTwo,
+      few: selectedRowCountTitleFew,
+      many: selectedRowCountTitleMany,
+      other: selectedRowCountTitleOther,
+      locale: _localeName,
+    ).replaceFirst(r'$selectedRowCount', formatDecimal(selectedRowCount));
   }
 
-  @override
-  String get cancelButtonLabel => _translationBundle.cancelButtonLabel;
-
-  @override
-  String get closeButtonLabel => _translationBundle.closeButtonLabel;
-
-  @override
-  String get continueButtonLabel => _translationBundle.continueButtonLabel;
-
-  @override
-  String get copyButtonLabel => _translationBundle.copyButtonLabel;
-
-  @override
-  String get cutButtonLabel => _translationBundle.cutButtonLabel;
-
-  @override
-  String get okButtonLabel => _translationBundle.okButtonLabel;
-
-  @override
-  String get pasteButtonLabel => _translationBundle.pasteButtonLabel;
-
-  @override
-  String get selectAllButtonLabel => _translationBundle.selectAllButtonLabel;
-
-  @override
-  String get viewLicensesButtonLabel => _translationBundle.viewLicensesButtonLabel;
-
-  @override
-  String get anteMeridiemAbbreviation => _translationBundle.anteMeridiemAbbreviation;
-
-  @override
-  String get postMeridiemAbbreviation => _translationBundle.postMeridiemAbbreviation;
-
-  @override
-  String get timePickerHourModeAnnouncement => _translationBundle.timePickerHourModeAnnouncement;
-
-  @override
-  String get timePickerMinuteModeAnnouncement => _translationBundle.timePickerMinuteModeAnnouncement;
-
-  @override
-  String get modalBarrierDismissLabel => _translationBundle.modalBarrierDismissLabel;
-
-  @override
-  String get signedInLabel => _translationBundle.signedInLabel;
-
-  @override
-  String get hideAccountsLabel => _translationBundle.hideAccountsLabel;
-
-  @override
-  String get showAccountsLabel => _translationBundle.showAccountsLabel;
+  /// The format to use for [timeOfDayFormat].
+  @protected
+  TimeOfDayFormat get timeOfDayFormatRaw;
 
   /// The [TimeOfDayFormat] corresponding to one of the following supported
   /// patterns:
@@ -409,44 +383,28 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///
   /// See also:
   ///
-  ///  * http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US shows the
-  ///    short time pattern used in locale en_US
+  ///  * <http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US>, which shows
+  ///    the short time pattern used in the `en_US` locale.
   @override
   TimeOfDayFormat timeOfDayFormat({ bool alwaysUse24HourFormat = false }) {
-    final String icuShortTimePattern = _translationBundle.timeOfDayFormat;
-
-    assert(() {
-      if (!_icuTimeOfDayToEnum.containsKey(icuShortTimePattern)) {
-        throw new FlutterError(
-          '"$icuShortTimePattern" is not one of the ICU short time patterns '
-          'supported by the material library. Here is the list of supported '
-          'patterns:\n  ' +
-          _icuTimeOfDayToEnum.keys.join('\n  ')
-        );
-      }
-      return true;
-    }());
-
-    final TimeOfDayFormat icuFormat = _icuTimeOfDayToEnum[icuShortTimePattern];
-
+    assert(alwaysUse24HourFormat != null);
     if (alwaysUse24HourFormat)
-      return _get24HourVersionOf(icuFormat);
-
-    return icuFormat;
+      return _get24HourVersionOf(timeOfDayFormatRaw);
+    return timeOfDayFormatRaw;
   }
+
+  /// The script category used by [localTextGeometry]. Must be one of the strings
+  /// declared in [MaterialTextGeometry].
+  ///
+  /// TODO(ianh): make this return a TextTheme from MaterialTextGeometry.
+  /// TODO(ianh): drop the constructor on MaterialTextGeometry.
+  /// TODO(ianh): drop the strings on MaterialTextGeometry.
+  @protected
+  String get scriptCategory;
 
   /// Looks up text geometry defined in [MaterialTextGeometry].
   @override
-  TextTheme get localTextGeometry => MaterialTextGeometry.forScriptCategory(_translationBundle.scriptCategory);
-
-  /// Creates an object that provides localized resource values for the
-  /// for the widgets of the material library.
-  ///
-  /// This method is typically used to create a [LocalizationsDelegate].
-  /// The [MaterialApp] does so by default.
-  static Future<MaterialLocalizations> load(Locale locale) {
-    return new SynchronousFuture<MaterialLocalizations>(new GlobalMaterialLocalizations(locale));
-  }
+  TextTheme get localTextGeometry => MaterialTextGeometry.forScriptCategory(scriptCategory);
 
   /// A [LocalizationsDelegate] that uses [GlobalMaterialLocalizations.load]
   /// to create an instance of this class.
@@ -458,6 +416,8 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   /// A value for [MaterialApp.localizationsDelegates] that's typically used by
   /// internationalized apps.
+  ///
+  /// ## Sample code
   ///
   /// To include the localizations provided by this class and by
   /// [GlobalWidgetsLocalizations] in a [MaterialApp],
@@ -481,17 +441,6 @@ class GlobalMaterialLocalizations implements MaterialLocalizations {
   ];
 }
 
-const Map<String, TimeOfDayFormat> _icuTimeOfDayToEnum = <String, TimeOfDayFormat>{
-  'HH:mm': TimeOfDayFormat.HH_colon_mm,
-  'HH.mm': TimeOfDayFormat.HH_dot_mm,
-  "HH 'h' mm": TimeOfDayFormat.frenchCanadian,
-  'HH:mm น.': TimeOfDayFormat.HH_colon_mm,
-  'H:mm': TimeOfDayFormat.H_colon_mm,
-  'h:mm a': TimeOfDayFormat.h_colon_mm_space_a,
-  'a h:mm': TimeOfDayFormat.a_space_h_colon_mm,
-  'ah:mm': TimeOfDayFormat.a_space_h_colon_mm,
-};
-
 /// Finds the [TimeOfDayFormat] to use instead of the `original` when the
 /// `original` uses 12-hour format and [MediaQueryData.alwaysUse24HourFormat]
 /// is true.
@@ -509,86 +458,91 @@ TimeOfDayFormat _get24HourVersionOf(TimeOfDayFormat original) {
   return TimeOfDayFormat.HH_colon_mm;
 }
 
-/// Tracks if date i18n data has been loaded.
-bool _dateIntlDataInitialized = false;
-
-/// Loads i18n data for dates if it hasn't be loaded yet.
-///
-/// Only the first invocation of this function has the effect of loading the
-/// data. Subsequent invocations have no effect.
-void _loadDateIntlDataIfNotLoaded() {
-  if (!_dateIntlDataInitialized) {
-    date_localizations.dateSymbols.forEach((String locale, dynamic data) {
-      assert(date_localizations.datePatterns.containsKey(locale));
-      final intl.DateSymbols symbols = new intl.DateSymbols.deserializeFromMap(data);
-      date_symbol_data_custom.initializeDateFormattingCustom(
-        locale: locale,
-        symbols: symbols,
-        patterns: date_localizations.datePatterns[locale],
-      );
-    });
-    _dateIntlDataInitialized = true;
-  }
-}
-
 class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   const _MaterialLocalizationsDelegate();
 
-  // Watch out: this list must match the one in the GlobalMaterialLocalizations
-  // class doc and the list we test, see test/translations_test.dart.
-  static const List<String> _supportedLanguages = <String>[
-    'ar', // Arabic
-    'bg', // Bulgarian
-    'bs', // Bosnian
-    'ca', // Catalan
-    'cs', // Czech
-    'da', // Danish
-    'de', // German
-    'el', // Greek
-    'en', // English
-    'es', // Spanish
-    'et', // Estonian
-    'fa', // Farsi (Persian)
-    'fi', // Finnish
-    'fil', //  Fillipino
-    'fr', // French
-    'gsw', // Swiss German
-    'he', // Hebrew
-    'hi', // Hindi
-    'hr', // Croatian
-    'hu', // Hungarian
-    'id', // Indonesian
-    'it', // Italian
-    'ja', // Japanese
-    'ko', // Korean
-    'lv', // Latvian
-    'lt', // Lithuanian
-    'ms', // Malay
-    'nl', // Dutch
-    'nb', // Norwegian
-    'pl', // Polish
-    'ps', // Pashto
-    'pt', // Portugese
-    'ro', // Romanian
-    'ru', // Russian
-    'sr', // Serbian
-    'sk', // Slovak
-    'sl', // Slovenian
-    'th', // Thai
-    'sv', // Swedish
-    'tl', // Tagalog
-    'tr', // Turkish
-    'uk', // Ukranian
-    'ur', // Urdu
-    'vi', // Vietnamese
-    'zh', // Chinese (simplified)
-  ];
+  @override
+  bool isSupported(Locale locale) => kSupportedLanguages.contains(locale.languageCode);
+
+  /// Tracks if date i18n data has been loaded.
+  static bool _dateIntlDataInitialized = false;
+
+  /// Loads i18n data for dates if it hasn't be loaded yet.
+  ///
+  /// Only the first invocation of this function has the effect of loading the
+  /// data. Subsequent invocations have no effect.
+  static void _loadDateIntlDataIfNotLoaded() {
+    if (!_dateIntlDataInitialized) {
+      date_localizations.dateSymbols.forEach((String locale, dynamic data) {
+        assert(date_localizations.datePatterns.containsKey(locale));
+        final intl.DateSymbols symbols = new intl.DateSymbols.deserializeFromMap(data);
+        date_symbol_data_custom.initializeDateFormattingCustom(
+          locale: locale,
+          symbols: symbols,
+          patterns: date_localizations.datePatterns[locale],
+        );
+      });
+      _dateIntlDataInitialized = true;
+    }
+  }
+
+  static final Map<Locale, Future<MaterialLocalizations>> _loadedTranslations = <Locale, Future<MaterialLocalizations>>{};
 
   @override
-  bool isSupported(Locale locale) => _supportedLanguages.contains(locale.languageCode);
+  Future<MaterialLocalizations> load(Locale locale) {
+    assert(isSupported(locale));
+    return _loadedTranslations.putIfAbsent(locale, () {
+      _loadDateIntlDataIfNotLoaded();
 
-  @override
-  Future<MaterialLocalizations> load(Locale locale) => GlobalMaterialLocalizations.load(locale);
+      final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+      intl.DateFormat fullYearFormat;
+      intl.DateFormat mediumDateFormat;
+      intl.DateFormat longDateFormat;
+      intl.DateFormat yearMonthFormat;
+      if (intl.DateFormat.localeExists(localeName)) {
+        fullYearFormat = new intl.DateFormat.y(localeName);
+        mediumDateFormat = new intl.DateFormat.MMMEd(localeName);
+        longDateFormat = new intl.DateFormat.yMMMMEEEEd(localeName);
+        yearMonthFormat = new intl.DateFormat.yMMMM(localeName);
+      } else if (intl.DateFormat.localeExists(locale.languageCode)) {
+        fullYearFormat = new intl.DateFormat.y(locale.languageCode);
+        mediumDateFormat = new intl.DateFormat.MMMEd(locale.languageCode);
+        longDateFormat = new intl.DateFormat.yMMMMEEEEd(locale.languageCode);
+        yearMonthFormat = new intl.DateFormat.yMMMM(locale.languageCode);
+      } else {
+        fullYearFormat = new intl.DateFormat.y();
+        mediumDateFormat = new intl.DateFormat.MMMEd();
+        longDateFormat = new intl.DateFormat.yMMMMEEEEd();
+        yearMonthFormat = new intl.DateFormat.yMMMM();
+      }
+
+      intl.NumberFormat decimalFormat;
+      intl.NumberFormat twoDigitZeroPaddedFormat;
+      if (intl.NumberFormat.localeExists(localeName)) {
+        decimalFormat = new intl.NumberFormat.decimalPattern(localeName);
+        twoDigitZeroPaddedFormat = new intl.NumberFormat('00', localeName);
+      } else if (intl.NumberFormat.localeExists(locale.languageCode)) {
+        decimalFormat = new intl.NumberFormat.decimalPattern(locale.languageCode);
+        twoDigitZeroPaddedFormat = new intl.NumberFormat('00', locale.languageCode);
+      } else {
+        decimalFormat = new intl.NumberFormat.decimalPattern();
+        twoDigitZeroPaddedFormat = new intl.NumberFormat('00');
+      }
+
+      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
+
+      return new SynchronousFuture<MaterialLocalizations>(getTranslation(
+        locale,
+        fullYearFormat,
+        mediumDateFormat,
+        longDateFormat,
+        yearMonthFormat,
+        decimalFormat,
+        twoDigitZeroPaddedFormat,
+      ));
+    });
+  }
 
   @override
   bool shouldReload(_MaterialLocalizationsDelegate old) => false;

--- a/packages/flutter_localizations/test/date_time_test.dart
+++ b/packages/flutter_localizations/test/date_time_test.dart
@@ -10,19 +10,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group(GlobalMaterialLocalizations, () {
-    test('uses exact locale when exists', () {
-      final GlobalMaterialLocalizations localizations = new GlobalMaterialLocalizations(const Locale('pt', 'PT'));
+    test('uses exact locale when exists', () async {
+      final GlobalMaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('pt', 'PT'));
       expect(localizations.formatDecimal(10000), '10\u00A0000');
     });
 
-    test('falls back to language code when exact locale is missing', () {
-      final GlobalMaterialLocalizations localizations = new GlobalMaterialLocalizations(const Locale('pt', 'XX'));
+    test('falls back to language code when exact locale is missing', () async {
+      final GlobalMaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('pt', 'XX'));
       expect(localizations.formatDecimal(10000), '10.000');
     });
 
-    test('falls back to default format when neither language code nor exact locale are available', () {
-      final GlobalMaterialLocalizations localizations = new GlobalMaterialLocalizations(const Locale('xx', 'XX'));
-      expect(localizations.formatDecimal(10000), '10,000');
+    test('fails when neither language code nor exact locale are available', () async {
+      await expectLater(() async {
+        await GlobalMaterialLocalizations.delegate.load(const Locale('xx', 'XX'));
+      }, throwsAssertionError);
     });
 
     group('formatHour', () {
@@ -65,8 +66,8 @@ void main() {
     });
 
     group('formatMinute', () {
-      test('formats English', () {
-        final GlobalMaterialLocalizations localizations = new GlobalMaterialLocalizations(const Locale('en', 'US'));
+      test('formats English', () async {
+        final GlobalMaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en', 'US'));
         expect(localizations.formatMinute(const TimeOfDay(hour: 1, minute: 32)), '32');
       });
     });

--- a/packages/flutter_localizations/test/override_test.dart
+++ b/packages/flutter_localizations/test/override_test.dart
@@ -6,9 +6,21 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart' as intl;
 
-class FooMaterialLocalizations extends GlobalMaterialLocalizations {
-  FooMaterialLocalizations(Locale locale, this.backButtonTooltip) : super(locale);
+class FooMaterialLocalizations extends MaterialLocalizationEn {
+  FooMaterialLocalizations(
+    Locale localeName,
+    this.backButtonTooltip,
+  ) : super(
+    localeName: localeName.toString(),
+    fullYearFormat: new intl.DateFormat.y(),
+    mediumDateFormat: new intl.DateFormat('E, MMM\u00a0d'),
+    longDateFormat: new intl.DateFormat.yMMMMEEEEd(),
+    yearMonthFormat: new intl.DateFormat.yMMMM(),
+    decimalFormat: new intl.NumberFormat.decimalPattern(),
+    twoDigitZeroPaddedFormat: new intl.NumberFormat('00'),
+  );
 
   @override
   final String backButtonTooltip;
@@ -44,7 +56,7 @@ Widget buildFrame({
   LocaleResolutionCallback localeResolutionCallback,
   Iterable<Locale> supportedLocales = const <Locale>[
     Locale('en', 'US'),
-    Locale('es', 'es'),
+    Locale('es', 'ES'),
   ],
 }) {
   return new MaterialApp(
@@ -81,12 +93,12 @@ void main() {
     expect(tester.widget<Text>(find.byKey(textKey)).data, 'Back');
 
     // Unrecognized locale falls back to 'en'
-    await tester.binding.setLocale('foo', 'bar');
+    await tester.binding.setLocale('foo', 'BAR');
     await tester.pump();
     expect(tester.widget<Text>(find.byKey(textKey)).data, 'Back');
 
     // Spanish Bolivia locale, falls back to just 'es'
-    await tester.binding.setLocale('es', 'bo');
+    await tester.binding.setLocale('es', 'BO');
     await tester.pump();
     expect(tester.widget<Text>(find.byKey(textKey)).data, 'Atrás');
   });
@@ -169,7 +181,6 @@ void main() {
           Locale('de', ''),
         ],
         buildContent: (BuildContext context) {
-          // Should always be 'foo', no matter what the locale is
           return new Text(
             MaterialLocalizations.of(context).backButtonTooltip,
             key: textKey,

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -7,63 +7,13 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // Watch out: this list must be kept in sync with the comment at the top of
-  // GlobalMaterialLocalizations.
-  final List<String> languages = <String>[
-    'ar', // Arabic
-    'bg', // Bulgarian
-    'bs', // Bosnian
-    'ca', // Catalan
-    'cs', // Czech
-    'da', // Danish
-    'de', // German
-    'el', // Greek
-    'en', // English
-    'es', // Spanish
-    'et', // Estonian
-    'fa', // Farsi (Persian)
-    'fi', // Finnish
-    'fil', //  Fillipino
-    'fr', // French
-    'gsw', // Swiss German
-    'he', // Hebrew
-    'hi', // Hindi
-    'hr', // Croatian
-    'hu', // Hungarian
-    'id', // Indonesian
-    'it', // Italian
-    'ja', // Japanese
-    'ko', // Korean
-    'lv', // Latvian
-    'lt', // Lithuanian
-    'ms', // Malay
-    'nl', // Dutch
-    'nb', // Norwegian
-    'pl', // Polish
-    'ps', // Pashto
-    'pt', // Portugese
-    'ro', // Romanian
-    'ru', // Russian
-    'sr', // Serbian
-    'sk', // Slovak
-    'sl', // Slovenian
-    'sv', // Swedish
-    'th', // Thai
-    'tl', // Tagalog
-    'tr', // Turkish
-    'uk', // Ukranian
-    'ur', // Urdu
-    'vi', // Vietnamese
-    'zh', // Chinese (simplified)
-  ];
-
-  for (String language in languages) {
+  for (String language in kSupportedLanguages) {
     testWidgets('translations exist for $language', (WidgetTester tester) async {
       final Locale locale = new Locale(language, '');
 
       expect(GlobalMaterialLocalizations.delegate.isSupported(locale), isTrue);
 
-      final MaterialLocalizations localizations = new GlobalMaterialLocalizations(locale);
+      final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(locale);
 
       expect(localizations.openAppDrawerTooltip, isNotNull);
       expect(localizations.backButtonTooltip, isNotNull);
@@ -119,22 +69,43 @@ void main() {
   }
 
   testWidgets('spot check selectedRowCount translations', (WidgetTester tester) async {
-    MaterialLocalizations localizations = new GlobalMaterialLocalizations(const Locale('en', ''));
+    MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en', ''));
     expect(localizations.selectedRowCountTitle(0), 'No items selected');
     expect(localizations.selectedRowCountTitle(1), '1 item selected');
     expect(localizations.selectedRowCountTitle(2), '2 items selected');
+    expect(localizations.selectedRowCountTitle(3), '3 items selected');
+    expect(localizations.selectedRowCountTitle(5), '5 items selected');
+    expect(localizations.selectedRowCountTitle(10), '10 items selected');
+    expect(localizations.selectedRowCountTitle(15), '15 items selected');
+    expect(localizations.selectedRowCountTitle(29), '29 items selected');
+    expect(localizations.selectedRowCountTitle(10000), '10,000 items selected');
+    expect(localizations.selectedRowCountTitle(10019), '10,019 items selected');
     expect(localizations.selectedRowCountTitle(123456789), '123,456,789 items selected');
 
-    localizations = new GlobalMaterialLocalizations(const Locale('es', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('es', ''));
     expect(localizations.selectedRowCountTitle(0), 'No se han seleccionado elementos');
     expect(localizations.selectedRowCountTitle(1), '1 elemento seleccionado');
     expect(localizations.selectedRowCountTitle(2), '2 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(3), '3 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(5), '5 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(10), '10 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(15), '15 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(29), '29 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(10000), '10.000 elementos seleccionados');
+    expect(localizations.selectedRowCountTitle(10019), '10.019 elementos seleccionados');
     expect(localizations.selectedRowCountTitle(123456789), '123.456.789 elementos seleccionados');
 
-    localizations = new GlobalMaterialLocalizations(const Locale('ro', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('ro', ''));
     expect(localizations.selectedRowCountTitle(0), 'Nu există elemente selectate');
     expect(localizations.selectedRowCountTitle(1), 'Un articol selectat');
-    expect(localizations.selectedRowCountTitle(2), '2 de articole selectate');
+    expect(localizations.selectedRowCountTitle(2), '2 articole selectate');
+    expect(localizations.selectedRowCountTitle(3), '3 articole selectate');
+    expect(localizations.selectedRowCountTitle(5), '5 articole selectate');
+    expect(localizations.selectedRowCountTitle(10), '10 articole selectate');
+    expect(localizations.selectedRowCountTitle(15), '15 articole selectate');
+    expect(localizations.selectedRowCountTitle(29), '29 de articole selectate');
+    expect(localizations.selectedRowCountTitle(10000), '10.000 de articole selectate');
+    expect(localizations.selectedRowCountTitle(10019), '10.019 articole selectate');
     expect(localizations.selectedRowCountTitle(123456789), '123.456.789 de articole selectate');
   });
 }


### PR DESCRIPTION
The following changes are made by this PR:

 * Translation bundles now implement MaterialLocalizations directly, and are public so that they can be directly extended.

 * The list of supported languages is now a generated constant.

 * The icuShortTimePattern/TimeOfDayFormat values are now pre-parsed.

 * Various other changes for consistency with the style guide and the rest of the codebase, e.g. the class names don't use `_`, the `path` library is imported as such, more dartdocs, fewer `// ignore`s, validation using exceptions.

This reduces our technical debt benchmark.

cc @HansMuller 
