### PR TITLE
FlutterProject refactoring and test coverage

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -200,22 +200,26 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
   }
 }
 
-/// Overwrite android/local.properties in the specified Flutter project, if needed.
+/// Overwrite local.properties in the specified Flutter project's Android
+/// sub-project, if needed.
 ///
-/// Throws, if `pubspec.yaml` or Android SDK cannot be located.
+/// Throws tool exit, if `pubspec.yaml` is invalid.
 ///
-/// If [requireSdk] is `true` this will fail with a tool-exit if no Android Sdk
+/// If [requireSdk] is `true` this will fail with a tool exit if no Android Sdk
 /// is found.
 Future<void> updateLocalProperties({
   @required FlutterProject project,
   BuildInfo buildInfo,
   bool requireAndroidSdk = true,
 }) async {
+  if (project.manifest == null) {
+    throwToolExit('Invalid `pubspec.yaml`');
+  }
   if (requireAndroidSdk && androidSdk == null) {
     throwToolExit('Unable to locate Android SDK. Please run `flutter doctor` for more details.');
   }
 
-  final File localProperties = project.androidLocalPropertiesFile;
+  final File localProperties = project.android.localPropertiesFile;
   bool changed = false;
 
   SettingsFile settings;

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -15,7 +15,6 @@ import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
-import '../bundle.dart' as bundle;
 import '../cache.dart';
 import '../flutter_manifest.dart';
 import '../globals.dart';
@@ -26,25 +25,6 @@ final RegExp _varExpr = new RegExp(r'\$\((.*)\)');
 
 String flutterFrameworkDir(BuildMode mode) {
   return fs.path.normalize(fs.path.dirname(artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, mode)));
-}
-
-/// Writes default Xcode properties files in the Flutter project at [projectPath],
-/// if project is an iOS project and such files are out of date or do not
-/// already exist.
-Future<void> generateXcodeProperties({FlutterProject project}) async {
-  if (project.manifest.isModule ||
-      project.ios.directory.existsSync()) {
-    if (!Cache.instance.fileOlderThanToolsStamp(project.generatedXcodePropertiesFile)) {
-      return;
-    }
-
-    await updateGeneratedXcodeProperties(
-      project: project,
-      buildInfo: BuildInfo.debug,
-      targetOverride: bundle.defaultMainPath,
-      previewDart2: true,
-    );
-  }
 }
 
 /// Writes or rewrites Xcode property files with the specified information.
