### PR TITLE
move where the mega_gallery benchmark code is generated by default

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -190,13 +190,18 @@ Future<Null> _analyzeRepo() async {
   await _checkForTrailingSpaces();
 
   // Try an analysis against a big version of the gallery.
+  // Generate into a directory that's not normally analyzed.
+  final String outDir = path.join(flutterRoot, 'bin', 'cache', 'dev', 'mega_gallery');
   await _runCommand(dart,
-    <String>['--preview-dart-2', path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart')],
+    <String>[
+      '--preview-dart-2',
+      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
+      '--out',
+      outDir,
+    ],
     workingDirectory: flutterRoot,
   );
-  await _runFlutterAnalyze(path.join(flutterRoot, 'dev', 'benchmarks', 'mega_gallery'),
-    options: <String>['--watch', '--benchmark'],
-  );
+  await _runFlutterAnalyze(outDir, options: <String>['--watch', '--benchmark']);
 
   print('${bold}DONE: Analysis successful.$reset');
 }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -189,19 +189,27 @@ Future<Null> _analyzeRepo() async {
 
   await _checkForTrailingSpaces();
 
-  // Try an analysis against a big version of the gallery.
-  // Generate into a directory that's not normally analyzed.
-  final String outDir = path.join(flutterRoot, 'bin', 'cache', 'dev', 'mega_gallery');
-  await _runCommand(dart,
-    <String>[
-      '--preview-dart-2',
-      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
-      '--out',
-      outDir,
-    ],
-    workingDirectory: flutterRoot,
-  );
-  await _runFlutterAnalyze(outDir, options: <String>['--watch', '--benchmark']);
+  // Try analysis against a big version of the gallery; generate into a temporary directory.
+  final String outDir = Directory.systemTemp.createTempSync('mega_gallery').path;
+
+  try {
+    await _runCommand(dart,
+      <String>[
+        '--preview-dart-2',
+        path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
+        '--out',
+        outDir,
+      ],
+      workingDirectory: flutterRoot,
+    );
+    await _runFlutterAnalyze(outDir, options: <String>['--watch', '--benchmark']);
+  } finally {
+    try {
+      new Directory(outDir).deleteSync(recursive: true);
+    } catch (e) {
+      // ignore
+    }
+  }
 
   print('${bold}DONE: Analysis successful.$reset');
 }

--- a/dev/tools/mega_gallery.dart
+++ b/dev/tools/mega_gallery.dart
@@ -18,8 +18,7 @@ void main(List<String> args) {
     Directory.current = Directory.current.parent.parent;
 
   final ArgParser argParser = new ArgParser();
-  // ../mega_gallery? dev/benchmarks/mega_gallery?
-  argParser.addOption('out', defaultsTo: _normalize('dev/benchmarks/mega_gallery'));
+  argParser.addOption('out');
   argParser.addOption('copies');
   argParser.addFlag('delete', negatable: false);
   argParser.addFlag('help', abbr: 'h', negatable: false);
@@ -43,6 +42,12 @@ void main(List<String> args) {
     }
 
     exit(0);
+  }
+
+  if (!results.wasParsed('out')) {
+    print('The --out parameter is required.');
+    print(argParser.usage);
+    exit(1);
   }
 
   int copies;
@@ -128,7 +133,7 @@ void _copyGallery(Directory galleryDir, int index) {
 
 void _copy(Directory source, Directory target) {
   if (!target.existsSync())
-    target.createSync();
+    target.createSync(recursive: true);
 
   for (FileSystemEntity entity in source.listSync(followLinks: false)) {
     final String name = path.basename(entity.path);


### PR DESCRIPTION
- instead of generating the mega_gallery benchmark code into `//dev/benchmarks/mega_gallery/`, generate into `//bin/cache/dev/mega_gallery/`. This location is less likely to make the benchmark analyzed by accident with the rest of the repo

@jcollins-g 
