### PR TITLE
Revert "Strip debug symbols from App.framework for non-debug builds (#22245)"

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -141,26 +141,7 @@ BuildApp() {
     fi
     StreamOutput "done"
 
-    local app_framework="${build_dir}/aot/App.framework"
-
-    RunCommand cp -r -- "${app_framework}" "${derived_dir}"
-
-    StreamOutput " ├─Generating dSYM file..."
-    RunCommand xcrun dsymutil -o "${build_dir}/aot/App.dSYM" "${app_framework}/App"
-    if [[ $? -ne 0 ]]; then
-      EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."
-      exit -1
-    fi
-    StreamOutput "done"
-
-    StreamOutput " ├─Stripping debug symbols..."
-    RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
-    if [[ $? -ne 0 ]]; then
-      EchoError "Failed to strip ${derived_dir}/App.framework/App."
-      exit -1
-    fi
-    StreamOutput "done"
-
+    RunCommand cp -r -- "${build_dir}/aot/App.framework" "${derived_dir}"
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"
 


### PR DESCRIPTION
Reverts #22245.

This reverts commit eda228404ce9bd0ddfd1594b45836f19eea4a517.

App Store upload with symbols doesn't work with this. :(