### PR TITLE
[Material] Fix 20051 FAB tooltip touch target

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -259,15 +259,15 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
     );
 
     if (widget.tooltip != null) {
-      final Widget tooltip = MergeSemantics(
-        child: Tooltip(
+      final Widget tooltip = new MergeSemantics(
+        child: new Tooltip(
           message: widget.tooltip,
           child: result,
         ),
       );
       // The long-pressable area for the tooltip should always be as big as
       // the tooltip even if there is no child.
-      result = widget.child != null ? tooltip : SizedBox.expand(child: tooltip);
+      result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);
     }
 
     if (widget.heroTag != null) {

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -260,12 +260,11 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
 
     if (widget.tooltip != null) {
       final Widget tooltip = MergeSemantics(
-        child: new Tooltip(
+        child: Tooltip(
           message: widget.tooltip,
           child: result,
         ),
       );
-
       // The long-pressable area for the tooltip should always be as big as
       // the tooltip even if there is no child.
       result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -267,7 +267,7 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
       );
       // The long-pressable area for the tooltip should always be as big as
       // the tooltip even if there is no child.
-      result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);
+      result = widget.child != null ? tooltip : SizedBox.expand(child: tooltip);
     }
 
     if (widget.heroTag != null) {

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -259,15 +259,12 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
     );
 
     if (widget.tooltip != null) {
-      final Widget tooltip = new MergeSemantics(
+      result = new MergeSemantics(
         child: new Tooltip(
           message: widget.tooltip,
           child: result,
         ),
       );
-      // The long-pressable area for the tooltip should always be as big as
-      // the tooltip even if there is no child.
-      result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);
     }
 
     if (widget.heroTag != null) {

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -243,16 +243,6 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
       );
     }
 
-    if (widget.tooltip != null) {
-      final Widget tooltip = new Tooltip(
-        message: widget.tooltip,
-        child: result,
-      );
-      // The long-pressable area for the tooltip should always be as big as
-      // the tooltip even if there is no child.
-      result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);
-    }
-
     result = new RawMaterialButton(
       onPressed: widget.onPressed,
       onHighlightChanged: _handleHighlightChanged,
@@ -267,6 +257,19 @@ class _FloatingActionButtonState extends State<FloatingActionButton> {
       shape: widget.shape,
       child: result,
     );
+
+    if (widget.tooltip != null) {
+      final Widget tooltip = MergeSemantics(
+        child: new Tooltip(
+          message: widget.tooltip,
+          child: result,
+        ),
+      );
+
+      // The long-pressable area for the tooltip should always be as big as
+      // the tooltip even if there is no child.
+      result = widget.child != null ? tooltip : new SizedBox.expand(child: tooltip);
+    }
 
     if (widget.heroTag != null) {
       result = new Hero(

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -50,7 +50,7 @@ void main() {
     expect(find.byTooltip('Add'), findsOneWidget);
   });
 
-  testWidgets('Floating Action Button tooltip (long press off center)', (WidgetTester tester) async {
+  testWidgets('Floating Action Button tooltip (long press button edge)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
         home: const Scaffold(

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -52,7 +52,7 @@ void main() {
 
   testWidgets('Floating Action Button tooltip (long press button edge)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      new MaterialApp(
+      MaterialApp(
         home: const Scaffold(
           floatingActionButton: FloatingActionButton(
             onPressed: null,

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -52,7 +52,7 @@ void main() {
 
   testWidgets('Floating Action Button tooltip (long press button edge)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      new MaterialApp(
         home: const Scaffold(
           floatingActionButton: FloatingActionButton(
             onPressed: null,

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -50,6 +50,27 @@ void main() {
     expect(find.byTooltip('Add'), findsOneWidget);
   });
 
+  testWidgets('Floating Action Button tooltip (tap off center)', (WidgetTester tester) async {
+    const Icon icon = Icon(Icons.add);
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          floatingActionButton: FloatingActionButton(
+            onPressed: null,
+            tooltip: 'Add',
+            child: icon,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Text), findsNothing);
+    await tester.longPressAt(tester.getTopRight(find.byType(Icon)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Text), findsOneWidget);
+  });
+
   testWidgets('Floating Action Button tooltip (no child)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -50,6 +50,7 @@ void main() {
     expect(find.byTooltip('Add'), findsOneWidget);
   });
 
+  // Regression test for: https://github.com/flutter/flutter/pull/21084
   testWidgets('Floating Action Button tooltip (long press button edge)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(
@@ -64,7 +65,27 @@ void main() {
     );
 
     expect(find.byType(Text), findsNothing);
-    await tester.longPressAt(tester.getTopRight(find.byType(Icon)));
+    await tester.longPressAt(_rightEdgeOfFab(tester));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Text), findsOneWidget);
+  });
+
+  // Regression test for: https://github.com/flutter/flutter/pull/21084
+  testWidgets('Floating Action Button tooltip (long press button edge - no child)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          floatingActionButton: FloatingActionButton(
+            onPressed: null,
+            tooltip: 'Add',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Text), findsNothing);
+    await tester.longPressAt(_rightEdgeOfFab(tester));
     await tester.pumpAndSettle();
 
     expect(find.byType(Text), findsOneWidget);
@@ -458,4 +479,9 @@ void main() {
       skip: !Platform.isLinux,
     );
   });
+}
+
+Offset _rightEdgeOfFab(WidgetTester tester) {
+  final Finder fab = find.byType(FloatingActionButton);
+  return tester.getRect(fab).centerRight - const Offset(1.0, 0.0);
 }

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -64,11 +64,11 @@ void main() {
       ),
     );
 
-    expect(find.byType(Text), findsNothing);
+    expect(find.text('Add'), findsNothing);
     await tester.longPressAt(_rightEdgeOfFab(tester));
     await tester.pumpAndSettle();
 
-    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('Add'), findsOneWidget);
   });
 
   // Regression test for: https://github.com/flutter/flutter/pull/21084
@@ -84,11 +84,11 @@ void main() {
       ),
     );
 
-    expect(find.byType(Text), findsNothing);
+    expect(find.text('Add'), findsNothing);
     await tester.longPressAt(_rightEdgeOfFab(tester));
     await tester.pumpAndSettle();
 
-    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('Add'), findsOneWidget);
   });
 
   testWidgets('Floating Action Button tooltip (no child)', (WidgetTester tester) async {
@@ -103,10 +103,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Text), findsNothing);
+    expect(find.text('Add'), findsNothing);
     await tester.longPress(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
-    expect(find.byType(Text), findsOneWidget);
+    expect(find.text('Add'), findsOneWidget);
   });
 
   testWidgets('FlatActionButton mini size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -50,6 +50,26 @@ void main() {
     expect(find.byTooltip('Add'), findsOneWidget);
   });
 
+  testWidgets('Floating Action Button tooltip (long press off center)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          floatingActionButton: FloatingActionButton(
+            onPressed: null,
+            tooltip: 'Add',
+            child: Icon(Icons.add),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Text), findsNothing);
+    await tester.longPressAt(tester.getTopRight(find.byType(Icon)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Text), findsOneWidget);
+  });
+
   testWidgets('Floating Action Button tooltip (no child)', (WidgetTester tester) async {
     await tester.pumpWidget(
       new MaterialApp(


### PR DESCRIPTION
FAB tooltip was only appearing when the icon widget inside of the FAB was long pressed, but not when the edge of the button was long pressed.

Fixed by moving tooltip addition to after the RawMaterialButton creation, so that the tooltip wraps the whole button. Had to merge semantics to keep the semantics information.

Added unit test for long press outside of the icon. 

Closes #20051 