### PR TITLE
Revert "Eliminate snapshot/depfile options to build bundle (#21507)"

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -176,7 +176,9 @@ BuildApp() {
     build bundle                                                            \
     --target-platform=ios                                                   \
     --target="${target_path}"                                               \
+    --snapshot="${build_dir}/snapshot_blob.bin"                             \
     --${build_mode}                                                         \
+    --depfile="${build_dir}/snapshot_blob.bin.d"                            \
     --asset-dir="${derived_dir}/flutter_assets"                             \
     ${precompilation_flag}                                                  \
     ${local_engine_flag}                                                    \

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -409,6 +409,11 @@ abstract class BaseFlutterTask extends DefaultTask {
         // first stage of AOT build in this mode, and it includes all the Dart
         // sources.
         depfiles += project.files("${intermediateDir}/kernel_compile.d")
+
+        // Include Core JIT kernel compiler depfile, since kernel compile is
+        // the first stage of JIT builds in this mode, and it includes all the
+        // Dart sources.
+        depfiles += project.files("${intermediateDir}/snapshot_blob.bin.d")
         return depfiles
     }
 
@@ -490,6 +495,8 @@ abstract class BaseFlutterTask extends DefaultTask {
             }
             if (buildMode == "release" || buildMode == "profile") {
                 args "--precompiled"
+            } else {
+                args "--depfile", "${intermediateDir}/snapshot_blob.bin.d"
             }
             args "--asset-dir", "${intermediateDir}/flutter_assets"
             if (buildMode == "debug") {

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -311,10 +311,12 @@ class AOTSnapshotter {
     if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
       printTrace('Extra front-end options: $extraFrontEndOptions');
 
+    final String depfilePath = fs.path.join(outputPath, 'kernel_compile.d');
     final CompilerOutput compilerOutput = await kernelCompiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       mainPath: mainPath,
       outputFilePath: fs.path.join(outputPath, 'app.dill'),
+      depFilePath: depfilePath,
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn: true,
       aot: true,

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -18,6 +18,8 @@ import 'globals.dart';
 const String defaultMainPath = 'lib/main.dart';
 const String defaultAssetBasePath = '.';
 const String defaultManifestPath = 'pubspec.yaml';
+String get defaultSnapshotPath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin');
+String get defaultDepfilePath => fs.path.join(getBuildDirectory(), 'snapshot_blob.bin.d');
 String get defaultApplicationKernelPath => fs.path.join(getBuildDirectory(), 'app.dill');
 const String defaultPrivateKeyPath = 'privatekey.der';
 
@@ -34,7 +36,9 @@ Future<void> build({
   BuildMode buildMode,
   String mainPath = defaultMainPath,
   String manifestPath = defaultManifestPath,
+  String snapshotPath,
   String applicationKernelFilePath,
+  String depfilePath,
   String privateKeyPath = defaultPrivateKeyPath,
   String assetDirPath,
   String packagesPath,
@@ -47,6 +51,8 @@ Future<void> build({
   List<String> fileSystemRoots,
   String fileSystemScheme,
 }) async {
+  snapshotPath ??= defaultSnapshotPath;
+  depfilePath ??= defaultDepfilePath;
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
   applicationKernelFilePath ??= defaultApplicationKernelPath;
@@ -62,6 +68,7 @@ Future<void> build({
           fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
       mainPath: fs.file(mainPath).absolute.path,
       outputFilePath: applicationKernelFilePath,
+      depFilePath: depfilePath,
       trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: extraFrontEndOptions,
       fileSystemRoots: fileSystemRoots,

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -22,6 +22,8 @@ class BuildBundleCommand extends BuildSubCommand {
       ..addOption('asset-base', help: 'Ignored. Will be removed.', hide: !verboseHelp)
       ..addOption('manifest', defaultsTo: defaultManifestPath)
       ..addOption('private-key', defaultsTo: defaultPrivateKeyPath)
+      ..addOption('snapshot', defaultsTo: defaultSnapshotPath)
+      ..addOption('depfile', defaultsTo: defaultDepfilePath)
       ..addOption('kernel-file', defaultsTo: defaultApplicationKernelPath)
       ..addOption('target-platform',
         defaultsTo: 'android-arm',
@@ -83,7 +85,9 @@ class BuildBundleCommand extends BuildSubCommand {
       buildMode: buildMode,
       mainPath: targetFile,
       manifestPath: argResults['manifest'],
+      snapshotPath: argResults['snapshot'],
       applicationKernelFilePath: argResults['kernel-file'],
+      depfilePath: argResults['depfile'],
       privateKeyPath: argResults['private-key'],
       assetDirPath: argResults['asset-dir'],
       precompiledSnapshot: argResults['precompiled'],

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -169,6 +169,7 @@ Hello!
           incrementalCompilerByteStorePath: anyNamed('incrementalCompilerByteStorePath'),
           mainPath: anyNamed('mainPath'),
           outputFilePath: anyNamed('outputFilePath'),
+          depFilePath: anyNamed('depFilePath'),
           trackWidgetCreation: anyNamed('trackWidgetCreation'),
           extraFrontEndOptions: anyNamed('extraFrontEndOptions'),
           fileSystemRoots: anyNamed('fileSystemRoots'),


### PR DESCRIPTION
This tickled a bug in KernelCompiler.compile() where the fingerprinter
doesn't include the outputFilePath in its list of dependencies. As such,
if the output .dill file is missing or corrupted, the fingerprint still
matches and re-compile is skipped, even though it shouldn't be. I'll fix
that in a followup, then look at how this triggered that issue. My
hypothesis is that that it's due to the aot kernel compile and bundle
kernel compile have separate output directories for the .dill files
(build/ vs build/aot) but the same output directory for the associated
depfiles (due to this patch).

This reverts commit 43a106e95a615679609ffd11a3ca3fa466a9712c.