### PR TITLE
add AOT smoke tests to Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,6 +62,14 @@ task:
       container:
         cpu: 4
         memory: 8G
+    - name: aot_build_tests-linux
+      env:
+        SHARD: aot_build_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 8G
     - name: codelabs-build-test
       env:
         SHARD: codelabs-build-test

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -21,6 +21,7 @@ final List<String> flutterTestArgs = <String>[];
 const Map<String, ShardRunner> _kShards = <String, ShardRunner>{
   'tests': _runTests,
   'tool_tests': _runToolTests,
+  'aot_build_tests': _runAotBuildTests,
   'coverage': _runCoverage,
 };
 
@@ -147,6 +148,27 @@ Future<void> _runToolTests() async {
   );
 
   print('${bold}DONE: All tests successful.$reset');
+}
+
+/// Verifies that AOT builds of some examples apps finish
+/// without crashing. It does not actually launch the AOT-built
+/// apps. That happens later in the devicelab. This is just
+/// a smoke-test.
+Future<void> _runAotBuildTests() async {
+  await _flutterBuildAot(path.join('examples', 'hello_world'));
+  await _flutterBuildAot(path.join('examples', 'flutter_gallery'));
+  await _flutterBuildAot(path.join('examples', 'flutter_view'));
+
+  print('${bold}DONE: All AOT build tests successful.$reset');
+}
+
+Future<void> _flutterBuildAot(String relativePathToApplication) {
+  return runCommand(flutter,
+    <String>['build', 'aot'],
+    workingDirectory: path.join(flutterRoot, relativePathToApplication),
+    expectNonZeroExit: false,
+    timeout: _kShortTimeout,
+  );
 }
 
 Future<void> _runTests() async {


### PR DESCRIPTION
This would have caught the breakage caused by https://github.com/flutter/flutter/commit/3c56e6c77dc5c351d610d5c2a11d86e8be88519f