### PR TITLE
Performance test cleanup

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -37,7 +37,7 @@ Future<TaskResult> task(TaskFunction task) {
 
   _isTaskRegistered = true;
 
-  // TODO: allow overriding logging.
+  // TODO(ianh): allow overriding logging.
   Logger.root.level = Level.ALL;
   Logger.root.onRecord.listen((LogRecord rec) {
     print('${rec.level.name}: ${rec.time}: ${rec.message}');
@@ -53,7 +53,7 @@ class _TaskRunner {
 
   final TaskFunction task;
 
-  // TODO: workaround for https://github.com/dart-lang/sdk/issues/23797
+  // TODO(ianh): workaround for https://github.com/dart-lang/sdk/issues/23797
   RawReceivePort _keepAlivePort;
   Timer _startTaskTimeout;
   bool _taskStarted = false;
@@ -86,7 +86,7 @@ class _TaskRunner {
       _completer.complete(result);
       return result;
     } on TimeoutException catch (_) {
-      print('Task timed out after $taskTimeout.');
+      print('Task timed out in framework.dart after $taskTimeout.');
       return new TaskResult.failure('Task timed out after $taskTimeout');
     } finally {
       print('Cleaning up after task...');
@@ -106,7 +106,7 @@ class _TaskRunner {
     _keepAlivePort = new RawReceivePort();
 
     // Timeout if nothing bothers to connect and ask us to run the task.
-    const Duration taskStartTimeout = Duration(seconds: 10);
+    const Duration taskStartTimeout = Duration(seconds: 60);
     _startTaskTimeout = new Timer(taskStartTimeout, () {
       if (!_taskStarted) {
         logger.severe('Task did not start in $taskStartTimeout.');

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -70,13 +70,13 @@ Future<Map<String, dynamic>> runTask(String taskName, { bool silent = false }) a
     final Map<String, dynamic> taskResult =
         await isolate.invokeExtension('ext.cocoonRunTask').timeout(taskTimeoutWithGracePeriod);
     waitingFor = 'task process to exit';
-    await runner.exitCode.timeout(const Duration(seconds: 1));
+    await runner.exitCode.timeout(const Duration(seconds: 60));
     return taskResult;
   } on TimeoutException catch (timeout) {
     runner.kill(ProcessSignal.sigint);
     return <String, dynamic>{
       'success': false,
-      'reason': 'Timeout waiting for $waitingFor: ${timeout.message}',
+      'reason': 'Timeout in runner.dart waiting for $waitingFor: ${timeout.message}',
     };
   } finally {
     if (!runnerFinished)

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -13,9 +13,6 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
-/// The maximum amount of time a single microbenchmark is allowed to take.
-const Duration _kBenchmarkTimeout = Duration(minutes: 10);
-
 /// Creates a device lab task that runs benchmarks in
 /// `dev/benchmarks/microbenchmarks` reports results to the dashboard.
 TaskFunction createMicrobenchmarkTask() {
@@ -52,7 +49,7 @@ TaskFunction createMicrobenchmarkTask() {
 
         return await _readJsonResults(flutterProcess);
       }
-      return _run().timeout(_kBenchmarkTimeout);
+      return _run();
     }
 
     final Map<String, double> allResults = <String, double>{};

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -90,8 +90,6 @@ TaskFunction createBasicMaterialCompileTest() {
 
 /// Measure application startup performance.
 class StartupTest {
-  static const Duration _startupTimeout = Duration(minutes: 5);
-
   const StartupTest(this.testDirectory, { this.reportMetrics = true });
 
   final String testDirectory;
@@ -111,7 +109,7 @@ class StartupTest {
         '--trace-startup',
         '-d',
         deviceId,
-      ]).timeout(_startupTimeout);
+      ]);
       final Map<String, dynamic> data = json.decode(file('$testDirectory/build/start_up_info.json').readAsStringSync());
 
       if (!reportMetrics)

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -92,8 +92,8 @@ class TimelineSummary {
         .map((Duration duration) => duration.inMicroseconds)
         .toList(),
       'frame_rasterizer_times': _extractGpuRasterizerDrawEvents()
-          .map((TimedEvent event) => event.duration.inMicroseconds)
-          .toList(),
+        .map((TimedEvent event) => event.duration.inMicroseconds)
+        .toList(),
     };
   }
 
@@ -151,8 +151,8 @@ class TimelineSummary {
       if (events.moveNext()) {
         final TimelineEvent endEvent = events.current;
         result.add(new TimedEvent(
-            beginEvent.timestampMicros,
-            endEvent.timestampMicros
+          beginEvent.timestampMicros,
+          endEvent.timestampMicros,
         ));
       }
     }
@@ -197,14 +197,8 @@ class TimelineSummary {
 /// Timing information about an event that happened in the event loop.
 class TimedEvent {
   /// Creates a timed event given begin and end timestamps in microseconds.
-  TimedEvent(this.beginTimeMicros, this.endTimeMicros)
+  TimedEvent(int beginTimeMicros, int endTimeMicros)
     : this.duration = new Duration(microseconds: endTimeMicros - beginTimeMicros);
-
-  /// The timestamp when the event began.
-  final int beginTimeMicros;
-
-  /// The timestamp when the event ended.
-  final int endTimeMicros;
 
   /// The duration of the event.
   final Duration duration;


### PR DESCRIPTION
* Fix TODO syntax.
* Clarify messages for some timeouts, to aid debugging.
* Increase some other timeouts that were a needlessly short, to reduce sources of flakes.
* Remove some more timeouts that were mostly redundant, to remove complexity.
* Minor style cleanup.
* Remove some dangerous traps (specifically, hide the explicit start/end times in TimedEvent since they shouldn't matter).