### PR TITLE
Goodnight Moon

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -395,7 +395,7 @@ class AnsiSpinner extends Status {
   // Windows console font has a limited set of Unicode characters.
   List<String> get _animation => platform.isWindows
       ? <String>[r'-', r'\', r'|', r'/']
-      : <String>['🌕', '🌖', '🌗', '🌘', '🌑', '🌒', '🌓', '🌔'];
+      : <String>['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
 
   String get _backspace => '\b' * _animation[0].length;
   String get _clear => ' ' *  _animation[0].length;

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -100,12 +100,12 @@ void main() {
         List<String> lines = outputStdout();
         expect(lines[0], startsWith(platform.isWindows
             ? ' \b-\b\\\b|\b/\b-\b\\\b|\b/'
-            : ' \b\b🌕\b\b🌖\b\b🌗\b\b🌘\b\b🌑\b\b🌒\b\b🌓\b\b🌔\b\b🌕\b\b🌖'));
+            : ' \b⣾\b⣽\b⣻\b⢿\b⡿\b⣟\b⣯\b⣷\b⣾\b⣽'));
         expect(lines[0].endsWith('\n'), isFalse);
         expect(lines.length, equals(1));
         ansiSpinner.stop();
         lines = outputStdout();
-        expect(lines[0], endsWith(platform.isWindows ? '\b \b' : '\b\b  \b\b'));
+        expect(lines[0], endsWith('\b \b'));
         expect(lines.length, equals(1));
 
         // Verify that stopping or canceling multiple times throws.
@@ -128,7 +128,7 @@ void main() {
         final List<String> lines = outputStdout();
         expect(outputStderr().length, equals(1));
         expect(outputStderr().first, isEmpty);
-        expect(lines[0], matches(platform.isWindows ? r'[ ]{64} [\b]-' : r'[ ]{64} [\b][\b]🌕'));
+        expect(lines[0], matches(platform.isWindows ? r'[ ]{64} [\b]-' : r'[ ]{64} [\b]⣾'));
       }, overrides: <Type, Generator>{
         Stdio: () => mockStdio,
         Platform: () => FakePlatform(operatingSystem: testOs),
@@ -141,7 +141,7 @@ void main() {
         List<String> lines = outputStdout();
         expect(lines[0], startsWith(platform.isWindows
             ? 'Hello world               \b-\b\\\b|\b/\b-\b\\\b|\b/'
-            : 'Hello world               \b\b🌕\b\b🌖\b\b🌗\b\b🌘\b\b🌑\b\b🌒\b\b🌓\b\b🌔\b\b🌕\b\b🌖'));
+            : 'Hello world               \b⣾\b⣽\b⣻\b⢿\b⡿\b⣟\b⣯\b⣷\b⣾\b⣽'));
         expect(lines.length, equals(1));
         expect(lines[0].endsWith('\n'), isFalse);
 
@@ -150,7 +150,7 @@ void main() {
         lines = outputStdout();
         final List<Match> matches = secondDigits.allMatches(lines[0]).toList();
         expect(matches, isEmpty);
-        expect(lines[0], endsWith(platform.isWindows ? '\b \b' : '\b\b  \b\b'));
+        expect(lines[0], endsWith('\b \b'));
         expect(called, equals(1));
         expect(lines.length, equals(2));
         expect(lines[1], equals(''));
@@ -169,7 +169,7 @@ void main() {
         List<String> lines = outputStdout();
         expect(lines[0], startsWith(platform.isWindows
             ? 'Hello world               \b-\b\\\b|\b/\b-\b\\\b|\b/'
-            : 'Hello world               \b\b🌕\b\b🌖\b\b🌗\b\b🌘\b\b🌑\b\b🌒\b\b🌓\b\b🌔\b\b🌕\b\b🌖'));
+            : 'Hello world               \b⣾\b⣽\b⣻\b⢿\b⡿\b⣟\b⣯\b⣷\b⣾\b⣽'));
         expect(lines.length, equals(1));
 
         // Verify a stop prints the time.


### PR DESCRIPTION
Swap out the moon emoji used for progress spinner for a single-cell character.

The moon emoji looked cool, but couldn't be used because of bugs in xterm.js, used for VSCode's terminal, among others.  The moon emoji is two character cells wide, but xterm.js doesn't advance by two cells when it adds the emoji, but does go back by two when it backspaces.

This changes us to a different character animation (dots) that is only one cell wide, and so doesn't have this problem.