### PR TITLE
Eliminate BuildInfo.previewDart2 (now always true)

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -11,7 +11,6 @@ import 'globals.dart';
 /// Information about a build to be performed or used.
 class BuildInfo {
   const BuildInfo(this.mode, this.flavor, {
-    this.previewDart2 = true,
     this.trackWidgetCreation = false,
     this.compilationTraceFilePath,
     this.extraFrontEndOptions,
@@ -33,9 +32,6 @@ class BuildInfo {
   /// `assemblePaidRelease`), and the Xcode build configuration will be
   /// Mode-Flavor (e.g. Release-Paid).
   final String flavor;
-
-  /// Whether build should be done using Dart2 Frontend parser.
-  final bool previewDart2;
 
   final List<String> fileSystemRoots;
   final String fileSystemScheme;
@@ -99,7 +95,6 @@ class BuildInfo {
 
   BuildInfo withTargetPlatform(TargetPlatform targetPlatform) =>
       new BuildInfo(mode, flavor,
-          previewDart2: previewDart2,
           trackWidgetCreation: trackWidgetCreation,
           compilationTraceFilePath: compilationTraceFilePath,
           extraFrontEndOptions: extraFrontEndOptions,

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -344,7 +344,7 @@ class AppDomain extends Domain {
 
     final FlutterDevice flutterDevice = new FlutterDevice(
       device,
-      previewDart2: options.buildInfo.previewDart2,
+      previewDart2: true,
       trackWidgetCreation: trackWidgetCreation,
       dillOutputPath: dillOutputPath,
     );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -236,7 +236,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   await updateGeneratedXcodeProperties(
     project: project,
     targetOverride: targetOverride,
-    previewDart2: buildInfo.previewDart2,
+    previewDart2: true,
     buildInfo: buildInfo,
   );
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -358,7 +358,6 @@ class IOSSimulator extends Device {
     // The build mode for the simulator is always debug.
 
     final BuildInfo debugBuildInfo = new BuildInfo(BuildMode.debug, buildInfo.flavor,
-        previewDart2: buildInfo.previewDart2,
         trackWidgetCreation: buildInfo.trackWidgetCreation,
         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
         extraGenSnapshotOptions: buildInfo.extraGenSnapshotOptions,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -453,10 +453,7 @@ abstract class ResidentRunner {
   String get projectRootPath => _projectRootPath;
   String _mainPath;
   String get mainPath => _mainPath;
-  String getReloadPath({bool fullRestart}) =>
-      debuggingOptions.buildInfo.previewDart2
-          ? mainPath + (fullRestart? '' : '.incremental') + '.dill'
-          : mainPath;
+  String getReloadPath({bool fullRestart}) => mainPath + (fullRestart ? '' : '.incremental') + '.dill';
   AssetBundle _assetBundle;
   AssetBundle get assetBundle => _assetBundle;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -239,7 +239,6 @@ abstract class FlutterCommand extends Command<Null> {
       argParser.options.containsKey('flavor')
         ? argResults['flavor']
         : null,
-      previewDart2: true,
       trackWidgetCreation: trackWidgetCreation,
       compilationTraceFilePath: argParser.options.containsKey('precompile')
           ? argResults['precompile']

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -136,15 +136,11 @@ class FlutterTesterDevice extends Device {
       precompiledSnapshot: false,
       trackWidgetCreation: buildInfo.trackWidgetCreation,
     );
-    if (buildInfo.previewDart2) {
-      mainPath = applicationKernelFilePath;
-    }
-
     command.add('--flutter-assets-dir=$assetDirPath');
 
     // TODO(scheglov): Either remove the check, or make it fail earlier.
-    if (mainPath != null) {
-      command.add(mainPath);
+    if (applicationKernelFilePath != null) {
+      command.add(applicationKernelFilePath);
     }
 
     try {

--- a/packages/flutter_tools/test/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/ios/xcodeproj_test.dart
@@ -285,10 +285,7 @@ Information about project "Runner":
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, any)).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
-      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null,
-        previewDart2: true,
-        targetPlatform: TargetPlatform.ios,
-      );
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
       final FlutterProject project = await FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
@@ -306,11 +303,7 @@ Information about project "Runner":
     testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, any)).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
-      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null,
-        previewDart2: true,
-        trackWidgetCreation: true,
-        targetPlatform: TargetPlatform.ios,
-      );
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, targetPlatform: TargetPlatform.ios);
       final FlutterProject project = await FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
@@ -328,10 +321,7 @@ Information about project "Runner":
     testUsingOsxContext('does not set TRACK_WIDGET_CREATION when trackWidgetCreation is false', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, any)).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
-      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null,
-        previewDart2: true,
-        targetPlatform: TargetPlatform.ios,
-      );
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
       final FlutterProject project = await FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
@@ -349,10 +339,7 @@ Information about project "Runner":
     testUsingOsxContext('sets ARCHS=armv7 when armv7 local engine is set', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, any)).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
-      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null,
-        previewDart2: true,
-        targetPlatform: TargetPlatform.ios,
-      );
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
 
       final FlutterProject project = await FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -140,8 +140,7 @@ void main() {
       testUsingContext('not debug', () async {
         final LaunchResult result = await device.startApp(null,
             mainPath: mainPath,
-            debuggingOptions: new DebuggingOptions.disabled(
-                const BuildInfo(BuildMode.release, null, previewDart2: true)));
+            debuggingOptions: new DebuggingOptions.disabled(const BuildInfo(BuildMode.release, null)));
         expect(result.started, isFalse);
       }, overrides: startOverrides);
 
@@ -150,8 +149,7 @@ void main() {
         expect(() async {
           await device.startApp(null,
               mainPath: mainPath,
-              debuggingOptions: new DebuggingOptions.disabled(
-                  const BuildInfo(BuildMode.debug, null, previewDart2: true)));
+              debuggingOptions: new DebuggingOptions.disabled(const BuildInfo(BuildMode.debug, null)));
         }, throwsToolExit());
       }, overrides: startOverrides);
 
@@ -184,8 +182,7 @@ Hello!
 
         final LaunchResult result = await device.startApp(null,
             mainPath: mainPath,
-            debuggingOptions: new DebuggingOptions.enabled(
-                const BuildInfo(BuildMode.debug, null, previewDart2: true)));
+            debuggingOptions: new DebuggingOptions.enabled(const BuildInfo(BuildMode.debug, null)));
         expect(result.started, isTrue);
         expect(result.observatoryUri, observatoryUri);
 


### PR DESCRIPTION
Dart 1 is no longer supported in Flutter.