### PR TITLE
reduce the number of runs on the analyze benchmark

### DIFF
--- a/dev/devicelab/lib/tasks/analysis.dart
+++ b/dev/devicelab/lib/tasks/analysis.dart
@@ -12,7 +12,7 @@ import '../framework/framework.dart';
 import '../framework/utils.dart';
 
 /// Run each benchmark this many times and compute average.
-const int _kRunsPerBenchmark = 4;
+const int _kRunsPerBenchmark = 3;
 
 /// Runs a benchmark once and reports the result as a lower-is-better numeric
 /// value.


### PR DESCRIPTION
- reduce the number of runs on the analyze benchmark from 4 to 3

We're missing runs on the benchmark; I haven't investigated, but I recently increased the number of runs from 3 to 4, so perhaps we're hitting a timeout.

@jcollins-g 