### PR TITLE
Make AndroidView take gesture recognizer factories.

### DIFF
--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -282,8 +282,6 @@ class _LazyListIterator<E> implements Iterator<E> {
 }
 
 /// A factory interface that also reports the type of the created objects.
-///
-/// The equality of [Factory] object is determined solely by [Factory.type].
 class Factory<T> {
   /// Creates a new factory.
   ///
@@ -295,18 +293,6 @@ class Factory<T> {
 
   /// The type of the objects created by this factory.
   Type get type => T;
-
-  @override
-  bool operator ==(Object other) {
-    if (other is! Factory<T>) {
-      return false;
-    }
-    final Factory<T> typedOther = other;
-    return type == typedOther.type;
-  }
-
-  @override
-  int get hashCode => T.hashCode;
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -281,25 +281,20 @@ class _LazyListIterator<E> implements Iterator<E> {
   }
 }
 
-/// A factory interface, that also reports the type of the created objects.
+/// A factory interface that also reports the type of the created objects.
 ///
 /// The equality of [Factory] object is determined solely by [Factory.type].
 class Factory<T> {
   /// Creates a new factory.
   ///
-  /// If `type` is null, [Factory.type] returns [T], else it returns `type`.
-  ///
   /// The `constructor` parameter must not be null.
-  const Factory(this.constructor, {Type type})
-      : assert(constructor != null),
-        _type = type;
+  const Factory(this.constructor) : assert(constructor != null);
 
   /// Creates a new object of type T.
   final ValueGetter<T> constructor;
 
-  final Type _type;
   /// The type of the objects created by this factory.
-  Type get type => _type ?? T;
+  Type get type => T;
 
   @override
   bool operator ==(Object other) {
@@ -311,6 +306,11 @@ class Factory<T> {
   }
 
   @override
-  int get hashCode => _type.hashCode;
+  int get hashCode => T.hashCode;
+
+  @override
+  String toString() {
+    return 'Factory(type: $type)';
+  }
 }
 

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -280,3 +280,37 @@ class _LazyListIterator<E> implements Iterator<E> {
     return true;
   }
 }
+
+/// A factory interface, that also reports the type of the created objects.
+///
+/// The equality of [Factory] object is determined solely by [Factory.type].
+class Factory<T> {
+  /// Creates a new factory.
+  ///
+  /// If `type` is null, [Factory.type] returns [T], else it returns `type`.
+  ///
+  /// The `constructor` parameter must not be null.
+  const Factory(this.constructor, {Type type})
+      : assert(constructor != null),
+        _type = type;
+
+  /// Creates a new object of type T.
+  final ValueGetter<T> constructor;
+
+  final Type _type;
+  /// The type of the objects created by this factory.
+  Type get type => _type ?? T;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! Factory<T>) {
+      return false;
+    }
+    final Factory<T> typedOther = other;
+    return type == typedOther.type;
+  }
+
+  @override
+  int get hashCode => _type.hashCode;
+}
+

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -48,7 +48,7 @@ enum _PlatformViewState {
 ///
 /// RenderAndroidView participates in Flutter's [GestureArena]s, and dispatches touch events to the
 /// Android view iff it won the arena. Specific gestures that should be dispatched to the Android
-/// view can be specified in [RenderAndroidView.gestureRecognizers]. If
+/// view can be specified with factories in [RenderAndroidView.gestureRecognizers]. If
 /// [RenderAndroidView.gestureRecognizers] is empty, the gesture will be dispatched to the Android
 /// view iff it was not claimed by any other gesture recognizer.
 ///
@@ -61,14 +61,14 @@ class RenderAndroidView extends RenderBox {
   RenderAndroidView({
     @required AndroidViewController viewController,
     @required this.hitTestBehavior,
-    List<OneSequenceGestureRecognizer> gestureRecognizers = const <OneSequenceGestureRecognizer> [],
+    @required Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   }) : assert(viewController != null),
        assert(hitTestBehavior != null),
        assert(gestureRecognizers != null),
        _viewController = viewController
   {
     _motionEventsDispatcher = _MotionEventsDispatcher(globalToLocal, viewController);
-    this.gestureRecognizers = gestureRecognizers;
+    this.gestureRecognizers = gestureRecognizers ?? Set<Factory<OneSequenceGestureRecognizer>>();
   }
 
   _PlatformViewState _state = _PlatformViewState.uninitialized;
@@ -94,13 +94,13 @@ class RenderAndroidView extends RenderBox {
 
   /// Which gestures should be forwarded to the Android view.
   ///
-  /// The gesture recognizers on this list participate in the gesture arena for each pointer
-  /// that was put down on the render box. If any of the recognizers on this list wins the
+  /// Gesture recognizers created by factories in this set participate in the gesture arena for each
+  /// pointer that was put down on the render box. If any of the recognizers on this list wins the
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
   /// will be dispatched to the Android view.
-  set gestureRecognizers(List<OneSequenceGestureRecognizer> recognizers) {
+  set gestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> recognizers) {
     assert(recognizers != null);
-    if (recognizers == _gestureRecognizer?.gestureRecognizers) {
+    if (setEquals(recognizers, _gestureRecognizer?.gestureRecognizerFactories)) {
       return;
     }
     _gestureRecognizer?.dispose();
@@ -211,8 +211,14 @@ class RenderAndroidView extends RenderBox {
 }
 
 class _AndroidViewGestureRecognizer extends OneSequenceGestureRecognizer {
-  _AndroidViewGestureRecognizer(this.dispatcher, List<OneSequenceGestureRecognizer> gestureRecognizers) {
-    this.gestureRecognizers = gestureRecognizers;
+  _AndroidViewGestureRecognizer(this.dispatcher, this.gestureRecognizerFactories) {
+    _gestureRecognizers = gestureRecognizerFactories
+        .map((Factory<OneSequenceGestureRecognizer> factory) => factory.constructor()).toSet();
+    team = new GestureArenaTeam();
+    team.captain = this;
+    for (OneSequenceGestureRecognizer recognizer in _gestureRecognizers) {
+      recognizer.team = team;
+    }
   }
 
   final _MotionEventsDispatcher dispatcher;
@@ -230,16 +236,8 @@ class _AndroidViewGestureRecognizer extends OneSequenceGestureRecognizer {
   // We use OneSequenceGestureRecognizers as they support gesture arena teams.
   // TODO(amirh): get a list of GestureRecognizers here.
   // https://github.com/flutter/flutter/issues/20953
-  List<OneSequenceGestureRecognizer> _gestureRecognizers;
-  List<OneSequenceGestureRecognizer> get gestureRecognizers => _gestureRecognizers;
-  set gestureRecognizers(List<OneSequenceGestureRecognizer> recognizers) {
-    _gestureRecognizers = recognizers;
-    team = GestureArenaTeam();
-    team.captain = this;
-    for (OneSequenceGestureRecognizer recognizer in _gestureRecognizers) {
-      recognizer.team = team;
-    }
-  }
+  final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizerFactories;
+  Set<OneSequenceGestureRecognizer> _gestureRecognizers;
 
   @override
   void addPointer(PointerDownEvent event) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -68,8 +68,11 @@ class RenderAndroidView extends RenderBox {
        _viewController = viewController
   {
     _motionEventsDispatcher = _MotionEventsDispatcher(globalToLocal, viewController);
-    this.gestureRecognizers = gestureRecognizers ?? Set<Factory<OneSequenceGestureRecognizer>>();
+    setGestureRecognizers(gestureRecognizers ?? _emptyRecognizersSet);
   }
+
+  static final Set<Factory<OneSequenceGestureRecognizer>> _emptyRecognizersSet =
+      Set<Factory<OneSequenceGestureRecognizer>>();
 
   _PlatformViewState _state = _PlatformViewState.uninitialized;
 
@@ -98,13 +101,13 @@ class RenderAndroidView extends RenderBox {
   /// pointer that was put down on the render box. If any of the recognizers on this list wins the
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
   /// will be dispatched to the Android view.
-  set gestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> recognizers) {
-    assert(recognizers != null);
-    if (setEquals(recognizers, _gestureRecognizer?.gestureRecognizerFactories)) {
+  void setGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {
+    assert(gestureRecognizers != null);
+    if (setEquals(gestureRecognizers, _gestureRecognizer?.gestureRecognizerFactories)) {
       return;
     }
     _gestureRecognizer?.dispose();
-    _gestureRecognizer = _AndroidViewGestureRecognizer(_motionEventsDispatcher, recognizers);
+    _gestureRecognizer = _AndroidViewGestureRecognizer(_motionEventsDispatcher, gestureRecognizers);
   }
 
   @override
@@ -214,7 +217,7 @@ class _AndroidViewGestureRecognizer extends OneSequenceGestureRecognizer {
   _AndroidViewGestureRecognizer(this.dispatcher, this.gestureRecognizerFactories) {
     _gestureRecognizers = gestureRecognizerFactories
         .map((Factory<OneSequenceGestureRecognizer> factory) => factory.constructor()).toSet();
-    team = new GestureArenaTeam();
+    team = GestureArenaTeam();
     team.captain = this;
     for (OneSequenceGestureRecognizer recognizer in _gestureRecognizers) {
       recognizer.team = team;

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -101,14 +101,38 @@ class RenderAndroidView extends RenderBox {
   /// pointer that was put down on the render box. If any of the recognizers on this list wins the
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
   /// will be dispatched to the Android view.
+  ///
+  /// `gestureRecognizers` must not contain more than one factory with the same [Factory.type].
+  ///
+  /// Setting a new set of gesture recognizer factories with the same [Factory.type]s as the current
+  /// set is ignored.
+  ///
+  /// Setting a new set of gesture recognizer factories with different [Factory.type]s
+  /// (e.g `gestureRecognizers.map((f) => f.type).toSet()` is different, will reject any active
+  /// gesture arena.
   void setGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {
     assert(gestureRecognizers != null);
-    if (setEquals(gestureRecognizers, _gestureRecognizer?.gestureRecognizerFactories)) {
+    assert(_factoriesTypeSet(gestureRecognizers).length == gestureRecognizers.length);
+    if (_factoryTypesSetEquals(gestureRecognizers, _gestureRecognizer?.gestureRecognizerFactories)) {
       return;
     }
     _gestureRecognizer?.dispose();
     _gestureRecognizer = _AndroidViewGestureRecognizer(_motionEventsDispatcher, gestureRecognizers);
   }
+
+  static bool _factoryTypesSetEquals<T>(Set<Factory<T>> a, Set<Factory<T>> b) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null ||  b == null) {
+      return false;
+    }
+    return setEquals(_factoriesTypeSet(a), _factoriesTypeSet(b));
+  }
+
+  static Set<Type> _factoriesTypeSet<T>(Set<Factory<T>> factories) =>
+      factories.map<Type>((Factory<T> factory) => factory.type).toSet();
+
 
   @override
   bool get sizedByParent => true;

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -50,7 +50,7 @@ import 'framework.dart';
 class AndroidView extends StatefulWidget {
   /// Creates a widget that embeds an Android view.
   ///
-  /// The `viewType`, `hitTestBehavior`, and `gestureRecognizers` parameters must not be null.
+  /// The `viewType`, and `hitTestBehavior` parameters must not be null.
   /// If `creationParams` is not null then `creationParamsCodec` must not be null.
   AndroidView({ // ignore: prefer_const_constructors_in_immutables
                 // TODO(aam): Remove lint ignore above once dartbug.com/34297 is fixed
@@ -59,12 +59,11 @@ class AndroidView extends StatefulWidget {
     this.onPlatformViewCreated,
     this.hitTestBehavior = PlatformViewHitTestBehavior.opaque,
     this.layoutDirection,
-    this.gestureRecognizers = const <OneSequenceGestureRecognizer> [],
+    this.gestureRecognizers,
     this.creationParams,
-    this.creationParamsCodec
+    this.creationParamsCodec,
   }) : assert(viewType != null),
        assert(hitTestBehavior != null),
-        assert(gestureRecognizers != null),
        assert(creationParams == null || creationParamsCodec != null),
        super(key: key);
 
@@ -92,10 +91,13 @@ class AndroidView extends StatefulWidget {
 
   /// Which gestures should be forwarded to the Android view.
   ///
-  /// The gesture recognizers on this list participate in the gesture arena for each pointer
-  /// that was put down on the widget. If any of the recognizers on this list wins the
+  /// The gesture recognizers built by factories in this set participate in the gesture arena for
+  /// each pointer that was put down on the widget. If any of these recognizers win the
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
   /// will be dispatched to the Android view.
+  ///
+  /// When null an empty set of gesture recognizer factories is used, and a pointer event sequence
+  /// wil only be dispatched to the Android view if no other member of the arena claimed it.
   ///
   /// For example, with the following setup vertical drags will not be dispatched to the Android
   /// view as the vertical drag gesture is claimed by the parent [GestureDetector].
@@ -104,12 +106,11 @@ class AndroidView extends StatefulWidget {
   ///   onVerticalDragStart: (DragStartDetails d) {},
   ///   child: AndroidView(
   ///     viewType: 'webview',
-  ///     gestureRecognizers: <OneSequenceGestureRecognizer>[],
   ///   ),
   /// )
   /// ```
   /// To get the [AndroidView] to claim the vertical drag gestures we can pass a vertical drag
-  /// gesture recognizer in [gestureRecognizers] e.g:
+  /// gesture recognizer factory in [gestureRecognizers] e.g:
   /// ```dart
   /// GestureDetector(
   ///   onVerticalDragStart: (DragStartDetails d) {},
@@ -118,19 +119,25 @@ class AndroidView extends StatefulWidget {
   ///     height: 100.0,
   ///     child: AndroidView(
   ///       viewType: 'webview',
-  ///       gestureRecognizers: <OneSequenceGestureRecognizer>[ new VerticalDragGestureRecognizer() ],
+  ///       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+  ///         new Factory<OneSequenceGestureRecognizer>(
+  ///           () => new EagerGestureRecognizer(),
+  ///           type: VerticalDragGestureRecognizer,
+  ///         ),
+  ///       ].toSet(),
   ///     ),
   ///   ),
   /// )
   /// ```
   ///
   /// An [AndroidView] can be configured to consume all pointers that were put down in its bounds
-  /// by passing an [EagerGestureRecognizer] in [gestureRecognizers]. [EagerGestureRecognizer] is a
-  /// special gesture recognizer that immediately claims the gesture after a pointer down event.
+  /// by passing a factory fo an [EagerGestureRecognizer] in [gestureRecognizers].
+  /// [EagerGestureRecognizer] is a special gesture recognizer that immediately claims the gesture
+  /// after a pointer down event.
   // We use OneSequenceGestureRecognizers as they support gesture arena teams.
   // TODO(amirh): get a list of GestureRecognizers here.
   // https://github.com/flutter/flutter/issues/20953
-  final List<OneSequenceGestureRecognizer> gestureRecognizers;
+  final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
   /// Passed as the args argument of [PlatformViewFactory#create](/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html#create-android.content.Context-int-java.lang.Object-)
   ///
@@ -160,7 +167,7 @@ class _AndroidViewState extends State<AndroidView> {
     return _AndroidPlatformView(
         controller: _controller,
         hitTestBehavior: widget.hitTestBehavior,
-        gestureRecognizers: widget.gestureRecognizers,
+        gestureRecognizers: widget.gestureRecognizers ?? new Set<Factory<OneSequenceGestureRecognizer>>(),
     );
   }
 
@@ -245,7 +252,7 @@ class _AndroidPlatformView extends LeafRenderObjectWidget {
 
   final AndroidViewController controller;
   final PlatformViewHitTestBehavior hitTestBehavior;
-  final List<OneSequenceGestureRecognizer> gestureRecognizers;
+  final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
   @override
   RenderObject createRenderObject(BuildContext context) =>

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -122,7 +122,6 @@ class AndroidView extends StatefulWidget {
   ///       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
   ///         new Factory<OneSequenceGestureRecognizer>(
   ///           () => new EagerGestureRecognizer(),
-  ///           type: VerticalDragGestureRecognizer,
   ///         ),
   ///       ].toSet(),
   ///     ),
@@ -131,9 +130,14 @@ class AndroidView extends StatefulWidget {
   /// ```
   ///
   /// An [AndroidView] can be configured to consume all pointers that were put down in its bounds
-  /// by passing a factory fo an [EagerGestureRecognizer] in [gestureRecognizers].
+  /// by passing a factory for an [EagerGestureRecognizer] in [gestureRecognizers].
   /// [EagerGestureRecognizer] is a special gesture recognizer that immediately claims the gesture
   /// after a pointer down event.
+  ///
+  /// `gestureRecognizers` must not contain more than one factory with the same [Factory.type].
+  ///
+  /// Changing `gestureRecognizers` results in rejection of any active gesture arenas (if the
+  /// Android view is actively participating in an arena).
   // We use OneSequenceGestureRecognizers as they support gesture arena teams.
   // TODO(amirh): get a list of GestureRecognizers here.
   // https://github.com/flutter/flutter/issues/20953

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -119,7 +119,7 @@ class AndroidView extends StatefulWidget {
   ///     height: 100.0,
   ///     child: AndroidView(
   ///       viewType: 'webview',
-  ///       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+  ///       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
   ///         new Factory<OneSequenceGestureRecognizer>(
   ///           () => new EagerGestureRecognizer(),
   ///         ),
@@ -134,7 +134,7 @@ class AndroidView extends StatefulWidget {
   /// [EagerGestureRecognizer] is a special gesture recognizer that immediately claims the gesture
   /// after a pointer down event.
   ///
-  /// `gestureRecognizers` must not contain more than one factory with the same [Factory.type].
+  /// The `gestureRecognizers` property must not contain more than one factory with the same [Factory.type].
   ///
   /// Changing `gestureRecognizers` results in rejection of any active gesture arenas (if the
   /// Android view is actively participating in an arena).
@@ -166,12 +166,15 @@ class _AndroidViewState extends State<AndroidView> {
   TextDirection _layoutDirection;
   bool _initialized = false;
 
+  static final Set<Factory<OneSequenceGestureRecognizer>> _emptyRecognizersSet =
+    Set<Factory<OneSequenceGestureRecognizer>>();
+
   @override
   Widget build(BuildContext context) {
     return _AndroidPlatformView(
         controller: _controller,
         hitTestBehavior: widget.hitTestBehavior,
-        gestureRecognizers: widget.gestureRecognizers ?? Set<Factory<OneSequenceGestureRecognizer>>(),
+        gestureRecognizers: widget.gestureRecognizers ?? _emptyRecognizersSet,
     );
   }
 
@@ -270,6 +273,6 @@ class _AndroidPlatformView extends LeafRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderAndroidView renderObject) {
     renderObject.viewController = controller;
     renderObject.hitTestBehavior = hitTestBehavior;
-    renderObject.setGestureRecognizers(gestureRecognizers);
+    renderObject.updateGestureRecognizers(gestureRecognizers);
   }
 }

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -50,7 +50,7 @@ import 'framework.dart';
 class AndroidView extends StatefulWidget {
   /// Creates a widget that embeds an Android view.
   ///
-  /// The `viewType`, and `hitTestBehavior` parameters must not be null.
+  /// The `viewType` and `hitTestBehavior` parameters must not be null.
   /// If `creationParams` is not null then `creationParamsCodec` must not be null.
   AndroidView({ // ignore: prefer_const_constructors_in_immutables
                 // TODO(aam): Remove lint ignore above once dartbug.com/34297 is fixed
@@ -96,8 +96,8 @@ class AndroidView extends StatefulWidget {
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
   /// will be dispatched to the Android view.
   ///
-  /// When null an empty set of gesture recognizer factories is used, and a pointer event sequence
-  /// wil only be dispatched to the Android view if no other member of the arena claimed it.
+  /// When null, an empty set of gesture recognizer factories is used, in which case a pointer event sequence
+  /// will only be dispatched to the Android view if no other member of the arena claimed it.
   ///
   /// For example, with the following setup vertical drags will not be dispatched to the Android
   /// view as the vertical drag gesture is claimed by the parent [GestureDetector].
@@ -167,7 +167,7 @@ class _AndroidViewState extends State<AndroidView> {
     return _AndroidPlatformView(
         controller: _controller,
         hitTestBehavior: widget.hitTestBehavior,
-        gestureRecognizers: widget.gestureRecognizers ?? new Set<Factory<OneSequenceGestureRecognizer>>(),
+        gestureRecognizers: widget.gestureRecognizers ?? Set<Factory<OneSequenceGestureRecognizer>>(),
     );
   }
 
@@ -266,6 +266,6 @@ class _AndroidPlatformView extends LeafRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderAndroidView renderObject) {
     renderObject.viewController = controller;
     renderObject.hitTestBehavior = hitTestBehavior;
-    renderObject.gestureRecognizers = gestureRecognizers;
+    renderObject.setGestureRecognizers(gestureRecognizers);
   }
 }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -562,7 +563,12 @@ void main() {
             height: 100.0,
             child: AndroidView(
               viewType: 'webview',
-              gestureRecognizers: <OneSequenceGestureRecognizer> [VerticalDragGestureRecognizer()],
+              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+                Factory<OneSequenceGestureRecognizer>(
+                  () => VerticalDragGestureRecognizer(),
+                  type: VerticalDragGestureRecognizer,
+                ),
+              ].toSet(),
               layoutDirection: TextDirection.ltr,
             ),
           ),
@@ -684,7 +690,12 @@ void main() {
             height: 100.0,
             child: AndroidView(
               viewType: 'webview',
-              gestureRecognizers: <OneSequenceGestureRecognizer>[ EagerGestureRecognizer() ],
+              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+                Factory<OneSequenceGestureRecognizer>(
+                  () => EagerGestureRecognizer(),
+                  type: VerticalDragGestureRecognizer,
+                ),
+              ].toSet(),
               layoutDirection: TextDirection.ltr,
             ),
           ),
@@ -704,5 +715,25 @@ void main() {
         const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
       ]),
     );
+  });
+
+  testWidgets('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    final FakePlatformViewsController viewsController = new FakePlatformViewsController(TargetPlatform.android);
+    viewsController.registerViewType('webview');
+
+    final AndroidView androidView = AndroidView(
+      viewType: 'webview',
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+        new Factory<OneSequenceGestureRecognizer>(
+          () => new EagerGestureRecognizer(),
+          type: VerticalDragGestureRecognizer,
+        ),
+      ].toSet(),
+      layoutDirection: TextDirection.ltr,
+    );
+
+    await tester.pumpWidget(androidView);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(androidView);
   });
 }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -564,9 +564,8 @@ void main() {
             child: AndroidView(
               viewType: 'webview',
               gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
-                Factory<OneSequenceGestureRecognizer>(
+                Factory<VerticalDragGestureRecognizer>(
                   () => VerticalDragGestureRecognizer(),
-                  type: VerticalDragGestureRecognizer,
                 ),
               ].toSet(),
               layoutDirection: TextDirection.ltr,
@@ -693,7 +692,6 @@ void main() {
               gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
                 Factory<OneSequenceGestureRecognizer>(
                   () => EagerGestureRecognizer(),
-                  type: VerticalDragGestureRecognizer,
                 ),
               ].toSet(),
               layoutDirection: TextDirection.ltr,
@@ -717,16 +715,15 @@ void main() {
     );
   });
 
-  testWidgets('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
-    final FakePlatformViewsController viewsController = new FakePlatformViewsController(TargetPlatform.android);
+  testWidgets('RenderAndroidView reconstructed with same gestureRecognizers', (WidgetTester tester) async {
+    final FakePlatformViewsController viewsController = FakePlatformViewsController(TargetPlatform.android);
     viewsController.registerViewType('webview');
 
     final AndroidView androidView = AndroidView(
       viewType: 'webview',
       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
-        new Factory<OneSequenceGestureRecognizer>(
-          () => new EagerGestureRecognizer(),
-          type: VerticalDragGestureRecognizer,
+        Factory<EagerGestureRecognizer>(
+          () => EagerGestureRecognizer(),
         ),
       ].toSet(),
       layoutDirection: TextDirection.ltr,
@@ -735,5 +732,39 @@ void main() {
     await tester.pumpWidget(androidView);
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpWidget(androidView);
+  });
+
+  testWidgets('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    final FakePlatformViewsController viewsController = FakePlatformViewsController(TargetPlatform.android);
+    viewsController.registerViewType('webview');
+
+    int factoryInvocationCount = 0;
+    final ValueGetter<EagerGestureRecognizer> constructRecognizer = () {
+        factoryInvocationCount += 1;
+        return EagerGestureRecognizer();
+      };
+
+    await tester.pumpWidget(
+      AndroidView(
+        viewType: 'webview',
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+          Factory<EagerGestureRecognizer>(constructRecognizer),
+        ].toSet(),
+        layoutDirection: TextDirection.ltr,
+      ),
+    );
+
+    await tester.pumpWidget(
+      AndroidView(
+        viewType: 'webview',
+        hitTestBehavior: PlatformViewHitTestBehavior.translucent,
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+          Factory<EagerGestureRecognizer>(constructRecognizer),
+        ].toSet(),
+        layoutDirection: TextDirection.ltr,
+      ),
+    );
+
+    expect(factoryInvocationCount, 1);
   });
 }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -261,9 +261,9 @@ void main() {
 
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionUp, <int> [0], <Offset> [Offset(50.0, 50.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionUp, <int>[0], <Offset>[Offset(50.0, 50.0)]),
       ]),
     );
   });
@@ -278,7 +278,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
-          children: <Widget> [
+          children: <Widget>[
             Listener(
               behavior: HitTestBehavior.opaque,
               onPointerDown: (PointerDownEvent e) { numPointerDownsOnParent++; },
@@ -321,7 +321,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
-          children: <Widget> [
+          children: <Widget>[
             Listener(
               behavior: HitTestBehavior.opaque,
               onPointerDown: (PointerDownEvent e) { numPointerDownsOnParent++; },
@@ -346,8 +346,8 @@ void main() {
 
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
       ]),
     );
     expect(
@@ -366,7 +366,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
-          children: <Widget> [
+          children: <Widget>[
             Listener(
               behavior: HitTestBehavior.opaque,
               onPointerDown: (PointerDownEvent e) { numPointerDownsOnParent++; },
@@ -391,8 +391,8 @@ void main() {
 
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
       ]),
     );
     expect(
@@ -424,9 +424,9 @@ void main() {
 
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(40.0, 40.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionUp, <int> [0], <Offset> [Offset(40.0, 40.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(40.0, 40.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionUp, <int>[0], <Offset>[Offset(40.0, 40.0)]),
       ]),
     );
   });
@@ -563,7 +563,7 @@ void main() {
             height: 100.0,
             child: AndroidView(
               viewType: 'webview',
-              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
                 Factory<VerticalDragGestureRecognizer>(
                   () => VerticalDragGestureRecognizer(),
                 ),
@@ -582,10 +582,10 @@ void main() {
     expect(verticalDragAcceptedByParent, false);
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionMove, <int> [0], <Offset> [Offset(50.0, 150.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionUp, <int> [0], <Offset> [Offset(50.0, 150.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionMove, <int>[0], <Offset>[Offset(50.0, 150.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionUp, <int>[0], <Offset>[Offset(50.0, 150.0)]),
       ]),
     );
   });
@@ -621,9 +621,9 @@ void main() {
     expect(verticalDragAcceptedByParent, false);
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionUp, <int> [0], <Offset> [Offset(50.0, 50.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionUp, <int>[0], <Offset>[Offset(50.0, 50.0)]),
       ]),
     );
   });
@@ -667,10 +667,10 @@ void main() {
 
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionMove, <int> [0], <Offset> [Offset(50.0, 150.0)]),
-        const FakeMotionEvent(AndroidViewController.kActionUp, <int> [0], <Offset> [Offset(50.0, 150.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionMove, <int>[0], <Offset>[Offset(50.0, 150.0)]),
+        const FakeMotionEvent(AndroidViewController.kActionUp, <int>[0], <Offset>[Offset(50.0, 150.0)]),
       ]),
     );
   });
@@ -689,7 +689,7 @@ void main() {
             height: 100.0,
             child: AndroidView(
               viewType: 'webview',
-              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+              gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
                 Factory<OneSequenceGestureRecognizer>(
                   () => EagerGestureRecognizer(),
                 ),
@@ -709,8 +709,8 @@ void main() {
     // pointer down event is immediately dispatched.
     expect(
       viewsController.motionEvents[currentViewId + 1],
-      orderedEquals(<FakeMotionEvent> [
-        const FakeMotionEvent(AndroidViewController.kActionDown, <int> [0], <Offset> [Offset(50.0, 50.0)]),
+      orderedEquals(<FakeMotionEvent>[
+        const FakeMotionEvent(AndroidViewController.kActionDown, <int>[0], <Offset>[Offset(50.0, 50.0)]),
       ]),
     );
   });
@@ -721,7 +721,7 @@ void main() {
 
     final AndroidView androidView = AndroidView(
       viewType: 'webview',
-      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
         Factory<EagerGestureRecognizer>(
           () => EagerGestureRecognizer(),
         ),
@@ -747,7 +747,7 @@ void main() {
     await tester.pumpWidget(
       AndroidView(
         viewType: 'webview',
-        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
           Factory<EagerGestureRecognizer>(constructRecognizer),
         ].toSet(),
         layoutDirection: TextDirection.ltr,
@@ -758,7 +758,7 @@ void main() {
       AndroidView(
         viewType: 'webview',
         hitTestBehavior: PlatformViewHitTestBehavior.translucent,
-        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>> [
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>[
           Factory<EagerGestureRecognizer>(constructRecognizer),
         ].toSet(),
         layoutDirection: TextDirection.ltr,


### PR DESCRIPTION
Before this PR AndroidView's gestureRecognizers field was a list of
gesture recognizers. This was problematic as when the widget was rebuilt
with the same gesture recognizer instances we would try to re-join the
recognizers to a gesture arena team and crash (as a OneSeqeunceGestureRecognizer
team can only be set once).

With this change, we instead take a set of factories.
This allows AndroidView to create the gesture recognizers just before
adding them to the team, and thus be sure that they are only added once to a
team.

The factories are identified by the type of the object they create, this
allows AndroidView to know when it is given an equivalent set of gesture
recognizer factories, and do nothing in that case.

Fixes #21514.