### PR TITLE
Cleanup uses of entry points files

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -14,10 +14,6 @@ import 'dart/sdk.dart';
 import 'globals.dart';
 
 enum Artifact {
-  dartIoEntriesTxt,
-  dartVmEntryPointsTxt,
-  entryPointsJson,
-  entryPointsExtraJson,
   genSnapshot,
   flutterTester,
   snapshotDart,
@@ -34,14 +30,6 @@ enum Artifact {
 
 String _artifactToFileName(Artifact artifact, [TargetPlatform platform, BuildMode mode]) {
   switch (artifact) {
-    case Artifact.dartIoEntriesTxt:
-      return 'dart_io_entries.txt';
-    case Artifact.dartVmEntryPointsTxt:
-      return 'dart_vm_entry_points.txt';
-    case Artifact.entryPointsJson:
-      return 'entry_points.json';
-    case Artifact.entryPointsExtraJson:
-      return 'entry_points_extra.json';
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
@@ -145,10 +133,6 @@ class CachedArtifacts extends Artifacts {
   String _getAndroidArtifactPath(Artifact artifact, TargetPlatform platform, BuildMode mode) {
     final String engineDir = _getEngineArtifactsPath(platform, mode);
     switch (artifact) {
-      case Artifact.dartIoEntriesTxt:
-      case Artifact.dartVmEntryPointsTxt:
-      case Artifact.entryPointsJson:
-      case Artifact.entryPointsExtraJson:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
         return fs.path.join(engineDir, _artifactToFileName(artifact));
@@ -165,10 +149,6 @@ class CachedArtifacts extends Artifacts {
   String _getIosArtifactPath(Artifact artifact, TargetPlatform platform, BuildMode mode) {
     final String engineDir = _getEngineArtifactsPath(platform, mode);
     switch (artifact) {
-      case Artifact.dartIoEntriesTxt:
-      case Artifact.dartVmEntryPointsTxt:
-      case Artifact.entryPointsJson:
-      case Artifact.entryPointsExtraJson:
       case Artifact.genSnapshot:
       case Artifact.snapshotDart:
       case Artifact.flutterFramework:
@@ -260,13 +240,6 @@ class LocalEngineArtifacts extends Artifacts {
   @override
   String getArtifactPath(Artifact artifact, [TargetPlatform platform, BuildMode mode]) {
     switch (artifact) {
-      case Artifact.dartIoEntriesTxt:
-        return fs.path.join(_engineSrcPath, 'third_party', 'dart', 'runtime', 'bin', _artifactToFileName(artifact));
-      case Artifact.dartVmEntryPointsTxt:
-        return fs.path.join(_engineSrcPath, 'flutter', 'runtime', _artifactToFileName(artifact));
-      case Artifact.entryPointsJson:
-      case Artifact.entryPointsExtraJson:
-        return fs.path.join(engineOutPath, 'dart_entry_points', _artifactToFileName(artifact));
       case Artifact.snapshotDart:
         return fs.path.join(_engineSrcPath, 'flutter', 'lib', 'snapshot', _artifactToFileName(artifact));
       case Artifact.genSnapshot:

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -116,18 +116,14 @@ class AOTSnapshotter {
     final String skyEnginePkg = _getPackagePath(packageMap, 'sky_engine');
     final String uiPath = fs.path.join(skyEnginePkg, 'lib', 'ui', 'ui.dart');
     final String vmServicePath = fs.path.join(skyEnginePkg, 'sdk_ext', 'vmservice_io.dart');
-    final String vmEntryPoints = artifacts.getArtifactPath(Artifact.dartVmEntryPointsTxt, platform, buildMode);
-    final String ioEntryPoints = artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, platform, buildMode);
 
-    final List<String> inputPaths = <String>[uiPath, vmServicePath, vmEntryPoints, ioEntryPoints, mainPath];
+    final List<String> inputPaths = <String>[uiPath, vmServicePath, mainPath];
     final Set<String> outputPaths = Set<String>();
 
     final String depfilePath = fs.path.join(outputDir.path, 'snapshot.d');
     final List<String> genSnapshotArgs = <String>[
       '--url_mapping=dart:ui,$uiPath',
       '--url_mapping=dart:vmservice_io,$vmServicePath',
-      '--embedder_entry_points_manifest=$vmEntryPoints',
-      '--embedder_entry_points_manifest=$ioEntryPoints',
     ];
     genSnapshotArgs.addAll(<String>[
       '--reify-generic-functions',
@@ -303,10 +299,6 @@ class AOTSnapshotter {
     outputDir.createSync(recursive: true);
 
     printTrace('Compiling Dart to kernel: $mainPath');
-    final List<String> entryPointsJsonFiles = <String>[
-      artifacts.getArtifactPath(Artifact.entryPointsJson, platform, buildMode),
-      artifacts.getArtifactPath(Artifact.entryPointsExtraJson, platform, buildMode),
-    ];
 
     if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
       printTrace('Extra front-end options: $extraFrontEndOptions');
@@ -320,7 +312,6 @@ class AOTSnapshotter {
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn: true,
       aot: true,
-      entryPointsJsonFiles: entryPointsJsonFiles,
       trackWidgetCreation: false,
       targetProductVm: buildMode == BuildMode.release,
     );

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -78,7 +78,6 @@ class KernelCompiler {
     String depFilePath,
     bool linkPlatformKernelIn = false,
     bool aot = false,
-    List<String> entryPointsJsonFiles,
     bool trackWidgetCreation = false,
     List<String> extraFrontEndOptions,
     String incrementalCompilerByteStorePath,
@@ -139,11 +138,6 @@ class KernelCompiler {
     }
     if (targetProductVm) {
       command.add('-Ddart.vm.product=true');
-    }
-    if (entryPointsJsonFiles != null) {
-      for (String entryPointsJson in entryPointsJsonFiles) {
-        command.addAll(<String>['--entry-points', entryPointsJson]);
-      }
     }
     if (incrementalCompilerByteStorePath != null) {
       command.add('--incremental');

--- a/packages/flutter_tools/test/artifacts_test.dart
+++ b/packages/flutter_tools/test/artifacts_test.dart
@@ -32,10 +32,6 @@ void main() {
           fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'ios-release', 'Flutter.framework')
       );
       expect(
-          artifacts.getArtifactPath(Artifact.entryPointsExtraJson, TargetPlatform.android_arm64, BuildMode.release),
-          fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'android-arm64-release', 'entry_points_extra.json')
-      );
-      expect(
           artifacts.getArtifactPath(Artifact.flutterTester),
           fs.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester')
       );
@@ -81,14 +77,6 @@ void main() {
     });
 
     testUsingContext('getArtifactPath', () {
-      expect(
-          artifacts.getArtifactPath(Artifact.dartIoEntriesTxt, TargetPlatform.android_arm, BuildMode.debug),
-          fs.path.join(tempDir.path, 'third_party', 'dart', 'runtime', 'bin', 'dart_io_entries.txt')
-      );
-      expect(
-          artifacts.getArtifactPath(Artifact.entryPointsJson, TargetPlatform.android_arm, BuildMode.profile),
-          fs.path.join(tempDir.path, 'out', 'android_debug_unopt', 'dart_entry_points', 'entry_points.json')
-      );
       expect(
           artifacts.getArtifactPath(Artifact.flutterFramework, TargetPlatform.ios, BuildMode.release),
           fs.path.join(tempDir.path, 'out', 'android_debug_unopt', 'Flutter.framework')

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -85,11 +85,7 @@ void main() {
   });
 
   group('Snapshotter - iOS AOT', () {
-    const String kVmEntrypoints = 'dart_vm_entry_points.txt';
-    const String kIoEntries = 'dart_io_entries.txt';
     const String kSnapshotDart = 'snapshot.dart';
-    const String kEntrypointsJson = 'entry_points.json';
-    const String kEntrypointsExtraJson = 'entry_points_extra.json';
     String skyEnginePath;
 
     _FakeGenSnapshot genSnapshot;
@@ -101,11 +97,7 @@ void main() {
 
     setUp(() async {
       fs = MemoryFileSystem();
-      fs.file(kVmEntrypoints).createSync();
-      fs.file(kIoEntries).createSync();
       fs.file(kSnapshotDart).createSync();
-      fs.file(kEntrypointsJson).createSync();
-      fs.file(kEntrypointsExtraJson).createSync();
       fs.file('.packages').writeAsStringSync('sky_engine:file:///flutter/bin/cache/pkg/sky_engine/lib/');
 
       skyEnginePath = fs.path.fromUri(Uri.file('/flutter/bin/cache/pkg/sky_engine'));
@@ -121,11 +113,7 @@ void main() {
       mockArtifacts = MockArtifacts();
       mockXcode = MockXcode();
       for (BuildMode mode in BuildMode.values) {
-        when(mockArtifacts.getArtifactPath(Artifact.dartVmEntryPointsTxt, any, mode)).thenReturn(kVmEntrypoints);
-        when(mockArtifacts.getArtifactPath(Artifact.dartIoEntriesTxt, any, mode)).thenReturn(kIoEntries);
         when(mockArtifacts.getArtifactPath(Artifact.snapshotDart, any, mode)).thenReturn(kSnapshotDart);
-        when(mockArtifacts.getArtifactPath(Artifact.entryPointsJson, any, mode)).thenReturn(kEntrypointsJson);
-        when(mockArtifacts.getArtifactPath(Artifact.entryPointsExtraJson, any, mode)).thenReturn(kEntrypointsExtraJson);
       }
     });
 
@@ -206,8 +194,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -252,8 +238,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -298,8 +282,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -349,8 +331,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -396,8 +376,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -442,8 +420,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -506,8 +482,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',
@@ -557,8 +531,6 @@ void main() {
       expect(genSnapshot.additionalArgs, <String>[
         '--url_mapping=dart:ui,${fs.path.join(skyEnginePath, 'lib', 'ui', 'ui.dart')}',
         '--url_mapping=dart:vmservice_io,${fs.path.join(skyEnginePath, 'sdk_ext', 'vmservice_io.dart')}',
-        '--embedder_entry_points_manifest=$kVmEntrypoints',
-        '--embedder_entry_points_manifest=$kIoEntries',
         '--reify-generic-functions',
         '--strong',
         '--sync-async',


### PR DESCRIPTION
Entry points files (both JSON and text) are deprecated and replaced with @pragma("vm:entry-point") annotations. By now, entry points files are empty and can be safely removed.