### PR TITLE
Fix flutter_gallery_instrumentation_test

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
@@ -9,6 +9,10 @@ import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
+// This test runs "//examples/flutter_gallery/test/live_smoketest.dart", which communicates
+// with the Java code to report its status. If this test fails due to a problem on the Dart
+// side, you can debug that by just running that file directly using `flutter run`.
+
 Future<Null> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 


### PR DESCRIPTION
Somehow I forgot to say "super.tap()" when calling "tap()" on the new
superclass, so it was just recursing infinitely but ended up actually
crashing on the first reuse of the finder.

The error was previously swallowed, I made this print it instead.