### PR TITLE
Give Flutter module a default route. (#20193)

### DIFF
--- a/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
@@ -18,7 +18,7 @@ class Router extends StatelessWidget {
   Widget build(BuildContext context) {
     final String route = window.defaultRouteName;
     switch (route) {
-      case 'route1':
+      case '/':
         return Container(
           child: Center(child: Text('Route 1\n${packageInfo.appName}')),
           color: Colors.green,


### PR DESCRIPTION
Give Flutter module a default route. (#20193)

This change, in addition to making it easier for developers to try the module approach, will cut the demo code in half for Mobile Week 2018 when we show how to use a module.