### PR TITLE
Gradle plugin support for adding flutter as subproject to another Android app

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -362,14 +362,25 @@ class FlutterPlugin implements Plugin<Project> {
                 extraGenSnapshotOptions extraGenSnapshotOptionsValue
             }
 
+            // We know that the flutter app is a subproject in another Android app when these tasks exist.
+            Task packageAssets = project.tasks.findByPath(":flutter:package${variant.name.capitalize()}Assets")
+            Task cleanPackageAssets = project.tasks.findByPath(":flutter:cleanPackage${variant.name.capitalize()}Assets")
             Task copyFlutterAssetsTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn flutterTask
-                dependsOn variant.mergeAssets
-                dependsOn "clean${variant.mergeAssets.name.capitalize()}"
-                into variant.mergeAssets.outputDir
+                dependsOn packageAssets ? packageAssets : variant.mergeAssets
+                dependsOn cleanPackageAssets ? cleanPackageAssets : "clean${variant.mergeAssets.name.capitalize()}"
+                into packageAssets ? packageAssets.outputDir : variant.mergeAssets.outputDir
                 with flutterTask.assets
             }
-            variant.outputs[0].processResources.dependsOn(copyFlutterAssetsTask)
+            if (packageAssets) {
+                // Only include configurations that exist in parent project.
+                Task mergeAssets = project.tasks.findByPath(":app:merge${variant.name.capitalize()}Assets")
+                if (mergeAssets) {
+                    mergeAssets.dependsOn(copyFlutterAssetsTask)
+                }
+            } else {
+                variant.outputs[0].processResources.dependsOn(copyFlutterAssetsTask)
+            }
         }
         if (project.android.hasProperty("applicationVariants")) {
             project.android.applicationVariants.all addFlutterDeps


### PR DESCRIPTION
This fixes #19818 by ensuring that VM snapshot is copied from artifacts before gradle merges assets.