### PR TITLE
Fix mkdir call to not fail if dir exists

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -151,7 +151,7 @@ BuildApp() {
     # `App.framework` it throws an error, which aborts the app store upload.
     # To avoid this, we place the dSYM files in a folder ending with ".noindex",
     # which hides it from Spotlight, https://github.com/flutter/flutter/issues/22560.
-    mkdir "${build_dir}/dSYMs.noindex"
+    RunCommand mkdir -p -- "${build_dir}/dSYMs.noindex"
     RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"
     if [[ $? -ne 0 ]]; then
       EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."


### PR DESCRIPTION
As pointed out by https://github.com/flutter/flutter/pull/22540#issuecomment-426577077.