### PR TITLE
Fix a retain cycle in the Objective-C platform_channel example

### DIFF
--- a/examples/platform_channel/ios/Runner/AppDelegate.m
+++ b/examples/platform_channel/ios/Runner/AppDelegate.m
@@ -19,10 +19,11 @@
   FlutterMethodChannel* batteryChannel = [FlutterMethodChannel
       methodChannelWithName:@"samples.flutter.io/battery"
             binaryMessenger:controller];
+  __weak typeof(self) weakSelf = self;
   [batteryChannel setMethodCallHandler:^(FlutterMethodCall* call,
                                          FlutterResult result) {
     if ([@"getBatteryLevel" isEqualToString:call.method]) {
-      int batteryLevel = [self getBatteryLevel];
+      int batteryLevel = [weakSelf getBatteryLevel];
       if (batteryLevel == -1) {
         result([FlutterError errorWithCode:@"UNAVAILABLE"
                                    message:@"Battery info unavailable"


### PR DESCRIPTION
willlarche pointed out in https://github.com/flutter/flutter/pull/21712 that the platform_channel_swift example created a retain cycle.  It appears that the Objective-C version has the same problem.