### PR TITLE
Change SnackBar to match new material design spec

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -82,7 +82,11 @@ class _SnackBarDemoState extends State<SnackBarDemo> {
         // Create an inner BuildContext so that the snackBar onPressed methods
         // can refer to the Scaffold with Scaffold.of().
         builder: buildBody
-      )
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.send),
+        onPressed: () {}
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -364,11 +364,6 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       positionChild(_ScaffoldSlot.bottomSheet, Offset((size.width - bottomSheetSize.width) / 2.0, contentBottom - bottomSheetSize.height));
     }
 
-    if (hasChild(_ScaffoldSlot.snackBar)) {
-      snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
-      positionChild(_ScaffoldSlot.snackBar, Offset(0.0, contentBottom - snackBarSize.height));
-    }
-
     Rect floatingActionButtonRect;
     if (hasChild(_ScaffoldSlot.floatingActionButton)) {
       final Size fabSize = layoutChild(_ScaffoldSlot.floatingActionButton, looseConstraints);
@@ -394,6 +389,12 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       );
       positionChild(_ScaffoldSlot.floatingActionButton, fabOffset);
       floatingActionButtonRect = fabOffset & fabSize;
+    }
+
+    if (hasChild(_ScaffoldSlot.snackBar)) {
+      snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
+      final double snackBarYOffsetBase = floatingActionButtonRect != null ? floatingActionButtonRect.top : contentBottom;
+      positionChild(_ScaffoldSlot.snackBar, Offset(0.0, snackBarYOffsetBase - snackBarSize.height));
     }
 
     if (hasChild(_ScaffoldSlot.statusBar)) {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -23,6 +23,7 @@ import 'floating_action_button_location.dart';
 import 'material.dart';
 import 'snack_bar.dart';
 import 'theme.dart';
+import 'theme_data.dart';
 
 const FloatingActionButtonLocation _kDefaultFloatingActionButtonLocation = FloatingActionButtonLocation.endFloat;
 const FloatingActionButtonAnimator _kDefaultFloatingActionButtonAnimator = FloatingActionButtonAnimator.scaling;
@@ -359,6 +360,12 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     Size bottomSheetSize = Size.zero;
     Size snackBarSize = Size.zero;
 
+    // Set the size of the SnackBar early if the behaviour is fixed one so
+    // the FAB can be positioned based on SnackBar availability.
+    if (hasChild(_ScaffoldSlot.snackBar) && !shouldShowFloatingSnackBar) {
+      snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
+    }
+
     if (hasChild(_ScaffoldSlot.bottomSheet)) {
       final BoxConstraints bottomSheetConstraints = BoxConstraints(
         maxWidth: fullWidthConstraints.maxWidth,
@@ -396,7 +403,9 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     }
 
     if (hasChild(_ScaffoldSlot.snackBar)) {
-      snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
+      if (snackBarSize == Size.zero) {
+        snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
+      }
       final double snackBarYOffsetBase =
       floatingActionButtonRect != null && shouldShowFloatingSnackBar
           ? floatingActionButtonRect.top
@@ -1593,9 +1602,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     if (_snackBars.isNotEmpty) {
       final bool removeBottomPadding = widget.persistentFooterButtons != null ||
         widget.bottomNavigationBar != null;
-      final SnackBar snackBar = _snackBars.first._widget;
       shouldShowFloatingSnackBar =
-          snackBar.snackBarBehaviour == SnackBarBehaviour.floating;
+          themeData.snackBarBehaviour == SnackBarBehaviour.floating;
       _addIfNonNull(
         children,
         _snackBars.first._widget,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -277,6 +277,8 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     @required this.currentFloatingActionButtonLocation,
     @required this.floatingActionButtonMoveAnimationProgress,
     @required this.floatingActionButtonMotionAnimator,
+    // for SnackBar positioning
+    @required this.shouldShowFloatingSnackBar,
   }) : assert(previousFloatingActionButtonLocation != null),
        assert(currentFloatingActionButtonLocation != null);
 
@@ -288,6 +290,8 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
   final FloatingActionButtonLocation currentFloatingActionButtonLocation;
   final double floatingActionButtonMoveAnimationProgress;
   final FloatingActionButtonAnimator floatingActionButtonMotionAnimator;
+
+  final bool shouldShowFloatingSnackBar;
 
   @override
   void performLayout(Size size) {
@@ -393,8 +397,12 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
     if (hasChild(_ScaffoldSlot.snackBar)) {
       snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
-      final double snackBarYOffsetBase = floatingActionButtonRect != null ? floatingActionButtonRect.top : contentBottom;
-      positionChild(_ScaffoldSlot.snackBar, Offset(0.0, snackBarYOffsetBase - snackBarSize.height));
+      final double snackBarYOffsetBase =
+      floatingActionButtonRect != null && shouldShowFloatingSnackBar
+          ? floatingActionButtonRect.top
+          : contentBottom;
+      positionChild(_ScaffoldSlot.snackBar,
+          Offset(0.0, snackBarYOffsetBase - snackBarSize.height));
     }
 
     if (hasChild(_ScaffoldSlot.statusBar)) {
@@ -1581,9 +1589,13 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
       );
     }
 
+    bool shouldShowFloatingSnackBar = false;
     if (_snackBars.isNotEmpty) {
       final bool removeBottomPadding = widget.persistentFooterButtons != null ||
         widget.bottomNavigationBar != null;
+      final SnackBar snackBar = _snackBars.first._widget;
+      shouldShowFloatingSnackBar =
+          snackBar.snackBarBehaviour == SnackBarBehaviour.floating;
       _addIfNonNull(
         children,
         _snackBars.first._widget,
@@ -1720,6 +1732,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
                 geometryNotifier: _geometryNotifier,
                 previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation,
                 textDirection: textDirection,
+                shouldShowFloatingSnackBar: shouldShowFloatingSnackBar,
               ),
             );
           }),

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -76,6 +76,7 @@ enum SnackBarBehaviour {
   /// Other than that SnackBar will caused the other non-fixed widget inside
   /// Scaffold to be pushed above (e.g. Floating Action Button).
   fixed,
+
   /// Change the design and behaviour of SnackBar to float like described in
   /// <https://material.io/design/components/snackbars.html>.
   /// This behaviour will cause SnackBar to be shown on top of other non-fixed
@@ -123,7 +124,8 @@ class _SnackBarActionState extends State<SnackBarAction> {
   bool _haveTriggeredAction = false;
 
   void _handlePressed() {
-    if (_haveTriggeredAction) return;
+    if (_haveTriggeredAction)
+      return;
     setState(() {
       _haveTriggeredAction = true;
     });

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -247,7 +247,7 @@ class SnackBar extends StatelessWidget {
       children.add(const SizedBox(width: _kSnackBarPadding));
     }
     final CurvedAnimation heightAnimation =
-        new CurvedAnimation(parent: animation, curve: _snackBarHeightCurve);
+        CurvedAnimation(parent: animation, curve: _snackBarHeightCurve);
     final CurvedAnimation fadeInAnimation =
         CurvedAnimation(parent: animation, curve: _snackBarFadeInCurve);
     final CurvedAnimation fadeOutAnimation = CurvedAnimation(

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -25,10 +25,8 @@ const Color _kSnackBackground = Color(0xFF323232);
 const Duration _kSnackBarTransitionDuration = Duration(milliseconds: 250);
 const Duration _kSnackBarDisplayDuration = Duration(milliseconds: 4000);
 const Curve _snackBarHeightCurve = Curves.fastOutSlowIn;
-const Curve _snackBarFadeInCurve =
-    Interval(0.45, 1.0, curve: Curves.fastOutSlowIn);
-const Curve _snackBarFadeOutCurve =
-    Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
+const Curve _snackBarFadeInCurve = Interval(0.45, 1.0, curve: Curves.fastOutSlowIn);
+const Curve _snackBarFadeOutCurve = Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
 
 /// Specify how a [SnackBar] was closed.
 ///
@@ -67,23 +65,6 @@ enum SnackBarClosedReason {
   timeout,
 }
 
-/// Configures whether SnackBar should be fixed to the bottom or floating
-/// like described in Material Design spec.
-enum SnackBarBehaviour {
-  /// Fixed the SnackBar position to the bottom of the Scaffold when possible.
-  /// One of the possible scenario where SnackBar will be shown above another
-  /// widget is SnackBar above BottomNavigationBar.
-  /// Other than that SnackBar will caused the other non-fixed widget inside
-  /// Scaffold to be pushed above (e.g. Floating Action Button).
-  fixed,
-
-  /// Change the design and behaviour of SnackBar to float like described in
-  /// <https://material.io/design/components/snackbars.html>.
-  /// This behaviour will cause SnackBar to be shown on top of other non-fixed
-  /// widget like Floating Action Button rather than pushing it above SnackBar.
-  floating
-}
-
 /// A button for a [SnackBar], known as an "action".
 ///
 /// Snack bar actions are always enabled. If you want to disable a snack bar
@@ -103,9 +84,9 @@ class SnackBarAction extends StatefulWidget {
     Key key,
     @required this.label,
     @required this.onPressed,
-  })  : assert(label != null),
-        assert(onPressed != null),
-        super(key: key);
+  }) : assert(label != null),
+       assert(onPressed != null),
+       super(key: key);
 
   /// The button label.
   final String label;
@@ -130,8 +111,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
       _haveTriggeredAction = true;
     });
     widget.onPressed();
