### PR TITLE
Fix latent type error in Flutter manifest

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -23,8 +23,16 @@ class FlutterManifest {
   /// Returns an empty manifest.
   static FlutterManifest empty() {
     final FlutterManifest manifest = new FlutterManifest._();
-    manifest._descriptor = <String, dynamic>{};
-    manifest._flutterDescriptor = <String, dynamic>{};
+    manifest._descriptor = const <String, dynamic>{};
+    manifest._flutterDescriptor = const <String, dynamic>{};
+    return manifest;
+  }
+
+  /// Returns a mock manifest with the given contents.
+  static FlutterManifest mock(Map<String, dynamic> contents) {
+    final FlutterManifest manifest = new FlutterManifest._();
+    manifest._descriptor = contents ?? const <String, dynamic>{};
+    manifest._flutterDescriptor = manifest._descriptor['flutter'] ?? const <String, dynamic>{};
     return manifest;
   }
 
@@ -108,14 +116,6 @@ class FlutterManifest {
     return _flutterDescriptor['uses-material-design'] ?? false;
   }
 
-  /// Properties defining how to expose this Flutter project as a module
-  /// for integration into an unspecified host app.
-  YamlMap get moduleDescriptor {
-    return _flutterDescriptor.containsKey('module')
-        ? _flutterDescriptor['module'] ?? const <String, dynamic>{}
-        : null;
-  }
-
   /// True if this manifest declares a Flutter module project.
   ///
   /// A Flutter project is considered a module when it has a `module:`
@@ -123,7 +123,28 @@ class FlutterManifest {
   /// existing host app.
   ///
   /// Such a project can be created using `flutter create -t module`.
-  bool get isModule => moduleDescriptor != null;
+  bool get isModule => _flutterDescriptor.containsKey('module');
+
+  /// True if this manifest declares a Flutter plugin project.
+  ///
+  /// A Flutter project is considered a plugin when it has a `plugin:`
+  /// descriptor. A Flutter plugin project wraps custom Android and/or
+  /// iOS code in a Dart interface for consumption by other Flutter app
+  /// projects.
+  ///
+  /// Such a project can be created using `flutter create -t plugin`.
+  bool get isPlugin => _flutterDescriptor.containsKey('plugin');
+
+  /// Returns the Android package declared by this manifest in its
+  /// module or plugin descriptor. Returns null, if there is no
+  /// such declaration.
+  String get androidPackage {
+    if (isModule)
+      return _flutterDescriptor['module']['androidPackage'];
+    if (isPlugin)
+      return _flutterDescriptor['plugin']['androidPackage'];
+    return null;
+  }
 
   List<Map<String, dynamic>> get fontsDescriptor {
     final List<dynamic> fontList = _flutterDescriptor['fonts'];

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -231,7 +231,7 @@ class AndroidModuleProject {
       template.render(
         directory,
         <String, dynamic>{
-          'androidIdentifier': project.manifest.moduleDescriptor['androidPackage'],
+          'androidIdentifier': project.manifest.androidPackage,
         },
         printStatusWhenWriting: false,
       );

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -362,6 +362,30 @@ flutter:
       expect(flutterManifest.isEmpty, false);
     });
 
+    test('allows a module declaration', () async {
+      const String manifest = '''
+name: test
+flutter:
+  module:
+    androidPackage: com.example
+''';
+      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      expect(flutterManifest.isModule, true);
+      expect(flutterManifest.androidPackage, 'com.example');
+    });
+
+    test('allows a plugin declaration', () async {
+      const String manifest = '''
+name: test
+flutter:
+  plugin:
+    androidPackage: com.example
+''';
+      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      expect(flutterManifest.isPlugin, true);
+      expect(flutterManifest.androidPackage, 'com.example');
+    });
+
     Future<void> checkManifestVersion({
       String manifest,
       String expectedAppVersion,

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -360,6 +360,9 @@ flutter:
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isEmpty, false);
+      expect(flutterManifest.isModule, false);
+      expect(flutterManifest.isPlugin, false);
+      expect(flutterManifest.androidPackage, null);
     });
 
     test('allows a module declaration', () async {


### PR DESCRIPTION
`FlutterManifest` has a latent type error, declaring a return type of `YamlMap`, but under certain circumstances returning a `const <String, dynamic>{}` which is not a `YamlMap`.

Changed to avoid handing out a sub-map, but instead providing getter for the contained scalar information.

Also added ways of creating a `FlutterManifest` for testing purposes (needed in an upcoming PR) without asynchronously validating yaml.