### PR TITLE
Don't reject the gesture after all pointers are up [AndroidView].

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -251,9 +251,7 @@ class _AndroidViewGestureRecognizer extends OneSequenceGestureRecognizer {
   String get debugDescription => 'Android view';
 
   @override
-  void didStopTrackingLastPointer(int pointer) {
-    resolve(GestureDisposition.rejected);
-  }
+  void didStopTrackingLastPointer(int pointer) {}
 
   @override
   void handleEvent(PointerEvent event) {


### PR DESCRIPTION
This was a bug, when e.g a LongPressGestureRecognizer was in the gesture
arena, the android view gesture team may not yet win the arena when the
last pointer was up. This change allows AndroidView to win the gesture
even after all pointers are up.