### PR TITLE
Add a clipBehavior parameter to BottomAppBar.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -41,16 +41,18 @@ import 'theme.dart';
 class BottomAppBar extends StatefulWidget {
   /// Creates a bottom application bar.
   ///
-  /// The [color] and [elevation] arguments must not be null.
+  /// The [color], [elevation], and [clipBehavior] arguments must not be null.
   const BottomAppBar({
     Key key,
     this.color,
     this.elevation = 8.0,
     this.shape,
+    this.clipBehavior = Clip.none,
     this.notchMargin = 4.0,
     this.child,
   }) : assert(elevation != null),
        assert(elevation >= 0.0),
+       assert(clipBehavior != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -76,6 +78,9 @@ class BottomAppBar extends StatefulWidget {
   ///
   /// If null the bottom app bar will be rectangular with no notch.
   final NotchedShape shape;
+
+  /// {@macro flutter.widgets.Clip}
+  final Clip clipBehavior;
 
   /// The margin between the [FloatingActionButton] and the [BottomAppBar]'s
   /// notch.
@@ -109,6 +114,7 @@ class _BottomAppBarState extends State<BottomAppBar> {
       clipper: clipper,
       elevation: widget.elevation,
       color: widget.color ?? Theme.of(context).bottomAppBarColor,
+      clipBehavior: widget.clipBehavior,
       child: new Material(
         type: MaterialType.transparency,
         child: widget.child == null

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -284,6 +284,41 @@ void main() {
       const Offset(50.0, 550.0),
     );
   });
+
+  testWidgets('clipBehavior is propagated', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          bottomNavigationBar:
+              BottomAppBar(
+                child: SizedBox(height: 100.0),
+                shape: RectangularNotch(),
+                notchMargin: 0.0,
+              ),
+        ),
+      ),
+    );
+
+    PhysicalShape physicalShape = tester.widget(find.byType(PhysicalShape));
+    expect(physicalShape.clipBehavior, Clip.none);
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        home: const Scaffold(
+          bottomNavigationBar:
+          BottomAppBar(
+            child: SizedBox(height: 100.0),
+            shape: RectangularNotch(),
+            notchMargin: 0.0,
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+          ),
+        ),
+      ),
+    );
+
+    physicalShape = tester.widget(find.byType(PhysicalShape));
+    expect(physicalShape.clipBehavior, Clip.antiAliasWithSaveLayer);
+  });
 }
 
 // The bottom app bar clip path computation is only available at paint time.


### PR DESCRIPTION
Setting the default clip behavior made bottom app bar to no longer clip
its children.
With this parameter users could opt-in to clipping.

While this doesn't fix the regression mentioned in #21413, it at least allows users to fix it in their code.