### PR TITLE
Reland flutter tester changes

### DIFF
--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -41,8 +41,9 @@ class FlutterTesterApp extends ApplicationPackage {
 
 // TODO(scheglov): This device does not currently work with full restarts.
 class FlutterTesterDevice extends Device {
-  FlutterTesterDevice(String deviceId) : super(deviceId);
+  FlutterTesterDevice(String deviceId, { this.workingDirectory }) : super(deviceId);
 
+  final String workingDirectory;
   Process _process;
   final DevicePortForwarder _portForwarder = new _NoopPortForwarder();
 
@@ -151,6 +152,7 @@ class FlutterTesterDevice extends Device {
         environment: <String, String>{
           'FLUTTER_TEST': 'true',
         },
+        workingDirectory: workingDirectory,
       );
       // Setting a bool can't fail in the callback.
       _process.exitCode.then((_) => _isRunning = false); // ignore: unawaited_futures

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -127,9 +127,13 @@ class FlutterTesterDevice extends Device {
     }
 
     // Build assets and perform initial compilation.
-    final String assetDirPath = getAssetBuildDirectory();
+    String inWorkingDir(String path) =>
+      workingDirectory != null && !fs.path.isAbsolute(path)
+        ? fs.path.join(workingDirectory, path)
+        : path;
+    final String assetDirPath = inWorkingDir(getAssetBuildDirectory());
     final String applicationKernelFilePath =
-        fs.path.join(getBuildDirectory(), 'flutter-tester-app.dill');
+        inWorkingDir(fs.path.join(getBuildDirectory(), 'flutter-tester-app.dill'));
     await bundle.build(
       mainPath: mainPath,
       assetDirPath: assetDirPath,

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -138,6 +138,8 @@ class FlutterTesterDevice extends Device {
       mainPath: mainPath,
       assetDirPath: assetDirPath,
       applicationKernelFilePath: applicationKernelFilePath,
+      depfilePath: inWorkingDir(bundle.defaultDepfilePath),
+      snapshotPath: inWorkingDir(bundle.defaultSnapshotPath),
       precompiledSnapshot: false,
       trackWidgetCreation: buildInfo.trackWidgetCreation,
     );

--- a/packages/flutter_tools/test/integration/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_tester_test.dart
@@ -15,25 +15,18 @@ import '../src/context.dart';
 import 'test_utils.dart';
 
 void main() {
-  Directory tempDir;
-  Directory oldCurrentDir;
-
-  setUp(() async {
-    tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
-    oldCurrentDir = fs.currentDirectory;
-    fs.currentDirectory = tempDir;
-  });
-
-  tearDown(() {
-    fs.currentDirectory = oldCurrentDir;
-    tryToDelete(tempDir);
-  });
 
   group('FlutterTesterDevice', () {
+    Directory tempDir;
     FlutterTesterDevice device;
 
-    setUp(() {
-      device = new FlutterTesterDevice('flutter-tester');
+    setUp(() async {
+      tempDir = fs.systemTempDirectory.createTempSync('flutter_tester_device_test.');
+      device = new FlutterTesterDevice('flutter-tester', workingDirectory: tempDir.path);
+    });
+
+    tearDown(() {
+      tryToDelete(tempDir);
     });
 
     Future<LaunchResult> start(String mainPath) async {
@@ -50,7 +43,7 @@ void main() {
       writePubspec(tempDir.path);
       writePackages(tempDir.path);
 
-      final String mainPath = fs.path.join('lib', 'main.dart');
+      final String mainPath = fs.path.join(tempDir.path, 'lib', 'main.dart');
       writeFile(mainPath, r'''
 import 'dart:async';
 void main() {


### PR DESCRIPTION
This is #21119 again (first changeset), with a fix (second changeset) to ensure the build is written to the same `workingDirectory` that we're launching from. I think the failure may have been because there were changes to these paths between me opening and landing the PR.