### PR TITLE
Change file paths to URIs to fix "Could not run configuration in engine" on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -921,13 +921,12 @@ class VM extends ServiceObjectOwner {
                                Uri main,
                                Uri packages,
                                Uri assetsDirectory) {
-    // TODO(goderbauer): Transfer Uri (instead of file path) when remote end supports it.
     return invokeRpc<ServiceMap>('_flutter.runInView',
       params: <String, dynamic> {
         'viewId': viewId,
-        'mainScript': main.toFilePath(windows: false),
-        'packagesFile': packages.toFilePath(windows: false),
-        'assetDirectory': assetsDirectory.toFilePath(windows: false)
+        'mainScript': main.toString(),
+        'packagesFile': packages.toString(),
+        'assetDirectory': assetsDirectory.toString()
     });
   }
 

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -4,8 +4,6 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/platform.dart';
-
 import 'package:vm_service_client/vm_service_client.dart';
 
 import '../src/common.dart';

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -37,9 +37,7 @@ void main() {
     test('restart works without error', () async {
       await _flutter.run();
       await _flutter.hotRestart();
-      // TODO(dantup): Unskip after flutter-tester restart issue is fixed on Windows:
-      // https://github.com/flutter/flutter/issues/21348.
-    }, skip: platform.isWindows);
+    });
 
     test('reload hits breakpoints with file:// prefixes after reload', () async {
       await _flutter.run(withDebugger: true);


### PR DESCRIPTION
Plus unskip test that was failing due to this.

Fixes #21348.