### PR TITLE
Visibility widget

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -145,15 +145,14 @@ class Directionality extends InheritedWidget {
 ///
 /// ## Opacity Animation
 ///
-/// [Opacity] animations should be built using [AnimatedOpacity] rather than
-/// manually rebuilding the [Opacity] widget.
-///
 /// Animating an [Opacity] widget directly causes the widget (and possibly its
 /// subtree) to rebuild each frame, which is not very efficient. Consider using
 /// an [AnimatedOpacity] instead.
 ///
 /// See also:
 ///
+///  * [Visibility], which can hide a child more efficiently (albeit less
+///    subtly).
 ///  * [ShaderMask], which can apply more elaborate effects to its child.
 ///  * [Transform], which applies an arbitrary transform to its child widget at
 ///    paint time.
@@ -169,8 +168,10 @@ class Opacity extends SingleChildRenderObjectWidget {
   const Opacity({
     Key key,
     @required this.opacity,
+    this.alwaysIncludeSemantics = false,
     Widget child,
   }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+       assert(alwaysIncludeSemantics != null),
        super(key: key, child: child);
 
   /// The fraction to scale the child's alpha value.
@@ -185,18 +186,36 @@ class Opacity extends SingleChildRenderObjectWidget {
   /// expensive.
   final double opacity;
 
+  /// Whether the semantic information of the children is always included.
+  ///
+  /// Defaults to false.
+  ///
+  /// When true, regardless of the opacity settings the child semantic
+  /// information is exposed as if the widget were fully visible. This is
+  /// useful in cases where labels may be hidden during animations that
+  /// would otherwise contribute relevant semantics.
+  final bool alwaysIncludeSemantics;
+
   @override
-  RenderOpacity createRenderObject(BuildContext context) => new RenderOpacity(opacity: opacity);
+  RenderOpacity createRenderObject(BuildContext context) {
+    return new RenderOpacity(
+      opacity: opacity,
+      alwaysIncludeSemantics: alwaysIncludeSemantics,
+    );
+  }
 
   @override
   void updateRenderObject(BuildContext context, RenderOpacity renderObject) {
-    renderObject.opacity = opacity;
+    renderObject
+      ..opacity = opacity
+      ..alwaysIncludeSemantics = alwaysIncludeSemantics;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(new DoubleProperty('opacity', opacity));
+    properties.add(new FlagProperty('alwaysIncludeSemantics', value: alwaysIncludeSemantics, ifTrue: 'alwaysIncludeSemantics'));
   }
 }
 
@@ -1710,6 +1729,12 @@ class SizedBox extends SingleChildRenderObjectWidget {
       height = double.infinity,
       super(key: key, child: child);
 
+  /// Creates a box that will become as small as its parent allows.
+  const SizedBox.shrink({ Key key, Widget child })
+    : width = 0.0,
+      height = 0.0,
+      super(key: key, child: child);
+
   /// Creates a box with the specified size.
   SizedBox.fromSize({ Key key, Widget child, Size size })
     : width = size?.width,
@@ -1740,17 +1765,27 @@ class SizedBox extends SingleChildRenderObjectWidget {
 
   @override
   String toStringShort() {
-    final String type = (width == double.infinity && height == double.infinity) ?
-                  '$runtimeType.expand' : '$runtimeType';
+    String type;
+    if (width == double.infinity && height == double.infinity) {
+      type = '$runtimeType.expand';
+    } else if (width == 0.0 && height == 0.0) {
+      type = '$runtimeType.shrink';
+    } else {
+      type = '$runtimeType';
+    }
     return key == null ? '$type' : '$type-$key';
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    final DiagnosticLevel level = (width == double.infinity && height == double.infinity)
-        ? DiagnosticLevel.hidden
-        : DiagnosticLevel.info;
+    DiagnosticLevel level;
+    if ((width == double.infinity && height == double.infinity) ||
+        (width == 0.0 && height == 0.0)) {
+      level = DiagnosticLevel.hidden;
+    } else {
+      level = DiagnosticLevel.info;
+    }
     properties.add(new DoubleProperty('width', width, defaultValue: null, level: level));
     properties.add(new DoubleProperty('height', height, defaultValue: null, level: level));
   }
@@ -2237,9 +2272,9 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
   }
 }
 
-/// A widget that lays the child out as if it was in the tree, but without painting anything,
-/// without making the child available for hit testing, and without taking any
-/// room in the parent.
+/// A widget that lays the child out as if it was in the tree, but without
+/// painting anything, without making the child available for hit testing, and
+/// without taking any room in the parent.
 ///
 /// Animations continue to run in offstage children, and therefore use battery
 /// and CPU time, regardless of whether the animations end up being visible.
@@ -2251,8 +2286,10 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///
 /// See also:
 ///
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * [Visibility], which can hide a child more efficiently (albeit less
+///    subtly).
 ///  * [TickerMode], which can be used to disable animations in a subtree.
+///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
 class Offstage extends SingleChildRenderObjectWidget {
   /// Creates a widget that visually hides its child.
   const Offstage({ Key key, this.offstage = true, Widget child })

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -152,7 +152,8 @@ class Directionality extends InheritedWidget {
 /// See also:
 ///
 ///  * [Visibility], which can hide a child more efficiently (albeit less
-///    subtly).
+///    subtly, because it is either visible or hidden, rather than allowing
+///    fractional opacity values).
 ///  * [ShaderMask], which can apply more elaborate effects to its child.
 ///  * [Transform], which applies an arbitrary transform to its child widget at
 ///    paint time.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -341,8 +341,8 @@ class FadeTransition extends SingleChildRenderObjectWidget {
   const FadeTransition({
     Key key,
     @required this.opacity,
-    Widget child,
     this.alwaysIncludeSemantics = false,
+    Widget child,
   }) : super(key: key, child: child);
 
   /// The animation that controls the opacity of the child.
@@ -382,6 +382,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(new DiagnosticsProperty<Animation<double>>('opacity', opacity));
+    properties.add(new FlagProperty('alwaysIncludeSemantics', value: alwaysIncludeSemantics, ifTrue: 'alwaysIncludeSemantics'));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -103,16 +103,17 @@ class Visibility extends StatelessWidget {
   /// Whether to maintain the [State] objects of the [child] subtree when it is
   /// not [visible].
   ///
-  /// Keeping the state of the subtree is expensive. It should only be
-  /// maintained if it cannot be recreated on demand. One example of when the
-  /// state would be maintained is if the child subtree contains a [Navigator],
-  /// since that widget maintains elaborate state that cannot be recreated on
-  /// the fly.
+  /// Keeping the state of the subtree is potentially expensive (because it
+  /// means all the objects are still in memory; their resources are not
+  /// released). It should only be maintained if it cannot be recreated on
+  /// demand. One example of when the state would be maintained is if the child
+  /// subtree contains a [Navigator], since that widget maintains elaborate
+  /// state that cannot be recreated on the fly.
   ///
-  /// If this is true, an [Offstage] widget is used to hide the child instead of
-  /// replacing it with [replacement].
+  /// If this property is true, an [Offstage] widget is used to hide the child
+  /// instead of replacing it with [replacement].
   ///
-  /// If this is false, then [maintainAnimation] must also be false.
+  /// If this property is false, then [maintainAnimation] must also be false.
   ///
   /// Dynamically changing this value may cause the current state of the
   /// subtree to be lost (and a new instance of the subtree, with new [State]
@@ -133,9 +134,9 @@ class Visibility extends StatelessWidget {
   /// then any [AnimationController]s hosted inside the [child] subtree will be
   /// muted while the [visible] flag is false.
   ///
-  /// If this is true, no [TickerMode] widget is used.
+  /// If this property is true, no [TickerMode] widget is used.
   ///
-  /// If this is false, then [maintainSize] must also be false.
+  /// If this property is false, then [maintainSize] must also be false.
   ///
   /// Dynamically changing this value may cause the current state of the
   /// subtree to be lost (and a new instance of the subtree, with new [State]
@@ -154,10 +155,10 @@ class Visibility extends StatelessWidget {
   /// [child] subtree is not trivial then it is significantly cheaper to not
   /// even keep the state (see [maintainState]).
   ///
-  /// If this is true, [Opacity] is used instead of [Offstage].
+  /// If this property is true, [Opacity] is used instead of [Offstage].
   ///
-  /// If this is false, then [maintainSemantics] and [maintainInteractivity]
-  /// must also be false.
+  /// If this property is false, then [maintainSemantics] and
+  /// [maintainInteractivity] must also be false.
   ///
   /// Dynamically changing this value may cause the current state of the
   /// subtree to be lost (and a new instance of the subtree, with new [State]

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -1,0 +1,209 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'ticker_provider.dart';
+
+/// Whether to show or hide a child.
+///
+/// By default, the [visible] property controls whether the [child] is included
+/// in the subtree or not; when it is not [visible], the [replacement] child
+/// (typically a zero-sized box) is included instead.
+///
+/// A variety of flags can be used to tweak exactly how the child is hidden.
+///
+/// These widgets provide some of the facets of this one:
+///
+///  * [Opacity], which can stop its child from being painted.
+///  * [Offstage], which can stop its child from being laid out or painted.
+///  * [TickerMode], which can stop its child from being animated.
+///  * [ExcludeSemantics], which can hide the child from accessibility tools.
+///  * [IgnorePointer], which can disable touch interactions with the child.
+///
+/// Using this widget is not necessary to hide children. The simplest way to
+/// hide a child is just to not include it, or, if a child _must_ be given (e.g.
+/// because this is a [StatelessWidget]) then to use [SizedBox.shrink] instead
+/// of the child that would otherwise be included.
+///
+/// See also:
+///
+///  * [AnimatedSwitcher], which can fade from one child to the next as the
+///    subtree changes.
+///  * [AnimatedCrossFade], which can fade between two specific children.
+class Visibility extends StatelessWidget {
+  /// Control whether the given [child] is [visible].
+  ///
+  /// The [child] and [replacement] arguments must not be null.
+  ///
+  /// The boolean arguments must not be null.
+  ///
+  /// The [maintainSemantics] and [maintainInteractivity] arguments can only be
+  /// set if [maintainSize] is set.
+  ///
+  /// The [maintainSize] argument can only be set if [maintainAnimation] is set.
+  ///
+  /// The [maintainAnimation] argument can only be set if [maintainState] is set.
+  const Visibility({
+    Key key,
+    @required this.child,
+    this.replacement = const SizedBox.shrink(),
+    this.visible = true,
+    this.maintainState = false,
+    this.maintainAnimation = false,
+    this.maintainSize = false,
+    this.maintainSemantics = false,
+    this.maintainInteractivity = false,
+  }) : assert(child != null),
+       assert(replacement != null),
+       assert(visible != null),
+       assert(maintainState != null),
+       assert(maintainAnimation != null),
+       assert(maintainSize != null),
+       assert(maintainState == true || maintainAnimation == false, 'Cannot maintain animations if the state is not also maintained.'),
+       assert(maintainAnimation == true || maintainSize == false, 'Cannot maintain size if animations are not maintained.'),
+       assert(maintainSize == true || maintainSemantics == false, 'Cannot maintain semantics if size is not maintained.'),
+       assert(maintainSize == true || maintainInteractivity == false, 'Cannot maintain interactivity if size is not maintained.'),
+       super(key: key);
+
+  /// The widget to show or hide, as controlled by [visible].
+  ///
+  /// {@macro flutter.widgets.child}
+  final Widget child;
+
+  /// The widget to use when the child is not [visible], assuming that none of
+  /// the `maintain` flags (in particular, [maintainState]) are set.
+  ///
+  /// The normal behavior is to replace the widget with a zero by zero box
+  /// ([SizedBox.shrink]).
+  ///
+  /// See also:
+  ///
+  ///  * [AnimatedCrossFade], which can animate between two children.
+  final Widget replacement;
+
+  /// Switches between showing the [child] or hiding it.
+  ///
+  /// The `maintain` flags should be set to the same values regardless of the
+  /// state of the [visible] property, otherwise they will not operate correctly
+  /// (specifically, the state will be lost regardless of the state of
+  /// [maintainState] whenever any of the `maintain` flags are changed, since
+  /// doing so will result in a subtree shape change).
+  final bool visible;
+
+  /// Whether to maintain the [State] objects of the [child] subtree when it is
+  /// not [visible].
+  ///
+  /// Keeping the state of the subtree is expensive. It should only be
+  /// maintained if it cannot be recreated on demand. One example of when the
+  /// state would be maintained is if the child subtree contains a [Navigator],
+  /// since that widget maintains elaborate state that cannot be recreated on
+  /// the fly.
+  ///
+  /// If this is true, an [Offstage] widget is used to hide the child instead of
+  /// replacing it with [replacement].
+  final bool maintainState;
+
+  /// Whether to maintain animations within the [child] subtree when it is
+  /// not [visible].
+  ///
+  /// To set this, [maintainState] must also be set.
+  ///
+  /// Keeping animations active when the widget is not visible is even more
+  /// expensive than only maintaining the state.
+  ///
+  /// One example when this might be useful is if the subtree contains an
+  /// animated [Image] that must be kept synchronized with other animated images
+  /// elsewhere in the interface.
+  ///
+  /// If this is true, no [TickerMode] widget is used.
+  final bool maintainAnimation;
+
+  /// Whether to maintain space for where the widget would have been.
+  ///
+  /// To set this, [maintainAnimation] must also be set.
+  ///
+  /// Maintaining the size when the widget is not [visible] is roughly as
+  /// expensive as keeping animations running, and may in some circumstances be
+  /// cheaper if the subtree is simple and the [visible] property is frequently
+  /// toggled, since it avoids triggering a layout change when the [visible]
+  /// property is toggled. However, if the [child] subtree is not trivial then
+  /// it is significantly cheaper to not even keep the state (see
+  /// [maintainState]).
+  ///
+  /// If this is true, [Opacity] is used instead of [Offstage].
+  ///
+  /// See also:
+  ///
+  ///  * [AnimatedOpacity] and [FadeTransition], which apply animations to the
+  ///    opacity for a more subtle effect.
+  final bool maintainSize;
+
+  /// Whether to maintain the semantics for the widget when it is hidden (e.g.
+  /// for accessibility).
+  ///
+  /// To set this, [maintainSize] must also be set.
+  ///
+  /// By default, with [maintainSemantics] set to false, the [child] is not
+  /// visible to accessibility tools when it is hidden from the user. If this
+  /// flag is set to true, then accessibility tools will report the widget as if
+  /// it was present.
+  final bool maintainSemantics;
+
+  /// Whether to allow the widget to be interactive when hidden.
+  ///
+  /// To set this, [maintainSize] must also be set.
+  ///
+  /// By default, with [maintainInteractivity] set to false, touch events cannot
+  /// reach the [child] when it is hidden from the user. If this flag is set to
+  /// true, then touch events will nonetheless be passed through.
+  final bool maintainInteractivity;
+
+  @override
+  Widget build(BuildContext context) {
+    if (maintainSize) {
+      Widget result = child;
+      if (!maintainInteractivity) {
+        result = new IgnorePointer(
+          child: child,
+          ignoring: !visible,
+          ignoringSemantics: !visible && !maintainSemantics,
+        );
+      }
+      return new Opacity(
+        opacity: visible ? 1.0 : 0.0,
+        alwaysIncludeSemantics: maintainSemantics,
+        child: result,
+      );
+    }
+    assert(!maintainInteractivity);
+    assert(!maintainSemantics);
+    assert(!maintainSize);
+    if (maintainState) {
+      Widget result = child;
+      if (!maintainAnimation)
+        result = new TickerMode(child: child, enabled: visible);
+      return new Offstage(
+        child: result,
+        offstage: !visible,
+      );
+    }
+    assert(!maintainAnimation);
+    assert(!maintainState);
+    return visible ? child : replacement;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(new FlagProperty('visible', value: visible, ifFalse: 'hidden', ifTrue: 'visible'));
+    properties.add(new FlagProperty('maintainState', value: maintainState, ifFalse: 'maintainState'));
+    properties.add(new FlagProperty('maintainAnimation', value: maintainAnimation, ifFalse: 'maintainAnimation'));
+    properties.add(new FlagProperty('maintainSize', value: maintainSize, ifFalse: 'maintainSize'));
+    properties.add(new FlagProperty('maintainSemantics', value: maintainSemantics, ifFalse: 'maintainSemantics'));
+    properties.add(new FlagProperty('maintainInteractivity', value: maintainInteractivity, ifFalse: 'maintainInteractivity'));
+  }
+}

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -15,6 +15,9 @@ import 'ticker_provider.dart';
 /// (typically a zero-sized box) is included instead.
 ///
 /// A variety of flags can be used to tweak exactly how the child is hidden.
+/// (Changing the flags dynamically is discouraged, as it can cause the [child]
+/// subtree to be rebuilt, with any state in the subtree being discarded.
+/// Typically, only the [visible] flag is changed dynamically.)
 ///
 /// These widgets provide some of the facets of this one:
 ///
@@ -26,8 +29,8 @@ import 'ticker_provider.dart';
 ///
 /// Using this widget is not necessary to hide children. The simplest way to
 /// hide a child is just to not include it, or, if a child _must_ be given (e.g.
-/// because this is a [StatelessWidget]) then to use [SizedBox.shrink] instead
-/// of the child that would otherwise be included.
+/// because the parent is a [StatelessWidget]) then to use [SizedBox.shrink]
+/// instead of the child that would otherwise be included.
 ///
 /// See also:
 ///
@@ -92,6 +95,9 @@ class Visibility extends StatelessWidget {
   /// (specifically, the state will be lost regardless of the state of
   /// [maintainState] whenever any of the `maintain` flags are changed, since
   /// doing so will result in a subtree shape change).
+  ///
+  /// Unless [maintainState] is set, the [child] subtree will be disposed
+  /// (removed from the tree) while hidden.
   final bool visible;
 
   /// Whether to maintain the [State] objects of the [child] subtree when it is
@@ -105,6 +111,12 @@ class Visibility extends StatelessWidget {
   ///
   /// If this is true, an [Offstage] widget is used to hide the child instead of
   /// replacing it with [replacement].
+  ///
+  /// If this is false, then [maintainAnimation] must also be false.
+  ///
+  /// Dynamically changing this value may cause the current state of the
+  /// subtree to be lost (and a new instance of the subtree, with new [State]
+  /// objects, to be immediately created if [visible] is true).
   final bool maintainState;
 
   /// Whether to maintain animations within the [child] subtree when it is
@@ -115,26 +127,41 @@ class Visibility extends StatelessWidget {
   /// Keeping animations active when the widget is not visible is even more
   /// expensive than only maintaining the state.
   ///
-  /// One example when this might be useful is if the subtree contains an
-  /// animated [Image] that must be kept synchronized with other animated images
-  /// elsewhere in the interface.
+  /// One example when this might be useful is if the subtree is animating its
+  /// layout in time with an [AnimationController], and the result of that
+  /// layout is being used to influence some other logic. If this flag is false,
+  /// then any [AnimationController]s hosted inside the [child] subtree will be
+  /// muted while the [visible] flag is false.
   ///
   /// If this is true, no [TickerMode] widget is used.
+  ///
+  /// If this is false, then [maintainSize] must also be false.
+  ///
+  /// Dynamically changing this value may cause the current state of the
+  /// subtree to be lost (and a new instance of the subtree, with new [State]
+  /// objects, to be immediately created if [visible] is true).
   final bool maintainAnimation;
 
   /// Whether to maintain space for where the widget would have been.
   ///
   /// To set this, [maintainAnimation] must also be set.
   ///
-  /// Maintaining the size when the widget is not [visible] is roughly as
-  /// expensive as keeping animations running, and may in some circumstances be
-  /// cheaper if the subtree is simple and the [visible] property is frequently
-  /// toggled, since it avoids triggering a layout change when the [visible]
-  /// property is toggled. However, if the [child] subtree is not trivial then
-  /// it is significantly cheaper to not even keep the state (see
-  /// [maintainState]).
+  /// Maintaining the size when the widget is not [visible] is not notably more
+  /// expensive than just keeping animations running without maintaining the
+  /// size, and may in some circumstances be slightly cheaper if the subtree is
+  /// simple and the [visible] property is frequently toggled, since it avoids
+  /// triggering a layout change when the [visible] property is toggled. If the
+  /// [child] subtree is not trivial then it is significantly cheaper to not
+  /// even keep the state (see [maintainState]).
   ///
   /// If this is true, [Opacity] is used instead of [Offstage].
+  ///
+  /// If this is false, then [maintainSemantics] and [maintainInteractivity]
+  /// must also be false.
+  ///
+  /// Dynamically changing this value may cause the current state of the
+  /// subtree to be lost (and a new instance of the subtree, with new [State]
+  /// objects, to be immediately created if [visible] is true).
   ///
   /// See also:
   ///
@@ -151,6 +178,10 @@ class Visibility extends StatelessWidget {
   /// visible to accessibility tools when it is hidden from the user. If this
   /// flag is set to true, then accessibility tools will report the widget as if
   /// it was present.
+  ///
+  /// Dynamically changing this value may cause the current state of the
+  /// subtree to be lost (and a new instance of the subtree, with new [State]
+  /// objects, to be immediately created if [visible] is true).
   final bool maintainSemantics;
 
   /// Whether to allow the widget to be interactive when hidden.
@@ -160,6 +191,10 @@ class Visibility extends StatelessWidget {
   /// By default, with [maintainInteractivity] set to false, touch events cannot
   /// reach the [child] when it is hidden from the user. If this flag is set to
   /// true, then touch events will nonetheless be passed through.
+  ///
+  /// Dynamically changing this value may cause the current state of the
+  /// subtree to be lost (and a new instance of the subtree, with new [State]
+  /// objects, to be immediately created if [visible] is true).
   final bool maintainInteractivity;
 
   @override

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -99,5 +99,6 @@ export 'src/widgets/title.dart';
 export 'src/widgets/transitions.dart';
 export 'src/widgets/unique_widget.dart';
 export 'src/widgets/viewport.dart';
+export 'src/widgets/visibility.dart';
 export 'src/widgets/widget_inspector.dart';
 export 'src/widgets/will_pop_scope.dart';

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -127,6 +127,13 @@ class TestRecordingPaintingContext extends ClipContext implements PaintingContex
   }
 
   @override
+  void pushOpacity(Offset offset, int alpha, PaintingContextCallback painter) {
+    canvas.saveLayer(null, null); // TODO(ianh): Expose the alpha somewhere.
+    painter(this, offset);
+    canvas.restore();
+  }
+
+  @override
   void pushLayer(Layer childLayer, PaintingContextCallback painter, Offset offset, {Rect childPaintBounds}) {
     painter(this, offset);
   }

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -1,0 +1,150 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/mock_canvas.dart';
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('Opacity', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+
+    // Opacity 1.0: Semantics and painting
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 1.0,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            rect: Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
+            label: 'a',
+            textDirection: TextDirection.rtl,
+          )
+        ],
+      ),
+    ));
+    expect(find.byType(Opacity), paints..paragraph());
+
+    // Opacity 0.0: Nothing
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.0,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(),
+    ));
+    expect(find.byType(Opacity), paintsNothing);
+
+    // Opacity 0.0 with semantics: Just semantics
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.0,
+        alwaysIncludeSemantics: true,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            rect: Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
+            label: 'a',
+            textDirection: TextDirection.rtl,
+          )
+        ],
+      ),
+    ));
+    expect(find.byType(Opacity), paintsNothing);
+
+    // Opacity 0.0 without semantics: Nothing
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.0,
+        alwaysIncludeSemantics: false,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(),
+    ));
+    expect(find.byType(Opacity), paintsNothing);
+
+    // Opacity 0.1: Semantics and painting
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.1,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            rect: Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
+            label: 'a',
+            textDirection: TextDirection.rtl,
+          )
+        ],
+      ),
+    ));
+    expect(find.byType(Opacity), paints..paragraph());
+
+    // Opacity 0.1 without semantics: Still has semantics and painting
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.1,
+        alwaysIncludeSemantics: false,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            rect: Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
+            label: 'a',
+            textDirection: TextDirection.rtl,
+          )
+        ],
+      ),
+    ));
+    expect(find.byType(Opacity), paints..paragraph());
+
+    // Opacity 0.1 with semantics: Semantics and painting
+    await tester.pumpWidget(
+      const Opacity(
+        child: Text('a', textDirection: TextDirection.rtl),
+        opacity: 0.1,
+        alwaysIncludeSemantics: true,
+      ),
+    );
+    expect(semantics, hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            id: 1,
+            rect: Rect.fromLTRB(0.0, 0.0, 800.0, 600.0),
+            label: 'a',
+            textDirection: TextDirection.rtl,
+          )
+        ],
+      ),
+    ));
+    expect(find.byType(Opacity), paints..paragraph());
+
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -225,8 +225,6 @@ class TestSemantics {
       DebugSemanticsDumpOrder childOrder = DebugSemanticsDumpOrder.inverseHitTest,
     }
   ) {
-    final SemanticsData nodeData = node.getSemanticsData();
-
     bool fail(String message) {
       matchState[TestSemantics] = '$message';
       return false;
@@ -236,6 +234,8 @@ class TestSemantics {
       return fail('could not find node with id $id.');
     if (!ignoreId && id != node.id)
       return fail('expected node id $id but found id ${node.id}.');
+
+    final SemanticsData nodeData = node.getSemanticsData();
 
     final int flagsBitmask = flags is int
       ? flags
@@ -372,7 +372,7 @@ class SemanticsTester {
   }
 
   @override
-  String toString() => 'SemanticsTester for ${tester.binding.pipelineOwner.semanticsOwner.rootSemanticsNode}';
+  String toString() => 'SemanticsTester for ${tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode}';
 
   /// Returns all semantics nodes in the current semantics tree whose properties
   /// match the non-null arguments.
@@ -487,7 +487,7 @@ class SemanticsTester {
   /// over-test. Prefer breaking your widgets into smaller widgets and test them
   /// individually.
   String generateTestSemanticsExpressionForCurrentSemanticsTree(DebugSemanticsDumpOrder childOrder) {
-    final SemanticsNode node = tester.binding.pipelineOwner.semanticsOwner.rootSemanticsNode;
+    final SemanticsNode node = tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode;
     return _generateSemanticsTestForNode(node, 0, childOrder);
   }
 
@@ -520,6 +520,8 @@ class SemanticsTester {
   /// Recursively generates [TestSemantics] code for [node] and its children,
   /// indenting the expression by `indentAmount`.
   static String _generateSemanticsTestForNode(SemanticsNode node, int indentAmount, DebugSemanticsDumpOrder childOrder) {
+    if (node == null)
+      return 'null';
     final String indent = '  ' * indentAmount;
     final StringBuffer buf = new StringBuffer();
     final SemanticsData nodeData = node.getSemanticsData();
@@ -590,7 +592,7 @@ class _HasSemantics extends Matcher {
   @override
   bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
     final bool doesMatch = _semantics._matches(
-      item.tester.binding.pipelineOwner.semanticsOwner.rootSemanticsNode,
+      item.tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode,
       matchState,
       ignoreTransform: ignoreTransform,
       ignoreRect: ignoreRect,
@@ -600,6 +602,9 @@ class _HasSemantics extends Matcher {
     if (!doesMatch) {
       matchState['would-match'] = item.generateTestSemanticsExpressionForCurrentSemanticsTree(childOrder);
     }
+    if (item.tester.binding.pipelineOwner.semanticsOwner == null) {
+      matchState['additional-notes'] = '(Check that the SemanticsTester has not been disposed early.)';
+    }
     return doesMatch;
   }
 
@@ -608,14 +613,25 @@ class _HasSemantics extends Matcher {
     return description.add('semantics node matching:\n$_semantics');
   }
 
+  String _indent(String text) {
+    return text.toString().trimRight().split('\n').map((String line) => '  $line').join('\n');
+  }
+
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription, Map<dynamic, dynamic> matchState, bool verbose) {
-    return mismatchDescription
-        .add('${matchState[TestSemantics]}\n')
-        .add('Current SemanticsNode tree:\n')
-        .add(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childOrder: childOrder))
-        .add('The semantics tree would have matched the following configuration:\n')
-        .add(matchState['would-match']);
+    Description result = mismatchDescription
+      .add('${matchState[TestSemantics]}\n')
+      .add('Current SemanticsNode tree:\n')
+      .add(_indent(RendererBinding.instance?.renderView?.debugSemantics?.toStringDeep(childOrder: childOrder)))
+      .add('\n')
+      .add('The semantics tree would have matched the following configuration:\n')
+      .add(_indent(matchState['would-match']));
+    if (matchState.containsKey('additional-notes')) {
+      result = result
+        .add('\n')
+        .add(matchState['additional-notes']);
+    }
+    return result;
   }
 }
 

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -30,6 +30,10 @@ void main() {
     const SizedBox f = SizedBox.expand();
     expect(f.width, double.infinity);
     expect(f.height, double.infinity);
+
+    const SizedBox g = SizedBox.shrink();
+    expect(g.width, 0.0);
+    expect(g.height, 0.0);
   });
 
   testWidgets('SizedBox - no child', (WidgetTester tester) async {
@@ -95,6 +99,15 @@ void main() {
       )
     );
     expect(patient.currentContext.size, equals(const Size(800.0, 600.0)));
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox.shrink(
+          key: patient,
+        )
+      )
+    );
+    expect(patient.currentContext.size, equals(const Size(0.0, 0.0)));
   });
 
   testWidgets('SizedBox - container child', (WidgetTester tester) async {
@@ -166,5 +179,15 @@ void main() {
       )
     );
     expect(patient.currentContext.size, equals(const Size(800.0, 600.0)));
+
+    await tester.pumpWidget(
+      new Center(
+        child: new SizedBox.shrink(
+          key: patient,
+          child: new Container(),
+        )
+      )
+    );
+    expect(patient.currentContext.size, equals(const Size(0.0, 0.0)));
   });
 }

--- a/packages/flutter/test/widgets/visibility_test.dart
+++ b/packages/flutter/test/widgets/visibility_test.dart
@@ -1,0 +1,197 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/mock_canvas.dart';
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('Visibility', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final List<String> log = <String>[];
+
+    final Widget testChild = new GestureDetector(
+      onTap: () { log.add('tap'); },
+      child: new Builder(
+        builder: (BuildContext context) {
+          final bool animating = TickerMode.of(context);
+          return new Text('a $animating', textDirection: TextDirection.rtl);
+        },
+      ),
+    );
+
+    final Matcher expectedSemanticsWhenPresent = hasSemantics(
+      new TestSemantics.root(
+        children: <TestSemantics>[
+          new TestSemantics.rootChild(
+            label: 'a true',
+            textDirection: TextDirection.rtl,
+            actions: <SemanticsAction>[SemanticsAction.tap],
+          )
+        ],
+      ),
+      ignoreId: true,
+      ignoreRect: true,
+      ignoreTransform: true,
+    );
+
+    final Matcher expectedSemanticsWhenAbsent = hasSemantics(new TestSemantics.root());
+
+    await tester.pumpWidget(new Visibility(child: testChild));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(800.0, 600.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Visibility(child: testChild, visible: false));
+    expect(find.byType(Text, skipOffstage: false), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), const Size(800.0, 600.0));
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false)));
+    expect(find.byType(Text, skipOffstage: false), findsNothing);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, replacement: const Placeholder(), visible: false)));
+    expect(find.byType(Text, skipOffstage: false), findsNothing);
+    expect(find.byType(Placeholder), findsOneWidget);
+    expect(find.byType(Visibility), paints..path());
+    expect(tester.getSize(find.byType(Visibility)), const Size(800.0, 600.0));
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, replacement: const Placeholder(), visible: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true, maintainState: true, maintainAnimation: true, maintainSize: true, maintainInteractivity: true, maintainSemantics: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true, maintainInteractivity: true, maintainSemantics: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true, maintainInteractivity: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true, maintainSemantics: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.byType(Text, skipOffstage: true), findsNothing);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.byType(Text, skipOffstage: true), findsNothing);
+    expect(find.text('a false', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false)));
+    expect(find.byType(Text, skipOffstage: false), findsNothing);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/widgets/visibility_test.dart
+++ b/packages/flutter/test/widgets/visibility_test.dart
@@ -8,6 +8,26 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 import 'semantics_tester.dart';
 
