### PR TITLE
Use (processors-1) for test runs (test defaults to processors/2)

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:path/path.dart' as path;
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -199,6 +199,8 @@ Future<void> _pubRunTest(
   bool enableFlutterToolAsserts = false
 }) {
   final List<String> args = <String>['run', 'test', '-rcompact'];
+  final int concurrency = math.max(1, Platform.numberOfProcessors - 1);
+  args.add('-j$concurrency');
   if (!hasColor)
     args.add('--no-color');
   if (testPath != null)


### PR DESCRIPTION
Re-land #22085. I reverted it in #22628 because after landing it we had lots of timeouts in some tests. I assumed they were related but they seemed to continue after the revert and may have been addressed by #22681.