-    Scaffold.of(context)
-        .hideCurrentSnackBar(reason: SnackBarClosedReason.action);
+    Scaffold.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.action);
   }
 
   @override
@@ -175,9 +155,8 @@ class SnackBar extends StatelessWidget {
     this.action,
     this.duration = _kSnackBarDisplayDuration,
     this.animation,
-    this.snackBarBehaviour = SnackBarBehaviour.fixed,
-  })  : assert(content != null),
-        super(key: key);
+  }) : assert(content != null),
+       super(key: key);
 
   /// The primary content of the snack bar.
   ///
@@ -210,9 +189,6 @@ class SnackBar extends StatelessWidget {
   /// The animation driving the entrance and exit of the snack bar.
   final Animation<double> animation;
 
-  /// Configures how SnackBar should be positioned and shown.
-  final SnackBarBehaviour snackBarBehaviour;
-
   @override
   Widget build(BuildContext context) {
     final MediaQueryData mediaQueryData = MediaQuery.of(context);
@@ -227,8 +203,7 @@ class SnackBar extends StatelessWidget {
       const SizedBox(width: _kSnackBarPadding),
       Expanded(
         child: Container(
-          padding:
-              const EdgeInsets.symmetric(vertical: _kSingleLineVerticalPadding),
+          padding: const EdgeInsets.symmetric(vertical: _kSingleLineVerticalPadding),
           child: DefaultTextStyle(
             style: darkTheme.textTheme.subhead,
             child: content,
@@ -256,7 +231,7 @@ class SnackBar extends StatelessWidget {
         reverseCurve: const Threshold(0.0));
 
     final bool isFloatingSnackBar =
-        snackBarBehaviour == SnackBarBehaviour.floating;
+        theme.snackBarBehaviour == SnackBarBehaviour.floating;
 
     Widget snackBar = SafeArea(
       top: false,
@@ -357,7 +332,6 @@ class SnackBar extends StatelessWidget {
       action: action,
       duration: duration,
       animation: newAnimation,
-      snackBarBehaviour: snackBarBehaviour,
     );
   }
 }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -75,6 +75,23 @@ enum MaterialTapTargetSize {
   shrinkWrap,
 }
 
+/// Configures whether SnackBar should be fixed to the bottom or floating
+/// like described in Material Design spec.
+enum SnackBarBehaviour {
+  /// Fixed the SnackBar position to the bottom of the Scaffold when possible.
+  /// One of the possible scenario where SnackBar will be shown above another
+  /// widget is SnackBar above BottomNavigationBar.
+  /// Other than that SnackBar will caused the other non-fixed widget inside
+  /// Scaffold to be pushed above (e.g. Floating Action Button).
+  fixed,
+
+  /// Change the design and behaviour of SnackBar to float like described in
+  /// <https://material.io/design/components/snackbars.html>.
+  /// This behaviour will cause SnackBar to be shown on top of other non-fixed
+  /// widget like Floating Action Button rather than pushing it above SnackBar.
+  floating
+}
+
 /// Holds the color and typography values for a material design theme.
 ///
 /// Use this class to configure a [Theme] widget.
@@ -149,6 +166,7 @@ class ThemeData extends Diagnosticable {
     MaterialTapTargetSize materialTapTargetSize,
     PageTransitionsTheme pageTransitionsTheme,
     ColorScheme colorScheme,
+    SnackBarBehaviour snackBarBehaviour,
   }) {
     brightness ??= Brightness.light;
     final bool isDark = brightness == Brightness.dark;
@@ -241,6 +259,7 @@ class ThemeData extends Diagnosticable {
       brightness: brightness,
       labelStyle: textTheme.body2,
     );
+    snackBarBehaviour ??= SnackBarBehaviour.fixed;
 
     return ThemeData.raw(
       brightness: brightness,
@@ -287,6 +306,7 @@ class ThemeData extends Diagnosticable {
       materialTapTargetSize: materialTapTargetSize,
       pageTransitionsTheme: pageTransitionsTheme,
       colorScheme: colorScheme,
+      snackBarBehaviour: snackBarBehaviour,
     );
   }
 
@@ -344,6 +364,7 @@ class ThemeData extends Diagnosticable {
     @required this.materialTapTargetSize,
     @required this.pageTransitionsTheme,
     @required this.colorScheme,
+    @required this.snackBarBehaviour,
   }) : assert(brightness != null),
        assert(primaryColor != null),
        assert(primaryColorBrightness != null),
@@ -386,7 +407,8 @@ class ThemeData extends Diagnosticable {
        assert(platform != null),
        assert(materialTapTargetSize != null),
        assert(pageTransitionsTheme != null),
-       assert(colorScheme != null);
+       assert(colorScheme != null),
+       assert(snackBarBehaviour != null);
 
   // Warning: make sure these properties are in the exact same order as in
   // hashValues() and in the raw constructor and in the order of fields in
@@ -612,6 +634,9 @@ class ThemeData extends Diagnosticable {
   /// that is possible without significant backwards compatibility breaks.
   final ColorScheme colorScheme;
 
+  /// Configures how SnackBar should be positioned and shown.
+  final SnackBarBehaviour snackBarBehaviour;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ThemeData copyWith({
     Brightness brightness,
@@ -658,6 +683,7 @@ class ThemeData extends Diagnosticable {
     MaterialTapTargetSize materialTapTargetSize,
     PageTransitionsTheme pageTransitionsTheme,
     ColorScheme colorScheme,
+    SnackBarBehaviour snackBarBehaviour,
   }) {
     return ThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -704,6 +730,7 @@ class ThemeData extends Diagnosticable {
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       colorScheme: colorScheme ?? this.colorScheme,
+      snackBarBehaviour: snackBarBehaviour ?? this.snackBarBehaviour,
     );
   }
 
@@ -829,6 +856,7 @@ class ThemeData extends Diagnosticable {
       materialTapTargetSize: t < 0.5 ? a.materialTapTargetSize : b.materialTapTargetSize,
       pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
       colorScheme: ColorScheme.lerp(a.colorScheme, b.colorScheme, t),
+      snackBarBehaviour: t < 0.5 ? a.snackBarBehaviour : b.snackBarBehaviour,
     );
   }
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -252,7 +252,7 @@ void main() {
     expect(find.text('bar2'), findsNothing);
     await tester.pump(const Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
     await tester.drag(find.text('bar1'), const Offset(0.0, 50.0));
-    await tester.pumpAndSettle(const Duration(seconds: 1)); // bar1 dismissed, bar2 begins animating
+    await tester.pump(); // bar1 dismissed, bar2 begins animating
     expect(find.text('bar1'), findsNothing);
     expect(find.text('bar2'), findsOneWidget);
   });
@@ -340,59 +340,11 @@ void main() {
     final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
     final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 39.0 + 10.0); // margin + left padding
-    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0 + 40.0); // margin + bottom padding
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0 + 40.0); // margin + bottom padding
     expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 39.0 + 30.0); // margin + right padding
-    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0 + 40.0); // margin + bottom padding
-  });
-
-  testWidgets('SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
-    await tester.pumpWidget(new MaterialApp(
-      home: new MediaQuery(
-        data: const MediaQueryData(
-          padding: EdgeInsets.only(
-            left: 10.0,
-            top: 20.0,
-            right: 30.0,
-            bottom: 40.0,
-          ),
-        ),
-        child: new Scaffold(
-          floatingActionButton: new FloatingActionButton(
-            child: const Icon(Icons.send),
-            onPressed: () {}
-          ),
-          body: new Builder(
-              builder: (BuildContext context) {
-                return new GestureDetector(
-                    onTap: () {
-                      Scaffold.of(context).showSnackBar(new SnackBar(
-                          content: const Text('I am a snack bar.'),
-                          duration: const Duration(seconds: 2),
-                          action: new SnackBarAction(label: 'ACTION', onPressed: () {})
-                      ));
-                    },
-                    child: const Text('X')
-                );
-              }
-          ),
-        ),
-      ),
-    ));
-    await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(milliseconds: 750));
-
-    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
-    final RenderBox floatingActionButtonBox = tester.firstRenderObject(find.byType(FloatingActionButton));
-
-    final Offset snackBarBottomCenter = snackBarBox.localToGlobal(snackBarBox.size.bottomCenter(Offset.zero));
-    final Offset floatingActionButtonTopCenter = floatingActionButtonBox.localToGlobal(floatingActionButtonBox.size.topCenter(Offset.zero));
-
-    // Since padding and margin is handled inside snackBarBox,
-    // the bottom offset of snackbar should equal with top offset of FAB
-    expect(snackBarBottomCenter.dy == floatingActionButtonTopCenter.dy, true);
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0 + 40.0); // margin + bottom padding
   });
 
   testWidgets('SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
@@ -445,11 +397,172 @@ void main() {
     final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
     final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
 
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0); // margin (with no bottom padding)
+    expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0); // margin (with no bottom padding)
+  });
+
+  testWidgets('Floating SnackBar button text alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: Scaffold(
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                    onTap: () {
+                      Scaffold.of(context).showSnackBar(SnackBar(
+                          content: const Text('I am a snack bar.'),
+                          duration: const Duration(seconds: 2),
+                          action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                          snackBarBehaviour: SnackBarBehaviour.floating,
+                      ));
+                    },
+                    child: const Text('X')
+                );
+              }
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final RenderBox textBox = tester.firstRenderObject(find.text('I am a snack bar.'));
+    final RenderBox actionTextBox = tester.firstRenderObject(find.text('ACTION'));
+    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
+
+    final Offset textBottomLeft = textBox.localToGlobal(textBox.size.bottomLeft(Offset.zero));
+    final Offset textBottomRight = textBox.localToGlobal(textBox.size.bottomRight(Offset.zero));
+    final Offset actionTextBottomLeft = actionTextBox.localToGlobal(actionTextBox.size.bottomLeft(Offset.zero));
+    final Offset actionTextBottomRight = actionTextBox.localToGlobal(actionTextBox.size.bottomRight(Offset.zero));
+    final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
+    final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
+
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 39.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0 + 40.0); // margin + bottom padding
+    expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 39.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0 + 40.0); // margin + bottom padding
+  });
+
+  testWidgets('Floating SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(icon: Icon(Icons.favorite), title: Text('Animutation')),
+              BottomNavigationBarItem(icon: Icon(Icons.block), title: Text('Zombo.com')),
+            ],
+          ),
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                    onTap: () {
+                      Scaffold.of(context).showSnackBar(SnackBar(
+                          content: const Text('I am a snack bar.'),
+                          duration: const Duration(seconds: 2),
+                          action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                          snackBarBehaviour: SnackBarBehaviour.floating,
+                      ));
+                    },
+                    child: const Text('X')
+                );
+              }
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final RenderBox textBox = tester.firstRenderObject(find.text('I am a snack bar.'));
+    final RenderBox actionTextBox = tester.firstRenderObject(find.text('ACTION'));
+    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
+
+    final Offset textBottomLeft = textBox.localToGlobal(textBox.size.bottomLeft(Offset.zero));
+    final Offset textBottomRight = textBox.localToGlobal(textBox.size.bottomRight(Offset.zero));
+    final Offset actionTextBottomLeft = actionTextBox.localToGlobal(actionTextBox.size.bottomLeft(Offset.zero));
+    final Offset actionTextBottomRight = actionTextBox.localToGlobal(actionTextBox.size.bottomRight(Offset.zero));
+    final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
+    final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
+
     expect(textBottomLeft.dx - snackBarBottomLeft.dx, 39.0 + 10.0); // margin + left padding
     expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0); // margin (with no bottom padding)
     expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
     expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 39.0 + 30.0); // margin + right padding
     expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0); // margin (with no bottom padding)
