### PR TITLE
Don't try to stop the same app twice in flutter_attach test

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -24,8 +24,11 @@ void main() {
   });
 
   tearDown(() async {
+    // We can't call stop() on both of these because they'll both try to stop the
+    // same app. Just quit the attach process and then send a stop to the original
+    // process.
+    await _flutterAttach.quit();
     await _flutterRun.stop();
-    await _flutterAttach.stop();
     tryToDelete(tempDir);
   });
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -179,6 +179,8 @@ class FlutterTestDriver {
     return _proc.exitCode.timeout(quitTimeout, onTimeout: _killGracefully);
   }
 
+  Future<int> quit() => _killGracefully();
+
   Future<int> _killGracefully() async {
     if (_procPid == null)
       return -1;


### PR DESCRIPTION
This test is sometimes flaky (#20822) because the two processes try to stop the same app. This changes to gracefully terminate the attach process without explicitly stopping the app and then uses the original spawning process to stop the app.

I can't repro the flake locally to be certain, but I've verified only one stop command is being sent now.

Fixes #20822 (hopefully).