### PR TITLE
Implement resizeToAvoidBottomPadding in CupertinoPageScaffold

### DIFF
--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -22,6 +22,7 @@ class CupertinoPageScaffold extends StatelessWidget {
     Key key,
     this.navigationBar,
     this.backgroundColor = CupertinoColors.white,
+    this.resizeToAvoidBottomPadding = true,
     @required this.child,
   }) : assert(child != null),
        super(key: key);
@@ -49,6 +50,15 @@ class CupertinoPageScaffold extends StatelessWidget {
   /// By default uses [CupertinoColors.white] color.
   final Color backgroundColor;
 
+  /// Whether the [child] should size itself to avoid the window's bottom padding.
+  ///
+  /// For example, if there is an onscreen keyboard displayed above the
+  /// scaffold, the body can be resized to avoid overlapping the keyboard, which
+  /// prevents widgets inside the body from being obscured by the keyboard.
+  ///
+  /// Defaults to true.
+  final bool resizeToAvoidBottomPadding;
+
   @override
   Widget build(BuildContext context) {
     final List<Widget> stacked = <Widget>[];
@@ -67,7 +77,10 @@ class CupertinoPageScaffold extends StatelessWidget {
       // obstructed area.
       if (navigationBar.fullObstruction) {
         paddedContent = new Padding(
-          padding: new EdgeInsets.only(top: topPadding),
+          padding: new EdgeInsets.only(
+            top: topPadding,
+            bottom: resizeToAvoidBottomPadding ? existingMediaQuery.viewInsets.bottom : 0.0,
+          ),
           child: child,
         );
       } else {
@@ -75,6 +88,7 @@ class CupertinoPageScaffold extends StatelessWidget {
           data: existingMediaQuery.copyWith(
             padding: existingMediaQuery.padding.copyWith(
               top: topPadding,
+              bottom: resizeToAvoidBottomPadding ? existingMediaQuery.viewInsets.bottom : 0.0,
             ),
           ),
           child: child,

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -22,10 +22,10 @@ class CupertinoPageScaffold extends StatelessWidget {
     Key key,
     this.navigationBar,
     this.backgroundColor = CupertinoColors.white,
-    this.resizeToAvoidBottomPadding = true,
+    this.resizeToAvoidBottomInset = true,
     @required this.child,
-  })  : assert(child != null),
-        super(key: key);
+  }) : assert(child != null),
+       super(key: key);
 
   /// The [navigationBar], typically a [CupertinoNavigationBar], is drawn at the
   /// top of the screen.
@@ -50,14 +50,14 @@ class CupertinoPageScaffold extends StatelessWidget {
   /// By default uses [CupertinoColors.white] color.
   final Color backgroundColor;
 
-  /// Whether the [child] should size itself to avoid the window's bottom padding.
+  /// Whether the [child] should size itself to avoid the window's bottom inset.
   ///
   /// For example, if there is an onscreen keyboard displayed above the
   /// scaffold, the body can be resized to avoid overlapping the keyboard, which
   /// prevents widgets inside the body from being obscured by the keyboard.
   ///
   /// Defaults to true.
-  final bool resizeToAvoidBottomPadding;
+  final bool resizeToAvoidBottomInset;
 
   @override
   Widget build(BuildContext context) {
@@ -73,9 +73,9 @@ class CupertinoPageScaffold extends StatelessWidget {
           navigationBar.preferredSize.height + existingMediaQuery.padding.top;
 
       // Propagate bottom padding and include viewInsets if appropriate
-      final double bottomPadding = resizeToAvoidBottomPadding
-              ? existingMediaQuery.viewInsets.bottom
-              : 0.0;
+      final double bottomPadding = resizeToAvoidBottomInset
+          ? existingMediaQuery.viewInsets.bottom
+          : 0.0;
 
       // If navigation bar is opaquely obstructing, directly shift the main content
       // down. If translucent, let main content draw behind navigation bar but hint the
@@ -90,10 +90,12 @@ class CupertinoPageScaffold extends StatelessWidget {
           data: existingMediaQuery.copyWith(
             padding: existingMediaQuery.padding.copyWith(
               top: topPadding,
-              bottom: existingMediaQuery.padding.bottom + bottomPadding,
             ),
           ),
-          child: child,
+          child: Padding(
+            padding: EdgeInsets.only(bottom: bottomPadding),
+            child: child,
+          ),
         );
       }
     }

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -72,10 +72,10 @@ class CupertinoPageScaffold extends StatelessWidget {
       final double topPadding =
           navigationBar.preferredSize.height + existingMediaQuery.padding.top;
 
-      // TODO: refactor with MediaQuery.padding.bottom
+      // Propagate bottom padding and include viewInsets if appropriate
       final double bottomPadding = resizeToAvoidBottomPadding
-          ? existingMediaQuery.viewInsets.bottom
-          : 0.0;
+              ? existingMediaQuery.viewInsets.bottom
+              : 0.0;
 
       // If navigation bar is opaquely obstructing, directly shift the main content
       // down. If translucent, let main content draw behind navigation bar but hint the
@@ -90,7 +90,7 @@ class CupertinoPageScaffold extends StatelessWidget {
           data: existingMediaQuery.copyWith(
             padding: existingMediaQuery.padding.copyWith(
               top: topPadding,
-              bottom: bottomPadding,
+              bottom: existingMediaQuery.padding.bottom + bottomPadding,
             ),
           ),
           child: child,

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -72,17 +72,17 @@ class CupertinoPageScaffold extends StatelessWidget {
       final double topPadding =
           navigationBar.preferredSize.height + existingMediaQuery.padding.top;
 
+      // TODO: refactor with MediaQuery.padding.bottom
+      final double bottomPadding = resizeToAvoidBottomPadding
+          ? existingMediaQuery.viewInsets.bottom
+          : 0.0;
+
       // If navigation bar is opaquely obstructing, directly shift the main content
       // down. If translucent, let main content draw behind navigation bar but hint the
       // obstructed area.
       if (navigationBar.fullObstruction) {
         paddedContent = new Padding(
-          padding: new EdgeInsets.only(
-            top: topPadding,
-            bottom: resizeToAvoidBottomPadding
-                ? existingMediaQuery.viewInsets.bottom
-                : 0.0,
-          ),
+          padding: new EdgeInsets.only(top: topPadding, bottom: bottomPadding),
           child: child,
         );
       } else {
@@ -90,10 +90,7 @@ class CupertinoPageScaffold extends StatelessWidget {
           data: existingMediaQuery.copyWith(
             padding: existingMediaQuery.padding.copyWith(
               top: topPadding,
-              bottom: existingMediaQuery.padding.bottom +
-                  (resizeToAvoidBottomPadding
-                      ? existingMediaQuery.viewInsets.bottom
-                      : 0.0),
+              bottom: bottomPadding,
             ),
           ),
           child: child,

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -25,6 +25,7 @@ class CupertinoPageScaffold extends StatelessWidget {
     this.resizeToAvoidBottomInset = true,
     @required this.child,
   }) : assert(child != null),
+       assert(resizeToAvoidBottomInset != null),
        super(key: key);
 
   /// The [navigationBar], typically a [CupertinoNavigationBar], is drawn at the

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -24,8 +24,8 @@ class CupertinoPageScaffold extends StatelessWidget {
     this.backgroundColor = CupertinoColors.white,
     this.resizeToAvoidBottomPadding = true,
     @required this.child,
-  }) : assert(child != null),
-       super(key: key);
+  })  : assert(child != null),
+        super(key: key);
 
   /// The [navigationBar], typically a [CupertinoNavigationBar], is drawn at the
   /// top of the screen.
@@ -69,8 +69,8 @@ class CupertinoPageScaffold extends StatelessWidget {
 
       // TODO(xster): Use real size after partial layout instead of preferred size.
       // https://github.com/flutter/flutter/issues/12912
-      final double topPadding = navigationBar.preferredSize.height
-          + existingMediaQuery.padding.top;
+      final double topPadding =
+          navigationBar.preferredSize.height + existingMediaQuery.padding.top;
 
       // If navigation bar is opaquely obstructing, directly shift the main content
       // down. If translucent, let main content draw behind navigation bar but hint the
@@ -79,7 +79,9 @@ class CupertinoPageScaffold extends StatelessWidget {
         paddedContent = new Padding(
           padding: new EdgeInsets.only(
             top: topPadding,
-            bottom: resizeToAvoidBottomPadding ? existingMediaQuery.viewInsets.bottom : 0.0,
+            bottom: resizeToAvoidBottomPadding
+                ? existingMediaQuery.viewInsets.bottom
+                : 0.0,
           ),
           child: child,
         );
@@ -88,7 +90,10 @@ class CupertinoPageScaffold extends StatelessWidget {
           data: existingMediaQuery.copyWith(
             padding: existingMediaQuery.padding.copyWith(
               top: topPadding,
-              bottom: resizeToAvoidBottomPadding ? existingMediaQuery.viewInsets.bottom : 0.0,
+              bottom: existingMediaQuery.padding.bottom +
+                  (resizeToAvoidBottomPadding
+                      ? existingMediaQuery.viewInsets.bottom
+                      : 0.0),
             ),
           ),
           child: child,

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -93,8 +93,8 @@ class CupertinoPageScaffold extends StatelessWidget {
               top: topPadding,
             ),
           ),
-          child: Padding(
-            padding: EdgeInsets.only(bottom: bottomPadding),
+          child: new Padding(
+            padding: new EdgeInsets.only(bottom: bottomPadding),
             child: child,
           ),
         );

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -25,6 +25,39 @@ void main() {
     expect(tester.getTopLeft(find.byType(Center)), const Offset(0.0, 0.0));
   });
 
+  testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
+        child: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+          ),
+          child: SafeArea(child: Container()),
+        ),
+      ),
+    ));
+
+    expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0 - 100.0);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
+        child: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+          ),
+          resizeToAvoidBottomPadding: false,
+          child: SafeArea(child: Container()),
+        ),
+      ),
+    ));
+
+    expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0);
+  });
+
   testWidgets('Contents are between opaque bars', (WidgetTester tester) async {
     const Center page1Center = Center();
 

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -32,9 +32,10 @@ void main() {
         data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
         child: CupertinoPageScaffold(
           navigationBar: const CupertinoNavigationBar(
-            middle: Text('Title'),
+            middle: Text('Opaque'),
+            backgroundColor: Color(0xFFF8F8F8),
           ),
-          child: SafeArea(child: Container()),
+          child: Container(),
         ),
       ),
     ));
