### PR TITLE
remove some temporary debug output

### DIFF
--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -5,14 +5,10 @@
 // Thanks for checking out Flutter!
 // Like what you see? Tweet us @flutterio
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'gallery/app.dart';
 
 void main() {
-  // Temporary debugging hook for https://github.com/flutter/flutter/issues/17888
-  debugInstrumentationEnabled = true;
-
   runApp(const GalleryApp());
 }


### PR DESCRIPTION
- remove some temporary debug output

I see that https://github.com/flutter/flutter/issues/17888 is closed, so I assume we no longer need this output?

@tvolkert @Hixie 