### PR TITLE
Fix out of range spring simulation in ClampingScrollSimulation

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -427,7 +427,7 @@ class ClampingScrollPhysics extends ScrollPhysics {
       return ScrollSpringSimulation(
         spring,
         position.pixels,
-        position.maxScrollExtent,
+        end,
         math.min(0.0, velocity),
         tolerance: tolerance
       );

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -89,4 +89,19 @@ void main() {
     await tester.pump();
     expect(scrollable.position.pixels, equals(50.0));
   });
+
+  testWidgets('ClampingScrollPhysics handles out of bounds ScrollPosition', (WidgetTester tester) async {
+    Future<void> testOutOfBounds(ScrollPhysics physics, double initialOffset, double expectedOffset) async {
+      final ScrollController scrollController = ScrollController(initialScrollOffset: initialOffset);
+      await tester.pumpWidget(buildFrame(physics, scrollController: scrollController));
+      final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+
+      expect(scrollable.position.pixels, equals(initialOffset));
+      await tester.pump(const Duration(seconds: 1)); // Allow overscroll to settle
+      expect(scrollable.position.pixels, equals(expectedOffset));
+    }
+
+    await testOutOfBounds(const ClampingScrollPhysics(), -400.0, 0.0);
+    await testOutOfBounds(const ClampingScrollPhysics(), 800.0, 50.0);
+  });
 }

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -11,10 +11,11 @@ import 'package:flutter/widgets.dart';
 // The top of the bottom widget is at 550 (the top of the top widget
 // is at 0). The top of the bottom widget is 500 when it has been
 // scrolled completely into view.
-Widget buildFrame(ScrollPhysics physics) {
+Widget buildFrame(ScrollPhysics physics, {ScrollController scrollController}) {
   return SingleChildScrollView(
     key: UniqueKey(),
     physics: physics,
+    controller: scrollController,
     child: SizedBox(
       height: 650.0,
       child: Column(


### PR DESCRIPTION
If the scroll is out of range for any reason (for instance, changing scroll physics or manually messing with scroll position), the spring simulation causes the scroll position to slingshot towards the end. Also, before this change, `end` was unused.