### PR TITLE
Don't push offset to leaf layers

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -566,12 +566,11 @@ class OffsetLayer extends ContainerLayer {
   @override
   void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
     // Skia has a fast path for concatenating scale/translation only matrices.
-    // Hence this operation should be fast. For retained rendering, we don't
-    // want to push the offset down to each leaf node. Otherwise, changing an
-    // offset layer on the very high level could cascade the change to too many
-    // leaves.
-    final Matrix4 matrix = Matrix4.translationValues(layerOffset.dx + offset.dx, layerOffset.dy + offset.dy, 0.0);
-    builder.pushTransform(matrix.storage);
+    // Hence pushing a translation-only transform layer should be fast. For
+    // retained rendering, we don't want to push the offset down to each leaf
+    // node. Otherwise, changing an offset layer on the very high level could
+    // cascade the change to too many leaves.
+    builder.pushOffset(layerOffset.dx + offset.dx, layerOffset.dy + offset.dy);
     addChildrenToScene(builder);
     builder.pop();
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -192,7 +192,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     Timeline.startSync('Compositing', arguments: timelineWhitelistArguments);
     try {
       final ui.SceneBuilder builder = ui.SceneBuilder();
-      layer.addToScene(builder, Offset.zero);
+      layer.addToScene(builder);
       final ui.Scene scene = builder.build();
       if (automaticSystemUiAdjustment)
         _updateSystemChrome();

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -54,8 +54,8 @@ class _ProxyLayer extends Layer {
   _ProxyLayer(this._layer);
 
   @override
-  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    _layer.addToScene(builder, layerOffset);
+  void addToScene(ui.SceneBuilder builder) {
+    _layer.addToScene(builder);
   }
 
   @override
@@ -312,8 +312,8 @@ Rect _calculateSubtreeBounds(RenderObject object) {
 /// screenshots render to the scene in the local coordinate system of the layer.
 class _ScreenshotContainerLayer extends OffsetLayer {
   @override
-  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    addChildrenToScene(builder, layerOffset);
+  void addToScene(ui.SceneBuilder builder) {
+    addChildrenToScene(builder);
   }
 }
 
@@ -588,7 +588,7 @@ class _ScreenshotPaintingContext extends PaintingContext {
     // We must build the regular scene before we can build the screenshot
     // scene as building the screenshot scene assumes addToScene has already
     // been called successfully for all layers in the regular scene.
-    repaintBoundary.layer.addToScene(ui.SceneBuilder(), Offset.zero);
+    repaintBoundary.layer.addToScene(ui.SceneBuilder());
 
     return data.containerLayer.toImage(renderBounds, pixelRatio: pixelRatio);
   }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -54,8 +54,8 @@ class _ProxyLayer extends Layer {
   _ProxyLayer(this._layer);
 
   @override
-  void addToScene(ui.SceneBuilder builder) {
-    _layer.addToScene(builder);
+  void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
+    _layer.addToScene(builder, layerOffset);
   }
 
   @override
@@ -312,8 +312,8 @@ Rect _calculateSubtreeBounds(RenderObject object) {
 /// screenshots render to the scene in the local coordinate system of the layer.
 class _ScreenshotContainerLayer extends OffsetLayer {
   @override
-  void addToScene(ui.SceneBuilder builder) {
-    addChildrenToScene(builder);
+  void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
+    addChildrenToScene(builder, layerOffset);
   }
 }
 
@@ -2235,7 +2235,7 @@ class _InspectorOverlayLayer extends Layer {
   double _textPainterMaxWidth;
 
   @override
-  void addToScene(ui.SceneBuilder builder) {
+  void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
     if (!selection.active)
       return;
 
@@ -2259,7 +2259,7 @@ class _InspectorOverlayLayer extends Layer {
       _lastState = state;
       _picture = _buildPicture(state);
     }
-    builder.addPicture(Offset.zero, _picture);
+    builder.addPicture(layerOffset, _picture);
   }
 
   ui.Picture _buildPicture(_InspectorOverlayRenderState state) {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2235,7 +2235,7 @@ class _InspectorOverlayLayer extends Layer {
   double _textPainterMaxWidth;
 
   @override
-  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
+  void addToScene(ui.SceneBuilder builder) {
     if (!selection.active)
       return;
 
@@ -2259,7 +2259,7 @@ class _InspectorOverlayLayer extends Layer {
       _lastState = state;
       _picture = _buildPicture(state);
     }
-    builder.addPicture(layerOffset, _picture);
+    builder.addPicture(Offset.zero, _picture);
   }
 
   ui.Picture _buildPicture(_InspectorOverlayRenderState state) {


### PR DESCRIPTION
For retained rendering, we don't want to push the offset down to each leaf layer. Otherwise, changing an offset layer on the very high level could cascade the change to too many leaves, which means that we can't retain them.

To not push the offset downwards, we simply push a TransformLayer when there's an offset. Skia has a fast path for concatenating scale/translation-only matrix so this operation should be fast (no performance regression is measured on Moto G4).

This also makes our compositor much cleaner as we don't have to pass `layerOffset` all over the places in `XXXLayer::addToScene`.

We can also remove the `offset_` field and its related operations from `flow::PictureLayer, flow::TextureLayer, flow::ChildSceneLayer` in flutter/engine once this change landed.

This is our first step towards https://github.com/flutter/flutter/issues/21756