### PR TITLE
Add pub cache, artifacts, pkgs to Cirrus cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,10 +20,10 @@ task:
     echo "SDK directory is: $PWD"
     ./bin/flutter --version
 
-    # disable analytics on the bots and download Flutter dependencies.
+    # disable analytics on the bots and download Flutter dependencies
     ./bin/flutter config --no-analytics
 
-    # run pub get in all the repo packages.
+    # run pub get in all the repo packages
     ./bin/flutter update-packages
 
     git fetch origin master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,13 +9,13 @@ task:
   git_fetch_script: git fetch origin
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
   flutter_pkg_cache:
     folder: bin/cache/pkg
-    fingerprint_script: cat bin/internal/engine.version
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
   artifacts_cache:
     folder: bin/cache/artifacts
-    fingerprint_script: cat bin/internal/engine.version
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
   setup_script: |
     echo "SDK directory is: $PWD"
     ./bin/flutter --version
@@ -65,13 +65,13 @@ task:
   pub_cache:
     folder: $APPDATA\Pub\Cache
     fingerprint_script:
-      - ps:  Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+      - ps:  $Env:OS; Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
   flutter_pkg_cache:
     folder: bin\cache\pkg
-    fingerprint_script: type bin\internal\engine.version
+    fingerprint_script: echo %OS% & type bin\internal\engine.version
   artifacts_cache:
     folder: bin\cache\artifacts
-    fingerprint_script: type bin\internal\engine.version
+    fingerprint_script: echo %OS% & type bin\internal\engine.version
   setup_script:
     - bin\flutter.bat config --no-analytics
     - bin\flutter.bat update-packages
@@ -94,13 +94,13 @@ task:
   git_fetch_script: git fetch origin
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
   flutter_pkg_cache:
     folder: bin/cache/pkg
-    fingerprint_script: cat bin/internal/engine.version
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
   artifacts_cache:
     folder: bin/cache/artifacts
-    fingerprint_script: cat bin/internal/engine.version
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter update-packages

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,7 +65,7 @@ task:
   pub_cache:
     folder: $APPDATA\Pub\Cache
     fingerprint_script:
-      - ps:  Get-ChildItem pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+      - ps:  Get-ChildItem -Path $Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
   flutter_pkg_cache:
     folder: bin\cache\pkg
     fingerprint_script: type bin\internal\engine.version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,7 +65,7 @@ task:
   pub_cache:
     folder: $APPDATA\Pub\Cache
     fingerprint_script:
-      - ps:  Get-ChildItem -Path $Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+      - ps:  Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
   flutter_pkg_cache:
     folder: bin\cache\pkg
     fingerprint_script: type bin\internal\engine.version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,10 +20,10 @@ task:
     echo "SDK directory is: $PWD"
     ./bin/flutter --version
 
-    # disable analytics on the bots and download Flutter dependencies
+    # disable analytics on the bots and download Flutter dependencies.
     ./bin/flutter config --no-analytics
 
-    # run pub get in all the repo packages
+    # run pub get in all the repo packages.
     ./bin/flutter update-packages
 
     git fetch origin master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ task:
   git_fetch_script: git fetch origin
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
+    fingerprint_script: grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version
@@ -94,7 +94,7 @@ task:
   git_fetch_script: git fetch origin
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
+    fingerprint_script: grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
-  pkg_cache:
+  flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version
   artifacts_cache:
@@ -66,7 +66,7 @@ task:
     folder: $APPDATA\Pub\Cache
     fingerprint_script:
       - ps:  Get-ChildItem pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-  pkg_cache:
+  flutter_pkg_cache:
     folder: bin\cache\pkg
     fingerprint_script: type bin\internal\engine.version
   artifacts_cache:
@@ -95,7 +95,7 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
-  pkg_cache:
+  flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version
   artifacts_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,9 @@ task:
   pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version
+  artifacts_cache:
+    folder: bin/cache/artifacts
+    fingerprint_script: cat bin/internal/engine.version
   setup_script: |
     echo "SDK directory is: $PWD"
     ./bin/flutter --version
@@ -59,6 +62,9 @@ task:
   pkg_cache:
     folder: bin\cache\pkg
     fingerprint_script: type bin\internal\engine.version
+  artifacts_cache:
+    folder: bin\cache\artifacts
+    fingerprint_script: cat bin\internal\engine.version
   setup_script:
     - bin\flutter.bat config --no-analytics
     - bin\flutter.bat update-packages
@@ -81,6 +87,9 @@ task:
   git_fetch_script: git fetch origin
   pkg_cache:
     folder: bin/cache/pkg
+    fingerprint_script: cat bin/internal/engine.version
+  artifacts_cache:
+    folder: bin/cache/artifacts
     fingerprint_script: cat bin/internal/engine.version
   setup_script:
     - bin/flutter config --no-analytics

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ task:
     fingerprint_script: type bin\internal\engine.version
   artifacts_cache:
     folder: bin\cache\artifacts
-    fingerprint_script: cat bin\internal\engine.version
+    fingerprint_script: type bin\internal\engine.version
   setup_script:
     - bin\flutter.bat config --no-analytics
     - bin\flutter.bat update-packages

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,9 @@ task:
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
 
   git_fetch_script: git fetch origin
+  pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: cat bin/internal/engine.version
   setup_script: |
     echo "SDK directory is: $PWD"
     ./bin/flutter --version
@@ -53,6 +56,9 @@ task:
   env:
     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
   git_fetch_script: git fetch origin
+  pkg_cache:
+    folder: bin\cache\pkg
+    fingerprint_script: type bin\internal\engine.version
   setup_script:
     - bin\flutter.bat config --no-analytics
     - bin\flutter.bat update-packages
@@ -73,6 +79,9 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
   git_fetch_script: git fetch origin
+  pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: cat bin/internal/engine.version
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter update-packages

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,9 @@ task:
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
 
   git_fetch_script: git fetch origin
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
   pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version
@@ -59,6 +62,10 @@ task:
   env:
     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
   git_fetch_script: git fetch origin
+  pub_cache:
+    folder: $APPDATA\Pub\Cache
+    fingerprint_script:
+      - ps:  Get-ChildItem pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
   pkg_cache:
     folder: bin\cache\pkg
     fingerprint_script: type bin\internal\engine.version
@@ -85,6 +92,9 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
   git_fetch_script: git fetch origin
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: find . -name 'pubspec.yaml' -exec grep -H 'PUBSPEC CHECKSUM' {} +
   pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: cat bin/internal/engine.version


### PR DESCRIPTION
This adds:

- pub's cache to the Cirrus cache. It caches based on the checksums in the pubspec (although pub has things in versioned folders, this'll prevent the cache just getting bigger over time).
- bin/cache/pkg. I think this only includes `sky_engine`. It caches based on the engine checksum.
- bin/cache/artifacts. This includes `engine`, `gradle_wrapper`, `material_fonts`. Also caches based on the engine checksum.