### PR TITLE
Eliminate Dart 1 support in devicelab tests

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_test.dart
@@ -56,12 +56,6 @@ void main() async {
       });
 
       await runProjectTest((FlutterProject project) async {
-        section('gradlew assembleDebug no-preview-dart-2');
-        await project.runGradleTask('assembleDebug',
-            options: <String>['-Ppreview-dart-2=false']);
-      });
-
-      await runProjectTest((FlutterProject project) async {
         section('gradlew assembleProfile');
         await project.runGradleTask('assembleProfile');
       });

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -20,7 +20,7 @@ TaskFunction createMicrobenchmarkTask() {
     final Device device = await devices.workingDevice;
     await device.unlock();
 
-    Future<Map<String, double>> _runMicrobench(String benchmarkPath, {bool previewDart2 = true}) async {
+    Future<Map<String, double>> _runMicrobench(String benchmarkPath) async {
       Future<Map<String, double>> _run() async {
         print('Running $benchmarkPath');
         final Directory appDir = dir(
@@ -35,10 +35,6 @@ TaskFunction createMicrobenchmarkTask() {
             '-d',
             device.deviceId,
           ];
-          if (previewDart2)
-            options.add('--preview-dart-2');
-          else
-            options.add('--no-preview-dart-2');
           setLocalEngineOptionIfNecessary(options);
           options.add(benchmarkPath);
           return await _startFlutter(

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -194,7 +194,7 @@ class CompileTest {
     });
   }
 
-  static Future<Map<String, dynamic>> _compileAot({ bool previewDart2 = true }) async {
+  static Future<Map<String, dynamic>> _compileAot() async {
     // Generate blobs instead of assembly.
     await flutter('clean');
     final Stopwatch watch = new Stopwatch()..start();
@@ -214,10 +214,6 @@ class CompileTest {
         options.add('android-arm');
         break;
     }
-    if (previewDart2)
-      options.add('--preview-dart-2');
-    else
-      options.add('--no-preview-dart-2');
     setLocalEngineOptionIfNecessary(options);
     final String compileLog = await evalFlutter('build', options: options);
     watch.stop();
@@ -235,15 +231,11 @@ class CompileTest {
     return metrics;
   }
 
-  static Future<Map<String, dynamic>> _compileApp({ bool previewDart2 = true, bool reportPackageContentSizes = false }) async {
+  static Future<Map<String, dynamic>> _compileApp({ bool reportPackageContentSizes = false }) async {
     await flutter('clean');
     final Stopwatch watch = new Stopwatch();
     int releaseSizeInBytes;
     final List<String> options = <String>['--release'];
-    if (previewDart2)
-      options.add('--preview-dart-2');
-    else
-      options.add('--no-preview-dart-2');
     setLocalEngineOptionIfNecessary(options);
     final Map<String, dynamic> metrics = <String, dynamic>{};
 
@@ -287,14 +279,10 @@ class CompileTest {
     return metrics;
   }
 
-  static Future<Map<String, dynamic>> _compileDebug({ bool previewDart2 = true }) async {
+  static Future<Map<String, dynamic>> _compileDebug() async {
     await flutter('clean');
     final Stopwatch watch = new Stopwatch();
     final List<String> options = <String>['--debug'];
-    if (previewDart2)
-      options.add('--preview-dart-2');
-    else
-      options.add('--no-preview-dart-2');
     setLocalEngineOptionIfNecessary(options);
     switch (deviceOperatingSystem) {
       case DeviceOperatingSystem.ios:


### PR DESCRIPTION
Flutter commands all default to --preview-dart-2. Eliminate support for
the use of this option and the previewDart2 parameter in dev/devicelab
tests.