### PR TITLE
[Material] Corrects default inactive switch track color

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -155,7 +155,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
     Color inactiveThumbColor;
     Color inactiveTrackColor;
     if (widget.onChanged != null) {
-      const Color black32 = Color(0x20000000); // Black with 32% opacity
+      const Color black32 = Color(0x52000000); // Black with 32% opacity
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade400 : Colors.grey.shade50);
       inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white30 : black32);
     } else {

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -155,8 +155,9 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
     Color inactiveThumbColor;
     Color inactiveTrackColor;
     if (widget.onChanged != null) {
+      const Color black32 = Color(0x20000000); // Black with 32% opacity
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade400 : Colors.grey.shade50);
-      inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white30 : const Color(0x20000000));
+      inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white30 : black32);
     } else {
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade800 : Colors.grey.shade400);
       inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white10 : Colors.black12);

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -156,7 +156,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
     Color inactiveTrackColor;
     if (widget.onChanged != null) {
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade400 : Colors.grey.shade50);
-      inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white30 : Colors.black26);
+      inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white30 : const Color(0x20000000));
     } else {
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade800 : Colors.grey.shade400);
       inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white10 : Colors.black12);

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -201,7 +201,7 @@ void main() {
         Material.of(tester.element(find.byType(Switch))),
         paints
           ..rrect(
-              color: const Color(0x20000000), // Black with 32% opacity
+              color: const Color(0x52000000), // Black with 32% opacity
               rrect: new RRect.fromLTRBR(
                   383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
           ..circle(color: const Color(0x33000000))

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -173,6 +173,127 @@ void main() {
     expect(value, isFalse);
   });
 
+  testWidgets('Switch has default colors when enabled', (WidgetTester tester) async {
+    bool value = false;
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.rtl,
+        child: new StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return new Material(
+              child: new Center(
+                child: new Switch(
+                  value: value,
+                  onChanged: (bool newValue) {
+                    setState(() {
+                      value = newValue;
+                    });
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(
+        Material.of(tester.element(find.byType(Switch))),
+        paints
+          ..rrect(
+              color: const Color(0x20000000), // Black with 32% opacity
+              rrect: new RRect.fromLTRBR(
+                  383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+          ..circle(color: const Color(0x33000000))
+          ..circle(color: const Color(0x24000000))
+          ..circle(color: const Color(0x1f000000))
+          ..circle(color: Colors.grey.shade50),
+      reason: 'Inactive enabled switch should match these colors',
+    );
+    await tester.drag(find.byType(Switch), const Offset(-30.0, 0.0));
+    await tester.pump();
+
+    expect(
+        Material.of(tester.element(find.byType(Switch))),
+        paints
+          ..rrect(
+              color: Colors.blue[600].withAlpha(0x80),
+              rrect: new RRect.fromLTRBR(
+                  383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+          ..circle(color: const Color(0x33000000))
+          ..circle(color: const Color(0x24000000))
+          ..circle(color: const Color(0x1f000000))
+          ..circle(color: Colors.blue[600]),
+      reason: 'Active enabled switch should match these colors',
+    );
+  });
+
+  testWidgets('Switch has default colors when disabled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.rtl,
+        child: new StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return const Material(
+              child: Center(
+                child: Switch(
+                  value: false,
+                  onChanged: null,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: Colors.black12,
+            rrect: new RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: Colors.grey.shade400),
+      reason: 'Inactive disabled switch should match these colors',
+    );
+
+    await tester.pumpWidget(
+      new Directionality(
+        textDirection: TextDirection.rtl,
+        child: new StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return const Material(
+              child: Center(
+                child: Switch(
+                  value: true,
+                  onChanged: null,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: Colors.black12,
+            rrect: new RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: Colors.grey.shade400),
+      reason: 'Active disabled switch should match these colors',
+    );
+  });
+
   testWidgets('Switch can be set color', (WidgetTester tester) async {
     bool value = false;
     await tester.pumpWidget(


### PR DESCRIPTION
Makes track 32% black when not selected.

Before:
![simulator screen shot - iphone 7 - 2018-09-04 at 20 36 43](https://user-images.githubusercontent.com/1271525/45112350-5bf4ce80-b115-11e8-80c0-6b0c4bbeef14.png)

After (slightly darker track):
![simulator screen shot - iphone 7 - 2018-09-04 at 20 36 32](https://user-images.githubusercontent.com/1271525/45112347-5a2b0b00-b115-11e8-952c-902d239a726c.png)
