### PR TITLE
check route exist in navigator history

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1817,6 +1817,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       pop();
   }
 
+  /// Return if `route` exist in the navigator history.
+  bool isRouteExist(Route<dynamic> route) {
+    return _history.indexOf(route) >= 0;
+  }
+
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.
   ///
   /// {@macro flutter.widgets.navigator.removeRoute}


### PR DESCRIPTION
call removeRoute(),  but route  is not exist in _history, could lead to some problems.
so, I want to check the route in the navigator history , when I call  removeRoute.