### PR TITLE
Fix gradle error in devicelab tests

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -279,20 +279,21 @@ class CreateCommand extends FlutterCommand {
     } else {
       printStatus('Recreating project $relativeDirPath...');
     }
+    final Directory relativeDir = fs.directory(projectDirPath);
     int generatedFileCount = 0;
     switch (template) {
       case _ProjectType.app:
-        generatedFileCount += await _generateLegacyApp(projectDir, templateContext);
+        generatedFileCount += await _generateLegacyApp(relativeDir, templateContext);
         break;
       case _ProjectType.module:
       case _ProjectType.application:
-        generatedFileCount += await _generateApplication(projectDir, templateContext);
+        generatedFileCount += await _generateApplication(relativeDir, templateContext);
         break;
       case _ProjectType.package:
-        generatedFileCount += await _generatePackage(projectDir, templateContext);
+        generatedFileCount += await _generatePackage(relativeDir, templateContext);
         break;
       case _ProjectType.plugin:
-        generatedFileCount += await _generatePlugin(projectDir, templateContext);
+        generatedFileCount += await _generatePlugin(relativeDir, templateContext);
         break;
     }
     printStatus('Wrote $generatedFileCount files.');


### PR DESCRIPTION
Fixes a gradle error where it was failing to find a plugin because of an absolute path in the .flutter-plugins file instead of a relative path.

I had originally removed this variable because I thought it was redundant with the projectDir, but apparently I was wrong about that (one resolves to a relative path, and one resolves to an absolute path).

This PR reverts that part of the change and reintroduces the (not really) redundant variable.