+  });
+
+  testWidgets('Floating SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: Scaffold(
+          floatingActionButton: FloatingActionButton(
+              child: const Icon(Icons.send),
+              onPressed: () {}
+          ),
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                    onTap: () {
+                      Scaffold.of(context).showSnackBar(SnackBar(
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                        snackBarBehaviour: SnackBarBehaviour.floating,
+                      ));
+                    },
+                    child: const Text('X')
+                );
+              }
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
+    final RenderBox floatingActionButtonBox = tester.firstRenderObject(find.byType(FloatingActionButton));
+
+    final Offset snackBarBottomCenter = snackBarBox.localToGlobal(snackBarBox.size.bottomCenter(Offset.zero));
+    final Offset floatingActionButtonTopCenter = floatingActionButtonBox.localToGlobal(floatingActionButtonBox.size.topCenter(Offset.zero));
+
+    print(snackBarBottomCenter);
+    print(floatingActionButtonTopCenter);
+    // Since padding and margin is handled inside snackBarBox,
+    // the bottom offset of snackbar should equal with top offset of FAB
+    expect(snackBarBottomCenter.dy == floatingActionButtonTopCenter.dy, true);
   });
 
   testWidgets('SnackBarClosedReason', (WidgetTester tester) async {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -252,7 +252,7 @@ void main() {
     expect(find.text('bar2'), findsNothing);
     await tester.pump(const Duration(milliseconds: 750)); // 0.75s // animation last frame; two second timer starts here
     await tester.drag(find.text('bar1'), const Offset(0.0, 50.0));
-    await tester.pump(); // bar1 dismissed, bar2 begins animating
+    await tester.pumpAndSettle(const Duration(seconds: 1)); // bar1 dismissed, bar2 begins animating
     expect(find.text('bar1'), findsNothing);
     expect(find.text('bar2'), findsOneWidget);
   });
@@ -340,11 +340,59 @@ void main() {
     final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
     final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
-    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0 + 40.0); // margin + bottom padding
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 39.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0 + 40.0); // margin + bottom padding
     expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
