### PR TITLE
undo changes to devicelab capabilities

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -464,7 +464,7 @@ tasks:
     description: >
       Measures the speed of Dart analyzer.
     stage: devicelab
-    required_agent_capabilities: ["fast_linux"]
+    required_agent_capabilities: ["linux/android"]
 
   flutter_gallery_ios32__start_up:
     description: >


### PR DESCRIPTION
Because those didn't work either.