### PR TITLE
Upgrade dartdoc to version 0.21.1.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -63,7 +63,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.20.4
+"$PUB" global activate dartdoc 0.21.1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
The main change here is the introduction of generic "categories" support (shown as 'Topics' by default in Dartdoc).  Since the generic categories support is not yet used or configured for Flutter, there is no immediate change to the generated docs.  Some non-visible whitespace changes occurred in the generated HTML due to refactoring in the templates to support categories.

Change notes:

https://github.com/dart-lang/dartdoc/releases/tag/v0.21.1
https://github.com/dart-lang/dartdoc/releases/tag/v0.21.0

