### PR TITLE
Remove unused snapshot.d depfile parameter

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -386,8 +386,7 @@ abstract class BaseFlutterTask extends DefaultTask {
 
     @OutputFiles
     FileCollection getDependenciesFiles() {
-        // For AOT and Core JIT builds, include the gen_snapshot depfile.
-        FileCollection depfiles = project.files("${intermediateDir}/snapshot.d")
+        FileCollection depfiles = project.files()
         if (previewDart2) {
             // For Dart 2, also include the kernel compiler depfile, since
             // kernel compile is the first stage of AOT build in this mode,

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -44,7 +44,6 @@ class GenSnapshot {
   Future<int> run({
     @required SnapshotType snapshotType,
     @required String packagesPath,
-    @required String depfilePath,
     IOSArch iosArch,
     Iterable<String> additionalArgs = const <String>[],
   }) {
@@ -121,7 +120,6 @@ class ScriptSnapshotter {
     final int exitCode = await genSnapshot.run(
       snapshotType: snapshotType,
       packagesPath: packagesPath,
-      depfilePath: depfilePath,
       additionalArgs: args,
     );
 
@@ -260,7 +258,7 @@ class AOTSnapshotter {
         'sharedLib': buildSharedLibrary.toString(),
         'extraGenSnapshotOptions': extraGenSnapshotOptions.join(' '),
       },
-      depfilePaths: <String>[depfilePath],
+      depfilePaths: <String>[],
     );
     if (await fingerprinter.doesFingerprintMatch()) {
       printTrace('Skipping AOT snapshot build. Fingerprint match.');
@@ -271,7 +269,6 @@ class AOTSnapshotter {
     final int genSnapshotExitCode = await genSnapshot.run(
       snapshotType: snapshotType,
       packagesPath: packageMap.packagesPath,
-      depfilePath: depfilePath,
       additionalArgs: genSnapshotArgs,
       iosArch: iosArch,
     );
@@ -283,7 +280,7 @@ class AOTSnapshotter {
     // Write path to gen_snapshot, since snapshots have to be re-generated when we roll
     // the Dart SDK.
     final String genSnapshotPath = GenSnapshot.getSnapshotterPath(snapshotType);
-    await outputDir.childFile('gen_snapshot.d').writeAsString('snapshot.d: $genSnapshotPath\n');
+    await outputDir.childFile('gen_snapshot.d').writeAsString('gen_snapshot.d: $genSnapshotPath\n');
 
     // On iOS, we use Xcode to compile the snapshot into a dynamic library that the
     // end-developer can link into their app.
@@ -497,7 +494,7 @@ class CoreJITSnapshotter {
         'entryPoint': mainPath,
         'extraGenSnapshotOptions': extraGenSnapshotOptions.join(' '),
       },
-      depfilePaths: <String>[depfilePath],
+      depfilePaths: <String>[],
     );
     if (await fingerprinter.doesFingerprintMatch()) {
       printTrace('Skipping Core JIT snapshot build. Fingerprint match.');
@@ -508,7 +505,6 @@ class CoreJITSnapshotter {
     final int genSnapshotExitCode = await genSnapshot.run(
       snapshotType: snapshotType,
       packagesPath: packagesPath,
-      depfilePath: depfilePath,
       additionalArgs: genSnapshotArgs,
     );
     if (genSnapshotExitCode != 0) {
@@ -519,7 +515,7 @@ class CoreJITSnapshotter {
     // Write path to gen_snapshot, since snapshots have to be re-generated when we roll
     // the Dart SDK.
     final String genSnapshotPath = GenSnapshot.getSnapshotterPath(snapshotType);
-    await outputDir.childFile('gen_snapshot.d').writeAsString('snapshot.d: $genSnapshotPath\n');
+    await outputDir.childFile('gen_snapshot.d').writeAsString('gen_snapshot.d: $genSnapshotPath\n');
 
     // Compute and record build fingerprint.
     await fingerprinter.writeFingerprint();

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -164,7 +164,6 @@ void main() {
       expect(genSnapshot.snapshotType.platform, isNull);
       expect(genSnapshot.snapshotType.mode, BuildMode.debug);
       expect(genSnapshot.packagesPath, '.packages');
-      expect(genSnapshot.depfilePath, 'output.snapshot.d');
       expect(genSnapshot.additionalArgs, <String>[
         '--snapshot_kind=script',
         '--script_snapshot=output.snapshot',


### PR DESCRIPTION
gen_snapshot --dependencies flag was removed in https://dart-review.googlesource.com/c/sdk/+/60020, but framework wasn't fixed up when engine was rolled in https://github.com/flutter/flutter/pull/18575.