### PR TITLE
remove unused argument

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3243,7 +3243,6 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     bool hidden,
     bool image,
     bool liveRegion,
-    bool isSwitch,
     String label,
     String value,
     String increasedValue,


### PR DESCRIPTION
This is entirely covered by the `toggled` parameter, and was accidentally left in during a PR.