### PR TITLE
Try to resolve an intermitted crash during coverage collection

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -22,7 +22,7 @@ class CoverageCollector extends TestWatcher {
   Map<String, dynamic> _globalHitmap;
 
   @override
-  Future<void> onFinishedTest(ProcessEvent event) async {
+  Future<void> handleFinishedTest(ProcessEvent event) async {
     printTrace('test ${event.childIndex}: collecting coverage');
     await collectCoverage(event.process, event.observatoryUri);
   }

--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -14,7 +14,7 @@ class EventPrinter extends TestWatcher {
   final StringSink _out;
 
   @override
-  void onStartedProcess(ProcessEvent event) {
+  void handleStartedProcess(ProcessEvent event) {
     _sendEvent('test.startedProcess',
         <String, dynamic>{'observatoryUri': event.observatoryUri.toString()});
   }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -814,7 +814,7 @@ class _FlutterPlatform extends PlatformPlugin {
     return processManager.start(command, environment: environment);
   }
 
-  Future<void> _pipeStandardStreamsToConsole(
+  void _pipeStandardStreamsToConsole(
     Process process, {
     void startTimeoutTimer(),
     void reportObservatoryUri(Uri uri),

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -820,11 +820,8 @@ class _FlutterPlatform extends PlatformPlugin {
     void reportObservatoryUri(Uri uri),
   }) {
     const String observatoryString = 'Observatory listening on ';
-    final List<Future<void>> futures = <Future<void>>[];
     for (Stream<List<int>> stream in
         <Stream<List<int>>>[process.stderr, process.stdout]) {
-      final Completer<void> completer = new Completer<void>();
-      futures.add(completer.future);
       stream.transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen(
@@ -851,13 +848,9 @@ class _FlutterPlatform extends PlatformPlugin {
           onError: (dynamic error) {
             printError('shell console stream for process pid ${process.pid} experienced an unexpected error: $error');
           },
-          onDone: () {
-            completer.complete();
-          },
           cancelOnError: true,
         );
     }
-    return Future.wait(futures).then<void>((List<void> results) => null);
   }
 
   String _getErrorMessage(String what, String testPath, String shellPath) {

--- a/packages/flutter_tools/lib/src/test/watcher.dart
+++ b/packages/flutter_tools/lib/src/test/watcher.dart
@@ -11,20 +11,20 @@ abstract class TestWatcher {
   ///
   /// If startPaused was true, the caller needs to resume in Observatory to
   /// start running the tests.
-  void onStartedProcess(ProcessEvent event) {}
+  void handleStartedProcess(ProcessEvent event) {}
 
   /// Called after the tests finish but before the process exits.
   ///
   /// The child process won't exit until this method completes.
   /// Not called if the process died.
-  Future<void> onFinishedTest(ProcessEvent event) async {}
+  Future<void> handleFinishedTest(ProcessEvent event) async {}
 
   /// Called when the test process crashed before connecting to test harness.
-  Future<void> onTestCrashed(ProcessEvent event) async {}
+  Future<void> handleTestCrashed(ProcessEvent event) async {}
 
   /// Called if we timed out waiting for the test process to connect to test
   /// harness.
-  Future<void> onTestTimedOut(ProcessEvent event) async {}
+  Future<void> handleTestTimedOut(ProcessEvent event) async {}
 }
 
 /// Describes a child process started during testing.
@@ -40,6 +40,6 @@ class ProcessEvent {
 
   final Process process;
 
-  /// The observatory Uri or null if not debugging.
+  /// The observatory URL or null if not debugging.
   final Uri observatoryUri;
 }


### PR DESCRIPTION
The only theory I can come up with is that maybe the test completes
before we finish processing the standard input, so I made the test
harness wait for the pipes to be closed.

Also, some code cleanup while I'm at it, e.g. avoiding using "onFoo"
for the names of methods, avoiding back-to-back switch statements with
the same values, avoiding `_` argument names, and using `?.` instead
of `if (foo != null) foo.`.