### PR TITLE
Fix devicelab tests to use --template=app after module => application rename.

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -65,7 +65,7 @@ class FlutterProject {
     await inDirectory(directory, () async {
       await flutter(
         'create',
-        options: <String>['--org', 'io.flutter.devicelab']..addAll(options)..add('plugintest')
+        options: <String>['--template=app', '--org', 'io.flutter.devicelab']..addAll(options)..add('plugintest')
       );
     });
     return FlutterProject(directory, 'plugintest');


### PR DESCRIPTION
Fixes the build after my module rename broke the Windows tests.