### PR TITLE
Remove mixin so we can roll Google3

### DIFF
--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -161,7 +161,7 @@ class FlatButton extends MaterialButton {
 ///
 /// This class only exists to give FlatButtons created with [FlatButton.icon]
 /// a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _FlatButtonWithIcon extends FlatButton with MaterialButtonWithIconMixin {
+class _FlatButtonWithIcon extends FlatButton implements MaterialButtonWithIconMixin {
   _FlatButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -279,4 +279,6 @@ class MaterialButton extends StatelessWidget {
 ///
 /// This mixin only exists to give the "label and icon" button widgets a distinct
 /// type for the sake of [ButtonTheme].
-mixin MaterialButtonWithIconMixin { }
+abstract class MaterialButtonWithIconMixin {
+  MaterialButtonWithIconMixin._();
+}

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -185,7 +185,7 @@ class OutlineButton extends MaterialButton {
 //
 // This class only exists to give RaisedButtons created with [RaisedButton.icon]
 // a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _OutlineButtonWithIcon extends OutlineButton with MaterialButtonWithIconMixin {
+class _OutlineButtonWithIcon extends OutlineButton implements MaterialButtonWithIconMixin {
   _OutlineButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -171,7 +171,7 @@ class RaisedButton extends MaterialButton {
 ///
 /// This class only exists to give RaisedButtons created with [RaisedButton.icon]
 /// a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _RaisedButtonWithIcon extends RaisedButton with MaterialButtonWithIconMixin {
+class _RaisedButtonWithIcon extends RaisedButton implements MaterialButtonWithIconMixin {
   _RaisedButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,


### PR DESCRIPTION
We'll roll this back as soon as the Dart analyzer gets upgraded in Google3.