### PR TITLE
Eliminate snapshot/depfile options to build bundle

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -176,9 +176,7 @@ BuildApp() {
     build bundle                                                            \
     --target-platform=ios                                                   \
     --target="${target_path}"                                               \
-    --snapshot="${build_dir}/snapshot_blob.bin"                             \
     --${build_mode}                                                         \
-    --depfile="${build_dir}/snapshot_blob.bin.d"                            \
     --asset-dir="${derived_dir}/flutter_assets"                             \
     ${precompilation_flag}                                                  \
     ${local_engine_flag}                                                    \

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -409,11 +409,6 @@ abstract class BaseFlutterTask extends DefaultTask {
         // first stage of AOT build in this mode, and it includes all the Dart
         // sources.
         depfiles += project.files("${intermediateDir}/kernel_compile.d")
-
-        // Include Core JIT kernel compiler depfile, since kernel compile is
-        // the first stage of JIT builds in this mode, and it includes all the
-        // Dart sources.
-        depfiles += project.files("${intermediateDir}/snapshot_blob.bin.d")
         return depfiles
     }
 
@@ -495,8 +490,6 @@ abstract class BaseFlutterTask extends DefaultTask {
             }
             if (buildMode == "release" || buildMode == "profile") {
                 args "--precompiled"
-            } else {
-                args "--depfile", "${intermediateDir}/snapshot_blob.bin.d"
             }
             args "--asset-dir", "${intermediateDir}/flutter_assets"
             if (buildMode == "debug") {

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -311,12 +311,10 @@ class AOTSnapshotter {
     if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
       printTrace('Extra front-end options: $extraFrontEndOptions');
 
-    final String depfilePath = fs.path.join(outputPath, 'kernel_compile.d');
     final CompilerOutput compilerOutput = await kernelCompiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       mainPath: mainPath,
       outputFilePath: fs.path.join(outputPath, 'app.dill'),
-      depFilePath: depfilePath,
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn: true,
       aot: true,

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -18,8 +18,6 @@ import 'globals.dart';
 const String defaultMainPath = 'lib/main.dart';
 const String defaultAssetBasePath = '.';
 const String defaultManifestPath = 'pubspec.yaml';
-String get defaultSnapshotPath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin');
-String get defaultDepfilePath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin.d');
 String get defaultApplicationKernelPath => fs.path.join(getBuildDirectory(), 'app.dill');
 const String defaultPrivateKeyPath = 'privatekey.der';
 
@@ -36,9 +34,7 @@ Future<void> build({
   BuildMode buildMode,
   String mainPath = defaultMainPath,
   String manifestPath = defaultManifestPath,
-  String snapshotPath,
   String applicationKernelFilePath,
-  String depfilePath,
   String privateKeyPath = defaultPrivateKeyPath,
   String assetDirPath,
   String packagesPath,
@@ -51,8 +47,6 @@ Future<void> build({
   List<String> fileSystemRoots,
   String fileSystemScheme,
 }) async {
-  snapshotPath ??= defaultSnapshotPath;
-  depfilePath ??= defaultDepfilePath;
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
   applicationKernelFilePath ??= defaultApplicationKernelPath;
@@ -68,7 +62,6 @@ Future<void> build({
           fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
       mainPath: fs.file(mainPath).absolute.path,
       outputFilePath: applicationKernelFilePath,
-      depFilePath: depfilePath,
       trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: extraFrontEndOptions,
       fileSystemRoots: fileSystemRoots,

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -22,8 +22,6 @@ class BuildBundleCommand extends BuildSubCommand {
       ..addOption('asset-base', help: 'Ignored. Will be removed.', hide: !verboseHelp)
       ..addOption('manifest', defaultsTo: defaultManifestPath)
       ..addOption('private-key', defaultsTo: defaultPrivateKeyPath)
-      ..addOption('snapshot', defaultsTo: defaultSnapshotPath)
-      ..addOption('depfile', defaultsTo: defaultDepfilePath)
       ..addOption('kernel-file', defaultsTo: defaultApplicationKernelPath)
       ..addOption('target-platform',
         defaultsTo: 'android-arm',
@@ -85,9 +83,7 @@ class BuildBundleCommand extends BuildSubCommand {
       buildMode: buildMode,
       mainPath: targetFile,
       manifestPath: argResults['manifest'],
-      snapshotPath: argResults['snapshot'],
       applicationKernelFilePath: argResults['kernel-file'],
-      depfilePath: argResults['depfile'],
       privateKeyPath: argResults['private-key'],
       assetDirPath: argResults['asset-dir'],
       precompiledSnapshot: argResults['precompiled'],

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -169,7 +169,6 @@ Hello!
           incrementalCompilerByteStorePath: anyNamed('incrementalCompilerByteStorePath'),
           mainPath: anyNamed('mainPath'),
           outputFilePath: anyNamed('outputFilePath'),
-          depFilePath: anyNamed('depFilePath'),
           trackWidgetCreation: anyNamed('trackWidgetCreation'),
           extraFrontEndOptions: anyNamed('extraFrontEndOptions'),
           fileSystemRoots: anyNamed('fileSystemRoots'),


### PR DESCRIPTION
The --snapshot argument was only necessary in Dart 1. The --depfile
argument was only used in Dart 2 mode to pass to the kernel compiler,
but was inconsistent with the 'build aot' command, where the depfile was
always set to build/kernel_compile.d.

This patch updates 'build bundle' to emit the depfile to a location
consistent with the 'build aot' command; since it's not intended to be
user-configurable and flutter.gradle hardcodes the location to
build/kernel_compile.d either way, this patch also eliminates the
ability to configure the filename altogether.