### PR TITLE
Revert "mark flaky benchmarks as flaky (#19492)"

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -447,14 +447,12 @@ tasks:
       Measures memory usage after repeated navigation in Gallery.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__back_button_memory:
     description: >
       Measures memory usage after Android app suspend and resume.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   analyzer_benchmark:
     description: >


### PR DESCRIPTION
This reverts commit 7a9dd709c6235153dd7500da65fb30dfbe76e560.

Bug: https://github.com/flutter/flutter/issues/19490