### PR TITLE
Use Xcode legacy build system for iOS builds

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -71,6 +71,7 @@ Future<T> runInContext<T>(
       KernelCompiler: () => const KernelCompiler(),
       Logger: () => platform.isWindows ? WindowsStdoutLogger() : StdoutLogger(),
       OperatingSystemUtils: () => OperatingSystemUtils(),
+      PlistBuddy: () => const PlistBuddy(),
       SimControl: () => SimControl(),
       Stdio: () => const Stdio(),
       Usage: () => Usage(),

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -32,8 +32,56 @@ const int kXcodeRequiredVersionMajor = 9;
 const int kXcodeRequiredVersionMinor = 0;
 
 IMobileDevice get iMobileDevice => context[IMobileDevice];
-
+PlistBuddy get plistBuddy => context[PlistBuddy];
 Xcode get xcode => context[Xcode];
+
+class PlistBuddy {
+  const PlistBuddy();
+
+  static const String path = '/usr/libexec/PlistBuddy';
+
+  Future<ProcessResult> run(List<String> args) => processManager.run(<String>[path]..addAll(args));
+}
+
+/// A property list is a key-value representation commonly used for
+/// configuration on macOS/iOS systems.
+class PropertyList {
+  const PropertyList(this.plistPath);
+
+  final String plistPath;
+
+  /// Prints the specified key, or returns null if not present.
+  Future<String> read(String key) async {
+    final ProcessResult result = await _runCommand('Print $key');
+    if (result.exitCode == 0)
+      return result.stdout.trim();
+    return null;
+  }
+
+  /// Adds [key]. Has no effect if the key already exists.
+  Future<void> addString(String key, String value) async {
+    await _runCommand('Add $key string $value');
+  }
+
+  /// Updates [key] with the new [value]. Has no effect if the key does not exist.
+  Future<void> update(String key, String value) async {
+    await _runCommand('Set $key $value');
+  }
+
+  /// Deletes [key].
+  Future<void> delete(String key) async {
+    await _runCommand('Delete $key');
+  }
+
+  /// Deletes the content of the property list and creates a new root of the specified type.
+  Future<void> clearToDict() async {
+    await _runCommand('Clear dict');
+  }
+
+  Future<ProcessResult> _runCommand(String command) async {
+    return await plistBuddy.run(<String>['-c', command, plistPath]);
+  }
+}
 
 class IMobileDevice {
   const IMobileDevice();
@@ -181,6 +229,41 @@ class Xcode {
   }
 }
 
+/// Sets the Xcode system.
+///
+/// Xcode 10 added a new (default) build system with better performance and
+/// stricter checks. Flutter apps without plugins build fine under the new
+/// system, but it causes build breakages in projects with CocoaPods enabled.
+/// This affects Flutter apps with plugins.
+///
+/// Once Flutter has been updated to be fully compliant with the new build
+/// system, this can be removed.
+//
+// TODO(cbracken): remove when https://github.com/flutter/flutter/issues/20685 is fixed.
+Future<void> setXcodeWorkspaceBuildSystem({
+  @required File workspaceSettings,
+  @required bool modern,
+}) async {
+  final PropertyList plist = PropertyList(workspaceSettings.path);
+  if (!workspaceSettings.existsSync()) {
+    workspaceSettings.parent.createSync(recursive: true);
+    await plist.clearToDict();
+  }
+
+  const String kBuildSystemType = 'BuildSystemType';
+  if (modern) {
+    printTrace('Using new Xcode build system.');
+    await plist.delete(kBuildSystemType);
+  } else {
+    printTrace('Using legacy Xcode build system.');
+    if (await plist.read(kBuildSystemType) == null) {
+      await plist.addString(kBuildSystemType, 'Original');
+    } else {
+      await plist.update(kBuildSystemType, 'Original');
+    }
+  }
+}
+
 Future<XcodeBuildResult> buildXcodeProject({
   BuildableIOSApp app,
   BuildInfo buildInfo,
@@ -194,6 +277,12 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   if (!_checkXcodeVersion())
     return XcodeBuildResult(success: false);
+
+  // TODO(cbracken) remove when https://github.com/flutter/flutter/issues/20685 is fixed.
+  await setXcodeWorkspaceBuildSystem(
+    workspaceSettings: app.project.xcodeWorkspaceSharedSettings,
+    modern: false,
+  );
 
   final XcodeProjectInfo projectInfo = xcodeProjectInterpreter.getInfo(app.project.directory.path);
   if (!projectInfo.targets.contains('Runner')) {

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -186,6 +186,15 @@ class IosProject {
   /// The '.pbxproj' file of the host app.
   File get xcodeProjectInfoFile => xcodeProject.childFile('project.pbxproj');
 
+  /// Xcode workspace directory of the host app.
+  Directory get xcodeWorkspace => directory.childDirectory('$_hostAppBundleName.xcworkspace');
+
+  /// Xcode workspace shared data directory for the host app.
+  Directory get xcodeWorkspaceSharedData => xcodeWorkspace.childDirectory('xcshareddata');
+
+  /// Xcode workspace shared workspace settings file for the host app.
+  File get xcodeWorkspaceSharedSettings => xcodeWorkspaceSharedData.childFile('WorkspaceSettings.xcsettings');
+
   /// The product bundle identifier of the host app, or null if not set or if
   /// iOS tooling needed to read it is not installed.
   String get productBundleIdentifier {


### PR DESCRIPTION
Xcode 10 introduces a new build system which includes stricter checks on
duplicate build outputs.

When plugins are in use, there are two competing build actions that copy
Flutter.framework into the build application Frameworks directory:

  1. The Embed Frameworks build phase for the Runner project
  2. The [CP] Embed Pods Frameworks build phase that pod install creates
     in the project.

Item (1) is there to ensure the framework is copied into the built app
in the case where there are no plugins (and therefore no CocoaPods
integration in the Xcode project). Item (2) is there because Flutter's
podspec declares Flutter.framework as a vended_framework, and CocoaPods
automatically adds a copy step for each such vended_framework in the
transitive closure of CocoaPods dependencies.

As an immediate fix, we opt back into the build system used by Xcode 9
and earlier. Longer term, we need to update our templates and
flutter_tools to correctly handle this situation.

See: https://github.com/flutter/flutter/issues/20685