### PR TITLE
Update dartdoc to 0.20.4.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -63,7 +63,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.20.3
+"$PUB" global activate dartdoc 0.20.4
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.20.4

Impact for flutter is fairly widespread but minor.  Most noticeable is the addition of ids on markdown headers and the removal of `@pragma` annotations.