### PR TITLE
Scale high-pixel-ratio images with BoxFit.none/BoxFit.scaleDown correctly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Noah Groß <gross@ngsger.de>
 Victor Choueiri <victor@ctrlanddev.com>
 Christian Mürtz <teraarts@t-online.de>
 Lukasz Piliszczuk <lukasz@intheloup.io>
+Felix Schmidt <felix.free@gmx.de>

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -254,6 +254,7 @@ class DecorationImagePainter {
       canvas: canvas,
       rect: rect,
       image: _image.image,
+      scale: _image.scale,
       colorFilter: _details.colorFilter,
       fit: _details.fit,
       alignment: _details.alignment.resolve(configuration.textDirection),
@@ -303,6 +304,8 @@ class DecorationImagePainter {
 ///
 ///  * `image`: The image to paint onto the canvas.
 ///
+///  * `scale`: The number of image pixels for each logical pixel.
+///
 ///  * `colorFilter`: If non-null, the color filter to apply when painting the
 ///    image.
 ///
@@ -339,7 +342,7 @@ class DecorationImagePainter {
 ///    when using this, to not flip images with integral shadows, text, or other
 ///    effects that will look incorrect when flipped.
 ///
-/// The `canvas`, `rect`, `image`, `alignment`, `repeat`, and `flipHorizontally`
+/// The `canvas`, `rect`, `image`, `scale`, `alignment`, `repeat`, and `flipHorizontally`
 /// arguments must not be null.
 ///
 /// See also:
@@ -351,6 +354,7 @@ void paintImage({
   @required Canvas canvas,
   @required Rect rect,
   @required ui.Image image,
+  double scale = 1.0,
   ColorFilter colorFilter,
   BoxFit fit,
   Alignment alignment = Alignment.center,
@@ -378,8 +382,8 @@ void paintImage({
   }
   fit ??= centerSlice == null ? BoxFit.scaleDown : BoxFit.fill;
   assert(centerSlice == null || (fit != BoxFit.none && fit != BoxFit.cover));
-  final FittedSizes fittedSizes = applyBoxFit(fit, inputSize, outputSize);
-  final Size sourceSize = fittedSizes.source;
+  final FittedSizes fittedSizes = applyBoxFit(fit, inputSize / scale, outputSize);
+  final Size sourceSize = fittedSizes.source * scale;
   Size destinationSize = fittedSizes.destination;
   if (centerSlice != null) {
     outputSize += sliceBorder;
@@ -421,7 +425,7 @@ void paintImage({
   }
   if (centerSlice == null) {
     final Rect sourceRect = alignment.inscribe(
-      fittedSizes.source, Offset.zero & inputSize
+      sourceSize, Offset.zero & inputSize
     );
     for (Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
       canvas.drawImageRect(image, sourceRect, tileRect, paint);

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -324,6 +324,7 @@ class RenderImage extends RenderBox {
       canvas: context.canvas,
       rect: offset & size,
       image: _image,
+      scale: _scale,
       colorFilter: _colorFilter,
       fit: _fit,
       alignment: _resolvedAlignment,

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -352,8 +352,8 @@ void main() {
     for (double scale = 1.0; scale <= 4.0; scale += 1.0) {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
-      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final image = TestImage();
+      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = TestImage();
 
       paintImage(
         canvas: canvas,
@@ -366,7 +366,7 @@ void main() {
         flipHorizontally: false,
       );
 
-      final imageSize = Size(100.0, 100.0);
+      const Size imageSize = Size(100.0, 100.0);
 
       final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
 
@@ -380,8 +380,8 @@ void main() {
 
       // Image should be scaled down (divided by scale)
       // and be positioned in the bottom right of the outputRect
-      final expectedTileSize = imageSize / scale;
-      final expectedTileRect = Rect.fromPoints(
+      final Size expectedTileSize = imageSize / scale;
+      final Rect expectedTileRect = Rect.fromPoints(
         outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
         outputRect.bottomRight,
       );
@@ -396,8 +396,8 @@ void main() {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
       // container size > scaled image size
-      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final image = TestImage();
+      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = TestImage();
 
       paintImage(
         canvas: canvas,
@@ -410,7 +410,7 @@ void main() {
         flipHorizontally: false,
       );
 
-      final imageSize = Size(100.0, 100.0);
+      const Size imageSize = Size(100.0, 100.0);
 
       final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
 
@@ -424,8 +424,8 @@ void main() {
 
       // Image should be scaled down (divided by scale)
       // and be positioned in the bottom right of the outputRect
-      final expectedTileSize = imageSize / scale;
-      final expectedTileRect = Rect.fromPoints(
+      final Size expectedTileSize = imageSize / scale;
+      final Rect expectedTileRect = Rect.fromPoints(
         outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
         outputRect.bottomRight,
       );
@@ -439,8 +439,8 @@ void main() {
     final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
     // container height (20 px) < scaled image height (50 px)
-    final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 20.0);
-    final image = TestImage();
+    final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 20.0);
+    final ui.Image image = TestImage();
 
     paintImage(
       canvas: canvas,
@@ -453,7 +453,7 @@ void main() {
       flipHorizontally: false,
     );
 
-    final imageSize = Size(100.0, 100.0);
+    const Size imageSize = Size(100.0, 100.0);
 
     final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
 
@@ -467,8 +467,8 @@ void main() {
 
     // Image should be scaled down to fit in hejght
     // and be positioned in the bottom right of the outputRect
-    final expectedTileSize = Size(20.0, 20.0);
-    final expectedTileRect = Rect.fromPoints(
+    const Size expectedTileSize = Size(20.0, 20.0);
+    final Rect expectedTileRect = Rect.fromPoints(
       outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
       outputRect.bottomRight,
     );
@@ -478,13 +478,21 @@ void main() {
   });
 
   test('paintImage boxFit, scale and alignment test', () {
-    final boxFits = [BoxFit.contain, BoxFit.cover, BoxFit.fitWidth, BoxFit.fitWidth, BoxFit.fitHeight, BoxFit.none, BoxFit.scaleDown,];
+    final List<BoxFit> boxFits = <BoxFit>[
+      BoxFit.contain,
+      BoxFit.cover,
+      BoxFit.fitWidth,
+      BoxFit.fitWidth,
+      BoxFit.fitHeight,
+      BoxFit.none,
+      BoxFit.scaleDown,
+    ];
 
     for(BoxFit boxFit in boxFits) {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
-      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final image = TestImage();
+      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = TestImage();
 
       paintImage(
         canvas: canvas,

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -352,8 +352,8 @@ void main() {
     for (double scale = 1.0; scale <= 4.0; scale += 1.0) {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
-      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final ui.Image image = TestImage();
+      final Rect outputRect = new Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = new TestImage();
 
       paintImage(
         canvas: canvas,
@@ -381,7 +381,7 @@ void main() {
       // Image should be scaled down (divided by scale)
       // and be positioned in the bottom right of the outputRect
       final Size expectedTileSize = imageSize / scale;
-      final Rect expectedTileRect = Rect.fromPoints(
+      final Rect expectedTileRect = new Rect.fromPoints(
         outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
         outputRect.bottomRight,
       );
@@ -396,8 +396,8 @@ void main() {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
       // container size > scaled image size
-      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final ui.Image image = TestImage();
+      final Rect outputRect = new Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = new TestImage();
 
       paintImage(
         canvas: canvas,
@@ -425,7 +425,7 @@ void main() {
       // Image should be scaled down (divided by scale)
       // and be positioned in the bottom right of the outputRect
       final Size expectedTileSize = imageSize / scale;
-      final Rect expectedTileRect = Rect.fromPoints(
+      final Rect expectedTileRect = new Rect.fromPoints(
         outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
         outputRect.bottomRight,
       );
@@ -439,8 +439,8 @@ void main() {
     final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
     // container height (20 px) < scaled image height (50 px)
-    final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 20.0);
-    final ui.Image image = TestImage();
+    final Rect outputRect = new Rect.fromLTWH(30.0, 30.0, 250.0, 20.0);
+    final ui.Image image = new TestImage();
 
     paintImage(
       canvas: canvas,
@@ -468,7 +468,7 @@ void main() {
     // Image should be scaled down to fit in hejght
     // and be positioned in the bottom right of the outputRect
     const Size expectedTileSize = Size(20.0, 20.0);
-    final Rect expectedTileRect = Rect.fromPoints(
+    final Rect expectedTileRect = new Rect.fromPoints(
       outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
       outputRect.bottomRight,
     );
@@ -478,7 +478,7 @@ void main() {
   });
 
   test('paintImage boxFit, scale and alignment test', () {
-    final List<BoxFit> boxFits = <BoxFit>[
+    const List<BoxFit> boxFits = <BoxFit>[
       BoxFit.contain,
       BoxFit.cover,
       BoxFit.fitWidth,
@@ -491,8 +491,8 @@ void main() {
     for(BoxFit boxFit in boxFits) {
       final TestCanvas canvas = new TestCanvas(<Invocation>[]);
 
-      final Rect outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
-      final ui.Image image = TestImage();
+      final Rect outputRect = new Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final ui.Image image = new TestImage();
 
       paintImage(
         canvas: canvas,

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -347,4 +347,163 @@ void main() {
     expect(Decoration.lerp(const FlutterLogoDecoration(), const BoxDecoration(), 0.75), isInstanceOf<BoxDecoration>()); // ignore: CONST_EVAL_THROWS_EXCEPTION
     expect(Decoration.lerp(const FlutterLogoDecoration(), const BoxDecoration(), 1.0), isInstanceOf<BoxDecoration>()); // ignore: CONST_EVAL_THROWS_EXCEPTION
   });
+
+  test('paintImage BoxFit.none scale test', () {
+    for (double scale = 1.0; scale <= 4.0; scale += 1.0) {
+      final TestCanvas canvas = new TestCanvas(<Invocation>[]);
+
+      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final image = TestImage();
+
+      paintImage(
+        canvas: canvas,
+        rect: outputRect,
+        image: image,
+        scale: scale,
+        alignment: Alignment.bottomRight,
+        fit: BoxFit.none,
+        repeat: ImageRepeat.noRepeat,
+        flipHorizontally: false,
+      );
+
+      final imageSize = Size(100.0, 100.0);
+
+      final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
+
+      expect(call.isMethod, isTrue);
+      expect(call.positionalArguments, hasLength(4));
+
+      expect(call.positionalArguments[0], isInstanceOf<TestImage>());
+
+      // sourceRect should contain all pixels of the source image
+      expect(call.positionalArguments[1], Offset.zero & imageSize);
+
+      // Image should be scaled down (divided by scale)
+      // and be positioned in the bottom right of the outputRect
+      final expectedTileSize = imageSize / scale;
+      final expectedTileRect = Rect.fromPoints(
+        outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
+        outputRect.bottomRight,
+      );
+      expect(call.positionalArguments[2], expectedTileRect);
+
+      expect(call.positionalArguments[3], isInstanceOf<Paint>());
+    }
+  });
+
+  test('paintImage BoxFit.scaleDown scale test', () {
+    for (double scale = 1.0; scale <= 4.0; scale += 1.0) {
+      final TestCanvas canvas = new TestCanvas(<Invocation>[]);
+
+      // container size > scaled image size
+      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final image = TestImage();
+
+      paintImage(
+        canvas: canvas,
+        rect: outputRect,
+        image: image,
+        scale: scale,
+        alignment: Alignment.bottomRight,
+        fit: BoxFit.scaleDown,
+        repeat: ImageRepeat.noRepeat,
+        flipHorizontally: false,
+      );
+
+      final imageSize = Size(100.0, 100.0);
+
+      final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
+
+      expect(call.isMethod, isTrue);
+      expect(call.positionalArguments, hasLength(4));
+
+      expect(call.positionalArguments[0], isInstanceOf<TestImage>());
+
+      // sourceRect should contain all pixels of the source image
+      expect(call.positionalArguments[1], Offset.zero & imageSize);
+
+      // Image should be scaled down (divided by scale)
+      // and be positioned in the bottom right of the outputRect
+      final expectedTileSize = imageSize / scale;
+      final expectedTileRect = Rect.fromPoints(
+        outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
+        outputRect.bottomRight,
+      );
+      expect(call.positionalArguments[2], expectedTileRect);
+
+      expect(call.positionalArguments[3], isInstanceOf<Paint>());
+    }
+  });
+
+  test('paintImage BoxFit.scaleDown test', () {
+    final TestCanvas canvas = new TestCanvas(<Invocation>[]);
+
+    // container height (20 px) < scaled image height (50 px)
+    final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 20.0);
+    final image = TestImage();
+
+    paintImage(
+      canvas: canvas,
+      rect: outputRect,
+      image: image,
+      scale: 2.0,
+      alignment: Alignment.bottomRight,
+      fit: BoxFit.scaleDown,
+      repeat: ImageRepeat.noRepeat,
+      flipHorizontally: false,
+    );
+
+    final imageSize = Size(100.0, 100.0);
+
+    final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
+
+    expect(call.isMethod, isTrue);
+    expect(call.positionalArguments, hasLength(4));
+
+    expect(call.positionalArguments[0], isInstanceOf<TestImage>());
+
+    // sourceRect should contain all pixels of the source image
+    expect(call.positionalArguments[1], Offset.zero & imageSize);
+
+    // Image should be scaled down to fit in hejght
+    // and be positioned in the bottom right of the outputRect
+    final expectedTileSize = Size(20.0, 20.0);
+    final expectedTileRect = Rect.fromPoints(
+      outputRect.bottomRight.translate(-expectedTileSize.width, -expectedTileSize.height),
+      outputRect.bottomRight,
+    );
+    expect(call.positionalArguments[2], expectedTileRect);
+
+    expect(call.positionalArguments[3], isInstanceOf<Paint>());
+  });
+
+  test('paintImage boxFit, scale and alignment test', () {
+    final boxFits = [BoxFit.contain, BoxFit.cover, BoxFit.fitWidth, BoxFit.fitWidth, BoxFit.fitHeight, BoxFit.none, BoxFit.scaleDown,];
+
+    for(BoxFit boxFit in boxFits) {
+      final TestCanvas canvas = new TestCanvas(<Invocation>[]);
+
+      final outputRect = Rect.fromLTWH(30.0, 30.0, 250.0, 250.0);
+      final image = TestImage();
+
+      paintImage(
+        canvas: canvas,
+        rect: outputRect,
+        image: image,
+        scale: 3.0,
+        alignment: Alignment.center,
+        fit: boxFit,
+        repeat: ImageRepeat.noRepeat,
+        flipHorizontally: false,
+      );
+
+      final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
+
+      expect(call.isMethod, isTrue);
+      expect(call.positionalArguments, hasLength(4));
+
+      // Image should be positioned in the center of the container
+      expect(call.positionalArguments[2].center, outputRect.center);
+    }
+  });
 }

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
 class TestImageInfo implements ImageInfo {
-  const TestImageInfo(this.value, { this.image, this.scale });
+  const TestImageInfo(this.value, { this.image, this.scale = 1.0 });
 
   @override
   final ui.Image image;


### PR DESCRIPTION
Fixes  #18682.

`paintImage` is used to paint `BoxDecoration` background images and `Image` widgets. This PR adds a new `scale` parameter so that the method can take into account the image scale (how many image pixels equal one logical pixel) so that 2.0x/3.0x variants are rendered correctly.
