### PR TITLE
Fix broken Flutter module with plugins

### DIFF
--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -31,6 +31,17 @@ Future<Null> main() async {
         );
       });
 
+      section('Add plugins');
+
+      final File pubspec = new File(path.join(directory.path, 'hello', 'pubspec.yaml'));
+      String content = await pubspec.readAsString();
+      content = content.replaceFirst(
+        '\ndependencies:\n',
+        '\ndependencies:\n  battery:\n  package_info:\n',
+      );
+      await pubspec.writeAsString(content, flush: true);
+
+
       section('Build Flutter module library archive');
 
       await inDirectory(new Directory(path.join(directory.path, 'hello', '.android')), () async {

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -148,7 +148,7 @@ class CocoaPods {
     return true;
   }
 
-  /// Ensures the iOS sub-project of the Flutter project at [appDirectory]
+  /// Ensures the given iOS sub-project of a parent Flutter project
   /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
   /// include pods configuration.
   void setupPodfile(IosProject iosProject) {
@@ -156,13 +156,14 @@ class CocoaPods {
       // Don't do anything for iOS when host platform doesn't support it.
       return;
     }
-    if (!iosProject.directory.childFile('Runner.xcodeproj').existsSync()) {
+    final Directory runnerProject = iosProject.directory.childDirectory('Runner.xcodeproj');
+    if (!runnerProject.existsSync()) {
       return;
     }
     final File podfile = iosProject.podfile;
     if (!podfile.existsSync()) {
       final bool isSwift = xcodeProjectInterpreter.getBuildSettings(
-        iosProject.directory.childFile('Runner.xcodeproj').path,
+        runnerProject.path,
         'Runner',
       ).containsKey('SWIFT_VERSION');
       final File podfileTemplate = fs.file(fs.path.join(

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -148,7 +148,7 @@ class CocoaPods {
     return true;
   }
 
-  /// Ensures the `ios` sub-project of the Flutter project at [appDirectory]
+  /// Ensures the iOS sub-project of the Flutter project at [appDirectory]
   /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
   /// include pods configuration.
   void setupPodfile(IosProject iosProject) {
@@ -156,7 +156,7 @@ class CocoaPods {
       // Don't do anything for iOS when host platform doesn't support it.
       return;
     }
-    if (!iosProject.directory.existsSync()) {
+    if (!iosProject.directory.childFile('Runner.xcodeproj').existsSync()) {
       return;
     }
     final File podfile = iosProject.podfile;

--- a/packages/flutter_tools/templates/module/android/Flutter.tmpl/src/main/java/io/flutter/facade/Flutter.java
+++ b/packages/flutter_tools/templates/module/android/Flutter.tmpl/src/main/java/io/flutter/facade/Flutter.java
@@ -12,6 +12,7 @@ import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.StringCodec;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterNativeView;
+import io.flutter.view.FlutterRunArguments;
 import io.flutter.view.FlutterView;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
@@ -91,8 +92,10 @@ public final class Flutter {
     lifecycle.addObserver(new LifecycleObserver() {
       @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
       public void onCreate() {
-        final String appBundlePath = FlutterMain.findAppBundlePath(activity.getApplicationContext());
-        flutterView.runFromBundle(appBundlePath, null, "main", true);
+        final FlutterRunArguments arguments = new FlutterRunArguments();
+        arguments.bundlePath = FlutterMain.findAppBundlePath(activity.getApplicationContext());
+        arguments.entrypoint = "main";
+        flutterView.runFromBundle(arguments);
         GeneratedPluginRegistrant.registerWith(flutterView.getPluginRegistry());
       }
 

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -46,7 +46,7 @@ void main() {
     mockProcessManager = new MockProcessManager();
     mockXcodeProjectInterpreter = new MockXcodeProjectInterpreter();
     projectUnderTest = await FlutterProject.fromDirectory(fs.directory('project'));
-    projectUnderTest.ios.directory.createSync(recursive: true);
+    projectUnderTest.ios.directory..childDirectory('Runner.xcodeproj').createSync(recursive: true);
     cocoaPodsUnderTest = new CocoaPods();
     pretendPodVersionIs('1.5.0');
     fs.file(fs.path.join(

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -46,7 +46,7 @@ void main() {
     mockProcessManager = new MockProcessManager();
     mockXcodeProjectInterpreter = new MockXcodeProjectInterpreter();
     projectUnderTest = await FlutterProject.fromDirectory(fs.directory('project'));
-    projectUnderTest.ios.directory..childDirectory('Runner.xcodeproj').createSync(recursive: true);
+    projectUnderTest.ios.directory.childDirectory('Runner.xcodeproj').createSync(recursive: true);
     cocoaPodsUnderTest = new CocoaPods();
     pretendPodVersionIs('1.5.0');
     fs.file(fs.path.join(


### PR DESCRIPTION
Flutter modules with plugins were broken, code path tripping over unfinished iOS support.
This PR removes the breakage and adds test coverage. The underlying issue of missing iOS support will be addressed by another PR.

This PR also removes a Java compiler warning (newly deprecated engine API).