### PR TITLE
Add custom semantics action to hasSemanticsData matcher

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -121,7 +121,6 @@ class CustomSemanticsAction {
   static final Map<CustomSemanticsAction, int> _ids = <CustomSemanticsAction, int>{};
 
   /// Get the identifier for a given `action`.
-  @visibleForTesting
   static int getIdentifier(CustomSemanticsAction action) {
     int result = _ids[action];
     if (result == null) {
@@ -133,7 +132,6 @@ class CustomSemanticsAction {
   }
 
   /// Get the `action` for a given identifier.
-  @visibleForTesting
   static CustomSemanticsAction getAction(int id) {
     return _actions[id];
   }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -345,8 +345,8 @@ Matcher matchesSemanticsData({
   bool hasPasteAction = false,
   bool hasDidGainAccessibilityFocusAction = false,
   bool hasDidLoseAccessibilityFocusAction = false,
-  bool hasCustomAction = false,
   bool hasDismissAction = false,
+  List<CustomSemanticsAction> customActions,
 }) {
   final List<SemanticsFlag> flags = <SemanticsFlag>[];
   if (hasCheckedState)
@@ -421,7 +421,7 @@ Matcher matchesSemanticsData({
     actions.add(SemanticsAction.didGainAccessibilityFocus);
   if (hasDidLoseAccessibilityFocusAction)
     actions.add(SemanticsAction.didLoseAccessibilityFocus);
-  if (hasCustomAction)
+  if (customActions != null && customActions.isNotEmpty)
     actions.add(SemanticsAction.customAction);
   if (hasDismissAction)
     actions.add(SemanticsAction.dismiss);
@@ -438,6 +438,7 @@ Matcher matchesSemanticsData({
     flags: flags,
     textDirection: textDirection,
     rect: rect,
+    customActions: customActions,
   );
 }
 
@@ -1467,12 +1468,14 @@ class _MatchesSemanticsData extends Matcher {
     this.actions,
     this.textDirection,
     this.rect,
+    this.customActions,
   });
 
   final String label;
   final String value;
   final String hint;
   final List<SemanticsAction> actions;
+  final List<CustomSemanticsAction> customActions;
   final List<SemanticsFlag> flags;
   final TextDirection textDirection;
   final Rect rect;
@@ -1494,6 +1497,8 @@ class _MatchesSemanticsData extends Matcher {
       description.add('with textDirection: $textDirection ');
     if (rect != null)
       description.add('with rect: $rect');
+    if (customActions != null)
+      description.add('with custom actions: $customActions');
     return description;
   }
 
@@ -1511,7 +1516,7 @@ class _MatchesSemanticsData extends Matcher {
       return failWithDescription(matchState, 'value was: ${data.value}');
     if (textDirection != null && textDirection != data.textDirection)
       return failWithDescription(matchState, 'textDirection was: $textDirection');
-    if (rect != null && rect == data.rect) {
+    if (rect != null && rect != data.rect) {
       return failWithDescription(matchState, 'rect was: $rect');
     }
     if (actions != null) {
@@ -1525,6 +1530,18 @@ class _MatchesSemanticsData extends Matcher {
             actionSummary.add(describeEnum(action));
         }
         return failWithDescription(matchState, 'actions were: $actionSummary');
+      }
+    }
+    if (customActions != null) {
+      if (customActions.length != data.customSemanticsActionIds.length)
+        return failWithDescription(matchState, 'custom semanitcs action ids were: ${data.customSemanticsActionIds}');
+      outer: for (int i = 0; i < customActions.length; i++) {
+        for (int j = 0; j < customActions.length; j++) {
+          if (CustomSemanticsAction.getIdentifier(customActions[i]) == data.customSemanticsActionIds[j]) {
+            continue outer;
+          }
+        }
+        return failWithDescription(matchState, 'custom semanitcs action ids were: ${data.customSemanticsActionIds}');
       }
     }
     if (flags != null) {

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -444,6 +444,7 @@ void main() {
     testWidgets('Can match all semantics flags and actions', (WidgetTester tester) async {
       int actions = 0;
       int flags = 0;
+      const CustomSemanticsAction action = const CustomSemanticsAction(label: 'test');
       for (int index in SemanticsAction.values.keys)
         actions |= index;
       for (int index in SemanticsFlag.values.keys)
@@ -462,6 +463,7 @@ void main() {
         scrollPosition: null,
         scrollExtentMax: null,
         scrollExtentMin: null,
+        customSemanticsActionIds: <int>[CustomSemanticsAction.getIdentifier(action)],
       );
 
       expect(data, matchesSemanticsData(
@@ -504,8 +506,8 @@ void main() {
          hasPasteAction: true,
          hasDidGainAccessibilityFocusAction: true,
          hasDidLoseAccessibilityFocusAction: true,
-         hasCustomAction: true,
          hasDismissAction: true,
+         customActions: <CustomSemanticsAction>[action],
       ));
     });
   });

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -398,6 +398,10 @@ void main() {
         hint: 'bar',
         value: 'baz',
         textDirection: TextDirection.rtl,
+        customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+          const CustomSemanticsAction(label: 'foo'): () {},
+          const CustomSemanticsAction(label: 'bar'): () {},
+        },
       ));
 
       expect(tester.getSemanticsData(find.byKey(key)),
@@ -410,7 +414,29 @@ void main() {
           isButton: true,
           isHeader: true,
           namesRoute: true,
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'bar')
+          ],
         ),
+      );
+
+      // Doesn't match custom actions
+      expect(tester.getSemanticsData(find.byKey(key)),
+        isNot(matchesSemanticsData(
+          label: 'foo',
+          hint: 'bar',
+          value: 'baz',
+          textDirection: TextDirection.rtl,
+          hasTapAction: true,
+          isButton: true,
+          isHeader: true,
+          namesRoute: true,
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'barz')
+          ],
+        )),
       );
       handle.dispose();
     });


### PR DESCRIPTION
Also removes `@visibleForTesting` annotation by necessity