### PR TITLE
Clean up the examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,55 +1,41 @@
 Flutter Examples
 ================
 
-This directory contains several examples of using Flutter. Each of these is an
-individual Dart application package.
+This directory contains several examples of using Flutter. To run an example,
+use `flutter run` inside that example's directory. See the [getting started
+guide](https://flutter.io/getting-started/) to install the `flutter` tool.
 
-To run an example, use `flutter run` inside that example's directory.  See the
-[getting started guide](https://flutter.io/getting-started/) to install
-the `flutter` tool.
-
-**Tip:** To see examples of how to use a specific Flutter framework class,
-copy and paste a URL with this format in your browser. Replace `foo` with the
-classname you are searching for (for example, here's the
-[query](https://github.com/flutter/flutter/search?q=path%3Aexamples+new+AppBar)
-for examples of the
-[`AppBar`](https://docs.flutter.io/flutter/material/AppBar-class.html) class).
-
-```
-https://github.com/flutter/flutter/search?q=path%3Aexamples+new+foo
-```
+For additional samples, see the
+[`flutter/samples`](https://github.com/flutter/samples) repo.
 
 Available examples include:
 
-- **Hello, world** The [hello world app](hello_world) is a basic app that shows
-  the text "hello, world."
+- **Hello, world** The [hello world app](hello_world) is a minimal Flutter app
+  that shows the text "hello, world."
 
 - **Flutter gallery** The [flutter gallery app](flutter_gallery) showcases
-  Flutter's widgets, including its implementation of
-  [material design](https://material.google.com/).
-
-- **Platform Channel** The [platform channel app](platform_channel)
-  demonstrates how to connect a Flutter app to platform-specific APIs. For
-  documentation, see <https://flutter.io/platform-channels/>.
-
-- **Platform Channel Swift** The [platform channel swift app](platform_channel_swift)
-  is the same as [platform channel](platform_channel) but the iOS version is in
-  Swift and there is no Android version.
-
-- **Flutter View** The [flutter view app](flutter_view) demonstrates how to
-  embed Flutter within an iOS or Android app.
+  Flutter's widgets, including its implementation of [material
+  design](https://material.google.com/).
 
 - **Layers** The [layers vignettes](layers) show how to use the various layers
-  in the Flutter framework. For details, see the [layers README](layers/README.md).
+  in the Flutter framework. For details, see the [layers
+  README](layers/README.md).
 
-- **Stocks** The [stocks](stocks) demo shows how one might structure
-  an application with several screens.
+- **Platform Channel** The [platform channel app](platform_channel) demonstrates
+  how to connect a Flutter app to platform-specific APIs. For documentation, see
+  <https://flutter.io/platform-channels/>.
+
+- **Platform Channel Swift** The [platform channel swift
+  app](platform_channel_swift) is the same as [platform
+  channel](platform_channel) but the iOS version is in Swift and there is no
+  Android version.
+
+## Notes
 
 Note on Gradle wrapper files in `.gitignore`:
 
-Gradle wrapper files should normally be checked into source control.
-The example projects don't do that to avoid having several copies of the
-wrapper binary in the Flutter repo. Instead, the Gradle wrapper is
-injected by Flutter tooling, and the wrapper files are .gitignore'd to
-avoid making the Flutter repository dirty as a side effect of running
-the examples.
+Gradle wrapper files should normally be checked into source control. The example
+projects don't do that to avoid having several copies of the wrapper binary in
+the Flutter repo. Instead, the Gradle wrapper is injected by Flutter tooling,
+and the wrapper files are .gitignore'd to avoid making the Flutter repository
+dirty as a side effect of running the examples.


### PR DESCRIPTION
A few changes:

* Remove the search tip (it relies on searching for the new keyword which we no longer use)
* Remove mentioning of examples that are either stale or only used for internal purposes (such as test)
* Cross-link to the samples repo
* Wrap all lines to 80-cols