### PR TITLE
change expand icon to use default icon colors

### DIFF
--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -327,7 +327,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [Typography.white], which uses this color for its text styles.
+  ///  * [ExpandIcon], which uses this color for dark themes.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
   ///  * [white, white30, white12, white10], which are variants on this color

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -321,6 +321,19 @@ class Colors {
   ///    but with different opacities.
   static const Color white70 = Color(0xB3FFFFFF);
 
+  /// White with 54% opacity.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
+  ///
+  /// See also:
+  ///
+  ///  * [Typography.white], which uses this color for its text styles.
+  ///  * [Theme.of], which allows you to select colors from the current theme
+  ///    rather than hard-coding colors in your build methods.
+  ///  * [white, white30, white12, white10], which are variants on this color
+  ///    but with different opacities.
+  static const Color white54 = Color(0x8AFFFFFF);
+
   /// White with 32% opacity.
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in dark themes.

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -116,7 +116,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       onTapHint: widget.onPressed == null ? null : onTapHint,
       child: new IconButton(
         padding: widget.padding,
-        color: Colors.black38,
+//        color: Colors.black38,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: new RotationTransition(
           turns: _iconTurns,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -5,7 +5,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
-import 'colors.dart';
 import 'debug.dart';
 import 'icon_button.dart';
 import 'icons.dart';

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -116,7 +116,6 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       onTapHint: widget.onPressed == null ? null : onTapHint,
       child: new IconButton(
         padding: widget.padding,
-//        color: Colors.black38,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: new RotationTransition(
           turns: _iconTurns,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -110,13 +110,14 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final ThemeData theme = Theme.of(context);
     final String onTapHint = widget.isExpanded ? localizations.expandedIconTapHint : localizations.collapsedIconTapHint;
 
     return new Semantics(
       onTapHint: widget.onPressed == null ? null : onTapHint,
       child: new IconButton(
         padding: widget.padding,
-//        color: Colors.black38,
+        color: theme.brightness == Brightness.dark ? Colors.white54 : Colors.black54,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: new RotationTransition(
           turns: _iconTurns,


### PR DESCRIPTION
Previously expand icon unconditionally used black38, which is problematic for dark themes. Instead we should just use the theme defaults.

~~Since the default is significantly darker than the old icon, we should discuss whether we want to add a workaround to restore the previous color black38 when using light themes.~~

Fixed to use black54/white54

Fixes https://github.com/flutter/flutter/issues/18992

<img width="250" src="https://user-images.githubusercontent.com/8975114/45173364-d3ca0400-b1bc-11e8-8299-f8266ffc9a92.png"><img width="250" src="https://user-images.githubusercontent.com/8975114/45173366-d4fb3100-b1bc-11e8-9d1a-bacac71d43f2.png">

