### PR TITLE
Make RotationTransition widget alignment configurable

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -265,7 +265,7 @@ class RotationTransition extends AnimatedWidget {
   Animation<double> get turns => listenable;
 
   /// The alignment of the origin of the coordinate system around which the
-  /// rotation occurs takes place, relative to the size of the box.
+  /// rotation occurs, relative to the size of the box.
   ///
   /// For example, to set the origin of the rotation to top right corner, use
   /// an alignment of (1.0, -1.0) or use [Alignment.topRight]

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -254,6 +254,7 @@ class RotationTransition extends AnimatedWidget {
   const RotationTransition({
     Key key,
     @required Animation<double> turns,
+    this.alignment = Alignment.center,
     this.child,
   }) : super(key: key, listenable: turns);
 
@@ -262,6 +263,13 @@ class RotationTransition extends AnimatedWidget {
   /// If the current value of the turns animation is v, the child will be
   /// rotated v * 2 * pi radians before being painted.
   Animation<double> get turns => listenable;
+
+  /// The alignment of the origin of the coordinate system around which the
+  /// rotation occurs takes place, relative to the size of the box.
+  ///
+  /// For example, to set the origin of the rotation to top right corner, use
+  /// an alignment of (1.0, -1.0) or use [Alignment.topRight]
+  final Alignment alignment;
 
   /// The widget below this widget in the tree.
   ///
@@ -274,7 +282,7 @@ class RotationTransition extends AnimatedWidget {
     final Matrix4 transform = new Matrix4.rotationZ(turnsValue * math.pi * 2.0);
     return new Transform(
       transform: transform,
-      alignment: Alignment.center,
+      alignment: alignment,
       child: child,
     );
   }

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -252,5 +254,55 @@ void main() {
     controller.value = 1.0;
     await tester.pump();
     expect(actualPositionedBox.widthFactor, 1.0);
+  });
+
+  testWidgets('RotationTransition animates', (WidgetTester tester) async {
+    final AnimationController controller =
+        new AnimationController(vsync: const TestVSync());
+    final Widget widget = new RotationTransition(
+      alignment: Alignment.topRight,
+      turns: controller,
+      child: const Text('Rotation', textDirection: TextDirection.ltr),
+    );
+
+    await tester.pumpWidget(widget);
+    Transform actualRotatedBox = tester.widget(find.byType(Transform));
+    Matrix4 actualTurns = actualRotatedBox.transform;
+    expect(actualTurns, equals(Matrix4.rotationZ(0.0)));
+
+    controller.value = 0.5;
+    await tester.pump();
+    actualRotatedBox = tester.widget(find.byType(Transform));
+    actualTurns = actualRotatedBox.transform;
+    expect(actualTurns, Matrix4.rotationZ(math.pi));
+
+    controller.value = 0.75;
+    await tester.pump();
+    actualRotatedBox = tester.widget(find.byType(Transform));
+    actualTurns = actualRotatedBox.transform;
+    expect(actualTurns, Matrix4.rotationZ(math.pi * 1.5));
+  });
+
+  testWidgets('RotationTransition maintains chosen alignment during animation',
+      (WidgetTester tester) async {
+    final AnimationController controller =
+        new AnimationController(vsync: const TestVSync());
+    final Widget widget = new RotationTransition(
+      alignment: Alignment.topRight,
+      turns: controller,
+      child: const Text('Rotation', textDirection: TextDirection.ltr),
+    );
+
+    await tester.pumpWidget(widget);
+    RotationTransition actualRotatedBox =
+        tester.widget(find.byType(RotationTransition));
+    Alignment actualAlignment = actualRotatedBox.alignment;
+    expect(actualAlignment, const Alignment(1.0, -1.0));
+
+    controller.value = 0.5;
+    await tester.pump();
+    actualRotatedBox = tester.widget(find.byType(RotationTransition));
+    actualAlignment = actualRotatedBox.alignment;
+    expect(actualAlignment, const Alignment(1.0, -1.0));
   });
 }

--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -10,14 +10,14 @@ import 'package:{{pluginProjectName}}/{{pluginProjectName}}.dart';
 {{/withPluginHook}}
 
 {{^withDriverTest}}
-void main() => runApp(new MyApp());
+void main() => runApp(MyApp());
 {{/withDriverTest}}
 {{#withDriverTest}}
 void main() {
   // Enable integration testing with the Flutter Driver extension.
   // See https://flutter.io/testing/ for more info.
   enableFlutterDriverExtension();
-  runApp(new MyApp());
+  runApp(MyApp());
 }
 {{/withDriverTest}}
 
@@ -26,9 +26,9 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'Flutter Demo',
-      theme: new ThemeData(
+      theme: ThemeData(
         // This is the theme of your application.
         //
         // Try running your application with "flutter run". You'll see the
@@ -39,7 +39,7 @@ class MyApp extends StatelessWidget {
         // counter didn't reset back to zero; the application is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: new MyHomePage(title: 'Flutter Demo Home Page'),
+      home: MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
@@ -59,7 +59,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => new _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -84,16 +84,16 @@ class _MyHomePageState extends State<MyHomePage> {
     // The Flutter framework has been optimized to make rerunning build methods
     // fast, so that you can just rebuild anything that needs updating rather
     // than having to individually change instances of widgets.
-    return new Scaffold(
-      appBar: new AppBar(
+    return Scaffold(
+      appBar: AppBar(
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
-        title: new Text(widget.title),
+        title: Text(widget.title),
       ),
-      body: new Center(
+      body: Center(
         // Center is a layout widget. It takes a single child and positions it
         // in the middle of the parent.
-        child: new Column(
+        child: Column(
           // Column is also layout widget. It takes a list of children and
           // arranges them vertically. By default, it sizes itself to fit its
           // children horizontally, and tries to be as tall as its parent.
@@ -109,20 +109,20 @@ class _MyHomePageState extends State<MyHomePage> {
           // horizontal).
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            new Text(
+            Text(
               'You have pushed the button this many times:',
             ),
-            new Text(
+            Text(
               '$_counter',
               style: Theme.of(context).textTheme.display1,
             ),
           ],
         ),
       ),
-      floatingActionButton: new FloatingActionButton(
+      floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',
-        child: new Icon(Icons.add),
+        child: Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
@@ -131,7 +131,7 @@ class _MyHomePageState extends State<MyHomePage> {
 {{#withPluginHook}}
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => new _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -165,13 +165,13 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
-      home: new Scaffold(
-        appBar: new AppBar(
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
           title: const Text('Plugin example app'),
         ),
-        body: new Center(
-          child: new Text('Running on: $_platformVersion\n'),
+        body: Center(
+          child: Text('Running on: $_platformVersion\n'),
         ),
       ),
     );

--- a/packages/flutter_tools/templates/create/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/create/lib/main.dart.tmpl
@@ -10,14 +10,14 @@ import 'package:{{pluginProjectName}}/{{pluginProjectName}}.dart';
 {{/withPluginHook}}
 
 {{^withDriverTest}}
-void main() => runApp(MyApp());
+void main() => runApp(new MyApp());
 {{/withDriverTest}}
 {{#withDriverTest}}
 void main() {
   // Enable integration testing with the Flutter Driver extension.
   // See https://flutter.io/testing/ for more info.
   enableFlutterDriverExtension();
-  runApp(MyApp());
+  runApp(new MyApp());
 }
 {{/withDriverTest}}
 
@@ -26,9 +26,9 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return new MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
+      theme: new ThemeData(
         // This is the theme of your application.
         //
         // Try running your application with "flutter run". You'll see the
@@ -39,7 +39,7 @@ class MyApp extends StatelessWidget {
         // counter didn't reset back to zero; the application is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
+      home: new MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
@@ -59,7 +59,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  _MyHomePageState createState() => new _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -84,16 +84,16 @@ class _MyHomePageState extends State<MyHomePage> {
     // The Flutter framework has been optimized to make rerunning build methods
     // fast, so that you can just rebuild anything that needs updating rather
     // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
+    return new Scaffold(
+      appBar: new AppBar(
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: new Text(widget.title),
       ),
-      body: Center(
+      body: new Center(
         // Center is a layout widget. It takes a single child and positions it
         // in the middle of the parent.
-        child: Column(
+        child: new Column(
           // Column is also layout widget. It takes a list of children and
           // arranges them vertically. By default, it sizes itself to fit its
           // children horizontally, and tries to be as tall as its parent.
@@ -109,20 +109,20 @@ class _MyHomePageState extends State<MyHomePage> {
           // horizontal).
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Text(
+            new Text(
               'You have pushed the button this many times:',
             ),
-            Text(
+            new Text(
               '$_counter',
               style: Theme.of(context).textTheme.display1,
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
+      floatingActionButton: new FloatingActionButton(
         onPressed: _incrementCounter,
         tooltip: 'Increment',
-        child: Icon(Icons.add),
+        child: new Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
@@ -131,7 +131,7 @@ class _MyHomePageState extends State<MyHomePage> {
 {{#withPluginHook}}
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => _MyAppState();
+  _MyAppState createState() => new _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -165,13 +165,13 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
+    return new MaterialApp(
+      home: new Scaffold(
+        appBar: new AppBar(
           title: const Text('Plugin example app'),
         ),
-        body: Center(
-          child: Text('Running on: $_platformVersion\n'),
+        body: new Center(
+          child: new Text('Running on: $_platformVersion\n'),
         ),
       ),
     );


### PR DESCRIPTION
The alignment of a RotationTransition widget is set to `Alignment.center` permanently. This proposal will help make it configurable so that users can choose any custom alignment property they desire.