### PR TITLE
Only register WidgetInspectorService extension in debug builds.

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -323,7 +323,10 @@ abstract class WidgetsBinding extends BindingBase with SchedulerBinding, Gesture
         }
     );
 
-    WidgetInspectorService.instance.initServiceExtensions(registerServiceExtension);
+    assert(() {
+      WidgetInspectorService.instance.initServiceExtensions(registerServiceExtension);
+      return true;
+    }());
   }
 
   Future<Null> _forceRebuild() {


### PR DESCRIPTION
I expect this to cause a couple benchmarks to regress.