### PR TITLE
Change waitForViews() to refreshViews() for hot reload

### DIFF
--- a/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
+++ b/packages/flutter_tools/lib/src/commands/fuchsia_reload.dart
@@ -168,7 +168,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
     for (int port in ports) {
       final VMService vmService = await _getVMService(port);
       await vmService.getVM();
-      await vmService.waitForViews();
+      await vmService.refreshViews();
       views.addAll(vmService.vm.views);
     }
     return views;
@@ -268,7 +268,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
     for (int port in ports) {
       final VMService vmService = await _getVMService(port);
       await vmService.getVM();
-      await vmService.waitForViews();
+      await vmService.refreshViews();
       printStatus(_vmServiceToString(vmService));
     }
   }
@@ -307,8 +307,10 @@ class FuchsiaReloadCommand extends FlutterCommand {
       throwToolExit('Give the GN target with --gn-target(-g).');
     final List<String> targetInfo = _extractPathAndName(gnTarget);
     _projectRoot = targetInfo[0];
+    printTrace('_projectRoot is $_projectRoot');
     _projectName = targetInfo[1];
     _fuchsiaProjectPath = '$_buildDir/../../$_projectRoot';
+    printTrace('_fuchsiaProjectPath is $_fuchsiaProjectPath');
     if (!_directoryExists(_fuchsiaProjectPath))
       throwToolExit('Target does not exist in the Fuchsia tree: $_fuchsiaProjectPath.');
 
@@ -330,6 +332,7 @@ class FuchsiaReloadCommand extends FlutterCommand {
     // to locate the .packages file.
     final String packagesFileName = '${_binaryName}_dart_library.packages';
     _dotPackagesPath = '$_buildDir/dartlang/gen/$_projectRoot/$packagesFileName';
+    printTrace('_dotPackagesPath is $_dotPackagesPath');
     if (!_fileExists(_dotPackagesPath))
       throwToolExit('Couldn\'t find .packages file at $_dotPackagesPath.');
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -100,12 +100,6 @@ class FlutterDevice {
       await service.getVM();
   }
 
-  Future<Null> waitForViews() async {
-    // Refresh the view list, and wait a bit for the list to populate.
-    for (VMService service in vmServices)
-      await service.waitForViews();
-  }
-
   Future<Null> stopApps() async {
     final List<FlutterView> flutterViews = views;
     if (flutterViews == null || flutterViews.isEmpty)
@@ -635,7 +629,7 @@ abstract class ResidentRunner {
       await device._connect(reloadSources: reloadSources,
           compileExpression: compileExpression);
       await device.getVMs();
-      await device.waitForViews();
+      await device.refreshViews();
       if (device.views.isEmpty)
         printStatus('No Flutter views available on ${device.device.name}');
       else

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -344,17 +344,10 @@ class VMService {
     return await _vm.reload();
   }
 
-  Future<Null> waitForViews({int attempts = 5, int attemptSeconds = 1}) async {
+  Future<Null> refreshViews() async {
     if (!vm.isFlutterEngine)
       return;
     await vm.refreshViews();
-    for (int i = 0; (vm.firstView == null) && (i < attempts); i++) {
-      // If the VM doesn't yet have a view, wait for one to show up.
-      printTrace('Waiting for Flutter view');
-      await Future<Null>.delayed(Duration(seconds: attemptSeconds));
-      await getVM();
-      await vm.refreshViews();
-    }
   }
 }
 


### PR DESCRIPTION
Hot reload currently calls waitForViews(), which takes 5 seconds to time out if there are no views in the VM. In Fuchsia there can be multiple running VMs without flutter views, which means hot reload start up times of 15 to 25 seconds. zanderso recommends replacing waitForViews() with refreshViews().