### PR TITLE
Fix ThemeData's cursorColor doesn't work.

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -174,7 +174,7 @@ class ThemeData extends Diagnosticable {
     secondaryHeaderColor ??= isDark ? Colors.grey[700] : primarySwatch[50];
     textSelectionColor ??= isDark ? accentColor : primarySwatch[200];
     // todo (sandrasandeep): change to color provided by Material Design team
-    cursorColor = const Color.fromRGBO(66, 133, 244, 1.0);
+    cursorColor = cursorColor ?? const Color.fromRGBO(66, 133, 244, 1.0);
     textSelectionHandleColor ??= isDark ? Colors.tealAccent[400] : primarySwatch[300];
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -142,4 +142,8 @@ void main() {
     expect(new ThemeData(primaryColor: Colors.teal).primaryColorBrightness, equals(Brightness.dark));
     expect(new ThemeData(primaryColor: Colors.indigo).primaryColorBrightness, equals(Brightness.dark));
   });
+
+  test('cursorColor', () {
+    expect(ThemeData(cursorColor: Colors.red).cursorColor, Colors.red);
+  });
 }


### PR DESCRIPTION
Because `ThemeData`'s `cursorColor` it is rewritten in the factory method.