### PR TITLE
Provide better error messages in integration tests when apps don't launch successfully

### DIFF
--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -76,13 +76,15 @@ class FlutterTestDriver {
 
   Future<void> _setupProcess(List<String> args, {bool withDebugger = false, bool pauseOnExceptions = false}) async {
     final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
-    _debugPrint('Spawning flutter $args in ${_projectFolder.path}');
+    final List<String> flutterArgs = withDebugger
+        ? args.followedBy(<String>['--start-paused']).toList()
+        : args;
+    _debugPrint('Spawning flutter $flutterArgs in ${_projectFolder.path}');
 
     const ProcessManager _processManager = LocalProcessManager();
     _proc = await _processManager.start(
         <String>[flutterBin]
-            .followedBy(args)
-            .followedBy(withDebugger ? <String>['--start-paused'] : <String>[])
+            .followedBy(flutterArgs)
             .toList(),
         workingDirectory: _projectFolder.path,
         environment: <String, String>{'FLUTTER_TEST': 'true'});

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -265,8 +265,12 @@ class FlutterTestDriver {
     return script.sourceLocation(frame.location.token);
   }
 
-  Future<Map<String, dynamic>> _waitFor({String event, int id, Duration timeout,
-      bool ignoreAppStopEvent = false}) async {
+  Future<Map<String, dynamic>> _waitFor({
+    String event,
+    int id,
+    Duration timeout,
+    bool ignoreAppStopEvent = false,
+  }) async {
     final Completer<Map<String, dynamic>> response = new Completer<Map<String, dynamic>>();
     StreamSubscription<String> sub;
     sub = _stdout.stream.listen((String line) async {
@@ -346,8 +350,10 @@ class FlutterTestDriver {
     // Set up the response future before we send the request to avoid any
     // races. If the method we're calling is app.stop then we tell waitFor not
     // to throw if it sees an app.stop event before the response to this request.
-    final Future<Map<String, dynamic>> responseFuture = _waitFor(id: requestId,
-        ignoreAppStopEvent: method == 'app.stop');
+    final Future<Map<String, dynamic>> responseFuture = _waitFor(
+      id: requestId,
+      ignoreAppStopEvent: method == 'app.stop',
+    );
     _proc.stdin.writeln(jsonEncoded);
     final Map<String, dynamic> response = await responseFuture;
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -265,13 +265,15 @@ class FlutterTestDriver {
 
   Future<Map<String, dynamic>> _waitFor({String event, int id, Duration timeout}) async {
     final Completer<Map<String, dynamic>> response = new Completer<Map<String, dynamic>>();
-    final StreamSubscription<String> sub = _stdout.stream.listen((String line) {
+    StreamSubscription<String> sub;
+    sub = _stdout.stream.listen((String line) async {
       final dynamic json = _parseFlutterResponse(line);
       if (json == null) {
         return;
       } else if (
           (event != null && json['event'] == event)
           || (id != null && json['id'] == id)) {
+        await sub.cancel();
         response.complete(json);
       }
     });

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -275,6 +275,18 @@ class FlutterTestDriver {
           || (id != null && json['id'] == id)) {
         await sub.cancel();
         response.complete(json);
+      } else if (json['event'] == 'app.stop') {
+        await sub.cancel();
+        final StringBuffer error = new StringBuffer();
+        error.write('Received app.stop event while waiting for ');
+        error.write('${event != null ? '$event event' : 'response to request $id.'}.\n\n');
+        if (json['params'] != null && json['params']['error'] != null) {
+          error.write('${json['params']['error']}\n\n');
+        }
+        if (json['params'] != null && json['params']['trace'] != null) {
+          error.write('${json['params']['trace']}\n\n');
+        }
+        response.completeError(error.toString());
       }
     });
 


### PR DESCRIPTION
This changes the `_waitFor` method that is called when waiting for an event (or response to a request) to complete with an error if an `app.stop` event comes through while it's waiting. There's an exclusion for when sending an `app.stop` command, since the event come through before the response to that request.

This should make it clearer what the failure is in cases like https://github.com/flutter/flutter/issues/19542#issuecomment-412327994 (which currently are reported as "timed out waiting for app.started" or "timed out waiting for app.debugPort").