### PR TITLE
fix active-tab change inCupertino

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -172,7 +172,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
                   child: new Column(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: <Widget> [
-                      new Expanded(child: new Center(child: items[index].icon)),
+                      new Expanded(child: new Center(child: active ? items[index].activeIcon : items[index].icon)),
                       items[index].title,
                     ],
                   ),


### PR DESCRIPTION
I think when we selected the tab,it should use the activeIcon ...