### PR TITLE
Logger framework basics.

### DIFF
--- a/packages/flutter/lib/logging.dart
+++ b/packages/flutter/lib/logging.dart
@@ -42,8 +42,7 @@
 /// ```dart
 /// profile(() {
 ///   _xLogger.info('X is starting...');
-///   return true;
-/// }());
+/// });
 /// ```
 ///
 /// In this case, logging is entirely ignored in release mode and no
@@ -62,7 +61,7 @@
 ///
 library logging;
 
-import 'dart:developer' as dev;
+import 'dart:developer' as developer;
 
 import 'package:flutter/src/logging/logging.dart';
 import 'package:logging/logging.dart';
@@ -132,7 +131,7 @@ class Logger {
     if (message is! String) {
       message = message.toString();
     }
-    dev.log(
+    developer.log(
       message,
       level: level.value,
       error: error,

--- a/packages/flutter/lib/logging.dart
+++ b/packages/flutter/lib/logging.dart
@@ -1,0 +1,160 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The Flutter logging framework.
+///
+/// Logging in Flutter revolves around a familiar pattern of named logger objects
+/// that correspond to specific systems or functional areas that, using a
+/// traditional dot-separated namespace, can be further treated as hierarchical
+/// by clients (tools such as IDEs).
+///
+/// From a client's perspective, named loggers correspond to "streams" of events
+/// that tools can opt into by subscription via a VM service call.  Loggers with
+/// no subscriptions do not produce any events. Common programming idioms can
+/// make logging calls very low cost.
+///
+/// The structure of logger calls is designed to be familiar and compatible with
+/// that of `package:logging`.  Behind the scenes, logged events are forwarded
+/// to the logging facility of `dart.developer`.
+///
+/// A logger is created via constructor call:
+///
+/// ```dart
+/// final Logger _xLogger = new Logger('functional.area.x');
+/// ```
+///
+/// Messages are logged with method calls that correspond to
+/// `package:logging` levels.  For example,
+///
+/// ```dart
+/// _xLogger.info('X is starting...');
+/// ```
+///
+/// produces a log event of [Level.INFO].
+///
+/// If no client is subscribed to its corresponding stream, logging calls are
+/// ignored (and no event passed on to the `dart.developer` log function).  The
+/// cost of logging calls can be further mitigated at call sites by invoking
+/// them in a function that is only evaluated in profile or debug modes. For
+/// example,
+///
+/// ```dart
+/// profile(() {
+///   _xLogger.info('X is starting...');
+///   return true;
+/// }());
+/// ```
+///
+/// In this case, logging is entirely ignored in release mode and no
+/// performance penalty is paid.
+///
+/// Clients interact with the loggers via VM Services.  Specifically,
+///
+///   * 'loggers' : provides an enumeration of available loggers
+///   * 'logger.subscribe' : supports logger subscriptions
+///
+/// See <https://github.com/dart-lang/logging> for more details on
+/// `package:logging`.
+///
+/// See <https://api.dartlang.org/stable/2.0.0/dart-developer/log.html> for more
+/// on the `log` function.
+///
+library logging;
+
+import 'dart:developer' as dev;
+
+import 'package:flutter/src/logging/logging.dart';
+import 'package:logging/logging.dart';
+
+/// A Logger object is used to log messages for specific systems or components.
+class Logger {
+  static int _sequenceNumber = 0;
+
+  /// Logger name.
+  final String name;
+
+  /// Logger description.
+  final String description;
+
+  /// Singleton constructor. Calling `Logger(name)` returns the same
+  /// actual instance whenever it is called with the same string name.
+  factory Logger(String name, {String description}) =>
+      _getOrRegisterLogger(name, description: description ?? '');
+
+  Logger._(this.name, {this.description});
+
+  static Logger _getOrRegisterLogger(String name, {String description}) =>
+      LoggingService.instance.loggers.putIfAbsent(
+          name, () => new Logger._(name, description: description));
+
+  /// The fully qualified name of this logging stream.
+  String get fullName => name;
+
+  /// Log message at level [Level.CONFIG].
+  void config(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.CONFIG, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.FINE].
+  void fine(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.FINE, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.FINER].
+  void finer(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.FINER, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.FINEST].
+  void finest(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.FINER, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.INFO].
+  void info(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.INFO, message, error, stackTrace);
+  }
+
+  /// Log [message] at the given [level] with optional [error] and [stackTrace].
+  void log(Level level, dynamic message,
+      [Object error, StackTrace stackTrace]) {
+    assert(level != null);
+    assert(message != null);
+    // If there are no subscribers, don't report.
+    if (!LoggingService.instance.hasSubscriptions(this)) {
+      return;
+    }
+
+    if (message is Function) {
+      message = message();
+    }
+    if (message is! String) {
+      message = message.toString();
+    }
+    dev.log(
+      message,
+      level: level.value,
+      error: error,
+      sequenceNumber: _sequenceNumber++,
+      name: fullName,
+      stackTrace: stackTrace,
+      time: DateTime.now(),
+    );
+  }
+
+  /// Log message at level [Level.SEVERE].
+  void severe(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.SEVERE, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.SHOUT].
+  void shout(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.SEVERE, message, error, stackTrace);
+  }
+
+  /// Log message at level [Level.WARNING].
+  void warning(dynamic message, [Object error, StackTrace stackTrace]) {
+    log(Level.WARNING, message, error, stackTrace);
+  }
+}

--- a/packages/flutter/lib/src/logging/logging.dart
+++ b/packages/flutter/lib/src/logging/logging.dart
@@ -1,0 +1,99 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/logging.dart';
+
+typedef void _RegisterServiceExtensionCallback(
+    {@required String name, @required ServiceExtensionCallback callback});
+
+/// Manages [Logger] services.
+class LoggingService {
+  /// The shared service instance.
+  static final LoggingService instance = new LoggingService._();
+
+  LoggingService._();
+
+  /// All the [Logger]s.
+  final Map<String, Logger> loggers = <String, Logger>{};
+
+  _RegisterServiceExtensionCallback _registerServiceExtensionCallback;
+
+  final Set<Logger> _subscriptions = new HashSet<Logger>();
+
+  /// Return `true` if the given [logger] has subscriptions.
+  bool hasSubscriptions(Logger logger) => _subscriptions.contains(logger);
+
+  /// Called to register service extensions.
+  void initServiceExtensions(
+      _RegisterServiceExtensionCallback registerServiceExtensionCallback) {
+    assert(registerServiceExtensionCallback != null);
+
+    _registerServiceExtensionCallback = registerServiceExtensionCallback;
+
+    _registerServiceExtension(
+        name: 'loggers',
+        callback: (Map<String, dynamic> parameters) async =>
+            <String, dynamic>{'value': _getLoggers()});
+
+    _registerServiceExtension(
+        name: 'logger.subscribe',
+        callback: (Map<String, Object> parameters) async {
+          final String loggerName = parameters['loggerName'];
+          if (loggerName != null) {
+            LoggingService.instance
+                .subscribe(loggerName, parameters['subscribe'] == 'true');
+          }
+          return <String, dynamic>{};
+        });
+  }
+
+  /// Subscribe (or unsubscribe) to the given logger stream identified by
+  /// [loggerName].
+  void subscribe(String loggerName, bool subscribe) {
+    final Logger logger = loggers[loggerName];
+    if (logger != null) {
+      if (subscribe) {
+        _subscriptions.add(logger);
+      } else {
+        _subscriptions.remove(logger);
+      }
+    } else {
+      // TODO(pq): consider reporting.
+    }
+  }
+
+  Map<String, Map<String, String>> _getLoggers() {
+    final Map<String, Map<String, String>> map =
+        <String, Map<String, String>>{};
+    for (Logger logger in loggers.values.toList()) {
+      map[logger.name] = <String, String>{
+        'enabled': hasSubscriptions(logger).toString(),
+        'description': logger.description,
+      };
+    }
+    return map;
+  }
+
+  /// Registers a service extension method with the given name (full
+  /// name "ext.flutter.logging.name").
+  ///
+  /// The given callback is called when the extension method is called. The
+  /// callback must return a value that can be converted to JSON using
+  /// `json.encode()` (see [JsonEncoder]). The return value is stored as a
+  /// property named `result` in the JSON. In case of failure, the failure is
+  /// reported to the remote caller and is dumped to the logs.
+  @protected
+  void _registerServiceExtension({
+    @required String name,
+    @required ServiceExtensionCallback callback,
+  }) {
+    _registerServiceExtensionCallback(
+      name: 'logging.$name',
+      callback: callback,
+    );
+  }
+}

--- a/packages/flutter/lib/src/logging/logging.dart
+++ b/packages/flutter/lib/src/logging/logging.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/logging.dart';
 
 typedef void _RegisterServiceExtensionCallback(
-    {@required String name, @required ServiceExtensionCallback callback});
+    { @required String name, @required ServiceExtensionCallback callback });
 
 /// Manages [Logger] services.
 class LoggingService {
@@ -61,9 +61,8 @@ class LoggingService {
       } else {
         _subscriptions.remove(logger);
       }
-    } else {
-      // TODO(pq): consider reporting.
     }
+    // TODO(pq): consider subscriptions to unregistered loggers.
   }
 
   Map<String, Map<String, String>> _getLoggers() {

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -11,6 +11,7 @@ import 'dart:ui' show AppLifecycleState;
 import 'package:collection/collection.dart' show PriorityQueue, HeapPriorityQueue;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/logging/logging.dart';
 
 import 'debug.dart';
 import 'priority.dart';
@@ -214,6 +215,8 @@ abstract class SchedulerBinding extends BindingBase with ServicesBinding {
         timeDilation = value;
       }
     );
+
+    LoggingService.instance.initServiceExtensions(registerServiceExtension);
   }
 
   /// Whether the application is visible, and if so, whether it is currently


### PR DESCRIPTION
Contributes a basic logging framework API.

The goal is for the framework to be unsurprising, performant and support opt-in monitoring of potentially noisy streams of logging events (e.g., platform channel communications, network activity, etc).

See: #21504 for discussion and further context.

If we feel good about this direction I'll start putting together some proper tests.  Needless to say, any feedback welcome!

/cc @Hixie @jacob314 @devoncarew 

