### PR TITLE
Add  material tap target size and text contrast test to gallery and some fixes to a11y guidelines

### DIFF
--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gallery/demo/all.dart';
+
+void main() {
+  group('All material demos meet recommended tap target sizes', () {
+    testWidgets('backdrop_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BackdropDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('bottom_app_bar_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BottomAppBarDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('bottom_navigation_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BottomNavigationDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('buttons_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ButtonsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('cards_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new CardsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('chip_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ChipDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('data_table_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DataTableDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('date_and_time_picker_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DateAndTimePickerDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21578
+
+    testWidgets('dialog_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DialogDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('drawer_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DrawerDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('elevation_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ElevationDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('expansion_panels_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ExpansionPanelsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('grid_list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const GridListDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('icons_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new IconsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('leave_behind_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const LeaveBehindDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('list_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const ListDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('menu_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const MenuDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ModalBottomSheetDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('overscroll_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const OverscrollDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('page_selector_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new PageSelectorDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new PersistentBottomSheetDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('progress_indicator_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ProgressIndicatorDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('reorderable_list_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const ReorderableListDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
+     final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ScrollableTabsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('search_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SearchDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('selection_controls_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SelectionControlsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('slider_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SliderDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('snack_bar_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const SnackBarDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tabs_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TabsDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tabs_fab_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TabsFabDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('text_form_field_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const TextFormFieldDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tooltip_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TooltipDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('two_level_list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TwoLevelListDemo()));
+      expect(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+  });
+}

--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -235,4 +235,237 @@ void main() {
       handle.dispose();
     });
   });
+
+  group('All material demos meet text contrast guidelines', () {
+    testWidgets('backdrop_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BackdropDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('bottom_app_bar_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BottomAppBarDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21651
+
+    testWidgets('bottom_navigation_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new BottomNavigationDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('buttons_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ButtonsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21647
+
+    testWidgets('cards_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new CardsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21651
+
+    testWidgets('chip_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ChipDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21647
+
+    testWidgets('data_table_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DataTableDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21647
+
+    testWidgets('date_and_time_picker_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DateAndTimePickerDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21647
+
+    testWidgets('dialog_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DialogDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('drawer_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new DrawerDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('elevation_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ElevationDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('expansion_panels_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ExpansionPanelsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('grid_list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const GridListDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('icons_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new IconsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21647
+
+    testWidgets('leave_behind_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const LeaveBehindDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const ListDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('menu_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const MenuDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ModalBottomSheetDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('overscroll_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const OverscrollDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('page_selector_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new PageSelectorDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new PersistentBottomSheetDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('progress_indicator_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ProgressIndicatorDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('reorderable_list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const ReorderableListDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new ScrollableTabsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('search_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SearchDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    }, skip: true); // https://github.com/flutter/flutter/issues/21651
+
+    testWidgets('selection_controls_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SelectionControlsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('slider_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new SliderDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('snack_bar_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const SnackBarDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tabs_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TabsDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tabs_fab_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TabsFabDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('text_form_field_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: const TextFormFieldDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('tooltip_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TooltipDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('two_level_list_demo', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(new MaterialApp(home: new TwoLevelListDemo()));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+      handle.dispose();
+    });
+  });
 }

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -101,7 +101,7 @@ class MinimumTapTargetGuideline extends AccessibilityGuideline {
       }
       // skip node if it is touching the edge of the screen, since it might
       // be partially scrolled offscreen.
-      const delta = 0.001;
+      const double delta = 0.001;
       if (paintBounds.left <= delta
         || paintBounds.top <= delta
         || (paintBounds.bottom - ui.window.physicalSize.height).abs() <= delta

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -40,8 +40,10 @@ class Evaluation {
     if (other == null)
       return this;
     final StringBuffer buffer = new StringBuffer();
-    if (reason != null)
+    if (reason != null) {
       buffer.write(reason);
+      buffer.write(' ');
+    }
     if (other.reason != null)
       buffer.write(other.reason);
     return new Evaluation._(passed && other.passed, buffer.isEmpty ? null : buffer.toString());
@@ -159,6 +161,8 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     final OffsetLayer layer = renderView.layer;
     ui.Image image;
     final ByteData byteData = await tester.binding.runAsync<ByteData>(() async  {
+      // Needs to be the same pixel ratio otherwise our dimensions won't match the
+      // last transform layer.
       image = await layer.toImage(renderView.paintBounds, pixelRatio: 1.0);
       return image.toByteData();
     });
@@ -181,7 +185,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       double fontSize;
       bool isBold;
       final String text = (data.label?.isEmpty == true) ? data.value : data.label;
-      final List<Element> elements = find.text(text).evaluate().toList();
+      final List<Element> elements = find.text(text).hitTestable().evaluate().toList();
       if (elements.length == 1) {
         final Element element = elements.single;
         final Widget widget = element.widget;
@@ -199,7 +203,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
           assert(false);
         }
       } else if (elements.length > 1) {
-        return const Evaluation.fail('Multiple nodes with the same label');
+        return new Evaluation.fail('Multiple nodes with the same label: ${data.label}\n');
       } else {
         // If we can't find the text node then assume the label does not
         // correspond to actual text.
@@ -209,13 +213,18 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       // Transform local coordinate to screen coordinates.
       Rect paintBounds = node.rect;
       SemanticsNode current = node;
-      while (current != null) {
+      while (current != null && current.parent != null) {
         if (current.transform != null)
           paintBounds = MatrixUtils.transformRect(current.transform, paintBounds);
         paintBounds = paintBounds.shift(current.parent?.rect?.topLeft ?? Offset.zero);
         current = current.parent;
       }
+      if (_isNodeOffScreen(paintBounds))
+        return result;
       final List<int> subset = _subsetToRect(byteData, paintBounds, image.width, image.height);
+      // Node was too far off screen.
+     if (subset.isEmpty)
+       return result;
       final _ContrastReport report = new _ContrastReport(subset);
       final double contrastRatio = report.contrastRatio();
       const double delta = -0.01;
@@ -247,6 +256,17 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     return false;
   }
 
+  // Returns a rect that is entirely on screen, or null if it is too far off.
+  //
+  // Given an 1800 * 2400 pixel buffer, can we actually get all the data from
+  // this node? allow a small delta overlap before culling the node.
+  bool _isNodeOffScreen(Rect paintBounds) {
+    return paintBounds.top < -50.0
+      || paintBounds.left <  -50.0
+      || paintBounds.bottom > 2400.0 + 50.0
+      || paintBounds.right > 1800.0 + 50.0;
+  }
+
   List<int> _subsetToRect(ByteData data, Rect paintBounds, int width, int height) {
     final int newWidth = paintBounds.size.width.ceil();
     final int newHeight = paintBounds.size.height.ceil();
@@ -259,8 +279,8 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     // Data is stored in row major order.
     for (int i = 0; i < data.lengthInBytes; i+=4) {
       final int index = i ~/ 4;
-      final int dy = index % width;
-      final int dx = index ~/ width;
+      final int dx = index % width;
+      final int dy = index ~/ width;
       if (dx >= leftX && dx <= rightX && dy >= topY && dy <= bottomY) {
         final int r = data.getUint8(i);
         final int g = data.getUint8(i + 1);
@@ -289,19 +309,15 @@ class _ContrastReport {
       final Color hslColor = new Color(colorHistogram.keys.first);
       return new _ContrastReport._(hslColor, hslColor);
     }
-    if (colorHistogram.length == 2) {
-      final Color firstColor = new Color(colorHistogram.keys.first);
-      final Color lastColor =  new Color(colorHistogram.keys.last);
-      if (firstColor.computeLuminance() < lastColor.computeLuminance()) {
-        return new _ContrastReport._(lastColor, firstColor);
-      }
-      return new _ContrastReport._(firstColor, lastColor);
-    }
     // to determine the lighter and darker color, partition the colors
     // by lightness and then choose the mode from each group.
-    final double averageLightness = colorHistogram.keys.fold(0.0, (double total, int color) {
-      return total + new HSLColor.fromColor(new Color(color)).lightness;
-    }) / colorHistogram.length;
+    double averageLightness = 0.0;
+    for (int color in colorHistogram.keys) {
+      final HSLColor hslColor = new HSLColor.fromColor(new Color(color));
+      averageLightness += hslColor.lightness * colorHistogram[color];
+    }
+    averageLightness /= colors.length;
+    assert(averageLightness != double.nan);
     int lightColor = 0;
     int darkColor = 0;
     int lightCount = 0;
@@ -310,14 +326,15 @@ class _ContrastReport {
     for (MapEntry<int, int> entry in colorHistogram.entries) {
       final HSLColor color = new HSLColor.fromColor(new Color(entry.key));
       final int count = entry.value;
-      if (color.lightness <= averageLightness && count > lightCount) {
+      if (color.lightness <= averageLightness && count > darkCount) {
         darkColor = entry.key;
         darkCount = count;
-      } else if (color.lightness > averageLightness && count > darkCount) {
+      } else if (color.lightness > averageLightness && count > lightCount) {
         lightColor = entry.key;
         lightCount = count;
       }
     }
+    assert (lightColor != 0 && darkColor != 0);
     return new _ContrastReport._(new Color(lightColor), new Color(darkColor));
   }
 

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -101,7 +101,7 @@ class MinimumTapTargetGuideline extends AccessibilityGuideline {
       }
       // skip node if it is touching the edge of the screen, since it might
       // be partially scrolled offscreen.
-      const delta = 0.001;
+      const double delta = 0.001;
       if (paintBounds.left <= delta
         || paintBounds.top <= delta
         || (paintBounds.bottom - ui.window.physicalSize.height).abs() <= delta
@@ -220,10 +220,11 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       final double contrastRatio = report.contrastRatio();
       const double delta = -0.01;
       double targetContrastRatio;
-      if ((isBold && fontSize > kBoldTextMinimumSize) || fontSize > kLargeTextMinimumSize)
+      if ((isBold && fontSize > kBoldTextMinimumSize) || (fontSize ?? 12.0) > kLargeTextMinimumSize) {
         targetContrastRatio = kMinimumRatioLargeText;
-      else
+      } else {
         targetContrastRatio = kMinimumRatioNormalText;
+      }
       if (contrastRatio - targetContrastRatio >= delta)
         return result + const Evaluation.pass();
       return result + new Evaluation.fail(

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -127,6 +127,27 @@ void main() {
         'See also: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html');
       handle.dispose();
     });
+
+    testWidgets('label without corresponding text is skipped', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(_boilerplate(
+        new Semantics(
+          label: 'This is not text',
+          container: true,
+          child: new Container(
+            width: 200.0,
+            height: 200.0,
+            child: const Placeholder(),
+          ),
+        ),
+      ));
+
+      final Evaluation result = await textContrastGuideline.evaluate(tester);
+      expect(result.passed, true);
+
+      handle.dispose();
+    });
   });
 
   group('tap target size guideline', () {
@@ -210,6 +231,83 @@ void main() {
         'SemanticsNode#36(Rect.fromLTRB(376.0, 276.5, 424.0, 323.5), actions: [tap]): expected tap '
         'target size of at least Size(48.0, 48.0), but found Size(48.0, 47.0)\n'
         'See also: https://support.google.com/accessibility/android/answer/7101858?hl=en');
+      handle.dispose();
+    });
+
+    testWidgets('Box that overlaps edge of window is skipped', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final Widget smallBox = new SizedBox(
+        width: 48.0,
+        height: 47.0,
+        child: new GestureDetector(
+          onTap: () {},
+        ),
+      );
+      await tester.pumpWidget(
+        new MaterialApp(
+          home: new Stack(
+            children: <Widget>[
+              new Positioned(
+                left: 0.0,
+                top: -1.0,
+                child: smallBox,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final Evaluation overlappingTopResult = await androidTapTargetGuideline.evaluate(tester);
+      expect(overlappingTopResult.passed, true);
+
+      await tester.pumpWidget(
+        new MaterialApp(
+          home: new Stack(
+            children: <Widget>[
+              new Positioned(
+                left: -1.0,
+                top: 0.0,
+                child: smallBox,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final Evaluation overlappingLeftResult = await androidTapTargetGuideline.evaluate(tester);
+      expect(overlappingLeftResult.passed, true);
+
+      await tester.pumpWidget(
+        new MaterialApp(
+          home: new Stack(
+            children: <Widget>[
+              new Positioned(
+                bottom: -1.0,
+                child: smallBox,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final Evaluation overlappingBottomResult = await androidTapTargetGuideline.evaluate(tester);
+      expect(overlappingBottomResult.passed, true);
+
+      await tester.pumpWidget(
+        new MaterialApp(
+          home: new Stack(
+            children: <Widget>[
+              new Positioned(
+                right: -1.0,
+                child: smallBox,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final Evaluation overlappingRightResult = await androidTapTargetGuideline.evaluate(tester);
+      expect(overlappingRightResult.passed, true);
       handle.dispose();
     });
   });


### PR DESCRIPTION
I've left each demo as a separate test so that they can be expanded upon to include more interaction.

I also fixed some bugs in the guidelines, but there are still some issues with the text contrast calculation. Since it seems like I am picking up extra colors, ~~I believe my logic for subsetting the rect is wrong.~~ Fixed