### PR TITLE
Increase initial delay for scroll_perf_test to try to reduce worst frame stats flakiness. 

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -25,7 +25,7 @@ void main() {
       // period of increased load on the device. Without this delay, the
       // benchmark has greater noise.
       // See: https://github.com/flutter/flutter/issues/19434
-      await Future<Null>.delayed(const Duration(milliseconds: 250));
+      await Future<Null>.delayed(const Duration(milliseconds: 1000));
       final Timeline timeline = await driver.traceAction(() async {
         // Find the scrollable stock list
         final SerializableFinder list = find.byValueKey(listKey);


### PR DESCRIPTION
I can't reproduce the flakiness locally so I am hoping this will fix the flakiness on the devicelab machines.