@@ -119,7 +99,7 @@ Future<void> updateGeneratedXcodeProperties({
     localsBuffer.writeln('TRACK_WIDGET_CREATION=true');
   }
 
-  final File generatedXcodePropertiesFile = project.generatedXcodePropertiesFile;
+  final File generatedXcodePropertiesFile = project.ios.generatedXcodePropertiesFile;
   generatedXcodePropertiesFile.createSync(recursive: true);
   generatedXcodePropertiesFile.writeAsStringSync(localsBuffer.toString());
 }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -158,7 +158,7 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
   };
 
   final String javaSourcePath = fs.path.join(
-    project.androidPluginRegistrantHost.path,
+    project.android.pluginRegistrantHost.path,
     'src',
     'main',
     'java',
@@ -247,8 +247,8 @@ Future<void> _writeIOSPluginRegistrant(FlutterProject project, List<Plugin> plug
     'plugins': iosPlugins,
   };
 
-  final String registryDirectory = project.iosPluginRegistrantHost.path;
-  if (project.manifest.isModule) {
+  final String registryDirectory = project.ios.pluginRegistrantHost.path;
+  if (project.isModule) {
     final String registryClassesDirectory = fs.path.join(registryDirectory, 'Classes');
     _renderTemplateToFile(
       _iosPluginRegistrantPodspecTemplate,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:meta/meta.dart';
 
 import 'android/gradle.dart' as gradle;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -114,9 +114,8 @@ class FlutterProject {
   /// Generates project files necessary to make Gradle builds work on Android
   /// and CocoaPods+Xcode work on iOS, for app and module projects only.
   Future<void> ensureReadyForPlatformSpecificTooling() async {
-    if (!directory.existsSync() || hasExampleApp) {
+    if (!directory.existsSync() || hasExampleApp)
       return;
-    }
     await android.ensureReadyForPlatformSpecificTooling(this);
     await ios.ensureReadyForPlatformSpecificTooling(this);
     await injectPlugins(this);
@@ -155,6 +154,10 @@ class IosProject {
   }
 
   Future<void> ensureReadyForPlatformSpecificTooling(FlutterProject parent) async {
+    if (isModule && _shouldRegenerateFromTemplate()) {
+      final Template template = new Template.fromName(fs.path.join('module', 'ios'));
+      template.render(directory, <String, dynamic>{}, printStatusWhenWriting: false);
+    }
     if (!directory.existsSync())
       return;
     if (Cache.instance.fileOlderThanToolsStamp(generatedXcodePropertiesFile)) {
@@ -164,11 +167,6 @@ class IosProject {
         targetOverride: bundle.defaultMainPath,
         previewDart2: true,
       );
-    }
-
-    if (isModule && _shouldRegenerateFromTemplate()) {
-      final Template template = new Template.fromName(fs.path.join('module', 'ios'));
-      template.render(directory, <String, dynamic>{}, printStatusWhenWriting: false);
     }
   }
 
@@ -228,9 +226,6 @@ class AndroidProject {
   }
 
   Future<void> ensureReadyForPlatformSpecificTooling(FlutterProject parent) async {
-    if (!directory.existsSync())
-      return;
-    await gradle.updateLocalProperties(project: parent, requireAndroidSdk: false);
     if (isModule && _shouldRegenerateFromTemplate()) {
       final Template template = new Template.fromName(fs.path.join('module', 'android'));
       template.render(
@@ -242,6 +237,9 @@ class AndroidProject {
       );
       gradle.injectGradleWrapper(directory);
     }
+    if (!directory.existsSync())
+      return;
+    await gradle.updateLocalProperties(project: parent, requireAndroidSdk: false);
   }
 
   bool _shouldRegenerateFromTemplate() {

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -228,7 +228,7 @@ FlutterProject aModuleProject() {
 void testInMemory(String description, Future<Null> testMethod()) {
   Cache.flutterRoot = 'flutter';
   final FileSystem fs = new MemoryFileSystem();
-  // Pretend we have a project template.
+  // Pretend we have a Flutter module project template.
   fs.directory(Cache.flutterRoot)
       .childDirectory('packages')
       .childDirectory('flutter_tools')
@@ -247,7 +247,7 @@ void testInMemory(String description, Future<Null> testMethod()) {
       .childFile('template_content.copy.tmpl')
       .createSync(recursive: true);
 
-  // Sets up cache in a text execution context where fs is the FileSystem.
+  // Sets up cache in a test execution context where `fs` is the file system.
   Cache cacheCreator() {
     final Cache cache = new Cache(rootOverride: fs.directory('flutter'));
     cache.getArtifactDirectory('gradle_wrapper')

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:test/test.dart';
@@ -23,73 +24,101 @@ void main() {
         (await FlutterProject.fromPath(directory.path)).directory.absolute.path,
         directory.absolute.path,
       );
+      expect(
+        (await FlutterProject.current()).directory.absolute.path,
+        fs.currentDirectory.absolute.path,
+      );
     });
+    
     group('ensure ready for platform-specific tooling', () {
       testInMemory('does nothing, if project is not created', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.directory.existsSync(), isFalse);
       });
       testInMemory('does nothing in plugin or package root project', () async {
-        final FlutterProject project = await aPluginProject();
+        final FlutterProject project = aPluginProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isFalse);
         expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isFalse);
       });
       testInMemory('injects plugins', () async {
-        final FlutterProject project = await aProjectWithIos();
+        final FlutterProject project = aProjectWithIos();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isTrue);
       });
       testInMemory('generates Xcode configuration', () async {
-        final FlutterProject project = await aProjectWithIos();
+        final FlutterProject project = aProjectWithIos();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
       });
     });
+
+    group('module status', () {
+      testInMemory('is known for module', () async {
+        final FlutterProject project = aModuleProject();
+        expect(project.isModule, isTrue);
+      });
+      testInMemory('is known for non-module', () async {
+        final FlutterProject project = someProject();
+        expect(project.isModule, isFalse);
+      });
+    });
+
+    group('example', () {
+      testInMemory('exists for plugin', () async {
+        final FlutterProject project = aPluginProject();
+        expect(project.hasExampleApp, isTrue);
+      });
+      testInMemory('does not exist for non-plugin', () async {
+        final FlutterProject project = someProject();
+        expect(project.hasExampleApp, isFalse);
+      });
+    });
+
     group('organization names set', () {
       testInMemory('is empty, if project not created', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         expect(await project.organizationNames(), isEmpty);
       });
       testInMemory('is empty, if no platform folders exist', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         project.directory.createSync();
         expect(await project.organizationNames(), isEmpty);
       });
       testInMemory('is populated from iOS bundle identifier', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addAndroidWithApplicationId(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from iOS bundle identifier in plugin example', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addIosWithBundleId(project.example.directory, 'io.flutter.someProject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID in plugin example', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addAndroidWithApplicationId(project.example.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android group in plugin', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addAndroidWithGroup(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is singleton, if sources agree', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         addAndroidWithApplicationId(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is non-singleton, if sources disagree', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         addAndroidWithApplicationId(project.directory, 'io.clutter.someproject');
         expect(
@@ -101,22 +130,43 @@ void main() {
   });
 }
 
-Future<FlutterProject> someProject() => FlutterProject.fromPath('some_project');
+FlutterProject someProject() => new FlutterProject(
+  fs.directory('some_project'),
+  FlutterManifest.empty(),
+  FlutterManifest.empty(),
+);
 
-Future<FlutterProject> aProjectWithIos() {
+FlutterProject aProjectWithIos() {
   final Directory directory = fs.directory('ios_project');
-  directory.childFile('pubspec.yaml').createSync(recursive: true);
   directory.childFile('.packages').createSync(recursive: true);
   directory.childDirectory('ios').createSync(recursive: true);
-  return FlutterProject.fromDirectory(directory);
+  return new FlutterProject(directory, FlutterManifest.empty(), FlutterManifest.empty());
 }
 
-Future<FlutterProject> aPluginProject() {
+FlutterProject aPluginProject() {
   final Directory directory = fs.directory('plugin_project/example');
-  directory.childFile('pubspec.yaml').createSync(recursive: true);
-  directory.childFile('.packages').createSync(recursive: true);
-  directory.childDirectory('ios').createSync(recursive: true);
-  return FlutterProject.fromDirectory(directory.parent);
+  directory.createSync(recursive: true);
+  return new FlutterProject(
+    directory.parent,
+    FlutterManifest.mock(const <String, dynamic>{
+      'flutter': <String, dynamic>{
+        'plugin': <String, dynamic>{}
+      }
+    }),
+    FlutterManifest.empty(),
+  );
+}
+
+FlutterProject aModuleProject() {
+  return new FlutterProject(
+    fs.directory('module_project'),
+    FlutterManifest.mock(const <String, dynamic>{
+      'flutter': <String, dynamic>{
+        'module': <String, dynamic>{}
+      }
+    }),
+    FlutterManifest.empty(),
+  );
 }
 
 void testInMemory(String description, Future<Null> testMethod()) {

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -76,10 +76,23 @@ void main() {
       testInMemory('creates Android library in module', () async {
         final FlutterProject project = aModuleProject();
         await project.ensureReadyForPlatformSpecificTooling();
+        expect(project.android.directory.childFile('template_content').existsSync(), isTrue);
         expect(project.android.directory.childFile('local.properties').existsSync(), isTrue);
-        expect(project.android.directory.childFile('settings.gradle').existsSync(), isTrue);
         expect(project.android.directory.childFile(
           'Flutter/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
+        ).existsSync(), isTrue);
+      });
+      testInMemory('creates iOS pod in module', () async {
+        final FlutterProject project = aModuleProject();
+        await project.ensureReadyForPlatformSpecificTooling();
+        final Directory flutter = project.ios.directory.childDirectory('Flutter');
+        expect(flutter.childFile('template_content').existsSync(), isTrue);
+        expect(flutter.childFile('Generated.xcconfig').existsSync(), isTrue);
+        expect(flutter.childFile(
+          'FlutterPluginRegistrant/Classes/GeneratedPluginRegistrant.h',
+        ).existsSync(), isTrue);
+        expect(flutter.childFile(
+          'FlutterPluginRegistrant/Classes/GeneratedPluginRegistrant.m',
         ).existsSync(), isTrue);
       });
     });
@@ -222,7 +235,16 @@ void testInMemory(String description, Future<Null> testMethod()) {
       .childDirectory('templates')
       .childDirectory('module')
       .childDirectory('android')
-      .childFile('settings.gradle.tmpl')
+      .childFile('template_content.copy.tmpl')
+      .createSync(recursive: true);
+  fs.directory(Cache.flutterRoot)
+      .childDirectory('packages')
+      .childDirectory('flutter_tools')
+      .childDirectory('templates')
+      .childDirectory('module')
+      .childDirectory('ios')
+      .childDirectory('Flutter.tmpl')
+      .childFile('template_content.copy.tmpl')
       .createSync(recursive: true);
 
   // Sets up cache in a text execution context where fs is the FileSystem.


### PR DESCRIPTION
Avoid separate types for `android/` and `.android/` sub-projects. Similarly for iOS.