### PR TITLE
Use maybePop in place of pop in ModalBarrier dismiss interaction

### DIFF
--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -83,7 +83,7 @@ class ModalBarrier extends StatelessWidget {
         child: GestureDetector(
           onTapDown: (TapDownDetails details) {
             if (dismissible)
-              Navigator.pop(context);
+              Navigator.maybePop(context);
           },
           behavior: HitTestBehavior.opaque,
           child: Semantics(

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -85,6 +85,86 @@ void main() {
       reason: 'The route should have been dismissed by tapping the barrier.');
   });
 
+  testWidgets('ModalBarrier does not pop the Navigator with a WillPopScope that returns false', (WidgetTester tester) async {
+    bool willPopCalled = false;
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => FirstWidget(),
+      '/modal': (BuildContext context) => Stack(
+        children: <Widget>[
+          SecondWidget(),
+          WillPopScope(
+            child: const SizedBox(),
+            onWillPop: () async {
+              willPopCalled = true;
+              return false;
+            },
+          ),
+      ],),
+    };
+
+    await tester.pumpWidget(MaterialApp(routes: routes));
+
+    // Initially the barrier is not visible
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+    // Tapping on X routes to the barrier
+    await tester.tap(find.text('X'));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+
+    expect(willPopCalled, isFalse);
+
+    // Tap on the barrier to attempt to dismiss it
+    await tester.tap(find.byKey(const ValueKey<String>('barrier')));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+
+    expect(find.byKey(const ValueKey<String>('barrier')), findsOneWidget,
+      reason: 'The route should still be present if the pop is vetoed.');
+
+    expect(willPopCalled, isTrue);
+  });
+
+  testWidgets('ModalBarrier pops the Navigator with a WillPopScope that returns true', (WidgetTester tester) async {
+    bool willPopCalled = false;
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => FirstWidget(),
+      '/modal': (BuildContext context) => Stack(
+        children: <Widget>[
+          SecondWidget(),
+          WillPopScope(
+            child: const SizedBox(),
+            onWillPop: () async {
+              willPopCalled = true;
+              return true;
+            },
+          ),
+        ],),
+    };
+
+    await tester.pumpWidget(MaterialApp(routes: routes));
+
+    // Initially the barrier is not visible
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+    // Tapping on X routes to the barrier
+    await tester.tap(find.text('X'));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+
+    expect(willPopCalled, isFalse);
+
+    // Tap on the barrier to attempt to dismiss it
+    await tester.tap(find.byKey(const ValueKey<String>('barrier')));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing,
+      reason: 'The route should still be present if the pop is vetoed.');
+
+    expect(willPopCalled, isTrue);
+  });
+
   testWidgets('Undismissible ModalBarrier hidden in semantic tree', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(const ModalBarrier(dismissible: false));

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -160,7 +160,7 @@ void main() {
     await tester.pump(const Duration(seconds: 1)); // end transition
 
     expect(find.byKey(const ValueKey<String>('barrier')), findsNothing,
-      reason: 'The route should still be present if the pop is vetoed.');
+      reason: 'The route should not be present if the pop is permitted.');
 
     expect(willPopCalled, isTrue);
   });


### PR DESCRIPTION
Rationale:
When the user interacts with the scrim of the ModalBarrier it should be possible to intercept the intent and accept/reject the disposal.

This improvement actually required a one-line change and, although strictly speaking it is a BC, that should cause no major harm to the current behaviour.

On the other hand, the benefit acquired is that by just adding a `WillPopScope` widget in the hierarchy, it will be now possibile to conditionally prevent the route to be popped and further customise the user experience, e.g. by adding a confirmation dialog, etc.