### PR TITLE
Add Card clipBehavior pass-through property

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -60,12 +60,15 @@ import 'theme.dart';
 ///  * <https://material.google.com/components/cards.html>
 class Card extends StatelessWidget {
   /// Creates a material design card.
+  ///
+  /// The [clipBehavior] argument must not be null.
   const Card({
     Key key,
     this.color,
     this.elevation,
     this.shape,
     this.margin = const EdgeInsets.all(4.0),
+    this.clipBehavior = Clip.none,
     this.child,
     this.semanticContainer = true,
   }) : super(key: key);
@@ -92,6 +95,9 @@ class Card extends StatelessWidget {
   /// The default shape is a [RoundedRectangleBorder] with a circular corner
   /// radius of 4.0.
   final ShapeBorder shape;
+
+  /// {@macro flutter.widgets.Clip}
+  final Clip clipBehavior;
 
   /// The empty space that surrounds the card.
   ///
@@ -133,6 +139,7 @@ class Card extends StatelessWidget {
           shape: shape ?? const RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(4.0)),
           ),
+          clipBehavior: clipBehavior,
           child: child,
         ),
       ),

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -157,4 +157,11 @@ void main() {
     expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
   });
 
+  testWidgets('Card clipBehavior property passes through to the Material', (WidgetTester tester) async {
+    await tester.pumpWidget(const Card());
+    expect(tester.widget<Material>(find.byType(Material)).clipBehavior, Clip.none);
+
+    await tester.pumpWidget(const Card(clipBehavior: Clip.antiAlias));
+    expect(tester.widget<Material>(find.byType(Material)).clipBehavior, Clip.antiAlias);
+  });
 }


### PR DESCRIPTION
Add a Card `clipBehavior` property that's just passed along to the Card's Material.

Applications expect a Card to clip its child to the Card's shape will need to specify a clipBehavior value like `Clip.antAlias`.

Fixes: https://github.com/flutter/flutter/issues/21094
