### PR TITLE
Support activeIcon in CupertinoTabBar

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -172,7 +172,12 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: <Widget> [
-                      Expanded(child: Center(child: items[index].icon)),
+                      Expanded(child:
+                        Center(child: active
+                            ? items[index].activeIcon
+                            : items[index].icon
+                        ),
+                      ),
                       items[index].title,
                     ],
                   ),

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -68,6 +68,39 @@ void main() {
     expect(actualActive.text.style.color, const Color(0xFF123456));
   });
 
+  testWidgets('Use active icon', (WidgetTester tester) async {
+    const TestImageProvider activeIcon = TestImageProvider(16, 16);
+    const TestImageProvider inactiveIcon = TestImageProvider(24, 24);
+
+    await pumpWidgetWithBoilerplate(tester, MediaQuery(
+      data: const MediaQueryData(),
+      child: CupertinoTabBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: ImageIcon(TestImageProvider(24, 24)),
+            title: Text('Tab 1'),
+          ),
+          BottomNavigationBarItem(
+            icon: ImageIcon(inactiveIcon),
+            activeIcon: ImageIcon(activeIcon),
+            title: Text('Tab 2'),
+          ),
+        ],
+        currentIndex: 1,
+        activeColor: const Color(0xFF123456),
+        inactiveColor: const Color(0xFF654321),
+      ),
+    ));
+
+    final Image image = tester.widget(find.descendant(
+      of: find.widgetWithText(GestureDetector, 'Tab 2'),
+      matching: find.byType(Image)
+    ));
+
+    expect(image.color, const Color(0xFF123456));
+    expect(image.image, activeIcon);
+  });
+
   testWidgets('Adjusts height to account for bottom padding', (WidgetTester tester) async {
     final CupertinoTabBar tabBar = CupertinoTabBar(
       items: const <BottomNavigationBarItem>[


### PR DESCRIPTION
Essentially adds tests to #21481