### PR TITLE
Fixed touch area of bottom navigation bar to be filled.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -520,7 +520,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ),
           ),
           ConstrainedBox(
-            constraints: BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding),
+            constraints: BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding * 2),
             child: Stack(
               children: <Widget>[
                 Positioned.fill(

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -499,7 +499,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     assert(debugCheckHasMaterialLocalizations(context));
 
     // Labels apply up to _bottomMargin padding. Remainder is media padding.
-    final double additionalBottomPadding = math.max(MediaQuery.of(context).padding.bottom - _kBottomMargin, 0.0);
+    final double additionalVerticalPadding = math.max(MediaQuery.of(context).padding.bottom - _kBottomMargin, 0.0);
     Color backgroundColor;
     switch (widget.type) {
       case BottomNavigationBarType.fixed:
@@ -520,7 +520,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ),
           ),
           ConstrainedBox(
-            constraints: BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalBottomPadding * 2),
+            constraints: BoxConstraints(minHeight: kBottomNavigationBarHeight + additionalVerticalPadding * 2),
             child: Stack(
               children: <Widget>[
                 Positioned.fill(
@@ -534,7 +534,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
                 Material( // Splashes.
                   type: MaterialType.transparency,
                   child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: additionalBottomPadding),
+                    padding: EdgeInsets.symmetric(vertical: additionalVerticalPadding),
                     child: MediaQuery.removePadding(
                       context: context,
                       removeBottom: true,

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -534,7 +534,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
                 Material( // Splashes.
                   type: MaterialType.transparency,
                   child: Padding(
-                    padding: EdgeInsets.only(bottom: additionalBottomPadding),
+                    padding: EdgeInsets.symmetric(vertical: additionalBottomPadding),
                     child: MediaQuery.removePadding(
                       context: context,
                       removeBottom: true,


### PR DESCRIPTION
Previously, the top of the touch area of BottomNavigationBarItem is slightly cut off.

Previous result:
![previous](https://user-images.githubusercontent.com/27461460/46496042-f437bd80-c851-11e8-9366-b9f05c1e056b.gif)

Fixed result:
![fixed](https://user-images.githubusercontent.com/27461460/46496054-fd288f00-c851-11e8-93b1-1f07b561ce25.gif)
