### PR TITLE
Fix integration hot-reload test on mac.

### DIFF
--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -49,10 +49,6 @@ void main() {
           new Uri.file(_project.breakpointFile).toString(),
           _project.breakpointLine);
       expect(isolate.pauseEvent, isInstanceOf<VMPauseBreakpointEvent>());
-
-      // TODO(dantup): Unskip for Mac when [1] is fixed.
-      // [1] hot reload/breakpoints fail when uris prefixed with file://
-      //     https://github.com/flutter/flutter/issues/18441
-    }, skip: !platform.isLinux && !platform.isWindows);
+    });
   }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/test_data/test_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/test_project.dart
@@ -16,7 +16,8 @@ abstract class TestProject {
   String get main;
 
   // Valid locations for a breakpoint for tests that just need to break somewhere.
-  String get breakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
+  String get breakpointFile => fs.file(fs.path.join(
+      dir.path, 'lib', 'main.dart')).resolveSymbolicLinksSync();
   int get breakpointLine => lineContaining(main, '// BREAKPOINT');
 
   Future<void> setUpIn(Directory dir) async {


### PR DESCRIPTION
Underlying issue with breakpoint was that /var path is a symlink to a /private/var on mac. Because of that breakpoint could not be resolved.

Fixes https://github.com/flutter/flutter/issues/18441