### PR TITLE
Use "gradle tasks --all" to query build variants

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -24,7 +24,7 @@ import 'android_sdk.dart';
 import 'android_studio.dart';
 
 const String gradleVersion = '4.4';
-final RegExp _assembleTaskPattern = RegExp(r'assemble([^:]+): task ');
+final RegExp _assembleTaskPattern = RegExp(r'assemble(\S+)');
 
 GradleProject _cachedGradleProject;
 String _cachedGradleExecutable;
@@ -97,18 +97,22 @@ Future<GradleProject> _readGradleProject() async {
   final Status status = logger.startProgress('Resolving dependencies...', expectSlowOperation: true);
   GradleProject project;
   try {
-    final RunResult runResult = await runCheckedAsync(
+    final RunResult propertiesRunResult = await runCheckedAsync(
       <String>[gradle, 'app:properties'],
       workingDirectory: flutterProject.android.hostAppGradleRoot.path,
       environment: _gradleEnv,
     );
-    final String properties = runResult.stdout.trim();
-    project = GradleProject.fromAppProperties(properties);
+    final RunResult tasksRunResult = await runCheckedAsync(
+      <String>[gradle, 'app:tasks', '--all'],
+      workingDirectory: flutterProject.android.hostAppGradleRoot.path,
+      environment: _gradleEnv,
+    );
+    project = GradleProject.fromAppProperties(propertiesRunResult.stdout, tasksRunResult.stdout);
   } catch (exception) {
     if (getFlutterPluginVersion(flutterProject.android) == FlutterPluginVersion.managed) {
       status.cancel();
       // Handle known exceptions. This will exit if handled.
-      handleKnownGradleExceptions(exception);
+      handleKnownGradleExceptions(exception.toString());
 
       // Print a general Gradle error and exit.
       printError('* Error running Gradle:\n$exception\n');
@@ -445,7 +449,7 @@ Map<String, String> get _gradleEnv {
 class GradleProject {
   GradleProject(this.buildTypes, this.productFlavors, this.apkDirectory);
 
-  factory GradleProject.fromAppProperties(String properties) {
+  factory GradleProject.fromAppProperties(String properties, String tasks) {
     // Extract build directory.
     final String buildDir = properties
         .split('\n')
@@ -455,7 +459,7 @@ class GradleProject {
 
     // Extract build types and product flavors.
     final Set<String> variants = Set<String>();
-    for (String s in properties.split('\n')) {
+    for (String s in tasks.split('\n')) {
       final Match match = _assembleTaskPattern.matchAsPrefix(s);
       if (match != null) {
         final String variant = match.group(1).toLowerCase();

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -63,53 +63,51 @@ void main() {
   });
 
   group('gradle project', () {
-    GradleProject projectFrom(String properties) => GradleProject.fromAppProperties(properties);
+    GradleProject projectFrom(String properties, String tasks) => GradleProject.fromAppProperties(properties, tasks);
 
     test('should extract build directory from app properties', () {
       final GradleProject project = projectFrom('''
 someProperty: someValue
 buildDir: /Users/some/apps/hello/build/app
 someOtherProperty: someOtherValue
-      ''');
+      ''', '');
       expect(
         fs.path.normalize(project.apkDirectory.path),
         fs.path.normalize('/Users/some/apps/hello/build/app/outputs/apk'),
       );
     });
     test('should extract default build variants from app properties', () {
-      final GradleProject project = projectFrom('''
-someProperty: someValue
-assemble: task ':app:assemble'
-assembleAndroidTest: task ':app:assembleAndroidTest'
-assembleDebug: task ':app:assembleDebug'
-assembleProfile: task ':app:assembleProfile'
-assembleRelease: task ':app:assembleRelease'
-buildDir: /Users/some/apps/hello/build/app
-someOtherProperty: someOtherValue
+      final GradleProject project = projectFrom('buildDir: /Users/some/apps/hello/build/app', '''
+someTask
+assemble
+assembleAndroidTest
+assembleDebug
+assembleProfile
+assembleRelease
+someOtherTask
       ''');
       expect(project.buildTypes, <String>['debug', 'profile', 'release']);
       expect(project.productFlavors, isEmpty);
     });
     test('should extract custom build variants from app properties', () {
-      final GradleProject project = projectFrom('''
-someProperty: someValue
-assemble: task ':app:assemble'
-assembleAndroidTest: task ':app:assembleAndroidTest'
-assembleDebug: task ':app:assembleDebug'
-assembleFree: task ':app:assembleFree'
-assembleFreeAndroidTest: task ':app:assembleFreeAndroidTest'
-assembleFreeDebug: task ':app:assembleFreeDebug'
-assembleFreeProfile: task ':app:assembleFreeProfile'
-assembleFreeRelease: task ':app:assembleFreeRelease'
-assemblePaid: task ':app:assemblePaid'
-assemblePaidAndroidTest: task ':app:assemblePaidAndroidTest'
-assemblePaidDebug: task ':app:assemblePaidDebug'
-assemblePaidProfile: task ':app:assemblePaidProfile'
-assemblePaidRelease: task ':app:assemblePaidRelease'
-assembleProfile: task ':app:assembleProfile'
-assembleRelease: task ':app:assembleRelease'
-buildDir: /Users/some/apps/hello/build/app
-someOtherProperty: someOtherValue
+      final GradleProject project = projectFrom('buildDir: /Users/some/apps/hello/build/app', '''
+someTask
+assemble
+assembleAndroidTest
+assembleDebug
+assembleFree
+assembleFreeAndroidTest
+assembleFreeDebug
+assembleFreeProfile
+assembleFreeRelease
+assemblePaid
+assemblePaidAndroidTest
+assemblePaidDebug
+assemblePaidProfile
+assemblePaidRelease
+assembleProfile
+assembleRelease
+someOtherTask
       ''');
       expect(project.buildTypes, <String>['debug', 'profile', 'release']);
       expect(project.productFlavors, <String>['free', 'paid']);


### PR DESCRIPTION
Previously flutter_tools had used "gradle properties" to find the build types
and flavors supported by the Gradle project.  Tasks should work more reliably
across different versions of the Android Gradle plugin.

Fixes https://github.com/flutter/flutter/issues/20781