### PR TITLE
Remove -j1 to run tools tests concurrently

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -144,7 +144,6 @@ Future<Null> _runToolTests() async {
   await _pubRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     enableFlutterToolAsserts: true,
-    runConcurrently: false,
   );
 
   print('${bold}DONE: All tests successful.$reset');
@@ -197,13 +196,9 @@ Future<Null> _runCoverage() async {
 Future<Null> _pubRunTest(
   String workingDirectory, {
   String testPath,
-  bool runConcurrently = true,
   bool enableFlutterToolAsserts = false
 }) {
   final List<String> args = <String>['run', 'test', '-rcompact'];
-  if (!runConcurrently) {
-    args.add('-j1');
-  }
   if (!hasColor)
     args.add('--no-color');
   if (testPath != null)

--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -6,5 +6,5 @@ To run the tests, ensure that no devices are connected,
 then navigate to `flutter_tools` and execute:
 
 ```shell
-../../bin/cache/dart-sdk/bin/pub run test -j1
+../../bin/cache/dart-sdk/bin/pub run test
 ```

--- a/packages/flutter_tools/test/integration/README.md
+++ b/packages/flutter_tools/test/integration/README.md
@@ -4,9 +4,8 @@ These tests are not hermetic, and use actual Flutter SDK.
 While they don't require actual devices, they run `flutter_tester` to test
 Dart VM and Flutter integration.
 
-Some of these tests change the current directory for the process,
-so only one test can be run at a time. Use this command to run:
+Use this command to run:
 
 ```shell
-../../bin/cache/dart-sdk/bin/pub run test -j1
+../../bin/cache/dart-sdk/bin/pub run test
 ```


### PR DESCRIPTION
Fixes #21113.

Related: #22037 will hopefully stop new tests that set fs.currentDirectory.