### PR TITLE
Allow FlutterTester to be provided with the working directory for execution

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -41,8 +41,9 @@ class FlutterTesterApp extends ApplicationPackage {
 
 // TODO(scheglov): This device does not currently work with full restarts.
 class FlutterTesterDevice extends Device {
-  FlutterTesterDevice(String deviceId) : super(deviceId);
+  FlutterTesterDevice(String deviceId, { this.workingDirectory }) : super(deviceId);
 
+  final String workingDirectory;
   Process _process;
   final DevicePortForwarder _portForwarder = new _NoopPortForwarder();
 
@@ -155,6 +156,7 @@ class FlutterTesterDevice extends Device {
         environment: <String, String>{
           'FLUTTER_TEST': 'true',
         },
+        workingDirectory: workingDirectory,
       );
       _process.exitCode.then((_) => _isRunning = false);
       _process.stdout

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -19,7 +19,7 @@ void main() {
   group('FlutterTesterDevice', () {
     Directory tempDir;
     FlutterTesterDevice device;
-  
+
     setUp(() async {
       tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
       device = new FlutterTesterDevice('flutter-tester', workingDirectory: tempDir.path);

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -15,25 +15,18 @@ import '../src/context.dart';
 import 'test_utils.dart';
 
 void main() {
-  Directory tempDir;
-  Directory oldCurrentDir;
-
-  setUp(() async {
-    tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
-    oldCurrentDir = fs.currentDirectory;
-    fs.currentDirectory = tempDir;
-  });
-
-  tearDown(() {
-    fs.currentDirectory = oldCurrentDir;
-    tryToDelete(tempDir);
-  });
 
   group('FlutterTesterDevice', () {
+    Directory tempDir;
     FlutterTesterDevice device;
+  
+    setUp(() async {
+      tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
+      device = new FlutterTesterDevice('flutter-tester', workingDirectory: tempDir.path);
+    });
 
-    setUp(() {
-      device = new FlutterTesterDevice('flutter-tester');
+    tearDown(() {
+      tryToDelete(tempDir);
     });
 
     Future<LaunchResult> start(String mainPath) async {
@@ -50,7 +43,7 @@ void main() {
       writePubspec(tempDir.path);
       writePackages(tempDir.path);
 
-      final String mainPath = fs.path.join('lib', 'main.dart');
+      final String mainPath = fs.path.join(tempDir.path, 'lib', 'main.dart');
       writeFile(mainPath, r'''
 import 'dart:async';
 void main() {


### PR DESCRIPTION
Previously these tests set `fs.currentDirectory` which prevents running tests concurrently. This change allows providing the working directory for a FlutterTester in the constructor and provides the location from the test (without setting `fs.currentDirectory`).