### PR TITLE
Re-enable integration tests

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 
 import 'package:vm_service_client/vm_service_client.dart';
 

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -107,8 +107,7 @@ void main() {
       await breakInBuildMethod(_flutter);
       await evaluateComplexReturningExpressions();
     });
-    // https://github.com/flutter/flutter/issues/17833
-    // The test appears to be flaky and time out some times, skipping while
-    // investigation is ongoing: https://github.com/flutter/flutter/issues/19542
-  }, timeout: const Timeout.factor(6), skip: true);
+    // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
+    // https://github.com/flutter/flutter/issues/17833.
+  }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -38,6 +38,7 @@ void main() {
       await _flutterAttach.attach(_flutterRun.vmServicePort);
       await _flutterAttach.hotReload();
     });
-    // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
+    // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
+    // https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -32,7 +32,8 @@ void main() {
     test('works without error', () async {
       await _flutter.run();
       await _flutter.hotReload();
-      // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
+      // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
+      // https://github.com/flutter/flutter/issues/17833.
     }, skip: platform.isWindows);
 
     test('hits breakpoints with file:// prefixes after reload', () async {
@@ -43,7 +44,12 @@ void main() {
           new Uri.file(_project.breakpointFile).toString(),
           _project.breakpointLine);
       expect(isolate.pauseEvent, isInstanceOf<VMPauseBreakpointEvent>());
-      // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/18441.
+      // TODO(dantup): Unskip for Mac when [1] is fixed, unskip on Windows when
+      // both [1] and [2] are fixed.
+      // [1] hot reload/breakpoints fail when uris prefixed with file://
+      //     https://github.com/flutter/flutter/issues/18441
+      // [2] flutter-tester doesn't work on Windows
+      //     https://github.com/flutter/flutter/issues/17833
     }, skip: !platform.isLinux);
   }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -45,6 +45,7 @@ void main() {
       await new Future<void>.delayed(requiredLifespan);
       expect(_flutter.hasExited, equals(false));
     });
-    // TODO(dantup): Unskip after https://github.com/flutter/flutter/issues/17833.
+    // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
+    // https://github.com/flutter/flutter/issues/17833.
   }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }


### PR DESCRIPTION
This re-enables the expression evaluation tests that were disabled for being flaky. There have been many changes since (including engine rolls, increased timeouts and improvements to logging) that may have fixed this or may at least provide better errors if they still flake.

I also added more notes to the remaining skip comments since I'm frequently opening them in GH to remind myself which issues are the reason for skips.