### PR TITLE
Swap order of attach/stop in flutter_attach integration test teardown

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -27,8 +27,8 @@ void main() {
     // We can't call stop() on both of these because they'll both try to stop the
     // same app. Just quit the attach process and then send a stop to the original
     // process.
-    await _flutterAttach.quit();
     await _flutterRun.stop();
+    await _flutterAttach.quit();
     tryToDelete(tempDir);
   });
 


### PR DESCRIPTION
This is a bit of a stab in the dark for a flake sometimes seen on bots (but I can't repro locally) #20822. Detaching from a Flutter app currently seems to terminate it (tested locally using the `flutter attach` command) so it may be the cause of the "app not found" in test teardown when trying to stop the original flutter process after we kill the attach process (though I can't repro even with a bit delay between the two commands in the original order).

Anyway, this swaps the order so we close the app cleanly first, then we'll terminate the attach process.