### PR TITLE
Make FlutterDevice.generator final

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -29,32 +29,28 @@ import 'run_hot.dart';
 import 'vmservice.dart';
 
 class FlutterDevice {
-  final Device device;
-  List<Uri> observatoryUris;
-  List<VMService> vmServices;
-  DevFS devFS;
-  ApplicationPackage package;
-  ResidentCompiler generator;
-  String dillOutputPath;
-  List<String> fileSystemRoots;
-  String fileSystemScheme;
-
-  StreamSubscription<String> _loggingSubscription;
-
   FlutterDevice(this.device, {
     @required bool trackWidgetCreation,
     this.dillOutputPath,
     this.fileSystemRoots,
     this.fileSystemScheme,
     ResidentCompiler generator,
-  }) {
-    this.generator = generator ?? new ResidentCompiler(
-      artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
-      trackWidgetCreation: trackWidgetCreation,
-      fileSystemRoots: fileSystemRoots, fileSystemScheme: fileSystemScheme
-    );
-  }
+  }) : this.generator = generator ?? new ResidentCompiler(
+         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
+         trackWidgetCreation: trackWidgetCreation,
+         fileSystemRoots: fileSystemRoots, fileSystemScheme: fileSystemScheme
+       );
 
+  final Device device;
+  final ResidentCompiler generator;
+  List<Uri> observatoryUris;
+  List<VMService> vmServices;
+  DevFS devFS;
+  ApplicationPackage package;
+  String dillOutputPath;
+  List<String> fileSystemRoots;
+  String fileSystemScheme;
+  StreamSubscription<String> _loggingSubscription;
   String viewFilter;
 
   /// If the [reloadSources] parameter is not null the 'reloadSources' service


### PR DESCRIPTION
Now that Dart 1 support has been eliminated, generator should always be
populated to a kernel compiler instance.

Also moves the constructor to the top of the class, and orders final
fields before non-final fields, as dictated by the style guide.