### PR TITLE
Unskip passing tests on Windows + add a new failing test with GH reference

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -110,5 +110,6 @@ void main() {
     });
     // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
     // https://github.com/flutter/flutter/issues/17833.
+    // https://github.com/flutter/flutter/issues/21348.
   }, timeout: const Timeout.factor(6), skip: platform.isWindows);
 }

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -13,7 +13,7 @@ import 'test_data/basic_project.dart';
 import 'test_driver.dart';
 
 void main() {
-  group('hot reload', () {
+  group('hot', () {
     Directory tempDir;
     final BasicProject _project = new BasicProject();
     FlutterTestDriver _flutter;
@@ -29,12 +29,19 @@ void main() {
       tryToDelete(tempDir);
     });
 
-    test('works without error', () async {
+    test('reload works without error', () async {
       await _flutter.run();
       await _flutter.hotReload();
     });
 
-    test('hits breakpoints with file:// prefixes after reload', () async {
+    test('restart works without error', () async {
+      await _flutter.run();
+      await _flutter.hotRestart();
+      // TODO(dantup): Unskip after flutter-tester restart issue is fixed on Windows:
+      // https://github.com/flutter/flutter/issues/21348.
+    }, skip: platform.isWindows);
+
+    test('reload hits breakpoints with file:// prefixes after reload', () async {
       await _flutter.run(withDebugger: true);
 
       // Hit breakpoint using a file:// URI.

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -45,7 +45,5 @@ void main() {
       await new Future<void>.delayed(requiredLifespan);
       expect(_flutter.hasExited, equals(false));
     });
-    // TODO(dantup): Unskip after flutter-tester is fixed on Windows:
-    // https://github.com/flutter/flutter/issues/17833.
-  }, timeout: const Timeout.factor(6), skip: platform.isWindows);
+  }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 
 import '../src/common.dart';
 import 'test_data/basic_project.dart';


### PR DESCRIPTION
The lifetime_test passes on Windows since @aam's recent changes. However, I found an issue with hot-restart so I've added a test (we only had hot reload) and marked skip on Windows with a reference to the new GH issue.