### PR TITLE
[frdp] Add optional dart isolate filter.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -120,9 +120,13 @@ class DartVm {
   ///
   /// This is not limited to Isolates running Flutter, but to any Isolate on the
   /// VM.
+  ///
+  /// `includeNonFlutterIsolates` makes sure to add non-flutter Dart isolates,
+  /// and defaults to `false`.
   Future<List<IsolateRef>> getMainIsolatesByPattern(
     Pattern pattern, {
     Duration timeout = _kRpcTimeout,
+    bool includeNonFlutterIsolates = false,
   }) async {
     final Map<String, dynamic> jsonVmRef =
         await invokeRpc('getVM', timeout: timeout);
@@ -130,7 +134,12 @@ class DartVm {
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
       final String name = jsonIsolate['name'];
       if (name.contains(pattern)) {
-        result.add(IsolateRef._fromJson(jsonIsolate, this));
+        // `:main()` is included at the end of a flutter isolate, whereas the
+        // name of a dart Isolate is concluded as if the name were a function.
+        if (includeNonFlutterIsolates || name.contains(RegExp(r':main\(\)'))) {
+          _log.fine('Found Isolate matching "$pattern": "$name"');
+          result.add(IsolateRef._fromJson(jsonIsolate, this));
+        }
       }
     }
     return result;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -133,13 +133,12 @@ class DartVm {
     final List<IsolateRef> result = <IsolateRef>[];
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
       final String name = jsonIsolate['name'];
-      if (name.contains(pattern)) {
-        // `:main()` is included at the end of a flutter isolate, whereas the
-        // name of a dart Isolate is concluded as if the name were a function.
-        if (includeNonFlutterIsolates || name.contains(RegExp(r':main\(\)'))) {
-          _log.fine('Found Isolate matching "$pattern": "$name"');
-          result.add(IsolateRef._fromJson(jsonIsolate, this));
-        }
+      // `:main()` is included at the end of a flutter isolate, whereas the
+      // name of a dart Isolate is concluded as if the name were a function.
+      if (name.contains(pattern) &&
+          (includeNonFlutterIsolates || name.contains(RegExp(r':main\(\)')))) {
+        _log.fine('Found Isolate matching "$pattern": "$name"');
+        result.add(IsolateRef._fromJson(jsonIsolate, this));
       }
     }
     return result;

--- a/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
@@ -85,9 +85,8 @@ void main() {
       };
 
       Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
-        when(mockPeer.sendRequest(any, any))
-            .thenAnswer((_) => Future<Map<String, dynamic>>(
-                () => flutterViewCannedResponses));
+        when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
+            Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
         return Future<json_rpc.Peer>(() => mockPeer);
       }
 
@@ -141,9 +140,8 @@ void main() {
       };
 
       Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
-        when(mockPeer.sendRequest(any, any))
-            .thenAnswer((_) => Future<Map<String, dynamic>>(
-                () => flutterViewCannedResponses));
+        when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
+            Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
         return Future<json_rpc.Peer>(() => mockPeer);
       }
 
@@ -189,8 +187,8 @@ void main() {
       };
 
       Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
-        when(mockPeer.sendRequest(any, any))
-            .thenAnswer((_) => Future<Map<String, dynamic>>(
+        when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
+            Future<Map<String, dynamic>>(
                 () => flutterViewCannedResponseMissingId));
         return Future<json_rpc.Peer>(() => mockPeer);
       }
@@ -220,24 +218,30 @@ void main() {
           <String, dynamic>{
             'type': '@Isolate',
             'fixedId': 'true',
-            'id': 'isolates/1',
-            'name': 'file://flutterBinary1:main()',
+            'id': 'isolates/2',
+            'name': '0:dart_name_pattern()',
             'number': '2',
           },
           <String, dynamic>{
             'type': '@Isolate',
             'fixedId': 'true',
-            'id': 'isolates/2',
+            'id': 'isolates/3',
             'name': 'file://flutterBinary2:main()',
             'number': '3',
+          },
+          <String, dynamic>{
+            'type': '@Isolate',
+            'fixedId': 'true',
+            'id': 'isolates/4',
+            'name': '0:some_other_dart_name_pattern()',
+            'number': '4',
           },
         ],
       };
 
       Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
-        when(mockPeer.sendRequest(any, any))
-            .thenAnswer((_) =>
-                Future<Map<String, dynamic>>(() => vmCannedResponse));
+        when(mockPeer.sendRequest(any, any)).thenAnswer(
+            (_) => Future<Map<String, dynamic>>(() => vmCannedResponse));
         return Future<json_rpc.Peer>(() => mockPeer);
       }
 
@@ -245,9 +249,15 @@ void main() {
       final DartVm vm =
           await DartVm.connect(Uri.parse('http://whatever.com/ws'));
       expect(vm, isNot(null));
-      final List<IsolateRef> isolates =
+      final List<IsolateRef> matchingFlutterIsolates =
           await vm.getMainIsolatesByPattern('flutterBinary');
-      expect(isolates.length, 2);
+      expect(matchingFlutterIsolates.length, 1);
+      final List<IsolateRef> allFlutterIsolates =
+          await vm.getMainIsolatesByPattern('');
+      expect(allFlutterIsolates.length, 2);
+      final List<IsolateRef> allIsolates = await vm.getMainIsolatesByPattern('',
+          includeNonFlutterIsolates: true);
+      expect(allIsolates.length, 4);
     });
 
     test('invalid flutter view missing ID', () async {
@@ -269,8 +279,8 @@ void main() {
       };
 
       Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
-        when(mockPeer.sendRequest(any, any))
-            .thenAnswer((_) => Future<Map<String, dynamic>>(
+        when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
+            Future<Map<String, dynamic>>(
                 () => flutterViewCannedResponseMissingIsolateName));
         return Future<json_rpc.Peer>(() => mockPeer);
       }


### PR DESCRIPTION
It's now default to filter out non-flutter isolates when searching
across Dart VM's.  This is due to a possible issue wherein an Isolate
for testing might have the same name as the flutter Isolate.

In addition, logging messages have been added in dart_vm.dart for
debugging.