### PR TITLE
Strip upstream from footer

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -96,6 +96,7 @@ Future<Null> main(List<String> arguments) async {
     exit(code);
 
   createFooter('dev/docs/lib/footer.html');
+
   final List<String> dartdocBaseArgs = <String>['global', 'run'];
   if (args['checked']) {
     dartdocBaseArgs.add('-c');

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -96,7 +96,6 @@ Future<Null> main(List<String> arguments) async {
     exit(code);
 
   createFooter('dev/docs/lib/footer.html');
-
   final List<String> dartdocBaseArgs = <String>['global', 'run'];
   if (args['checked']) {
     dartdocBaseArgs.add('-c');
@@ -208,7 +207,7 @@ void createFooter(String footerPath) {
     throw 'git status exit with non-zero exit code: ${gitResult.exitCode}';
   final Match gitBranchMatch = gitBranchRegexp.firstMatch(
       gitResult.stdout.trim().split('\n').first);
-  final String gitBranchOut = gitBranchMatch == null ? '' : '• </span class="no-break">${gitBranchMatch.group(1)}</span>';
+  final String gitBranchOut = gitBranchMatch == null ? '' : '• </span class="no-break">${gitBranchMatch.group(1).split('...').first}</span>';
 
   gitRevision = gitRevision.length > kGitRevisionLength ? gitRevision.substring(0, kGitRevisionLength) : gitRevision;
 


### PR DESCRIPTION
In #20711 it was not my intention to display the upstream branch, only the local one, but I must not have retested that after the last revisions.    This corrects that oversight by stripping upstream branch information from the footer and only displaying the current branch.  With this change, 'master...origin/master' becomes 'master' on https://master-docs-flutter-io.firebaseapp.com/.

Open to not doing this too if the extra information is really valuable, but most of the time I believe it won't be.