### PR TITLE
add option to show/hide controls in material stepper

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -137,6 +137,7 @@ class Stepper extends StatefulWidget {
     @required this.steps,
     this.type = StepperType.vertical,
     this.currentStep = 0,
+    this.showControls: true,
     this.onStepTapped,
     this.onStepContinue,
     this.onStepCancel,
@@ -159,6 +160,9 @@ class Stepper extends StatefulWidget {
 
   /// The index into [steps] of the current step whose content is displayed.
   final int currentStep;
+
+  /// Wheter to show navigation controls
+  final bool showControls;
 
   /// The callback called when a step is tapped, with its index passed as
   /// an argument.
@@ -325,6 +329,10 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   }
 
   Widget _buildVerticalControls() {
+    if (!widget.showControls){
+	return new Container();
+	}
+
     Color cancelColor;
 
     switch (Theme.of(context).brightness) {

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -137,7 +137,7 @@ class Stepper extends StatefulWidget {
     @required this.steps,
     this.type = StepperType.vertical,
     this.currentStep = 0,
-    this.showControls: true,
+    this.showControls = true,
     this.onStepTapped,
     this.onStepContinue,
     this.onStepCancel,


### PR DESCRIPTION
Material Stepper doesn't have an option to customize navigation controls "Continue"and "Cancel". This first patch is intended to give the developer an option to remove the default controls in order to create its own controls. #20237 