### PR TITLE
fix Curves.bounceInOut math

### DIFF
--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -369,7 +369,7 @@ class _BounceInOutCurve extends Curve {
   double transform(double t) {
     assert(t >= 0.0 && t <= 1.0);
     if (t < 0.5)
-      return (1.0 - _bounce(1.0 - t)) * 0.5;
+      return (1.0 - _bounce(1.0 - t * 2.0)) * 0.5;
     else
       return _bounce(t * 2.0 - 1.0) * 0.5 + 0.5;
   }

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -34,6 +34,29 @@ void main() {
     expect(step.transform(1.0), 1.0);
   });
 
+  void assertMaximumSlope(Curve curve, double maximumSlope) {
+    const double delta = 0.005;
+    for (double x = 0.0; x < 1.0 - delta; x += delta) {
+      final double deltaY = curve.transform(x) - curve.transform(x + delta);
+      assert(deltaY.abs() < delta * maximumSlope, '${curve.toString()} discontinuous at $x');
+    }
+  }
+
+  test('Curve is continuous', () {
+    assertMaximumSlope(Curves.linear, 20.0);
+    assertMaximumSlope(Curves.decelerate, 20.0);
+    assertMaximumSlope(Curves.bounceIn, 20.0);
+    assertMaximumSlope(Curves.bounceOut, 20.0);
+    assertMaximumSlope(Curves.bounceInOut, 20.0);
+    assertMaximumSlope(Curves.elasticOut, 20.0);
+    assertMaximumSlope(Curves.elasticInOut, 20.0);
+    assertMaximumSlope(Curves.ease, 20.0);
+    assertMaximumSlope(Curves.easeIn, 20.0);
+    assertMaximumSlope(Curves.easeOut, 20.0);
+    assertMaximumSlope(Curves.easeInOut, 20.0);
+    assertMaximumSlope(Curves.fastOutSlowIn, 20.0);
+  });
+
   void expectStaysInBounds(Curve curve) {
     expect(curve.transform(0.0), inInclusiveRange(0.0, 1.0));
     expect(curve.transform(0.1), inInclusiveRange(0.0, 1.0));


### PR DESCRIPTION
`Curves.bounceInOut` is built piecewise, but the the first section was scaled incorrectly in the t dimension, leading to a discontinuity.

the problem can be seen here: https://docs.flutter.io/flutter/animation/Curves/bounceInOut-constant.html

fixes https://github.com/flutter/flutter/issues/12869

I would verify this change by rebuilding docs and viewing the resulting video, but I'm not sure how to do that locally.