### PR TITLE
Mark module_test_ios as not-flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -302,7 +302,6 @@ tasks:
       Checks that the module project template works and supports add2app on iOS.
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
-    flaky: true
 
   external_ui_integration_test_ios:
     description: >


### PR DESCRIPTION
The only reds on the dashboard for this test are on rows that have many failures across the run; this does not appear to be at all flaky.