### PR TITLE
Do not pass --preview-dart-2 to Dart VM

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -46,7 +46,7 @@ Future<Null> main(List<String> args) async {
 
   // Analyze all the sample code in the repo
   await runCommand(dart,
-    <String>['--preview-dart-2', path.join(flutterRoot, 'dev', 'bots', 'analyze-sample-code.dart')],
+    <String>[path.join(flutterRoot, 'dev', 'bots', 'analyze-sample-code.dart')],
     workingDirectory: flutterRoot,
   );
 
@@ -66,7 +66,6 @@ Future<Null> main(List<String> args) async {
   try {
     await runCommand(dart,
       <String>[
-        '--preview-dart-2',
         path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
         '--out',
         outDir.path,
@@ -89,7 +88,6 @@ Future<Null> _verifyInternationalizations() async {
   final EvalResult genResult = await _evalCommand(
     dart,
     <String>[
-      '--preview-dart-2',
       path.join('dev', 'tools', 'gen_localizations.dart'),
     ],
     workingDirectory: flutterRoot,

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -282,14 +282,15 @@ Future<Null> _runTests(List<String> testArgs, String observatoryUri) async {
   printTrace('Running driver tests.');
 
   PackageMap.globalPackagesPath = fs.path.normalize(fs.path.absolute(PackageMap.globalPackagesPath));
-  final List<String> args = testArgs.toList()
-    ..add('--packages=${PackageMap.globalPackagesPath}')
-    ..add('-rexpanded')
-    ..add('--preview-dart-2');
-
   final String dartVmPath = fs.path.join(dartSdkPath, 'bin', 'dart');
   final int result = await runCommandAndStreamOutput(
-    <String>[dartVmPath]..addAll(dartVmFlags)..addAll(args),
+    <String>[dartVmPath]
+      ..addAll(dartVmFlags)
+      ..addAll(testArgs)
+      ..addAll(<String>[
+        '--packages=${PackageMap.globalPackagesPath}',
+        '-rexpanded',
+      ]),
     environment: <String, String>{ 'VM_SERVICE_URL': observatoryUri }
   );
   if (result != 0)


### PR DESCRIPTION
--preview-dart-2 is no longer necessary as it is now the default for the
standalone Dart VM.