### PR TITLE
Update devicelab test for rename of materialize -> make-host-app-editable

### DIFF
--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -103,11 +103,11 @@ Future<Null> main() async {
         await flutter('clean');
       });
 
-      section('Materialize host app');
+      section('Running `flutter make-host-app-editable` to Materialize host app');
 
       await inDirectory(Directory(path.join(tempDir.path, 'hello')), () async {
         await flutter(
-          'materialize',
+          'make-host-app-editable',
           options: <String>['android'],
         );
       });


### PR DESCRIPTION
This fixes the devicelab failure after #22006 renamed this command.

(fyi @matthew-carroll)