### PR TITLE
Turkish translation fix

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/material_tr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tr.arb
@@ -26,7 +26,7 @@
   "okButtonLabel": "Tamam",
   "pasteButtonLabel": "YAPIŞTIR",
   "selectAllButtonLabel": "TÜMÜNÜ SEÇ",
-  "viewLicensesButtonLabel": "LİSANLARI GÖSTER",
+  "viewLicensesButtonLabel": "LİSANSLARI GÖSTER",
   "anteMeridiemAbbreviation": "ÖÖ",
   "postMeridiemAbbreviation": "ÖS",
   "timePickerHourModeAnnouncement": "Saati seçin",


### PR DESCRIPTION
"LİSANLARI GÖSTER" means "viewLanguages". 
For "viewLicenses" it should be "LİSANSLARI GÖSTER" .