### PR TITLE
Fix flake in logger_test

### DIFF
--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -281,11 +281,9 @@ void main() {
     testUsingContext('sequential startProgress calls with StdoutLogger', () async {
       context[Logger].startProgress('AAA')..stop();
       context[Logger].startProgress('BBB')..stop();
-      expect(outputStdout(), <String>[
-        'AAA                                                               0ms',
-        'BBB                                                               0ms',
-        '',
-      ]);
+      expect(outputStdout().length, equals(3));
+      expect(outputStdout()[0], matches(RegExp(r'AAA[ ]{60}[\d ]{3}[\d]ms')));
+      expect(outputStdout()[1], matches(RegExp(r'BBB[ ]{60}[\d ]{3}[\d]ms')));
     }, overrides: <Type, Generator>{
       Stdio: () => mockStdio,
       Logger: () => StdoutLogger()..supportsColor = false,


### PR DESCRIPTION
This fixes a flaky test where it included `0ms` as part of an output check.  Kind of a classic flaky test.