### PR TITLE
Fix a bug that the cursor jump abnormally when setting text for a TextEditingController.

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -79,7 +79,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// actions, not during the build, layout, or paint phases.
   set text(String newText) {
     value = value.copyWith(text: newText,
-                           selection: TextSelection.fromPosition(new TextPosition(offset: newText.length)),
+                           selection: TextSelection.collapsed(offset: newText.length),
                            composing: TextRange.empty);
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -79,7 +79,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// actions, not during the build, layout, or paint phases.
   set text(String newText) {
     value = value.copyWith(text: newText,
-                           selection: const TextSelection.collapsed(offset: -1),
+                           selection: TextSelection.fromPosition(new TextPosition(offset: newText.length)),
                            composing: TextRange.empty);
   }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -971,7 +971,6 @@ void main() {
           actions: <SemanticsAction>[
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorBackwardByWord,
-            SemanticsAction.setSelection,
           ],
         ));
 
@@ -1427,8 +1426,13 @@ void main() {
                             SemanticsFlag.isTextField,
                             SemanticsFlag.isObscured
                           ],
+                          actions: <SemanticsAction>[
+                            SemanticsAction.moveCursorBackwardByCharacter,
+                            SemanticsAction.moveCursorBackwardByWord,
+                          ],
                           value: expectedValue,
                           textDirection: TextDirection.ltr,
+                          textSelection: const TextSelection(baseOffset: 24, extentOffset: 24),
                         ),
                       ],
                     ),


### PR DESCRIPTION
This commit fix a bug that the cursor jump(very beginning and the end) when calling "TextEditingController.setText". A small screenshot video is given below:

https://www.youtube.com/watch?v=vq4_IBVd5Ro