### PR TITLE
Throw if trying to set fs.currentDirectory in tests

### DIFF
--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -81,6 +81,7 @@ void testUsingContext(String description, dynamic testMethod(), {
           SimControl: () => MockSimControl(),
           Usage: () => MockUsage(),
           XcodeProjectInterpreter: () => MockXcodeProjectInterpreter(),
+          FileSystem: () => LocalFileSystemBlockingSetCurrentDirectory(),
         },
         body: () {
           final String flutterRoot = getFlutterRoot();
@@ -300,3 +301,11 @@ class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockClock extends Mock implements Clock {}
 
 class MockHttpClient extends Mock implements HttpClient {}
+
+class LocalFileSystemBlockingSetCurrentDirectory extends LocalFileSystem {
+  @override
+  set currentDirectory(dynamic value) {
+    throw 'fs.currentDirectory should not be set during tests '
+          'as this can cause race conditions with concurrent tests.';
+  }
+}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -305,7 +305,9 @@ class MockHttpClient extends Mock implements HttpClient {}
 class LocalFileSystemBlockingSetCurrentDirectory extends LocalFileSystem {
   @override
   set currentDirectory(dynamic value) {
-    throw 'fs.currentDirectory should not be set during tests '
-          'as this can cause race conditions with concurrent tests.';
+    throw 'fs.currentDirectory should not be set on the local file system during '
+          'tests as this can cause race conditions with concurrent tests. '
+          'Consider using a MemoryFileSystem for testing if possible or refactor '
+          'code to not require setting fs.currentDirectory.';
   }
 }


### PR DESCRIPTION
This isn't perfect, it only covers tests using testUsingContext, but I think that is the huge majority of tests. It should definitely reduce the chance of people adding tests that may cause races once we remove `-j1` from the tools tests.

I believe I've fixed all existing tests doing this; locally I get 0 failures now.

@Hixie 