### PR TITLE
Increase startup delay for semantics_perf_test.

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/semantics_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/semantics_perf_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     test('inital tree creation', () async {
       // Let app become fully idle.
-      await Future<Null>.delayed(const Duration(seconds: 1));
+      await Future<Null>.delayed(const Duration(seconds: 2));
 
       final Timeline timeline = await driver.traceAction(() async {
         expect(await driver.setSemantics(true), isTrue);


### PR DESCRIPTION
I will revert if this does not fix the benchmark regression.