### PR TITLE
Make platform_channels_swift use more idiomatic Swift

### DIFF
--- a/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
+++ b/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
@@ -47,7 +47,7 @@ import Flutter
                        eventSink: @escaping FlutterEventSink) -> FlutterError? {
     self.eventSink = eventSink
     UIDevice.current.isBatteryMonitoringEnabled = true
-    self.sendBatteryStateEvent()
+    sendBatteryStateEvent()
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(onBatteryStateDidChange),
@@ -57,7 +57,7 @@ import Flutter
   }
 
   @objc private func onBatteryStateDidChange(notification: NSNotification) {
-    self.sendBatteryStateEvent()
+    sendBatteryStateEvent()
   }
 
   private func sendBatteryStateEvent() {

--- a/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
+++ b/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
@@ -7,86 +7,82 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate, FlutterStreamHandler {
-  private var eventSink: FlutterEventSink?;
+  private var eventSink: FlutterEventSink?
 
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    GeneratedPluginRegistrant.register(with: self);
-    let controller : FlutterViewController = window?.rootViewController as! FlutterViewController;
-    let batteryChannel = FlutterMethodChannel.init(name: "samples.flutter.io/battery",
-                                                   binaryMessenger: controller);
+    GeneratedPluginRegistrant.register(with: self)
+    let controller: FlutterViewController = window?.rootViewController as! FlutterViewController
+    let batteryChannel = FlutterMethodChannel(name: "samples.flutter.io/battery",
+                                              binaryMessenger: controller)
     batteryChannel.setMethodCallHandler({
       (call: FlutterMethodCall, result: FlutterResult) -> Void in
-      if ("getBatteryLevel" == call.method) {
-        self.receiveBatteryLevel(result: result);
+      if "getBatteryLevel" == call.method {
+        self.receiveBatteryLevel(result: result)
       } else {
-        result(FlutterMethodNotImplemented);
+        result(FlutterMethodNotImplemented)
       }
-    });
+    })
 
-    let chargingChannel = FlutterEventChannel.init(name: "samples.flutter.io/charging",
-                                                   binaryMessenger: controller);
-    chargingChannel.setStreamHandler(self);
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions);
+    let chargingChannel = FlutterEventChannel(name: "samples.flutter.io/charging",
+                                              binaryMessenger: controller)
+    chargingChannel.setStreamHandler(self)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   private func receiveBatteryLevel(result: FlutterResult) {
-    let device = UIDevice.current;
-    device.isBatteryMonitoringEnabled = true;
-    if (device.batteryState == UIDeviceBatteryState.unknown) {
-      result(FlutterError.init(code: "UNAVAILABLE",
-                               message: "Battery info unavailable",
-                               details: nil));
+    let device = UIDevice.current
+    device.isBatteryMonitoringEnabled = true
+    if device.batteryState == UIDeviceBatteryState.unknown {
+      result(FlutterError(code: "UNAVAILABLE",
+                          message: "Battery info unavailable",
+                          details: nil))
     } else {
-      result(Int(device.batteryLevel * 100));
+      result(Int(device.batteryLevel * 100))
     }
   }
 
   public func onListen(withArguments arguments: Any?,
                        eventSink: @escaping FlutterEventSink) -> FlutterError? {
-    self.eventSink = eventSink;
-    UIDevice.current.isBatteryMonitoringEnabled = true;
-    self.sendBatteryStateEvent();
+    self.eventSink = eventSink
+    UIDevice.current.isBatteryMonitoringEnabled = true
+    self.sendBatteryStateEvent()
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(onBatteryStateDidChange),
       name: NSNotification.Name.UIDeviceBatteryStateDidChange,
       object: nil)
-    return nil;
+    return nil
   }
 
   @objc private func onBatteryStateDidChange(notification: NSNotification) {
-    self.sendBatteryStateEvent();
+    self.sendBatteryStateEvent()
   }
 
   private func sendBatteryStateEvent() {
-    if (eventSink == nil) {
-      return;
+    if eventSink == nil {
+      return
     }
 
-    let state = UIDevice.current.batteryState;
+    let state = UIDevice.current.batteryState
     switch state {
     case UIDeviceBatteryState.full:
-      eventSink!("charging");
-      break;
+      eventSink!("charging")
     case UIDeviceBatteryState.charging:
-      eventSink!("charging");
-      break;
+      eventSink!("charging")
     case UIDeviceBatteryState.unplugged:
-      eventSink!("discharging");
-      break;
+      eventSink!("discharging")
     default:
-      eventSink!(FlutterError.init(code: "UNAVAILABLE",
-                                   message: "Charging status unavailable",
-                                   details: nil));
-      break;
+      eventSink!(FlutterError(code: "UNAVAILABLE",
+                              message: "Charging status unavailable",
+                              details: nil))
     }
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    NotificationCenter.default.removeObserver(self);
-    eventSink = nil;
-    return nil;
+    NotificationCenter.default.removeObserver(self)
+    eventSink = nil
+    return nil
   }
 }


### PR DESCRIPTION
* Remove semicolons.
* `if (condition)` => `if condition`.
* `Class.init(...)` => `Class(...)`.
* Remove `break` statements from `switch` cases.