### PR TITLE
Strip debug symbols from App.framework for non-debug builds

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -138,7 +138,26 @@ BuildApp() {
     fi
     StreamOutput "done"
 
-    RunCommand cp -r -- "${build_dir}/aot/App.framework" "${derived_dir}"
+    local app_framework="${build_dir}/aot/App.framework"
+
+    RunCommand cp -r -- "${app_framework}" "${derived_dir}"
+
+    StreamOutput " ├─Generating dSYM file..."
+    RunCommand xcrun dsymutil -o "${build_dir}/aot/App.dSYM" "${app_framework}/App"
+    if [[ $? -ne 0 ]]; then
+      EchoError "Failed to generate dSYM file for ${app_framework}/App."
+      exit -1
+    fi
+    StreamOutput "done"
+
+    # StreamOutput " ├─Stripping debug symbols..."
+    # RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
+    # if [[ $? -ne 0 ]]; then
+    #   EchoError "Failed to strip ${derived_dir}/App.framework/App."
+    #   exit -1
+    # fi
+    # StreamOutput "done"
+
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"
 

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -145,7 +145,7 @@ BuildApp() {
     StreamOutput " ├─Generating dSYM file..."
     RunCommand xcrun dsymutil -o "${build_dir}/aot/App.dSYM" "${app_framework}/App"
     if [[ $? -ne 0 ]]; then
-      EchoError "Failed to generate dSYM file for ${app_framework}/App."
+      EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."
       exit -1
     fi
     StreamOutput "done"

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -150,13 +150,13 @@ BuildApp() {
     fi
     StreamOutput "done"
 
-    # StreamOutput " ├─Stripping debug symbols..."
-    # RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
-    # if [[ $? -ne 0 ]]; then
-    #   EchoError "Failed to strip ${derived_dir}/App.framework/App."
-    #   exit -1
-    # fi
-    # StreamOutput "done"
+    StreamOutput " ├─Stripping debug symbols..."
+    RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
+    if [[ $? -ne 0 ]]; then
+      EchoError "Failed to strip ${derived_dir}/App.framework/App."
+      exit -1
+    fi
+    StreamOutput "done"
 
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"


### PR DESCRIPTION
A dSYM file is created for the stripped `App.framework` and placed at `build/aot/App.dSYM`.

Reduces `App.framework` for Flutter Gallery by 6MB uncompressed, minus 23%.
Reduces `App.framework` for Hello World by 1.6MB uncompressed, minus 22%.

Fixes #4287.
Fixes #18693.
Helps with #21813.
See also #12012.

This change depends on https://dart-review.googlesource.com/c/sdk/+/76306.