### PR TITLE
Add a flutter namespace to flutter library declarations

### DIFF
--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -9,7 +9,7 @@
 /// See [flutter.io/animations](https://flutter.io/animations/) for an overview.
 ///
 /// This library depends only on core Dart libraries and the `physics.dart` library.
-library animation;
+library flutter.animation;
 
 export 'src/animation/animation.dart';
 export 'src/animation/animation_controller.dart';

--- a/packages/flutter/lib/cupertino.dart
+++ b/packages/flutter/lib/cupertino.dart
@@ -5,7 +5,7 @@
 /// Flutter widgets implementing the current iOS design language.
 ///
 /// To use, import `package:flutter/cupertino.dart`.
-library cupertino;
+library flutter.cupertino;
 
 export 'src/cupertino/action_sheet.dart';
 export 'src/cupertino/activity_indicator.dart';

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -7,7 +7,7 @@
 /// The features defined in this library are the lowest-level utility
 /// classes and functions used by all the other layers of the Flutter
 /// framework.
-library foundation;
+library flutter.foundation;
 
 export 'package:meta/meta.dart' show
   immutable,

--- a/packages/flutter/lib/gestures.dart
+++ b/packages/flutter/lib/gestures.dart
@@ -5,7 +5,7 @@
 /// The Flutter gesture recognizers.
 ///
 /// To use, import `package:flutter/gestures.dart`.
-library gestures;
+library flutter.gestures;
 
 export 'src/gestures/arena.dart';
 export 'src/gestures/binding.dart';

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -12,7 +12,7 @@
 ///    for a catalog of commonly-used Flutter widgets.
 ///  * [material.google.com](https://material.google.com/)
 ///    for an introduction to Material Design.
-library material;
+library flutter.material;
 
 export 'src/material/about.dart';
 export 'src/material/animated_icons.dart';

--- a/packages/flutter/lib/painting.dart
+++ b/packages/flutter/lib/painting.dart
@@ -15,7 +15,7 @@
 ///  * Use the [TextPainter] class for painting text.
 ///  * Use [Decoration] (and more concretely [BoxDecoration]) for
 ///    painting boxes.
-library painting;
+library flutter.painting;
 
 export 'src/painting/alignment.dart';
 export 'src/painting/basic_types.dart';

--- a/packages/flutter/lib/physics.dart
+++ b/packages/flutter/lib/physics.dart
@@ -6,7 +6,7 @@
 /// gravity, for use in user interface animations.
 ///
 /// To use, import `package:flutter/physics.dart`.
-library physics;
+library flutter.physics;
 
 export 'src/physics/clamped_simulation.dart';
 export 'src/physics/friction_simulation.dart';

--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -19,7 +19,7 @@
 /// [ServicesBinding], [GestureBinding], [SchedulerBinding], [PaintingBinding],
 /// and [RendererBinding]. The rendering library does not automatically create a
 /// binding, but relies on one being initialized with those features.
-library rendering;
+library flutter.rendering;
 
 export 'package:flutter/foundation.dart' show
   VoidCallback,

--- a/packages/flutter/lib/scheduler.dart
+++ b/packages/flutter/lib/scheduler.dart
@@ -11,7 +11,7 @@
 ///
 /// The library makes sure that tasks are only run when appropriate.
 /// For example, an idle-task is only executed when no animation is running.
-library scheduler;
+library flutter.scheduler;
 
 export 'src/scheduler/binding.dart';
 export 'src/scheduler/debug.dart';

--- a/packages/flutter/lib/semantics.dart
+++ b/packages/flutter/lib/semantics.dart
@@ -11,7 +11,7 @@
 ///
 /// The [SemanticsNode] hierarchy represents the semantic structure of the UI
 /// and is used by the platform-specific accessibility services.
-library semantics;
+library flutter.semantics;
 
 export 'src/semantics/binding.dart';
 export 'src/semantics/debug.dart';

--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -8,7 +8,7 @@
 ///
 /// This library depends only on core Dart libraries and the `foundation`
 /// library.
-library services;
+library flutter.services;
 
 export 'src/services/asset_bundle.dart';
 export 'src/services/binding.dart';

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -10,7 +10,7 @@
 ///
 ///  * [flutter.io/widgets](https://flutter.io/widgets/)
 ///    for a catalog of commonly-used Flutter widgets.
-library widgets;
+library flutter.widgets;
 
 export 'package:vector_math/vector_math_64.dart' show Matrix4;
 


### PR DESCRIPTION
It is not possible to import two libraries with identical declared library definitions. For example, there is a fuchsia services library and a flutter services library. Adding a prefix import does not resolve this.

To make it less likely that our libs conflict, we can add a flutter namespace. I don't believe this is breaking in anyway but I am still waiting on confirmation.