### PR TITLE
Clip the flutter_gallery front layer

### DIFF
--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -304,6 +304,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
                   borderRadius: _kFrontHeadingBevelRadius.lerp(_controller.value),
                 ),
               ),
+              clipBehavior: Clip.antiAlias,
               child: child,
             );
           },


### PR DESCRIPTION
This will be needed once PhysicalShape sets the default clipBehavior to Clip.none.