### PR TITLE
Enforce that WidgetsBindingObserver is only used as a mixin or interface

### DIFF
--- a/examples/flutter_gallery/test_memory/back_button.dart
+++ b/examples/flutter_gallery/test_memory/back_button.dart
@@ -19,7 +19,7 @@ Future<void> endOfAnimation() async {
 
 int iteration = 0;
 
-class LifecycleObserver extends WidgetsBindingObserver {
+class LifecycleObserver extends Object with WidgetsBindingObserver {
    @override
    void didChangeAppLifecycleState(AppLifecycleState state) {
      debugPrint('==== MEMORY BENCHMARK ==== $state ====');

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -74,6 +74,10 @@ export 'dart:ui' show AppLifecycleState, Locale;
 /// To respond to other notifications, replace the [didChangeAppLifecycleState]
 /// method above with other methods from this class.
 abstract class WidgetsBindingObserver {
+  // This class is intended to be used either as an interface or as a mixin,
+  // and should not be extended directly.
+  factory WidgetsBindingObserver._() => null;
+
   /// Called when the system tells the app to pop the current route.
   /// For example, on Android, this is called when the user presses
   /// the back button.

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-class MemoryPressureObserver extends WidgetsBindingObserver {
+class MemoryPressureObserver with WidgetsBindingObserver {
   bool sawMemoryPressure = false;
 
   @override
@@ -17,7 +17,7 @@ class MemoryPressureObserver extends WidgetsBindingObserver {
   }
 }
 
-class AppLifecycleStateObserver extends WidgetsBindingObserver {
+class AppLifecycleStateObserver with WidgetsBindingObserver {
   AppLifecycleState lifecycleState;
 
   @override
@@ -26,7 +26,7 @@ class AppLifecycleStateObserver extends WidgetsBindingObserver {
   }
 }
 
-class PushRouteObserver extends WidgetsBindingObserver {
+class PushRouteObserver with WidgetsBindingObserver {
   String pushedRoute;
 
   @override


### PR DESCRIPTION
`WidgetsBindingObserver` is used as an interface, as a mixin, and in rare cases as a super-class. We normally prevent extensions by defining a private factory ([example](https://github.com/flutter/flutter/blob/d927c9331005f81157fa39dff7b5dab415ad330b/packages/flutter/lib/src/widgets/ticker_provider.dart#L80)), but for some reason we didn't do it for this mixin. This change enforces that it is used only as an interface or as a mixin, but never as a super-class.

**This is a breaking change**. The breakage is likely manageable because `WidgetsBindingObserver` is not a commonly used class.

I'm open to alternatives, but we need to do something because mixins in Dart 2.1 and beyond will no longer allow extensions.

@leafpetersen @lrhn @eernstg @Hixie 
