### PR TITLE
Restrict analyzer benchmarks to faster linux machine

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -464,7 +464,7 @@ tasks:
     description: >
       Measures the speed of Dart analyzer.
     stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+    required_agent_capabilities: ["linux/android", "fast_linux"]
 
   flutter_gallery_ios32__start_up:
     description: >


### PR DESCRIPTION
I've also updated linux2 to have this capability.

CC @devoncarew 