### PR TITLE
Run macOS builds only if analyze task passed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,8 @@ task:
         SHARD: tool_tests
 
 task:
+  depends_on:
+    - analyze
   osx_instance:
     image: high-sierra-xcode-9.4.1
   env:


### PR DESCRIPTION
This will reduce load on macOS community cluster.