### PR TITLE
Fix docked FAB bottom padding when BottomBar size is 0

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -166,6 +166,7 @@ abstract class _DockedFloatingActionButtonLocation extends FloatingActionButtonL
     final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
     final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
     final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
+    final double bottomPadding = scaffoldGeometry.bottomPadding;
 
     double fabY = contentBottom - fabHeight / 2.0;
     // The FAB should sit with a margin between it and the snack bar.
@@ -175,7 +176,10 @@ abstract class _DockedFloatingActionButtonLocation extends FloatingActionButtonL
     if (bottomSheetHeight > 0.0)
       fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
 
-    final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight;
+    /// subtracting the bottom padding raises the FAB in the event that [BottomAppBar]
+    /// has a size of 0 from [SizeTransition]
+    final double maxFabY =
+        scaffoldGeometry.scaffoldSize.height - fabHeight - bottomPadding;
     return math.min(maxFabY, fabY);
   }
 }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -62,7 +62,17 @@ class ScaffoldPrelayoutGeometry {
     @required this.scaffoldSize,
     @required this.snackBarSize,
     @required this.textDirection,
+    @required this.bottomPadding,
   });
+
+  /// The vertical padding for the bottom of the screen
+  /// [Scaffold.body].
+  ///
+  /// This is useful in a [FloatingActionButtonLocation] designed to
+  /// place the [FloatingActionButton] at the bottom of the screen in the
+  /// safe area when the [BottomSheet] had a size of 0 when the
+  /// [SizeTransition] is used.
+  final double bottomPadding;
 
   /// The [Size] of [Scaffold.floatingActionButton].
   ///
@@ -276,8 +286,9 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     @required this.currentFloatingActionButtonLocation,
     @required this.floatingActionButtonMoveAnimationProgress,
     @required this.floatingActionButtonMotionAnimator,
-  }) : assert(previousFloatingActionButtonLocation != null),
-       assert(currentFloatingActionButtonLocation != null);
+    @required this.bottomPadding,
+  })  : assert(previousFloatingActionButtonLocation != null),
+        assert(currentFloatingActionButtonLocation != null);
 
   final EdgeInsets minInsets;
   final TextDirection textDirection;
@@ -287,6 +298,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
   final FloatingActionButtonLocation currentFloatingActionButtonLocation;
   final double floatingActionButtonMoveAnimationProgress;
   final FloatingActionButtonAnimator floatingActionButtonMotionAnimator;
+  final double bottomPadding;
 
   @override
   void performLayout(Size size) {
@@ -383,6 +395,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
         scaffoldSize: size,
         snackBarSize: snackBarSize,
         textDirection: textDirection,
+        bottomPadding: bottomPadding,
       );
       final Offset currentFabOffset = currentFloatingActionButtonLocation.getOffset(currentGeometry);
       final Offset previousFabOffset = previousFloatingActionButtonLocation.getOffset(currentGeometry);
@@ -1695,6 +1708,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
                 geometryNotifier: _geometryNotifier,
                 previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation,
                 textDirection: textDirection,
+                    bottomPadding: MediaQuery.of(context).padding.bottom,
               ),
             );
           }),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -62,7 +62,22 @@ class ScaffoldPrelayoutGeometry {
     @required this.scaffoldSize,
     @required this.snackBarSize,
     @required this.textDirection,
+    @required this.bottomPadding,
   });
+
+  /// The vertical padding for the bottom of the screen
+  /// [Scaffold.body].
+  ///
+  /// This is useful in a [FloatingActionButtonLocation] designed to
+  /// place the [FloatingActionButton] at the bottom of the screen, while
+  /// keeping it above the [BottomSheet], the [Scaffold.bottomNavigationBar],
+  /// or the keyboard.
+  ///
+  /// This is useful in a [FloatingActionButtonLocation] designed to
+  /// place the [FloatingActionButton] at the bottom of the screen in the
+  /// safe area when the [BottomSheet] had a size of 0 when the
+  /// [SizeTransition] is used.
+  final double bottomPadding;
 
   /// The [Size] of [Scaffold.floatingActionButton].
   ///
@@ -276,8 +291,9 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     @required this.currentFloatingActionButtonLocation,
     @required this.floatingActionButtonMoveAnimationProgress,
     @required this.floatingActionButtonMotionAnimator,
-  }) : assert(previousFloatingActionButtonLocation != null),
-       assert(currentFloatingActionButtonLocation != null);
+    @required this.bottomPadding,
+  })  : assert(previousFloatingActionButtonLocation != null),
+        assert(currentFloatingActionButtonLocation != null);
 
   final EdgeInsets minInsets;
   final TextDirection textDirection;
