### PR TITLE
increase size of user account drawer headers to 48 by 48

### DIFF
--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -31,13 +31,16 @@ class _AccountPictures extends StatelessWidget {
           end: 0.0,
           child: new Row(
             children: (otherAccountsPictures ?? <Widget>[]).take(3).map((Widget picture) {
-              return new Semantics(
-                explicitChildNodes: true,
-                child: new Container(
-                  margin: const EdgeInsetsDirectional.only(start: 16.0),
-                  width: 40.0,
-                  height: 40.0,
-                  child: picture
+              return new Container(
+                margin: const EdgeInsetsDirectional.only(start: 8.0),
+                width: 48.0,
+                height: 48.0,
+                child: new Semantics(
+                  container: true,
+                  child: new Padding(
+                    child: picture,
+                    padding: const EdgeInsets.all(4.0),
+                  ),
                 ),
               );
             }).toList(),

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -375,6 +375,7 @@ void main() {
   });
 
   testWidgets('alternative account selectors have sufficient tap targets', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
     await pumpTestWidget(tester);
 
     expect(tester.getSemanticsData(find.text('B')), matchesSemanticsData(
@@ -391,6 +392,7 @@ void main() {
       label: 'D',
       size: const Size(48.0, 48.0),
     ));
+    handle.dispose();
   });
 
   testWidgets('UserAccountsDrawerHeader provides semantics with missing properties', (WidgetTester tester) async {

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -374,6 +374,25 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('alternative account selectors have sufficient tap targets', (WidgetTester tester) async {
+    await pumpTestWidget(tester);
+
+    expect(tester.getSemanticsData(find.text('B')), matchesSemanticsData(
+      label: 'B',
+      size: const Size(48.0, 48.0),
+    ));
+
+    expect(tester.getSemanticsData(find.text('C')), matchesSemanticsData(
+      label: 'C',
+      size: const Size(48.0, 48.0),
+    ));
+
+    expect(tester.getSemanticsData(find.text('D')), matchesSemanticsData(
+      label: 'D',
+      size: const Size(48.0, 48.0),
+    ));
+  });
+
   testWidgets('UserAccountsDrawerHeader provides semantics with missing properties', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
     await pumpTestWidget(

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -98,8 +98,8 @@ void main() {
 
     expect(avatarATopLeft.dx - topLeft.dx, equals(16.0 + 10.0)); // left padding
     expect(avatarATopLeft.dy - topLeft.dy, equals(16.0 + 20.0)); // add top padding
-    expect(topRight.dx - avatarDTopRight.dx, equals(16.0 + 30.0)); // right padding
-    expect(avatarDTopRight.dy - topRight.dy, equals(16.0 + 20.0)); // add top padding
+    expect(topRight.dx - avatarDTopRight.dx, equals(16.0 + 34.0)); // right padding
+    expect(avatarDTopRight.dy - topRight.dy, equals(16.0 + 24.0)); // add top padding
     expect(avatarDTopRight.dx - avatarCTopRight.dx, equals(40.0 + 16.0)); // size + space between
   });
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -306,6 +306,7 @@ Matcher matchesSemanticsData({
   String value,
   TextDirection textDirection,
   Rect rect,
+  Size size,
   // Flags //
   bool hasCheckedState = false,
   bool isChecked = false,
@@ -447,6 +448,7 @@ Matcher matchesSemanticsData({
     flags: flags,
     textDirection: textDirection,
     rect: rect,
+    size: size,
     customActions: customActions,
     hintOverrides: hintOverrides,
   );
@@ -1478,6 +1480,7 @@ class _MatchesSemanticsData extends Matcher {
     this.actions,
     this.textDirection,
     this.rect,
+    this.size,
     this.customActions,
     this.hintOverrides,
   });
@@ -1491,6 +1494,7 @@ class _MatchesSemanticsData extends Matcher {
   final List<SemanticsFlag> flags;
   final TextDirection textDirection;
   final Rect rect;
+  final Size size;
 
   @override
   Description describe(Description description) {
@@ -1509,6 +1513,8 @@ class _MatchesSemanticsData extends Matcher {
       description.add('with textDirection: $textDirection ');
     if (rect != null)
       description.add('with rect: $rect');
+    if (size != null)
+      description.add('with size: $size');
     if (customActions != null)
       description.add('with custom actions: $customActions');
     if (hintOverrides != null)
@@ -1530,9 +1536,10 @@ class _MatchesSemanticsData extends Matcher {
       return failWithDescription(matchState, 'value was: ${data.value}');
     if (textDirection != null && textDirection != data.textDirection)
       return failWithDescription(matchState, 'textDirection was: $textDirection');
-    if (rect != null && rect != data.rect) {
-      return failWithDescription(matchState, 'rect was: $rect');
-    }
+    if (rect != null && rect != data.rect)
+      return failWithDescription(matchState, 'rect was: ${data.rect}');
+    if (size != null && size != data.rect.size)
+      return failWithDescription(matchState, 'size was: ${data.rect.size}');
     if (actions != null) {
       int actionBits = 0;
       for (SemanticsAction action in actions)

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -483,11 +483,11 @@ void main() {
       final SemanticsData data = new SemanticsData(
         flags: flags,
         actions: actions,
-        label: '',
-        increasedValue: '',
-        value: '',
-        decreasedValue: '',
-        hint: '',
+        label: 'a',
+        increasedValue: 'b',
+        value: 'c',
+        decreasedValue: 'd',
+        hint: 'e',
         textDirection: TextDirection.ltr,
         rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
         textSelection: null,
@@ -498,6 +498,8 @@ void main() {
       );
 
       expect(data, matchesSemanticsData(
+         rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
+         size: const Size(10.0, 10.0),
          /* Flags */
          hasCheckedState: true,
          isChecked: true,


### PR DESCRIPTION
-Also augments semanticsData matcher with size argument.
- No change in layout, moved margin into padding to achieve tap target.

## Old | New
<img src="https://user-images.githubusercontent.com/8975114/43730492-5a09347a-9960-11e8-8de2-16ac3449b3d5.png" width="250"><img src="https://user-images.githubusercontent.com/8975114/43730494-5b631fd4-9960-11e8-9249-8e16e8abe76e.png" width="250">
