### PR TITLE
When dispatching a semantic event, check if the node has been merged with parent

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2206,7 +2206,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   void sendSemanticsEvent(SemanticsEvent semanticsEvent) {
     if (owner.semanticsOwner == null)
       return;
-    if (_semantics != null) {
+    if (_semantics != null && !_semantics.isMergedIntoParent) {
       _semantics.sendEvent(semanticsEvent);
     } else if (parent != null) {
       final RenderObject renderParent = parent;


### PR DESCRIPTION
Fixes Switch/Checkbox/Radio list tile and related patterns from not announcing state change

Fixes https://github.com/flutter/flutter/issues/19959