### PR TITLE
Fixes the project detection logic when creating new projects over existing directories.

### DIFF
--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -63,8 +63,8 @@ void main() {
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('can create a default project if empty directory exists', () async {
-    await fs.directory(projectDir).create(recursive: true);
-    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+    await projectDir.create(recursive: true);
+    return _createAndAnalyzeProject(projectDir, <String>[], <String>[
       '.android/app/',
       '.gitignore',
       '.ios/Flutter',
@@ -77,30 +77,40 @@ void main() {
       'android/',
       'ios/',
     ]);
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('creates a legacy app project correctly', () async {
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>['--template=app'],
+      <String>[
+        'android/app/src/main/java/com/example/flutterproject/MainActivity.java',
+        'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
+        'flutter_project.iml',
+        'ios/Flutter/AppFrameworkInfo.plist',
+        'ios/Runner/AppDelegate.m',
+        'ios/Runner/GeneratedPluginRegistrant.h',
+      ],
+    );
     return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
-  testUsingContext('cannot create a project if non-empty non-project directory exists', () async {
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'blag')).create(recursive: true);
+  testUsingContext('cannot create a project if non-empty non-project directory exists with .metadata', () async {
+    await projectDir.absolute.childDirectory('blag').create(recursive: true);
+    await projectDir.absolute.childFile('.metadata').writeAsString('project_type: blag\n');
     expect(() async => await _createAndAnalyzeProject(projectDir, <String>[], <String>[
-      '.android/app/',
-      '.gitignore',
-      '.ios/Flutter',
-      '.metadata',
-      'lib/main.dart',
-      'pubspec.yaml',
-      'README.md',
-      'test/widget_test.dart',
     ], unexpectedPaths: <String>[
       'android/',
       'ios/',
+      '.android/',
+      '.ios/',
     ]), throwsToolExit(message: 'Sorry, unable to detect the type of project to recreate'));
   }, timeout: allowForRemotePubInvocation);
 
-  testUsingContext('detects and recreates an application project correctly', () async {
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
-    await fs.directory(fs.path.join(projectDir.absolute.path, '.ios')).create(recursive: true);
-    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+  testUsingContext('Will create an application project if non-empty non-project directory exists without .metadata', () async {
+    await projectDir.absolute.childDirectory('blag').create(recursive: true);
+    await projectDir.absolute.childDirectory('.idea').create(recursive: true);
+    return _createAndAnalyzeProject(projectDir, <String>[], <String>[
       '.android/app/',
       '.gitignore',
       '.ios/Flutter',
@@ -113,13 +123,30 @@ void main() {
       'android/',
       'ios/',
     ]);
-    return _runFlutterTest(projectDir);
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('detects and recreates an application project correctly', () async {
+    await projectDir.absolute.childDirectory('lib').create(recursive: true);
+    await projectDir.absolute.childDirectory('.ios').create(recursive: true);
+    return _createAndAnalyzeProject(projectDir, <String>[], <String>[
+      '.android/app/',
+      '.gitignore',
+      '.ios/Flutter',
+      '.metadata',
+      'lib/main.dart',
+      'pubspec.yaml',
+      'README.md',
+      'test/widget_test.dart',
+    ], unexpectedPaths: <String>[
+      'android/',
+      'ios/',
+    ]);
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('detects and recreates a plugin project correctly', () async {
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'ios', 'Classes')).create(recursive: true);
-    await _createAndAnalyzeProject(
+    await projectDir.create(recursive: true);
+    await projectDir.absolute.childFile('.metadata').writeAsString('project_type: plugin\n');
+    return _createAndAnalyzeProject(
       projectDir,
       <String>[],
       <String>[
@@ -135,12 +162,12 @@ void main() {
         'lib/flutter_project.dart',
       ],
     );
-    return _runFlutterTest(projectDir.childDirectory('example'));
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('detects and recreates a package project correctly', () async {
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
-    await _createAndAnalyzeProject(
+    await projectDir.create(recursive: true);
+    await projectDir.absolute.childFile('.metadata').writeAsString('project_type: package\n');
+    return _createAndAnalyzeProject(
       projectDir,
       <String>[],
       <String>[
@@ -164,41 +191,27 @@ void main() {
         'test/widget_test.dart',
       ],
     );
-    return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('detects and recreates a legacy app project correctly', () async {
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
-    await fs.directory(fs.path.join(projectDir.absolute.path, 'ios', 'Flutter')).create(recursive: true);
-    await _createAndAnalyzeProject(
+    await projectDir.absolute.childDirectory('lib').create(recursive: true);
+    await projectDir.absolute.childDirectory('ios').childDirectory('Flutter').create(recursive: true);
+    return _createAndAnalyzeProject(
       projectDir,
       <String>[],
       <String>[
-        'lib/flutter_project.dart',
-        'test/flutter_project_test.dart',
-      ],
-      unexpectedPaths: <String>[
         'android/app/src/main/java/com/example/flutterproject/MainActivity.java',
-        'android/src/main/java/com/example/flutterproject/FlutterProjectPlugin.java',
-        'example/android/app/src/main/java/com/example/flutterprojectexample/MainActivity.java',
-        'example/ios/Runner/AppDelegate.h',
-        'example/ios/Runner/AppDelegate.m',
-        'example/ios/Runner/main.m',
-        'example/lib/main.dart',
-        'ios/Classes/FlutterProjectPlugin.h',
-        'ios/Classes/FlutterProjectPlugin.m',
-        'ios/Runner/AppDelegate.h',
+        'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
+        'flutter_project.iml',
+        'ios/Flutter/AppFrameworkInfo.plist',
         'ios/Runner/AppDelegate.m',
-        'ios/Runner/main.m',
-        'lib/main.dart',
-        'test/widget_test.dart',
+        'ios/Runner/GeneratedPluginRegistrant.h',
       ],
     );
-    return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('can create a legacy module project', () async {
-    await _createAndAnalyzeProject(projectDir, <String>[
+    return _createAndAnalyzeProject(projectDir, <String>[
       '--template=module',
     ], <String>[
       '.android/app/',
@@ -213,7 +226,6 @@ void main() {
       'android/',
       'ios/',
     ]);
-    return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
   testUsingContext('kotlin/swift legacy app project', () async {
@@ -235,7 +247,7 @@ void main() {
     );
   }, timeout: allowForCreateFlutterProject);
 
-  testUsingContext('package project', () async {
+  testUsingContext('can create a package project', () async {
     await _createAndAnalyzeProject(
       projectDir,
       <String>['--template=package'],
@@ -263,7 +275,7 @@ void main() {
     return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
-  testUsingContext('plugin project', () async {
+  testUsingContext('can create a plugin project', () async {
     await _createAndAnalyzeProject(
       projectDir,
       <String>['--template=plugin'],

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -62,6 +62,141 @@ void main() {
     return _runFlutterTest(projectDir);
   }, timeout: allowForRemotePubInvocation);
 
+  testUsingContext('can create a default project if empty directory exists', () async {
+    await fs.directory(projectDir).create(recursive: true);
+    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+      '.android/app/',
+      '.gitignore',
+      '.ios/Flutter',
+      '.metadata',
+      'lib/main.dart',
+      'pubspec.yaml',
+      'README.md',
+      'test/widget_test.dart',
+    ], unexpectedPaths: <String>[
+      'android/',
+      'ios/',
+    ]);
+    return _runFlutterTest(projectDir);
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('cannot create a project if non-empty non-project directory exists', () async {
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'blag')).create(recursive: true);
+    expect(() async => await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+      '.android/app/',
+      '.gitignore',
+      '.ios/Flutter',
+      '.metadata',
+      'lib/main.dart',
+      'pubspec.yaml',
+      'README.md',
+      'test/widget_test.dart',
+    ], unexpectedPaths: <String>[
+      'android/',
+      'ios/',
+    ]), throwsToolExit(message: 'Sorry, unable to detect the type of project to recreate'));
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('detects and recreates an application project correctly', () async {
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
+    await fs.directory(fs.path.join(projectDir.absolute.path, '.ios')).create(recursive: true);
+    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+      '.android/app/',
+      '.gitignore',
+      '.ios/Flutter',
+      '.metadata',
+      'lib/main.dart',
+      'pubspec.yaml',
+      'README.md',
+      'test/widget_test.dart',
+    ], unexpectedPaths: <String>[
+      'android/',
+      'ios/',
+    ]);
+    return _runFlutterTest(projectDir);
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('detects and recreates a plugin project correctly', () async {
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'ios', 'Classes')).create(recursive: true);
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>[],
+      <String>[
+        'android/src/main/java/com/example/flutterproject/FlutterProjectPlugin.java',
+        'example/android/app/src/main/java/com/example/flutterprojectexample/MainActivity.java',
+        'example/ios/Runner/AppDelegate.h',
+        'example/ios/Runner/AppDelegate.m',
+        'example/ios/Runner/main.m',
+        'example/lib/main.dart',
+        'flutter_project.iml',
+        'ios/Classes/FlutterProjectPlugin.h',
+        'ios/Classes/FlutterProjectPlugin.m',
+        'lib/flutter_project.dart',
+      ],
+    );
+    return _runFlutterTest(projectDir.childDirectory('example'));
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('detects and recreates a package project correctly', () async {
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>[],
+      <String>[
+        'lib/flutter_project.dart',
+        'test/flutter_project_test.dart',
+      ],
+      unexpectedPaths: <String>[
+        'android/app/src/main/java/com/example/flutterproject/MainActivity.java',
+        'android/src/main/java/com/example/flutterproject/FlutterProjectPlugin.java',
+        'example/android/app/src/main/java/com/example/flutterprojectexample/MainActivity.java',
+        'example/ios/Runner/AppDelegate.h',
+        'example/ios/Runner/AppDelegate.m',
+        'example/ios/Runner/main.m',
+        'example/lib/main.dart',
+        'ios/Classes/FlutterProjectPlugin.h',
+        'ios/Classes/FlutterProjectPlugin.m',
+        'ios/Runner/AppDelegate.h',
+        'ios/Runner/AppDelegate.m',
+        'ios/Runner/main.m',
+        'lib/main.dart',
+        'test/widget_test.dart',
+      ],
+    );
+    return _runFlutterTest(projectDir);
+  }, timeout: allowForRemotePubInvocation);
+
+  testUsingContext('detects and recreates a legacy app project correctly', () async {
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'lib')).create(recursive: true);
+    await fs.directory(fs.path.join(projectDir.absolute.path, 'ios', 'Flutter')).create(recursive: true);
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>[],
+      <String>[
+        'lib/flutter_project.dart',
+        'test/flutter_project_test.dart',
+      ],
+      unexpectedPaths: <String>[
+        'android/app/src/main/java/com/example/flutterproject/MainActivity.java',
+        'android/src/main/java/com/example/flutterproject/FlutterProjectPlugin.java',
+        'example/android/app/src/main/java/com/example/flutterprojectexample/MainActivity.java',
+        'example/ios/Runner/AppDelegate.h',
+        'example/ios/Runner/AppDelegate.m',
+        'example/ios/Runner/main.m',
+        'example/lib/main.dart',
+        'ios/Classes/FlutterProjectPlugin.h',
+        'ios/Classes/FlutterProjectPlugin.m',
+        'ios/Runner/AppDelegate.h',
+        'ios/Runner/AppDelegate.m',
+        'ios/Runner/main.m',
+        'lib/main.dart',
+        'test/widget_test.dart',
+      ],
+    );
+    return _runFlutterTest(projectDir);
+  }, timeout: allowForRemotePubInvocation);
+
   testUsingContext('can create a legacy module project', () async {
     await _createAndAnalyzeProject(projectDir, <String>[
       '--template=module',


### PR DESCRIPTION
This all happened because I was trying to be a little too helpful...

Part of the job of the "create" command is to recreate missing pieces of existing projects, and now that the default has changed, I wanted to make it so that if someone had created a default `flutter create` project before, that they could run a default `flutter create` there again, and not have it trashed by using the new default template (application) over the old one (app).

This meant I had to detect what type of project it was. Unfortunately, in the past we didn't write anything in the `.metadata` file to identify the type of project, and since the goal was regenerating missing files, I can't count on _anything_ existing, so it's just a heuristic match.

This simplifies the heuristics down to just detecting the difference between "app" and "application" projects, and only detect the other types if they're explicitly listed in the .metadata file (I changed the code in my original PR to add the project type to the .metadata file). People used to have to specify the type for those anyhow, so it shouldn't be a surprise to users.

So, the main difference in the new heuristics from my last attempt is that if you have a directory that has some other stuff it (like maybe a "plugin" project), then we'll recreate (pronounced "mess up") the project using the "application" template, but that was true before (except it would use the "app" template).

Fixes #22726