-    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0 + 40.0); // margin + bottom padding
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 39.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0 + 40.0); // margin + bottom padding
+  });
+
+  testWidgets('SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(
+      home: new MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: new Scaffold(
+          floatingActionButton: new FloatingActionButton(
+            child: const Icon(Icons.send),
+            onPressed: () {}
+          ),
+          body: new Builder(
+              builder: (BuildContext context) {
+                return new GestureDetector(
+                    onTap: () {
+                      Scaffold.of(context).showSnackBar(new SnackBar(
+                          content: const Text('I am a snack bar.'),
+                          duration: const Duration(seconds: 2),
+                          action: new SnackBarAction(label: 'ACTION', onPressed: () {})
+                      ));
+                    },
+                    child: const Text('X')
+                );
+              }
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
+    final RenderBox floatingActionButtonBox = tester.firstRenderObject(find.byType(FloatingActionButton));
+
+    final Offset snackBarBottomCenter = snackBarBox.localToGlobal(snackBarBox.size.bottomCenter(Offset.zero));
+    final Offset floatingActionButtonTopCenter = floatingActionButtonBox.localToGlobal(floatingActionButtonBox.size.topCenter(Offset.zero));
+
+    // Since padding and margin is handled inside snackBarBox,
+    // the bottom offset of snackbar should equal with top offset of FAB
+    expect(snackBarBottomCenter.dy == floatingActionButtonTopCenter.dy, true);
   });
 
   testWidgets('SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
@@ -397,11 +445,11 @@ void main() {
     final Offset snackBarBottomLeft = snackBarBox.localToGlobal(snackBarBox.size.bottomLeft(Offset.zero));
     final Offset snackBarBottomRight = snackBarBox.localToGlobal(snackBarBox.size.bottomRight(Offset.zero));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
-    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0); // margin (with no bottom padding)
+    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 39.0 + 10.0); // margin + left padding
+    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0); // margin (with no bottom padding)
     expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
