### PR TITLE
Don't time out if process terminates when told to stop

### DIFF
--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -89,7 +89,10 @@ class FlutterTestDriver {
         workingDirectory: _projectFolder.path,
         environment: <String, String>{'FLUTTER_TEST': 'true'});
 
-    _proc.exitCode.then((_) => _hasExited = true);
+    _proc.exitCode.then((int code) {
+      _debugPrint('Process exited ($code)');
+      _hasExited = true;
+    });
     _transformToLines(_proc.stdout).listen((String line) => _stdout.add(line));
     _transformToLines(_proc.stderr).listen((String line) => _stderr.add(line));
 

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -166,10 +166,13 @@ class FlutterTestDriver {
     }
     if (_currentRunningAppId != null) {
       _debugPrint('Stopping app');
-      await _sendRequest(
-        'app.stop',
-        <String, dynamic>{'appId': _currentRunningAppId}
-      ).timeout(
+      await Future.any<void>(<Future<void>>[
+        _proc.exitCode,
+        _sendRequest(
+          'app.stop',
+          <String, dynamic>{'appId': _currentRunningAppId}
+        ),
+      ]).timeout(
         quitTimeout,
         onTimeout: () { _debugPrint('app.stop did not return within $quitTimeout'); }
       );


### PR DESCRIPTION
…as not processed

While trying to reproduce #20822 I found a condition where the app may quit before the `app.stop` response is received but this code (which is called in integration test teardown) would sit around waiting and time out. With this change, the process exit is considered a valid response to the stop request.