### PR TITLE
Fix a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Flutter is Google’s mobile app SDK for crafting high-quality native interfaces
 * **Main site: [flutter.io][]**
 * [Install](https://flutter.io/get-started/install/)
 * [Get started](https://flutter.io/get-started/)
-* [Contribute](CONTRIBUTING.md)
+* [Contribute](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md#contributing-to-flutter)
 
 ## Fast development
 


### PR DESCRIPTION
Fix a link that works in GitHub but not in dartdoc.

/cc @timsneath 