### PR TITLE
Hide App.framework.dSYM from Spotlight

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -146,7 +146,10 @@ BuildApp() {
     RunCommand cp -r -- "${app_framework}" "${derived_dir}"
 
     StreamOutput " ├─Generating dSYM file..."
-    RunCommand xcrun dsymutil -o "${build_dir}/aot/App.dSYM" "${app_framework}/App"
+    # Placing dSYMs in a folder ending with ".noindex" so xcode cannot find them
+    # via Spotlight and get confused when uploading an App to the App Store.
+    mkdir "${build_dir}/dSYMs.noindex"
+    RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"
     if [[ $? -ne 0 ]]; then
       EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."
       exit -1

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -146,7 +146,7 @@ BuildApp() {
     RunCommand cp -r -- "${app_framework}" "${derived_dir}"
 
     StreamOutput " ├─Generating dSYM file..."
-    # Placing dSYMs in a folder ending with ".noindex" so xcode cannot find them
+    # Placing dSYMs in a folder ending with ".noindex" so Xcode cannot find them
     # via Spotlight and get confused when uploading an App to the App Store.
     mkdir "${build_dir}/dSYMs.noindex"
     RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -146,8 +146,11 @@ BuildApp() {
     RunCommand cp -r -- "${app_framework}" "${derived_dir}"
 
     StreamOutput " ├─Generating dSYM file..."
-    # Placing dSYMs in a folder ending with ".noindex" so Xcode cannot find them
-    # via Spotlight and get confused when uploading an App to the App Store.
+    # Xcode calls `symbols` during app store upload, which uses Spotlight to
+    # find dSYM files for embedded frameworks. When it finds the dSYM file for
+    # `App.framework` it throws an error, which aborts the app store upload.
+    # To avoid this, we place the dSYM files in a folder ending with ".noindex",
+    # which hides it from Spotlight, https://github.com/flutter/flutter/issues/22560.
     mkdir "${build_dir}/dSYMs.noindex"
     RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
When Xcode uploads an app to the App Store it invokes `symbols` to generate debug information for embedded frameworks. `symbols` uses Spotlight to find dSYM files for the framework binaries (`mdfind "com_apple_xcode_dsym_uuids == <uuid of framework>"`) and for some reason it exits with an error code (bug?) if it finds a dSYM file. The error exit code causes the app store upload to fail.

This change hides the dSYM file from Xcode by placing it in a folder ending with `.noindex`.