+class TestState extends StatefulWidget {
+  const TestState({ Key key, this.child, this.log }) : super(key: key);
+  final Widget child;
+  final List<String> log;
+  @override
+  State<TestState> createState() => new _TestStateState();
+}
+
+class _TestStateState extends State<TestState> {
+  @override
+  void initState() {
+    super.initState();
+    widget.log.add('created new state');
+  }
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
 void main() {
   testWidgets('Visibility', (WidgetTester tester) async {
     final SemanticsTester semantics = new SemanticsTester(tester);
@@ -18,7 +38,10 @@ void main() {
       child: new Builder(
         builder: (BuildContext context) {
           final bool animating = TickerMode.of(context);
-          return new Text('a $animating', textDirection: TextDirection.rtl);
+          return new TestState(
+            log: log,
+            child: new Text('a $animating', textDirection: TextDirection.rtl),
+          );
         },
       ),
     );
@@ -40,15 +63,19 @@ void main() {
 
     final Matcher expectedSemanticsWhenAbsent = hasSemantics(new TestSemantics.root());
 
+    // We now run a sequence of pumpWidget calls one after the other. In
+    // addition to verifying that the right behaviour is seen in each case, this
+    // also verifies that the widget can dynamically change from state to state.
+
     await tester.pumpWidget(new Visibility(child: testChild));
     expect(find.byType(Text, skipOffstage: false), findsOneWidget);
     expect(find.text('a true', skipOffstage: false), findsOneWidget);
     expect(find.byType(Visibility), paints..paragraph());
     expect(tester.getSize(find.byType(Visibility)), const Size(800.0, 600.0));
     expect(semantics, expectedSemanticsWhenPresent);
-    expect(log, <String>[]);
+    expect(log, <String>['created new state']);
     await tester.tap(find.byType(Visibility));
-    expect(log, <String>['tap']);
+    expect(log, <String>['created new state', 'tap']);
     log.clear();
 
     await tester.pumpWidget(new Visibility(child: testChild, visible: false));
@@ -90,9 +117,9 @@ void main() {
     expect(find.byType(Visibility), paints..paragraph());
     expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
     expect(semantics, expectedSemanticsWhenPresent);
-    expect(log, <String>[]);
+    expect(log, <String>['created new state']);
     await tester.tap(find.byType(Visibility));
-    expect(log, <String>['tap']);
+    expect(log, <String>['created new state', 'tap']);
     log.clear();
 
     await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true, maintainState: true, maintainAnimation: true, maintainSize: true, maintainInteractivity: true, maintainSemantics: true)));
@@ -102,9 +129,9 @@ void main() {
     expect(find.byType(Visibility), paints..paragraph());
     expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
     expect(semantics, expectedSemanticsWhenPresent);
-    expect(log, <String>[]);
+    expect(log, <String>['created new state']);
     await tester.tap(find.byType(Visibility));
-    expect(log, <String>['tap']);
+    expect(log, <String>['created new state', 'tap']);
     log.clear();
 
     await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true, maintainInteractivity: true, maintainSemantics: true)));
@@ -138,9 +165,9 @@ void main() {
     expect(find.byType(Visibility), paintsNothing);
     expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
     expect(semantics, expectedSemanticsWhenPresent);
-    expect(log, <String>[]);
+    expect(log, <String>['created new state']);
     await tester.tap(find.byType(Visibility));
-    expect(log, <String>[]);
+    expect(log, <String>['created new state']);
     log.clear();
 
     await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true, maintainAnimation: true, maintainSize: true)));
