### PR TITLE
reduce flakiness of semantics test

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/src/common.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/common.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
@@ -227,4 +228,13 @@ class Size {
 
   @override
   String toString() => 'Size{$width, $height}';
+}
+
+/// Attempt to synchonize with platform semantics by waiting.
+///
+/// Semantics on the platform side can easily end up several frames behind the
+/// semantics of the framework. To resolve this for the integration test we can
+/// work around the issue with a sleep.
+Future<void> waitForSemantics() async {
+  await new Future<void>.delayed(const Duration(seconds: 1));
 }

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -15,6 +15,7 @@ void main() {
   group('AccessibilityBridge', () {
     FlutterDriver driver;
     Future<AndroidSemanticsNode> getSemantics(SerializableFinder finder) async {
+      await waitForSemantics();
       final int id = await driver.getSemanticsId(finder);
       final String data = await driver.requestData('getSemanticsNode#$id');
       return new AndroidSemanticsNode.deserialize(data);


### PR DESCRIPTION
Adds a 1 second delay to the beginning of each query for semantics data to resolve framework and platform getting out of sync.