### PR TITLE
PageTransitionsTheme, new MountainView page transition

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -69,6 +69,7 @@ export 'src/material/material_localizations.dart';
 export 'src/material/mergeable_material.dart';
 export 'src/material/outline_button.dart';
 export 'src/material/page.dart';
+export 'src/material/page_transitions_theme.dart';
 export 'src/material/paginated_data_table.dart';
 export 'src/material/popup_menu.dart';
 export 'src/material/progress_indicator.dart';

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -273,8 +273,10 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     return backController;
   }
 
-  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full screen dialog,
-  /// otherwise a [CupertinoPageTransition] is returned.
+  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full
+  /// screen dialog, otherwise a [CupertinoPageTransition] is returned.
+  ///
+  /// Used by [CupertinoPageRoute.buildTransitions].
   ///
   /// This method can be applied to any [PageRoute], not just
   /// [CupertinoPageRoute]. It's typically used to provide a Cupertino style

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -176,26 +176,21 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     super.dispose();
   }
 
-  /// Whether a pop gesture is currently underway.
-  ///
-  /// This starts returning true when pop gesture is started by the user. It
-  /// returns false if that has not yet occurred or if the most recent such
-  /// gesture has completed.
+  /// True if a Cupertino pop gesture is currently underway for [route].
   ///
   /// See also:
   ///
-  ///  * [popGestureEnabled], which returns whether a pop gesture is appropriate
-  ///    in the first place.
+  ///  * [popGestureEnabled], which returns true if a user-triggered pop gesture
+  ///    would be allowed.
   static bool isPopGestureInProgress(PageRoute<dynamic> route) => _popGestureInProgress.contains(route);
   static final Set<PageRoute<dynamic>> _popGestureInProgress = Set<PageRoute<dynamic>>();
 
   /// Whether a pop gesture can be started by the user.
   ///
-  /// This returns true if the user can edge-swipe to a previous route,
-  /// otherwise false.
+  /// Returns true if the user can edge-swipe to a previous route.
   ///
-  /// This will return false once [popGestureInProgress] is true, but
-  /// [popGestureInProgress] can only become true if [popGestureEnabled] was
+  /// Returns false once [isPopGestureInProgress] is true, but
+  /// [isPopGestureInProgress] can only become true if [popGestureEnabled] was
   /// true first.
   ///
   /// This should only be used between frames, not during build.
@@ -278,7 +273,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   ///
   /// See also:
   ///
-  ///  * [CupertinoPageTransitionsBuilder] - which uses this method to define a
+  ///  * [CupertinoPageTransitionsBuilder], which uses this method to define a
   ///    [PageTransitionsBuilder] for the [PageTransitionTheme].
   static Widget buildPageTransitions<T>(
     PageRoute<T> route,
@@ -306,6 +301,8 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
         ),
       );
     }
+    assert(false);
+    return null;
   }
 
   @override
@@ -368,11 +365,10 @@ class CupertinoPageTransition extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasDirectionality(context));
     final TextDirection textDirection = Directionality.of(context);
