### PR TITLE
Add back screenshot extension that was temporarily disabled.

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -13,6 +13,7 @@ import 'dart:ui' as ui
         window,
         ClipOp,
         Image,
+        ImageByteFormat,
         Paragraph,
         Picture,
         PictureRecorder,
@@ -1026,6 +1027,36 @@ class WidgetInspectorService {
       name: 'isWidgetCreationTracked',
       callback: isWidgetCreationTracked,
     );
+    assert(() {
+      registerServiceExtension(
+        name: 'screenshot',
+        callback: (Map<String, String> parameters) async {
+          assert(parameters.containsKey('id'));
+          assert(parameters.containsKey('width'));
+          assert(parameters.containsKey('height'));
+
+          final ui.Image image = await screenshot(
+            toObject(parameters['id']),
+            width: double.parse(parameters['width']),
+            height: double.parse(parameters['height']),
+            margin: parameters.containsKey('margin') ?
+                double.parse(parameters['margin']) : 0.0,
+            maxPixelRatio: parameters.containsKey('maxPixelRatio') ?
+                double.parse(parameters['maxPixelRatio']) : 1.0,
+            debugPaint: parameters['debugPaint'] == 'true',
+          );
+          if (image == null) {
+            return <String, Object>{'result': null};
+          }
+          final ByteData byteData = await image.toByteData(format:ui.ImageByteFormat.png);
+
+          return <String, Object>{
+            'result': base64.encoder.convert(Uint8List.view(byteData.buffer)),
+          };
+        },
+      );
+      return true;
+    }());
   }
 
   /// Clear all InspectorService object references.

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -512,7 +512,7 @@ void main() {
 
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 37);
+    expect(binding.extensions.length, 38);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -280,7 +280,7 @@ Matcher coversSameAreaAs(Path expectedPath, {@required Rect areaToCompare, int s
 ///    verify that two different code paths create identical images.
 ///  * [flutter_test] for a discussion of test configurations, whereby callers
 ///    may swap out the backend for this matcher.
-Matcher matchesGoldenFile(dynamic key) {
+AsyncMatcher matchesGoldenFile(dynamic key) {
   if (key is Uri) {
     return _MatchesGoldenFile(key);
   } else if (key is String) {
@@ -303,6 +303,15 @@ Matcher matchesGoldenFile(dynamic key) {
 /// ## Sample code
 ///
 /// ```dart
+/// final ui.Paint paint = ui.Paint()
+///   ..style = ui.PaintingStyle.stroke
+///   ..strokeWidth = 1.0;
+/// final ui.PictureRecorder recorder = ui.PictureRecorder();
+/// final ui.Canvas pictureCanvas = ui.Canvas(recorder);
+/// pictureCanvas.drawCircle(Offset.zero, 20.0, paint);
+/// final ui.Picture picture = recorder.endRecording();
+/// ui.Image referenceImage = picture.toImage(50, 50);
+///
 /// await expectLater(find.text('Save'), matchesReferenceImage(referenceImage));
 /// await expectLater(image, matchesReferenceImage(referenceImage);
 /// await expectLater(imageFuture, matchesReferenceImage(referenceImage));
@@ -312,7 +321,7 @@ Matcher matchesGoldenFile(dynamic key) {
 ///
 ///  * [matchesGoldenFile], which should be used instead if you need to verify
 ///    that a [Finder] or [ui.Image] matches a golden image.
-Matcher matchesReferenceImage(ui.Image image) {
+AsyncMatcher matchesReferenceImage(ui.Image image) {
   return _MatchesReferenceImage(image);
 }
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'dart:ui';
 
@@ -275,6 +276,8 @@ Matcher coversSameAreaAs(Path expectedPath, {@required Rect areaToCompare, int s
 /// See also:
 ///
 ///  * [goldenFileComparator], which acts as the backend for this matcher.
+///  * [matchesReferenceImage], which should be used instead if you want to
+///    verify that two different code paths create identical images.
 ///  * [flutter_test] for a discussion of test configurations, whereby callers
 ///    may swap out the backend for this matcher.
 Matcher matchesGoldenFile(dynamic key) {
@@ -284,6 +287,33 @@ Matcher matchesGoldenFile(dynamic key) {
     return _MatchesGoldenFile.forStringPath(key);
   }
   throw ArgumentError('Unexpected type for golden file: ${key.runtimeType}');
+}
+
+/// Asserts that a [Finder], [Future<ui.Image>], or [ui.Image] matches a
+/// reference image identified by [image].
+///
+/// For the case of a [Finder], the [Finder] must match exactly one widget and
+/// the rendered image of the first [RepaintBoundary] ancestor of the widget is
+/// treated as the image for the widget.
+///
+/// This is an asynchronous matcher, meaning that callers should use
+/// [expectLater] when using this matcher and await the future returned by
+/// [expectLater].
+///
+/// ## Sample code
+///
+/// ```dart
+/// await expectLater(find.text('Save'), matchesReferenceImage(referenceImage));
+/// await expectLater(image, matchesReferenceImage(referenceImage);
+/// await expectLater(imageFuture, matchesReferenceImage(referenceImage));
+/// ```
+///
+/// See also:
+///
+///  * [matchesGoldenFile], which should be used instead if you need to verify
+///    that a [Finder] or [ui.Image] matches a golden image.
+Matcher matchesReferenceImage(ui.Image image) {
+  return _MatchesReferenceImage(image);
 }
 
 /// Asserts that a [SemanticsData] contains the specified information.
@@ -1511,6 +1541,76 @@ Future<ui.Image> _captureImage(Element element) {
   assert(!renderObject.debugNeedsPaint);
   final OffsetLayer layer = renderObject.layer;
   return layer.toImage(renderObject.paintBounds);
+}
+
+int _countDifferentPixels(Uint8List imageA, Uint8List imageB) {
+  assert(imageA.length == imageB.length);
+  int delta = 0;
+  for (int i = 0; i < imageA.length; i+=4) {
+    if (imageA[i] != imageB[i] ||
+      imageA[i+1] != imageB[i+1] ||
+      imageA[i+2] != imageB[i+2] ||
+      imageA[i+3] != imageB[i+3]) {
+      delta++;
+    }
+  }
+  return delta;
+}
+
+class _MatchesReferenceImage extends AsyncMatcher {
+  const _MatchesReferenceImage(this.referenceImage);
+
+  final ui.Image referenceImage;
+
+  @override
+  Future<String> matchAsync(dynamic item) async {
+    Future<ui.Image> imageFuture;
+    if (item is Future<ui.Image>) {
+      imageFuture = item;
+    } else if (item is ui.Image) {
+      imageFuture = Future<ui.Image>.value(item);
+    } else {
+      final Finder finder = item;
+      final Iterable<Element> elements = finder.evaluate();
+      if (elements.isEmpty) {
+        return 'could not be rendered because no widget was found';
+      } else if (elements.length > 1) {
+        return 'matched too many widgets';
+      }
+      imageFuture = _captureImage(elements.single);
+    }
+
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    return binding.runAsync<String>(() async {
+      final ui.Image image = await imageFuture;
+      final ByteData bytes = await image.toByteData()
+        .timeout(const Duration(seconds: 10), onTimeout: () => null);
+      if (bytes == null) {
+        return 'Failed to generate an image from engine within the 10,000ms timeout.';
+      }
+
+      final ByteData referenceBytes = await referenceImage.toByteData()
+        .timeout(const Duration(seconds: 10), onTimeout: () => null);
+      if (referenceBytes == null) {
+        return 'Failed to generate an image from engine within the 10,000ms timeout.';
+      }
+
+      if (referenceImage.height != image.height || referenceImage.width != image.width) {
+        return 'does not match as width or height do not match. $image != $referenceImage';
+      }
+
+      final int countDifferentPixels = _countDifferentPixels(
+        Uint8List.view(bytes.buffer),
+        Uint8List.view(referenceBytes.buffer),
+      );
+      return countDifferentPixels == 0 ? null : 'does not match on $countDifferentPixels pixels';
+    }, additionalTime: const Duration(seconds: 21));
+  }
+
+  @override
+  Description describe(Description description) {
+    return description.add('rasterized image matches that of a $referenceImage reference image');
+  }
 }
 
 class _MatchesGoldenFile extends AsyncMatcher {

--- a/packages/flutter_test/test/reference_image_test.dart
+++ b/packages/flutter_test/test/reference_image_test.dart
@@ -5,7 +5,6 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:test/src/frontend/async_matcher.dart'; // ignore: implementation_imports
 
 ui.Image createTestImage(int width, int height, ui.Color color) {
   final ui.Paint paint = ui.Paint()
@@ -49,21 +48,19 @@ void main() {
 
   group('fails', () {
     testWidgets('when image sizes do not match', (WidgetTester tester) async {
-      final AsyncMatcher matcher = matchesReferenceImage(createTestImage(50, 50, red));
       expect(
-        await matcher.matchAsync(createTestImage(100, 100, red)),
+        await matchesReferenceImage(createTestImage(50, 50, red)).matchAsync(createTestImage(100, 100, red)),
         equals('does not match as width or height do not match. [100×100] != [50×50]'),
       );
     });
 
     testWidgets('when image pixels do not match', (WidgetTester tester) async {
-      final AsyncMatcher matcher = matchesReferenceImage(createTestImage(100, 100, red));
       expect(
-        await matcher.matchAsync(createTestImage(100, 100, transparentRed)),
+        await matchesReferenceImage(createTestImage(100, 100, red)).matchAsync(createTestImage(100, 100, transparentRed)),
         equals('does not match on 53 pixels'),
       );
       expect(
-        await matcher.matchAsync(createTestImage(100, 100, green)),
+        await matchesReferenceImage(createTestImage(100, 100, red)).matchAsync(createTestImage(100, 100, green)),
         equals('does not match on 57 pixels'),
       );
     });

--- a/packages/flutter_test/test/reference_image_test.dart
+++ b/packages/flutter_test/test/reference_image_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/src/frontend/async_matcher.dart'; // ignore: implementation_imports
+
+ui.Image createTestImage(int width, int height, ui.Color color) {
+  final ui.Paint paint = ui.Paint()
+    ..style = ui.PaintingStyle.stroke
+    ..strokeWidth = 1.0
+    ..color = color;
+  final ui.PictureRecorder recorder = ui.PictureRecorder();
+  final ui.Canvas pictureCanvas = ui.Canvas(recorder);
+  pictureCanvas.drawCircle(Offset.zero, 20.0, paint);
+  final ui.Picture picture = recorder.endRecording();
+  return picture.toImage(width, height);
+}
+
+void main() {
+  const ui.Color red = ui.Color.fromARGB(255, 255, 0, 0);
+  const ui.Color green = ui.Color.fromARGB(255, 0, 255, 0);
+  const ui.Color transparentRed = ui.Color.fromARGB(128, 255, 0, 0);
+
+  group('succeeds', () {
+    testWidgets('when images have the same content', (WidgetTester tester) async {
+      await expectLater(
+        createTestImage(100, 100, red),
+        matchesReferenceImage(createTestImage(100, 100, red)),
+      );
+      await expectLater(
+        createTestImage(100, 100, green),
+        matchesReferenceImage(createTestImage(100, 100, green)),
+      );
+
+      await expectLater(
+        createTestImage(100, 100, transparentRed),
+        matchesReferenceImage(createTestImage(100, 100, transparentRed)),
+      );
+    });
+
+    testWidgets('when images are identical', (WidgetTester tester) async {
+      final ui.Image image = createTestImage(100, 100, red);
+      await expectLater(image, matchesReferenceImage(image));
+    });
+  });
+
+  group('fails', () {
+    testWidgets('when image sizes do not match', (WidgetTester tester) async {
+      final AsyncMatcher matcher = matchesReferenceImage(createTestImage(50, 50, red));
+      expect(
+        await matcher.matchAsync(createTestImage(100, 100, red)),
+        equals('does not match as width or height do not match. [100×100] != [50×50]'),
+      );
+    });
+
+    testWidgets('when image pixels do not match', (WidgetTester tester) async {
+      final AsyncMatcher matcher = matchesReferenceImage(createTestImage(100, 100, red));
+      expect(
+        await matcher.matchAsync(createTestImage(100, 100, transparentRed)),
+        equals('does not match on 53 pixels'),
+      );
+      expect(
+        await matcher.matchAsync(createTestImage(100, 100, green)),
+        equals('does not match on 57 pixels'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Add matchesReferenceImage matcher to test that the screenshot extension
generates equivalent images to InspectorService.instance.screenshot.