### PR TITLE
Replace Intl.plural() with Intl.pluralLogic() in MaterialLocalizations

### DIFF
--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -353,7 +353,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   @override
   String selectedRowCountTitle(int selectedRowCount) {
-    return intl.Intl.plural(
+    return intl.Intl.pluralLogic(
       selectedRowCount,
       zero: selectedRowCountTitleZero,
       one: selectedRowCountTitleOne,


### PR DESCRIPTION
Although there's never a need to apply the Dart intl_translation package's "extract_to_arb" tool to the Flutter sources, some apps appear to do this.

The extract_to_arb tool converts `Intl.message() ` and `Intl.plural()` calls in Dart source code to `.arb` message translation files. The addition of the Intl.plural() call in MaterialLocalizations (https://github.com/flutter/flutter/pull/20018) looked like an invalid message to extract_to_arb.

Fortunately Intl.pluralLogic(), which is not scanned by the extract_to_arb tool, can be used in this case.

I have not included a test with this change because verifying that extract_to_arb can be safely applied to the flutter and flutter_localizations packages' source code seems unnecessary.
