### PR TITLE
Revert "Increase initial delay for scroll_perf_test to try to reduce worst frame stats flakiness."

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -25,7 +25,7 @@ void main() {
       // period of increased load on the device. Without this delay, the
       // benchmark has greater noise.
       // See: https://github.com/flutter/flutter/issues/19434
-      await Future<Null>.delayed(const Duration(milliseconds: 1000));
+      await Future<Null>.delayed(const Duration(milliseconds: 250));
       final Timeline timeline = await driver.traceAction(() async {
         // Find the scrollable stock list
         final SerializableFinder list = find.byValueKey(listKey);


### PR DESCRIPTION
This change did not improve worst case flakiness.

This reverts commit 8cf68731e010023e5dcae1f00991f4ac5b1b758b.