### PR TITLE
Make font manifest descriptors consistent with the paths used for font assets

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -149,6 +149,10 @@ class FlutterManifest {
   }
 
   List<Map<String, dynamic>> get fontsDescriptor {
+    return fonts.map((Font font) => font.descriptor).toList();
+  }
+
+  List<Map<String, dynamic>> get _rawFontsDescriptor {
     final List<dynamic> fontList = _flutterDescriptor['fonts'];
     return fontList == null
         ? const <Map<String, dynamic>>[]
@@ -179,7 +183,7 @@ class FlutterManifest {
       return <Font>[];
 
     final List<Font> fonts = <Font>[];
-    for (Map<String, dynamic> fontFamily in fontsDescriptor) {
+    for (Map<String, dynamic> fontFamily in _rawFontsDescriptor) {
       final List<dynamic> fontFiles = fontFamily['fonts'];
       final String familyName = fontFamily['family'];
       if (familyName == null) {

--- a/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_package_fonts_test.dart
@@ -89,8 +89,8 @@ $fontsSection
     }
 
     expect(
-      utf8.decode(await bundle.entries['FontManifest.json'].contentsAsBytes()),
-      expectedAssetManifest,
+      json.decode(utf8.decode(await bundle.entries['FontManifest.json'].contentsAsBytes())),
+      json.decode(expectedAssetManifest),
     );
   }
 

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -92,13 +92,13 @@ flutter:
         - asset: a/bar
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
-
-      expect(flutterManifest.fontsDescriptor.toString(), '[{fonts: [{asset: a/bar}], family: foo}]');
+      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 1);
       final Font font = fonts[0];
-      const String fontDescriptor = '{family: foo, fonts: [{asset: a/bar}]}';
-      expect(font.descriptor.toString(), fontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(font.descriptor, fooFontDescriptor);
       expect(font.familyName, 'foo');
       final List<FontAsset> assets = font.fontAssets;
       expect(assets.length, 1);
@@ -124,14 +124,13 @@ flutter:
           weight: 400
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
-
-      const String expectedFontsDescriptor = '[{fonts: [{asset: a/bar}, {weight: 400, asset: a/bar}], family: foo}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 1);
       final Font font = fonts[0];
-      const String fontDescriptor = '{family: foo, fonts: [{asset: a/bar}, {weight: 400, asset: a/bar}]}';
-      expect(font.descriptor.toString(), fontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(font.descriptor, fooFontDescriptor);
       expect(font.familyName, 'foo');
       final List<FontAsset> assets = font.fontAssets;
       expect(assets.length, 2);
@@ -162,14 +161,14 @@ flutter:
           style: italic
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
 
-      const String expectedFontsDescriptor = '[{fonts: [{asset: a/bar}, {style: italic, weight: 400, asset: a/bar}], family: foo}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 1);
       final Font font = fonts[0];
-      const String fontDescriptor = '{family: foo, fonts: [{asset: a/bar}, {weight: 400, style: italic, asset: a/bar}]}';
-      expect(font.descriptor.toString(), fontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(font.descriptor, fooFontDescriptor);
       expect(font.familyName, 'foo');
       final List<FontAsset> assets = font.fontAssets;
       expect(assets.length, 2);
@@ -206,16 +205,17 @@ flutter:
           style: italic
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
-
-      const String expectedFontsDescriptor = '[{fonts: [{asset: a/bar}, {style: italic, weight: 400, asset: a/bar}], family: foo},'
-                                             ' {fonts: [{asset: a/baz}, {style: italic, weight: 400, asset: a/baz}], family: bar}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      final dynamic expectedFontsDescriptor = <dynamic>[
+          {'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}, // ignore: always_specify_types
+          {'fonts': [{'asset': 'a/baz'}, {'style': 'italic', 'weight': 400, 'asset': 'a/baz'}], 'family': 'bar'}, // ignore: always_specify_types
+      ];
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 2);
 
       final Font fooFont = fonts[0];
-      const String barFontDescriptor = '{family: foo, fonts: [{asset: a/bar}, {weight: 400, style: italic, asset: a/bar}]}';
-      expect(fooFont.descriptor.toString(), barFontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(fooFont.descriptor, fooFontDescriptor);
       expect(fooFont.familyName, 'foo');
       final List<FontAsset> fooAassets = fooFont.fontAssets;
       expect(fooAassets.length, 2);
@@ -229,7 +229,7 @@ flutter:
       expect(fooFontAsset1.style, 'italic');
 
       final Font barFont = fonts[1];
-      const String fontDescriptor = '{family: bar, fonts: [{asset: a/baz}, {weight: 400, style: italic, asset: a/baz}]}';
+      const String fontDescriptor = '{family: bar, fonts: [{asset: a/baz}, {weight: 400, style: italic, asset: a/baz}]}'; // ignore: always_specify_types
       expect(barFont.descriptor.toString(), fontDescriptor);
       expect(barFont.familyName, 'bar');
       final List<FontAsset> barAssets = barFont.fontAssets;
@@ -267,15 +267,13 @@ flutter:
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
 
-
-      const String expectedFontsDescriptor = '[{fonts: [{asset: a/bar}, {style: italic, weight: 400, asset: a/bar}], family: foo},'
-                                             ' {fonts: [{asset: a/baz}, {style: italic, weight: 400, asset: a/baz}]}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 1);
       final Font fooFont = fonts[0];
-      const String barFontDescriptor = '{family: foo, fonts: [{asset: a/bar}, {weight: 400, style: italic, asset: a/bar}]}';
-      expect(fooFont.descriptor.toString(), barFontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(fooFont.descriptor, fooFontDescriptor);
       expect(fooFont.familyName, 'foo');
       final List<FontAsset> fooAassets = fooFont.fontAssets;
       expect(fooAassets.length, 2);
@@ -307,15 +305,13 @@ flutter:
     - family: bar
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
-
-      const String expectedFontsDescriptor = '[{fonts: [{asset: a/bar}, {style: italic, weight: 400, asset: a/bar}], family: foo},'
-                                             ' {family: bar}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
+      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 1);
       final Font fooFont = fonts[0];
-      const String barFontDescriptor = '{family: foo, fonts: [{asset: a/bar}, {weight: 400, style: italic, asset: a/bar}]}';
-      expect(fooFont.descriptor.toString(), barFontDescriptor);
+      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
+      expect(fooFont.descriptor, fooFontDescriptor);
       expect(fooFont.familyName, 'foo');
       final List<FontAsset> fooAassets = fooFont.fontAssets;
       expect(fooAassets.length, 2);
@@ -344,8 +340,7 @@ flutter:
 ''';
       final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
 
-      const String expectedFontsDescriptor = '[{fonts: [{weight: 400}], family: foo}]';
-      expect(flutterManifest.fontsDescriptor.toString(), expectedFontsDescriptor);
+      expect(flutterManifest.fontsDescriptor, <dynamic>[]);
       final List<Font> fonts = flutterManifest.fonts;
       expect(fonts.length, 0);
     });


### PR DESCRIPTION
The asset subsystem uses URIs to represent asset locations.  The font manifest
should also use URI-encoded paths instead of unencoded paths taken directly
from the manifest YAML.

Fixes https://github.com/flutter/flutter/issues/19452