### PR TITLE
Add assert for null duration on snackbar

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -155,6 +155,7 @@ class SnackBar extends StatelessWidget {
     this.duration = _kSnackBarDisplayDuration,
     this.animation,
   }) : assert(content != null),
+       assert(duration != null),
        super(key: key);
 
   /// The primary content of the snack bar.

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -662,4 +662,32 @@ void main() {
     expect(find.text('test'), findsNothing);
   });
 
+  testWidgets('Snackbar asserts if passed a null duration', (WidgetTester tester) async {
+      const Key tapTarget = Key('tap-target');
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(SnackBar(
+                    content: Text(nonconst('hello')),
+                    duration: null,
+                  ));
+                },
+                behavior: HitTestBehavior.opaque,
+                child: Container(
+                  height: 100.0,
+                  width: 100.0,
+                  key: tapTarget
+                ),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byKey(tapTarget));
+      expect(tester.takeException(), isNotNull);
+  });
 }

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -663,31 +663,31 @@ void main() {
   });
 
   testWidgets('Snackbar asserts if passed a null duration', (WidgetTester tester) async {
-      const Key tapTarget = Key('tap-target');
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (BuildContext context) {
-              return GestureDetector(
-                onTap: () {
-                  Scaffold.of(context).showSnackBar(SnackBar(
-                    content: Text(nonconst('hello')),
-                    duration: null,
-                  ));
-                },
-                behavior: HitTestBehavior.opaque,
-                child: Container(
-                  height: 100.0,
-                  width: 100.0,
-                  key: tapTarget
-                ),
-              );
-            },
-          ),
+    const Key tapTarget = Key('tap-target');
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onTap: () {
+                Scaffold.of(context).showSnackBar(SnackBar(
+                  content: Text(nonconst('hello')),
+                  duration: null,
+                ));
+              },
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+                key: tapTarget
+              ),
+            );
+          },
         ),
-      ));
+      ),
+    ));
 
-      await tester.tap(find.byKey(tapTarget));
-      expect(tester.takeException(), isNotNull);
+    await tester.tap(find.byKey(tapTarget));
+    expect(tester.takeException(), isNotNull);
   });
 }


### PR DESCRIPTION
Though it has a default value, a user can still pass a null duration which will cause an exception in the scaffold.

Fixes https://github.com/flutter/flutter/issues/22738