@@ -163,9 +190,36 @@ void main() {
     expect(find.byType(Visibility), paintsNothing);
     expect(tester.getSize(find.byType(Visibility)), Size.zero);
     expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>['created new state']);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['created new state']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.byType(Text, skipOffstage: true), findsNothing);
+    expect(find.text('a false', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>['created new state']);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['created new state']);
+    log.clear();
+
+    // Now we toggle the visibility off and on a few times to make sure that works.
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true, maintainState: true)));
+    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
     expect(log, <String>[]);
     await tester.tap(find.byType(Visibility));
-    expect(log, <String>[]);
+    expect(log, <String>['tap']);
     log.clear();
 
     await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true)));
@@ -181,6 +235,33 @@ void main() {
     expect(log, <String>[]);
     log.clear();
 
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true, maintainState: true)));
+    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false, maintainState: true)));
+    expect(find.byType(Text, skipOffstage: false), findsOneWidget);
+    expect(find.byType(Text, skipOffstage: true), findsNothing);
+    expect(find.text('a false', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    // Same but without maintainState.
+
     await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false)));
     expect(find.byType(Text, skipOffstage: false), findsNothing);
     expect(find.byType(Placeholder), findsNothing);
@@ -190,6 +271,41 @@ void main() {
     expect(log, <String>[]);
     await tester.tap(find.byType(Visibility));
     expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true)));
+    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>['created new state']);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['created new state', 'tap']);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: false)));
+    expect(find.byType(Text, skipOffstage: false), findsNothing);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paintsNothing);
+    expect(tester.getSize(find.byType(Visibility)), Size.zero);
+    expect(semantics, expectedSemanticsWhenAbsent);
+    expect(log, <String>[]);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>[]);
+    log.clear();
+
+    await tester.pumpWidget(new Center(child: new Visibility(child: testChild, visible: true)));
+    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('a true', skipOffstage: false), findsOneWidget);
+    expect(find.byType(Placeholder), findsNothing);
+    expect(find.byType(Visibility), paints..paragraph());
+    expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
+    expect(semantics, expectedSemanticsWhenPresent);
+    expect(log, <String>['created new state']);
+    await tester.tap(find.byType(Visibility));
+    expect(log, <String>['created new state', 'tap']);
     log.clear();
 
     semantics.dispose();


### PR DESCRIPTION
This attempts to address the confusion around how to hide a widget subtree.

Also, add alwaysIncludeSemantics to Opacity for consistency.

Also, create a SizedBox.shrink for this common case.