### PR TITLE
Use unsafePackageSerialization when running tests

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -250,7 +250,7 @@ class ResidentCompiler {
   ResidentCompiler(this._sdkRoot, {bool trackWidgetCreation = false,
       String packagesPath, List<String> fileSystemRoots, String fileSystemScheme,
       CompilerMessageConsumer compilerMessageConsumer = printError,
-      String initializeFromDill})
+      String initializeFromDill, bool unsafePackageSerialization})
     : assert(_sdkRoot != null),
       _trackWidgetCreation = trackWidgetCreation,
       _packagesPath = packagesPath,
@@ -258,7 +258,8 @@ class ResidentCompiler {
       _fileSystemScheme = fileSystemScheme,
       _stdoutHandler = _StdoutHandler(consumer: compilerMessageConsumer),
       _controller = StreamController<_CompilationRequest>(),
-      _initializeFromDill = initializeFromDill {
+      _initializeFromDill = initializeFromDill,
+      _unsafePackageSerialization = unsafePackageSerialization {
     // This is a URI, not a file path, so the forward slash is correct even on Windows.
     if (!_sdkRoot.endsWith('/'))
       _sdkRoot = '$_sdkRoot/';
@@ -272,6 +273,7 @@ class ResidentCompiler {
   Process _server;
   final _StdoutHandler _stdoutHandler;
   String _initializeFromDill;
+  bool _unsafePackageSerialization;
 
   final StreamController<_CompilationRequest> _controller;
 
@@ -368,6 +370,9 @@ class ResidentCompiler {
     }
     if (_initializeFromDill != null) {
       command.addAll(<String>['--initialize-from-dill', _initializeFromDill]);
+    }
+    if (_unsafePackageSerialization == true) {
+      command.add('--unsafe-package-serialization');
     }
     printTrace(command.join(' '));
     _server = await processManager.start(command);

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -238,7 +238,8 @@ class _Compiler {
         packagesPath: PackageMap.globalPackagesPath,
         trackWidgetCreation: trackWidgetCreation,
         compilerMessageConsumer: reportCompilerMessage,
-        initializeFromDill: testFilePath
+        initializeFromDill: testFilePath,
+        unsafePackageSerialization: true,
       );
     }
 


### PR DESCRIPTION
Running `flutter test` in flutter/packages/flutter:

Without:
02:32 +3115 ~25: All tests passed!

With:
01:43 +3115 ~25: All tests passed!