### PR TITLE
Provide api to decouple cursor and keyboard for an editable text

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -633,7 +633,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// focus, the control will then attach to the keyboard and request that the
   /// keyboard become visible.
   void requestKeyboard() {
-    if (_hasFocus)
+    if (_hasFocus && !widget.focusNode.disableKeyboard)
       _openInputConnection();
     else
       FocusScope.of(context).requestFocus(widget.focusNode);

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -43,6 +43,13 @@ class FocusNode extends ChangeNotifier {
   FocusManager _manager;
   bool _hasKeyboardToken = false;
 
+  /// Whether the keyboard is disabled especially when there is a custom keyboard
+  bool _disableKeyboard = false;
+  bool get disableKeyboard => _disableKeyboard;
+  set disableKeyboard(bool isDisabled) {
+    _disableKeyboard = isDisabled;
+  }
+
   /// Whether this node has the overall focus.
   ///
   /// A [FocusNode] has the overall focus when the node is focused in its
@@ -74,8 +81,7 @@ class FocusNode extends ChangeNotifier {
   ///
   /// Returns whether this function successfully consumes a keyboard token.
   bool consumeKeyboardToken() {
-    if (!_hasKeyboardToken)
-      return false;
+    if (!_hasKeyboardToken || _disableKeyboard) return false;
     _hasKeyboardToken = false;
     return true;
   }

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -44,11 +44,7 @@ class FocusNode extends ChangeNotifier {
   bool _hasKeyboardToken = false;
 
   /// Whether the keyboard is disabled especially when there is a custom keyboard
-  bool _disableKeyboard = false;
-  bool get disableKeyboard => _disableKeyboard;
-  set disableKeyboard(bool isDisabled) {
-    _disableKeyboard = isDisabled;
-  }
+  bool disableKeyboard = false;
 
   /// Whether this node has the overall focus.
   ///
@@ -81,7 +77,8 @@ class FocusNode extends ChangeNotifier {
   ///
   /// Returns whether this function successfully consumes a keyboard token.
   bool consumeKeyboardToken() {
-    if (!_hasKeyboardToken || _disableKeyboard) return false;
+    if (!_hasKeyboardToken || disableKeyboard)
+      return false;
     _hasKeyboardToken = false;
     return true;
   }


### PR DESCRIPTION
Provide new api so that a cursor could be decoupled from the keyboard when specified disableKeyboard, this is helpful especially when the developers need a customized keyboard, where the cursor is needed but the keyboard would be always hidden.

What is was before:
![img_5024](https://user-images.githubusercontent.com/817851/46246173-ef2ad680-c42b-11e8-9d23-49b2e4b5dbc8.PNG)


What we want:
![img_5025](https://user-images.githubusercontent.com/817851/46246174-f225c700-c42b-11e8-950e-5d6c80b2e9b4.PNG)

