### PR TITLE
Fix access of null compiler in flutter tests that fail before creating the compiler.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -285,8 +285,12 @@ class _Compiler {
   }
 
   Future<dynamic> shutdown() async {
-    await compiler.shutdown();
-    compiler = null;
+    // Check for null in case this instance is shut down before the
+    // lazily-created compiler has been created.
+    if (compiler != null) {
+      await compiler.shutdown();
+      compiler = null;
+    }
   }
 
   static Future<T> handleTimeout<T>(Future<T> value, String path) {


### PR DESCRIPTION
In certain cases, the test would fail before creating the (lazily created) compiler object, and then we'd
try to call `shutdown()` on `null` in those cases.

Fixes #18610