### PR TITLE
Use markdown table instead of HTML table in Element.updateChild documentation

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2681,11 +2681,10 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// The following table summarizes the above:
   ///
-  /// <table>
-  /// <tr><th><th>`newWidget == null`<th>`newWidget != null`
-  /// <tr><th>`child == null`<td>Returns null.<td>Returns new [Element].
-  /// <tr><th>`child != null`<td>Old child is removed, returns null.<td>Old child updated if possible, returns child or new [Element].
-  /// </table>
+  /// |                     | **newWidget == null**  | **newWidget != null**   |
+  /// | :-----------------: | :--------------------- | :---------------------- |
+  /// |  **child == null**  |  Returns null.         |  Returns new [Element]. |
+  /// |  **child != null**  |  Old child is removed, returns null. | Old child updated if possible, returns child or new [Element]. |
   @protected
   Element updateChild(Element child, Widget newWidget, dynamic newSlot) {
     assert(() {


### PR DESCRIPTION
Fixes dart-lang/dartdoc#1467.

With dart-lang/dartdoc#1453 fixed, @Hixie's preferred solution to dart-lang/dartdoc#1467 is now possible -- using markdown tables.  Comment references are automatically linked in dartdoc's markdown tables.

This PR does that.

Compare this:

![screenshot from 2018-08-16 17-19-47](https://user-images.githubusercontent.com/14116827/44241490-234a8080-a179-11e8-8fa9-831a9da271d1.png)

to the original at https://master-docs-flutter-io.firebaseapp.com/flutter/widgets/Element/updateChild.html.