### PR TITLE
Add spaces to path for macOS too

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,8 @@ task:
 task:
   osx_instance:
     image: high-sierra-xcode-9.4.1
+  env:
+    CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
   git_fetch_script: git fetch origin
   setup_script:
     - bin/flutter config --no-analytics


### PR DESCRIPTION
Linux and Windows have spaces in their paths but macOS didn't.

(One of these will go away with #20077)