### PR TITLE
Fix typo in in raw_keyboard.dart

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -77,7 +77,7 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
 ///
 ///  * [RawKeyboard], which uses this interface to expose key data.
 class RawKeyEventDataFuchsia extends RawKeyEventData {
-  /// Creates a key event data structure specific for Android.
+  /// Creates a key event data structure specific for Fuchsia.
   ///
   /// The [hidUsage], [codePoint], and [modifiers] arguments must not be null.
   const RawKeyEventDataFuchsia({


### PR DESCRIPTION
Obviously a small change, looks like a little copy-paste accident.