### PR TITLE
Temporarily disabling Docs deployment again.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -75,6 +75,10 @@ fi
 # Ensure google webmaster tools can verify our site.
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
+# Temporarily stopping docs deployment because the Firebase server is over-budget.
+# TODO(gspencer): remove the next line once Firebase account is working again.
+exit 0
+
 # Upload new API docs when running on Cirrus
 if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"


### PR DESCRIPTION
This reverts commit fef759f410ea00fee91aecf44e789ce4ba2c0dcc, because apparently
the service is still "unavailable".