### PR TITLE
Eliminate snapshot, depfile opts from bundle cmd

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -308,7 +308,7 @@ class AOTSnapshotter {
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       mainPath: mainPath,
       outputFilePath: fs.path.join(outputPath, 'app.dill'),
-      depFilePath: depfilePath,
+      depfilePath: depfilePath,
       extraFrontEndOptions: extraFrontEndOptions,
       linkPlatformKernelIn: true,
       aot: true,

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -35,9 +35,7 @@ Future<void> build({
   BuildMode buildMode,
   String mainPath = defaultMainPath,
   String manifestPath = defaultManifestPath,
-  String snapshotPath,
   String applicationKernelFilePath,
-  String depfilePath,
   String privateKeyPath = defaultPrivateKeyPath,
   String assetDirPath,
   String packagesPath,
@@ -51,8 +49,6 @@ Future<void> build({
   List<String> fileSystemRoots,
   String fileSystemScheme,
 }) async {
-  snapshotPath ??= defaultSnapshotPath;
-  depfilePath ??= defaultDepfilePath;
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
   applicationKernelFilePath ??= defaultApplicationKernelPath;
@@ -68,7 +64,7 @@ Future<void> build({
           fs.path.absolute(getIncrementalCompilerByteStoreDirectory()),
       mainPath: fs.file(mainPath).absolute.path,
       outputFilePath: applicationKernelFilePath,
-      depFilePath: depfilePath,
+      depfilePath: defaultDepfilePath,
       trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: extraFrontEndOptions,
       fileSystemRoots: fileSystemRoots,

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -22,8 +22,6 @@ class BuildBundleCommand extends BuildSubCommand {
       ..addOption('asset-base', help: 'Ignored. Will be removed.', hide: !verboseHelp)
       ..addOption('manifest', defaultsTo: defaultManifestPath)
       ..addOption('private-key', defaultsTo: defaultPrivateKeyPath)
-      ..addOption('snapshot', defaultsTo: defaultSnapshotPath)
-      ..addOption('depfile', defaultsTo: defaultDepfilePath)
       ..addOption('kernel-file', defaultsTo: defaultApplicationKernelPath)
       ..addOption('target-platform',
         defaultsTo: 'android-arm',
@@ -93,9 +91,7 @@ class BuildBundleCommand extends BuildSubCommand {
       buildMode: buildMode,
       mainPath: targetFile,
       manifestPath: argResults['manifest'],
-      snapshotPath: argResults['snapshot'],
       applicationKernelFilePath: argResults['kernel-file'],
-      depfilePath: argResults['depfile'],
       privateKeyPath: argResults['private-key'],
       assetDirPath: argResults['asset-dir'],
       precompiledSnapshot: argResults['precompiled'],

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -81,7 +81,7 @@ class KernelCompiler {
     String sdkRoot,
     String mainPath,
     String outputFilePath,
-    String depFilePath,
+    String depfilePath,
     bool linkPlatformKernelIn = false,
     bool aot = false,
     bool trackWidgetCreation = false,
@@ -100,16 +100,16 @@ class KernelCompiler {
     // Currently the compiler emits buildbot paths for the core libs in the
     // depfile. None of these are available on the local host.
     Fingerprinter fingerprinter;
-    if (depFilePath != null) {
+    if (depfilePath != null) {
       fingerprinter = Fingerprinter(
-        fingerprintPath: '$depFilePath.fingerprint',
+        fingerprintPath: '$depfilePath.fingerprint',
         paths: <String>[mainPath],
         properties: <String, String>{
           'entryPoint': mainPath,
           'trackWidgetCreation': trackWidgetCreation.toString(),
           'linkPlatformKernelIn': linkPlatformKernelIn.toString(),
         },
-        depfilePaths: <String>[depFilePath],
+        depfilePaths: <String>[depfilePath],
         pathFilter: (String path) => !path.startsWith('/b/build/slave/'),
       );
 
@@ -154,8 +154,8 @@ class KernelCompiler {
     if (outputFilePath != null) {
       command.addAll(<String>['--output-dill', outputFilePath]);
     }
-    if (depFilePath != null && (fileSystemRoots == null || fileSystemRoots.isEmpty)) {
-      command.addAll(<String>['--depfile', depFilePath]);
+    if (depfilePath != null && (fileSystemRoots == null || fileSystemRoots.isEmpty)) {
+      command.addAll(<String>['--depfile', depfilePath]);
     }
     if (fileSystemRoots != null) {
       for (String root in fileSystemRoots) {

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -169,7 +169,7 @@ Hello!
           incrementalCompilerByteStorePath: anyNamed('incrementalCompilerByteStorePath'),
           mainPath: anyNamed('mainPath'),
           outputFilePath: anyNamed('outputFilePath'),
-          depFilePath: anyNamed('depFilePath'),
+          depfilePath: anyNamed('depfilePath'),
           trackWidgetCreation: anyNamed('trackWidgetCreation'),
           extraFrontEndOptions: anyNamed('extraFrontEndOptions'),
           fileSystemRoots: anyNamed('fileSystemRoots'),


### PR DESCRIPTION
Eliminates the --snapshot and --depfile parameters from the flutter
bundle command. The snapshot parameter is unused in Dart 2 -- code is
built to kernel .dill files and for profile/release builds, then AOT
compiled.

While depfiles are still used in Dart 2 (e.g. by the kernel compiler),
there are enough assumptions in the code that they lie in the default
location (e.g. in the Gradle build) and no reasons to support
user-cusomisation that it makes sense to eliminate the --depfile option
as well, and always use the default location.

This commit also renames 'depFilePath' to 'depfilePath' for consistency
across the codebase.