### PR TITLE
Material Switch optionally adapts per platform: Switch.adaptive()

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
@@ -196,14 +196,8 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
             }
           ),
           // Disabled switches
-          const Switch.adaptive(
-            value: true,
-            onChanged: null
-          ),
-          const Switch.adaptive(
-            value: false,
-            onChanged: null
-          )
+          const Switch.adaptive(value: true, onChanged: null),
+          const Switch.adaptive(value: false, onChanged: null),
         ],
       ),
     );

--- a/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
@@ -187,7 +187,7 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Switch(
+          Switch.adaptive(
             value: switchValue,
             onChanged: (bool value) {
               setState(() {
@@ -196,8 +196,14 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
             }
           ),
           // Disabled switches
-          const Switch(value: true, onChanged: null),
-          const Switch(value: false, onChanged: null)
+          const Switch.adaptive(
+            value: true,
+            onChanged: null
+          ),
+          const Switch.adaptive(
+            value: false,
+            onChanged: null
+          )
         ],
       ),
     );

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -22,6 +23,8 @@ const double _kThumbRadius = 10.0;
 const double _kSwitchWidth = _kTrackWidth - 2 * _kTrackRadius + 2 * kRadialReactionRadius;
 const double _kSwitchHeight = 2 * kRadialReactionRadius + 8.0;
 const double _kSwitchHeightCollapsed = 2 * kRadialReactionRadius;
+
+enum _SwitchType { material, adaptive }
 
 /// A material design switch.
 ///
@@ -65,7 +68,30 @@ class Switch extends StatefulWidget {
     this.activeThumbImage,
     this.inactiveThumbImage,
     this.materialTapTargetSize,
-  }) : super(key: key);
+  }) : _switchType = _SwitchType.material,
+       super(key: key);
+
+  /// Creates a [CupertinoSwitch] if the target platform is iOS, creates a
+  /// material design switch otherwise.
+  ///
+  /// If a [CupertinoSwitch] is created, the following parameters are
+  /// ignored: [activeTrackColor], [inactiveThumbColor], [inactiveTrackColor],
+  /// [activeThumbImage], [inactiveThumbImage], [materialTapTargetSize].
+  ///
+  /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  const Switch.adaptive({
+    Key key,
+    @required this.value,
+    @required this.onChanged,
+    this.activeColor,
+    this.activeTrackColor,
+    this.inactiveThumbColor,
+    this.inactiveTrackColor,
+    this.activeThumbImage,
+    this.inactiveThumbImage,
+    this.materialTapTargetSize,
+  }) : _switchType = _SwitchType.adaptive,
+       super(key: key);
 
   /// Whether this switch is on or off.
   ///
