### PR TITLE
fix race in devicelab concurrent hot reload

### DIFF
--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -64,6 +64,8 @@ void main() {
           print('service protocol connection available at port $vmServicePort');
         } else if (json != null && json['event'] == 'app.started') {
           appId = json['params']['appId'];
+        }
+        if (vmServicePort != null && appId != null) {
           print('run: ready!');
           ready.complete();
           ok ??= true;


### PR DESCRIPTION
The concurrent hot reload test flakes out every so often when the 'appId' is processed before the 'vmServicePort', and the completer is marked as ready before the port is available.  This can be seen in the logs with things like:

```
2018-09-27T22:12:16.803141: run: ready!
2018-09-27T22:12:16.823703: Task failed: FormatException: Invalid port (at character 16)
ws://localhost:null/ws
               ^
2018-09-27T22:12:16.823995: 

Stack trace:2018-09-27T22:12:16.824087: 
2018-09-27T22:12:16.866707: dart:core                                                  Uri.parse
package:vm_service_client/vm_service_client.dart 111:35    new VMServiceClient.connect
bin/tasks/run_machine_concurrent_hot_reload.dart 83:27     main..
===== asynchronous gap ===========================
dart:async                                                 _AsyncAwaitCompleter.completeError
bin/tasks/run_machine_concurrent_hot_reload.dart           main..
===== asynchronous gap ===========================
dart:async                                                 _asyncThenWrapperHelper
bin/tasks/run_machine_concurrent_hot_reload.dart           main..
package:flutter_devicelab/framework/utils.dart 379:24      inDirectory
===== asynchronous gap ===========================
dart:async                                                 _asyncThenWrapperHelper
bin/tasks/run_machine_concurrent_hot_reload.dart           main.
package:flutter_devicelab/framework/framework.dart 128:32  _TaskRunner._performTask.

2018-09-27T22:12:16.867792: Cleaning up after task...
2018-09-27T22:12:16.868938: run:stdout: [  +72 ms] DevFS: Created new filesystem on the device (file:///data/user/0/com.yourcompany.integration_ui/cache/uiHBBIIT/ui/)
run:stdout: [{"event":"app.debugPort","params":{"appId":"faf415cb-0a0c-4f7e-a653-1da6a3491022","port":59238,"wsUri":"ws://127.0.0.1:59238/ws","baseUri":"file:///data/user/0/com.yourcompany.integration_ui/cache/uiHBBIIT/ui/"}}]
2018-09-27T22:12:16.869612: service protocol connection available at port 59238
```

This should make the task less flaky.