### PR TITLE
Migrate devfs tests to Dart 2

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert' show base64, utf8;
 
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
+import 'package:meta/meta.dart';
 
 import 'asset.dart';
 import 'base/context.dart';
@@ -401,18 +402,18 @@ class DevFS {
   ///
   /// Returns the number of bytes synced.
   Future<int> update({
-    String mainPath,
+    @required String mainPath,
     String target,
     AssetBundle bundle,
     DateTime firstBuildTime,
     bool bundleFirstUpload = false,
     bool bundleDirty = false,
     Set<String> fileFilter,
-    ResidentCompiler generator,
+    @required ResidentCompiler generator,
     String dillOutputPath,
     bool fullRestart = false,
     String projectRootPath,
-    String pathToReload,
+    @required String pathToReload,
   }) async {
     // Mark all entries as possibly deleted.
     for (DevFSContent content in _entries.values) {

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
@@ -429,5 +430,37 @@ class MockDevFSOperations extends BasicMock implements DevFSOperations {
   Future<dynamic> deleteFile(String fsName, Uri deviceUri) async {
     messages.add('deleteFile $fsName $deviceUri');
     devicePathToContent.remove(deviceUri);
+  }
+}
+
+class MockResidentCompiler extends BasicMock implements ResidentCompiler {
+  @override
+  void accept() {}
+
+  @override
+  void reject() {}
+
+  @override
+  void reset() {}
+
+  @override
+  Future<dynamic> shutdown() async {}
+
+  @override
+  Future<CompilerOutput> compileExpression(
+    String expression,
+    List<String> definitions,
+    List<String> typeDefinitions,
+    String libraryUri,
+    String klass,
+    bool isStatic
+  ) async {
+    return null;
+  }
+  @override
+  Future<CompilerOutput> recompile(String mainPath, List<String> invalidatedFiles, {String outputPath, String packagesFilePath}) async {
+    fs.file(outputPath).createSync(recursive: true);
+    fs.file(outputPath).writeAsStringSync('compiled_kernel_output');
+    return new CompilerOutput(outputPath, 0);
   }
 }


### PR DESCRIPTION
DevFS.update only runs in Dart 2 mode when the generator parameter is
supplied. In Dart 2 mode, both mainPath and pathToReload are required
parameters; this patch marks them as such.

generator is required for running in Dart 2. All call sites other than tests already explicitly set this value.

Note the statements on line 510 and line 516 for why mainPath and pathToReload are required.