### PR TITLE
Support colors in terminal, make error output red.

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -75,22 +75,15 @@ Future<int> _handleToolError(
     String getFlutterVersion(),
     ) async {
   if (error is UsageException) {
-    stderr.writeln(error.message);
-    stderr.writeln();
-    stderr.writeln(
-        "Run 'flutter -h' (or 'flutter <command> -h') for available "
-            'flutter commands and options.'
-    );
+    printError('${error.message}\n');
+    printError("Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.");
     // Argument error exit code.
     return _exit(64);
   } else if (error is ToolExit) {
     if (error.message != null)
-      stderr.writeln(error.message);
-    if (verbose) {
-      stderr.writeln();
-      stderr.writeln(stackTrace.toString());
-      stderr.writeln();
-    }
+      printError(error.message);
+    if (verbose)
+      printError('\n$stackTrace\n');
     return _exit(error.exitCode ?? 1);
   } else if (error is ProcessExit) {
     // We've caught an exit code.

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -20,19 +20,50 @@ AnsiTerminal get terminal {
       : context[AnsiTerminal];
 }
 
-class AnsiTerminal {
-  static const String _bold  = '\u001B[1m';
-  static const String _reset = '\u001B[0m';
-  static const String _clear = '\u001B[2J\u001B[H';
+enum TerminalColor {
+  red,
+  green,
+  blue,
+  cyan,
+  yellow,
+  magenta,
+  grey,
+}
 
-  bool supportsColor = platform.stdoutSupportsAnsi;
+class AnsiTerminal {
+  static const String bold = '\u001B[1m';
+  static const String reset = '\u001B[0m';
+  static const String clear = '\u001B[2J\u001B[H';
+
+  static const String red = '\u001b[31m';
+  static const String green = '\u001b[32m';
+  static const String blue = '\u001b[34m';
+  static const String cyan = '\u001b[36m';
+  static const String magenta = '\u001b[35m';
+  static const String yellow = '\u001b[33m';
+  static const String grey = '\u001b[1;30m';
+
+  static const Map<TerminalColor, String> _colorMap = <TerminalColor, String>{
+    TerminalColor.red: red,
+    TerminalColor.green: green,
+    TerminalColor.blue: blue,
+    TerminalColor.cyan: cyan,
+    TerminalColor.magenta: magenta,
+    TerminalColor.yellow: yellow,
+    TerminalColor.grey: grey,
+  };
+
+  static String colorCode(TerminalColor color) => _colorMap[color];
+
+  bool supportsColor = platform.stdoutSupportsAnsi ?? false;
 
   String bolden(String message) {
-    if (!supportsColor)
+    assert(message != null);
+    if (!supportsColor || message.isEmpty)
       return message;
     final StringBuffer buffer = StringBuffer();
     for (String line in message.split('\n'))
-      buffer.writeln('$_bold$line$_reset');
+      buffer.writeln('$bold$line$reset');
     final String result = buffer.toString();
     // avoid introducing a new newline to the emboldened text
     return (!message.endsWith('\n') && result.endsWith('\n'))
@@ -40,7 +71,21 @@ class AnsiTerminal {
         : result;
   }
 
-  String clearScreen() => supportsColor ? _clear : '\n\n';
+  String color(String message, TerminalColor color) {
+    assert(message != null);
+    if (!supportsColor || color == null || message.isEmpty)
+      return message;
+    final StringBuffer buffer = StringBuffer();
+    for (String line in message.split('\n'))
+      buffer.writeln('${_colorMap[color]}$line$reset');
+    final String result = buffer.toString();
+    // avoid introducing a new newline to the colored text
+    return (!message.endsWith('\n') && result.endsWith('\n'))
+        ? result.substring(0, result.length - 1)
+        : result;
+  }
+
+  String clearScreen() => supportsColor ? clear : '\n\n';
 
   set singleCharMode(bool value) {
     final Stream<List<int>> stdin = io.stdin;
@@ -113,4 +158,3 @@ class AnsiTerminal {
     return choice;
   }
 }
-

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -13,6 +13,7 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -746,15 +747,18 @@ class NotifyingLogger extends Logger {
   Stream<LogMessage> get onMessage => _messageController.stream;
 
   @override
-  void printError(String message, { StackTrace stackTrace, bool emphasis = false }) {
+  void printError(String message, { StackTrace stackTrace, bool emphasis = false, TerminalColor color }) {
     _messageController.add(LogMessage('error', message, stackTrace));
   }
 
   @override
   void printStatus(
-    String message,
-    { bool emphasis = false, bool newline = true, String ansiAlternative, int indent }
-  ) {
+      String message, {
+        bool emphasis = false,
+        TerminalColor color,
+        bool newline = true,
+        int indent,
+      }) {
     _messageController.add(LogMessage('status', message));
   }
 
@@ -868,7 +872,7 @@ class _AppRunLogger extends Logger {
   int _nextProgressId = 0;
 
   @override
-  void printError(String message, { StackTrace stackTrace, bool emphasis = false }) {
+  void printError(String message, { StackTrace stackTrace, bool emphasis, TerminalColor color}) {
     if (parent != null) {
       parent.printError(message, stackTrace: stackTrace, emphasis: emphasis);
     } else {
@@ -889,14 +893,22 @@ class _AppRunLogger extends Logger {
 
   @override
   void printStatus(
-    String message, {
-    bool emphasis = false, bool newline = true, String ansiAlternative, int indent
-  }) {
+      String message, {
+        bool emphasis = false,
+        TerminalColor color,
+        bool newline = true,
+        int indent,
+      }) {
     if (parent != null) {
-      parent.printStatus(message, emphasis: emphasis, newline: newline,
-          ansiAlternative: ansiAlternative, indent: indent);
+      parent.printStatus(
+        message,
+        emphasis: emphasis,
+        color: color,
+        newline: newline,
+        indent: indent,
+      );
     } else {
-      _sendLogEvent(<String, dynamic>{ 'log': message });
+      _sendLogEvent(<String, dynamic>{'log': message});
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -10,6 +10,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process_manager.dart';
+import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../bundle.dart' as bundle;
 import '../cache.dart';
@@ -188,9 +189,6 @@ class FuchsiaReloadCommand extends FlutterCommand {
     return result;
   }
 
-  static const String _bold = '\u001B[0;1m';
-  static const String _reset = '\u001B[0m';
-
   String _vmServiceToString(VMService vmService, {int tabDepth = 0}) {
     final Uri addr = vmService.httpAddress;
     final String embedder = vmService.vm.embedder;
@@ -218,7 +216,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
     final String tabs = '\t' * tabDepth;
     final String extraTabs = '\t' * (tabDepth + 1);
     final StringBuffer stringBuffer = StringBuffer(
-      '$tabs$_bold$embedder at $addr$_reset\n'
+      '$tabs${terminal.bolden('$embedder at $addr')}\n'
       '${extraTabs}RSS: $maxRSS\n'
       '${extraTabs}Native allocations: $heapSize\n'
       '${extraTabs}New Spaces: $newUsed of $newCap\n'
@@ -257,7 +255,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
     final String tabs = '\t' * tabDepth;
     final String extraTabs = '\t' * (tabDepth + 1);
     return
-      '$tabs$_bold$shortName$_reset\n'
+      '$tabs${terminal.bolden(shortName)}\n'
       '${extraTabs}Isolate number: $number\n'
       '${extraTabs}Observatory: $isolateAddr\n'
       '${extraTabs}Debugger: $debuggerAddr\n'

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -13,11 +13,12 @@ import 'base/context.dart';
 import 'base/fingerprint.dart';
 import 'base/io.dart';
 import 'base/process_manager.dart';
+import 'base/terminal.dart';
 import 'globals.dart';
 
 KernelCompiler get kernelCompiler => context[KernelCompiler];
 
-typedef CompilerMessageConsumer = void Function(String message);
+typedef CompilerMessageConsumer = void Function(String message, {bool emphasis, TerminalColor color});
 
 class CompilerOutput {
   final String outputFilename;

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -6,6 +6,7 @@ import 'artifacts.dart';
 import 'base/config.dart';
 import 'base/context.dart';
 import 'base/logger.dart';
+import 'base/terminal.dart';
 import 'cache.dart';
 
 Logger get logger => context[Logger];
@@ -16,9 +17,21 @@ Artifacts get artifacts => Artifacts.instance;
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.
 ///
-/// Set `emphasis` to true to make the output bold if it's supported.
-void printError(String message, { StackTrace stackTrace, bool emphasis = false }) {
-  logger.printError(message, stackTrace: stackTrace, emphasis: emphasis);
+/// Set [emphasis] to true to make the output bold if it's supported.
+/// Set [color] to a [TerminalColor] to color the output, if the logger
+/// supports it. The [color] defaults to [TerminalColor.red].
+void printError(
+  String message, {
+  StackTrace stackTrace,
+  bool emphasis,
+  TerminalColor color,
+}) {
+  logger.printError(
+    message,
+    stackTrace: stackTrace,
+    emphasis: emphasis ?? false,
+    color: color,
+  );
 }
 
 /// Display normal output of the command. This should be used for things like
@@ -28,20 +41,21 @@ void printError(String message, { StackTrace stackTrace, bool emphasis = false }
 ///
 /// Set `newline` to false to skip the trailing linefeed.
 ///
-/// If `ansiAlternative` is provided, and the terminal supports color, that
-/// string will be printed instead of the message.
-///
-/// If `indent` is provided, each line of the message will be prepended by the specified number of
-/// whitespaces.
+/// If `indent` is provided, each line of the message will be prepended by the
+/// specified number of whitespaces.
 void printStatus(
-  String message,
-  { bool emphasis = false, bool newline = true, String ansiAlternative, int indent }) {
+  String message, {
+  bool emphasis,
+  bool newline,
+  TerminalColor color,
+  int indent,
+}) {
   logger.printStatus(
     message,
-    emphasis: emphasis,
-    newline: newline,
-    ansiAlternative: ansiAlternative,
-    indent: indent
+    emphasis: emphasis ?? false,
+    color: color,
+    newline: newline ?? true,
+    indent: indent,
   );
 }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -455,8 +455,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // Free pipe file.
   tempDir?.deleteSync(recursive: true);
   printStatus(
-    'Xcode build done.',
-    ansiAlternative: 'Xcode build done.'.padRight(kDefaultStatusPadding + 1)
+    'Xcode build done.'.padRight(kDefaultStatusPadding + 1)
         + '${getElapsedAsSeconds(buildStopwatch.elapsed).padLeft(5)}',
   );
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -13,6 +13,7 @@ import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
+import 'base/terminal.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'compile.dart';
@@ -740,14 +741,12 @@ class HotRunner extends ResidentRunner {
   @override
   void printHelp({ @required bool details }) {
     const String fire = '🔥';
-    const String red = '\u001B[31m';
-    const String bold = '\u001B[0;1m';
-    const String reset = '\u001B[0m';
-    printStatus(
-      '$fire  To hot reload changes while running, press "r". To hot restart (and rebuild state), press "R".',
-      ansiAlternative: '$red$fire$bold  To hot reload changes while running, press "r". '
-                       'To hot restart (and rebuild state), press "R".$reset'
+    final String message = terminal.color(
+      fire + terminal.bolden('  To hot reload changes while running, press "r". '
+          'To hot restart (and rebuild state), press "R".'),
+      TerminalColor.red,
     );
+    printStatus(message);
     for (FlutterDevice device in flutterDevices) {
       final String dname = device.device.name;
       for (Uri uri in device.observatoryUris)

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -18,6 +18,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process_manager.dart';
+import '../base/terminal.dart';
 import '../build_info.dart';
 import '../compile.dart';
 import '../dart/package_map.dart';
@@ -212,13 +213,17 @@ class _Compiler {
     printTrace('Compiler will use the following file as its incremental dill file: ${outputDill.path}');
 
     bool suppressOutput = false;
-    void reportCompilerMessage(String message) {
+    void reportCompilerMessage(String message, {bool emphasis, TerminalColor color}) {
       if (suppressOutput)
         return;
 
       if (message.startsWith('compiler message: Error: Could not resolve the package \'test\'')) {
         printTrace(message);
-        printError('\n\nFailed to load test harness. Are you missing a dependency on flutter_test?\n');
+        printError(
+          '\n\nFailed to load test harness. Are you missing a dependency on flutter_test?\n',
+          emphasis: emphasis,
+          color: color,
+        );
         suppressOutput = true;
         return;
       }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -76,7 +76,7 @@ void testUsingContext(String description, dynamic testMethod(), {
             when(mock.getAttachedDevices()).thenReturn(<IOSSimulator>[]);
             return mock;
           },
-          Logger: () => BufferLogger(),
+          Logger: () => BufferLogger()..supportsColor = false,
           OperatingSystemUtils: () => MockOperatingSystemUtils(),
           SimControl: () => MockSimControl(),
           Usage: () => MockUsage(),

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -287,10 +287,14 @@ class MemoryIOSink implements IOSink {
 /// A Stdio that collects stdout and supports simulated stdin.
 class MockStdio extends Stdio {
   final MemoryIOSink _stdout = MemoryIOSink();
+  final MemoryIOSink _stderr = MemoryIOSink();
   final StreamController<List<int>> _stdin = StreamController<List<int>>();
 
   @override
   IOSink get stdout => _stdout;
+
+  @override
+  IOSink get stderr => _stderr;
 
   @override
   Stream<List<int>> get stdin => _stdin.stream;
@@ -300,6 +304,7 @@ class MockStdio extends Stdio {
   }
 
   List<String> get writtenToStdout => _stdout.writes.map(_stdout.encoding.decode).toList();
+  List<String> get writtenToStderr => _stderr.writes.map(_stderr.encoding.decode).toList();
 }
 
 class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {


### PR DESCRIPTION
This adds support to AnsiTerminal for colored output, and makes all tool output written to stderr (with the `printError` function) colored red.

No color codes are sent if the terminal doesn't support color (or isn't a terminal).

Also makes "progress" output print the elapsed time when not connected to a terminal, so that redirected output and terminal output match (redirected output doesn't print the spinner, however).

Addresses #17307