### PR TITLE
Move asset_bundle_variant_test to MemoryFileSystem to avoid setting fs.currentDirectory in tests

### DIFF
--- a/packages/flutter_tools/test/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_variant_test.dart
@@ -5,36 +5,43 @@
 import 'dart:convert';
 
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 
 import 'src/common.dart';
 import 'src/context.dart';
+import 'src/pubspec_schema.dart';
 
 void main() {
-  // These tests do not use a memory file system because we want to ensure that
-  // asset bundles work correctly on Windows and Posix systems.
-  Directory tempDir;
-  Directory oldCurrentDir;
-
-  setUp(() async {
-    tempDir = fs.systemTempDirectory.createTempSync('flutter_asset_bundle_variant_test.');
-    oldCurrentDir = fs.currentDirectory;
-    fs.currentDirectory = tempDir;
-  });
-
-  tearDown(() {
-    fs.currentDirectory = oldCurrentDir;
-    tryToDelete(tempDir);
-  });
+  String fixPath(String path) {
+    // The in-memory file system is strict about slashes on Windows being the
+    // correct way so until https://github.com/google/file.dart/issues/112 is
+    // fixed we fix them here.
+    // TODO(dantup): Remove this function once the above issue is fixed and
+    // rolls into Flutter.
+    return path?.replaceAll('/', fs.path.separator);
+  }
 
   group('AssetBundle asset variants', () {
+    FileSystem testFileSystem;
+    setUp(() async {
+      testFileSystem = new MemoryFileSystem(
+        style: platform.isWindows
+          ? FileSystemStyle.windows
+          : FileSystemStyle.posix,
+      );
+      testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_variant_test.');
+    });
+
     testUsingContext('main asset and variants', () async {
       // Setting flutterRoot here so that it picks up the MemoryFileSystem's
       // path separator.
       Cache.flutterRoot = getFlutterRoot();
+      writeEmptySchemaFile(fs);
 
       fs.file('pubspec.yaml')
         ..createSync()
@@ -58,7 +65,7 @@ flutter:
         'a/b/c/var3/foo',
       ];
       for (String asset in assets) {
-        fs.file(asset)
+        fs.file(fixPath(asset))
           ..createSync(recursive: true)
           ..writeAsStringSync(asset);
       }
@@ -72,7 +79,7 @@ flutter:
         expect(utf8.decode(await bundle.entries[asset].contentsAsBytes()), asset);
       }
 
-      fs.file('a/b/c/foo').deleteSync();
+      fs.file(fixPath('a/b/c/foo')).deleteSync();
       bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
 
@@ -83,7 +90,8 @@ flutter:
         expect(bundle.entries.containsKey(asset), true);
         expect(utf8.decode(await bundle.entries[asset].contentsAsBytes()), asset);
       }
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
     });
-
   });
 }


### PR DESCRIPTION
More work towards #21113. This makes the same changes I made to other asset tests to use the MemoryFileSystem with the style of the platform running the tests (this mirrors the behaviour when running on the real filesystem).

There's a temporary `fixPath` method to fix slash direction while the MemoryFileSystem doesn't handle them correctly (this exists in a few tests - I kept it local to avoid polluting other files, but I hope it's short-lived).