### PR TITLE
Double all timeouts on flutter_tools integration tests

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -110,5 +110,5 @@ void main() {
     // https://github.com/flutter/flutter/issues/17833
     // The test appears to be flaky and time out some times, skipping while
     // investigation is ongoing: https://github.com/flutter/flutter/issues/19542
-  }, timeout: const Timeout.factor(3), skip: true);
+  }, timeout: const Timeout.factor(6), skip: true);
 }

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -36,5 +36,5 @@ void main() {
       await _flutterAttach.hotReload();
     });
     // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
-  }, timeout: const Timeout.factor(3), skip: platform.isWindows);
+  }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -45,5 +45,5 @@ void main() {
       expect(isolate.pauseEvent, isInstanceOf<VMPauseBreakpointEvent>());
       // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/18441.
     }, skip: !platform.isLinux);
-  }, timeout: const Timeout.factor(3));
+  }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -46,5 +46,5 @@ void main() {
       expect(_flutter.hasExited, equals(false));
     });
     // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
-  }, timeout: const Timeout.factor(3), skip: platform.isWindows);
+  }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -18,9 +18,9 @@ import '../src/common.dart';
 
 // Set this to true for debugging to get JSON written to stdout.
 const bool _printJsonAndStderr = false;
-const Duration defaultTimeout = Duration(seconds: 20);
-const Duration appStartTimeout = Duration(seconds: 60);
-const Duration quitTimeout = Duration(seconds: 5);
+const Duration defaultTimeout = Duration(seconds: 40);
+const Duration appStartTimeout = Duration(seconds: 120);
+const Duration quitTimeout = Duration(seconds: 10);
 
 class FlutterTestDriver {
   FlutterTestDriver(this._projectFolder);


### PR DESCRIPTION
Due to CPU contention we've seen these go pretty slow on Cirrus (see https://github.com/flutter/flutter/issues/19542#issuecomment-414265152) and there's also a chance our flakes are timeouts due to running slow rather than hanging.