### PR TITLE
Simplify gradle compiler output

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -45,6 +45,13 @@ class FlutterPlugin implements Plugin<Project> {
     private File dynamicProfileFlutterJar
     private File dynamicReleaseFlutterJar
 
+    // The name prefix for flutter builds.  This is used to identify gradle tasks
+    // where we expect the flutter tool to provide any error output, and skip the
+    // standard Gradle error output in the FlutterEventLogger. If you change this,
+    // be sure to change any instances of this string in symbols in the code below
+    // to match.
+    static final String flutterBuildPrefix = "flutterBuild"
+
     private Properties readPropertiesIfExist(File propertiesFile) {
         Properties result = new Properties()
         if (propertiesFile.exists()) {
@@ -152,7 +159,7 @@ class FlutterPlugin implements Plugin<Project> {
 
             // Add x86/x86_64 native library. Debug mode only, for now.
             flutterX86Jar = project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/flutter-x86.jar")
-            Task flutterX86JarTask = project.tasks.create("flutterBuildX86Jar", Jar) {
+            Task flutterX86JarTask = project.tasks.create("${flutterBuildPrefix}X86Jar", Jar) {
                 destinationDir flutterX86Jar.parentFile
                 archiveName flutterX86Jar.name
                 from("${flutterRoot}/bin/cache/artifacts/engine/android-x86/libflutter.so") {
@@ -319,7 +326,7 @@ class FlutterPlugin implements Plugin<Project> {
 
         def addFlutterDeps = { variant ->
             String flutterBuildMode = buildModeFor(variant.buildType)
-            if (flutterBuildMode == 'debug' && project.tasks.findByName('flutterBuildX86Jar')) {
+            if (flutterBuildMode == 'debug' && project.tasks.findByName('${flutterBuildPrefix}X86Jar')) {
                 Task task = project.tasks.findByName("compile${variant.name.capitalize()}JavaWithJavac")
                 if (task) {
                     task.dependsOn project.flutterBuildX86Jar
@@ -330,7 +337,7 @@ class FlutterPlugin implements Plugin<Project> {
                 }
             }
 
-            FlutterTask flutterTask = project.tasks.create(name: "flutterBuild${variant.name.capitalize()}", type: FlutterTask) {
+            FlutterTask flutterTask = project.tasks.create(name: "${flutterBuildPrefix}${variant.name.capitalize()}", type: FlutterTask) {
                 flutterRoot this.flutterRoot
                 flutterExecutable this.flutterExecutable
                 buildMode flutterBuildMode
@@ -582,5 +589,25 @@ class FlutterTask extends BaseFlutterTask {
     @TaskAction
     void build() {
         buildBundle()
+    }
+}
+
+gradle.useLogger(new FlutterEventLogger())
+
+class FlutterEventLogger extends BuildAdapter implements TaskExecutionListener {
+    String mostRecentTask = ""
+
+    void beforeExecute(Task task) {
+        mostRecentTask = task.name
+    }
+
+    void afterExecute(Task task, TaskState state) {}
+
+    void buildFinished(BuildResult result) {
+        if (result.failure != null) {
+            if (!(result.failure instanceof GradleException) || !mostRecentTask.startsWith(FlutterPlugin.flutterBuildPrefix)) {
+                result.rethrowFailure()
+            }
+        }
     }
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -299,7 +299,11 @@ Future<Null> buildGradleProject({
 
 Future<Null> _buildGradleProjectV1(FlutterProject project, String gradle) async {
   // Run 'gradlew build'.
-  final Status status = logger.startProgress('Running \'gradlew build\'...', expectSlowOperation: true);
+  final Status status = logger.startProgress(
+    "Running 'gradlew build'...",
+    expectSlowOperation: true,
+    multilineOutput: true,
+  );
   final int exitCode = await runCommandAndStreamOutput(
     <String>[fs.file(gradle).absolute.path, 'build'],
     workingDirectory: project.android.hostAppGradleRoot.path,
@@ -337,7 +341,11 @@ Future<Null> _buildGradleProjectV2(
       throwToolExit('Gradle build aborted.');
     }
   }
-  final Status status = logger.startProgress('Running \'gradlew $assembleTask\'...', expectSlowOperation: true);
+  final Status status = logger.startProgress(
+    "Gradle task '$assembleTask'...",
+    expectSlowOperation: true,
+    multilineOutput: true,
+  );
   final String gradlePath = fs.file(gradle).absolute.path;
   final List<String> command = <String>[gradlePath];
   if (logger.isVerbose) {
@@ -382,7 +390,7 @@ Future<Null> _buildGradleProjectV2(
   status.stop();
 
   if (exitCode != 0)
-    throwToolExit('Gradle build failed: $exitCode', exitCode: exitCode);
+    throwToolExit('Gradle task $assembleTask failed with exit code $exitCode', exitCode: exitCode);
 
   final File apkFile = _findApkFile(project, buildInfo);
   if (apkFile == null)

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -155,6 +155,11 @@ class Stdio {
   Stream<List<int>> get stdin => io.stdin;
   io.IOSink get stdout => io.stdout;
   io.IOSink get stderr => io.stderr;
+
+  bool get hasTerminal => io.stdout.hasTerminal;
+  int get terminalColumns => hasTerminal ? io.stdout.terminalColumns : null;
+  int get terminalLines => hasTerminal ? io.stdout.terminalLines : null;
+  bool get supportsAnsiEscapes => hasTerminal ? io.stdout.supportsAnsiEscapes : false;
 }
 
 io.IOSink get stderr => context[Stdio].stderr;
@@ -162,3 +167,5 @@ io.IOSink get stderr => context[Stdio].stderr;
 Stream<List<int>> get stdin => context[Stdio].stdin;
 
 io.IOSink get stdout => context[Stdio].stdout;
+
+Stdio get stdio => context[Stdio];

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -772,6 +772,7 @@ class NotifyingLogger extends Logger {
     String message, {
     String progressId,
     bool expectSlowOperation = false,
+    bool multilineOutput,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     printStatus(message);
@@ -928,6 +929,7 @@ class _AppRunLogger extends Logger {
     String message, {
     String progressId,
     bool expectSlowOperation = false,
+    bool multilineOutput,
     int progressIndicatorPadding = 52,
   }) {
     final int id = _nextProgressId++;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -413,7 +413,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   Status initialBuildStatus;
   Directory tempDir;
 
-  if (logger.supportsColor) {
+  if (logger.hasTerminal) {
     tempDir = fs.systemTempDirectory.createTempSync('flutter_build_log_pipe.');
     final File scriptOutputPipeFile = tempDir.childFile('pipe_to_stdout');
     os.makePipe(scriptOutputPipeFile.path);

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -217,7 +217,7 @@ class _Compiler {
       if (suppressOutput)
         return;
 
-      if (message.startsWith('compiler message: Error: Could not resolve the package \'test\'')) {
+      if (message.startsWith('Error: Could not resolve the package \'test\'')) {
         printTrace(message);
         printError(
           '\n\nFailed to load test harness. Are you missing a dependency on flutter_test?\n',

--- a/packages/flutter_tools/test/commands/test_test.dart
+++ b/packages/flutter_tools/test/commands/test_test.dart
@@ -116,7 +116,11 @@ Future<Null> _testFile(String testName, String workingDirectory, String testDire
   int outputLineNumber = 0;
   bool haveSeenStdErrMarker = false;
   while (expectationLineNumber < expectations.length) {
-    expect(output, hasLength(greaterThan(outputLineNumber)));
+    expect(
+      output,
+      hasLength(greaterThan(outputLineNumber)),
+      reason: 'Failure in $testName to compare to $fullTestExpectation',
+    );
     final String expectationLine = expectations[expectationLineNumber];
     final String outputLine = output[outputLineNumber];
     if (expectationLine == '<<skip until matching line>>') {

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -50,10 +50,11 @@ void main() {
         mainPath: '/path/to/main.dart'
       );
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
+      expect(logger.errorText, equals('\nCompiler message:\nline1\nline2\n'));
       expect(output.outputFilename, equals('/path/to/main.dart.dill'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('single dart failed compilation', () async {
@@ -70,10 +71,11 @@ void main() {
         mainPath: '/path/to/main.dart'
       );
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
+      expect(logger.errorText, equals('\nCompiler message:\nline1\nline2\n'));
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('single dart abnormal compiler termination', () async {
@@ -92,10 +94,11 @@ void main() {
           mainPath: '/path/to/main.dart'
       );
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
+      expect(logger.errorText, equals('\nCompiler message:\nline1\nline2\n'));
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
   });
 
@@ -146,10 +149,11 @@ void main() {
       );
       expect(mockFrontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
       verifyNoMoreInteractions(mockFrontendServerStdIn);
-      expect(logger.errorText, equals('compiler message: line1\ncompiler message: line2\n'));
+      expect(logger.errorText, equals('\nCompiler message:\nline1\nline2\n'));
       expect(output.outputFilename, equals('/path/to/main.dart.dill'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('single dart compile abnormally terminates', () async {
@@ -163,6 +167,7 @@ void main() {
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('compile and recompile', () async {
@@ -181,11 +186,12 @@ void main() {
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
       expect(logger.errorText, equals(
-        'compiler message: line0\ncompiler message: line1\n'
-        'compiler message: line1\ncompiler message: line2\n'
+        '\nCompiler message:\nline0\nline1\n'
+        '\nCompiler message:\nline1\nline2\n'
       ));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('compile and recompile twice', () async {
@@ -208,12 +214,13 @@ void main() {
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
       expect(logger.errorText, equals(
-        'compiler message: line0\ncompiler message: line1\n'
-        'compiler message: line1\ncompiler message: line2\n'
-        'compiler message: line2\ncompiler message: line3\n'
+        '\nCompiler message:\nline0\nline1\n'
+        '\nCompiler message:\nline1\nline2\n'
+        '\nCompiler message:\nline2\nline3\n'
       ));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
   });
 
@@ -283,7 +290,7 @@ void main() {
             'compile /path/to/main.dart\n');
         verifyNoMoreInteractions(mockFrontendServerStdIn);
         expect(logger.errorText,
-            equals('compiler message: line1\ncompiler message: line2\n'));
+            equals('\nCompiler message:\nline1\nline2\n'));
         expect(output.outputFilename, equals('/path/to/main.dart.dill'));
 
         compileExpressionResponseCompleter.complete(
@@ -302,6 +309,7 @@ void main() {
 
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
 
     testUsingContext('compile expressions without awaiting', () async {
@@ -325,7 +333,7 @@ void main() {
           '/path/to/main.dart', null /* invalidatedFiles */
       ).then((CompilerOutput outputCompile) {
         expect(logger.errorText,
-            equals('compiler message: line1\ncompiler message: line2\n'));
+            equals('\nCompiler message:\nline1\nline2\n'));
         expect(outputCompile.outputFilename, equals('/path/to/main.dart.dill'));
 
         compileExpressionResponseCompleter1.complete(Future<List<int>>.value(utf8.encode(
@@ -363,6 +371,7 @@ void main() {
       expect(await lastExpressionCompleted.future, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      Logger: () => BufferLogger()..supportsColor = false,
     });
   });
 }


### PR DESCRIPTION
This changes the compiler output for gradle to be less verbose and more easily read.

It changes this:
```
hello_world > flutter build apk
Initializing gradle...                                       1.0s
Resolving dependencies...                                    8.9s
Running 'gradlew assembleRelease'...                             
compiler message: lib/main.dart:7:43: Error: Method not found: 'Txt'.
compiler message: void main() => runApp(const Center(child: Txt('Hello, world!', textDirection: TextDirection.ltr)));
compiler message:                                           ^
Compiler terminated unexpectedly.

FAILURE: Build failed with an exception.

* Where:
Script '/usr/local/google/home/gspencer/code/flutter/packages/flutter_tools/gradle/flutter.gradle' line: 428

* What went wrong:
Execution failed for task ':app:flutterBuildRelease'.
> Process 'command '/usr/local/google/home/gspencer/code/flutter/bin/flutter'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
 7.1s
Gradle build failed: 1
```

To this:
```
hello_world > flutter build apk
Building flutter tool...
Running "flutter packages get" in hello_world...             0.7s
Initializing gradle...                                       0.8s
Resolving dependencies...                                    1.4s
Gradle task 'assembleRelease'...                                 

Compiler message:
lib/main.dart:7:43: Error: Method not found: 'Txt'.
void main() => runApp(const Center(child: Txt('Hello, world!', textDirection: TextDirection.ltr)));
                                          ^
Compiler terminated unexpectedly.
    
Gradle task 'assembleRelease'... Done                        6.7s
Gradle task assembleRelease failed with exit code 1

```

This only applies to compilation error messages: other gradle messages will continue to print as before.

It also fixes a small problem with the performance measurement printing (see that "7.1s" on it's own line in the original?) so that if something is expected to have multiple lines of output, it prints an initial line, and a "Done" line with the elapsed time, so that it's possible to know what the time applies to.

Addresses https://github.com/flutter/flutter/issues/17307