### PR TITLE
Use matrix for Win/Mac config on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,6 @@ task:
         memory: 8G
 
 task:
-  name: tests-windows
   env:
     SHARD: tests
   windows_container:
@@ -62,29 +61,15 @@ task:
     - git fetch origin master
   test_all_script:
     - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
+  matrix:
+    - name: tests-windows
+      env:
+        SHARD: tests
+    - name: tool_tests-windows
+      env:
+        SHARD: tool_tests
 
 task:
-  name: tool_tests-windows
-  env:
-    SHARD: tool_tests
-  windows_container:
-    image: cirrusci/windowsservercore:2016
-    os_version: 2016
-    cpu: 4
-  env:
-    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
-  git_fetch_script: git fetch origin
-  setup_script:
-    - bin\flutter.bat config --no-analytics
-    - bin\flutter.bat update-packages
-    - git fetch origin master
-  test_all_script:
-    - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
-
-task:
-  name: tests-macos
-  env:
-    SHARD: tests
   osx_instance:
     image: high-sierra-xcode-9.4.1
   git_fetch_script: git fetch origin
@@ -94,17 +79,10 @@ task:
   test_all_script: |
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart
-
-task:
-  name: tool_tests-macos
-  env:
-    SHARD: tool_tests
-  osx_instance:
-    image: high-sierra-xcode-9.4.1
-  git_fetch_script: git fetch origin
-  setup_script:
-    - bin/flutter config --no-analytics
-    - bin/flutter update-packages
-  test_all_script: |
-    ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-    bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart
+  matrix:
+    - name: tests-macos
+      env:
+        SHARD: tests
+    - name: tool_tests-macos
+      env:
+        SHARD: tool_tests


### PR DESCRIPTION
In the Cirrus config the Mac/Windows sections were duplicated for the tests/tool_tests builds even though the only difference was the name/SHARD env variable. This uses the `matrix` option the same as Linux so there's less duplication.