### PR TITLE
Skip tests that are expected to fail with timeouts

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -37,9 +37,8 @@ void main() {
     testUsingContext('can hot reload', () async {
       await _flutterRun.run(withDebugger: true);
       await _flutterAttach.attach(_flutterRun.vmServicePort);
-
       await _flutterAttach.hotReload();
     });
-    // Skip on Windows due to https://github.com/flutter/flutter/issues/17833
+    // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(3), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -39,6 +39,6 @@ void main() {
       await _flutterAttach.attach(_flutterRun.vmServicePort);
       await _flutterAttach.hotReload();
     });
-    // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
+    // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(3), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -33,41 +33,19 @@ void main() {
 
     test('works without error', () async {
       await _flutter.run();
-
-      // Due to https://github.com/flutter/flutter/issues/17833 this will
-      // throw on Windows. If you merge a fix for this and this test starts failing
-      // because it didn't throw on Windows, you should delete the wrapping expect()
-      // and just `await` the hotReload directly
-      // (dantup)
-
-      await expectLater(
-        _flutter.hotReload(),
-        platform.isWindows ? throwsA(anything) : completes,
-      );
-    });
+      await _flutter.hotReload();
+      // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
+    }, skip: platform.isWindows);
 
     test('hits breakpoints with file:// prefixes after reload', () async {
       await _flutter.run(withDebugger: true);
 
-      // This test fails due to // https://github.com/flutter/flutter/issues/18441
-      // If you merge a fix for this and the test starts failing because it's not
-      // throwing, delete the wrapping expect/return below.
-      // (dantup)
-      //
-      // final VMIsolate isolate = await _flutter.breakAt(
-      //     new Uri.file(_project.breakpointFile).toString(),
-      //     _project.breakpointLine
-      // );
-      // expect(isolate.pauseEvent, const isInstanceOf<VMPauseBreakpointEvent>());
-      await expectLater(() async {
-        // Hit breakpoint using a file:// URI.
-        final VMIsolate isolate = await _flutter.breakAt(
-            new Uri.file(_project.breakpointFile).toString(),
-            _project.breakpointLine
-        );
-        expect(isolate.pauseEvent, const isInstanceOf<VMPauseBreakpointEvent>());
-      }(), platform.isLinux ? completes : throwsA(anything)
-      );
-    });
+      // Hit breakpoint using a file:// URI.
+      final VMIsolate isolate = await _flutter.breakAt(
+          new Uri.file(_project.breakpointFile).toString(),
+          _project.breakpointLine);
+      expect(isolate.pauseEvent, const isInstanceOf<VMPauseBreakpointEvent>());
+      // SKIP(dantup): https://github.com/flutter/flutter/issues/18441.
+    }, skip: !platform.isLinux);
   }, timeout: const Timeout.factor(3));
 }

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -34,7 +34,7 @@ void main() {
     test('works without error', () async {
       await _flutter.run();
       await _flutter.hotReload();
-      // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
+      // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
     }, skip: platform.isWindows);
 
     test('hits breakpoints with file:// prefixes after reload', () async {
@@ -45,7 +45,7 @@ void main() {
           new Uri.file(_project.breakpointFile).toString(),
           _project.breakpointLine);
       expect(isolate.pauseEvent, const isInstanceOf<VMPauseBreakpointEvent>());
-      // SKIP(dantup): https://github.com/flutter/flutter/issues/18441.
+      // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/18441.
     }, skip: !platform.isLinux);
   }, timeout: const Timeout.factor(3));
 }

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -44,6 +44,6 @@ void main() {
       await new Future<void>.delayed(requiredLifespan);
       expect(_flutter.hasExited, equals(false));
     });
-    // Skip on Windows due to https://github.com/flutter/flutter/issues/17833
+    // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(3), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -44,6 +44,6 @@ void main() {
       await new Future<void>.delayed(requiredLifespan);
       expect(_flutter.hasExited, equals(false));
     });
-    // SKIP(dantup): https://github.com/flutter/flutter/issues/17833.
+    // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(3), skip: platform.isWindows);
 }


### PR DESCRIPTION
We previously changed these tests to "expect failure" so that when a fix for the underlying issues is merged, they'll fail and be fixed up (if we skip, there's a danger we forget to unskip).

However, because the expected failure requires a timeout, these tests are needlessly slowing down all CI builds (adding at least a few minutes on to each tools-test shard).

Since I already have a recurring reminder to review the skipped integration tests (because there are some we couldn't reasonably expect failure without making it complicated to fix the test up for whoever rolls a fix in) I think we're better just skipping these too.