### PR TITLE
Avoid null manifests in FlutterProject

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -203,18 +203,13 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 /// Overwrite local.properties in the specified Flutter project's Android
 /// sub-project, if needed.
 ///
-/// Throws tool exit, if `pubspec.yaml` is invalid.
-///
-/// If [requireSdk] is `true` this will fail with a tool exit if no Android Sdk
-/// is found.
+/// If [requireAndroidSdk] is true (the default) and no Android SDK is found,
+/// this will fail with a [ToolExit].
 Future<void> updateLocalProperties({
   @required FlutterProject project,
   BuildInfo buildInfo,
   bool requireAndroidSdk = true,
 }) async {
-  if (project.manifest == null) {
-    throwToolExit('Invalid `pubspec.yaml`');
-  }
   if (requireAndroidSdk && androidSdk == null) {
     throwToolExit('Unable to locate Android SDK. Please run `flutter doctor` for more details.');
   }

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -78,8 +78,10 @@ class FlutterManifest {
   /// A map representation of the `flutter` section in the `pubspec.yaml` file.
   Map<String, dynamic> _flutterDescriptor;
 
+  /// True if the `pubspec.yaml` file does not exist.
   bool get isEmpty => _descriptor.isEmpty;
 
+  /// The string value of the top-level `name` property in the `pubspec.yaml` file.
   String get appName => _descriptor['name'] ?? '';
 
   /// The version String from the `pubspec.yaml` file.

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -28,14 +28,6 @@ class FlutterManifest {
     return manifest;
   }
 
-  /// Returns a mock manifest with the given contents.
-  static FlutterManifest mock(Map<String, dynamic> contents) {
-    final FlutterManifest manifest = new FlutterManifest._();
-    manifest._descriptor = contents ?? const <String, dynamic>{};
-    manifest._flutterDescriptor = manifest._descriptor['flutter'] ?? const <String, dynamic>{};
-    return manifest;
-  }
-
   /// Returns null on invalid manifest. Returns empty manifest on missing file.
   static Future<FlutterManifest> createFromPath(String path) async {
     if (path == null || !fs.isFileSync(path))

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -16,7 +16,6 @@ import '../base/process_manager.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../flutter_manifest.dart';
 import '../globals.dart';
 import '../project.dart';
 
@@ -59,20 +58,19 @@ Future<void> updateGeneratedXcodeProperties({
 
   localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
 
-  final FlutterManifest manifest = project.manifest;
-  if (!manifest.isModule) {
+  if (!project.isModule) {
     // For module projects we do not want to write the FLUTTER_FRAMEWORK_DIR
     // explicitly. Rather we rely on the xcode backend script and the Podfile
     // logic to derive it from FLUTTER_ROOT and FLUTTER_BUILD_MODE.
     localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=${flutterFrameworkDir(buildInfo.mode)}');
   }
 
-  final String buildName = buildInfo?.buildName ?? manifest.buildName;
+  final String buildName = buildInfo?.buildName ?? project.manifest.buildName;
   if (buildName != null) {
     localsBuffer.writeln('FLUTTER_BUILD_NAME=$buildName');
   }
 
-  final int buildNumber = buildInfo?.buildNumber ?? manifest.buildNumber;
+  final int buildNumber = buildInfo?.buildNumber ?? project.manifest.buildNumber;
   if (buildNumber != null) {
     localsBuffer.writeln('FLUTTER_BUILD_NUMBER=$buildNumber');
   }

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -25,14 +25,25 @@ void main() {
         );
       });
 
+      Future<Null> expectToolExitLater(Future<dynamic> future, Matcher messageMatcher) async {
+        try {
+          await future;
+          fail('ToolExit expected, but nothing thrown');
+        } on ToolExit catch(e) {
+          expect(e.message, messageMatcher);
+        } catch(e) {
+          fail('ToolExit expected, got $e');
+        }
+      }
+
       testInMemory('fails on invalid pubspec.yaml', () async {
         final Directory directory = fs.directory('myproject');
         directory.childFile('pubspec.yaml')
           ..createSync(recursive: true)
           ..writeAsStringSync(invalidPubspec);
-        await expectLater(
+        await expectToolExitLater(
           FlutterProject.fromDirectory(directory),
-          throwsA(const isInstanceOf<ToolExit>()),
+          contains('pubspec.yaml'),
         );
       });
 
@@ -41,9 +52,9 @@ void main() {
         directory.childDirectory('example').childFile('pubspec.yaml')
           ..createSync(recursive: true)
           ..writeAsStringSync(invalidPubspec);
-        await expectLater(
+        await expectToolExitLater(
           FlutterProject.fromDirectory(directory),
-          throwsA(const isInstanceOf<ToolExit>()),
+          contains('pubspec.yaml'),
         );
       });
 

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -286,7 +287,9 @@ flutter:
 /// is in memory.
 void testInMemory(String description, Future<Null> testMethod()) {
   Cache.flutterRoot = getFlutterRoot();
-  final FileSystem testFileSystem = new MemoryFileSystem();
+  final FileSystem testFileSystem = new MemoryFileSystem(
+    style: platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+  );
   // Transfer needed parts of the Flutter installation folder
   // to the in-memory file system used during testing.
   transfer(new Cache().getArtifactDirectory('gradle_wrapper'), testFileSystem);

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:test/test.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'src/common.dart';
 import 'src/context.dart';
 
 void main() {
@@ -95,7 +96,7 @@ void main() {
         expect(project.directory.existsSync(), isFalse);
       });
       testInMemory('does nothing in plugin or package root project', () async {
-        final FlutterProject project = aPluginProject();
+        final FlutterProject project = await aPluginProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isFalse);
         expect(project.android.directory.childFile(
@@ -105,41 +106,41 @@ void main() {
         expect(project.android.directory.childFile('local.properties').existsSync(), isFalse);
       });
       testInMemory('injects plugins for iOS', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Runner/GeneratedPluginRegistrant.h').existsSync(), isTrue);
       });
       testInMemory('generates Xcode configuration for iOS', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.ios.directory.childFile('Flutter/Generated.xcconfig').existsSync(), isTrue);
       });
       testInMemory('injects plugins for Android', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.android.directory.childFile(
           'app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
         ).existsSync(), isTrue);
       });
       testInMemory('updates local properties for Android', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         await project.ensureReadyForPlatformSpecificTooling();
         expect(project.android.directory.childFile('local.properties').existsSync(), isTrue);
       });
       testInMemory('creates Android library in module', () async {
-        final FlutterProject project = aModuleProject();
+        final FlutterProject project = await aModuleProject();
         await project.ensureReadyForPlatformSpecificTooling();
-        expect(project.android.directory.childFile('template_content').existsSync(), isTrue);
+        expect(project.android.directory.childFile('settings.gradle').existsSync(), isTrue);
         expect(project.android.directory.childFile('local.properties').existsSync(), isTrue);
         expect(project.android.directory.childFile(
           'Flutter/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
         ).existsSync(), isTrue);
       });
       testInMemory('creates iOS pod in module', () async {
-        final FlutterProject project = aModuleProject();
+        final FlutterProject project = await aModuleProject();
         await project.ensureReadyForPlatformSpecificTooling();
         final Directory flutter = project.ios.directory.childDirectory('Flutter');
-        expect(flutter.childFile('template_content').existsSync(), isTrue);
+        expect(flutter.childFile('podhelper.rb').existsSync(), isTrue);
         expect(flutter.childFile('Generated.xcconfig').existsSync(), isTrue);
         expect(flutter.childFile(
           'FlutterPluginRegistrant/Classes/GeneratedPluginRegistrant.h',
@@ -152,7 +153,7 @@ void main() {
 
     group('module status', () {
       testInMemory('is known for module', () async {
-        final FlutterProject project = aModuleProject();
+        final FlutterProject project = await aModuleProject();
         expect(project.isModule, isTrue);
         expect(project.android.isModule, isTrue);
         expect(project.ios.isModule, isTrue);
@@ -160,7 +161,7 @@ void main() {
         expect(project.ios.directory.path, startsWith('module_project/.ios'));
       });
       testInMemory('is known for non-module', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         expect(project.isModule, isFalse);
         expect(project.android.isModule, isFalse);
         expect(project.ios.isModule, isFalse);
@@ -171,58 +172,58 @@ void main() {
 
     group('example', () {
       testInMemory('exists for plugin', () async {
-        final FlutterProject project = aPluginProject();
+        final FlutterProject project = await aPluginProject();
         expect(project.hasExampleApp, isTrue);
       });
       testInMemory('does not exist for non-plugin', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         expect(project.hasExampleApp, isFalse);
       });
     });
 
     group('organization names set', () {
       testInMemory('is empty, if project not created', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         expect(await project.organizationNames(), isEmpty);
       });
       testInMemory('is empty, if no platform folders exist', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         project.directory.createSync();
         expect(await project.organizationNames(), isEmpty);
       });
       testInMemory('is populated from iOS bundle identifier', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addAndroidWithApplicationId(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from iOS bundle identifier in plugin example', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addIosWithBundleId(project.example.directory, 'io.flutter.someProject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID in plugin example', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addAndroidWithApplicationId(project.example.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is populated from Android group in plugin', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addAndroidWithGroup(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is singleton, if sources agree', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         addAndroidWithApplicationId(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames(), <String>['io.flutter']);
       });
       testInMemory('is non-singleton, if sources disagree', () async {
-        final FlutterProject project = someProject();
+        final FlutterProject project = await someProject();
         addIosWithBundleId(project.directory, 'io.flutter.someProject');
         addAndroidWithApplicationId(project.directory, 'io.clutter.someproject');
         expect(
@@ -234,98 +235,81 @@ void main() {
   });
 }
 
-FlutterProject someProject() {
+Future<FlutterProject> someProject() async {
   final Directory directory = fs.directory('some_project');
   directory.childFile('.packages').createSync(recursive: true);
   directory.childDirectory('ios').createSync(recursive: true);
   directory.childDirectory('android').createSync(recursive: true);
-  return new FlutterProject(
-    directory,
-    FlutterManifest.empty(),
-    FlutterManifest.empty(),
-  );
+  return FlutterProject.fromDirectory(directory);
 }
 
-FlutterProject aPluginProject() {
+Future<FlutterProject> aPluginProject() async {
   final Directory directory = fs.directory('plugin_project');
   directory.childDirectory('ios').createSync(recursive: true);
   directory.childDirectory('android').createSync(recursive: true);
   directory.childDirectory('example').createSync(recursive: true);
-  return new FlutterProject(
-    directory,
-    FlutterManifest.mock(const <String, dynamic>{
-      'flutter': <String, dynamic>{
-        'plugin': <String, dynamic>{}
-      }
-    }),
-    FlutterManifest.empty(),
-  );
+  directory.childFile('pubspec.yaml').writeAsStringSync('''
+name: my_plugin
+flutter:
+  plugin:
+    androidPackage: com.example
+    pluginClass: MyPlugin
+    iosPrefix: FLT
+''');
+  return FlutterProject.fromDirectory(directory);
 }
 
-FlutterProject aModuleProject() {
+Future<FlutterProject> aModuleProject() async {
   final Directory directory = fs.directory('module_project');
   directory.childFile('.packages').createSync(recursive: true);
-  return new FlutterProject(
-    directory,
-    FlutterManifest.mock(const <String, dynamic>{
-      'flutter': <String, dynamic>{
-        'module': <String, dynamic>{
-          'androidPackage': 'com.example'
-        }
-      }
-    }),
-    FlutterManifest.empty(),
-  );
+  directory.childFile('pubspec.yaml').writeAsStringSync('''
+name: my_module
+flutter:
+  module:
+    androidPackage: com.example
+''');
+  return FlutterProject.fromDirectory(directory);
 }
 
+/// Executes the [testMethod] in a context where the file system
+/// is in memory.
 void testInMemory(String description, Future<Null> testMethod()) {
-  Cache.flutterRoot = 'flutter';
-  final FileSystem fs = new MemoryFileSystem();
-  // Pretend we have a pubspec.yaml schema
-  fs.directory(Cache.flutterRoot)
+  Cache.flutterRoot = getFlutterRoot();
+  final FileSystem testFileSystem = new MemoryFileSystem();
+  // Transfer needed parts of the Flutter installation folder
+  // to the in-memory file system used during testing.
+  transfer(new Cache().getArtifactDirectory('gradle_wrapper'), testFileSystem);
+  transfer(fs.directory(Cache.flutterRoot)
       .childDirectory('packages')
       .childDirectory('flutter_tools')
-      .childDirectory('schema')
-      .childFile('pubspec_yaml.json')
-      ..createSync(recursive: true)
-      ..writeAsStringSync(pubspecSchema);
-  // Pretend we have a Flutter module project template.
-  fs.directory(Cache.flutterRoot)
+      .childDirectory('templates'), testFileSystem);
+  transfer(fs.directory(Cache.flutterRoot)
       .childDirectory('packages')
       .childDirectory('flutter_tools')
-      .childDirectory('templates')
-      .childDirectory('module')
-      .childDirectory('android')
-      .childFile('template_content.copy.tmpl')
-      .createSync(recursive: true);
-  fs.directory(Cache.flutterRoot)
-      .childDirectory('packages')
-      .childDirectory('flutter_tools')
-      .childDirectory('templates')
-      .childDirectory('module')
-      .childDirectory('ios')
-      .childDirectory('Flutter.tmpl')
-      .childFile('template_content.copy.tmpl')
-      .createSync(recursive: true);
-
-  // Sets up cache in a test execution context where `fs` is the file system.
-  Cache cacheCreator() {
-    final Cache cache = new Cache(rootOverride: fs.directory('flutter'));
-    cache.getArtifactDirectory('gradle_wrapper')
-        .childDirectory('gradle')
-        .childDirectory('wrapper')
-        .childFile('gradle-wrapper.properties')
-        .createSync(recursive: true);
-    return cache;
-  }
+      .childDirectory('schema'), testFileSystem);
   testUsingContext(
     description,
     testMethod,
     overrides: <Type, Generator>{
-      FileSystem: () => fs,
-      Cache: cacheCreator,
+      FileSystem: () => testFileSystem,
+      Cache: () => new Cache(),
     },
   );
+}
+
+/// Transfers files and folders from the local file system's Flutter
+/// installation to an (in-memory) file system used for testing.
+void transfer(FileSystemEntity entity, FileSystem target) {
+  if (entity is Directory) {
+    target.directory(entity.path).createSync(recursive: true);
+    for (FileSystemEntity child in entity.listSync()) {
+      transfer(child, target);
+    }
+  } else if (entity is File) {
+    target.file(entity.path).writeAsBytesSync(entity.readAsBytesSync(), flush: true);
+  } else {
+    throw 'Unsupported FileSystemEntity ${entity.runtimeType}';
+  }
 }
 
 void addIosWithBundleId(Directory directory, String id) {
@@ -351,25 +335,6 @@ void addAndroidWithGroup(Directory directory, String id) {
     ..createSync(recursive: true)
     ..writeAsStringSync(gradleFileWithGroupId(id));
 }
-
-String get pubspecSchema => '''
-{
-    "\$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "pubspec.yaml",
-    "type": "object",
-    "additionalProperties": true,
-    "properties": {
-        "name": { "type": "string" },
-        "flutter": {
-            "oneOf": [
-                { "type": "object" },
-                { "type": "null" }
-            ],
-            "additionalProperties": false
-        }
-    }
-}
-''';
 
 String get validPubspec => '''
 name: hello

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -31,8 +31,8 @@ void main() {
           fail('ToolExit expected, but nothing thrown');
         } on ToolExit catch(e) {
           expect(e.message, messageMatcher);
-        } catch(e) {
-          fail('ToolExit expected, got $e');
+        } catch(e, trace) {
+          fail('ToolExit expected, got $e\n$trace');
         }
       }
 

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -312,12 +312,12 @@ void testInMemory(String description, Future<Null> testMethod()) {
 /// installation to an (in-memory) file system used for testing.
 void transfer(FileSystemEntity entity, FileSystem target) {
   if (entity is Directory) {
-    target.directory(entity.path).createSync(recursive: true);
+    target.directory(entity.absolute.path).createSync(recursive: true);
     for (FileSystemEntity child in entity.listSync()) {
       transfer(child, target);
     }
   } else if (entity is File) {
-    target.file(entity.path).writeAsBytesSync(entity.readAsBytesSync(), flush: true);
+    target.file(entity.absolute.path).writeAsBytesSync(entity.readAsBytesSync(), flush: true);
   } else {
     throw 'Unsupported FileSystemEntity ${entity.runtimeType}';
   }


### PR DESCRIPTION
Follow up on review comment in #20296:
* Refactoring to avoid dealing with invalid `pubspec.yaml` files and therefore null `FlutterManifest`s in `FlutterProject` instances.
* Added unit test coverage.

