### PR TITLE
[frdp] Removes regex check for Isolate search.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -118,7 +118,7 @@ class DartVm {
 
   /// Returns a [List] of [IsolateRef] objects whose name matches `pattern`.
   ///
-  /// This is not limited to isolates running Flutter, but to any Isolate on the
+  /// This is not limited to Isolates running Flutter, but to any Isolate on the
   /// VM.
   Future<List<IsolateRef>> getMainIsolatesByPattern(Pattern pattern) async {
     final Map<String, dynamic> jsonVmRef =

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -118,16 +118,15 @@ class DartVm {
 
   /// Returns a [List] of [IsolateRef] objects whose name matches `pattern`.
   ///
-  /// Also checks to make sure it was launched from the `main()` function.
+  /// This is not limited to isolates running Flutter, but to any Isolate on the
+  /// VM.
   Future<List<IsolateRef>> getMainIsolatesByPattern(Pattern pattern) async {
     final Map<String, dynamic> jsonVmRef =
         await invokeRpc('getVM', timeout: _kRpcTimeout);
     final List<IsolateRef> result = <IsolateRef>[];
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
       final String name = jsonIsolate['name'];
-      if (name.contains(pattern) && name.contains(RegExp(r':main\(\)'))) {
-        result.add(IsolateRef._fromJson(jsonIsolate, this));
-      }
+      result.add(IsolateRef._fromJson(jsonIsolate, this));
     }
     return result;
   }

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -125,7 +125,6 @@ class DartVm {
         await invokeRpc('getVM', timeout: _kRpcTimeout);
     final List<IsolateRef> result = <IsolateRef>[];
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
-      final String name = jsonIsolate['name'];
       result.add(IsolateRef._fromJson(jsonIsolate, this));
     }
     return result;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -125,7 +125,10 @@ class DartVm {
         await invokeRpc('getVM', timeout: _kRpcTimeout);
     final List<IsolateRef> result = <IsolateRef>[];
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
-      result.add(IsolateRef._fromJson(jsonIsolate, this));
+      final String name = jsonIsolate['name'];
+      if (name.contains(pattern)) {
+        result.add(IsolateRef._fromJson(jsonIsolate, this));
+      }
     }
     return result;
   }


### PR DESCRIPTION
This will now make it so that the Dart VM class returns any Isolate that
matches the passed Pattern, without checking for any specific strings
like "main()"

This causes the search to skip over Isolates that would have matched.