### PR TITLE
Implement a way to opt-out colorization in ImageIcon

### DIFF
--- a/packages/flutter/lib/src/widgets/image_icon.dart
+++ b/packages/flutter/lib/src/widgets/image_icon.dart
@@ -27,6 +27,7 @@ class ImageIcon extends StatelessWidget {
     Key key,
     this.size,
     this.color,
+    this.shouldRecolor = true,
     this.semanticLabel,
   }) : super(key: key);
 
@@ -48,11 +49,17 @@ class ImageIcon extends StatelessWidget {
   /// The color to use when drawing the icon.
   ///
   /// Defaults to the current [IconTheme] color, if any. If there is
-  /// no [IconTheme], then it defaults to not recolorizing the image.
+  /// no [IconTheme], then it defaults to [IconThemeData.fallback].
   ///
   /// The image will additionally be adjusted by the opacity of the current
   /// [IconTheme], if any.
   final Color color;
+
+  /// Flag to decide if ImageIcon should recolor the image or not.
+  ///
+  /// Defaults to true, if set to false ImageIcon will ignore any color
+  /// attribute including [IconTheme] color too.
+  final bool shouldRecolor;
 
   /// Semantic label for the icon.
   ///
@@ -76,22 +83,29 @@ class ImageIcon extends StatelessWidget {
         child: SizedBox(width: iconSize, height: iconSize)
       );
 
-    final double iconOpacity = iconTheme.opacity;
-    Color iconColor = color ?? iconTheme.color;
+    double iconOpacity = iconTheme.opacity;
+    Color iconColor;
 
-    if (iconOpacity != null && iconOpacity != 1.0)
-      iconColor = iconColor.withOpacity(iconColor.opacity * iconOpacity);
+    if (shouldRecolor) {
+      iconColor = color ?? iconTheme.color;
+      if (iconOpacity != null && iconOpacity != 1.0) {
+        iconOpacity = iconColor.opacity * iconOpacity;
+      }
+    }
 
     return Semantics(
       label: semanticLabel,
-      child: Image(
-        image: image,
-        width: iconSize,
-        height: iconSize,
-        color: iconColor,
-        fit: BoxFit.scaleDown,
-        alignment: Alignment.center,
-        excludeFromSemantics: true,
+      child: Opacity(
+        opacity: iconOpacity,
+        child: Image(
+          image: image,
+          width: iconSize,
+          height: iconSize,
+          color: iconColor,
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.center,
+          excludeFromSemantics: true,
+        ),
       ),
     );
   }

--- a/packages/flutter/test/widgets/image_icon_test.dart
+++ b/packages/flutter/test/widgets/image_icon_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,9 +34,9 @@ void main() {
       ),
     );
 
-    final Image image = tester.widget(find.byType(Image));
-    expect(image, isNotNull);
-    expect(image.color.alpha, equals(128));
+    final Opacity opacity = tester.widget(find.byType(Opacity));
+    expect(opacity, isNotNull);
+    expect(opacity.opacity, equals(0.5));
   });
 
   testWidgets('ImageIcon sizing - no theme, explicit size', (WidgetTester tester) async {
@@ -116,6 +117,77 @@ void main() {
       textDirection: TextDirection.ltr,
     ));
     handle.dispose();
+  });
+
+  testWidgets('ImageIcon should not recolor when color is provided',
+    (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: ImageIcon(
+          _kImage,
+          color: Colors.blue,
+        ),
+      ),
+    );
+
+    final Image image = tester.widget(find.byType(Image));
+    expect(image, isNotNull);
+    expect(image.color, equals(Colors.blue));
+  });
+
+  testWidgets('ImageIcon should inherit IconTheme color',
+    (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: IconTheme(
+          data: IconThemeData(color: Colors.blue),
+          child: ImageIcon(
+            _kImage,
+          ),
+        ),
+      ),
+    );
+
+    final Image image = tester.widget(find.byType(Image));
+    expect(image, isNotNull);
+    expect(image.color, equals(Colors.blue));
+  });
+
+  testWidgets('ImageIcon should not recolor when shouldRecolor is false',
+    (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: ImageIcon(
+          _kImage,
+          color: Colors.blue,
+          shouldRecolor: false,
+        ),
+      ),
+    );
+
+    final Image image = tester.widget(find.byType(Image));
+    expect(image, isNotNull);
+    expect(image.color, isNull);
+  });
+
+  testWidgets(
+    'ImageIcon should ignore IconTheme color when shouldRecolor is false',
+    (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: IconTheme(
+          data: IconThemeData(color: Colors.blue),
+          child: ImageIcon(
+            _kImage,
+            shouldRecolor: false,
+          ),
+        ),
+      ),
+    );
+
+    final Image image = tester.widget(find.byType(Image));
+    expect(image, isNotNull);
+    expect(image.color, isNull);
   });
 
 }


### PR DESCRIPTION
Fix [#11593](https://github.com/flutter/flutter/issues/11593)

Add a flag to give user a way to opt-out colorization in ImageIcon.
Defaults to true to match current behaviour. 
Change the opacity handling with Opacity widget to able to handle opacity when shouldRecolor is false.