-    // TODO(ianh): tell the transform to be un-transformed for hit testing
-    // but not while being controlled by a gesture.
     return SlideTransition(
       position: _secondaryPositionAnimation,
       textDirection: textDirection,
+      transformHitTests: false,
       child: SlideTransition(
         position: _primaryPositionAnimation,
         textDirection: textDirection,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -92,7 +92,6 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     RouteSettings settings,
     this.maintainState = true,
     bool fullscreenDialog = false,
-    this.hostRoute,
   }) : assert(builder != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
@@ -151,16 +150,6 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   @override
   final bool maintainState;
 
-  /// The route that owns this one.
-  ///
-  /// The [MaterialPageRoute] creates a [CupertinoPageRoute] to handle iOS-style
-  /// navigation. When this happens, the [MaterialPageRoute] is the [hostRoute]
-  /// of this [CupertinoPageRoute].
-  ///
-  /// The [hostRoute] is responsible for calling [dispose] on the route. When
-  /// there is a [hostRoute], the [CupertinoPageRoute] must not be [install]ed.
-  final PageRoute<T> hostRoute;
-
   @override
   Duration get transitionDuration => const Duration(milliseconds: 350);
 
@@ -182,26 +171,10 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  void install(OverlayEntry insertionPoint) {
-    assert(() {
-      if (hostRoute == null)
-        return true;
-      throw FlutterError(
-        'Cannot install a subsidiary route (one with a hostRoute).\n'
-        'This route ($this) cannot be installed, because it has a host route ($hostRoute).'
-      );
-    }());
-    super.install(insertionPoint);
-  }
-
-  @override
   void dispose() {
-    _backGestureController?.dispose();
-    _backGestureController = null;
+    _popGestureInProgress.remove(this);
     super.dispose();
   }
-
-  _CupertinoBackGestureController<T> _backGestureController;
 
   /// Whether a pop gesture is currently underway.
   ///
@@ -213,7 +186,8 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   ///
   ///  * [popGestureEnabled], which returns whether a pop gesture is appropriate
   ///    in the first place.
-  bool get popGestureInProgress => _backGestureController != null;
+  static bool isPopGestureInProgress(PageRoute<dynamic> route) => _popGestureInProgress.contains(route);
+  static final Set<PageRoute<dynamic>> _popGestureInProgress = new Set<PageRoute<dynamic>>();
 
   /// Whether a pop gesture can be started by the user.
   ///
@@ -225,8 +199,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   /// true first.
   ///
   /// This should only be used between frames, not during build.
-  bool get popGestureEnabled {
-    final PageRoute<T> route = hostRoute ?? this;
+  bool get popGestureEnabled => _isPopGestureEnabled(this);
+
+  static bool _isPopGestureEnabled<T>(PageRoute<T> route) {
     // If there's nothing to go back to, then obviously we don't support
     // the back gesture.
     if (route.isFirst)
@@ -240,52 +215,17 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     if (route.hasScopedWillPopCallback)
       return false;
     // Fullscreen dialogs aren't dismissable by back swipe.
-    if (fullscreenDialog)
+    if (route.fullscreenDialog)
       return false;
     // If we're in an animation already, we cannot be manually swiped.
     if (route.controller.status != AnimationStatus.completed)
       return false;
     // If we're in a gesture already, we cannot start another.
-    if (popGestureInProgress)
+    if (_popGestureInProgress.contains(route))
       return false;
+
     // Looks like a back gesture would be welcome!
     return true;
-  }
-
-  /// Begin dismissing this route from a horizontal swipe, if appropriate.
-  ///
-  /// Swiping will be disabled if the page is a fullscreen dialog or if
-  /// dismissals can be overridden because a [WillPopCallback] was
-  /// defined for the route.
-  ///
-  /// When this method decides a pop gesture is appropriate, it returns a
-  /// [CupertinoBackGestureController].
-  ///
-  /// See also:
-  ///
-  ///  * [hasScopedWillPopCallback], which is true if a `willPop` callback
-  ///    is defined for this route.
-  ///  * [popGestureEnabled], which returns whether a pop gesture is
-  ///    appropriate.
-  ///  * [Route.startPopGesture], which describes the contract that this method
-  ///    must implement.
-  _CupertinoBackGestureController<T> _startPopGesture() {
-    assert(!popGestureInProgress);
-    assert(popGestureEnabled);
-    final PageRoute<T> route = hostRoute ?? this;
-    _backGestureController = _CupertinoBackGestureController<T>(
-      navigator: route.navigator,
-      controller: route.controller,
-      onEnded: _endPopGesture,
-    );
-    return _backGestureController;
-  }
-
-  void _endPopGesture() {
-    // In practice this only gets called if for some reason popping the route
-    // did not cause this route to get disposed.
-    _backGestureController?.dispose();
-    _backGestureController = null;
   }
 
   @override
@@ -307,10 +247,48 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     return result;
   }
 
-  @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
-    if (fullscreenDialog) {
-      return CupertinoFullscreenDialogTransition(
+  // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
+  // gesture is detected. The returned controller handles all of the subsquent
+  // drag events.
+  static _CupertinoBackGestureController<T> _startPopGesture<T>(PageRoute<T> route) {
+    assert(!_popGestureInProgress.contains(route));
+    assert(_isPopGestureEnabled(route));
+    _popGestureInProgress.add(route);
+
+    _CupertinoBackGestureController<T> backController;
+    backController = new _CupertinoBackGestureController<T>(
+      navigator: route.navigator,
+      controller: route.controller,
+      onEnded: () {
+        backController?.dispose();
+        backController = null;
+        _popGestureInProgress.remove(route);
+      },
+    );
+    return backController;
+  }
+
+  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full screen dialog,
+  /// otherwise a [CupertinoPageTransition] is returned.
+  ///
+  /// This method can be applied to any [PageRoute], not just
+  /// [CupertinoPageRoute]. It's typically used to provide a Cupertino style
+  /// horizontal transition for material widgets when the target platform
+  /// is [TargetPlatform.iOS].
+  ///
+  /// See also:
+  ///
+  ///  * [CupertinoPageTransitionsBuilder] - which uses this method to define a
+  ///    [PageTransitionsBuilder] for the [PageTransitionTheme].
+  static Widget buildPageTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    if (route.fullscreenDialog) {
+      return new CupertinoFullscreenDialogTransition(
         animation: animation,
         child: child,
       );
@@ -320,14 +298,19 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
         secondaryRouteAnimation: secondaryAnimation,
         // In the middle of a back gesture drag, let the transition be linear to
         // match finger motions.
-        linearTransition: popGestureInProgress,
-        child: _CupertinoBackGestureDetector<T>(
-          enabledCallback: () => popGestureEnabled,
-          onStartPopGesture: _startPopGesture,
+        linearTransition: _popGestureInProgress.contains(route),
+        child: new _CupertinoBackGestureDetector<T>(
+          enabledCallback: () => _isPopGestureEnabled<T>(route),
+          onStartPopGesture: () => _startPopGesture<T>(route),
           child: child,
         ),
       );
     }
+  }
+
+  @override
+  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+    return buildPageTransitions<T>(this, context, animation, secondaryAnimation, child);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -187,7 +187,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   ///  * [popGestureEnabled], which returns whether a pop gesture is appropriate
   ///    in the first place.
   static bool isPopGestureInProgress(PageRoute<dynamic> route) => _popGestureInProgress.contains(route);
-  static final Set<PageRoute<dynamic>> _popGestureInProgress = new Set<PageRoute<dynamic>>();
+  static final Set<PageRoute<dynamic>> _popGestureInProgress = Set<PageRoute<dynamic>>();
 
   /// Whether a pop gesture can be started by the user.
   ///
@@ -256,7 +256,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     _popGestureInProgress.add(route);
 
     _CupertinoBackGestureController<T> backController;
-    backController = new _CupertinoBackGestureController<T>(
+    backController = _CupertinoBackGestureController<T>(
       navigator: route.navigator,
       controller: route.controller,
       onEnded: () {
@@ -288,7 +288,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     Widget child,
   ) {
     if (route.fullscreenDialog) {
-      return new CupertinoFullscreenDialogTransition(
+      return CupertinoFullscreenDialogTransition(
         animation: animation,
         child: child,
       );
@@ -299,7 +299,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
         // In the middle of a back gesture drag, let the transition be linear to
         // match finger motions.
         linearTransition: _popGestureInProgress.contains(route),
-        child: new _CupertinoBackGestureDetector<T>(
+        child: _CupertinoBackGestureDetector<T>(
           enabledCallback: () => _isPopGestureEnabled<T>(route),
           onStartPopGesture: () => _startPopGesture<T>(route),
           child: child,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -274,7 +274,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   /// See also:
   ///
   ///  * [CupertinoPageTransitionsBuilder], which uses this method to define a
-  ///    [PageTransitionsBuilder] for the [PageTransitionTheme].
+  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme].
   static Widget buildPageTransitions<T>(
     PageRoute<T> route,
     BuildContext context,
@@ -301,8 +301,6 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
         ),
       );
     }
-    assert(false);
-    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -185,6 +185,16 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   static bool isPopGestureInProgress(PageRoute<dynamic> route) => _popGestureInProgress.contains(route);
   static final Set<PageRoute<dynamic>> _popGestureInProgress = Set<PageRoute<dynamic>>();
 
+  /// True if a Cupertino pop gesture is currently underway for this route.
+  ///
+  /// See also:
+  ///
+  ///  * [isPopGestureInProgress], which returns true if a Cupertino pop gesture
+  ///    is currently underway for specific route.
+  ///  * [popGestureEnabled], which returns true if a user-triggered pop gesture
+  ///    would be allowed.
+  bool get popGestureInProgress => isPopGestureInProgress(this);
+
   /// Whether a pop gesture can be started by the user.
   ///
   /// Returns true if the user can edge-swipe to a previous route.

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -5,46 +5,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 
+import 'page_transitions_theme.dart';
 import 'theme.dart';
-
-// Fractional offset from 1/4 screen below the top to fully on screen.
-final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
-  begin: const Offset(0.0, 0.25),
-  end: Offset.zero,
-);
-
-// Used for Android and Fuchsia.
-class _MountainViewPageTransition extends StatelessWidget {
-  _MountainViewPageTransition({
-    Key key,
-    @required bool fade,
-    @required Animation<double> routeAnimation, // The route's linear 0.0 - 1.0 animation.
-    @required this.child,
-  }) : _positionAnimation = routeAnimation.drive(_kBottomUpTween.chain(_fastOutSlowInTween)),
-       _opacityAnimation = fade
-         ? routeAnimation.drive(_easeInTween) // Eyeballed from other Material apps.
-         : const AlwaysStoppedAnimation<double>(1.0),
-       super(key: key);
-
-  static final Animatable<double> _fastOutSlowInTween = CurveTween(curve: Curves.fastOutSlowIn);
-  static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
-
-  final Animation<Offset> _positionAnimation;
-  final Animation<double> _opacityAnimation;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO(ianh): tell the transform to be un-transformed for hit testing
-    return SlideTransition(
-      position: _positionAnimation,
-      child: FadeTransition(
-        opacity: _opacityAnimation,
-        child: child,
-      ),
-    );
-  }
-}
 
 /// A modal route that replaces the entire screen with a platform-adaptive
 /// transition.
@@ -71,10 +33,10 @@ class _MountainViewPageTransition extends StatelessWidget {
 ///
 /// See also:
 ///
-///  * [CupertinoPageRoute], which this [PageRoute] delegates transition
-///    animations to for iOS.
+///  * [PageTransitionTheme], which defines the default page transitions used
+///    by [MaterialPageRoute].
+///
 class MaterialPageRoute<T> extends PageRoute<T> {
-  /// Creates a page route for use in a material design app.
   MaterialPageRoute({
     @required this.builder,
     RouteSettings settings,
@@ -91,26 +53,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   final bool maintainState;
-
-  /// A delegate PageRoute to which iOS themed page operations are delegated to.
-  /// It's lazily created on first use.
-  CupertinoPageRoute<T> get _cupertinoPageRoute {
-    assert(_useCupertinoTransitions);
-    _internalCupertinoPageRoute ??= CupertinoPageRoute<T>(
-      builder: builder, // Not used.
-      fullscreenDialog: fullscreenDialog,
-      hostRoute: this,
-    );
-    return _internalCupertinoPageRoute;
-  }
-  CupertinoPageRoute<T> _internalCupertinoPageRoute;
-
-  /// Whether we should currently be using Cupertino transitions. This is true
-  /// if the theme says we're on iOS, or if we're in an active gesture.
-  bool get _useCupertinoTransitions {
-    return _internalCupertinoPageRoute?.popGestureInProgress == true
-        || Theme.of(navigator.context).platform == TargetPlatform.iOS;
-  }
 
   @override
   Duration get transitionDuration => const Duration(milliseconds: 300);
@@ -134,12 +76,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  void dispose() {
-    _internalCupertinoPageRoute?.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     final Widget result = Semantics(
       scopesRoute: true,
@@ -160,15 +96,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
-    if (_useCupertinoTransitions) {
-      return _cupertinoPageRoute.buildTransitions(context, animation, secondaryAnimation, child);
-    } else {
-      return _MountainViewPageTransition(
-        routeAnimation: animation,
-        child: child,
-        fade: true,
-      );
-    }
+    final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
+    return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
   }
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -33,16 +33,22 @@ import 'theme.dart';
 ///
 /// See also:
 ///
-///  * [PageTransitionTheme], which defines the default page transitions used
-///    by [MaterialPageRoute].
+///  * [PageTransitionsTheme], which defines the default page transitions used
+///    by [MaterialPageRoute.buildTransitions].
 ///
 class MaterialPageRoute<T> extends PageRoute<T> {
+  /// Construct a MaterialPageRoute whose contents are defined by [builder].
+  ///
+  /// The values of [builder], [maintainState], and [fullScreenDialog] must not
+  /// be null.
   MaterialPageRoute({
     @required this.builder,
     RouteSettings settings,
     this.maintainState = true,
     bool fullscreenDialog = false,
   }) : assert(builder != null),
+       assert(maintainState != null),
+       assert(fullscreenDialog != null),
        super(settings: settings, fullscreenDialog: fullscreenDialog) {
     // ignore: prefer_asserts_in_initializer_lists , https://github.com/dart-lang/sdk/issues/31223
     assert(opaque);

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -1,0 +1,349 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'colors.dart';
+import 'theme.dart';
+
+// Fractional offset from 1/4 screen below the top to fully on screen.
+final Tween<Offset> _kBottomUpTween = new Tween<Offset>(
+  begin: const Offset(0.0, 0.25),
+  end: Offset.zero,
+);
+
+// Slides the page upwards and fades it in, starting from 1/4 screen
+// below the top.
+class _GenericPageTransition extends StatelessWidget {
+  _GenericPageTransition({
+    Key key,
+    @required Animation<double> routeAnimation,
+    @required this.child,
+  }) : _positionAnimation = routeAnimation.drive(_kBottomUpTween.chain(_fastOutSlowInTween)),
+       _opacityAnimation = routeAnimation.drive(_easeInTween),
+       super(key: key);
+
+  static final Animatable<double> _fastOutSlowInTween = CurveTween(curve: Curves.fastOutSlowIn);
+  static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
+
+  final Animation<Offset> _positionAnimation;
+  final Animation<double> _opacityAnimation;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(ianh): tell the transform to be un-transformed for hit testing
+    return new SlideTransition(
+      position: _positionAnimation,
+      child: new FadeTransition(
+        opacity: _opacityAnimation,
+        child: child,
+      ),
+    );
+  }
+}
+
+// This transition is intended to match the default for Android P.
+class _MountainViewPageTransition extends StatelessWidget {
+  const _MountainViewPageTransition({
+    Key key,
+    this.animation,
+    this.secondaryAnimation,
+    this.child,
+  }) : super(key: key);
+
+  // The new page slides upwards just a little as its clip
+  // rectangle exposes the page from bottom to top.
+  static final Tween<Offset> _primaryTranslationTween = new Tween<Offset>(
+    begin: const Offset(0.0, 0.05),
+    end: Offset.zero,
+  );
+
+  // The old page slides downwards a little as the new page appears.
+  static final Tween<Offset> _secondaryTranslationTween = new Tween<Offset>(
+    begin: Offset.zero,
+    end: const Offset(0.0, -0.025),
+  );
+
+  // The scrim obscures the old page by becoming increasingly opaque.
+  static final Tween<double> _scrimOpacityTween = new Tween<double>(
+    begin: 0.0,
+    end: 0.25,
+  );
+
+  // Used by all of the transition animations.
+  static const Curve _transitionCurve = Cubic(0.20, 0.00, 0.00, 1.00);
+
+  final Animation<double> animation;
+  final Animation<double> secondaryAnimation;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return new LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final Size size = constraints.biggest;
+
+        // Gradually expose the new page from bottom to top.
+        final Animation<double> clipAnimation = new Tween<double>(
+          begin: 0.0,
+          end: size.height,
+        ).animate(
+          new CurvedAnimation(
+            parent: animation,
+            curve: _transitionCurve,
+            reverseCurve: _transitionCurve.flipped,
+          ),
+        );
+
+        final Animation<double> opacityAnimation = _scrimOpacityTween.animate(
+          new CurvedAnimation(
+            parent: animation,
+            curve: _transitionCurve,
+            reverseCurve: _transitionCurve.flipped,
+          ),
+        );
+
+        final Animation<Offset> primaryTranslationAnimation = _primaryTranslationTween.animate(
+          new CurvedAnimation(
+            parent: animation,
+            curve: _transitionCurve,
+            reverseCurve: _transitionCurve.flipped,
+          ),
+        );
+
+        final Animation<Offset> secondaryTranslationAnimation = _secondaryTranslationTween.animate(
+          new CurvedAnimation(
+            parent: secondaryAnimation,
+            curve: _transitionCurve,
+            reverseCurve: _transitionCurve.flipped,
+          ),
+        );
+
+        return new AnimatedBuilder(
+          animation: animation,
+          builder: (BuildContext context, Widget _) {
+            return new Container(
+              color: Colors.black.withOpacity(opacityAnimation.value),
+              alignment: Alignment.bottomLeft,
+              child: new ClipRect(
+                child: new SizedBox(
+                  height: clipAnimation.value,
+                  child: new OverflowBox(
+                    alignment: Alignment.bottomLeft,
+                    maxHeight: size.height,
+                    child: new AnimatedBuilder(
+                      animation: secondaryAnimation,
+                      child: new FractionalTranslation(
+                        translation: primaryTranslationAnimation.value,
+                        child: child,
+                      ),
+                      builder: (BuildContext context, Widget child) {
+                        return new FractionalTranslation(
+                          translation: secondaryTranslationAnimation.value,
+                          child: child,
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/// Used by [PageTransitionsTheme] to define a [MaterialPageRoute] page
+/// transition animation.
+///
+/// If [platform] is non-null then this transition is preferred when
+/// it matches the current platform, [ThemeData.platform].
+///
+/// Apps can configure the list of builders for [ThemeData.platformTheme]
+/// to customize the default [MaterialPageRoute] page transition animation
+/// for different platforms.
+///
+/// See also:
+///
+///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
+///    transition that matches nativer iOS page transitions.
+abstract class PageTransitionsBuilder {
+  const PageTransitionsBuilder({ this.platform });
+
+  final TargetPlatform platform;
+
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  );
+
+  @override
+  String toString() {
+    return '[$runtimeType${platform == null ? "" : " for $platform"}]';
+  }
+}
+
+/// Used by [PageTransitionsTheme] to define a default [MaterialPageRoute] page
+/// transition animation.
+///
+/// The default animation fades the new page in while translating it upwards,
+/// starting from about 25% below the top of the screen.
+///
+/// The [platform] for this builder is null which indicates that it's not
+/// platform-specific.
+///
+/// See also:
+///
+///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
+///    transition that matches nativer iOS page transitions.
+class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
+  const GenericPageTransitionsBuilder() : super(platform: null);
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return new _GenericPageTransition(routeAnimation: animation, child: child);
+  }
+}
+
+/// Used by [PageTransitionsTheme] to define a vertical [MaterialPageRoute] page
+/// transition animation that looks like the default page transition
+/// used on Android P.
+///
+/// The [platform] for this builder [TargetPlatform.android].
+///
+/// See also:
+///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
+///    transition that matches nativer iOS page transitions.
+class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
+  const MountainViewPageTransitionsBuilder() : super(platform: TargetPlatform.android);
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return new _MountainViewPageTransition(
+      animation: animation,
+      secondaryAnimation: secondaryAnimation,
+      child: child,
+    );
+  }
+}
+
+/// Used by [PageTransitionsTheme] to define a horizontal [MaterialPageRoute]
+/// page transition animation that matches native iOS page transitions.
+///
+/// The [platform] for this builder [TargetPlatform.iOS].
+///
+/// See also:
+///
+///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
+  const CupertinoPageTransitionsBuilder() : super(platform: TargetPlatform.iOS);
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return CupertinoPageRoute.buildPageTransitions<T>(route, context, animation, secondaryAnimation, child);
+  }
+}
+
+/// Defines the page transition animations used by [MaterialPageRoute]
+/// for different [TargetPlatform]s.
+///
+/// The [MaterialPageRoute.buildTransitions] method looks up the current
+/// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionTheme`
+/// and delegates to [buildTransitions].
+///
+/// If a builder with a matching platform is not found, the first builder
+/// with a null [PageTransitionsBuilder.platform] is used.
+@immutable
+class PageTransitionsTheme extends Diagnosticable {
+  const PageTransitionsTheme({
+    this.builders = const <PageTransitionsBuilder>[
+      GenericPageTransitionsBuilder(),
+      CupertinoPageTransitionsBuilder(),
+    ],
+  }) : assert(builders != null);
+
+  final Iterable<PageTransitionsBuilder> builders;
+
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    TargetPlatform platform = Theme.of(context).platform;
+
+    if (CupertinoPageRoute.isPopGestureInProgress(route))
+      platform = TargetPlatform.iOS;
+
+    PageTransitionsBuilder matchingBuilder;
+    for (PageTransitionsBuilder builder in builders) {
+      if (builder.platform == platform) {
+        matchingBuilder = builder;
+        break;
+      }
+      if (builder.platform == null)
+        matchingBuilder ??= builder;
+    }
+    assert(matchingBuilder != null);
+    return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    final PageTransitionsTheme typedOther = other;
+    if (identical(builders, other.builders))
+      return true;
+    return listEquals<PageTransitionsBuilder>(builders, typedOther.builders);
+  }
+
+  @override
+  int get hashCode => hashList(builders);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    const PageTransitionsTheme defaultTheme = PageTransitionsTheme();
+    properties.add(new DiagnosticsProperty<Iterable<PageTransitionsBuilder>>('builders', builders, defaultValue: defaultTheme.builders));
+  }
+}

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -125,7 +125,7 @@ class _MountainViewPageTransition extends StatelessWidget {
 
         return AnimatedBuilder(
           animation: animation,
-          builder: (BuildContext context, Widget _) {
+          builder: (BuildContext context, Widget child) {
             return Container(
               color: Colors.black.withOpacity(opacityAnimation.value),
               alignment: Alignment.bottomLeft,
@@ -135,24 +135,25 @@ class _MountainViewPageTransition extends StatelessWidget {
                   child: OverflowBox(
                     alignment: Alignment.bottomLeft,
                     maxHeight: size.height,
-                    child: AnimatedBuilder(
-                      animation: secondaryAnimation,
-                      child: FractionalTranslation(
-                        translation: primaryTranslationAnimation.value,
-                        child: child,
-                      ),
-                      builder: (BuildContext context, Widget child) {
-                        return FractionalTranslation(
-                          translation: secondaryTranslationAnimation.value,
-                          child: child,
-                        );
-                      },
-                    ),
+                    child: child,
                   ),
                 ),
               ),
             );
           },
+          child: AnimatedBuilder(
+            animation: secondaryAnimation,
+            child: FractionalTranslation(
+              translation: primaryTranslationAnimation.value,
+              child: child,
+            ),
+            builder: (BuildContext context, Widget child) {
+              return FractionalTranslation(
+                translation: secondaryTranslationAnimation.value,
+                child: child,
+              );
+            },
+          ),
         );
       },
     );
@@ -175,7 +176,7 @@ class _MountainViewPageTransition extends StatelessWidget {
 ///  * [MountainViewPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
-///    transition that matches nativer iOS page transitions.
+///    transition that matches native iOS page transitions.
 abstract class PageTransitionsBuilder {
   const PageTransitionsBuilder({ this.platform });
 
@@ -209,7 +210,7 @@ abstract class PageTransitionsBuilder {
 ///  * [MountainViewPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
-///    transition that matches nativer iOS page transitions.
+///    transition that matches native iOS page transitions.
 class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
   const GenericPageTransitionsBuilder() : super(platform: null);
 
@@ -234,7 +235,7 @@ class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
 /// See also:
 ///  * [GenericPageTransitionsBuilder], which defines a default page transition.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
-///    transition that matches nativer iOS page transitions.
+///    transition that matches native iOS page transitions.
 class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
   const MountainViewPageTransitionsBuilder() : super(platform: TargetPlatform.android);
 
@@ -264,7 +265,6 @@ class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [GenericPageTransitionsBuilder], which defines a default page transition.
 ///  * [MountainViewPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
-///  * [GenericPageTransitionsBuilder], which defines a default page transition.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   const CupertinoPageTransitionsBuilder() : super(platform: TargetPlatform.iOS);
 
@@ -289,8 +289,19 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 /// If a builder with a matching platform is not found, the first builder
 /// with a null [PageTransitionsBuilder.platform] is used.
+///
+/// See also:
+///
+///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
+///    transition that matches native iOS page transitions.
 @immutable
 class PageTransitionsTheme extends Diagnosticable {
+  /// Construct a PageTransitionsTheme [ThemeData] value.
+  ///
+  /// The [builders] parameter must not be null.
   const PageTransitionsTheme({
     this.builders = const <PageTransitionsBuilder>[
       GenericPageTransitionsBuilder(),
@@ -300,6 +311,10 @@ class PageTransitionsTheme extends Diagnosticable {
 
   final Iterable<PageTransitionsBuilder> builders;
 
+  /// Wraps the child with one or more transition widgets which define how [route]
+  /// arrives on and leaves the screen.
+  ///
+  /// [MaterialPageRoute.builderTransitions] delegates to this method.
   Widget buildTransitions<T>(
     PageRoute<T> route,
     BuildContext context,

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -200,9 +200,6 @@ abstract class PageTransitionsBuilder {
 /// The default animation fades the new page in while translating it upwards,
 /// starting from about 25% below the top of the screen.
 ///
-/// The [platform] for this builder is null which indicates that it's not
-/// platform-specific.
-///
 /// See also:
 ///
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
@@ -210,7 +207,7 @@ abstract class PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class FadeUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Construct a FadeUpwardsPageTransitionsBuilder with a null [platform].
+  /// Construct a [FadeUpwardsPageTransitionsBuilder].
   const FadeUpwardsPageTransitionsBuilder();
 
   @override
@@ -234,7 +231,7 @@ class FadeUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Construct a OpenUpwardsPageTransitionsBuilder.
+  /// Construct a [OpenUpwardsPageTransitionsBuilder].
   const OpenUpwardsPageTransitionsBuilder();
 
   @override
@@ -262,7 +259,7 @@ class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Construct a CupertinoPageTransitionsBuilder.
+  /// Construct a [CupertinoPageTransitionsBuilder].
   const CupertinoPageTransitionsBuilder();
 
   @override
@@ -305,9 +302,9 @@ class PageTransitionsTheme extends Diagnosticable {
   /// and [TargetPlatform.iOS] respectively.
   const PageTransitionsTheme({ Map<TargetPlatform, PageTransitionsBuilder> builders }) : _builders = builders;
 
-  static final Map<TargetPlatform, PageTransitionsBuilder> _defaultBuilders = <TargetPlatform, PageTransitionsBuilder>{
-    TargetPlatform.android: const FadeUpwardsPageTransitionsBuilder(),
-    TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
+  static const Map<TargetPlatform, PageTransitionsBuilder> _defaultBuilders = <TargetPlatform, PageTransitionsBuilder>{
+    TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+    TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
   };
 
   /// The [PageTransitionsBuilder]s supported by this theme.
@@ -335,6 +332,8 @@ class PageTransitionsTheme extends Diagnosticable {
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 
+  // Just used to the buidlers Map to a list with one PageTransitionsBuilder per platform
+  // for the operator == overload.
   List<PageTransitionsBuilder> _all(Map<TargetPlatform, PageTransitionsBuilder> builders) {
     return TargetPlatform.values.map((TargetPlatform platform) => builders[platform]).toList();
   }
@@ -357,7 +356,12 @@ class PageTransitionsTheme extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    const PageTransitionsTheme defaultTheme = PageTransitionsTheme();
-    properties.add(DiagnosticsProperty<Map<TargetPlatform, PageTransitionsBuilder>>('builders', builders, defaultValue: defaultTheme.builders));
+    properties.add(
+      DiagnosticsProperty<Map<TargetPlatform, PageTransitionsBuilder>>(
+        'builders',
+        builders,
+        defaultValue: PageTransitionsTheme._defaultBuilders
+      ),
+    );
   }
 }

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -86,33 +86,20 @@ class _OpenUpwardsPageTransition extends StatelessWidget {
       builder: (BuildContext context, BoxConstraints constraints) {
         final Size size = constraints.biggest;
 
+        final CurvedAnimation primaryAnimation = CurvedAnimation(
+          parent: animation,
+          curve: _transitionCurve,
+          reverseCurve: _transitionCurve.flipped,
+        );
+
         // Gradually expose the new page from bottom to top.
         final Animation<double> clipAnimation = Tween<double>(
           begin: 0.0,
           end: size.height,
-        ).animate(
-          CurvedAnimation(
-            parent: animation,
-            curve: _transitionCurve,
-            reverseCurve: _transitionCurve.flipped,
-          ),
-        );
+        ).animate(primaryAnimation);
 
-        final Animation<double> opacityAnimation = _scrimOpacityTween.animate(
-          CurvedAnimation(
-            parent: animation,
-            curve: _transitionCurve,
-            reverseCurve: _transitionCurve.flipped,
-          ),
-        );
-
-        final Animation<Offset> primaryTranslationAnimation = _primaryTranslationTween.animate(
-          CurvedAnimation(
-            parent: animation,
-            curve: _transitionCurve,
-            reverseCurve: _transitionCurve.flipped,
-          ),
-        );
+        final Animation<double> opacityAnimation = _scrimOpacityTween.animate(primaryAnimation);
+        final Animation<Offset> primaryTranslationAnimation = _primaryTranslationTween.animate(primaryAnimation);
 
         final Animation<Offset> secondaryTranslationAnimation = _secondaryTranslationTween.animate(
           CurvedAnimation(

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -17,8 +17,8 @@ final Tween<Offset> _kBottomUpTween = Tween<Offset>(
 
 // Slides the page upwards and fades it in, starting from 1/4 screen
 // below the top.
-class _GenericPageTransition extends StatelessWidget {
-  _GenericPageTransition({
+class _FadeUpwardsPageTransition extends StatelessWidget {
+  _FadeUpwardsPageTransition({
     Key key,
     @required Animation<double> routeAnimation, // The route's linear 0.0 - 1.0 animation.
     @required this.child,
@@ -47,8 +47,8 @@ class _GenericPageTransition extends StatelessWidget {
 }
 
 // This transition is intended to match the default for Android P.
-class _MountainViewPageTransition extends StatelessWidget {
-  const _MountainViewPageTransition({
+class _OpenUpwardsPageTransition extends StatelessWidget {
+  const _OpenUpwardsPageTransition({
     Key key,
     this.animation,
     this.secondaryAnimation,
@@ -172,8 +172,8 @@ class _MountainViewPageTransition extends StatelessWidget {
 ///
 /// See also:
 ///
-///  * [GenericPageTransitionsBuilder], which defines a default page transition.
-///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
@@ -218,13 +218,13 @@ abstract class PageTransitionsBuilder {
 ///
 /// See also:
 ///
-///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
-class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Construct a GenericPageTransitionsBuilder with a null [platform].
-  const GenericPageTransitionsBuilder() : super(platform: null);
+class FadeUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Construct a FadeUpwardsPageTransitionsBuilder with a null [platform].
+  const FadeUpwardsPageTransitionsBuilder() : super(platform: null);
 
   @override
   Widget buildTransitions<T>(
@@ -234,7 +234,7 @@ class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return _GenericPageTransition(routeAnimation: animation, child: child);
+    return _FadeUpwardsPageTransition(routeAnimation: animation, child: child);
   }
 }
 
@@ -245,13 +245,13 @@ class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
 /// The [platform] for this builder [TargetPlatform.android].
 ///
 /// See also:
-///  * [GenericPageTransitionsBuilder], which defines a default page transition.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
-class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Construct a MountainViewPageTransitionsBuilder with a
+class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Construct a OpenUpwardsPageTransitionsBuilder with a
   /// [TargetPlatform.android] [platform].
-  const MountainViewPageTransitionsBuilder() : super(platform: TargetPlatform.android);
+  const OpenUpwardsPageTransitionsBuilder() : super(platform: TargetPlatform.android);
 
   @override
   Widget buildTransitions<T>(
@@ -261,7 +261,7 @@ class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return _MountainViewPageTransition(
+    return _OpenUpwardsPageTransition(
       animation: animation,
       secondaryAnimation: secondaryAnimation,
       child: child,
@@ -276,8 +276,8 @@ class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 /// See also:
 ///
-///  * [GenericPageTransitionsBuilder], which defines a default page transition.
-///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Construct a CupertinoPageTransitionsBuilder with a
@@ -310,8 +310,8 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 ///  * [ThemeData.pageTransitionsTheme], which defines the default page
 ///    transitions for the overall theme.
-///  * [GenericPageTransitionsBuilder], which defines a default page transition.
-///  * [MountainViewPageTransitionsBuilder], which defines a page transition
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
@@ -321,11 +321,11 @@ class PageTransitionsTheme extends Diagnosticable {
   ///
   /// The [builders] parameter must not be null.
   ///
-  /// By default the list of builders is: [GenericPageTransitionBuilder],
+  /// By default the list of builders is: [FadeUpwardsPageTransitionsBuilder],
   /// [CupertinoPageTransitionsBuilder].
   const PageTransitionsTheme({
     this.builders = const <PageTransitionsBuilder>[
-      GenericPageTransitionsBuilder(),
+      FadeUpwardsPageTransitionsBuilder(),
       CupertinoPageTransitionsBuilder(),
     ],
   }) : assert(builders != null);
@@ -339,7 +339,7 @@ class PageTransitionsTheme extends Diagnosticable {
   ///
   /// If a builder with a matching platform is not found, the first
   /// builder whose platform is null is used. By default that's the
-  /// [GenericPageTransitionBuilder].
+  /// [FadeUpwardsPageTransitionsBuilder].
   ///
   /// [MaterialPageRoute.builderTransitions] delegates to this method.
   Widget buildTransitions<T>(

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -35,9 +35,9 @@ class _GenericPageTransition extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO(ianh): tell the transform to be un-transformed for hit testing
     return SlideTransition(
       position: _positionAnimation,
+      // TODO(ianh): tell the transform to be un-transformed for hit testing
       child: FadeTransition(
         opacity: _opacityAnimation,
         child: child,
@@ -178,10 +178,21 @@ class _MountainViewPageTransition extends StatelessWidget {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 abstract class PageTransitionsBuilder {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
   const PageTransitionsBuilder({ this.platform });
 
+  /// The [TargetPlatform] this builder is to be used for or null if the
+  /// builder is not platform-specific.
   final TargetPlatform platform;
 
+  /// Wraps the child with one or more transition widgets which define how [route]
+  /// arrives on and leaves the screen.
+  ///
+  /// The [MaterialPageRoute.buildTransitions] method looks up the current
+  /// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
+  /// and delegates to this method with a [PageTransitionsBuilder] that has
+  /// a matching [PageTransitionsBuilder.platform].
   Widget buildTransitions<T>(
     PageRoute<T> route,
     BuildContext context,
@@ -212,6 +223,7 @@ abstract class PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Construct a GenericPageTransitionsBuilder with a null [platform].
   const GenericPageTransitionsBuilder() : super(platform: null);
 
   @override
@@ -237,6 +249,8 @@ class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Construct a MountainViewPageTransitionsBuilder with a
+  /// [TargetPlatform.android] [platform].
   const MountainViewPageTransitionsBuilder() : super(platform: TargetPlatform.android);
 
   @override
@@ -266,6 +280,8 @@ class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [MountainViewPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Construct a CupertinoPageTransitionsBuilder with a
+  /// [TargetPlatform.iOS] [platform].
   const CupertinoPageTransitionsBuilder() : super(platform: TargetPlatform.iOS);
 
   @override
@@ -284,7 +300,7 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 /// for different [TargetPlatform]s.
 ///
 /// The [MaterialPageRoute.buildTransitions] method looks up the current
-/// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionTheme`
+/// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
 /// and delegates to [buildTransitions].
 ///
 /// If a builder with a matching platform is not found, the first builder
@@ -292,6 +308,8 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 /// See also:
 ///
+///  * [ThemeData.pageTransitionsTheme], which defines the default page
+///    transitions for the overall theme.
 ///  * [GenericPageTransitionsBuilder], which defines a default page transition.
 ///  * [MountainViewPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
@@ -299,9 +317,12 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///    transition that matches native iOS page transitions.
 @immutable
 class PageTransitionsTheme extends Diagnosticable {
-  /// Construct a PageTransitionsTheme [ThemeData] value.
+  /// Construct a PageTransitionsTheme.
   ///
   /// The [builders] parameter must not be null.
+  ///
+  /// By default the list of builders is: [GenericPageTransitionBuilder],
+  /// [CupertinoPageTransitionsBuilder].
   const PageTransitionsTheme({
     this.builders = const <PageTransitionsBuilder>[
       GenericPageTransitionsBuilder(),
@@ -309,10 +330,16 @@ class PageTransitionsTheme extends Diagnosticable {
     ],
   }) : assert(builders != null);
 
+  /// The [PageTransitionsBuilder]s supported by this theme.
   final Iterable<PageTransitionsBuilder> builders;
 
-  /// Wraps the child with one or more transition widgets which define how [route]
-  /// arrives on and leaves the screen.
+  /// Delegates to the first builder in [builders] whose
+  /// [PageTransitionsBuilder.platform] matches the current target
+  /// platform: `Theme.of(context).platform`.
+  ///
+  /// If a builder with a matching platform is not found, the first
+  /// builder whose platform is null is used. By default that's the
+  /// [GenericPageTransitionBuilder].
   ///
   /// [MaterialPageRoute.builderTransitions] delegates to this method.
   Widget buildTransitions<T>(

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -10,7 +10,7 @@ import 'colors.dart';
 import 'theme.dart';
 
 // Fractional offset from 1/4 screen below the top to fully on screen.
-final Tween<Offset> _kBottomUpTween = new Tween<Offset>(
+final Tween<Offset> _kBottomUpTween = Tween<Offset>(
   begin: const Offset(0.0, 0.25),
   end: Offset.zero,
 );
@@ -20,7 +20,7 @@ final Tween<Offset> _kBottomUpTween = new Tween<Offset>(
 class _GenericPageTransition extends StatelessWidget {
   _GenericPageTransition({
     Key key,
-    @required Animation<double> routeAnimation,
+    @required Animation<double> routeAnimation, // The route's linear 0.0 - 1.0 animation.
     @required this.child,
   }) : _positionAnimation = routeAnimation.drive(_kBottomUpTween.chain(_fastOutSlowInTween)),
        _opacityAnimation = routeAnimation.drive(_easeInTween),
@@ -36,9 +36,9 @@ class _GenericPageTransition extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // TODO(ianh): tell the transform to be un-transformed for hit testing
-    return new SlideTransition(
+    return SlideTransition(
       position: _positionAnimation,
-      child: new FadeTransition(
+      child: FadeTransition(
         opacity: _opacityAnimation,
         child: child,
       ),
@@ -57,19 +57,19 @@ class _MountainViewPageTransition extends StatelessWidget {
 
   // The new page slides upwards just a little as its clip
   // rectangle exposes the page from bottom to top.
-  static final Tween<Offset> _primaryTranslationTween = new Tween<Offset>(
+  static final Tween<Offset> _primaryTranslationTween = Tween<Offset>(
     begin: const Offset(0.0, 0.05),
     end: Offset.zero,
   );
 
   // The old page slides downwards a little as the new page appears.
-  static final Tween<Offset> _secondaryTranslationTween = new Tween<Offset>(
+  static final Tween<Offset> _secondaryTranslationTween = Tween<Offset>(
     begin: Offset.zero,
-    end: const Offset(0.0, -0.025),
+    end: const Offset(0.0, 0.025),
   );
 
   // The scrim obscures the old page by becoming increasingly opaque.
-  static final Tween<double> _scrimOpacityTween = new Tween<double>(
+  static final Tween<double> _scrimOpacityTween = Tween<double>(
     begin: 0.0,
     end: 0.25,
   );
@@ -83,16 +83,16 @@ class _MountainViewPageTransition extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new LayoutBuilder(
+    return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final Size size = constraints.biggest;
 
         // Gradually expose the new page from bottom to top.
-        final Animation<double> clipAnimation = new Tween<double>(
+        final Animation<double> clipAnimation = Tween<double>(
           begin: 0.0,
           end: size.height,
         ).animate(
-          new CurvedAnimation(
+          CurvedAnimation(
             parent: animation,
             curve: _transitionCurve,
             reverseCurve: _transitionCurve.flipped,
@@ -100,7 +100,7 @@ class _MountainViewPageTransition extends StatelessWidget {
         );
 
         final Animation<double> opacityAnimation = _scrimOpacityTween.animate(
-          new CurvedAnimation(
+          CurvedAnimation(
             parent: animation,
             curve: _transitionCurve,
             reverseCurve: _transitionCurve.flipped,
@@ -108,7 +108,7 @@ class _MountainViewPageTransition extends StatelessWidget {
         );
 
         final Animation<Offset> primaryTranslationAnimation = _primaryTranslationTween.animate(
-          new CurvedAnimation(
+          CurvedAnimation(
             parent: animation,
             curve: _transitionCurve,
             reverseCurve: _transitionCurve.flipped,
@@ -116,33 +116,33 @@ class _MountainViewPageTransition extends StatelessWidget {
         );
 
         final Animation<Offset> secondaryTranslationAnimation = _secondaryTranslationTween.animate(
-          new CurvedAnimation(
+          CurvedAnimation(
             parent: secondaryAnimation,
             curve: _transitionCurve,
             reverseCurve: _transitionCurve.flipped,
           ),
         );
 
-        return new AnimatedBuilder(
+        return AnimatedBuilder(
           animation: animation,
           builder: (BuildContext context, Widget _) {
-            return new Container(
+            return Container(
               color: Colors.black.withOpacity(opacityAnimation.value),
               alignment: Alignment.bottomLeft,
-              child: new ClipRect(
-                child: new SizedBox(
+              child: ClipRect(
+                child: SizedBox(
                   height: clipAnimation.value,
-                  child: new OverflowBox(
+                  child: OverflowBox(
                     alignment: Alignment.bottomLeft,
                     maxHeight: size.height,
-                    child: new AnimatedBuilder(
+                    child: AnimatedBuilder(
                       animation: secondaryAnimation,
-                      child: new FractionalTranslation(
+                      child: FractionalTranslation(
                         translation: primaryTranslationAnimation.value,
                         child: child,
                       ),
                       builder: (BuildContext context, Widget child) {
-                        return new FractionalTranslation(
+                        return FractionalTranslation(
                           translation: secondaryTranslationAnimation.value,
                           child: child,
                         );
@@ -221,7 +221,7 @@ class GenericPageTransitionsBuilder extends PageTransitionsBuilder {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return new _GenericPageTransition(routeAnimation: animation, child: child);
+    return _GenericPageTransition(routeAnimation: animation, child: child);
   }
 }
 
@@ -246,7 +246,7 @@ class MountainViewPageTransitionsBuilder extends PageTransitionsBuilder {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return new _MountainViewPageTransition(
+    return _MountainViewPageTransition(
       animation: animation,
       secondaryAnimation: secondaryAnimation,
       child: child,
@@ -344,6 +344,6 @@ class PageTransitionsTheme extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const PageTransitionsTheme defaultTheme = PageTransitionsTheme();
-    properties.add(new DiagnosticsProperty<Iterable<PageTransitionsBuilder>>('builders', builders, defaultValue: defaultTheme.builders));
+    properties.add(DiagnosticsProperty<Iterable<PageTransitionsBuilder>>('builders', builders, defaultValue: defaultTheme.builders));
   }
 }

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -61,10 +61,10 @@ class _OpenUpwardsPageTransition extends StatelessWidget {
     end: Offset.zero,
   );
 
-  // The old page slides downwards a little as the new page appears.
+  // The old page slides upwards a little as the new page appears.
   static final Tween<Offset> _secondaryTranslationTween = Tween<Offset>(
     begin: Offset.zero,
-    end: const Offset(0.0, 0.025),
+    end: const Offset(0.0, -0.025),
   );
 
   // The scrim obscures the old page by becoming increasingly opaque.

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -9,12 +9,6 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'theme.dart';
 
-// Fractional offset from 1/4 screen below the top to fully on screen.
-final Tween<Offset> _kBottomUpTween = Tween<Offset>(
-  begin: const Offset(0.0, 0.25),
-  end: Offset.zero,
-);
-
 // Slides the page upwards and fades it in, starting from 1/4 screen
 // below the top.
 class _FadeUpwardsPageTransition extends StatelessWidget {
@@ -22,10 +16,15 @@ class _FadeUpwardsPageTransition extends StatelessWidget {
     Key key,
     @required Animation<double> routeAnimation, // The route's linear 0.0 - 1.0 animation.
     @required this.child,
-  }) : _positionAnimation = routeAnimation.drive(_kBottomUpTween.chain(_fastOutSlowInTween)),
+  }) : _positionAnimation = routeAnimation.drive(_bottomUpTween.chain(_fastOutSlowInTween)),
        _opacityAnimation = routeAnimation.drive(_easeInTween),
        super(key: key);
 
+  // Fractional offset from 1/4 screen below the top to fully on screen.
+  static final Tween<Offset> _bottomUpTween = Tween<Offset>(
+    begin: const Offset(0.0, 0.25),
+    end: Offset.zero,
+  );
   static final Animatable<double> _fastOutSlowInTween = CurveTween(curve: Curves.fastOutSlowIn);
   static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -14,6 +14,7 @@ import 'colors.dart';
 import 'ink_splash.dart';
 import 'ink_well.dart' show InteractiveInkFeatureFactory;
 import 'input_decorator.dart';
+import 'page_transitions_theme.dart';
 import 'slider_theme.dart';
 import 'typography.dart';
 
@@ -143,6 +144,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
+    PageTransitionsTheme pageTransitionsTheme,
   }) {
     materialTapTargetSize ??= MaterialTapTargetSize.padded;
     brightness ??= Brightness.light;
@@ -182,6 +184,7 @@ class ThemeData extends Diagnosticable {
     hintColor ??= isDark ?  const Color(0x80FFFFFF) : const Color(0x8A000000);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
+    pageTransitionsTheme ??= const PageTransitionsTheme();
     primaryIconTheme ??= primaryIsDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
     accentIconTheme ??= accentIsDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black);
     iconTheme ??= isDark ? const IconThemeData(color: Colors.white) : const IconThemeData(color: Colors.black87);
@@ -251,6 +254,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme,
       platform: platform,
       materialTapTargetSize: materialTapTargetSize,
+      pageTransitionsTheme: pageTransitionsTheme,
     );
   }
 
@@ -302,6 +306,7 @@ class ThemeData extends Diagnosticable {
     @required this.chipTheme,
     @required this.platform,
     @required this.materialTapTargetSize,
+    @required this.pageTransitionsTheme,
   }) : assert(brightness != null),
        assert(primaryColor != null),
        assert(primaryColorBrightness != null),
@@ -341,7 +346,8 @@ class ThemeData extends Diagnosticable {
        assert(sliderTheme != null),
        assert(chipTheme != null),
        assert(platform != null),
-       assert(materialTapTargetSize != null);
+       assert(materialTapTargetSize != null),
+       assert(pageTransitionsTheme != null);
 
   /// A default light blue theme.
   ///
@@ -543,6 +549,9 @@ class ThemeData extends Diagnosticable {
   /// Configures the hit test size of certain Material widgets.
   final MaterialTapTargetSize materialTapTargetSize;
 
+  /// Default [PageRoute] transitions per [TargetPlatform].
+  final PageTransitionsTheme pageTransitionsTheme;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ThemeData copyWith({
     Brightness brightness,
@@ -586,6 +595,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
+    PageTransitionsTheme pageTransitionsTheme,
   }) {
     return ThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -629,6 +639,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme ?? this.chipTheme,
       platform: platform ?? this.platform,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
+      pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
     );
   }
 
@@ -758,6 +769,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t),
       platform: t < 0.5 ? a.platform : b.platform,
       materialTapTargetSize: t < 0.5 ? a.materialTapTargetSize : b.materialTapTargetSize,
+      pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
     );
   }
 
@@ -804,7 +816,8 @@ class ThemeData extends Diagnosticable {
            (otherData.sliderTheme == sliderTheme) &&
            (otherData.chipTheme == chipTheme) &&
            (otherData.platform == platform) &&
-           (otherData.materialTapTargetSize == materialTapTargetSize);
+           (otherData.materialTapTargetSize == materialTapTargetSize) &&
+           (otherData.pageTransitionsTheme == pageTransitionsTheme);
   }
 
   @override
@@ -829,7 +842,7 @@ class ThemeData extends Diagnosticable {
       secondaryHeaderColor,
       textSelectionColor,
       textSelectionHandleColor,
-      hashValues(  // Too many values.
+      hashValues(  // hashValues only supports 20 arguments
         toggleableActiveColor,
         backgroundColor,
         accentColor,
@@ -849,7 +862,10 @@ class ThemeData extends Diagnosticable {
         chipTheme,
         platform,
         materialTapTargetSize,
-        cursorColor
+        hashValues(
+          pageTransitionsTheme,
+          cursorColor,
+        ),
       ),
     );
   }
@@ -896,6 +912,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<SliderThemeData>('sliderTheme', sliderTheme));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize));
+    properties.add(new DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
   }
 }
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -212,6 +212,7 @@ class ThemeData extends Diagnosticable {
       brightness: brightness,
       labelStyle: textTheme.body2,
     );
+
     return ThemeData.raw(
       brightness: brightness,
       primaryColor: primaryColor,
@@ -265,6 +266,9 @@ class ThemeData extends Diagnosticable {
   /// create intermediate themes based on two themes created with the
   /// [new ThemeData] constructor.
   const ThemeData.raw({
+    // Warning: make sure these properties are in the exact same order as in
+    // operator == and in the hashValues method and in the order of fields
+    // in this class, and in the lerp() method.
     @required this.brightness,
     @required this.primaryColor,
     @required this.primaryColorBrightness,
@@ -549,7 +553,11 @@ class ThemeData extends Diagnosticable {
   /// Configures the hit test size of certain Material widgets.
   final MaterialTapTargetSize materialTapTargetSize;
 
-  /// Default [PageRoute] transitions per [TargetPlatform].
+  /// Default [MaterialPageRoute] transitions per [TargetPlatform].
+  ///
+  /// [MaterialPageRoute.buildTransitions] delegates to a [PageTransitionsBuilder]
+  /// whose [PageTransitionsBuilder.platform] matches [platform]. If a matching
+  /// builder is not found, a builder whose platform is null is used.
   final PageTransitionsTheme pageTransitionsTheme;
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
@@ -734,6 +742,8 @@ class ThemeData extends Diagnosticable {
       primaryColorLight: Color.lerp(a.primaryColorLight, b.primaryColorLight, t),
       primaryColorDark: Color.lerp(a.primaryColorDark, b.primaryColorDark, t),
       canvasColor: Color.lerp(a.canvasColor, b.canvasColor, t),
+      accentColor: Color.lerp(a.accentColor, b.accentColor, t),
+      accentColorBrightness: t < 0.5 ? a.accentColorBrightness : b.accentColorBrightness,
       scaffoldBackgroundColor: Color.lerp(a.scaffoldBackgroundColor, b.scaffoldBackgroundColor, t),
       bottomAppBarColor: Color.lerp(a.bottomAppBarColor, b.bottomAppBarColor, t),
       cardColor: Color.lerp(a.cardColor, b.cardColor, t),
@@ -745,6 +755,7 @@ class ThemeData extends Diagnosticable {
       unselectedWidgetColor: Color.lerp(a.unselectedWidgetColor, b.unselectedWidgetColor, t),
       disabledColor: Color.lerp(a.disabledColor, b.disabledColor, t),
       buttonColor: Color.lerp(a.buttonColor, b.buttonColor, t),
+      toggleableActiveColor: Color.lerp(a.toggleableActiveColor, b.toggleableActiveColor, t),
       buttonTheme: t < 0.5 ? a.buttonTheme : b.buttonTheme,
       secondaryHeaderColor: Color.lerp(a.secondaryHeaderColor, b.secondaryHeaderColor, t),
       textSelectionColor: Color.lerp(a.textSelectionColor, b.textSelectionColor, t),
@@ -752,12 +763,9 @@ class ThemeData extends Diagnosticable {
       textSelectionHandleColor: Color.lerp(a.textSelectionHandleColor, b.textSelectionHandleColor, t),
       backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
       dialogBackgroundColor: Color.lerp(a.dialogBackgroundColor, b.dialogBackgroundColor, t),
-      accentColor: Color.lerp(a.accentColor, b.accentColor, t),
-      accentColorBrightness: t < 0.5 ? a.accentColorBrightness : b.accentColorBrightness,
       indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t),
       hintColor: Color.lerp(a.hintColor, b.hintColor, t),
       errorColor: Color.lerp(a.errorColor, b.errorColor, t),
-      toggleableActiveColor: Color.lerp(a.toggleableActiveColor, b.toggleableActiveColor, t),
       textTheme: TextTheme.lerp(a.textTheme, b.textTheme, t),
       primaryTextTheme: TextTheme.lerp(a.primaryTextTheme, b.primaryTextTheme, t),
       accentTextTheme: TextTheme.lerp(a.accentTextTheme, b.accentTextTheme, t),
@@ -778,9 +786,16 @@ class ThemeData extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final ThemeData otherData = other;
+    // Warning: make sure these properties are in the exact same order as in
+    // hashValues() and in the raw constructor and in the order of fields in
+    // the class and in the lerp() method.
     return (otherData.brightness == brightness) &&
            (otherData.primaryColor == primaryColor) &&
            (otherData.primaryColorBrightness == primaryColorBrightness) &&
+           (otherData.primaryColorLight == primaryColorLight) &&
+           (otherData.primaryColorDark == primaryColorDark) &&
+           (otherData.accentColor == accentColor) &&
+           (otherData.accentColorBrightness == accentColorBrightness) &&
            (otherData.canvasColor == canvasColor) &&
            (otherData.scaffoldBackgroundColor == scaffoldBackgroundColor) &&
            (otherData.bottomAppBarColor == bottomAppBarColor) &&
@@ -801,8 +816,6 @@ class ThemeData extends Diagnosticable {
            (otherData.textSelectionHandleColor == textSelectionHandleColor) &&
            (otherData.backgroundColor == backgroundColor) &&
            (otherData.dialogBackgroundColor == dialogBackgroundColor) &&
-           (otherData.accentColor == accentColor) &&
-           (otherData.accentColorBrightness == accentColorBrightness) &&
            (otherData.indicatorColor == indicatorColor) &&
            (otherData.hintColor == hintColor) &&
            (otherData.errorColor == errorColor) &&
@@ -822,10 +835,18 @@ class ThemeData extends Diagnosticable {
 
   @override
   int get hashCode {
+    // The hashValues() function supports up to 20 arguments.
     return hashValues(
+      // Warning: make sure these properties are in the exact same order as in
+      // operator == and in the raw constructor and in the order of fields in
+      // the class and in the lerp() method.
       brightness,
       primaryColor,
       primaryColorBrightness,
+      primaryColorLight,
+      primaryColorDark,
+      accentColor,
+      accentColorBrightness,
       canvasColor,
       scaffoldBackgroundColor,
       bottomAppBarColor,
@@ -836,35 +857,32 @@ class ThemeData extends Diagnosticable {
       splashFactory,
       selectedRowColor,
       unselectedWidgetColor,
-      disabledColor,
       buttonColor,
       buttonTheme,
-      secondaryHeaderColor,
-      textSelectionColor,
-      textSelectionHandleColor,
-      hashValues(  // hashValues only supports 20 arguments
-        toggleableActiveColor,
+      hashValues(
+        secondaryHeaderColor,
+        textSelectionColor,
+        cursorColor,
+        textSelectionHandleColor,
         backgroundColor,
-        accentColor,
-        accentColorBrightness,
-        indicatorColor,
         dialogBackgroundColor,
+        indicatorColor,
         hintColor,
         errorColor,
+        toggleableActiveColor,
         textTheme,
         primaryTextTheme,
         accentTextTheme,
-        iconTheme,
         inputDecorationTheme,
+        iconTheme,
         primaryIconTheme,
         accentIconTheme,
         sliderTheme,
         chipTheme,
         platform,
-        materialTapTargetSize,
         hashValues(
+          materialTapTargetSize,
           pageTransitionsTheme,
-          cursorColor,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -912,7 +912,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<SliderThemeData>('sliderTheme', sliderTheme));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize));
-    properties.add(new DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
+    properties.add(DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
   }
 }
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -879,8 +879,8 @@ class ThemeData extends Diagnosticable {
         accentIconTheme,
         sliderTheme,
         chipTheme,
-        platform,
         hashValues(
+          platform,
           materialTapTargetSize,
           pageTransitionsTheme,
         ),

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -917,7 +917,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// The parameters `viewport` and `offset` are required and cannot be null.
   /// If `descendant` is null, this is a no-op and `rect` is returned.
   ///
-  /// If both `decedent` and `rect` are null, null is returned because there is
+  /// If both `descendant` and `rect` are null, null is returned because there is
   /// nothing to be shown in the viewport.
   ///
   /// The `duration` parameter can be set to a non-zero value to animate the

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -41,7 +41,7 @@ void main() {
     expect(find.byType(CupertinoPageTransition), findsOneWidget);
   });
 
-  testWidgets('Default PageTranstionsTheme builds a _GenericPageTransition for android', (WidgetTester tester) async {
+  testWidgets('Default PageTranstionsTheme builds a _FadeUpwardsPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: FlatButton(
@@ -59,23 +59,23 @@ void main() {
       ),
     );
 
-    Finder findGenericPageTransition() {
+    Finder findFadeUpwardsPageTransition() {
       return find.descendant(
         of: find.byType(MaterialApp),
-        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_GenericPageTransition'),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_FadeUpwardsPageTransition'),
       );
     }
 
     expect(Theme.of(tester.element(find.text('push'))).platform, TargetPlatform.android);
-    expect(findGenericPageTransition(), findsOneWidget);
+    expect(findFadeUpwardsPageTransition(), findsOneWidget);
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
-    expect(findGenericPageTransition(), findsOneWidget);
+    expect(findFadeUpwardsPageTransition(), findsOneWidget);
   });
 
-  testWidgets('pageTranstionsTheme override builds a _MountainViewPageTransition for android', (WidgetTester tester) async {
+  testWidgets('pageTranstionsTheme override builds a _OpenUpwardsPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: FlatButton(
@@ -92,8 +92,8 @@ void main() {
           platform: TargetPlatform.android,
           pageTransitionsTheme: const PageTransitionsTheme(
             builders: <PageTransitionsBuilder>[
-              GenericPageTransitionsBuilder(),
-              MountainViewPageTransitionsBuilder(), // creates a _MoutainViewPageTransition
+              FadeUpwardsPageTransitionsBuilder(),
+              OpenUpwardsPageTransitionsBuilder(), // creates a _MoutainViewPageTransition
             ],
           ),
         ),
@@ -101,20 +101,20 @@ void main() {
       ),
     );
 
-    Finder findMountainViewPageTransition() {
+    Finder findOpenUpwardsPageTransition() {
       return find.descendant(
         of: find.byType(MaterialApp),
-        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MountainViewPageTransition'),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_OpenUpwardsPageTransition'),
       );
     }
 
     expect(Theme.of(tester.element(find.text('push'))).platform, TargetPlatform.android);
-    expect(findMountainViewPageTransition(), findsOneWidget);
+    expect(findOpenUpwardsPageTransition(), findsOneWidget);
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
-    expect(findMountainViewPageTransition(), findsOneWidget);
+    expect(findOpenUpwardsPageTransition(), findsOneWidget);
   });
 
 }

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Default PageTranstionsTheme includes a builder with a null platform', (WidgetTester tester) async {
-    await tester.pumpWidget(new MaterialApp(home: const Text('home')));
+    await tester.pumpWidget(MaterialApp(home: const Text('home')));
     final PageTransitionsTheme theme = Theme.of(tester.element(find.text('home'))).pageTransitionsTheme;
     expect(theme.builders, isNotNull);
     expect(theme.builders.map((PageTransitionsBuilder builder) => builder.platform), contains(null));
@@ -16,8 +16,8 @@ void main() {
 
   testWidgets('Default PageTranstionsTheme builds a CupertionPageTransition for iOS', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
-      '/': (BuildContext context) => new Material(
-        child: new FlatButton(
+      '/': (BuildContext context) => Material(
+        child: FlatButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -26,8 +26,8 @@ void main() {
     };
 
     await tester.pumpWidget(
-      new MaterialApp(
-        theme: new ThemeData(platform: TargetPlatform.iOS),
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
         routes: routes,
       ),
     );
@@ -43,8 +43,8 @@ void main() {
 
   testWidgets('Default PageTranstionsTheme builds a _GenericPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
-      '/': (BuildContext context) => new Material(
-        child: new FlatButton(
+      '/': (BuildContext context) => Material(
+        child: FlatButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -53,8 +53,8 @@ void main() {
     };
 
     await tester.pumpWidget(
-      new MaterialApp(
-        theme: new ThemeData(platform: TargetPlatform.android),
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
         routes: routes,
       ),
     );
@@ -77,8 +77,8 @@ void main() {
 
   testWidgets('pageTranstionsTheme override builds a _MountainViewPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
-      '/': (BuildContext context) => new Material(
-        child: new FlatButton(
+      '/': (BuildContext context) => Material(
+        child: FlatButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -87,8 +87,8 @@ void main() {
     };
 
     await tester.pumpWidget(
-      new MaterialApp(
-        theme: new ThemeData(
+      MaterialApp(
+        theme: ThemeData(
           platform: TargetPlatform.android,
           pageTransitionsTheme: const PageTransitionsTheme(
             builders: <PageTransitionsBuilder>[

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Default PageTranstionsTheme includes a builder with a null platform', (WidgetTester tester) async {
+    await tester.pumpWidget(new MaterialApp(home: const Text('home')));
+    final PageTransitionsTheme theme = Theme.of(tester.element(find.text('home'))).pageTransitionsTheme;
+    expect(theme.builders, isNotNull);
+    expect(theme.builders.map((PageTransitionsBuilder builder) => builder.platform), contains(null));
+  });
+
+  testWidgets('Default PageTranstionsTheme builds a CupertionPageTransition for iOS', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => new Material(
+        child: new FlatButton(
+          child: const Text('push'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => const Text('page b'),
+    };
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.iOS),
+        routes: routes,
+      ),
+    );
+
+    expect(Theme.of(tester.element(find.text('push'))).platform, TargetPlatform.iOS);
+    expect(find.byType(CupertinoPageTransition), findsOneWidget);
+
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+    expect(find.text('page b'), findsOneWidget);
+    expect(find.byType(CupertinoPageTransition), findsOneWidget);
+  });
+
+  testWidgets('Default PageTranstionsTheme builds a _GenericPageTransition for android', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => new Material(
+        child: new FlatButton(
+          child: const Text('push'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => const Text('page b'),
+    };
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(platform: TargetPlatform.android),
+        routes: routes,
+      ),
+    );
+
+    Finder findGenericPageTransition() {
+      return find.descendant(
+        of: find.byType(MaterialApp),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_GenericPageTransition'),
+      );
+    }
+
+    expect(Theme.of(tester.element(find.text('push'))).platform, TargetPlatform.android);
+    expect(findGenericPageTransition(), findsOneWidget);
+
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+    expect(find.text('page b'), findsOneWidget);
+    expect(findGenericPageTransition(), findsOneWidget);
+  });
+
+  testWidgets('pageTranstionsTheme override builds a _MountainViewPageTransition for android', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => new Material(
+        child: new FlatButton(
+          child: const Text('push'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => const Text('page b'),
+    };
+
+    await tester.pumpWidget(
+      new MaterialApp(
+        theme: new ThemeData(
+          platform: TargetPlatform.android,
+          pageTransitionsTheme: const PageTransitionsTheme(
+            builders: <PageTransitionsBuilder>[
+              GenericPageTransitionsBuilder(),
+              MountainViewPageTransitionsBuilder(), // creates a _MoutainViewPageTransition
+            ],
+          ),
+        ),
+        routes: routes,
+      ),
+    );
+
+    Finder findMountainViewPageTransition() {
+      return find.descendant(
+        of: find.byType(MaterialApp),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MountainViewPageTransition'),
+      );
+    }
+
+    expect(Theme.of(tester.element(find.text('push'))).platform, TargetPlatform.android);
+    expect(findMountainViewPageTransition(), findsOneWidget);
+
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+    expect(find.text('page b'), findsOneWidget);
+    expect(findMountainViewPageTransition(), findsOneWidget);
+  });
+
+}

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -7,11 +7,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Default PageTranstionsTheme includes a builder with a null platform', (WidgetTester tester) async {
+  testWidgets('Default PageTranstionsTheme platform', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(home: const Text('home')));
     final PageTransitionsTheme theme = Theme.of(tester.element(find.text('home'))).pageTransitionsTheme;
     expect(theme.builders, isNotNull);
-    expect(theme.builders.map((PageTransitionsBuilder builder) => builder.platform), contains(null));
+    expect(theme.builders[TargetPlatform.android], isNotNull);
+    expect(theme.builders[TargetPlatform.iOS], isNotNull);
   });
 
   testWidgets('Default PageTranstionsTheme builds a CupertionPageTransition for iOS', (WidgetTester tester) async {
@@ -91,10 +92,9 @@ void main() {
         theme: ThemeData(
           platform: TargetPlatform.android,
           pageTransitionsTheme: const PageTransitionsTheme(
-            builders: <PageTransitionsBuilder>[
-              FadeUpwardsPageTransitionsBuilder(),
-              OpenUpwardsPageTransitionsBuilder(), // creates a _MoutainViewPageTransition
-            ],
+            builders: <TargetPlatform, PageTransitionsBuilder>{
+              TargetPlatform.android: OpenUpwardsPageTransitionsBuilder(), // creates a _OpenUpwardsPageTransition
+            },
           ),
         ),
         routes: routes,


### PR DESCRIPTION
MaterialPageRoute transitions are now defined by the Theme. Added (optional) support for Android P style page transitions.

The default MaterialPageRoute transitions have not changed: the horizontal `CuperitinoPageTransition` is still used when the target platform is `iOS` and the fading upwards transition is used for all other target platforms.

Added a `ThemeData.pageTransitionsTheme` which provides the default implementation of `MaterialPageRoute.buildTransitions` per target platform. Subclasses of `PageTransitionsBuilder` define `buildTransitions` methods.

Three `PageTransitionsBuilder` subclasses are provided: `FadeUpwardsTransitionsBuilder`, `CupertinoPageTransitionsBuilder`, `OpenUpwardsPageTransitionsBuilder.`

By default `PageTransitionsTheme` only includes FadeUpwardsPageTransitionsBuilder, and CupertinoPageTransitionsBuilder. 

To use the new Android P style page transition when the target platform is Android, include `OpenUpwardsPageTransitionsBuilder` in the Theme's `pageTransitionsTheme`. For example:

```
new MaterialApp(
  theme: new ThemeData(
    pageTransitionsTheme: const PageTransitionsTheme(
      builders: <TargetPlatform, PageTransitionsBuilder>{
        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
        TargetPlatform.android: OpenUpwardsPageTransitionsBuilder(),
      },
    ),
  ),
  ...
)

```

Two of the CupertinoPageRoute methods that had been used to enable building a MaterialPageRoute that used a "host" CupertinoPageRoute's `buildTransitions()` method have been removed or changed:

```
PageRoute<T> get hostRoute;  // also removed the constructor parameter
bool get popGestureInProgress;
```

The last method was replaced by a static method that reports the same value for any route that's using a Cupertino transition:

```
  static bool isPopGestureInProgress(PageRoute route)
```

These are backwards incompatible changes. However it seems unlikely that any existing apps depended on them.

