### PR TITLE
Let bot/devicelab tests run concurrently

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -298,6 +298,7 @@ Future<Null> _runToolTests() async {
   await _pubRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     enableFlutterToolAsserts: true,
+    runConcurrently: false,
   );
 
   print('${bold}DONE: All tests successful.$reset');
@@ -350,9 +351,13 @@ Future<Null> _runCoverage() async {
 Future<Null> _pubRunTest(
   String workingDirectory, {
   String testPath,
+  bool runConcurrently = true,
   bool enableFlutterToolAsserts = false
 }) {
-  final List<String> args = <String>['run', 'test', '-j1', '-rcompact'];
+  final List<String> args = <String>['run', 'test', '-rcompact'];
+  if (!runConcurrently) {
+    args.add('-j1');
+  }
   if (!hasColor)
     args.add('--no-color');
   if (testPath != null)


### PR DESCRIPTION
I believe it was accidental that we were using `-j1` for these other tests, they were just made to use the same function to run pub tests that `flutter_tools` does.