### PR TITLE
Expose the history getter for NavigatorState 

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-
+import 'dart:collection';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -1295,7 +1295,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   final FocusScopeNode focusScopeNode = new FocusScopeNode();
 
   final List<OverlayEntry> _initialOverlayEntries = <OverlayEntry>[];
-  List<Route<dynamic>> get history => _history;
+  UnmodifiableListView<Route<dynamic>> get history =>
+      new UnmodifiableListView<Route<dynamic>>(_history);
 
   @override
   void initState() {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1295,6 +1295,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   final FocusScopeNode focusScopeNode = new FocusScopeNode();
 
   final List<OverlayEntry> _initialOverlayEntries = <OverlayEntry>[];
+  List<Route<dynamic>> get history => _history;
 
   @override
   void initState() {


### PR DESCRIPTION
This commit add history getter for NavigatorState so that developers can have more control of the navigation history. 
For UINavigationController in iOS, push, pop and popToViewcontroller, popToRoot and viewControllers(getter for navigation stack) are enough for developers. 
If the history can be fetched, codes related could be more flexible when processing the navigation stack.