### PR TITLE
Allow passing a restart reason through to analytics

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -82,6 +82,7 @@ The `restart()` restarts the given application. It returns a Map of `{ int code,
 
 - `appId`: the id of a previously started app; this is required.
 - `fullRestart`: optional; whether to do a full (rather than an incremental) restart of the application
+- `reason`: optional; the reason for the full restart (eg. `save`, `manual`) for reporting purposes
 - `pause`: optional; when doing a hot restart the isolate should enter a paused mode
 
 #### app.callServiceExtension

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -464,6 +464,7 @@ class AppDomain extends Domain {
     final String appId = _getStringArg(args, 'appId', required: true);
     final bool fullRestart = _getBoolArg(args, 'fullRestart') ?? false;
     final bool pauseAfterRestart = _getBoolArg(args, 'pause') ?? false;
+    final String restartReason = _getStringArg(args, 'reason');
 
     final AppInstance app = _getApp(appId);
     if (app == null)
@@ -473,7 +474,7 @@ class AppDomain extends Domain {
       throw 'hot restart already in progress';
 
     _inProgressHotReload = app._runInZone<OperationResult>(this, () {
-      return app.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart);
+      return app.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart, reason: restartReason);
     });
     return _inProgressHotReload.whenComplete(() {
       _inProgressHotReload = null;
@@ -795,8 +796,8 @@ class AppInstance {
 
   _AppRunLogger _logger;
 
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false }) {
-    return runner.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart);
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) {
+    return runner.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart, reason: reason);
   }
 
   Future<void> stop() => runner.stop();

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -460,7 +460,7 @@ abstract class ResidentRunner {
 
   bool get supportsRestart => false;
 
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false }) {
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) {
     throw 'unsupported';
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -399,7 +399,12 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<OperationResult> _restartFromSources() async {
+  Future<OperationResult> _restartFromSources({String reason}) async {
+    final Map<String, String> analyticsParameters =
+      reason == null
+        ? null
+        : <String, String>{kEventReasonParameterName: reason};
+
     if (!_isPaused()) {
       printTrace('Refreshing active FlutterViews before restarting.');
       await refreshViews();
@@ -446,7 +451,7 @@ class HotRunner extends ResidentRunner {
     _runningFromSnapshot = false;
     _addBenchmarkData('hotRestartMillisecondsToFrame',
         restartTimer.elapsed.inMilliseconds);
-    flutterUsage.sendEvent('hot', 'restart');
+    flutterUsage.sendEvent('hot', 'restart', parameters: analyticsParameters);
     flutterUsage.sendTiming('hot', 'restart', restartTimer.elapsed);
     return OperationResult.ok;
   }
@@ -492,7 +497,7 @@ class HotRunner extends ResidentRunner {
   bool get supportsRestart => true;
 
   @override
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false }) async {
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) async {
     final Stopwatch timer = Stopwatch()..start();
     if (fullRestart) {
       final Status status = logger.startProgress(
@@ -502,7 +507,7 @@ class HotRunner extends ResidentRunner {
       try {
         if (!(await hotRunnerConfig.setupHotRestart()))
           return OperationResult(1, 'setupHotRestart failed');
-        final OperationResult result = await _restartFromSources();
+        final OperationResult result = await _restartFromSources(reason: reason);
         if (!result.isOk)
           return result;
       } finally {
@@ -519,7 +524,7 @@ class HotRunner extends ResidentRunner {
       );
       OperationResult result;
       try {
-        result = await _reloadSources(pause: pauseAfterRestart);
+        result = await _reloadSources(pause: pauseAfterRestart, reason: reason);
       } finally {
         status.cancel();
       }
@@ -531,7 +536,11 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<OperationResult> _reloadSources({ bool pause = false }) async {
+  Future<OperationResult> _reloadSources({ bool pause = false, String reason }) async {
+    final Map<String, String> analyticsParameters =
+      reason == null
+        ? null
+        : <String, String>{kEventReasonParameterName: reason};
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         if (view.uiIsolate == null)
@@ -617,7 +626,7 @@ class HotRunner extends ResidentRunner {
         flutterUsage.sendEvent('hot', 'reload-reject');
         return OperationResult(1, 'Reload rejected');
       } else {
-        flutterUsage.sendEvent('hot', 'reload');
+        flutterUsage.sendEvent('hot', 'reload', parameters: analyticsParameters);
         final int loadedLibraryCount = reloadReport['details']['loadedLibraryCount'];
         final int finalLibraryCount = reloadReport['details']['finalLibraryCount'];
         printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -399,11 +399,11 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<OperationResult> _restartFromSources({String reason}) async {
+  Future<OperationResult> _restartFromSources({ String reason }) async {
     final Map<String, String> analyticsParameters =
       reason == null
         ? null
-        : <String, String>{kEventReasonParameterName: reason};
+        : <String, String>{ kEventReloadReasonParameterName: reason };
 
     if (!_isPaused()) {
       printTrace('Refreshing active FlutterViews before restarting.');
@@ -540,7 +540,7 @@ class HotRunner extends ResidentRunner {
     final Map<String, String> analyticsParameters =
       reason == null
         ? null
-        : <String, String>{kEventReasonParameterName: reason};
+        : <String, String>{ kEventReloadReasonParameterName: reason };
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         if (view.uiIsolate == null)

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -18,7 +18,7 @@ import 'version.dart';
 const String _kFlutterUA = 'UA-67589403-6';
 // TODO(dantup): This MUST be updated to match the real custom dimension configured
 // in the live account before merging.
-const String kEventReasonParameterName = 'cd1';
+const String kEventReasonParameterName = 'cd5';
 
 Usage get flutterUsage => Usage.instance;
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -16,8 +16,6 @@ import 'globals.dart';
 import 'version.dart';
 
 const String _kFlutterUA = 'UA-67589403-6';
-// TODO(dantup): This MUST be updated to match the real custom dimension configured
-// in the live account before merging.
 const String kEventReasonParameterName = 'cd5';
 
 Usage get flutterUsage => Usage.instance;

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -16,7 +16,7 @@ import 'globals.dart';
 import 'version.dart';
 
 const String _kFlutterUA = 'UA-67589403-6';
-const String kEventReasonParameterName = 'cd5';
+const String kEventReloadReasonParameterName = 'cd5';
 
 Usage get flutterUsage => Usage.instance;
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -16,6 +16,9 @@ import 'globals.dart';
 import 'version.dart';
 
 const String _kFlutterUA = 'UA-67589403-6';
+// TODO(dantup): This MUST be updated to match the real custom dimension configured
+// in the live account before merging.
+const String kEventReasonParameterName = 'cd1';
 
 Usage get flutterUsage => Usage.instance;
 


### PR DESCRIPTION
This allows a tool to pass a `reason` with a restart event through the daemon to allow reload-on-saves to be separated from manual reloads.

TODO:

- [x] Verify this works (I've sent some logs to a test account, but custom dimensions can't be seen real-time!)
- [x] Have a custom dimension created in the live account and update the constant here