### PR TITLE
Wrap the ReorderableList's children with a MergeSemantics

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -391,10 +391,10 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
       //
       // We also apply the relevant custom accessibility actions for moving the item
       // up, down, to the start, and to the end of the list.
-      return new KeyedSubtree(key: keyIndexGlobalKey, child: new Semantics(
+      return new KeyedSubtree(key: keyIndexGlobalKey, child: new MergeSemantics(child: new Semantics(
         customSemanticsActions: semanticsActions,
         child: toWrap,
-      ));
+      )));
     }
 
     Widget buildDragTarget(BuildContext context, List<Key> acceptedCandidates, List<dynamic> rejectedCandidates) {

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -392,7 +392,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
       // We also apply the relevant custom accessibility actions for moving the item
       // up, down, to the start, and to the end of the list.
       return new KeyedSubtree(
-        key: keyIndexGlobalKey, 
+        key: keyIndexGlobalKey,
         child: new MergeSemantics(
           child: new Semantics(
             customSemanticsActions: semanticsActions,

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -391,10 +391,15 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
       //
       // We also apply the relevant custom accessibility actions for moving the item
       // up, down, to the start, and to the end of the list.
-      return new KeyedSubtree(key: keyIndexGlobalKey, child: new MergeSemantics(child: new Semantics(
-        customSemanticsActions: semanticsActions,
-        child: toWrap,
-      )));
+      return new KeyedSubtree(
+        key: keyIndexGlobalKey, 
+        child: new MergeSemantics(
+          child: new Semantics(
+            customSemanticsActions: semanticsActions,
+            child: toWrap,
+          ),
+        ),
+      );
     }
 
     Widget buildDragTarget(BuildContext context, List<Key> acceptedCandidates, List<dynamic> rejectedCandidates) {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -393,25 +393,23 @@ void main() {
           ));
 
           // Get the switch tile's semantics:
-          // final RenderMergeSemantics semantics = find.descendant(
-          //   of: find.byKey(const Key('Switch tile')),
-          //   matching: find.byType(MergeSemantics),
-          // ).evaluate().first.renderObject;
-          // final Map<CustomSemanticsAction, VoidCallback> semanticsActions = semantics..customSemanticsActions;
-
           final SemanticsData semanticsData = tester.getSemanticsData(find.byKey(const Key('Switch tile')));
-          print(semanticsData);
-          debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversalOrder);
           
-          // Check for properties of a SwitchTile semantics.
-          expect(semanticsData.hasFlag(SemanticsFlag.hasToggledState), true);
-          expect(semanticsData.hasFlag(SemanticsFlag.isToggled), true);
-          // Check for properties of the ReorderableListView semantics.
-          expect(semanticsData.customSemanticsActionIds, hasLength(4), reason: 'List item with its own semantics should have the 4 reorderable custom actions plus its own.');
-          // expect(semanticsActions.containsKey(moveToStart), true, reason: 'Should be able to `Move to the start`.');
-          // expect(semanticsActions.containsKey(moveUp), true, reason: 'Should be able to `Move up`.');
-          // expect(semanticsActions.containsKey(moveDown), true, reason: 'Should be able to `Move down`.');
-          // expect(semanticsActions.containsKey(moveToEnd), true, reason: 'Should be able to `Move to the end`.');
+          // Check for properties of both SwitchTile semantics and the ReorderableListView custom semantics actions.
+          expect(semanticsData, matchesSemanticsData(
+            hasToggledState: true,
+            isToggled: true,
+            isEnabled: true,
+            hasEnabledState: true,
+            label: 'Switch tile',
+            hasTapAction: true,
+            customActions: const <CustomSemanticsAction>[
+              CustomSemanticsAction(label: 'Move up'),
+              CustomSemanticsAction(label: 'Move down'),
+              CustomSemanticsAction(label: 'Move to the end'),
+              CustomSemanticsAction(label: 'Move to the start'),
+            ],
+          ));
           handle.dispose();
         });
       });

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:flutter/gestures.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
-
-import '../widgets/semantics_tester.dart';
 
 void main() {
   group('$ReorderableListView', () {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -389,7 +389,7 @@ void main() {
 
           // Get the switch tile's semantics:
           final SemanticsData semanticsData = tester.getSemanticsData(find.byKey(const Key('Switch tile')));
-          
+
           // Check for properties of both SwitchTile semantics and the ReorderableListView custom semantics actions.
           expect(semanticsData, matchesSemanticsData(
             hasToggledState: true,


### PR DESCRIPTION
This prevents the list's semantics from getting hidden by children that have semantics in them.

Fixes #20589 

cc @alanrussian 