### PR TITLE
Use differrent name for initial flutter tester kernel file.

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -127,7 +127,8 @@ class FlutterTesterDevice extends Device {
 
     // Build assets and perform initial compilation.
     final String assetDirPath = getAssetBuildDirectory();
-    final String applicationKernelFilePath = bundle.defaultApplicationKernelPath;
+    final String applicationKernelFilePath =
+        fs.path.join(getBuildDirectory(), 'flutter-tester-app.dill');
     await bundle.build(
       mainPath: mainPath,
       assetDirPath: assetDirPath,


### PR DESCRIPTION
With default kernel file name Dart VM and incremental compiler both running on the same machine, both are clashing over the same kernel file. This change switches initial kernel file to a different name, removes the conflict.

Fixes https://github.com/flutter/flutter/issues/17833