### PR TITLE
Remove duplicated assets under /pkg/data

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -27,6 +27,7 @@ const List<String> _kRequiredOptions = <String>[
   _kOptionPackages,
   _kOptionAsset,
   _kOptionAssetManifestOut,
+  _kOptionComponentName,
 ];
 
 Future<Null> main(List<String> args) {
@@ -89,10 +90,7 @@ Future<Null> writeFuchsiaManifest(AssetBundle assets, String outputBase, String 
   final libfs.IOSink outFile = destFile.openWrite();
 
   for (String path in assets.entries.keys) {
-    outFile.write('data/$path=$outputBase/$path\n');
-    if (componentName != null && componentName.isNotEmpty) {
-      outFile.write('data/$componentName/$path=$outputBase/$path\n');
-    }
+    outFile.write('data/$componentName/$path=$outputBase/$path\n');
   }
   await outFile.flush();
   await outFile.close();


### PR DESCRIPTION
Require componentName to ensure assets are placed under /pkg/data/<component-name>

TESTED=topaz tests with {fx set x64, fx set x64 --release}