### PR TITLE
Start logger in startProgress to avoid assertion failure

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -296,7 +296,7 @@ Future<Null> _runToolTests() async {
 
   await _pubRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
-    enableAsserts: true,
+    enableFlutterToolAsserts: true,
   );
 
   print('${bold}DONE: All tests successful.$reset');
@@ -349,7 +349,7 @@ Future<Null> _runCoverage() async {
 Future<Null> _pubRunTest(
   String workingDirectory, {
   String testPath,
-  bool enableAsserts = false
+  bool enableFlutterToolAsserts = false
 }) {
   final List<String> args = <String>['run', 'test', '-j1', '-rcompact'];
   if (!hasColor)
@@ -360,7 +360,7 @@ Future<Null> _pubRunTest(
   if (new Directory(pubCache).existsSync()) {
     pubEnvironment['PUB_CACHE'] = pubCache;
   }
-  if (enableAsserts) {
+  if (enableFlutterToolAsserts) {
     // If an existing env variable exists append to it, but only if
     // it doesn't appear to already include enable-asserts.
     String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -294,7 +294,10 @@ Future<Null> _runSmokeTests() async {
 Future<Null> _runToolTests() async {
   await _runSmokeTests();
 
-  await _pubRunTest(path.join(flutterRoot, 'packages', 'flutter_tools'));
+  await _pubRunTest(
+    path.join(flutterRoot, 'packages', 'flutter_tools'),
+    enableAsserts: true,
+  );
 
   print('${bold}DONE: All tests successful.$reset');
 }
@@ -346,6 +349,7 @@ Future<Null> _runCoverage() async {
 Future<Null> _pubRunTest(
   String workingDirectory, {
   String testPath,
+  bool enableAsserts = false
 }) {
   final List<String> args = <String>['run', 'test', '-j1', '-rcompact'];
   if (!hasColor)
@@ -355,6 +359,14 @@ Future<Null> _pubRunTest(
   final Map<String, String> pubEnvironment = <String, String>{};
   if (new Directory(pubCache).existsSync()) {
     pubEnvironment['PUB_CACHE'] = pubCache;
+  }
+  if (enableAsserts) {
+    // If an existing env variable exists append to it, but only if
+    // it doesn't appear to already include enable-asserts.
+    var toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
+    if (!toolsArgs.contains('--enable-asserts'))
+        toolsArgs += ' --enable-asserts';
+    pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
   }
   return _runCommand(
     pub, args,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -363,7 +363,7 @@ Future<Null> _pubRunTest(
   if (enableAsserts) {
     // If an existing env variable exists append to it, but only if
     // it doesn't appear to already include enable-asserts.
-    var toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
+    String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
     if (!toolsArgs.contains('--enable-asserts'))
         toolsArgs += ' --enable-asserts';
     pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -908,7 +908,7 @@ class _AppRunLogger extends Logger {
         'progressId': progressId,
         'finished': true
       });
-    });
+    })..start();
     return _status;
   }
 


### PR DESCRIPTION
There are lots of places that create a `Status()` and all but two of them call `..start()` immediately. This is one of the places that doesn't which causes an assertion failure when running with `--enable-asserts` and the other is in the same file (I suspect it's also incorrect, but haven't managed to trigger it yet so I don't want to blindly change it).

Fixes #20812.