### PR TITLE
fixed imported parkage in projectName_test.dart.tmpl

### DIFF
--- a/packages/flutter_tools/templates/package/test/projectName_test.dart.tmpl
+++ b/packages/flutter_tools/templates/package/test/projectName_test.dart.tmpl
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:{{projectName}}/{{projectName}}.dart';
 


### PR DESCRIPTION
When I tried to create a new package, the error was occurred.

  ## Steps to Reproduce
  1. `$ flutter create --template=package <package_name>`
  2. `$ cd <path_to_package>`
  3. `$ flutter package pub publish -n`
  4. print the following log 
  ```
  Suggestions:
* line 2, column 1 of test/<package_name>_test.dart: This package doesn't depend on test.
  import 'package:test/test.dart';
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ```