### PR TITLE
Don't size Android views to (0,0)

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -100,7 +100,10 @@ class RenderAndroidView extends RenderBox {
   Size _currentAndroidViewSize;
 
   Future<Null> _sizePlatformView() async {
-    if (_state == _PlatformViewState.resizing) {
+    // Android virtual displays cannot have a zero size.
+    // Trying to size it to 0 crashes the app, which was happening when starting the app
+    // with a locked screen (see: https://github.com/flutter/flutter/issues/20456).
+    if (_state == _PlatformViewState.resizing || size.isEmpty) {
       return;
     }
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -427,7 +427,8 @@ class AndroidViewController {
 
   /// Sizes the Android View.
   ///
-  /// `size` is the view's new size in logical pixel, and must not be null.
+  /// `size` is the view's new size in logical pixel, it must not be null and must
+  /// be bigger than zero.
   ///
   /// The first time a size is set triggers the creation of the Android view.
   Future<void> setSize(Size size) async {
@@ -435,6 +436,7 @@ class AndroidViewController {
       throw new FlutterError('trying to size a disposed Android View. View id: $id');
 
     assert(size != null);
+    assert(!size.isEmpty);
 
     if (_state == _AndroidViewState.waitingForSize)
       return _create(size);

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -37,6 +37,26 @@ void main() {
     );
   });
 
+  testWidgets('Zero sized Android view is not created', (WidgetTester tester) async {
+    final FakePlatformViewsController viewsController = new FakePlatformViewsController(TargetPlatform.android);
+    viewsController.registerViewType('webview');
+
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 0.0,
+          height: 0.0,
+          child: AndroidView(viewType: 'webview', layoutDirection: TextDirection.ltr),
+        ),
+      ),
+    );
+
+    expect(
+      viewsController.views,
+      isEmpty,
+    );
+  });
+
   testWidgets('Resize Android view', (WidgetTester tester) async {
     final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
     final FakePlatformViewsController viewsController = new FakePlatformViewsController(TargetPlatform.android);


### PR DESCRIPTION
Virtual displays must have a non zero size. This was causing a crash:
Fixes: #20456