@@ -47,15 +48,30 @@ void main() {
         data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
         child: CupertinoPageScaffold(
           navigationBar: const CupertinoNavigationBar(
-            middle: Text('Title'),
+            middle: Text('Transparent'),
           ),
-          resizeToAvoidBottomPadding: false,
-          child: SafeArea(child: Container()),
+          child: Container(),
         ),
       ),
     ));
 
-    expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0);
+    expect(tester.getSize(find.byType(Container)).height, 600.0 - 100.0);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
+        child: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+          ),
+          resizeToAvoidBottomInset: false,
+          child: Container(),
+        ),
+      ),
+    ));
+
+    expect(tester.getSize(find.byType(Container)).height, 600.0);
   });
 
   testWidgets('Contents are between opaque bars', (WidgetTester tester) async {


### PR DESCRIPTION
Currently CupertinoPageScaffold doesn't use viewInsets to pad content as Material Scaffold does.

You can see actual master behavior below and fixed version next to it.

master | fix
--- | ---
![broken](https://user-images.githubusercontent.com/3293161/44494381-cb75b300-a66b-11e8-9593-e61525a0f898.gif) | ![fixed](https://user-images.githubusercontent.com/3293161/44494390-d16b9400-a66b-11e8-8cba-cd834ef189ec.gif)

Repository for above PoC app: https://github.com/SPodjasek/flutter_scaffold_poc