### PR TITLE
Add a localization for counter text, separate into own semantic node

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -58,6 +58,9 @@ class _PasswordFieldState extends State<PasswordField> {
       onSaved: widget.onSaved,
       validator: widget.validator,
       onFieldSubmitted: widget.onFieldSubmitted,
+      maxLengthSemanticFormatterCallback: (int current, int max) {
+        return '$current characters out of $max';
+      },
       decoration: new InputDecoration(
         border: const UnderlineInputBorder(),
         filled: true,
@@ -266,6 +269,9 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                   ),
                   maxLength: 8,
                   obscureText: true,
+                  maxLengthSemanticFormatterCallback: (int current, int max) {
+                    return '$current characters out of $max';
+                  },
                   validator: _validatePassword,
                 ),
                 const SizedBox(height: 24.0),

--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -58,9 +58,6 @@ class _PasswordFieldState extends State<PasswordField> {
       onSaved: widget.onSaved,
       validator: widget.validator,
       onFieldSubmitted: widget.onFieldSubmitted,
-      maxLengthSemanticFormatterCallback: (int current, int max) {
-        return '$current characters out of $max';
-      },
       decoration: new InputDecoration(
         border: const UnderlineInputBorder(),
         filled: true,
@@ -269,9 +266,6 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                   ),
                   maxLength: 8,
                   obscureText: true,
-                  maxLengthSemanticFormatterCallback: (int current, int max) {
-                    return '$current characters out of $max';
-                  },
                   validator: _validatePassword,
                 ),
                 const SizedBox(height: 24.0),

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2203,6 +2203,8 @@ class InputDecoration {
   ///
   /// Rendered using [counterStyle]. Uses [helperStyle] if [counterStyle] is
   /// null.
+  ///
+  /// The semantic label can be replaced by providing a [semanticCounterText].
   final String counterText;
 
   /// The style to use for the [counterText].
@@ -2386,7 +2388,11 @@ class InputDecoration {
   /// This property is true by default.
   final bool enabled;
 
-  /// An alternative semantic label for the [counterText].
+  /// A semantic label for the [counterText].
+  ///
+  /// Defaults to null.
+  ///
+  /// If provided, this replaces the semantic label of the [counterText].
   final String semanticCounterText;
 
   /// Creates a copy of this input decoration with the given fields replaced

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1813,10 +1813,14 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     );
 
     final Widget counter = decoration.counterText == null ? null :
-      new Text(
-        decoration.counterText,
-        style: _getHelperStyle(themeData).merge(decoration.counterStyle),
-        overflow: TextOverflow.ellipsis,
+      new Semantics(
+        container: true,
+        child: new Text(
+          decoration.counterText,
+          style: _getHelperStyle(themeData).merge(decoration.counterStyle),
+          overflow: TextOverflow.ellipsis,
+          semanticsLabel: decoration.semanticCounterText,
+        ),
       );
 
     // The _Decoration widget and _RenderDecoration assume that contentPadding
@@ -1940,6 +1944,7 @@ class InputDecoration {
     this.enabledBorder,
     this.border,
     this.enabled = true,
+    this.semanticCounterText,
   }) : assert(enabled != null),
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not allowed'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not allowed'),
@@ -1983,7 +1988,8 @@ class InputDecoration {
        focusedBorder = null,
        focusedErrorBorder = null,
        disabledBorder = null,
-       enabledBorder = null;
+       enabledBorder = null,
+       semanticCounterText = null;
 
   /// An icon to show before the input field and outside of the decoration's
   /// container.
@@ -2380,6 +2386,9 @@ class InputDecoration {
   /// This property is true by default.
   final bool enabled;
 
+  /// An alternative semantic label for the [counterText].
+  final String semanticCounterText;
+
   /// Creates a copy of this input decoration with the given fields replaced
   /// by the new values.
   ///
@@ -2416,6 +2425,7 @@ class InputDecoration {
     InputBorder enabledBorder,
     InputBorder border,
     bool enabled,
+    String semanticCounterText,
   }) {
     return new InputDecoration(
       icon: icon ?? this.icon,
@@ -2449,6 +2459,7 @@ class InputDecoration {
       enabledBorder: enabledBorder ?? this.enabledBorder,
       border: border ?? this.border,
       enabled: enabled ?? this.enabled,
+      semanticCounterText: semanticCounterText ?? this.semanticCounterText,
     );
   }
 
@@ -2518,7 +2529,8 @@ class InputDecoration {
         && typedOther.disabledBorder == disabledBorder
         && typedOther.enabledBorder == enabledBorder
         && typedOther.border == border
-        && typedOther.enabled == enabled;
+        && typedOther.enabled == enabled
+        && typedOther.semanticCounterText == semanticCounterText;
   }
 
   @override
@@ -2565,6 +2577,7 @@ class InputDecoration {
         enabledBorder,
         border,
         enabled,
+        semanticCounterText,
       ),
     );
   }