@@ -131,6 +157,8 @@ class Switch extends StatefulWidget {
   ///   * [MaterialTapTargetSize], for a description of how this affects tap targets.
   final MaterialTapTargetSize materialTapTargetSize;
 
+  final _SwitchType _switchType;
+
   @override
   _SwitchState createState() => _SwitchState();
 
@@ -143,13 +171,25 @@ class Switch extends StatefulWidget {
 }
 
 class _SwitchState extends State<Switch> with TickerProviderStateMixin {
-  @override
-  Widget build(BuildContext context) {
-    assert(debugCheckHasMaterial(context));
-    final ThemeData themeData = Theme.of(context);
-    final bool isDark = themeData.brightness == Brightness.dark;
+  Size getSwitchSize(ThemeData theme) {
+    switch (widget.materialTapTargetSize ?? theme.materialTapTargetSize) {
+      case MaterialTapTargetSize.padded:
+        return const Size(_kSwitchWidth, _kSwitchHeight);
+        break;
+      case MaterialTapTargetSize.shrinkWrap:
+        return const Size(_kSwitchWidth, _kSwitchHeightCollapsed);
+        break;
+    }
+    assert(false);
+    return null;
+  }
 
-    final Color activeThumbColor = widget.activeColor ?? themeData.toggleableActiveColor;
+  Widget buildMaterialSwitch(BuildContext context) {
+    assert(debugCheckHasMaterial(context));
+    final ThemeData theme = Theme.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final Color activeThumbColor = widget.activeColor ?? theme.toggleableActiveColor;
     final Color activeTrackColor = widget.activeTrackColor ?? activeThumbColor.withAlpha(0x80);
 
     Color inactiveThumbColor;
@@ -162,16 +202,6 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
       inactiveThumbColor = widget.inactiveThumbColor ?? (isDark ? Colors.grey.shade800 : Colors.grey.shade400);
       inactiveTrackColor = widget.inactiveTrackColor ?? (isDark ? Colors.white10 : Colors.black12);
     }
-    Size size;
-    switch (widget.materialTapTargetSize ?? themeData.materialTapTargetSize) {
-      case MaterialTapTargetSize.padded:
-        size = const Size(_kSwitchWidth, _kSwitchHeight);
-        break;
-      case MaterialTapTargetSize.shrinkWrap:
-        size = const Size(_kSwitchWidth, _kSwitchHeightCollapsed);
-        break;
-    }
-    final BoxConstraints additionalConstraints = BoxConstraints.tight(size);
 
     return _SwitchRenderObjectWidget(
       value: widget.value,
@@ -183,9 +213,45 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
       inactiveTrackColor: inactiveTrackColor,
       configuration: createLocalImageConfiguration(context),
       onChanged: widget.onChanged,
-      additionalConstraints: additionalConstraints,
+      additionalConstraints: BoxConstraints.tight(getSwitchSize(theme)),
       vsync: this,
     );
+  }
+
+  Widget buildCupertinoSwitch(BuildContext context) {
+    final Size size = getSwitchSize(Theme.of(context));
+    return Container(
+      width: size.width,
+      height: size.height,
+      alignment: Alignment.center,
+      child: CupertinoSwitch(
+        value: widget.value,
+        onChanged: widget.onChanged,
+        activeColor: widget.activeColor,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (widget._switchType) {
+      case _SwitchType.material:
+        return buildMaterialSwitch(context);
+
+      case _SwitchType.adaptive: {
+        final ThemeData theme = Theme.of(context);
+        assert(theme.platform != null);
+        switch (theme.platform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+            return buildMaterialSwitch(context);
+          case TargetPlatform.iOS:
+            return buildCupertinoSwitch(context);
+        }
+      }
+    }
+    assert(false);
+    return null;
   }
 }
 

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -130,22 +130,32 @@ class Switch extends StatefulWidget {
   /// The color to use on the track when this switch is on.
   ///
   /// Defaults to [ThemeData.toggleableActiveColor] with the opacity set at 50%.
+  ///
+  /// Ignored if this switch is created with [Switch.adaptive].
   final Color activeTrackColor;
 
   /// The color to use on the thumb when this switch is off.
   ///
   /// Defaults to the colors described in the Material design specification.
+  ///
+  /// Ignored if this switch is created with [Switch.adaptive].
   final Color inactiveThumbColor;
 
   /// The color to use on the track when this switch is off.
   ///
   /// Defaults to the colors described in the Material design specification.
+  ///
+  /// Ignored if this switch is created with [Switch.adaptive].
   final Color inactiveTrackColor;
 
   /// An image to use on the thumb of this switch when the switch is on.
+  ///
+  /// Ignored if this switch is created with [Switch.adaptive].
   final ImageProvider activeThumbImage;
 
   /// An image to use on the thumb of this switch when the switch is off.
+  ///
+  /// Ignored if this switch is created with [Switch.adaptive].
   final ImageProvider inactiveThumbImage;
 
   /// Configures the minimum size of the tap target.
@@ -221,7 +231,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
   Widget buildCupertinoSwitch(BuildContext context) {
     final Size size = getSwitchSize(Theme.of(context));
     return Container(
-      width: size.width,
+      width: size.width,  // Same size as the Material switch.
       height: size.height,
       alignment: Alignment.center,
       child: CupertinoSwitch(

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -485,4 +487,46 @@ void main() {
     semanticsTester.dispose();
     SystemChannels.accessibility.setMockMessageHandler(null);
   });
+
+  testWidgets('Switch.adaptive', (WidgetTester tester) async {
+    bool value = false;
+
+    Widget buildFrame(TargetPlatform platform) {
+      return MaterialApp(
+        theme: ThemeData(platform: platform),
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Material(
+              child: Center(
+                child: Switch.adaptive(
+                  value: value,
+                  onChanged: (bool newValue) {
+                    setState(() {
+                      value = newValue;
+                    });
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(TargetPlatform.iOS));
+    expect(find.byType(CupertinoSwitch), findsOneWidget);
+
+    expect(value, isFalse);
+    await tester.tap(find.byType(Switch));
+    expect(value, isTrue);
+
+    await tester.pumpWidget(buildFrame(TargetPlatform.android));
+    await tester.pumpAndSettle(); // Finish the theme change animation.
+    expect(find.byType(CupertinoSwitch), findsNothing);
+    expect(value, isTrue);
+    await tester.tap(find.byType(Switch));
+    expect(value, isFalse);
+
+  });
+
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/22101

Currently we have a small number of iOS-specific Material adaptations which are primarily visual:

- On iOS the San Francisco font is substituted for Roboto. Font geometries (sizes, weights, colors) are the same as for Roboto.
- BackButtonIcon and BackButton use `Icons.arrow_back_ios` on iOS, instead of `Icons.arrow_back`
- Viewports don't include the `GlowingOverscrollIndicator` on iOS, and iOS scroll physics bounce on overscroll. On other platforms overscrolls are clamped.
- AppBar titles are centered on iOS.
- PopupMenuButton uses `Icons.more_horiz` instead of `Icons.more_vert`.
- Scrollbar builds a `CupertinoScrollbar` on iOS.

These iOS adaptations tend to be visually subtle. They don't lead to any compromises in functionality.

Automatically substituting a cupertino library switch for the material version on iOS has some issues:

- It's not a subtle visual change. Cupertino switches stand out when arranged in an otherwise Material property sheet.
- The CupertinoSwitch only supports configuring its `activeColor`. The MaterialSwitch has five other visual parameters.
- MaterialSwitches can be configured with active/inactive thumb images. Apps do this to convey additional status information to the user. Cupertino switches don't support this because it's typically not done on iOS.

If we were to make Switch automatically build a CupertinoSwitch on iOS (now), we'd break applications that don't want that. So I've added a named constructor that apps can use to opt into the adaptation: `Switch.adaptive`. The constructor parameters are the same as Switch however on iOS most of them are ignored.
