### PR TITLE
Temporarily remove screenshot service extension that is causing code size issues

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -293,23 +293,20 @@ abstract class WidgetsBinding extends BindingBase with SchedulerBinding, Gesture
       }
     );
 
-    assert(() {
-      // This service extension is deprecated and will be removed by 7/1/2018.
-      // Use ext.flutter.inspector.show instead.
-      registerBoolServiceExtension(
-          name: 'debugWidgetInspector',
-          getter: () async => WidgetsApp.debugShowWidgetInspectorOverride,
-          setter: (bool value) {
-            if (WidgetsApp.debugShowWidgetInspectorOverride == value)
-              return Future<Null>.value();
-            WidgetsApp.debugShowWidgetInspectorOverride = value;
-            return _forceRebuild();
-          }
-      );
+    // This service extension is deprecated and will be removed by 7/1/2018.
+    // Use ext.flutter.inspector.show instead.
+    registerBoolServiceExtension(
+        name: 'debugWidgetInspector',
+        getter: () async => WidgetsApp.debugShowWidgetInspectorOverride,
+        setter: (bool value) {
+          if (WidgetsApp.debugShowWidgetInspectorOverride == value)
+            return Future<Null>.value();
+          WidgetsApp.debugShowWidgetInspectorOverride = value;
+          return _forceRebuild();
+        }
+    );
 
-      WidgetInspectorService.instance.initServiceExtensions(registerServiceExtension);
-      return true;
-    }());
+    WidgetInspectorService.instance.initServiceExtensions(registerServiceExtension);
   }
 
   Future<Null> _forceRebuild() {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1027,33 +1027,6 @@ class WidgetInspectorService {
       name: 'isWidgetCreationTracked',
       callback: isWidgetCreationTracked,
     );
-    registerServiceExtension(
-      name: 'screenshot',
-      callback: (Map<String, String> parameters) async {
-        assert(parameters.containsKey('id'));
-        assert(parameters.containsKey('width'));
-        assert(parameters.containsKey('height'));
-
-        final ui.Image image = await screenshot(
-          toObject(parameters['id']),
-          width: double.parse(parameters['width']),
-          height: double.parse(parameters['height']),
-          margin: parameters.containsKey('margin') ?
-              double.parse(parameters['margin']) : 0.0,
-          maxPixelRatio: parameters.containsKey('maxPixelRatio') ?
-              double.parse(parameters['maxPixelRatio']) : 1.0,
-          debugPaint: parameters['debugPaint'] == 'true',
-        );
-        if (image == null) {
-          return <String, Object>{'result': null};
-        }
-        final ByteData byteData = await image.toByteData(format:ui.ImageByteFormat.png);
-
-        return <String, Object>{
-          'result': base64.encoder.convert(Uint8List.view(byteData.buffer)),
-        };
-      },
-    );
   }
 
   /// Clear all InspectorService object references.

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -13,7 +13,6 @@ import 'dart:ui' as ui
         window,
         ClipOp,
         Image,
-        ImageByteFormat,
         Paragraph,
         Picture,
         PictureRecorder,

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -512,7 +512,7 @@ void main() {
 
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 38);
+    expect(binding.extensions.length, 37);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;


### PR DESCRIPTION
Wrapping all inspector service extension registrations in an assert caused an unexplained performance
regression for two tests so has been reverted. To fix the code size regression caused by the screenshot functionality I've completely removed the service extension to create screenshots. 

Unfortunately, reverting the full screenshot CL causes a large number of merge conflicts due to intermediate CLs (specifically optional new) so I think trying this intermediate step before fully reverting the screenshot CL.