@@ -2630,6 +2643,8 @@ class InputDecoration {
       description.add('border: $border');
     if (!enabled)
       description.add('enabled: false');
+    if (semanticCounterText != null)
+      description.add('semanticCounterText: $semanticCounterText');
     return 'InputDecoration(${description.join(', ')})';
   }
 }

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -307,6 +307,9 @@ abstract class MaterialLocalizations {
   /// The semantics hint to describe the tap action on a collapsed [ExpandIcon].
   String get collapsedIconTapHint => 'Expand';
 
+  /// The label for the [TextField]'s character counter.
+  String remainingTextFieldCharacterCount(int remaining);
+
   /// The `MaterialLocalizations` from the closest [Localizations] instance
   /// that encloses the given context.
   ///
@@ -709,4 +712,16 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   ///
   /// [MaterialApp] automatically adds this value to [MaterialApp.localizationsDelegates].
   static const LocalizationsDelegate<MaterialLocalizations> delegate = _MaterialLocalizationsDelegate();
+
+  @override
+  String remainingTextFieldCharacterCount(int remaining) {
+    switch (remaining) {
+      case 0:
+        return 'No characters remaining';
+      case 1:
+        return '1 character remaining';
+      default:
+        return '$remaining characters remaining';
+    }
+  }
 }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -392,7 +392,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
 
     final int currentLength = _effectiveController.value.text.runes.length;
     final String counterText = '$currentLength/${widget.maxLength}';
-    final int remaining = currentLength > widget.maxLength ? 0 : widget.maxLength - currentLength;
+    final int remaining = (widget.maxLength - currentLength).clamp(0, widget.maxLength);
     final String semanticCounterText = localizations.remainingTextFieldCharacterCount(remaining);
     if (_effectiveController.value.text.runes.length > widget.maxLength) {
       final ThemeData themeData = Theme.of(context);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -14,14 +14,11 @@ import 'feedback.dart';
 import 'ink_well.dart' show InteractiveInkFeature;
 import 'input_decorator.dart';
 import 'material.dart';
+import 'material_localizations.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization;
-
-/// A Callback which produces an alternative semantic label for the max lines
-/// decoration of the [TextField].
-typedef String MaxLengthSemanticFormatterCallback(int currentLines, int maxLines);
 
 /// A material design text field.
 ///
@@ -123,7 +120,6 @@ class TextField extends StatefulWidget {
     this.cursorRadius,
     this.cursorColor,
     this.keyboardAppearance,
-    this.maxLengthSemanticFormatterCallback,
     this.scrollPadding = const EdgeInsets.all(20.0),
   }) : assert(textAlign != null),
        assert(autofocus != null),
