### PR TITLE
Fix Dart check failure.

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -476,6 +476,8 @@ class AndroidViewController {
         return kAndroidLayoutDirectionLtr;
       case TextDirection.rtl:
         return kAndroidLayoutDirectionRtl;
+      default:
+        throw new UnsupportedError('Direction $direction is not supported');
     }
   }
 


### PR DESCRIPTION
```
This function has a return type of 'int', but doesn't end with a return statement. #missing_return
```

This should have been caught by analyzer. Is it because TextDirection is part of dart:ui?

It also sucks that this is an error at all. This should be an error only when a new value is added to enum. 