### PR TITLE
Remove SHARD env that was overriding matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,8 +46,6 @@ task:
         memory: 8G
 
 task:
-  env:
-    SHARD: tests
   windows_container:
     image: cirrusci/windowsservercore:2016
     os_version: 2016


### PR DESCRIPTION
In #20077 I switched to using `matrix` in the Windows/macOS Cirrus configs to reduce duplicate. I left a (seemingly redundant) `SHARD` env variable at the top of the config, but it looks like that one was used, so the Windows tools tests have been running the non-tools tests since 🙈

This removes that extra SHARD env variable so it should come from the matrix (this also feels like a Cirrus bug, so once the build has run and I've confirmed fixed, I'll mentioned it to them).