### PR TITLE
Fix small TabBar inconsistencies

### DIFF
--- a/packages/flutter/lib/src/material/constants.dart
+++ b/packages/flutter/lib/src/material/constants.dart
@@ -29,7 +29,7 @@ const int kRadialReactionAlpha = 0x1F;
 const Duration kTabScrollDuration = Duration(milliseconds: 300);
 
 /// The horizontal padding included by [Tab]s.
-const EdgeInsets kTabLabelPadding = EdgeInsets.symmetric(horizontal: 12.0);
+const EdgeInsets kTabLabelPadding = EdgeInsets.symmetric(horizontal: 16.0);
 
 /// The padding added around material list items.
 const EdgeInsets kMaterialListPadding = EdgeInsets.symmetric(vertical: 8.0);

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -90,7 +90,7 @@ class _UnderlinePainter extends BoxPainter {
     final Rect rect = offset & configuration.size;
     final TextDirection textDirection = configuration.textDirection;
     final Rect indicator = _indicatorRectFor(rect, textDirection).deflate(borderSide.width / 2.0);
-    final Paint paint = borderSide.toPaint()..strokeCap=StrokeCap.square;
+    final Paint paint = borderSide.toPaint()..strokeCap = StrokeCap.square;
     canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, paint);
   }
 }

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -90,6 +90,7 @@ class _UnderlinePainter extends BoxPainter {
     final Rect rect = offset & configuration.size;
     final TextDirection textDirection = configuration.textDirection;
     final Rect indicator = _indicatorRectFor(rect, textDirection).deflate(borderSide.width / 2.0);
-    canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, borderSide.toPaint());
+    final Paint paint = borderSide.toPaint()..strokeCap=StrokeCap.square;
+    canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, paint);
   }
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1277,8 +1277,8 @@ void main() {
   testWidgets('Overflowing RTL tab bar', (WidgetTester tester) async {
     final List<Widget> tabs = new List<Widget>.filled(100,
       // For convenience padded width of each tab will equal 100:
-      // 76 + kTabLabelPadding.horizontal(24)
-      new SizedBox(key: new UniqueKey(), width: 76.0, height: 40.0),
+      // 68 + kTabLabelPadding.horizontal(32)
+      new SizedBox(key: new UniqueKey(), width: 68.0, height: 40.0),
     );
 
     final TabController controller = new TabController(
@@ -1384,15 +1384,15 @@ void main() {
                         actions: SemanticsAction.tap.index,
                         flags: SemanticsFlag.isSelected.index,
                         label: 'TAB #0\nTab 1 of 2',
-                        rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
+                        rect: new Rect.fromLTRB(0.0, 0.0, 116.0, kTextTabBarHeight),
                         transform: new Matrix4.translationValues(0.0, 276.0, 0.0),
                       ),
                       new TestSemantics(
                         id: 5,
                         actions: SemanticsAction.tap.index,
                         label: 'TAB #1\nTab 2 of 2',
-                        rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
-                        transform: new Matrix4.translationValues(108.0, 276.0, 0.0),
+                        rect: new Rect.fromLTRB(0.0, 0.0, 116.0, kTextTabBarHeight),
+                        transform: new Matrix4.translationValues(116.0, 276.0, 0.0),
                       ),
                     ]
                 )
@@ -1647,15 +1647,15 @@ void main() {
                         actions: SemanticsAction.tap.index,
                         flags: SemanticsFlag.isSelected.index,
                         label: 'Semantics override 0\nTab 1 of 2',
-                        rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
+                        rect: new Rect.fromLTRB(0.0, 0.0, 116.0, kTextTabBarHeight),
                         transform: new Matrix4.translationValues(0.0, 276.0, 0.0),
                       ),
                       new TestSemantics(
                         id: 5,
                         actions: SemanticsAction.tap.index,
                         label: 'Semantics override 1\nTab 2 of 2',
-                        rect: new Rect.fromLTRB(0.0, 0.0, 108.0, kTextTabBarHeight),
-                        transform: new Matrix4.translationValues(108.0, 276.0, 0.0),
+                        rect: new Rect.fromLTRB(0.0, 0.0, 116.0, kTextTabBarHeight),
+                        transform: new Matrix4.translationValues(116.0, 276.0, 0.0),
                       ),
                     ]
                 )


### PR DESCRIPTION
Fixes #20886 

For reference, [here](https://material.io/design/components/tabs.html?image=https%3A%2F%2Fstorage.googleapis.com%2Fspec-host-backup%2Fmio-design%252Fassets%252F16CdW8EmEfI6c803pdGoHJNiqXWg5Aqlw%252Ftabs-spec-cell-minwidth.png#spec) are the material specs for tabs (with the 16 unit padding).

This is how my example app looks like with the fixes (dark border is intentional):

before|after
---------------|------------------
<img src="https://user-images.githubusercontent.com/22688477/44452570-23be9d80-a5f7-11e8-8552-1661f1a7e154.png" width="200"> | <img src="https://user-images.githubusercontent.com/22688477/44432126-09f26b80-a5a1-11e8-9cae-ddf64632db7c.png" width="200">