### PR TITLE
Control, Shift and Arrow Key functionality for Chromebook

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -203,15 +203,15 @@ class RenderEditable extends RenderBox {
   static const int _kUpArrowCode = 19;
   static const int _kDownArrowCode = 20;
 
-  // The current extent offset used to calculate the selection
   int _extentOffset = -1;
-
-  // The current base offset used to calculate the selection
   int _baseOffset = -1;
 
-  // The previous text index of the cursor in the case that the user attempts
-  // to highlight until the end or beginning of the text field.
+  // Holds the last location the user selected in the case that he selects all
+  // the way to the end or beginning of the field.
   int _previousCursorLocation = -1;
+
+  // Whether we should reset the location of the cursor in the case the user
+  // selects all the way to the end or the beginning of a field.
   bool _resetCursor = false;
 
   static const int _kShiftMask = 1;
@@ -242,9 +242,6 @@ class RenderEditable extends RenderBox {
     final bool upArrow = pressedKeyCode == _kUpArrowCode;
     final bool downArrow = pressedKeyCode == _kDownArrowCode;
     final bool arrow = leftArrow || rightArrow || upArrow || downArrow;
-
-    // TODO: all this should be changed to work in terms of extended grapheme
-    // TODO: clusters instead of UTF-16 words
 
     // We will only move select or more the caret if an arrow is pressed
     if (arrow) {
@@ -333,9 +330,7 @@ class RenderEditable extends RenderBox {
   // Handles the selection of text or removal of the selection and placing
   // of the caret.
   int _handleShift(bool rightArrow, bool leftArrow, bool shift, int newOffset) {
-    if (onSelectionChanged != null)
-      return newOffset;
-      // For some reason, deletion only works if the base offset is less
+    // For some reason, deletion only works if the base offset is less
     // than the extent offset.
     if (shift) {
       if (_baseOffset < newOffset) {
@@ -365,6 +360,11 @@ class RenderEditable extends RenderBox {
     }
     return newOffset;
   }
+
+
+
+
+
 
   /// Marks the render object as needing to be laid out again and have its text
   /// metrics recomputed.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -198,11 +198,6 @@ class RenderEditable extends RenderBox {
 
   Rect _lastCaretRect;
 
-  bool _rightArrowDown = false;
-  bool _leftArrowDown = false;
-  bool _upArrowDown = false;
-  bool _downArrowDown = false;
-
   static const int _kLeftArrowCode = 21;
   static const int _kRightArrowCode = 22;
   static const int _kUpArrowCode = 19;
@@ -218,7 +213,7 @@ class RenderEditable extends RenderBox {
   static const int _kControlMask = 1 << 12;
 
   void _handleKeyEvent(RawKeyEvent keyEvent){
-    if(defaultTargetPlatform != TargetPlatform.android)
+    if (defaultTargetPlatform != TargetPlatform.android)
       return;
 
     final RawKeyEventDataAndroid rawAndroidEvent = keyEvent.data;
@@ -235,15 +230,11 @@ class RenderEditable extends RenderBox {
     final bool shiftIsDown = pressedKeyMetaState & _kShiftMask > 0;
     final bool ctrlIsDown = pressedKeyMetaState & _kControlMask > 0;
 
-    if (pressedKeyCode == _kLeftArrowCode)
-      _leftArrowDown = pressedDown;
-    else if (pressedKeyCode == _kRightArrowCode)
-      _rightArrowDown = pressedDown;
-    else if (pressedKeyCode == _kUpArrowCode)
-      _upArrowDown = pressedDown;
-    else if (pressedKeyCode == _kDownArrowCode)
-      _downArrowDown = pressedDown;
-    final bool arrowDown = _leftArrowDown || _rightArrowDown || _upArrowDown || _downArrowDown;
+    final bool rightArrowDown = pressedKeyCode == _kRightArrowCode ? pressedDown : false;
+    final bool leftArrowDown = pressedKeyCode == _kLeftArrowCode ? pressedDown : false;
+    final bool upArrowDown = pressedKeyCode == _kUpArrowCode ? pressedDown : false;
+    final bool downArrowDown = pressedKeyCode == _kDownArrowCode ? pressedDown : false;
+    final bool arrowDown = leftArrowDown || rightArrowDown || upArrowDown || downArrowDown;
 
     // We will only move select or more the caret if an arrow is pressed
     if (arrowDown) {
@@ -252,10 +243,10 @@ class RenderEditable extends RenderBox {
       // If control is pressed, we will decide which way to look for a word
       // based on which arrow is pressed.
       if (pressedDown && ctrlIsDown) {
-        if (_leftArrowDown && _extentOffset > 2) {
+        if (leftArrowDown && _extentOffset > 2) {
           final TextSelection textSelection = _selectWordAtOffset(new TextPosition(offset: _extentOffset - 2));
           newOffset = textSelection.baseOffset + 1;
-        } else if (_rightArrowDown && _extentOffset < text.text.length - 2) {
+        } else if (rightArrowDown && _extentOffset < text.text.length - 2) {
           final TextSelection textSelection = _selectWordAtOffset(new TextPosition(offset: _extentOffset + 1));
           newOffset = textSelection.extentOffset - 1;
         }
@@ -263,23 +254,23 @@ class RenderEditable extends RenderBox {
 
       // Set the new offset to be +/- 1 depending on which arrow is pressed
       // If shift is down, we also want to update the previous cursor location
-      if (_rightArrowDown && _extentOffset < text.text.length) {
+      if (rightArrowDown && _extentOffset < text.text.length) {
         newOffset += 1;
         if (shiftIsDown)
           _previousCursorLocation += 1;
       }
-      if (_leftArrowDown && _extentOffset > 0) {
+      if (leftArrowDown && _extentOffset > 0) {
         newOffset -= 1;
         if (shiftIsDown)
           _previousCursorLocation -= 1;
       }
 
-      if (_downArrowDown || _upArrowDown) {
+      if (downArrowDown || upArrowDown) {
         // The caret offset gives a location in the upper left hand corner of
         // the caret so the middle of the line above is a half line above that
         // point and the line below is 1.5 lines below that point.
         final double plh = _textPainter.preferredLineHeight;
-        final double verticalOffset = _upArrowDown ? -0.5 * plh : 1.5 * plh;
+        final double verticalOffset = upArrowDown ? -0.5 * plh : 1.5 * plh;
 
         final Offset caretOffset = _textPainter.getOffsetForCaret(new TextPosition(offset: _extentOffset), _caretPrototype);
         final Offset caretOffsetTranslated = caretOffset.translate(0.0, verticalOffset);
@@ -290,9 +281,9 @@ class RenderEditable extends RenderBox {
         // cursor location. This allows us to restore to this position in the
         // case that the user wants to unhighlight some text.
         if (position.offset == _extentOffset){
-          if (_downArrowDown)
+          if (downArrowDown)
             newOffset = text.text.length;
-          else if (_upArrowDown)
+          else if (upArrowDown)
             newOffset = 0;
           _resetCursor = shiftIsDown;
         } else if (_resetCursor && shiftIsDown) {
@@ -320,9 +311,9 @@ class RenderEditable extends RenderBox {
       // arrow is used while there is a selection.
       else if (pressedDown){
         if (!selection.isCollapsed) {
-          if (_leftArrowDown)
+          if (leftArrowDown)
             newOffset = _baseOffset < _extentOffset ? _baseOffset : _extentOffset;
-          else if (_rightArrowDown)
+          else if (rightArrowDown)
             newOffset = _baseOffset > _extentOffset ? _baseOffset : _extentOffset;
         }
         onSelectionChanged(new TextSelection.fromPosition(

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math' as math;
 import 'dart:ui' as ui show TextBox;
-import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -14,7 +13,6 @@ import 'package:flutter/services.dart';
 import 'box.dart';
 import 'object.dart';
 import 'viewport_offset.dart';
-import 'package:flutter/foundation.dart';
 
 const double _kCaretGap = 1.0; // pixels
 const double _kCaretHeightOffset = 2.0; // pixels

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -490,7 +490,7 @@ class RenderEditable extends RenderBox {
       _listenerAttached = true;
     }
     else {
-      assert(!_listenerAttached);
+      assert(_listenerAttached);
       RawKeyboard.instance.removeListener(_handleKeyEvent);
       _listenerAttached = false;
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -239,7 +239,6 @@ class RenderEditable extends RenderBox {
     else if (pressedKeyCode == _downArrowCode)
       _downArrowDown = keyEvent is RawKeyDownEvent ? true : false;
 
-
     final bool arrowDown = _leftArrowDown || _rightArrowDown || _upArrowDown || _downArrowDown;
     if (arrowDown && _extentOffset != -1) {
       int newOffset = _extentOffset;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -456,7 +456,7 @@ class RenderEditable extends RenderBox {
   /// Whether the editable is currently focused.
   bool get hasFocus => _hasFocus;
   bool _hasFocus;
-  bool _listenerAttached;
+  bool _listenerAttached = false;
   set hasFocus(bool value) {
     assert(value != null);
     if (_hasFocus == value)
@@ -625,8 +625,6 @@ class RenderEditable extends RenderBox {
     super.attach(owner);
     _offset.addListener(markNeedsPaint);
     _showCursor.addListener(markNeedsPaint);
-    if (!_listenerAttached)
-      RawKeyboard.instance.addListener(_handleKeyEvent);
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -203,7 +203,10 @@ class RenderEditable extends RenderBox {
   static const int _kUpArrowCode = 19;
   static const int _kDownArrowCode = 20;
 
+  // The extent offset of the current selection
   int _extentOffset = -1;
+  
+  // The base offset of the current selection
   int _baseOffset = -1;
 
   // Holds the last location the user selected in the case that he selects all

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -428,6 +428,7 @@ class RenderEditable extends RenderBox {
   bool get hasFocus => _hasFocus;
   bool _hasFocus;
   set hasFocus(bool value) {
+    debugPrint(value.toString() + " and " + this.hashCode.toString());
     assert(value != null);
     if (_hasFocus == value)
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -166,9 +166,6 @@ class RenderEditable extends RenderBox {
       ..onTap = _handleTap;
     _longPress = new LongPressGestureRecognizer(debugOwner: this)
       ..onLongPress = _handleLongPress;
-    _drag = new PanGestureRecognizer(debugOwner: this)
-      ..onStart = _handleDragStart
-      ..onEnd = _handleDragEnd;
   }
 
   /// Character used to obscure text if [obscureText] is true.
@@ -808,7 +805,6 @@ class RenderEditable extends RenderBox {
 
   TapGestureRecognizer _tap;
   LongPressGestureRecognizer _longPress;
-  DragGestureRecognizer _drag;
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
@@ -873,18 +869,6 @@ class RenderEditable extends RenderBox {
   void _handleLongPress() {
     assert(!ignorePointer);
     handleLongPress();
-  }
-
-  void _handleDragStart(DragStartDetails details) {
-    if (details.deviceKind == PointerDeviceKind.mouse) {
-//      details.
-    }
-  }
-
-  void _handleDragEnd(DragEndDetails details) {
-    if (details.deviceKind == PointerDeviceKind.mouse) {
-
-    }
   }
 
   TextSelection _selectWordAtOffset(TextPosition position) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -330,19 +330,27 @@ class RenderEditable extends RenderBox {
   // Handles the selection of text or removal of the selection and placing
   // of the caret.
   int _handleShift(bool rightArrow, bool leftArrow, bool shift, int newOffset) {
+    if (onSelectionChanged == null)
+      return;
     // For some reason, deletion only works if the base offset is less
     // than the extent offset.
     if (shift) {
       if (_baseOffset < newOffset) {
         onSelectionChanged(
           new TextSelection(
-            baseOffset: _baseOffset, extentOffset: newOffset),
-            this, SelectionChangedCause.keyboard);
+            baseOffset: _baseOffset,
+            extentOffset: newOffset
+          ),
+          this,
+          SelectionChangedCause.keyboard);
       } else {
         onSelectionChanged(
           new TextSelection(
-            baseOffset: newOffset, extentOffset: _baseOffset),
-            this, SelectionChangedCause.keyboard);
+            baseOffset: newOffset,
+            extentOffset: _baseOffset
+          ),
+          this,
+          SelectionChangedCause.keyboard);
       }
     } else {
       // We want to put the cursor at the correct location depending on which
@@ -355,16 +363,15 @@ class RenderEditable extends RenderBox {
       }
       onSelectionChanged(
         new TextSelection.fromPosition(
-          new TextPosition(offset: newOffset)),
-          this, SelectionChangedCause.keyboard);
+          new TextPosition(
+              offset: newOffset
+          )
+        ),
+        this,
+        SelectionChangedCause.keyboard);
     }
     return newOffset;
   }
-
-
-
-
-
 
   /// Marks the render object as needing to be laid out again and have its text
   /// metrics recomputed.
@@ -475,10 +482,12 @@ class RenderEditable extends RenderBox {
       return;
     _hasFocus = value;
     if (_hasFocus) {
+      assert(!_listenerAttached);
       RawKeyboard.instance.addListener(_handleKeyEvent);
       _listenerAttached = true;
     }
     else {
+      assert(!_listenerAttached);
       RawKeyboard.instance.removeListener(_handleKeyEvent);
       _listenerAttached = false;
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -217,9 +217,10 @@ class RenderEditable extends RenderBox {
   // selects all the way to the end or the beginning of a field.
   bool _resetCursor = false;
 
-  static const int _kShiftMask = 1;
-  static const int _kControlMask = 1 << 12;
+  static const int _kShiftMask = 1; // https://developer.android.com/reference/android/view/KeyEvent.html#META_SHIFT_ON
+  static const int _kControlMask = 1 << 12; // https://developer.android.com/reference/android/view/KeyEvent.html#META_CTRL_ON
 
+  // TODO: All this should be changed to work in terms of extended grapheme clusters instead of UTF-16 words
   void _handleKeyEvent(RawKeyEvent keyEvent){
     if (defaultTargetPlatform != TargetPlatform.android)
       return;
@@ -253,7 +254,7 @@ class RenderEditable extends RenderBox {
       // Because the user can use multiple keys to change how he selects
       // the new offset variable is threaded through these four functions
       // and potentially changes after each one.
-      if (ctrl) 
+      if (ctrl)
         newOffset = _handleControl(rightArrow, leftArrow, ctrl, newOffset);
       newOffset = _handleHorizontalArrows(rightArrow, leftArrow, shift, newOffset);
       if (downArrow || upArrow)
@@ -333,8 +334,8 @@ class RenderEditable extends RenderBox {
   int _handleShift(bool rightArrow, bool leftArrow, bool shift, int newOffset) {
     if (onSelectionChanged == null)
       return newOffset;
-    // For some reason, deletion only works if the base offset is less
-    // than the extent offset.
+    // In the text_selection class, a TextSelection is defined such that the
+    // base offset is always less than the extent offset.
     if (shift) {
       if (_baseOffset < newOffset) {
         onSelectionChanged(
@@ -343,7 +344,8 @@ class RenderEditable extends RenderBox {
             extentOffset: newOffset
           ),
           this,
-          SelectionChangedCause.keyboard);
+          SelectionChangedCause.keyboard,
+        );
       } else {
         onSelectionChanged(
           new TextSelection(
@@ -351,7 +353,8 @@ class RenderEditable extends RenderBox {
             extentOffset: _baseOffset
           ),
           this,
-          SelectionChangedCause.keyboard);
+          SelectionChangedCause.keyboard,
+        );
       }
     } else {
       // We want to put the cursor at the correct location depending on which
@@ -369,7 +372,8 @@ class RenderEditable extends RenderBox {
           )
         ),
         this,
-        SelectionChangedCause.keyboard);
+        SelectionChangedCause.keyboard,
+      );
     }
     return newOffset;
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -220,7 +220,7 @@ class RenderEditable extends RenderBox {
   static const int _kShiftMask = 1; // https://developer.android.com/reference/android/view/KeyEvent.html#META_SHIFT_ON
   static const int _kControlMask = 1 << 12; // https://developer.android.com/reference/android/view/KeyEvent.html#META_CTRL_ON
 
-  // TODO: All this should be changed to work in terms of extended grapheme clusters instead of UTF-16 words
+  // TODO(goderbauer): doesn't handle extended grapheme clusters with more than one Unicode scalar value (https://github.com/flutter/flutter/issues/13404).
   void _handleKeyEvent(RawKeyEvent keyEvent){
     if (defaultTargetPlatform != TargetPlatform.android)
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -205,7 +205,7 @@ class RenderEditable extends RenderBox {
 
   // The extent offset of the current selection
   int _extentOffset = -1;
-  
+
   // The base offset of the current selection
   int _baseOffset = -1;
 
@@ -334,7 +334,7 @@ class RenderEditable extends RenderBox {
   // of the caret.
   int _handleShift(bool rightArrow, bool leftArrow, bool shift, int newOffset) {
     if (onSelectionChanged == null)
-      return;
+      return newOffset;
     // For some reason, deletion only works if the base offset is less
     // than the extent offset.
     if (shift) {

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -218,7 +218,6 @@ class RawKeyboard {
   static final RawKeyboard instance = new RawKeyboard._();
 
   final List<ValueChanged<RawKeyEvent>> _listeners = <ValueChanged<RawKeyEvent>>[];
-  
   /// Calls the listener every time the user presses or releases a key.
   ///
   /// Listeners can be removed with [removeListener].

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -218,13 +218,7 @@ class RawKeyboard {
   static final RawKeyboard instance = new RawKeyboard._();
 
   final List<ValueChanged<RawKeyEvent>> _listeners = <ValueChanged<RawKeyEvent>>[];
-
-  /// Whether the shift key is currently down.
-  static bool shiftDown = false;
-
-  /// Whether the control key is current down.
-  static bool controlDown = false;
-
+  
   /// Calls the listener every time the user presses or releases a key.
   ///
   /// Listeners can be removed with [removeListener].
@@ -239,20 +233,7 @@ class RawKeyboard {
     _listeners.remove(listener);
   }
 
-  static const int _kLeftShiftCode = 59;
-  static const int _kRightShiftCode = 60;
-  static const int _kLeftControlCode = 113;
-  static const int _kRightControlCode = 114;
-
   Future<dynamic> _handleKeyEvent(dynamic message) async {
-    if (message['keymap'] == 'android') {
-      final int keyCode = message['keyCode'];
-      final bool isDown = message['type'] == 'keydown';
-      if (keyCode == _kLeftShiftCode || keyCode == _kRightShiftCode) {
-        shiftDown = isDown;
-      } else if (keyCode == _kLeftControlCode || keyCode == _kRightControlCode)
-        controlDown = isDown;
-    }
     if (_listeners.isEmpty)
       return;
     final RawKeyEvent event = new RawKeyEvent.fromMessage(message);

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -239,18 +239,18 @@ class RawKeyboard {
     _listeners.remove(listener);
   }
 
-  final int _leftShiftCode = 59;
-  final int _rightShiftCode = 60;
-  final int _leftControlCode = 113;
-  final int _rightControlCode = 114;
+  static const int _kLeftShiftCode = 59;
+  static const int _kRightShiftCode = 60;
+  static const int _kLeftControlCode = 113;
+  static const int _kRightControlCode = 114;
 
   Future<dynamic> _handleKeyEvent(dynamic message) async {
     if (message['keymap'] == 'android') {
       final int keyCode = message['keyCode'];
       final bool isDown = message['type'] == 'keydown';
-      if (keyCode == _leftShiftCode || keyCode == _rightShiftCode) {
+      if (keyCode == _kLeftShiftCode || keyCode == _kRightShiftCode) {
         shiftDown = isDown;
-      } else if (keyCode == _leftControlCode || keyCode == _rightControlCode)
+      } else if (keyCode == _kLeftControlCode || keyCode == _kRightControlCode)
         controlDown = isDown;
     }
     if (_listeners.isEmpty)

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -218,6 +218,7 @@ class RawKeyboard {
   static final RawKeyboard instance = new RawKeyboard._();
 
   final List<ValueChanged<RawKeyEvent>> _listeners = <ValueChanged<RawKeyEvent>>[];
+
   /// Calls the listener every time the user presses or releases a key.
   ///
   /// Listeners can be removed with [removeListener].

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -219,6 +219,12 @@ class RawKeyboard {
 
   final List<ValueChanged<RawKeyEvent>> _listeners = <ValueChanged<RawKeyEvent>>[];
 
+  /// Whether the shift key is currently down.
+  static bool shiftDown = false;
+
+  /// Whether the control key is current down.
+  static bool controlDown = false;
+
   /// Calls the listener every time the user presses or releases a key.
   ///
   /// Listeners can be removed with [removeListener].
@@ -233,7 +239,20 @@ class RawKeyboard {
     _listeners.remove(listener);
   }
 
+  final int _leftShiftCode = 59;
+  final int _rightShiftCode = 60;
+  final int _leftControlCode = 113;
+  final int _rightControlCode = 114;
+
   Future<dynamic> _handleKeyEvent(dynamic message) async {
+    if (message['keymap'] == 'android') {
+      final int keyCode = message['keyCode'];
+      final bool isDown = message['type'] == 'keydown';
+      if (keyCode == _leftShiftCode || keyCode == _rightShiftCode) {
+        shiftDown = isDown;
+      } else if (keyCode == _leftControlCode || keyCode == _rightControlCode)
+        controlDown = isDown;
+    }
     if (_listeners.isEmpty)
       return;
     final RawKeyEvent event = new RawKeyEvent.fromMessage(message);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/services.dart';
 
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
-import 'dart:developer';
 
 class MockClipboard {
   Object _clipboardData = <String, dynamic>{
@@ -1921,11 +1920,6 @@ void main() {
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 5);
     });
-
-    // 2 focused text fields, both should
-    // Switch focus between two text fields, only the focused one should react
-    // Change the location of a text field using its global key, make sure it still reacts correctly
-
   });
 
   testWidgets('Changing positions of text fields', (WidgetTester tester) async{

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2062,7 +2062,7 @@ void main() {
                     child: TextField(
                       controller: c2,
                       maxLines: 3,
-                    ),
+//                    ),
                   ) ,
                 ),
               ),
@@ -2070,10 +2070,10 @@ void main() {
           ],
         ),
     );
-    debugger(when:true);
+//    debugger(when:true);
     await tester.idle();
     await tester.tap(find.byType(TextField).first);
-    await tester.showKeyboard(find.byType(TextField).first);
+//    await tester.showKeyboard(find.byType(TextField).first);
 
     const String testValue = 'a big house';
     await tester.enterText(find.byType(TextField).first, testValue);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/services.dart';
 
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
-import 'dart:ui' as ui;
 
 class MockClipboard {
   Object _clipboardData = <String, dynamic>{

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2015,6 +2015,79 @@ void main() {
 
   });
 
+
+  testWidgets('Changing focus test', (WidgetTester tester) async {
+    final FocusNode focusNode = new FocusNode();
+    final List<RawKeyEvent> events = <RawKeyEvent>[];
+
+    final TextEditingController c1 = new TextEditingController();
+    final TextEditingController c2 = new TextEditingController();
+    final Key key1 = new UniqueKey();
+    final Key key2 = new UniqueKey();
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home:
+        Material(
+          child: new RawKeyboardListener(
+            focusNode: focusNode,
+            onKey: events.add,
+            child: new Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                TextField(
+                  key: key1,
+                  controller: c1,
+                  maxLines: 3,
+                ),
+                TextField(
+                  key: key2,
+                  controller: c2,
+                  maxLines: 3,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+
+    await tester.idle();
+    await tester.tap(find.byType(TextField).first);
+
+    const String testValue = 'a big house';
+    await tester.enterText(find.byType(TextField).first, testValue);
+
+    await tester.pumpAndSettle();
+
+    for (int i = 0; i < 5; i += 1) {
+      sendKeyEventWithCode(22, true, true, false); // RIGHT_ARROW keydown
+      await tester.pumpAndSettle();
+    }
+
+    expect(c1.selection.extentOffset - c1.selection.baseOffset, 5);
+    expect(c2.selection.extentOffset - c2.selection.baseOffset, 0);
+
+
+    await tester.idle();
+    await tester.tap(find.byType(TextField).last);
+
+    await tester.enterText(find.byType(TextField).last, testValue);
+
+    await tester.pumpAndSettle();
+
+    for (int i = 0; i < 5; i += 1) {
+      sendKeyEventWithCode(22, true, true, false); // RIGHT_ARROW keydown
+      await tester.pumpAndSettle();
+    }
+
+
+    expect(c1.selection.extentOffset - c1.selection.baseOffset, 0);
+    expect(c2.selection.extentOffset - c2.selection.baseOffset, 5);
+
+  });
+
   testWidgets('Simultaneous focus test', (WidgetTester tester) async{
 
     final FocusNode focusNode = new FocusNode();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1809,11 +1809,11 @@ void main() {
             focusNode: focusNode,
             onKey: events.add,
             child: DefaultTextStyle(
-              style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+              style: const TextStyle(fontFamily: 'Ahem', fontSize: 10.0), maxLines: 10,
               child: Center(
                 child: TextField(
-                  maxLength: 10,
                   controller: controller,
+                  maxLines: 10,
                 ),
               ) ,
             ),
@@ -1895,12 +1895,36 @@ void main() {
         sendKeyEventWithCode(22);
         await tester.pumpAndSettle();
       }
-      sendKeyEventWithCode(59, false);
+      sendKeyEventWithCode(59);
       await tester.pumpAndSettle();
+      sendKeyEventWithCode(20);
+      await tester.pumpAndSettle();
+      // 'mom\nis ap'
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 10);
+
+      sendKeyEventWithCode(20);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 15);
+
       sendKeyEventWithCode(20, false);
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 0);
+      sendKeyEventWithCode(19);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 10);
+
+      sendKeyEventWithCode(19);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 1);
+
+      sendKeyEventWithCode(19);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 5);
+
     });
   });
   testWidgets('Caret works when maxLines is null', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1797,6 +1797,11 @@ void main() {
     setUp( () {
       events = <RawKeyEvent>[];
       controller = new TextEditingController();
+      sendKeyEventWithCode(59, false);
+      sendKeyEventWithCode(19, false);
+      sendKeyEventWithCode(20, false);
+      sendKeyEventWithCode(21, false);
+      sendKeyEventWithCode(113, false);
     });
 
     MaterialApp setupWidget() {
@@ -1891,6 +1896,9 @@ void main() {
       await tester.tap(find.byType(TextField));
       await tester.pumpAndSettle();
 
+      sendKeyEventWithCode(59, false);
+      await tester.pumpAndSettle();
+
       for (int i = 0; i < 5; i += 1) {
         sendKeyEventWithCode(22);
         await tester.pumpAndSettle();
@@ -1913,12 +1921,12 @@ void main() {
       sendKeyEventWithCode(19);
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 10);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 11);
 
       sendKeyEventWithCode(19);
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 1);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 2);
 
       sendKeyEventWithCode(19);
       await tester.pumpAndSettle();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2012,7 +2012,6 @@ void main() {
     }
 
     expect(c1.selection.extentOffset - c1.selection.baseOffset, 10);
-
   });
 
 
@@ -2052,7 +2051,6 @@ void main() {
       ),
     );
 
-
     await tester.idle();
     await tester.tap(find.byType(TextField).first);
 
@@ -2069,7 +2067,6 @@ void main() {
     expect(c1.selection.extentOffset - c1.selection.baseOffset, 5);
     expect(c2.selection.extentOffset - c2.selection.baseOffset, 0);
 
-
     await tester.idle();
     await tester.tap(find.byType(TextField).last);
 
@@ -2082,94 +2079,9 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-
     expect(c1.selection.extentOffset - c1.selection.baseOffset, 0);
     expect(c2.selection.extentOffset - c2.selection.baseOffset, 5);
-
   });
-
-  testWidgets('Simultaneous focus test', (WidgetTester tester) async{
-
-    final FocusNode focusNode = new FocusNode();
-    final FocusNode focusNode2 = new FocusNode();
-
-    final List<RawKeyEvent> events = <RawKeyEvent>[];
-    final List<RawKeyEvent> events2 = <RawKeyEvent>[];
-
-    final TextEditingController c1 = new TextEditingController();
-    final TextEditingController c2 = new TextEditingController();
-
-    await tester.pumpWidget(
-      new Column(
-        children: <Widget>[
-          new Container(
-            width: 200.0,
-            height: 200.0,
-            child:
-              new MaterialApp(
-                home:
-                Material(
-                  child:
-                  new RawKeyboardListener(
-                  focusNode: focusNode,
-                  onKey: events.add,
-                  child: TextField(
-                    controller: c1,
-                    maxLines: 3,
-                  ),
-                ) ,
-              ),
-            ),
-          ),
-          new Container(
-            width: 200.0,
-            height: 200.0,
-            child:
-              new MaterialApp(
-                home:
-                  Material(
-                  child:
-                  new RawKeyboardListener(
-                    focusNode: focusNode2,
-                    onKey: events2.add,
-                    child: TextField(
-                      controller: c2,
-                      maxLines: 3,
-//                    ),
-                  ) ,
-                ),
-              ),
-            ),
-          ],
-        ),
-    );
-//    debugger(when:true);
-    await tester.idle();
-    await tester.tap(find.byType(TextField).first);
-//    await tester.showKeyboard(find.byType(TextField).first);
-
-    const String testValue = 'a big house';
-    await tester.enterText(find.byType(TextField).first, testValue);
-
-    await tester.pumpAndSettle();
-
-    await tester.idle();
-    await tester.tap(find.byType(TextField).last);
-    await tester.showKeyboard(find.byType(TextField).last);
-
-    await tester.enterText(find.byType(TextField).last, testValue);
-
-    await tester.pumpAndSettle();
-
-    for (int i = 0; i < 5; i++) {
-      sendKeyEventWithCode(22, true, true, false); // DOWN_ARROW keydown
-      await tester.pumpAndSettle();
-    }
-
-    expect(c1.selection.extentOffset - c1.selection.baseOffset, 5);
-    expect(c2.selection.extentOffset - c2.selection.extentOffset, 5);
-  });
-
 
   testWidgets('Caret works when maxLines is null', (WidgetTester tester) async {
     final TextEditingController controller = new TextEditingController();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1789,25 +1789,22 @@ void main() {
   }
 
   group('Keyboard Tests', (){
-    List<RawKeyEvent> events;
     TextEditingController controller;
 
     setUp( () {
-      events = <RawKeyEvent>[];
       controller = new TextEditingController();
     });
 
     MaterialApp setupWidget() {
 
       final FocusNode focusNode = new FocusNode();
-      events = <RawKeyEvent>[];
       controller = new TextEditingController();
 
       return new MaterialApp(
         home:  Material(
           child: new RawKeyboardListener(
             focusNode: focusNode,
-            onKey: events.add,
+            onKey: null,
             child: TextField(
               controller: controller,
               maxLines: 3,

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1837,8 +1837,8 @@ void main() {
       await tester.tap(find.byType(TextField));
       await tester.pumpAndSettle();
 
-      sendKeyEventWithCode(59);
-      sendKeyEventWithCode(22);
+      sendKeyEventWithCode(59);  // SHIFT keydown
+      sendKeyEventWithCode(22);  // RIGHT_ARROW keydown
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 1);
     });
@@ -1852,11 +1852,11 @@ void main() {
       await tester.tap(find.byType(TextField));
       await tester.pumpAndSettle();
 
-      sendKeyEventWithCode(59);
+      sendKeyEventWithCode(59);         // SHIFT keydown
       await tester.pumpAndSettle();
-      sendKeyEventWithCode(113);
+      sendKeyEventWithCode(113);        // CONTROL keydown
       await tester.pumpAndSettle();
-      sendKeyEventWithCode(22);
+      sendKeyEventWithCode(22);         // RIGHT_ARROW keydown
 
       await tester.pumpAndSettle();
 
@@ -1872,15 +1872,15 @@ void main() {
       await tester.tap(find.byType(TextField));
       await tester.pumpAndSettle();
 
-      sendKeyEventWithCode(59);
+      sendKeyEventWithCode(59);         // SHIFT keydown
       await tester.pumpAndSettle();
-      sendKeyEventWithCode(20);
+      sendKeyEventWithCode(20);         // DOWN_ARROW keydown
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 11);
-      sendKeyEventWithCode(20, false);
+      sendKeyEventWithCode(20, false);    // DOWN_ARROW keyup
       await tester.pumpAndSettle();
-      sendKeyEventWithCode(19);
+      sendKeyEventWithCode(19);           // UP_ARROW keydown
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 0);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1830,7 +1830,7 @@ void main() {
     testWidgets('Shift test 1', (WidgetTester tester) async{
 
       await tester.pumpWidget(setupWidget());
-      const String testValue = 'your mom';
+      const String testValue = 'a big house';
       await tester.enterText(find.byType(TextField), testValue);
 
       await tester.idle();
@@ -1845,7 +1845,7 @@ void main() {
 
     testWidgets('Control Shift test', (WidgetTester tester) async{
       await tester.pumpWidget(setupWidget());
-      const String testValue = 'your mom';
+      const String testValue = 'their big house';
       await tester.enterText(find.byType(TextField), testValue);
 
       await tester.idle();
@@ -1860,12 +1860,12 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 5);
     });
 
     testWidgets('Down and up test', (WidgetTester tester) async{
       await tester.pumpWidget(setupWidget());
-      const String testValue = 'your mom';
+      const String testValue = 'a big house';
       await tester.enterText(find.byType(TextField), testValue);
 
       await tester.idle();
@@ -1877,7 +1877,7 @@ void main() {
       sendKeyEventWithCode(20);
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 8);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 11);
       sendKeyEventWithCode(20, false);
       await tester.pumpAndSettle();
       sendKeyEventWithCode(19);
@@ -1889,46 +1889,60 @@ void main() {
 
     testWidgets('Down and up test 2', (WidgetTester tester) async{
       await tester.pumpWidget(setupWidget());
-      const String testValue = 'your mom\nis a person';
+      const String testValue = 'a big house\njumped over a mouse'; // 11 \n 19
       await tester.enterText(find.byType(TextField), testValue);
 
       await tester.idle();
       await tester.tap(find.byType(TextField));
       await tester.pumpAndSettle();
 
-      sendKeyEventWithCode(59, false);
+      sendKeyEventWithCode(59, false);        // SHIFT keyup
       await tester.pumpAndSettle();
 
       for (int i = 0; i < 5; i += 1) {
-        sendKeyEventWithCode(22);
+        sendKeyEventWithCode(22);             // RIGHT_ARROW keydown
+        await tester.pumpAndSettle();
+        sendKeyEventWithCode(22, false);      // RIGHT_ARROW keyup
         await tester.pumpAndSettle();
       }
-      sendKeyEventWithCode(59);
+      sendKeyEventWithCode(59);               // SHIFT keydown
       await tester.pumpAndSettle();
-      sendKeyEventWithCode(20);
+      sendKeyEventWithCode(20);               // DOWN_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(20, false);        // DOWN_ARROW keyup
       await tester.pumpAndSettle();
       // 'mom\nis ap'
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 10);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 12);
 
-      sendKeyEventWithCode(20);
+      sendKeyEventWithCode(20);               // DOWN_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(20, false);        // DOWN_ARROW keyup
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 15);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 26);
 
-      sendKeyEventWithCode(20, false);
+      sendKeyEventWithCode(20);               // DOWN_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(20, false);        // DOWN_ARROW keyup
       await tester.pumpAndSettle();
 
-      sendKeyEventWithCode(19);
+      sendKeyEventWithCode(19);               // UP_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(19, false);        // UP_ARROW keyup
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 11);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 12);
 
-      sendKeyEventWithCode(19);
+      sendKeyEventWithCode(19);               // UP_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(19, false);        // UP_ARROW keyup
       await tester.pumpAndSettle();
 
-      expect(controller.selection.extentOffset - controller.selection.baseOffset, 2);
+      expect(controller.selection.extentOffset - controller.selection.baseOffset, 0);
 
-      sendKeyEventWithCode(19);
+      sendKeyEventWithCode(19);               // UP_ARROW keydown
+      await tester.pumpAndSettle();
+      sendKeyEventWithCode(19, false);        // UP_ARROW keyup
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 5);


### PR DESCRIPTION
fixes #15758

Added control, shift and arrow key text manipulation to keyboards on the chromebook and bluetooth keyboards connected to android devices. The up and down arrows now function correctly in respect to a text field moving the cursor up and down as expected.