@@ -347,16 +343,6 @@ class TextField extends StatefulWidget {
   /// Defaults to EdgeInserts.all(20.0).
   final EdgeInsets scrollPadding;
 
-  /// The callback used to create a semantic value from the current and maximum
-  /// length values.
-  ///
-  /// If not provided, the semantic label for the character counter element
-  /// will default to the same as the visual text.
-  ///
-  /// This is used by accessibility frameworks like TalkBack on Android to
-  /// provide a more useful description of the maximum length.
-  final MaxLengthSemanticFormatterCallback maxLengthSemanticFormatterCallback;
-
   @override
   _TextFieldState createState() => new _TextFieldState();
 
@@ -394,6 +380,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     && widget.decoration.counterText == null;
 
   InputDecoration _getEffectiveDecoration() {
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final InputDecoration effectiveDecoration = (widget.decoration ?? const InputDecoration())
       .applyDefaults(Theme.of(context).inputDecorationTheme)
       .copyWith(
@@ -403,11 +390,10 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     if (!needsCounter)
       return effectiveDecoration;
 
-    final int currentLines = _effectiveController.value.text.runes.length;
-    final String counterText = '$currentLines/${widget.maxLength}';
-    final String semanticCounterText = widget.maxLengthSemanticFormatterCallback != null
-      ? widget.maxLengthSemanticFormatterCallback(currentLines, widget.maxLength)
-      : counterText;
+    final int currentLength = _effectiveController.value.text.runes.length;
+    final String counterText = '$currentLength/${widget.maxLength}';
+    final int remaining = currentLength > widget.maxLength ? 0 : widget.maxLength - currentLength;
+    final String semanticCounterText = localizations.remainingTextFieldCharacterCount(remaining);
     if (_effectiveController.value.text.runes.length > widget.maxLength) {
       final ThemeData themeData = Theme.of(context);
       return effectiveDecoration.copyWith(

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -74,7 +74,6 @@ class TextFormField extends FormField<String> {
     bool enabled,
     Brightness keyboardAppearance,
     EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
-    MaxLengthSemanticFormatterCallback maxLengthSemanticFormatterCallback,
   }) : assert(initialValue == null || controller == null),
        assert(textAlign != null),
        assert(autofocus != null),
@@ -117,7 +116,6 @@ class TextFormField extends FormField<String> {
         enabled: enabled,
         scrollPadding: scrollPadding,
         keyboardAppearance: keyboardAppearance,
-        maxLengthSemanticFormatterCallback: maxLengthSemanticFormatterCallback,
       );
     },
   );

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -74,6 +74,7 @@ class TextFormField extends FormField<String> {
     bool enabled,
     Brightness keyboardAppearance,
     EdgeInsets scrollPadding = const EdgeInsets.all(20.0),
+    MaxLengthSemanticFormatterCallback maxLengthSemanticFormatterCallback,
   }) : assert(initialValue == null || controller == null),
        assert(textAlign != null),
        assert(autofocus != null),
@@ -116,6 +117,7 @@ class TextFormField extends FormField<String> {
         enabled: enabled,
         scrollPadding: scrollPadding,
         keyboardAppearance: keyboardAppearance,
+        maxLengthSemanticFormatterCallback: maxLengthSemanticFormatterCallback,
       );
     },
   );

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2580,11 +2580,14 @@ void main() {
         child: new TextField(
           key: key,
           controller: controller,
+          maxLengthSemanticFormatterCallback: (int current, int max) {
+            return '$current characters out of $max';
+          },
+          maxLength: 10,
           decoration: const InputDecoration(
             labelText: 'label',
             hintText: 'hint',
             helperText: 'helper',
-            counterText: 'counter',
           ),
         ),
       ),
@@ -2593,7 +2596,7 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          label: 'label\nhelper\ncounter',
+          label: 'label\nhelper',
           id: 1,
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
@@ -2601,6 +2604,13 @@ void main() {
           ],
           flags: <SemanticsFlag>[
             SemanticsFlag.isTextField,
+          ],
+          children: <TestSemantics>[
+            new TestSemantics(
+              id: 2,
+              label: '0 characters out of 10',
+              textDirection: TextDirection.ltr,
+            ),
           ],
         ),
       ],
