### PR TITLE
improve semantics of chip demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/chip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/chip_demo.dart
@@ -81,29 +81,41 @@ class _ChipsTile extends StatelessWidget {
   // Wraps a list of chips into a ListTile for display as a section in the demo.
   @override
   Widget build(BuildContext context) {
-    return new ListTile(
-      title: new Padding(
+    final List<Widget> cardChildren = <Widget>[
+      new Container(
         padding: const EdgeInsets.only(top: 16.0, bottom: 4.0),
+        alignment: Alignment.center,
         child: new Text(label, textAlign: TextAlign.start),
       ),
-      subtitle: children.isEmpty
-          ? new Center(
-              child: new Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: new Text(
-                  'None',
-                  style: Theme.of(context).textTheme.caption.copyWith(fontStyle: FontStyle.italic),
-                ),
-              ),
-            )
-          : new Wrap(
-              children: children
-                  .map((Widget chip) => new Padding(
-                        padding: const EdgeInsets.all(4.0),
-                        child: chip,
-                      ))
-                  .toList(),
-            ),
+    ];
+    if (children.isNotEmpty) {
+      cardChildren.add(new Wrap(
+        children: children.map((Widget chip) {
+        return new Padding(
+          padding: const EdgeInsets.all(2.0),
+          child: chip,
+        );
+      }).toList()));
+    } else {
+      final TextStyle textStyle = Theme.of(context).textTheme.caption.copyWith(fontStyle: FontStyle.italic);
+      cardChildren.add(
+        new Semantics(
+          container: true,
+          child: new Container(
+            alignment: Alignment.center,
+            constraints: const BoxConstraints(minWidth: 48.0, minHeight: 48.0),
+            padding: const EdgeInsets.all(8.0),
+            child: new Text('None', style: textStyle),
+          ),
+        ));
+    }
+
+    return new Card(
+      semanticContainer: false,
+      child: new Column(
+        mainAxisSize: MainAxisSize.min,
+        children: cardChildren,
+      )
     );
   }
 }
@@ -297,7 +309,7 @@ class _ChipDemoState extends State<ChipDemo> {
                 _showShapeBorder = !_showShapeBorder;
               });
             },
-            icon: const Icon(Icons.vignette),
+            icon: const Icon(Icons.vignette, semanticLabel: 'Update border shape'),
           )
         ],
       ),
@@ -313,7 +325,7 @@ class _ChipDemoState extends State<ChipDemo> {
       ),
       floatingActionButton: new FloatingActionButton(
         onPressed: () => setState(_reset),
-        child: const Icon(Icons.refresh),
+        child: const Icon(Icons.refresh, semanticLabel: 'Reset chips'),
       ),
     );
   }

--- a/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
@@ -21,7 +21,7 @@ void main() {
       hasTapAction: true,
       label: 'Update border shape',
     ));
-    
+
     expect(tester.getSemanticsData(find.byIcon(Icons.refresh)), matchesSemanticsData(
       isButton: true,
       hasEnabledState: true,

--- a/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_gallery/demo/material/chip_demo.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Chip demo has semantic labels', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(new MaterialApp(
+      theme: new ThemeData(platform: TargetPlatform.iOS),
+      home: new ChipDemo(),
+    ));
+
+    expect(tester.getSemanticsData(find.byIcon(Icons.vignette)), matchesSemanticsData(
+      isButton: true,
+      hasEnabledState: true,
+      isEnabled: true,
+      hasTapAction: true,
+      label: 'Update border shape',
+    ));
+    
+    expect(tester.getSemanticsData(find.byIcon(Icons.refresh)), matchesSemanticsData(
+      isButton: true,
+      hasEnabledState: true,
+      isEnabled: true,
+      hasTapAction: true,
+      label: 'Reset chips',
+    ));
+
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
Add semanticLabel to the fab and chip border buttons.  Replace ListTile with a card so that we can prevent each section from being individually focus-able. Only the chips + title are focusable now.