-    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0); // margin (with no bottom padding)
+    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 39.0 + 30.0); // margin + right padding
+    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0); // margin (with no bottom padding)
   });
 
   testWidgets('SnackBarClosedReason', (WidgetTester tester) async {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -404,8 +404,61 @@ void main() {
     expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0); // margin (with no bottom padding)
   });
 
+  testWidgets('SnackBar should push FloatingActionButton above', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(
+            left: 10.0,
+            top: 20.0,
+            right: 30.0,
+            bottom: 40.0,
+          ),
+        ),
+        child: Scaffold(
+          floatingActionButton: FloatingActionButton(
+            child: const Icon(Icons.send),
+            onPressed: () {}
+          ),
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(SnackBar(
+                    content: const Text('I am a snack bar.'),
+                    duration: const Duration(seconds: 2),
+                    action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                  ));
+                },
+                child: const Text('X')
+              );
+            }
+          ),
+        ),
+      ),
+    ));
+    final RenderBox floatingActionButtonOriginBox= tester.firstRenderObject(find.byType(FloatingActionButton));
+    final Offset floatingActionButtonOriginBottomCenter = floatingActionButtonOriginBox.localToGlobal(floatingActionButtonOriginBox.size.bottomCenter(Offset.zero));
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final RenderBox snackBarBox = tester.firstRenderObject(find.byType(SnackBar));
+    final RenderBox floatingActionButtonBox = tester.firstRenderObject(find.byType(FloatingActionButton));
+
+    final Offset snackBarTopCenter = snackBarBox.localToGlobal(snackBarBox.size.topCenter(Offset.zero));
+    final Offset floatingActionButtonBottomCenter = floatingActionButtonBox.localToGlobal(floatingActionButtonBox.size.bottomCenter(Offset.zero));
+
+    expect(floatingActionButtonOriginBottomCenter.dy > floatingActionButtonBottomCenter.dy, true);
+    expect(snackBarTopCenter.dy > floatingActionButtonBottomCenter.dy, true);
+  });
+
   testWidgets('Floating SnackBar button text alignment', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        snackBarBehaviour: SnackBarBehaviour.floating,
+      ),
       home: MediaQuery(
         data: const MediaQueryData(
           padding: EdgeInsets.only(
@@ -424,7 +477,6 @@ void main() {
                           content: const Text('I am a snack bar.'),
                           duration: const Duration(seconds: 2),
                           action: SnackBarAction(label: 'ACTION', onPressed: () {}),
-                          snackBarBehaviour: SnackBarBehaviour.floating,
                       ));
                     },
                     child: const Text('X')
@@ -458,6 +510,9 @@ void main() {
 
   testWidgets('Floating SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        snackBarBehaviour: SnackBarBehaviour.floating,
+      ),
       home: MediaQuery(
         data: const MediaQueryData(
           padding: EdgeInsets.only(
@@ -482,7 +537,6 @@ void main() {
                           content: const Text('I am a snack bar.'),
                           duration: const Duration(seconds: 2),
                           action: SnackBarAction(label: 'ACTION', onPressed: () {}),
-                          snackBarBehaviour: SnackBarBehaviour.floating,
                       ));
                     },
                     child: const Text('X')
@@ -516,6 +570,9 @@ void main() {
 
   testWidgets('Floating SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        snackBarBehaviour: SnackBarBehaviour.floating,
+      ),
       home: MediaQuery(
         data: const MediaQueryData(
           padding: EdgeInsets.only(
@@ -538,7 +595,6 @@ void main() {
                         content: const Text('I am a snack bar.'),
                         duration: const Duration(seconds: 2),
                         action: SnackBarAction(label: 'ACTION', onPressed: () {}),
-                        snackBarBehaviour: SnackBarBehaviour.floating,
                       ));
                     },
                     child: const Text('X')
@@ -558,8 +614,6 @@ void main() {
     final Offset snackBarBottomCenter = snackBarBox.localToGlobal(snackBarBox.size.bottomCenter(Offset.zero));
     final Offset floatingActionButtonTopCenter = floatingActionButtonBox.localToGlobal(floatingActionButtonBox.size.topCenter(Offset.zero));
 
-    print(snackBarBottomCenter);
-    print(floatingActionButtonTopCenter);
     // Since padding and margin is handled inside snackBarBox,
     // the bottom offset of snackbar should equal with top offset of FAB
     expect(snackBarBottomCenter.dy == floatingActionButtonTopCenter.dy, true);


### PR DESCRIPTION
Fix #21220

New SnackBar spec : https://material.io/design/components/snackbars.html

Padding, Margin, Elevation, etc are made based on observation and spec above, open to any suggestion.

Multiple screenshots for multiple scenario

### Flutter Gallery (No additional widget on bottom)
<img src="https://user-images.githubusercontent.com/1751188/45146623-38f21980-b1fe-11e8-92ff-9eb5aa5d5d2c.jpg" width="350">

### With BottomNavigationBar
<img src="https://user-images.githubusercontent.com/1751188/45146695-51faca80-b1fe-11e8-8834-3e6cd9cd1f78.jpg" width="350">

### With FAB
<img src="https://user-images.githubusercontent.com/1751188/45146709-58894200-b1fe-11e8-9989-ffbc89903101.jpg" width="350">

### With BottomNavigationBar + FAB
<img src="https://user-images.githubusercontent.com/1751188/45146732-60e17d00-b1fe-11e8-9c34-3e7339058f90.jpg" width="350">

