### PR TITLE
Avoid having flutter_tools test outcome depend on packages get

### DIFF
--- a/packages/flutter_tools/test/commands/test_test.dart
+++ b/packages/flutter_tools/test/commands/test_test.dart
@@ -104,10 +104,10 @@ Future<Null> _testFile(String testName, String workingDirectory, String testDire
 
   expect(exec.exitCode, exitCode);
   final List<String> output = exec.stdout.split('\n');
-  while (output.first == 'Waiting for another flutter command to release the startup lock...'
-      || output.first.startsWith('Running "flutter packages get" in')) {
+  if (output.first == 'Waiting for another flutter command to release the startup lock...')
     output.removeAt(0);
-  }
+  if (output.first.startsWith('Running "flutter packages get" in'))
+    output.removeAt(0);
   output.add('<<stderr>>');
   output.addAll(exec.stderr.split('\n'));
   final List<String> expectations = fs.file(fullTestExpectation).readAsLinesSync();

--- a/packages/flutter_tools/test/commands/test_test.dart
+++ b/packages/flutter_tools/test/commands/test_test.dart
@@ -104,8 +104,10 @@ Future<Null> _testFile(String testName, String workingDirectory, String testDire
 
   expect(exec.exitCode, exitCode);
   final List<String> output = exec.stdout.split('\n');
-  if (output.first == 'Waiting for another flutter command to release the startup lock...')
+  while (output.first == 'Waiting for another flutter command to release the startup lock...'
+      || output.first.startsWith('Running "flutter packages get" in')) {
     output.removeAt(0);
+  }
   output.add('<<stderr>>');
   output.addAll(exec.stderr.split('\n'));
   final List<String> expectations = fs.file(fullTestExpectation).readAsLinesSync();


### PR DESCRIPTION
Running the `flutter_tools` test suite fails if `flutter packages get` is not called for the `dev/automated_tests` folder prior to execution.