### PR TITLE
Revert "Remove code signing special casing for Googlers"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -163,11 +163,19 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   if (await opensslProcess.exitCode != 0)
     return null;
 
-  return <String, String> {
+  final Map<String, String> signingConfigs = <String, String> {
     'DEVELOPMENT_TEAM': _certificateOrganizationalUnitExtractionPattern
       .firstMatch(opensslOutput)
       ?.group(1),
   };
+
+  if (opensslOutput.contains('iPhone Developer: Google Development')) {
+    signingConfigs['PROVISIONING_PROFILE_SPECIFIER'] = 'Google Development';
+    signingConfigs['CODE_SIGN_STYLE'] = 'Manual';
+    printStatus("Manually selecting Google's mobile provisioning profile (see go/google-flutter-signing).");
+  }
+
+  return signingConfigs;
 }
 
 Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities, bool usesTerminalUi) async {

--- a/packages/flutter_tools/test/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/ios/code_signing_test.dart
@@ -149,6 +149,69 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('Test Google cert also manually selects a provisioning profile', () async {
+      when(mockProcessManager.runSync(<String>['which', 'security']))
+          .thenReturn(exitsHappy);
+      when(mockProcessManager.runSync(<String>['which', 'openssl']))
+          .thenReturn(exitsHappy);
+      when(mockProcessManager.runSync(
+      argThat(contains('find-identity')),
+        environment: anyNamed('environment'),
+        workingDirectory: anyNamed('workingDirectory'),
+      )).thenReturn(ProcessResult(
+        1, // pid
+        0, // exitCode
+        '''
+1) 86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 "iPhone Developer: Google Development (1111AAAA11)"
+    1 valid identities found''',
+        ''
+      ));
+      when(mockProcessManager.runSync(
+        <String>['security', 'find-certificate', '-c', '1111AAAA11', '-p'],
+        environment: anyNamed('environment'),
+        workingDirectory: anyNamed('workingDirectory'),
+      )).thenReturn(ProcessResult(
+        1, // pid
+        0, // exitCode
+        'This is a mock certificate',
+        '',
+      ));
+
+      final MockProcess mockProcess = MockProcess();
+      final MockStdIn mockStdIn = MockStdIn();
+      final MockStream mockStdErr = MockStream();
+
+      when(mockProcessManager.start(
+      argThat(contains('openssl')),
+        environment: anyNamed('environment'),
+        workingDirectory: anyNamed('workingDirectory'),
+      )).thenAnswer((Invocation invocation) => Future<Process>.value(mockProcess));
+
+      when(mockProcess.stdin).thenReturn(mockStdIn);
+      when(mockProcess.stdout)
+          .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
+            Future<List<int>>.value(utf8.encode(
+              'subject= /CN=iPhone Developer: Google Development (1111AAAA11)/OU=3333CCCC33/O=My Team/C=US'
+            ))
+          ));
+      when(mockProcess.stderr).thenAnswer((Invocation invocation) => mockStdErr);
+      when(mockProcess.exitCode).thenAnswer((_) async => 0);
+
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+
+      expect(testLogger.statusText, contains('iPhone Developer: Google Development (1111AAAA11)'));
+      expect(testLogger.errorText, isEmpty);
+      verify(mockStdIn.write('This is a mock certificate'));
+      expect(signingConfigs, <String, String> {
+        'DEVELOPMENT_TEAM': '3333CCCC33',
+        'PROVISIONING_PROFILE_SPECIFIER': 'Google Development',
+        'CODE_SIGN_STYLE': 'Manual',
+      });
+    },
+    overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('Test multiple identity and certificate organization works', () async {
       when(mockProcessManager.runSync(<String>['which', 'security']))
           .thenReturn(exitsHappy);


### PR DESCRIPTION
Wrongfully assumed devicelab had its own xcconfig merging mechanism for provisioning