@@ -287,6 +303,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
   final FloatingActionButtonLocation currentFloatingActionButtonLocation;
   final double floatingActionButtonMoveAnimationProgress;
   final FloatingActionButtonAnimator floatingActionButtonMotionAnimator;
+  final double bottomPadding;
 
   @override
   void performLayout(Size size) {
@@ -383,6 +400,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
         scaffoldSize: size,
         snackBarSize: snackBarSize,
         textDirection: textDirection,
+        bottomPadding: bottomPadding,
       );
       final Offset currentFabOffset = currentFloatingActionButtonLocation.getOffset(currentGeometry);
       final Offset previousFabOffset = previousFloatingActionButtonLocation.getOffset(currentGeometry);
@@ -1695,6 +1713,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
                 geometryNotifier: _geometryNotifier,
                 previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation,
                 textDirection: textDirection,
+                    bottomPadding: MediaQuery.of(context).padding.bottom,
               ),
             );
           }),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -69,11 +69,6 @@ class ScaffoldPrelayoutGeometry {
   /// [Scaffold.body].
   ///
   /// This is useful in a [FloatingActionButtonLocation] designed to
-  /// place the [FloatingActionButton] at the bottom of the screen, while
-  /// keeping it above the [BottomSheet], the [Scaffold.bottomNavigationBar],
-  /// or the keyboard.
-  ///
-  /// This is useful in a [FloatingActionButtonLocation] designed to
   /// place the [FloatingActionButton] at the bottom of the screen in the
   /// safe area when the [BottomSheet] had a size of 0 when the
   /// [SizeTransition] is used.


### PR DESCRIPTION
https://material.io/design/components/app-bars-bottom.html#behavior
Used to replicate the scrolling behavior of material design
![Example](https://media.giphy.com/media/1zlBGnSmSsciPYJ4uY/giphy.gif)
Without this fix the FAB will stick to the bottom, ignoring padding.
```
class _MyHomePageState extends State<MyHomePage>
    with SingleTickerProviderStateMixin {
  AnimationController animationDouble;

  @override
  void initState() {
    super.initState();
    animationDouble = new AnimationController(
        vsync: this, value: 1.0, duration: Duration(milliseconds: 250));
  }

  @override
  Widget build(BuildContext context) {
    return new Scaffold(
      appBar: new AppBar(
        title: new Text(widget.title),
      ),
      body: new NotificationListener(
        onNotification: (t) {
          if (t is UserScrollNotification) {
            if (t.direction == ScrollDirection.reverse) {
              animationDouble.reverse();
            } else if (t.direction == ScrollDirection.forward) {
              animationDouble.forward();
            }
          }
        },
        child: new ListView(
          children: <Widget>[
            new ListTile(
              title: Text("Test 1"),
            ),
            new ListTile(
              title: Text("Test 2"),
            ),
            new ListTile(
              title: Text("Test 3"),
            ),
            new ListTile(
              title: Text("Test 4"),
            ),
            new ListTile(
              title: Text("Test 5"),
            ),
            new ListTile(
              title: Text("Test 6"),
            ),
            new ListTile(
              title: Text("Test 7"),
            ),
            new ListTile(
              title: Text("Test 8"),
            ),
            new ListTile(
              title: Text("Test 9"),
            ),
            new ListTile(
              title: Text("Test 1"),
            ),
            new ListTile(
              title: Text("Test 2"),
            ),
            new ListTile(
              title: Text("Test 3"),
            ),
            new ListTile(
              title: Text("Test 4"),
            ),
            new ListTile(
              title: Text("Test 5"),
            ),
            new ListTile(
              title: Text("Test 6"),
            ),
          ],
        ),
      ),
      bottomNavigationBar: new SizeTransition(
        sizeFactor: animationDouble,
        child: new BottomAppBar(
          shape: CircularNotchedRectangle(),
          notchMargin: 8.0,
          color: Colors.blueAccent,
          child: new Row(
            children: <Widget>[
              IconButton(
                icon: Icon(Icons.menu),
                onPressed: () {
                  print("open menu");
                },
                color: Colors.white,
              )
            ],
          ),
        ),
      ),
      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
      floatingActionButton: new FloatingActionButton(
        onPressed: () {},
        tooltip: 'Add',
        child: new Icon(Icons.add),
      ),
    );
  }
}
```