### PR TITLE
make /timeline-dashboard consistent between build and paint profiles

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3644,7 +3644,7 @@ abstract class ComponentElement extends Element {
   void performRebuild() {
     assert(() {
       if (debugProfileBuildsEnabled)
-        Timeline.startSync('${widget.runtimeType}');
+        Timeline.startSync('${widget.runtimeType}',  arguments: timelineWhitelistArguments);
       return true;
     }());
 


### PR DESCRIPTION
The simplified timeline currently only works with debugProfilePaintsEnabled but not with debugProfileBuildsEnabled.