### PR TITLE
[Material] Updated BottomNavigationBar effects

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -179,6 +179,7 @@ class _BottomNavigationTile extends StatelessWidget {
       heightFactor: 1.0,
       child: new Container(
         margin: new EdgeInsets.only(
+          bottom: 3.0,
           top: new Tween<double>(
             begin: tweenStart,
             end: _kTopMargin,
@@ -197,7 +198,7 @@ class _BottomNavigationTile extends StatelessWidget {
 
   Widget _buildFixedLabel() {
     return new Align(
-      alignment: Alignment.bottomCenter,
+      alignment: Alignment.topCenter,
       heightFactor: 1.0,
       child: new Container(
         margin: const EdgeInsets.only(bottom: _kBottomMargin),
@@ -218,7 +219,7 @@ class _BottomNavigationTile extends StatelessWidget {
                 ).evaluate(animation),
               ),
             ),
-            alignment: Alignment.bottomCenter,
+            alignment: Alignment.topCenter,
             child: item.title,
           ),
         ),


### PR DESCRIPTION
The active effect has been improved. When the user taps at the Navigation Bar item, te text should increase his size and the icon should elevate a little.

But comparing Flutters's with native Google's apps, the text should also come down a little bit. When active, on Flutter, the text size is correct, and the icon as well, but the text is too close of the icon. 

With this change, the text has a new margin between the icon, and the effect using animation, the text come down like the native.