### PR TITLE
Fix race condition in resident_runner

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -423,7 +423,12 @@ class AppDomain extends Domain {
     final Completer<void> appStartedCompleter = new Completer<void>();
     // We don't want to wait for this future to complete and callbacks won't fail.
     // As it just writes to stdout.
-    appStartedCompleter.future.then<void>((_) { // ignore: unawaited_futures
+    appStartedCompleter.future.timeout(const Duration(minutes: 1), onTimeout: () { // ignore: unawaited_futures
+      _sendAppEvent(app, 'log', <String, dynamic>{
+        'log': 'timeout waiting for the application to start',
+        'error': true,
+      });
+    }).then<void>((_) {
       _sendAppEvent(app, 'started');
     });
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -65,7 +65,7 @@ class FlutterDevice {
   Future<Null> _connect({ReloadSources reloadSources, CompileExpression compileExpression}) async {
     if (vmServices != null)
       return;
-    List<VMService> localVmServices = new List<VMService>(observatoryUris.length);
+    final List<VMService> localVmServices = new List<VMService>(observatoryUris.length);
     for (int i = 0; i < observatoryUris.length; i++) {
       printTrace('Connecting to service protocol: ${observatoryUris[i]}');
       localVmServices[i] = await VMService.connect(observatoryUris[i],

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -65,14 +65,15 @@ class FlutterDevice {
   Future<Null> _connect({ReloadSources reloadSources, CompileExpression compileExpression}) async {
     if (vmServices != null)
       return;
-    vmServices = new List<VMService>(observatoryUris.length);
+    List<VMService> localVmServices = new List<VMService>(observatoryUris.length);
     for (int i = 0; i < observatoryUris.length; i++) {
       printTrace('Connecting to service protocol: ${observatoryUris[i]}');
-      vmServices[i] = await VMService.connect(observatoryUris[i],
+      localVmServices[i] = await VMService.connect(observatoryUris[i],
           reloadSources: reloadSources,
           compileExpression: compileExpression);
       printTrace('Successfully connected to service protocol: ${observatoryUris[i]}');
     }
+    vmServices = localVmServices;
   }
 
   Future<Null> refreshViews() async {


### PR DESCRIPTION
* Don't set the `vmServices` member variable until it's fully initialized.
* Add a timeout to the future that sends the 'started' event to the IDE

https://github.com/flutter/flutter/issues/16604