### PR TITLE
Fix windows crash running `flutter run` which tries to find Xcode

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -70,7 +70,15 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
 
   @override
   List<Workflow> get workflows {
-    _workflows ??= <Workflow>[iosWorkflow, androidWorkflow];
+    if (_workflows == null) {
+      _workflows = <Workflow>[];
+
+      if (iosWorkflow.appliesToHostPlatform)
+        _workflows.add(iosWorkflow);
+
+      if (androidWorkflow.appliesToHostPlatform)
+        _workflows.add(androidWorkflow);
+    }
     return _workflows;
   }
 

--- a/packages/flutter_tools/test/integration/flutter_run.dart
+++ b/packages/flutter_tools/test/integration/flutter_run.dart
@@ -1,0 +1,44 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:process/process.dart';
+
+import '../src/common.dart';
+import 'test_data/basic_project.dart';
+
+void main() {
+  group('flutter_run', () {
+    Directory tempDir;
+    final BasicProject _project = new BasicProject();
+
+    setUp(() async {
+      tempDir = fs.systemTempDirectory.createTempSync('flutter_run_integration_test.');
+      await _project.setUpIn(tempDir);
+    });
+
+    tearDown(() async {
+      tryToDelete(tempDir);
+    });
+    test('reports an error if an invalid device is supplied', () async {
+      // This test forces flutter to check for all possible devices to catch issues
+      // like https://github.com/flutter/flutter/issues/21418 which were skipped
+      // over because other integration tesst run using flutter-tester which short-cuts
+      // some of the checks for devices.
+      final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+
+      const ProcessManager _processManager = LocalProcessManager();
+      final ProcessResult _proc = await _processManager.run(
+        <String>[flutterBin, 'run', '-d', 'invalid-device-id'],
+        workingDirectory: tempDir.path
+      );
+
+      expect(_proc.stdout, isNot(contains('flutter has exited unexpectedly')));
+      expect(_proc.stderr, isNot(contains('flutter has exited unexpectedly')));
+      expect(_proc.stderr, contains('Unable to locate a development'));
+    });
+  }, timeout: const Timeout.factor(6));
+}


### PR DESCRIPTION
This fixes #21418 which is a crash on Windows caused by trying to look for Xcode. It came in with #20758 which lost some platform filters on workflows.

It also adds an integration test that runs `flutter run` with an invalid `deviceId` to ensure that this code is exercised during builds (checking for devices is short-cut when we pass `flutter-tester`).