### PR TITLE
Revert "Allow FlutterTester to be provided with the working directory for execution"

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -41,9 +41,8 @@ class FlutterTesterApp extends ApplicationPackage {
 
 // TODO(scheglov): This device does not currently work with full restarts.
 class FlutterTesterDevice extends Device {
-  FlutterTesterDevice(String deviceId, { this.workingDirectory }) : super(deviceId);
+  FlutterTesterDevice(String deviceId) : super(deviceId);
 
-  final String workingDirectory;
   Process _process;
   final DevicePortForwarder _portForwarder = new _NoopPortForwarder();
 
@@ -152,7 +151,6 @@ class FlutterTesterDevice extends Device {
         environment: <String, String>{
           'FLUTTER_TEST': 'true',
         },
-        workingDirectory: workingDirectory,
       );
       // Setting a bool can't fail in the callback.
       _process.exitCode.then((_) => _isRunning = false); // ignore: unawaited_futures

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -15,18 +15,25 @@ import '../src/context.dart';
 import 'test_utils.dart';
 
 void main() {
+  Directory tempDir;
+  Directory oldCurrentDir;
+
+  setUp(() async {
+    tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
+    oldCurrentDir = fs.currentDirectory;
+    fs.currentDirectory = tempDir;
+  });
+
+  tearDown(() {
+    fs.currentDirectory = oldCurrentDir;
+    tryToDelete(tempDir);
+  });
 
   group('FlutterTesterDevice', () {
-    Directory tempDir;
     FlutterTesterDevice device;
 
-    setUp(() async {
-      tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
-      device = new FlutterTesterDevice('flutter-tester', workingDirectory: tempDir.path);
-    });
-
-    tearDown(() {
-      tryToDelete(tempDir);
+    setUp(() {
+      device = new FlutterTesterDevice('flutter-tester');
     });
 
     Future<LaunchResult> start(String mainPath) async {
@@ -43,7 +50,7 @@ void main() {
       writePubspec(tempDir.path);
       writePackages(tempDir.path);
 
-      final String mainPath = fs.path.join(tempDir.path, 'lib', 'main.dart');
+      final String mainPath = fs.path.join('lib', 'main.dart');
       writeFile(mainPath, r'''
 import 'dart:async';
 void main() {


### PR DESCRIPTION
Reverts flutter/flutter#21119

This test timed out on Cirrus after landing, and on the re-run. Reverting while I investigate.