### PR TITLE
 Track number of package dependencies in Flutter

### DIFF
--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -43,24 +43,51 @@ Future<double> findCostsForFile(File file) async {
   return total;
 }
 
-const String _kBenchmarkKey = 'technical_debt_in_dollars';
+Future<double> findCostsForRepo() async {
+  final Process git = await startProcess(
+    'git',
+    <String>['ls-files', '--full-name', flutterDirectory.path],
+    workingDirectory: flutterDirectory.path,
+  );
+  double total = 0.0;
+  await for (String entry in git.stdout.transform(utf8.decoder).transform(const LineSplitter()))
+    total += await findCostsForFile(new File(path.join(flutterDirectory.path, entry)));
+  final int gitExitCode = await git.exitCode;
+  if (gitExitCode != 0)
+    throw new Exception('git exit with unexpected error code $gitExitCode');
+  return total;
+}
+
+Future<int> countDependencies() async {
+  final Process subprocess = await startProcess(
+    'flutter',
+    <String>['update-packages', '--transitive-closure'],
+    workingDirectory: flutterDirectory.path,
+  );
+  final List<String> lines = await subprocess.stdout.transform(utf8.decoder).transform(const LineSplitter()).toList();
+  final int subprocessExitCode = await subprocess.exitCode;
+  if (subprocessExitCode != 0)
+    throw new Exception('flutter exit with unexpected error code $subprocessExitCode');
+  final int count = lines.where((String line) => line.contains('->')).length;
+  if (count < 2) // we'll always have flutter and flutter_test, at least...
+    throw new Exception('"flutter update-packages --transitive-closure" returned bogus output:\n${lines.join("\n")}');
+  return count;
+}
+
+const String _kCostBenchmarkKey = 'technical_debt_in_dollars';
+const String _kNumberOfDependenciesKey = 'dependencies_count';
 
 Future<Null> main() async {
   await task(() async {
-    final Process git = await startProcess(
-      'git',
-      <String>['ls-files', '--full-name', flutterDirectory.path],
-      workingDirectory: flutterDirectory.path,
-    );
-    double total = 0.0;
-    await for (String entry in git.stdout.transform(utf8.decoder).transform(const LineSplitter()))
-      total += await findCostsForFile(new File(path.join(flutterDirectory.path, entry)));
-    final int gitExitCode = await git.exitCode;
-    if (gitExitCode != 0)
-      throw new Exception('git exit with unexpected error code $gitExitCode');
     return new TaskResult.success(
-      <String, dynamic>{_kBenchmarkKey: total},
-      benchmarkScoreKeys: <String>[_kBenchmarkKey],
+      <String, dynamic>{
+        _kCostBenchmarkKey: await findCostsForRepo(),
+        _kNumberOfDependenciesKey: await countDependencies(),
+      },
+      benchmarkScoreKeys: <String>[
+        _kCostBenchmarkKey,
+        _kNumberOfDependenciesKey,
+      ],
     );
   });
 }

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -59,15 +59,10 @@ Future<double> findCostsForRepo() async {
 }
 
 Future<int> countDependencies() async {
-  final Process subprocess = await startProcess(
-    'flutter',
-    <String>['update-packages', '--transitive-closure'],
-    workingDirectory: flutterDirectory.path,
-  );
-  final List<String> lines = await subprocess.stdout.transform(utf8.decoder).transform(const LineSplitter()).toList();
-  final int subprocessExitCode = await subprocess.exitCode;
-  if (subprocessExitCode != 0)
-    throw new Exception('flutter exit with unexpected error code $subprocessExitCode');
+  final List<String> lines = (await evalFlutter(
+    'update-packages',
+    options: <String>['--transitive-closure'],
+  )).split('\n');
   final int count = lines.where((String line) => line.contains('->')).length;
   if (count < 2) // we'll always have flutter and flutter_test, at least...
     throw new Exception('"flutter update-packages --transitive-closure" returned bogus output:\n${lines.join("\n")}');

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -265,7 +265,7 @@ Future<int> exec(
   String executable,
   List<String> arguments, {
   Map<String, String> environment,
-  bool canFail = false,
+  bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
 }) async {
   final Process process = await startProcess(executable, arguments, environment: environment);
 
@@ -300,7 +300,7 @@ Future<String> eval(
   String executable,
   List<String> arguments, {
   Map<String, String> environment,
-  bool canFail = false,
+  bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
 }) async {
   final Process process = await startProcess(executable, arguments, environment: environment);
 
@@ -332,7 +332,7 @@ Future<String> eval(
 
 Future<int> flutter(String command, {
   List<String> options = const <String>[],
-  bool canFail = false,
+  bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String> environment,
 }) {
   final List<String> args = <String>[command]..addAll(options);
@@ -343,7 +343,7 @@ Future<int> flutter(String command, {
 /// Runs a `flutter` command and returns the standard output as a string.
 Future<String> evalFlutter(String command, {
   List<String> options = const <String>[],
-  bool canFail = false,
+  bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String> environment,
 }) {
   final List<String> args = <String>[command]..addAll(options);


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/20722, with the following change: "Use evalFlutter instead of startProcess. That way we don't need `flutter` on the PATH."