### PR TITLE
Eliminate --preview-dart-2 flag

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -112,13 +112,6 @@ BuildApp() {
     local_engine_flag="--local-engine=$LOCAL_ENGINE"
   fi
 
-  local preview_dart_2_flag=""
-  if [[ -n "$PREVIEW_DART_2" ]]; then
-    preview_dart_2_flag="--preview-dart-2"
-  else
-    preview_dart_2_flag="--no-preview-dart-2"
-  fi
-
   local track_widget_creation_flag=""
   if [[ -n "$TRACK_WIDGET_CREATION" ]]; then
     track_widget_creation_flag="--track-widget-creation"
@@ -137,7 +130,6 @@ BuildApp() {
       --${build_mode}                                                       \
       --ios-arch="${archs}"                                                 \
       ${local_engine_flag}                                                  \
-      ${preview_dart_2_flag}                                                \
       ${track_widget_creation_flag}
 
     if [[ $? -ne 0 ]]; then
@@ -190,7 +182,6 @@ BuildApp() {
     --asset-dir="${derived_dir}/flutter_assets"                             \
     ${precompilation_flag}                                                  \
     ${local_engine_flag}                                                    \
-    ${preview_dart_2_flag}                                                  \
     ${track_widget_creation_flag}
 
   if [[ $? -ne 0 ]]; then

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -284,10 +284,6 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('verbose')) {
             verboseValue = project.property('verbose').toBoolean()
         }
-        Boolean previewDart2Value = true
-        if (project.hasProperty('preview-dart-2')) {
-            previewDart2Value = project.property('preview-dart-2').toBoolean()
-        }
         String[] fileSystemRootsValue = null
         if (project.hasProperty('filesystem-roots')) {
             fileSystemRootsValue = project.property('filesystem-roots').split('\\|')
@@ -342,7 +338,6 @@ class FlutterPlugin implements Plugin<Project> {
                 localEngineSrcPath this.localEngineSrcPath
                 targetPath target
                 verbose verboseValue
-                previewDart2 previewDart2Value
                 fileSystemRoots fileSystemRootsValue
                 fileSystemScheme fileSystemSchemeValue
                 trackWidgetCreation trackWidgetCreationValue
@@ -388,8 +383,6 @@ abstract class BaseFlutterTask extends DefaultTask {
     @Optional @Input
     Boolean verbose
     @Optional @Input
-    Boolean previewDart2
-    @Optional @Input
     String[] fileSystemRoots
     @Optional @Input
     String fileSystemScheme
@@ -411,12 +404,11 @@ abstract class BaseFlutterTask extends DefaultTask {
     @OutputFiles
     FileCollection getDependenciesFiles() {
         FileCollection depfiles = project.files()
-        if (previewDart2) {
-            // For Dart 2, also include the kernel compiler depfile, since
-            // kernel compile is the first stage of AOT build in this mode,
-            // and it includes all the Dart sources.
-            depfiles += project.files("${intermediateDir}/kernel_compile.d")
-        }
+
+        // Include the kernel compiler depfile, since kernel compile is the
+        // first stage of AOT build in this mode, and it includes all the Dart
+        // sources.
+        depfiles += project.files("${intermediateDir}/kernel_compile.d")
 
         // Include Core JIT kernel compiler depfile, since kernel compile is
         // the first stage of JIT builds in this mode, and it includes all the
@@ -446,11 +438,6 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "--target", targetPath
                 args "--target-platform", "android-arm"
                 args "--output-dir", "${intermediateDir}"
-                if (previewDart2) {
-                    args "--preview-dart-2"
-                } else {
-                    args "--no-preview-dart-2"
-                }
                 if (trackWidgetCreation) {
                     args "--track-widget-creation"
                 }
@@ -483,11 +470,6 @@ abstract class BaseFlutterTask extends DefaultTask {
             if (verbose) {
                 args "--verbose"
             }
-            if (previewDart2) {
-                args "--preview-dart-2"
-            } else {
-                args "--no-preview-dart-2"
-            }
             if (fileSystemRoots != null) {
                 for (root in fileSystemRoots) {
                     args "--filesystem-root", root
@@ -515,9 +497,6 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "--precompiled"
             } else {
                 args "--depfile", "${intermediateDir}/snapshot_blob.bin.d"
-                if (!previewDart2) {
-                    args "--snapshot", "${intermediateDir}/snapshot_blob.bin"
-                }
             }
             args "--asset-dir", "${intermediateDir}/flutter_assets"
             if (buildMode == "debug") {
@@ -585,9 +564,7 @@ class FlutterTask extends BaseFlutterTask {
             // We have a dependencies file. Add a dependency on gen_snapshot as well, since the
             // snapshots have to be rebuilt if it changes.
             sources += readDependencies(project.file("${intermediateDir}/gen_snapshot.d"))
-            if (previewDart2) {
-                sources += readDependencies(project.file("${intermediateDir}/frontend_server.d"))
-            }
+            sources += readDependencies(project.file("${intermediateDir}/frontend_server.d"))
             if (localEngineSrcPath != null) {
                 sources += project.files("$localEngineSrcPath/$localEngine")
             }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -353,23 +353,18 @@ Future<Null> _buildGradleProjectV2(
   if (target != null) {
     command.add('-Ptarget=$target');
   }
-  if (buildInfo.previewDart2) {
-    command.add('-Ppreview-dart-2=true');
-    if (buildInfo.trackWidgetCreation)
-      command.add('-Ptrack-widget-creation=true');
-    if (buildInfo.compilationTraceFilePath != null)
-      command.add('-Pprecompile=${buildInfo.compilationTraceFilePath}');
-    if (buildInfo.extraFrontEndOptions != null)
-      command.add('-Pextra-front-end-options=${buildInfo.extraFrontEndOptions}');
-    if (buildInfo.extraGenSnapshotOptions != null)
-      command.add('-Pextra-gen-snapshot-options=${buildInfo.extraGenSnapshotOptions}');
-    if (buildInfo.fileSystemRoots != null && buildInfo.fileSystemRoots.isNotEmpty)
-      command.add('-Pfilesystem-roots=${buildInfo.fileSystemRoots.join('|')}');
-    if (buildInfo.fileSystemScheme != null)
-      command.add('-Pfilesystem-scheme=${buildInfo.fileSystemScheme}');
-  } else {
-    command.add('-Ppreview-dart-2=false');
-  }
+  if (buildInfo.trackWidgetCreation)
+    command.add('-Ptrack-widget-creation=true');
+  if (buildInfo.compilationTraceFilePath != null)
+    command.add('-Pprecompile=${buildInfo.compilationTraceFilePath}');
+  if (buildInfo.extraFrontEndOptions != null)
+    command.add('-Pextra-front-end-options=${buildInfo.extraFrontEndOptions}');
+  if (buildInfo.extraGenSnapshotOptions != null)
+    command.add('-Pextra-gen-snapshot-options=${buildInfo.extraGenSnapshotOptions}');
+  if (buildInfo.fileSystemRoots != null && buildInfo.fileSystemRoots.isNotEmpty)
+    command.add('-Pfilesystem-roots=${buildInfo.fileSystemRoots.join('|')}');
+  if (buildInfo.fileSystemScheme != null)
+    command.add('-Pfilesystem-scheme=${buildInfo.fileSystemScheme}');
   if (buildInfo.buildSharedLibrary && androidSdk.ndk != null) {
     command.add('-Pbuild-shared-library=true');
   }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -11,7 +11,7 @@ import 'globals.dart';
 /// Information about a build to be performed or used.
 class BuildInfo {
   const BuildInfo(this.mode, this.flavor, {
-    this.previewDart2 = false,
+    this.previewDart2 = true,
     this.trackWidgetCreation = false,
     this.compilationTraceFilePath,
     this.extraFrontEndOptions,

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -43,7 +43,7 @@ Future<void> build({
   String privateKeyPath = defaultPrivateKeyPath,
   String assetDirPath,
   String packagesPath,
-  bool previewDart2  = false,
+  bool previewDart2 = true,
   bool precompiledSnapshot = false,
   bool reportLicensedPackages = false,
   bool trackWidgetCreation = false,

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -47,11 +47,6 @@ class AttachCommand extends FlutterCommand {
         'project-root',
         hide: !verboseHelp,
         help: 'Normally used only in run target',
-      )..addFlag(
-        'preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
       )..addFlag('machine',
           hide: !verboseHelp,
           negatable: false,
@@ -124,7 +119,7 @@ class AttachCommand extends FlutterCommand {
       final FlutterDevice flutterDevice = new FlutterDevice(
         device,
         trackWidgetCreation: false,
-        previewDart2: argResults['preview-dart-2'],
+        previewDart2: true,
         dillOutputPath: argResults['output-dill'],
         fileSystemRoots: argResults['filesystem-root'],
         fileSystemScheme: argResults['filesystem-scheme'],

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -19,8 +19,8 @@ import 'build_ios.dart';
 class BuildCommand extends FlutterCommand {
   BuildCommand({bool verboseHelp = false}) {
     addSubcommand(new BuildApkCommand(verboseHelp: verboseHelp));
-    addSubcommand(new BuildAotCommand(verboseHelp: verboseHelp));
-    addSubcommand(new BuildIOSCommand(verboseHelp: verboseHelp));
+    addSubcommand(new BuildAotCommand());
+    addSubcommand(new BuildIOSCommand());
     addSubcommand(new BuildFlxCommand());
     addSubcommand(new BuildBundleCommand(verboseHelp: verboseHelp));
   }

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -17,7 +17,7 @@ import '../runner/flutter_command.dart';
 import 'build.dart';
 
 class BuildAotCommand extends BuildSubCommand {
-  BuildAotCommand({bool verboseHelp = false}) {
+  BuildAotCommand() {
     usesTargetOption();
     addBuildModeFlags();
     usesPubOption();
@@ -28,11 +28,6 @@ class BuildAotCommand extends BuildSubCommand {
         allowed: <String>['android-arm', 'android-arm64', 'ios']
       )
       ..addFlag('quiet', defaultsTo: false)
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
-      )
       ..addFlag('build-shared-library',
         negatable: false,
         defaultsTo: false,
@@ -81,23 +76,20 @@ class BuildAotCommand extends BuildSubCommand {
     }
     final String outputPath = argResults['output-dir'] ?? getAotBuildDirectory();
     try {
-      final bool previewDart2 = argResults['preview-dart-2'];
       String mainPath = findMainDartFile(targetFile);
       final AOTSnapshotter snapshotter = new AOTSnapshotter();
 
-      // Compile to kernel, if Dart 2.
-      if (previewDart2) {
-        mainPath = await snapshotter.compileKernel(
-          platform: platform,
-          buildMode: buildMode,
-          mainPath: mainPath,
-          outputPath: outputPath,
-          extraFrontEndOptions: argResults[FlutterOptions.kExtraFrontEndOptions],
-        );
-        if (mainPath == null) {
-          throwToolExit('Compiler terminated unexpectedly.');
-          return;
-        }
+      // Compile to kernel.
+      mainPath = await snapshotter.compileKernel(
+        platform: platform,
+        buildMode: buildMode,
+        mainPath: mainPath,
+        outputPath: outputPath,
+        extraFrontEndOptions: argResults[FlutterOptions.kExtraFrontEndOptions],
+      );
+      if (mainPath == null) {
+        throwToolExit('Compiler terminated unexpectedly.');
+        return;
       }
 
       // Build AOT snapshot.
@@ -118,7 +110,7 @@ class BuildAotCommand extends BuildSubCommand {
             mainPath: mainPath,
             packagesPath: PackageMap.globalPackagesPath,
             outputPath: outputPath,
-            previewDart2: previewDart2,
+            previewDart2: true,
             buildSharedLibrary: false,
             extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
           ).then((int buildExitCode) {
@@ -149,7 +141,7 @@ class BuildAotCommand extends BuildSubCommand {
           mainPath: mainPath,
           packagesPath: PackageMap.globalPackagesPath,
           outputPath: outputPath,
-          previewDart2: previewDart2,
+          previewDart2: true,
           buildSharedLibrary: argResults['build-shared-library'],
           extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
         );

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -18,11 +18,6 @@ class BuildApkCommand extends BuildSubCommand {
     usesBuildNameOption();
 
     argParser
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
-      )
       ..addFlag('track-widget-creation', negatable: false, hide: !verboseHelp)
       ..addFlag('build-shared-library',
         negatable: false,

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -25,11 +25,6 @@ class BuildBundleCommand extends BuildSubCommand {
       ..addOption('snapshot', defaultsTo: defaultSnapshotPath)
       ..addOption('depfile', defaultsTo: defaultDepfilePath)
       ..addOption('kernel-file', defaultsTo: defaultApplicationKernelPath)
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
-      )
       ..addOption('target-platform',
         defaultsTo: 'android-arm',
         allowed: <String>['android-arm', 'android-arm64', 'ios']
@@ -95,7 +90,7 @@ class BuildBundleCommand extends BuildSubCommand {
       depfilePath: argResults['depfile'],
       privateKeyPath: argResults['private-key'],
       assetDirPath: argResults['asset-dir'],
-      previewDart2: argResults['preview-dart-2'],
+      previewDart2: true,
       precompiledSnapshot: argResults['precompiled'],
       reportLicensedPackages: argResults['report-licensed-packages'],
       trackWidgetCreation: argResults['track-widget-creation'],

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -13,7 +13,7 @@ import '../ios/mac.dart';
 import 'build.dart';
 
 class BuildIOSCommand extends BuildSubCommand {
-  BuildIOSCommand({bool verboseHelp = false}) {
+  BuildIOSCommand() {
     usesTargetOption();
     usesFlavorOption();
     usesPubOption();
@@ -38,11 +38,7 @@ class BuildIOSCommand extends BuildSubCommand {
       ..addFlag('codesign',
         defaultsTo: true,
         help: 'Codesign the application bundle (only available on device builds).',
-      )
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.');
+      );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -62,10 +62,7 @@ class DriveCommand extends RunCommandBase {
               'just before the extension, so e.g. if the target is "lib/main.dart", the\n'
               'driver will be "test_driver/main_test.dart".',
         valueHelp: 'path',
-      )
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        help: 'Preview Dart 2.0 functionality.');
+      );
   }
 
   @override
@@ -123,7 +120,7 @@ class DriveCommand extends RunCommandBase {
     Cache.releaseLockEarly();
 
     try {
-      await testRunner(<String>[testFile], observatoryUri, argResults['preview-dart-2']);
+      await testRunner(<String>[testFile], observatoryUri);
     } catch (error, stackTrace) {
       if (error is ToolExit)
         rethrow;
@@ -275,24 +272,20 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
 }
 
 /// Runs driver tests.
-typedef Future<Null> TestRunner(List<String> testArgs, String observatoryUri, bool previewDart2);
+typedef Future<Null> TestRunner(List<String> testArgs, String observatoryUri);
 TestRunner testRunner = _runTests;
 void restoreTestRunner() {
   testRunner = _runTests;
 }
 
-Future<Null> _runTests(List<String> testArgs, String observatoryUri, bool previewDart2) async {
+Future<Null> _runTests(List<String> testArgs, String observatoryUri) async {
   printTrace('Running driver tests.');
 
   PackageMap.globalPackagesPath = fs.path.normalize(fs.path.absolute(PackageMap.globalPackagesPath));
   final List<String> args = testArgs.toList()
     ..add('--packages=${PackageMap.globalPackagesPath}')
-    ..add('-rexpanded');
-  if (previewDart2) {
-    args.add('--preview-dart-2');
-  } else {
-    args.add('--no-preview-dart-2');
-  }
+    ..add('-rexpanded')
+    ..add('--preview-dart-2');
 
   final String dartVmPath = fs.path.join(dartSdkPath, 'bin', 'dart');
   final int result = await runCommandAndStreamOutput(

--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -53,10 +53,6 @@ class FuchsiaReloadCommand extends FlutterCommand {
     argParser.addOption('name-override',
       abbr: 'n',
       help: 'On-device name of the application binary.');
-    argParser.addFlag('preview-dart-2',
-      abbr: '2',
-      defaultsTo: false,
-      help: 'Preview Dart 2.0 functionality.');
     argParser.addOption('target',
       abbr: 't',
       defaultsTo: bundle.defaultMainPath,
@@ -137,7 +133,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
       final FlutterDevice flutterDevice = new FlutterDevice(
         device,
         trackWidgetCreation: false,
-        previewDart2: false,
+        previewDart2: true,
       );
       flutterDevice.observatoryUris = observatoryUris;
       final HotRunner hotRunner = new HotRunner(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -120,11 +120,6 @@ class RunCommand extends RunCommandBase {
         hide: !verboseHelp,
         help: 'Specify a pre-built application binary to use when running.',
       )
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
-      )
       ..addOption('precompile',
         hide: !verboseHelp,
         help: 'Precompile functions specified in input file. This flag is only\n'
@@ -344,7 +339,7 @@ class RunCommand extends RunCommandBase {
     final List<FlutterDevice> flutterDevices = devices.map((Device device) {
       return new FlutterDevice(
         device,
-        previewDart2: argResults['preview-dart-2'],
+        previewDart2: true,
         trackWidgetCreation: argResults['track-widget-creation'],
         dillOutputPath: argResults['output-dill'],
         fileSystemRoots: argResults['filesystem-root'],

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -64,11 +64,6 @@ class TestCommand extends FlutterCommand {
         help: 'Handle machine structured JSON command input\n'
               'and provide output and progress in machine friendly format.',
       )
-      ..addFlag('preview-dart-2',
-        defaultsTo: true,
-        hide: !verboseHelp,
-        help: 'Preview Dart 2.0 functionality.',
-      )
       ..addFlag('track-widget-creation',
         negatable: false,
         hide: !verboseHelp,
@@ -172,7 +167,7 @@ class TestCommand extends FlutterCommand {
       startPaused: startPaused,
       ipv6: argResults['ipv6'],
       machine: machine,
-      previewDart2: argResults['preview-dart-2'],
+      previewDart2: true,
       trackWidgetCreation: argResults['track-widget-creation'],
       updateGoldens: argResults['update-goldens'],
       concurrency: jobs,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -470,10 +470,9 @@ class DevFS {
       String archivePath;
       if (deviceUri.path.startsWith(assetBuildDirPrefix))
         archivePath = deviceUri.path.substring(assetBuildDirPrefix.length);
-      // When doing full restart in preview-dart-2 mode, copy content so
-      // that isModified does not reset last check timestamp because we
-      // want to report all modified files to incremental compiler next time
-      // user does hot reload.
+      // When doing full restart, copy content so that isModified does not
+      // reset last check timestamp because we want to report all modified
+      // files to incremental compiler next time user does hot reload.
       if (content.isModified || ((bundleDirty || bundleFirstUpload) && archivePath != null)) {
         dirtyEntries[deviceUri] = content;
         numBytes += content.size;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -416,7 +416,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       outputDir = expectedOutputDirectory.replaceFirst('/$configuration-', '/');
       if (fs.isDirectorySync(outputDir)) {
         // Previous output directory might have incompatible artifacts
-        // (for example, kernel binary files produced from previous `--preview-dart-2` run).
+        // (for example, kernel binary files produced from previous run).
         fs.directory(outputDir).deleteSync(recursive: true);
       }
       copyDirectorySync(fs.directory(expectedOutputDirectory), fs.directory(outputDir));

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -215,10 +215,6 @@ abstract class FlutterCommand extends Command<Null> {
   }
 
   BuildInfo getBuildInfo() {
-    final bool previewDart2 = argParser.options.containsKey('preview-dart-2')
-        ? argResults['preview-dart-2']
-        : true;
-
     TargetPlatform targetPlatform;
     if (argParser.options.containsKey('target-platform') &&
         argResults['target-platform'] != 'default') {
@@ -228,10 +224,6 @@ abstract class FlutterCommand extends Command<Null> {
     final bool trackWidgetCreation = argParser.options.containsKey('track-widget-creation')
         ? argResults['track-widget-creation']
         : false;
-    if (trackWidgetCreation == true && previewDart2 == false) {
-      throw new UsageException(
-          '--track-widget-creation is valid only when --preview-dart-2 is specified.', null);
-    }
 
     int buildNumber;
     try {
@@ -247,7 +239,7 @@ abstract class FlutterCommand extends Command<Null> {
       argParser.options.containsKey('flavor')
         ? argResults['flavor']
         : null,
-      previewDart2: previewDart2,
+      previewDart2: true,
       trackWidgetCreation: trackWidgetCreation,
       compilationTraceFilePath: argParser.options.containsKey('precompile')
           ? argResults['precompile']

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -67,7 +67,7 @@ void installHook({
   bool enableObservatory = false,
   bool machine = false,
   bool startPaused = false,
-  bool previewDart2 = false,
+  bool previewDart2 = true,
   int port = 0,
   String precompiledDillPath,
   bool trackWidgetCreation = false,
@@ -425,7 +425,7 @@ class _FlutterPlatform extends PlatformPlugin {
         cancelOnError: true,
       );
 
-      printTrace('test $ourTestCount: starting shell process${previewDart2? " in preview-dart-2 mode":""}');
+      printTrace('test $ourTestCount: starting shell process');
 
       // [precompiledDillPath] can be set only if [previewDart2] is [true].
       assert(precompiledDillPath == null || previewDart2);

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -29,7 +29,7 @@ Future<int> runTests(
   bool startPaused = false,
   bool ipv6 = false,
   bool machine = false,
-  bool previewDart2 = false,
+  bool previewDart2 = true,
   String precompiledDillPath,
   bool trackWidgetCreation = false,
   bool updateGoldens = false,
@@ -38,7 +38,7 @@ Future<int> runTests(
 }) async {
   if (trackWidgetCreation && !previewDart2) {
     throw new UsageException(
-      '--track-widget-creation is valid only when --preview-dart-2 is specified.',
+      '--track-widget-creation is valid only when previewDart2 is specified.',
       null,
     );
   }

--- a/packages/flutter_tools/test/commands/drive_test.dart
+++ b/packages/flutter_tools/test/commands/drive_test.dart
@@ -53,7 +53,7 @@ void main() {
       appStarter = (DriveCommand command) {
         throw 'Unexpected call to appStarter';
       };
-      testRunner = (List<String> testArgs, String observatoryUri, bool previewDart2) {
+      testRunner = (List<String> testArgs, String observatoryUri) {
         throw 'Unexpected call to testRunner';
       };
       appStopper = (DriveCommand command) {
@@ -169,7 +169,7 @@ void main() {
       appStarter = expectAsync1((DriveCommand command) async {
         return new LaunchResult.succeeded();
       });
-      testRunner = expectAsync3((List<String> testArgs, String observatoryUri, bool previewDart2) async {
+      testRunner = expectAsync2((List<String> testArgs, String observatoryUri) async {
         expect(testArgs, <String>[testFile]);
         return null;
       });
@@ -200,7 +200,7 @@ void main() {
       appStarter = expectAsync1((DriveCommand command) async {
         return new LaunchResult.succeeded();
       });
-      testRunner = (List<String> testArgs, String observatoryUri, bool previewDart2) async {
+      testRunner = (List<String> testArgs, String observatoryUri) async {
         throwToolExit(null, exitCode: 123);
       };
       appStopper = expectAsync1((DriveCommand command) async {

--- a/packages/flutter_tools/test/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/ios/xcodeproj_test.dart
@@ -407,7 +407,7 @@ Information about project "Runner":
       await updateGeneratedXcodeProperties(
         project: await FlutterProject.fromPath('path/to/project'),
         buildInfo: buildInfo,
-        previewDart2: false,
+        previewDart2: true,
       );
 
       final File localPropertiesFile = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');


### PR DESCRIPTION
This patch eliminates the --preview-dart-2/--no-preview-dart-2 flag,
hardcoding all uses to true. It also defaults all previewDart2 method
parameters to true, where they hadn't yet been.

A series of subsequent patches will eliminate all previewDart2
parameters and the associated code from within the codebase.