### PR TITLE
Fixes resulting from audit of issues links

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -68,21 +68,21 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    # - avoid_returning_null # we do this commonly
-    # - avoid_returning_this # https://github.com/dart-lang/linter/issues/842
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_this # there are plenty of valid reasons to return this
     # - avoid_setters_without_getters # not yet tested
     # - avoid_single_cascade_in_expression_statements # not yet tested
     - avoid_slow_async_io
-    # - avoid_types_as_parameter_names # https://github.com/dart-lang/linter/pull/954/files
+    - avoid_types_as_parameter_names
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
-    # - avoid_unused_constructor_parameters # https://github.com/dart-lang/linter/pull/847
+    - avoid_unused_constructor_parameters
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
-    # - close_sinks # https://github.com/flutter/flutter/issues/5789
-    # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
-    # - constant_identifier_names # https://github.com/dart-lang/linter/issues/204
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     - directives_ordering
     - empty_catches
@@ -90,13 +90,13 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    # - invariant_booleans # https://github.com/flutter/flutter/issues/5790
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
     - iterable_contains_unrelated_type
     # - join_return_with_assignment # not yet tested
     - library_names
     - library_prefixes
     - list_remove_unrelated_type
-    # - literal_only_boolean_expressions # https://github.com/flutter/flutter/issues/5791
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
@@ -127,7 +127,7 @@ linter:
     # - prefer_function_declarations_over_variables # not yet tested
     - prefer_initializing_formals
     # - prefer_interpolation_to_compose_strings # not yet tested
-    # - prefer_iterable_whereType # https://github.com/dart-lang/sdk/issues/32463
+    - prefer_iterable_whereType
     - prefer_is_empty
     - prefer_is_not_empty
     - prefer_single_quotes
@@ -141,11 +141,11 @@ linter:
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # https://github.com/flutter/flutter/issues/5793
+    # - unawaited_futures # too many false positives
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_getters_setters
-    # - unnecessary_lambdas # https://github.com/dart-lang/linter/issues/498
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
@@ -155,7 +155,7 @@ linter:
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
     # - use_setters_to_change_properties # not yet tested
