### PR TITLE
Fix bundle id pattern to eliminate double quotes

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -148,7 +148,7 @@ class FlutterProject {
 /// Instances will reflect the contents of the `ios/` sub-folder of
 /// Flutter applications and the `.ios/` sub-folder of Flutter modules.
 class IosProject {
-  static final RegExp _productBundleIdPattern = RegExp(r'^\s*PRODUCT_BUNDLE_IDENTIFIER\s*=\s*(.*);\s*$');
+  static final RegExp _productBundleIdPattern = RegExp(r'^\s*PRODUCT_BUNDLE_IDENTIFIER\s*=\s*"?(.*?)"?;\s*$');
   static const String _productBundleIdVariable = r'$(PRODUCT_BUNDLE_IDENTIFIER)';
   static const String _hostAppBundleName = 'Runner';
 


### PR DESCRIPTION
Issue:

If the bundle identifier is surrounded with double quotes in the project.pbxproj, the regex `_productBundleIdPattern` can't extract it properly.

Fix:

This fix changes the regex to be able to extract the bundle identifier even with double quotes surrounded.

Related to #21335