### PR TITLE
Really fix the flutter dartdoc link

### DIFF
--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -8,4 +8,4 @@ source.
 * **Main site: [flutter.io](https://flutter.io/)**
 * [Install](https://flutter.io/setup/)
 * [Get started](https://flutter.io/getting-started/)
-* [Contribute](CONTRIBUTING.md)
+* [Contribute](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md#contributing-to-flutter)


### PR DESCRIPTION
It turns out that #21888 didn't really fix the bad link at docs.flutter.io, because *this* is the README used by dartdoc for flutter.