-    # - use_string_buffers # https://github.com/dart-lang/linter/pull/664
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
     - valid_regexps
     # - void_checks # not yet tested

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -610,8 +610,8 @@ Future<Null> _verifyNoBadImportsInFlutter(String workingDirectory) async {
     .map<String>((FileSystemEntity entity) => path.basenameWithoutExtension(entity.path))
     .toList()..sort();
   final List<String> directories = new Directory(srcPath).listSync()
-    .where((FileSystemEntity entity) => entity is Directory)
-    .map<String>((FileSystemEntity entity) => path.basename(entity.path))
+    .whereType<Directory>()
+    .map<String>((Directory entity) => path.basename(entity.path))
     .toList()..sort();
   if (!_matches(packages, directories)) {
     errors.add(

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     test('exits with code 1 when fails to connect', () async {
       await expectScriptResult(<String>['smoke_test_setup_failure'], 1);
-    });
+    }, skip: true); // https://github.com/flutter/flutter/issues/5901
 
     test('exits with code 1 when results are mixed', () async {
       await expectScriptResult(<String>[

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     test('exits with code 1 when fails to connect', () async {
       await expectScriptResult(<String>['smoke_test_setup_failure'], 1);
-    }, skip: true); // https://github.com/flutter/flutter/issues/5901
+    });
 
     test('exits with code 1 when results are mixed', () async {
       await expectScriptResult(<String>[

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -147,7 +147,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
                 value: LeaveBehindDemoAction.reset,
                 child: Text('Reset the list')
               ),
-              const PopupMenuDivider(), // ignore: list_element_type_not_assignable, https://github.com/flutter/flutter/issues/5771
+              const PopupMenuDivider(),
               new CheckedPopupMenuItem<LeaveBehindDemoAction>(
                 value: LeaveBehindDemoAction.horizontalSwipe,
                 checked: _dismissDirection == DismissDirection.horizontal,

--- a/examples/flutter_gallery/lib/demo/material/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/menu_demo.dart
@@ -140,7 +140,7 @@ class MenuDemoState extends State<MenuDemo> {
                     title: Text('Get link')
                   )
                 ),
-                const PopupMenuDivider(), // ignore: list_element_type_not_assignable, https://github.com/flutter/flutter/issues/5771
+                const PopupMenuDivider(),
                 const PopupMenuItem<String>(
                   value: 'Remove',
                   child: ListTile(

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -67,11 +67,7 @@ class _TappableWhileStatusIsState extends State<_TappableWhileStatusIs> {
   Widget build(BuildContext context) {
     return new AbsorbPointer(
       absorbing: !_active,
-      // Redundant. TODO(xster): remove after https://github.com/flutter/flutter/issues/17179.
-      child: new IgnorePointer(
-        ignoring: !_active,
-        child: widget.child
-      ),
+      child: widget.child,
     );
   }
 }

--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 import 'gallery/app.dart';
 
 void main() {
-  // Temporary debugging hook for https://github.com/flutter/flutter/issues/17956
+  // Temporary debugging hook for https://github.com/flutter/flutter/issues/17888
   debugInstrumentationEnabled = true;
 
   // Overriding https://github.com/flutter/flutter/issues/13736 for better

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -132,11 +132,10 @@ class CalculationManager {
   Isolate _isolate;
 
   void _runCalculation() {
-    // Load the JSON string. Note that this is done in the main isolate; at the
-    // moment, spawned isolates do not have access to Mojo services, including
-    // the root bundle (see https://github.com/flutter/flutter/issues/3294).
-    // However, the loading process is asynchronous, so the UI will not block
-    // while the file is loaded.
+    // Load the JSON string. This is done in the main isolate because spawned
+    // isolates do not have access to the root bundle. However, the loading
+    // process is asynchronous, so the UI will not block while the file is
+    // loaded.
     rootBundle.loadString('services/data.json').then<Null>((String data) {
       if (isRunning) {
         final CalculationMessage message = new CalculationMessage(data, _receivePort.sendPort);

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -27,7 +27,7 @@ analyzer:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
-    # TODO: https://github.com/flutter/flutter/issues/20114
+    # TODO(ianh): https://github.com/flutter/flutter/issues/20114
     missing_return: ignore
     # allow having TODOs in the code
     todo: ignore
@@ -48,7 +48,7 @@ linter:
     - camel_case_types
     - cancel_subscriptions
     - close_sinks
-    # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
+    # - comment_references # we do not presume as to what people want to reference in their dartdocs
     # - constant_identifier_names # https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     - empty_constructor_bodies

--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -162,8 +162,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
           new Expanded(
             child: new Semantics(
               selected: active,
-              // TODO(https://github.com/flutter/flutter/issues/13452):
-              // This needs localization support.
+              // TODO(xster): This needs localization support. https://github.com/flutter/flutter/issues/13452
               hint: 'tab, ${index + 1} of ${items.length}',
               child: new GestureDetector(
                 behavior: HitTestBehavior.opaque,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -95,7 +95,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
        assert(maintainState != null),
        assert(fullscreenDialog != null),
        super(settings: settings, fullscreenDialog: fullscreenDialog) {
-    // ignore: prefer_asserts_in_initializer_lists , https://github.com/dart-lang/sdk/issues/31223
+    // ignore: prefer_asserts_in_initializer_lists, https://github.com/dart-lang/sdk/issues/31223
     assert(opaque); // PageRoute makes it return true.
   }
 

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -115,9 +115,9 @@ class _TextSelectionToolbar extends StatelessWidget {
             child: new Row(mainAxisSize: MainAxisSize.min, children: items),
           ),
         ),
-        // TODO(https://github.com/flutter/flutter/issues/11274):
-        // Position the triangle based on the layout delegate.
-        // And avoid letting the triangle line up with any dividers.
+        // TODO(xster): Position the triangle based on the layout delegate, and
+        // avoid letting the triangle line up with any dividers.
+        // https://github.com/flutter/flutter/issues/11274
         triangle,
       ],
     );

--- a/packages/flutter/lib/src/foundation/key.dart
+++ b/packages/flutter/lib/src/foundation/key.dart
@@ -76,7 +76,7 @@ class ValueKey<T> extends LocalKey {
   String toString() {
     final String valueString = T == String ? '<\'$value\'>' : '<$value>';
     // The crazy on the next line is a workaround for
-    // https://github.com/dart-lang/sdk/issues/28548
+    // https://github.com/dart-lang/sdk/issues/33297
     if (runtimeType == new _TypeLiteral<ValueKey<T>>().type)
       return '[$valueString]';
     return '[$T $valueString]';

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -41,7 +41,8 @@ class AnimatedIcon extends StatelessWidget {
     this.semanticLabel,
     this.textDirection,
   }) : assert(progress != null),
-       assert(icon != null);
+       assert(icon != null),
+       super(key: key);
 
   /// The animation progress for the animated icon.
   ///

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -368,11 +368,4 @@ class _RenderCheckbox extends RenderToggleable {
       }
     }
   }
-
-  // TODO(hmuller): smooth segues for cases where the value changes
-  // in the middle of position's animation cycle.
-  // https://github.com/flutter/flutter/issues/14674
-
-  // TODO(hmuller): accessibility support for tristate checkboxes.
-  // https://github.com/flutter/flutter/issues/14677
 }

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -15,6 +15,7 @@ import 'data_table_source.dart';
 import 'dropdown.dart';
 import 'icon_button.dart';
 import 'icons.dart';
+import 'ink_decoration.dart';
 import 'material_localizations.dart';
 import 'progress_indicator.dart';
 import 'theme.dart';
@@ -397,20 +398,19 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                   opacity: 0.54
                 ),
                 child: new ButtonTheme.bar(
-                  child: new Container(
+                  child: new Ink(
                     height: 64.0,
-                    padding: new EdgeInsetsDirectional.only(start: startPadding, end: 14.0),
-                    // TODO(ianh): This decoration will prevent ink splashes from being visible.
-                    // Instead, we should have a widget that prints the decoration on the material.
-                    // See https://github.com/flutter/flutter/issues/3782
                     color: _selectedRowCount > 0 ? themeData.secondaryHeaderColor : null,
-                    child: new Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: headerWidgets
-                    )
-                  )
-                )
-              )
+                    child: new Padding(
+                      padding: new EdgeInsetsDirectional.only(start: startPadding, end: 14.0),
+                      child: new Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: headerWidgets
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
           new SingleChildScrollView(

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -61,7 +61,7 @@ class Tab extends StatelessWidget {
     this.icon,
     this.child,
   }) : assert(text != null || child != null || icon != null),
-       assert(!(text != null && null != child)), // TODO(goderbauer): https://github.com/dart-lang/sdk/issues/31140
+       assert(!(text != null && null != child)), // TODO(goderbauer): https://github.com/dart-lang/sdk/issues/34180
        super(key: key);
 
   /// The text to display as the tab's label.

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -83,7 +83,7 @@ class BoxDecoration extends Decoration {
     this.backgroundBlendMode,
     this.shape = BoxShape.rectangle,
   }) : assert(shape != null),
-       // TODO(mattcarroll): Use "backgroundBlendMode == null" when https://github.com/dart-lang/sdk/issues/31140 is in.
+       // TODO(mattcarroll): Use "backgroundBlendMode == null" when https://github.com/dart-lang/sdk/issues/34180 is in.
        assert(
          identical(backgroundBlendMode, null) || color != null || gradient != null,
          'backgroundBlendMode applies to BoxDecoration\'s background color or '

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2059,9 +2059,8 @@ abstract class RenderBox extends RenderObject {
   ///   // ... handle the event ...
   /// }
   /// ```
-  // TODO(ianh): Fix the type of the argument here once https://github.com/dart-lang/sdk/issues/25232 is fixed
   @override
-  void handleEvent(PointerEvent event, covariant HitTestEntry entry) {
+  void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
     super.handleEvent(event, entry);
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -53,7 +53,7 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 /// This class can be used as a mixin for situations where the proxying behavior
 /// of [RenderProxyBox] is desired but inheriting from [RenderProxyBox] is
 /// impractical (e.g. because you want to mix in other classes as well).
-// TODO(ianh): Remove this class once https://github.com/dart-lang/sdk/issues/15101 is fixed
+// TODO(ianh): Remove this class once https://github.com/dart-lang/sdk/issues/31543 is fixed
 @optionalTypeArgs
 abstract class RenderProxyBoxMixin<T extends RenderBox> extends RenderBox with RenderObjectWithChildMixin<T> {
   // This class is intended to be used as a mixin, and should not be
@@ -3243,7 +3243,6 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     bool hidden,
     bool image,
     bool liveRegion,
-    bool isSwitch,
     String label,
     String value,
     String increasedValue,

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -239,7 +239,7 @@ abstract class RenderAligningShiftedBox extends RenderShiftedBox {
        super(child);
 
   /// A constructor to be used only when the extending class also has a mixin.
-  // TODO(gspencer): Remove this constructor once https://github.com/dart-lang/sdk/issues/15101 is fixed.
+  // TODO(gspencer): Remove this constructor once https://github.com/dart-lang/sdk/issues/31543 is fixed.
   @protected
   RenderAligningShiftedBox.mixin(AlignmentGeometry alignment,TextDirection textDirection, RenderBox child)
     : this(alignment: alignment, textDirection: textDirection, child: child);

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -366,7 +366,6 @@ class RenderTable extends RenderBox {
     TableBorder border,
     List<Decoration> rowDecorations,
     ImageConfiguration configuration = ImageConfiguration.empty,
-    Decoration defaultRowDecoration,
     TableCellVerticalAlignment defaultVerticalAlignment = TableCellVerticalAlignment.top,
     TextBaseline textBaseline,
     List<List<RenderBox>> children

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -694,10 +694,7 @@ abstract class WidgetsBinding extends BindingBase with SchedulerBinding, Gesture
     deferFirstFrameReport();
     if (renderViewElement != null)
       buildOwner.reassemble(renderViewElement);
-    // TODO(hansmuller): eliminate the value variable after analyzer bug
-    // https://github.com/flutter/flutter/issues/11646 is fixed.
-    final Future<Null> value = super.performReassemble();
-    return value.then((Null _) {
+    return super.performReassemble().then((Null value) {
       allowFirstFrameReport();
     });
   }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1326,7 +1326,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       if (plannedInitialRoutes.contains(null)) {
         assert(() {
           FlutterError.reportError(
-            new FlutterErrorDetails( // ignore: prefer_const_constructors, https://github.com/dart-lang/sdk/issues/29952
+            new FlutterErrorDetails(
               exception:
                 'Could not navigate to initial route.\n'
                 'The requested route name was: "/$initialRouteName"\n'

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1513,7 +1513,6 @@ class RenderSliverOverlapInjector extends RenderSliver {
   /// The [handle] must not be null.
   RenderSliverOverlapInjector({
     @required SliverOverlapAbsorberHandle handle,
-    RenderSliver child,
   }) : assert(handle != null), _handle = handle;
 
   double _currentLayoutExtent;

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -287,7 +287,7 @@ class _SliverScrollingPersistentHeader extends _SliverPersistentHeaderRenderObje
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/15101
+// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
 abstract class _RenderSliverScrollingPersistentHeader extends RenderSliverScrollingPersistentHeader { }
 
 class _RenderSliverScrollingPersistentHeaderForWidgets extends _RenderSliverScrollingPersistentHeader
@@ -305,7 +305,7 @@ class _SliverPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectW
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/15101
+// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
 abstract class _RenderSliverPinnedPersistentHeader extends RenderSliverPinnedPersistentHeader { }
 
 class _RenderSliverPinnedPersistentHeaderForWidgets extends _RenderSliverPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
@@ -319,7 +319,7 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
     // Not passing this snapConfiguration as a constructor parameter to avoid the
-    // additional layers added due to https://github.com/dart-lang/sdk/issues/15101
+    // additional layers added due to https://github.com/dart-lang/sdk/issues/31543
     return new _RenderSliverFloatingPersistentHeaderForWidgets()
       ..snapConfiguration = delegate.snapConfiguration;
   }
@@ -330,7 +330,7 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/15101
+// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
 abstract class _RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFloatingPinnedPersistentHeader { }
 
 class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends _RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
@@ -344,7 +344,7 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
     // Not passing this snapConfiguration as a constructor parameter to avoid the
-    // additional layers added due to https://github.com/dart-lang/sdk/issues/15101
+    // additional layers added due to https://github.com/dart-lang/sdk/issues/31543
     return new _RenderSliverFloatingPinnedPersistentHeaderForWidgets()
       ..snapConfiguration = delegate.snapConfiguration;
   }
@@ -355,7 +355,7 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/15101
+// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
 abstract class _RenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersistentHeader { }
 
 class _RenderSliverFloatingPersistentHeaderForWidgets extends _RenderSliverFloatingPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -119,7 +119,6 @@ class _SerializeConfig {
   _SerializeConfig.merge(
     _SerializeConfig base, {
     int subtreeDepth,
-    bool omitChildren,
     Iterable<Diagnosticable> pathToInclude,
   }) :
     groupName = base.groupName,
@@ -837,7 +836,7 @@ class WidgetInspectorService {
               new _SerializeConfig.merge(config, pathToInclude: config.pathToInclude.skip(1)),
             );
           } else {
-            return _nodeToJson(node, new _SerializeConfig.merge(config, omitChildren: true));
+            return _nodeToJson(node, new _SerializeConfig.merge(config));
           }
         }
         // The tricky special case here is that when in the detailsTree,

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -52,7 +52,6 @@ void main() {
       await expectLater(
         find.byType(RichText),
         matchesGoldenFile('localized_fonts.rich_text.styled_text_span.png'),
-        skip: !Platform.isLinux,
       );
     },
     skip: !Platform.isLinux,
@@ -105,7 +104,6 @@ void main() {
       await expectLater(
         find.byType(Row),
         matchesGoldenFile('localized_fonts.text_ambient_locale.chars.png'),
-        skip: !Platform.isLinux,
       );
     },
     skip: !Platform.isLinux,
@@ -150,7 +148,6 @@ void main() {
       await expectLater(
         find.byType(Row),
         matchesGoldenFile('localized_fonts.text_explicit_locale.chars.png'),
-        skip: !Platform.isLinux,
       );
     },
     skip: !Platform.isLinux,

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1029,9 +1029,8 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   int get microtaskCount {
-    // Unsupported until we have a wrapper around the real async API
-    // https://github.com/flutter/flutter/issues/4637
-    assert(false);
+    // The Dart SDK doesn't report this number.
+    assert(false, 'microtaskCount cannot be reported when running in real time');
     return -1;
   }
 

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -136,12 +136,8 @@ abstract class WidgetController {
   Iterable<State> get allStates {
     TestAsyncUtils.guardSync();
     return allElements
-           // TODO(vegorov) replace with Iterable.whereType, when it is available. https://github.com/dart-lang/sdk/issues/27827
-           .where((Element element) => element is StatefulElement)
-           .map((Element element) {
-             final StatefulElement statefulElement = element;
-             return statefulElement.state;
-           });
+           .whereType<StatefulElement>()
+           .map((StatefulElement element) => element.state);
   }
 
   /// The matching state in the widget tree.
@@ -151,7 +147,7 @@ abstract class WidgetController {
   ///
   /// * Use [firstState] if you expect to match several states but only want the first.
   /// * Use [stateList] if you expect to match several states and want all of them.
-  T state<T extends State<StatefulWidget>>(Finder finder) { // TODO(leafp): remove '<StatefulWidget>' when https://github.com/dart-lang/sdk/issues/28580 is fixed
+  T state<T extends State>(Finder finder) {
     TestAsyncUtils.guardSync();
     return _stateOf<T>(finder.evaluate().single, finder);
   }
@@ -163,7 +159,7 @@ abstract class WidgetController {
   /// matching widget has no state.
   ///
   /// * Use [state] if you only expect to match one state.
-  T firstState<T extends State<StatefulWidget>>(Finder finder) { // TODO(leafp): remove '<StatefulWidget>' when https://github.com/dart-lang/sdk/issues/28580 is fixed
+  T firstState<T extends State>(Finder finder) {
     TestAsyncUtils.guardSync();
     return _stateOf<T>(finder.evaluate().first, finder);
   }
@@ -175,12 +171,12 @@ abstract class WidgetController {
   ///
   /// * Use [state] if you only expect to match one state.
   /// * Use [firstState] if you expect to match several but only want the first.
-  Iterable<T> stateList<T extends State<StatefulWidget>>(Finder finder) { // TODO(leafp): remove '<StatefulWidget>' when https://github.com/dart-lang/sdk/issues/28580 is fixed
+  Iterable<T> stateList<T extends State>(Finder finder) {
     TestAsyncUtils.guardSync();
     return finder.evaluate().map((Element element) => _stateOf<T>(element, finder));
   }
 
-  T _stateOf<T extends State<StatefulWidget>>(Element element, Finder finder) { // TODO(leafp): remove '<StatefulWidget>' when https://github.com/dart-lang/sdk/issues/28580 is fixed
+  T _stateOf<T extends State>(Element element, Finder finder) {
     TestAsyncUtils.guardSync();
     if (element is StatefulElement)
       return element.state;

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -45,7 +45,7 @@ void main() {
       test_package.expect(completed, isFalse);
       await future;
       test_package.expect(completed, isTrue);
-    }, skip: true /* Enable once https://github.com/dart-lang/test/pull/831 lands */);
+    });
   });
 
   group('findsOneWidget', () {

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -73,7 +73,7 @@ Future<Null> main(List<String> args) async {
     new PrecacheCommand(),
     new RunCommand(verboseHelp: verboseHelp),
     new ScreenshotCommand(),
-    new ShellCompletionCommand(verboseHelp: verboseHelp),
+    new ShellCompletionCommand(),
     new StopCommand(),
     new TestCommand(verboseHelp: verboseHelp),
     new TraceCommand(),

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -17,7 +17,6 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
-import '../base/utils.dart';
 import '../build_info.dart';
 import '../device.dart';
 import '../globals.dart';
@@ -518,32 +517,6 @@ class AndroidDevice extends Device {
     await runCheckedAsync(adbCommandForDevice(<String>['shell', 'screencap', '-p', remotePath]));
     await runCheckedAsync(adbCommandForDevice(<String>['pull', remotePath, outputFile.path]));
     await runCheckedAsync(adbCommandForDevice(<String>['shell', 'rm', remotePath]));
-  }
-
-  // TODO(dantup): discoverApps is no longer used and can possibly be removed.
-  // Waiting for a response here:
-  // https://github.com/flutter/flutter/pull/18873#discussion_r198862179
-  @override
-  Future<List<DiscoveredApp>> discoverApps() async {
-    final RegExp discoverExp = new RegExp(r'DISCOVER: (.*)');
-    final List<DiscoveredApp> result = <DiscoveredApp>[];
-    final StreamSubscription<String> logs = getLogReader().logLines.listen((String line) {
-      final Match match = discoverExp.firstMatch(line);
-      if (match != null) {
-        final Map<String, dynamic> app = json.decode(match.group(1));
-        result.add(new DiscoveredApp(app['id'], app['observatoryPort']));
-      }
-    });
-
-    await runCheckedAsync(adbCommandForDevice(<String>[
-      'shell', 'am', 'broadcast', '-a', 'io.flutter.view.DISCOVER'
-    ]));
-
-    await waitGroup<Null>(<Future<Null>>[
-      new Future<Null>.delayed(const Duration(seconds: 1)),
-      logs.cancel(),
-    ]);
-    return result;
   }
 }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -361,11 +361,7 @@ class AndroidSdk {
     if (platformsDir.existsSync()) {
       platforms = platformsDir
         .listSync()
-        .where((FileSystemEntity entity) => entity is Directory)
-        .map<Directory>((FileSystemEntity entity) {
-          final Directory dir = entity;
-          return dir;
-        });
+        .whereType<Directory>();
     }
 
     List<Version> buildTools = <Version>[]; // 19.1.0, 22.0.1, ...

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -150,8 +150,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         final Iterable<Directory> directories = fs
             .directory(path)
             .listSync()
-            .where((FileSystemEntity e) => e is Directory)
-            .cast<Directory>();
+            .whereType<Directory>();
         for (Directory directory in directories) {
           final String name = directory.basename;
           // An exact match, or something like 'Android Studio 3.0 Preview.app'.

--- a/packages/flutter_tools/lib/src/base/process_manager.dart
+++ b/packages/flutter_tools/lib/src/base/process_manager.dart
@@ -46,14 +46,7 @@ Future<ReplayProcessManager> getReplayProcessManager(String location) async {
 
   ProcessManager manager;
   try {
-    manager = await ReplayProcessManager.create(dir,
-      // TODO(tvolkert): Once https://github.com/flutter/flutter/issues/7166 is
-      //     resolved, we can use the default `streamDelay`. In the
-      //     meantime, native file I/O operations cause our `tail` process
-      //     streams to flush before our protocol discovery is listening on
-      //     them, causing us to timeout waiting for the observatory port.
-      streamDelay: const Duration(milliseconds: 50),
-    );
+    manager = await ReplayProcessManager.create(dir);
   } on ArgumentError catch (error) {
     throwToolExit('Invalid replay-from: $error');
   }

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -25,22 +25,6 @@ class AnsiTerminal {
   static const String _reset = '\u001B[0m';
   static const String _clear = '\u001B[2J\u001B[H';
 
-  static const int _EBADF = 9;
-  static const int _ENXIO = 6;
-  static const int _ENOTTY = 25;
-  static const int _ENETRESET = 102;
-  static const int _INVALID_HANDLE = 6;
-
-  /// Setting the line mode can throw for some terminals (with "Operation not
-  /// supported on socket"), but the error can be safely ignored.
-  static const List<int> _lineModeIgnorableErrors = <int>[
-    _EBADF,
-    _ENXIO,
-    _ENOTTY,
-    _ENETRESET,
-    _INVALID_HANDLE,
-  ];
-
   bool supportsColor = platform.stdoutSupportsAnsi;
 
   String bolden(String message) {
@@ -59,24 +43,15 @@ class AnsiTerminal {
   String clearScreen() => supportsColor ? _clear : '\n\n';
 
   set singleCharMode(bool value) {
-    // TODO(goderbauer): instead of trying to set lineMode and then catching
-    // [_ENOTTY] or [_INVALID_HANDLE], we should check beforehand if stdin is
-    // connected to a terminal or not.
-    // (Requires https://github.com/dart-lang/sdk/issues/29083 to be resolved.)
     final Stream<List<int>> stdin = io.stdin;
-    if (stdin is io.Stdin) {
-      try {
-        // The order of setting lineMode and echoMode is important on Windows.
-        if (value) {
-          stdin.echoMode = false;
-          stdin.lineMode = false;
-        } else {
-          stdin.lineMode = true;
-          stdin.echoMode = true;
-        }
-      } on io.StdinException catch (error) {
-        if (!_lineModeIgnorableErrors.contains(error.osError?.errorCode))
-          rethrow;
+    if (stdin is io.Stdin && stdin.hasTerminal) {
+      // The order of setting lineMode and echoMode is important on Windows.
+      if (value) {
+        stdin.echoMode = false;
+        stdin.lineMode = false;
+      } else {
+        stdin.lineMode = true;
+        stdin.echoMode = true;
       }
     }
   }

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -21,7 +21,7 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(new BuildApkCommand(verboseHelp: verboseHelp));
     addSubcommand(new BuildAotCommand(verboseHelp: verboseHelp));
     addSubcommand(new BuildIOSCommand(verboseHelp: verboseHelp));
-    addSubcommand(new BuildFlxCommand(verboseHelp: verboseHelp));
+    addSubcommand(new BuildFlxCommand());
     addSubcommand(new BuildBundleCommand(verboseHelp: verboseHelp));
   }
 

--- a/packages/flutter_tools/lib/src/commands/build_flx.dart
+++ b/packages/flutter_tools/lib/src/commands/build_flx.dart
@@ -8,8 +8,6 @@ import '../globals.dart';
 import 'build.dart';
 
 class BuildFlxCommand extends BuildSubCommand {
-
-  BuildFlxCommand({bool verboseHelp = false});
   @override
   final String name = 'flx';
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -129,10 +129,7 @@ class CreateCommand extends FlutterCommand {
     final bool generatePackage = template == 'package';
 
     final Directory projectDir = fs.directory(argResults.rest.first);
-    String dirPath = fs.path.normalize(projectDir.absolute.path);
-    // TODO(goderbauer): Work-around for: https://github.com/dart-lang/path/issues/24
-    if (fs.path.basename(dirPath) == '.')
-      dirPath = fs.path.dirname(dirPath);
+    final String dirPath = fs.path.normalize(projectDir.absolute.path);
     String organization = argResults['org'];
     if (!argResults.wasParsed('org')) {
       final FlutterProject project = await FlutterProject.fromDirectory(projectDir);

--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -231,13 +231,9 @@ class IdeConfigCommand extends FlutterCommand {
     }
 
     final String flutterRoot = fs.path.absolute(Cache.flutterRoot);
-    String dirPath = fs.path.normalize(
+    final String dirPath = fs.path.normalize(
       fs.directory(fs.path.absolute(Cache.flutterRoot)).absolute.path,
     );
-    // TODO(goderbauer): Work-around for: https://github.com/dart-lang/path/issues/24
-    if (fs.path.basename(dirPath) == '.') {
-      dirPath = fs.path.dirname(dirPath);
-    }
 
     final String error = _validateFlutterDir(dirPath, flutterRoot: flutterRoot);
     if (error != null) {

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -12,7 +12,7 @@ import '../base/io.dart';
 import '../runner/flutter_command.dart';
 
 class ShellCompletionCommand extends FlutterCommand {
-  ShellCompletionCommand({bool verboseHelp = false}) {
+  ShellCompletionCommand() {
     argParser.addFlag(
       'overwrite',
       defaultsTo: false,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -277,13 +277,6 @@ abstract class Device {
 
   Future<void> takeScreenshot(File outputFile) => new Future<Null>.error('unimplemented');
 
-  // TODO(dantup): discoverApps is no longer used and can possibly be removed.
-  // Waiting for a response here:
-  // https://github.com/flutter/flutter/pull/18873#discussion_r198862179
-  /// Find the apps that are currently running on this device.
-  Future<List<DiscoveredApp>> discoverApps() =>
-      new Future<List<DiscoveredApp>>.value(<DiscoveredApp>[]);
-
   @override
   int get hashCode => id.hashCode;
 

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -91,7 +91,7 @@ class Doctor {
   }
 
   List<Workflow> get workflows {
-    return new List<Workflow>.from(validators.where((DoctorValidator validator) => validator is Workflow));
+    return validators.whereType<Workflow>().toList();
   }
 
   /// Print a summary of the state of the tooling, as well as how to get more info.
@@ -479,19 +479,17 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     }
 
     try {
-      final Iterable<FileSystemEntity> installDirs = installPaths
+      final Iterable<Directory> installDirs = installPaths
               .map((String installPath) => fs.directory(installPath))
               .map((Directory dir) => dir.existsSync() ? dir.listSync() : <FileSystemEntity>[])
               .expand((List<FileSystemEntity> mappedDirs) => mappedDirs)
-              .where((FileSystemEntity mappedDir) => mappedDir is Directory);
-      for (FileSystemEntity dir in installDirs) {
-        if (dir is Directory) {
-          checkForIntelliJ(dir);
-          if (!dir.path.endsWith('.app')) {
-            for (FileSystemEntity subdir in dir.listSync()) {
-              if (subdir is Directory) {
-                checkForIntelliJ(subdir);
-              }
+              .whereType<Directory>();
+      for (Directory dir in installDirs) {
+        checkForIntelliJ(dir);
+        if (!dir.path.endsWith('.app')) {
+          for (FileSystemEntity subdir in dir.listSync()) {
+            if (subdir is Directory) {
+              checkForIntelliJ(subdir);
             }
           }
         }

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -34,9 +34,8 @@ class VsCode {
     final Iterable<FileSystemEntity> extensionDirs = fs
         .directory(extensionDirectory)
         .listSync()
-        .where((FileSystemEntity d) => d is Directory)
-        .where(
-            (FileSystemEntity d) => d.basename.toLowerCase().startsWith(extensionIdentifierLower));
+        .whereType<Directory>()
+        .where((Directory d) => d.basename.toLowerCase().startsWith(extensionIdentifierLower));
 
     if (extensionDirs.isNotEmpty) {
       final FileSystemEntity extensionDir = extensionDirs.first;

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -196,8 +196,8 @@ void main() {
         }
         fileFilter.addAll(fs.directory(pkgUri)
             .listSync(recursive: true)
-            .where((FileSystemEntity file) => file is File)
-            .map((FileSystemEntity file) => canonicalizePath(file.path))
+            .whereType<File>()
+            .map<String>((File file) => canonicalizePath(file.path))
             .toList());
       }
       final int bytes = await devFS.update(fileFilter: fileFilter);


### PR DESCRIPTION
I looked at every link to GitHub in our repo. For cases where we had a TODO that was waiting for a bug to be fixed, and the bug has now been fixed, I applied the pending change. For cases where the link was out of date, I updated the link.

There are some tests that were skipped at both the `expect` level and the `test` level, I removed the inner redundant skip. There were also some lints that could be enabled; one of them found some unused constructor arguments which I removed.