### PR TITLE
Increase timeout waiting for app to start

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -426,7 +426,7 @@ class AppDomain extends Domain {
     final Completer<void> appStartedCompleter = Completer<void>();
     // We don't want to wait for this future to complete and callbacks won't fail.
     // As it just writes to stdout.
-    appStartedCompleter.future.timeout(const Duration(minutes: 1), onTimeout: () { // ignore: unawaited_futures
+    appStartedCompleter.future.timeout(const Duration(minutes: 3), onTimeout: () { // ignore: unawaited_futures
       _sendAppEvent(app, 'log', <String, dynamic>{
         'log': 'timeout waiting for the application to start',
         'error': true,


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/22338#issuecomment-425794734 shows almost 1 minute being spent on the `Resolving Dependencies` step alone. Possibly this needs to go higher still, but this should be a good start.

@tvolkert @dnfield This is related to comments at https://github.com/flutter/flutter/pull/22403#issuecomment-425836461. The timeout is firing for normal users and it's not cancelling the build so everything continues running (but the `app.started` event fired early, which might be causing issues).