### PR TITLE
Mark the embedded_android_views_test as non flaky.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -135,7 +135,6 @@ tasks:
       Tests embedded Android views.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-    flaky: true
 
   run_release_test:
     description: >


### PR DESCRIPTION
Was marked as flaky as that's our policy for assing new device lab
tests. It's been consistently green so marking as non flaky.