### PR TITLE
Add RichText support to find.text

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -504,9 +504,10 @@ class _TextFinder extends MatchFinder {
       // twice. We make an exception for semantics since those may be placed
       // between a Text and Rich text.
       candidate.visitAncestorElements((Element parent) {
-        if (parent.widget is Text)
+        if (parent.widget is Text) {
           parentIsText = true;
-        if (parent.widget is ExcludeSemantics || parent.widget is Semantics)
+          return false;
+        } else if (parent.widget is ExcludeSemantics || parent.widget is Semantics)
           return true;
         return false;
       });

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -498,6 +498,17 @@ class _TextFinder extends MatchFinder {
     } else if (candidate.widget is EditableText) {
       final EditableText editable = candidate.widget;
       return editable.controller.text == text;
+    } else if (candidate.widget is RichText) {
+      bool parentIsText = false;
+      // check if the direct parent is a Text widget.
+      // if so, do not match it twice.
+      candidate.visitAncestorElements((Element parent) {
+        if (parent.widget is Text)
+          parentIsText = true;
+        return false;
+      });
+      final RichText richText = candidate.widget;
+      return !parentIsText && richText.text.toPlainText() == text;
     }
     return false;
   }

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -500,11 +500,14 @@ class _TextFinder extends MatchFinder {
       return editable.controller.text == text;
     } else if (candidate.widget is RichText) {
       bool parentIsText = false;
-      // check if the direct parent is a Text widget.
-      // if so, do not match it twice.
+      // check if the direct parent is a Text widget. if so, do not match it
+      // twice. We make an exception for semantics since those may be placed
+      // between a Text and Rich text.
       candidate.visitAncestorElements((Element parent) {
         if (parent.widget is Text)
           parentIsText = true;
+        if (parent.widget is ExcludeSemantics || parent.widget is Semantics)
+          return true;
         return false;
       });
       final RichText richText = candidate.widget;

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -507,8 +507,9 @@ class _TextFinder extends MatchFinder {
         if (parent.widget is Text) {
           parentIsText = true;
           return false;
-        } else if (parent.widget is ExcludeSemantics || parent.widget is Semantics)
+        } else if (parent.widget is ExcludeSemantics || parent.widget is Semantics) {
           return true;
+        }
         return false;
       });
       final RichText richText = candidate.widget;

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -27,6 +27,25 @@ void main() {
 
       expect(find.text('test'), findsOneWidget);
     });
+
+    testWidgets('finds RichText widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+        const RichText(text: TextSpan(text: 't', children: <TextSpan>[
+          TextSpan(text: 'est'),
+        ]))
+      ));
+
+      expect(find.text('test'), findsOneWidget);
+    });
+
+    testWidgets('Does not find Text widgets', (WidgetTester tester) async {
+      // If rich: true found both Text and RichText, this would find two widgets.
+      await tester.pumpWidget(_boilerplate(
+        const Text('test'),
+      ));
+
+      expect(find.text('test'), findsOneWidget);
+    });
   });
 
   group('hitTestable', () {

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -38,10 +38,18 @@ void main() {
       expect(find.text('test'), findsOneWidget);
     });
 
-    testWidgets('Does not find Text widgets', (WidgetTester tester) async {
-      // If rich: true found both Text and RichText, this would find two widgets.
+    testWidgets('Does not find Text and RichText widgets', (WidgetTester tester) async {
       await tester.pumpWidget(_boilerplate(
         const Text('test'),
+      ));
+
+      expect(find.text('test'), findsOneWidget);
+    });
+
+    testWidgets('Does not find Text and RichText separated by semantics widgets', (WidgetTester tester) async {
+      // If rich: true found both Text and RichText, this would find two widgets.
+      await tester.pumpWidget(_boilerplate(
+        const Text('test', semanticsLabel: 'foo'),
       ));
 
       expect(find.text('test'), findsOneWidget);


### PR DESCRIPTION
Check RichText in find.text if the direct parent element is not a Text widget. This allows users to find the text value of `RichText` without double-counting the RichText widget created by Text.

Fixes https://github.com/flutter/flutter/issues/21961