@@ -2612,7 +2622,7 @@ void main() {
     expect(semantics, hasSemantics(new TestSemantics.root(
       children: <TestSemantics>[
         new TestSemantics.rootChild(
-          label: 'hint\nhelper\ncounter',
+          label: 'hint\nhelper',
           id: 1,
           textDirection: TextDirection.ltr,
           textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
@@ -2625,6 +2635,13 @@ void main() {
             SemanticsFlag.isTextField,
             SemanticsFlag.isFocused,
           ],
+          children: <TestSemantics>[
+            new TestSemantics(
+              id: 2,
+              label: '0 characters out of 10',
+              textDirection: TextDirection.ltr,
+            ),
+          ],
         ),
       ],
     ), ignoreTransform: true, ignoreRect: true));
@@ -2634,4 +2651,49 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('InputDecoration counterText can have a semanticCounterText', (WidgetTester tester) async {
+    final SemanticsTester semantics = new SemanticsTester(tester);
+    final TextEditingController controller = new TextEditingController();
+    final Key key = new UniqueKey();
+
+    await tester.pumpWidget(
+      overlay(
+        child: new TextField(
+          key: key,
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: 'label',
+            hintText: 'hint',
+            helperText: 'helper',
+            counterText: '0/10',
+            semanticCounterText: '0 characters out of 10',
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(new TestSemantics.root(
+      children: <TestSemantics>[
+        new TestSemantics.rootChild(
+          label: 'label\nhelper',
+          id: 1,
+          textDirection: TextDirection.ltr,
+          actions: <SemanticsAction>[
+            SemanticsAction.tap,
+          ],
+          flags: <SemanticsFlag>[
+            SemanticsFlag.isTextField,
+          ],
+          children: <TestSemantics>[
+            new TestSemantics(
+              label: '0 characters out of 10',
+              textDirection: TextDirection.ltr,
+            ),
+          ],
+        ),
+      ],
+    ), ignoreTransform: true, ignoreRect: true, ignoreId: true));
+
+    semantics.dispose();
+  });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2580,9 +2580,6 @@ void main() {
         child: new TextField(
           key: key,
           controller: controller,
-          maxLengthSemanticFormatterCallback: (int current, int max) {
-            return '$current characters out of $max';
-          },
           maxLength: 10,
           decoration: const InputDecoration(
             labelText: 'label',
@@ -2608,7 +2605,7 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 2,
-              label: '0 characters out of 10',
+              label: '10 characters remaining',
               textDirection: TextDirection.ltr,
             ),
           ],
@@ -2638,7 +2635,7 @@ void main() {
           children: <TestSemantics>[
             new TestSemantics(
               id: 2,
-              label: '0 characters out of 10',
+              label: '10 characters remaining',
               textDirection: TextDirection.ltr,
             ),
           ],
@@ -2666,7 +2663,7 @@ void main() {
             hintText: 'hint',
             helperText: 'helper',
             counterText: '0/10',
-            semanticCounterText: '0 characters out of 10',
+            semanticCounterText: '0 out of 10',
           ),
         ),
       ),
@@ -2686,7 +2683,7 @@ void main() {
           ],
           children: <TestSemantics>[
             new TestSemantics(
-              label: '0 characters out of 10',
+              label: '0 out of 10',
               textDirection: TextDirection.ltr,
             ),
           ],

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -132,6 +132,15 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'الصفحة السابقة';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -313,6 +322,15 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Предишната страница';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -498,6 +516,15 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Prethodna stranica';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -679,6 +706,15 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Pàgina anterior';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -864,6 +900,15 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Předchozí stránka';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -1047,6 +1092,15 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Forrige side';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -1228,6 +1282,15 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Vorherige Seite';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -1443,6 +1506,15 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Προηγούμενη σελίδα';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -1624,6 +1696,15 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Previous page';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'1 character remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'$remainingCount characters remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'No characters remaining';
 
   @override
   String get reorderItemDown => r'Move down';
@@ -2068,6 +2149,15 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -3576,6 +3666,15 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Eelmine leht';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -3757,6 +3856,15 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'صفحه قبل';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -3942,6 +4050,15 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Edellinen sivu';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -4125,6 +4242,15 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Nakaraang page';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -4306,6 +4432,15 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Page précédente';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -4518,6 +4653,15 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Vorherige Seite';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -4699,6 +4843,15 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'הדף הקודם';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -4884,6 +5037,15 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'पिछला पेज';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -5065,6 +5227,15 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -5250,6 +5421,15 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Előző oldal';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -5431,6 +5611,15 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -5616,6 +5805,15 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Pagina precedente';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -5797,6 +5995,15 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'前のページ';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -5982,6 +6189,15 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'이전 페이지';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -6163,6 +6379,15 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Ankstesnis puslapis';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -6348,6 +6573,15 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Iepriekšējā lapa';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -6529,6 +6763,15 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -6714,6 +6957,15 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Forrige side';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -6895,6 +7147,15 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Vorige pagina';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -7080,6 +7341,15 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Poprzednia strona';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -7263,6 +7533,15 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'مخکینی مخ';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -7444,6 +7723,15 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -7698,6 +7986,15 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Pagina anterioară';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -7879,6 +8176,15 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Предыдущая страница';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -8064,6 +8370,15 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Predchádzajúca stránka';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -8247,6 +8562,15 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Prejšnja stran';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -8428,6 +8752,15 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Претходна страница';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -8751,6 +9084,15 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Föregående sida';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -8932,6 +9274,15 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'หน้าก่อน';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -9117,6 +9468,15 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Nakaraang page';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -9298,6 +9658,15 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Önceki sayfa';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -9483,6 +9852,15 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Попередня сторінка';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -9664,6 +10042,15 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'گزشتہ صفحہ';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';
@@ -9849,6 +10236,15 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Trang trước';
 
   @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
+
+  @override
   String get reorderItemDown => r'TBD';
 
   @override
@@ -10030,6 +10426,15 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'上一页';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'TBD';
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'TBD';
 
   @override
   String get reorderItemDown => r'TBD';

--- a/packages/flutter_localizations/lib/src/l10n/material_ar.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ar.arb
@@ -51,5 +51,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_bg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bg.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_bs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bs.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ca.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ca.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_cs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_cs.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_da.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_da.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_el.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_el.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -245,5 +245,13 @@
   "collapsedIconTapHint": "Expand",
   "@collapsedIconTapHint": {
     "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
   }
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "Move left",
   "reorderItemRight": "Move right",
   "expandedIconTapHint": "Collapse",
-  "collapsedIconTapHint": "Expand"
+  "collapsedIconTapHint": "Expand",
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
@@ -41,5 +41,8 @@
   "alertDialogLabel": "Alerta",
   "searchFieldLabel": "Buscar",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_et.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_et.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fa.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fa.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fi.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fil.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fil.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fr.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_he.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_he.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hi.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hr.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hu.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_id.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_id.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_it.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_it.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ja.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ja.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ko.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ko.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_lt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lt.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_lv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lv.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ms.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ms.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nb.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nl.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pl.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ps.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ps.arb
@@ -46,5 +46,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ro.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ro.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ru.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ru.arb
@@ -50,5 +50,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sk.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sl.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sr.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sr_Latn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sr_Latn.arb
@@ -48,5 +48,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sv.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_th.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_th.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_tl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tl.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_tr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tr.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_uk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_uk.arb
@@ -49,5 +49,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ur.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_vi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_vi.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
@@ -47,5 +47,8 @@
   "reorderItemLeft": "TBD",
   "reorderItemRight": "TBD",
   "expandedIconTapHint": "TBD",
-  "collapsedIconTapHint": "TBD"
+  "collapsedIconTapHint": "TBD",
+  "remainingTextFieldCharacterCountZero": "TBD",
+  "remainingTextFieldCharacterCountOne": "TBD",
+  "remainingTextFieldCharacterCountOther": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -393,6 +393,58 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
     return timeOfDayFormatRaw;
   }
 
+  /// The "zero" form of [remainingTextFieldCharacterCount].
+  ///
+  /// This form is required.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [selectedRowCountTitleZero], the "zero" form
+  ///  * [selectedRowCountTitleOne], the "one" form
+  ///  * [selectedRowCountTitleTwo], the "two" form
+  ///  * [selectedRowCountTitleFew], the "few" form
+  ///  * [selectedRowCountTitleMany], the "many" form
+  @protected
+  String get remainingTextFieldCharacterCountZero;
+
+  /// The "one" form of [remainingTextFieldCharacterCount].
+  ///
+  /// This form is optional.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
+  ///  * [remainingTextFieldCharacterCountOne], the "one" form
+  ///  * [remainingTextFieldCharacterCountOther], the "other" form
+  @protected
+  String get remainingTextFieldCharacterCountOne => null;
+
+  /// The "other" form of [remainingTextFieldCharacterCount].
+  ///
+  /// This form is required.
+  ///
+  /// See also:
+  ///
+  ///  * [Intl.plural], to which this form is passed.
+  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
+  ///  * [remainingTextFieldCharacterCountOne], the "one" form
+  ///  * [remainingTextFieldCharacterCountOther], the "other" form
+  @protected
+  String get remainingTextFieldCharacterCountOther;
+
+  @override
+  String remainingTextFieldCharacterCount(int remainingCount) {
+    return intl.Intl.pluralLogic(
+      remainingCount,
+      zero: remainingTextFieldCharacterCountZero,
+      one: remainingTextFieldCharacterCountOne,
+      other: remainingTextFieldCharacterCountOther,
+      locale: _localeName,
+    ).replaceFirst(r'$remainingCount', formatDecimal(remainingCount));
+  }
+
   /// The script category used by [localTextGeometry]. Must be one of the strings
   /// declared in [MaterialTextGeometry].
   //

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -400,11 +400,9 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   /// See also:
   ///
   ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleMany], the "many" form
+  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
+  ///  * [remainingTextFieldCharacterCountOne], the "one" form
+  ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
   String get remainingTextFieldCharacterCountZero;
 

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -41,6 +41,13 @@ void main() {
       expect(localizations.collapsedIconTapHint, isNotNull);
       expect(localizations.expandedIconTapHint, isNotNull);
 
+      expect(localizations.remainingTextFieldCharacterCount(0), isNotNull);
+      expect(localizations.remainingTextFieldCharacterCount(1), isNotNull);
+      expect(localizations.remainingTextFieldCharacterCount(10), isNotNull);
+      expect(localizations.remainingTextFieldCharacterCount(0), isNot(contains(r'$remainingCount')));
+      expect(localizations.remainingTextFieldCharacterCount(1), isNot(contains(r'$remainingCount')));
+      expect(localizations.remainingTextFieldCharacterCount(10), isNot(contains(r'$remainingCount')));
+
       expect(localizations.aboutListTileTitle('FOO'), isNotNull);
       expect(localizations.aboutListTileTitle('FOO'), contains('FOO'));
 


### PR DESCRIPTION
Based on a11y recommendation - the character counter should likely be exposed to accessibility as a separate focusable element distinct from the text entry field.

TalkBack will read "1/8" as a fraction, so we now provide a localized default.

Fixes https://github.com/flutter/flutter/issues/19520