### PR TITLE
Re-land text wrapping/color PR

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -223,7 +223,7 @@ linter:
     print('Found $sampleCodeSections sample code sections.');
     final Process process = await Process.start(
       _flutter,
-      <String>['analyze', '--no-preamble', '--no-congratulate', mainDart.parent.path],
+      <String>['--no-wrap', 'analyze', '--no-preamble', '--no-congratulate', mainDart.parent.path],
       workingDirectory: tempDir.path,
     );
     final List<String> errors = <String>[];

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -80,7 +80,7 @@ class NoAndroidStudioValidator extends DoctorValidator {
         'Android Studio not found; download from https://developer.android.com/studio/index.html\n'
         '(or visit https://flutter.io/setup/#android-setup for detailed instructions).'));
 
-    return ValidationResult(ValidationType.missing, messages,
+    return ValidationResult(ValidationType.notAvailable, messages,
         statusInfo: 'not installed');
   }
 }

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -21,9 +21,6 @@ abstract class Logger {
   bool quiet = false;
 
   bool get supportsColor => terminal.supportsColor;
-  set supportsColor(bool value) {
-    terminal.supportsColor = value;
-  }
 
   bool get hasTerminal => stdio.hasTerminal;
 

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -11,6 +11,7 @@ import '../globals.dart';
 import 'context.dart';
 import 'io.dart' as io;
 import 'platform.dart';
+import 'utils.dart';
 
 final AnsiTerminal _kAnsiTerminal = AnsiTerminal();
 
@@ -28,6 +29,45 @@ enum TerminalColor {
   yellow,
   magenta,
   grey,
+}
+
+final OutputPreferences _kOutputPreferences = OutputPreferences();
+
+OutputPreferences get outputPreferences => (context == null || context[OutputPreferences] == null)
+    ? _kOutputPreferences
+    : context[OutputPreferences];
+
+/// A class that contains the context settings for command text output to the
+/// console.
+class OutputPreferences {
+  OutputPreferences({
+    bool wrapText,
+    int wrapColumn,
+    bool showColor,
+  })  : wrapText = wrapText ?? true,
+        wrapColumn = wrapColumn ?? const io.Stdio().terminalColumns ?? kDefaultTerminalColumns,
+        showColor = showColor ?? platform.stdoutSupportsAnsi ?? false;
+
+  /// If [wrapText] is true, then output text sent to the context's [Logger]
+  /// instance (e.g. from the [printError] or [printStatus] functions) will be
+  /// wrapped to be no longer than the [wrapColumn] specifies. Defaults to true.
+  final bool wrapText;
+
+  /// The column at which any output sent to the context's [Logger] instance
+  /// (e.g. from the [printError] or [printStatus] functions) will be wrapped.
+  /// Ignored if [wrapText] is false. Defaults to the width of the output
+  /// terminal, or to [kDefaultTerminalColumns] if not writing to a terminal.
+  final int wrapColumn;
+
+  /// Whether or not to output ANSI color codes when writing to the output
+  /// terminal. Defaults to whatever [platform.stdoutSupportsAnsi] says if
+  /// writing to a terminal, and false otherwise.
+  final bool showColor;
+
+  @override
+  String toString() {
+    return '$runtimeType[wrapText: $wrapText, wrapColumn: $wrapColumn, showColor: $showColor]';
+  }
 }
 
 class AnsiTerminal {
@@ -62,8 +102,16 @@ class AnsiTerminal {
     if (!supportsColor || message.isEmpty)
       return message;
     final StringBuffer buffer = StringBuffer();
-    for (String line in message.split('\n'))
+    for (String line in message.split('\n')) {
+      // If there were resets in the string before, then keep them, but
+      // restart the bold right after. This prevents embedded resets from
+      // stopping the boldness.
+      line = line.replaceAll(reset, '$reset$bold');
+      // Remove all codes at the end of the string, since we're just going
+      // to reset them, and they would either be redundant, or have no effect.
+      line = line.replaceAll(RegExp('(\u001b\[[0-9;]+m)+\$'), '');
       buffer.writeln('$bold$line$reset');
+    }
     final String result = buffer.toString();
     // avoid introducing a new newline to the emboldened text
     return (!message.endsWith('\n') && result.endsWith('\n'))
@@ -76,8 +124,17 @@ class AnsiTerminal {
     if (!supportsColor || color == null || message.isEmpty)
       return message;
     final StringBuffer buffer = StringBuffer();
-    for (String line in message.split('\n'))
-      buffer.writeln('${_colorMap[color]}$line$reset');
+    final String colorCodes = _colorMap[color];
+    for (String line in message.split('\n')) {
+      // If there were resets in the string before, then keep them, but
+      // restart the color right after. This prevents embedded resets from
+      // stopping the colors.
+      line = line.replaceAll(reset, '$reset$colorCodes');
+      // Remove any extra codes at the end of the string, since we're just going
+      // to reset them.
+      line = line.replaceAll(RegExp('(\u001b\[[0-9;]*m)+\$'), '');
+      buffer.writeln('$colorCodes$line$reset');
+    }
     final String result = buffer.toString();
     // avoid introducing a new newline to the colored text
     return (!message.endsWith('\n') && result.endsWith('\n'))

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math' show Random;
+import 'dart:math' show Random, max;
 
 import 'package:crypto/crypto.dart';
 import 'package:intl/intl.dart';
@@ -13,7 +13,9 @@ import 'package:quiver/time.dart';
 import '../globals.dart';
 import 'context.dart';
 import 'file_system.dart';
+import 'io.dart' as io;
 import 'platform.dart';
+import 'terminal.dart';
 
 const BotDetector _kBotDetector = BotDetector();
 
@@ -299,4 +301,230 @@ class Poller {
 /// it contains nulls.
 Future<List<T>> waitGroup<T>(Iterable<Future<T>> futures) {
   return Future.wait<T>(futures.where((Future<T> future) => future != null));
+}
+/// The terminal width used by the [wrapText] function if there is no terminal
+/// attached to [io.Stdio], --wrap is on, and --wrap-columns was not specified.
+const int kDefaultTerminalColumns = 100;
+
+/// Smallest column that will be used for text wrapping. If the requested column
+/// width is smaller than this, then this is what will be used.
+const int kMinColumnWidth = 10;
+
+/// Wraps a block of text into lines no longer than [columnWidth].
+///
+/// Tries to split at whitespace, but if that's not good enough to keep it
+/// under the limit, then it splits in the middle of a word.
+///
+/// Preserves indentation (leading whitespace) for each line (delimited by '\n')
+/// in the input, and will indent wrapped lines that same amount, adding
+/// [indent] spaces in addition to any existing indent.
+///
+/// If [hangingIndent] is supplied, then that many additional spaces will be
+/// added to each line, except for the first line. The [hangingIndent] is added
+/// to the specified [indent], if any. This is useful for wrapping
+/// text with a heading prefix (e.g. "Usage: "):
+///
+/// ```dart
+/// String prefix = "Usage: ";
+/// print(prefix + wrapText(invocation, indent: 2, hangingIndent: prefix.length, columnWidth: 40));
+/// ```
+///
+/// yields:
+/// ```
+///   Usage: app main_command <subcommand>
+///          [arguments]
+/// ```
+///
+/// If [columnWidth] is not specified, then the column width will be the
+/// [outputPreferences.wrapColumn], which is set with the --wrap-column option.
+///
+/// If [outputPreferences.wrapText] is false, then the text will be returned
+/// unchanged.
+///
+/// The [indent] and [hangingIndent] must be smaller than [columnWidth] when
+/// added together.
+String wrapText(String text, {int columnWidth, int hangingIndent, int indent}) {
+  if (text == null || text.isEmpty) {
+    return '';
+  }
+  indent ??= 0;
+  columnWidth ??= outputPreferences.wrapColumn;
+  columnWidth -= indent;
+  assert(columnWidth >= 0);
+
+  hangingIndent ??= 0;
+  final List<String> splitText = text.split('\n');
+  final List<String> result = <String>[];
+  for (String line in splitText) {
+    String trimmedText = line.trimLeft();
+    final String leadingWhitespace = line.substring(0, line.length - trimmedText.length);
+    List<String> notIndented;
+    if (hangingIndent != 0) {
+      // When we have a hanging indent, we want to wrap the first line at one
+      // width, and the rest at another (offset by hangingIndent), so we wrap
+      // them twice and recombine.
+      final List<String> firstLineWrap = _wrapTextAsLines(
+        trimmedText,
+        columnWidth: columnWidth - leadingWhitespace.length,
+      );
+      notIndented = <String>[firstLineWrap.removeAt(0)];
+      trimmedText = trimmedText.substring(notIndented[0].length).trimLeft();
+      if (firstLineWrap.isNotEmpty) {
+        notIndented.addAll(_wrapTextAsLines(
+          trimmedText,
+          columnWidth: columnWidth - leadingWhitespace.length - hangingIndent,
+        ));
+      }
+    } else {
+      notIndented = _wrapTextAsLines(
+        trimmedText,
+        columnWidth: columnWidth - leadingWhitespace.length,
+      );
+    }
+    String hangingIndentString;
+    final String indentString = ' ' * indent;
+    result.addAll(notIndented.map(
+      (String line) {
+        // Don't return any lines with just whitespace on them.
+        if (line.isEmpty) {
+          return '';
+        }
+        final String result = '$indentString${hangingIndentString ?? ''}$leadingWhitespace$line';
+        hangingIndentString ??= ' ' * hangingIndent;
+        return result;
+      },
+    ));
+  }
+  return result.join('\n');
+}
+
+// Used to represent a run of ANSI control sequences next to a visible
+// character.
+class _AnsiRun {
+  _AnsiRun(this.original, this.character);
+
+  String original;
+  String character;
+}
+
+/// Wraps a block of text into lines no longer than [columnWidth], starting at the
+/// [start] column, and returning the result as a list of strings.
+///
+/// Tries to split at whitespace, but if that's not good enough to keep it
+/// under the limit, then splits in the middle of a word. Preserves embedded
+/// newlines, but not indentation (it trims whitespace from each line).
+///
+/// If [columnWidth] is not specified, then the column width will be the width of the
+/// terminal window by default. If the stdout is not a terminal window, then the
+/// default will be [outputPreferences.wrapColumn].
+///
+/// If [outputPreferences.wrapText] is false, then the text will be returned
+/// simply split at the newlines, but not wrapped.
+List<String> _wrapTextAsLines(String text, {int start = 0, int columnWidth}) {
+  if (text == null || text.isEmpty) {
+    return <String>[''];
+  }
+  columnWidth ??= const io.Stdio().terminalColumns ?? kDefaultTerminalColumns;
+  assert(columnWidth >= 0);
+  assert(start >= 0);
+
+  /// Returns true if the code unit at [index] in [text] is a whitespace
+  /// character.
+  ///
+  /// Based on: https://en.wikipedia.org/wiki/Whitespace_character#Unicode
+  bool isWhitespace(_AnsiRun run) {
+    final int rune = run.character.isNotEmpty ? run.character.codeUnitAt(0) : 0x0;
+    return rune >= 0x0009 && rune <= 0x000D ||
+        rune == 0x0020 ||
+        rune == 0x0085 ||
+        rune == 0x1680 ||
+        rune == 0x180E ||
+        rune >= 0x2000 && rune <= 0x200A ||
+        rune == 0x2028 ||
+        rune == 0x2029 ||
+        rune == 0x202F ||
+        rune == 0x205F ||
+        rune == 0x3000 ||
+        rune == 0xFEFF;
+  }
+
+  // Splits a string so that the resulting list has the same number of elements
+  // as there are visible characters in the string, but elements may include one
+  // or more adjacent ANSI sequences. Joining the list elements again will
+  // reconstitute the original string. This is useful for manipulating "visible"
+  // characters in the presence of ANSI control codes.
+  List<_AnsiRun> splitWithCodes(String input) {
+    final RegExp characterOrCode = RegExp('(\u001b\[[0-9;]*m|.)', multiLine: true);
+    List<_AnsiRun> result = <_AnsiRun>[];
+    final StringBuffer current = StringBuffer();
+    for (Match match in characterOrCode.allMatches(input)) {
+      current.write(match[0]);
+      if (match[0].length < 4) {
+        // This is a regular character, write it out.
+        result.add(_AnsiRun(current.toString(), match[0]));
+        current.clear();
+      }
+    }
+    // If there's something accumulated, then it must be an ANSI sequence, so
+    // add it to the end of the last entry so that we don't lose it.
+    if (current.isNotEmpty) {
+      if (result.isNotEmpty) {
+        result.last.original += current.toString();
+      } else {
+        // If there is nothing in the string besides control codes, then just
+        // return them as the only entry.
+        result = <_AnsiRun>[_AnsiRun(current.toString(), '')];
+      }
+    }
+    return result;
+  }
+
+  String joinRun(List<_AnsiRun> list, int start, [int end]) {
+    return list.sublist(start, end).map<String>((_AnsiRun run) => run.original).join().trim();
+  }
+
+  final List<String> result = <String>[];
+  final int effectiveLength = max(columnWidth - start, kMinColumnWidth);
+  for (String line in text.split('\n')) {
+    // If the line is short enough, even with ANSI codes, then we can just add
+    // add it and move on.
+    if (line.length <= effectiveLength || !outputPreferences.wrapText) {
+      result.add(line);
+      continue;
+    }
+    final List<_AnsiRun> splitLine = splitWithCodes(line);
+    if (splitLine.length <= effectiveLength) {
+      result.add(line);
+      continue;
+    }
+
+    int currentLineStart = 0;
+    int lastWhitespace;
+    // Find the start of the current line.
+    for (int index = 0; index < splitLine.length; ++index) {
+      if (splitLine[index].character.isNotEmpty && isWhitespace(splitLine[index])) {
+        lastWhitespace = index;
+      }
+
+      if (index - currentLineStart >= effectiveLength) {
+        // Back up to the last whitespace, unless there wasn't any, in which
+        // case we just split where we are.
+        if (lastWhitespace != null) {
+          index = lastWhitespace;
+        }
+
+        result.add(joinRun(splitLine, currentLineStart, index));
+
+        // Skip any intervening whitespace.
+        while (isWhitespace(splitLine[index]) && index < splitLine.length) {
+          index++;
+        }
+
+        currentLineStart = index;
+        lastWhitespace = null;
+      }
+    }
+    result.add(joinRun(splitLine, currentLineStart));
+  }
+  return result;
 }

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -424,7 +424,7 @@ List<String> _wrapTextAsLines(String text, {int start = 0, int columnWidth}) {
   if (text == null || text.isEmpty) {
     return <String>[''];
   }
-  columnWidth ??= const io.Stdio().terminalColumns ?? kDefaultTerminalColumns;
+  assert(columnWidth != null);
   assert(columnWidth >= 0);
   assert(start >= 0);
 

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -20,7 +20,7 @@ class AnalyzeCommand extends FlutterCommand {
         help: 'Analyze the current project, if applicable.', defaultsTo: true);
     argParser.addFlag('dartdocs',
         negatable: false,
-        help: 'List every public member that is lacking documentation.\n'
+        help: 'List every public member that is lacking documentation. '
               '(The public_member_api_docs lint must be enabled in analysis_options.yaml)',
         hide: !verboseHelp);
     argParser.addFlag('watch',
@@ -45,7 +45,7 @@ class AnalyzeCommand extends FlutterCommand {
 
     // Not used by analyze --watch
     argParser.addFlag('congratulate',
-        help: 'Show output even when there are no errors, warnings, hints, or lints.\n'
+        help: 'Show output even when there are no errors, warnings, hints, or lints. '
               'Ignored if --watch is specified.',
         defaultsTo: true);
     argParser.addFlag('preamble',

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -132,7 +132,7 @@ class AnalyzeOnce extends AnalyzeBase {
       printStatus('');
     errors.sort();
     for (AnalysisError error in errors)
-      printStatus(error.toString());
+      printStatus(error.toString(), hangingIndent: 7);
 
     final String seconds = (timer.elapsedMilliseconds / 1000.0).toStringAsFixed(1);
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -50,7 +50,7 @@ class AttachCommand extends FlutterCommand {
       )..addFlag('machine',
           hide: !verboseHelp,
           negatable: false,
-          help: 'Handle machine structured JSON command input and provide output\n'
+          help: 'Handle machine structured JSON command input and provide output '
                 'and progress in machine friendly format.',
       );
     hotRunnerFactory ??= HotRunnerFactory();

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -34,8 +34,8 @@ class BuildApkCommand extends BuildSubCommand {
 
   @override
   final String description = 'Build an Android APK file from your app.\n\n'
-    'This command can build debug and release versions of your application. \'debug\' builds support\n'
-    'debugging and a quick development cycle. \'release\' builds don\'t support debugging and are\n'
+    'This command can build debug and release versions of your application. \'debug\' builds support '
+    'debugging and a quick development cycle. \'release\' builds don\'t support debugging and are '
     'suitable for deploying to app stores.';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -34,19 +34,19 @@ class BuildBundleCommand extends BuildSubCommand {
       )
       ..addOption('precompile',
         hide: !verboseHelp,
-        help: 'Precompile functions specified in input file. This flag is only\n'
-              'allowed when using --dynamic. It takes a Dart compilation trace\n'
-              'file produced by the training run of the application. With this\n'
-              'flag, instead of using default Dart VM snapshot provided by the\n'
-              'engine, the application will use its own snapshot that includes\n'
+        help: 'Precompile functions specified in input file. This flag is only '
+              'allowed when using --dynamic. It takes a Dart compilation trace '
+              'file produced by the training run of the application. With this '
+              'flag, instead of using default Dart VM snapshot provided by the '
+              'engine, the application will use its own snapshot that includes '
               'additional compiled functions.'
       )
       ..addFlag('hotupdate',
         hide: !verboseHelp,
-        help: 'Build differential snapshot based on the last state of the build\n'
-              'tree and any changes to the application source code since then.\n'
-              'This flag is only allowed when using --dynamic. With this flag,\n'
-              'a partial VM snapshot is generated that is loaded on top of the\n'
+        help: 'Build differential snapshot based on the last state of the build '
+              'tree and any changes to the application source code since then. '
+              'This flag is only allowed when using --dynamic. With this flag, '
+              'a partial VM snapshot is generated that is loaded on top of the '
               'original VM snapshot that contains precompiled code.'
       )
       ..addMultiOption(FlutterOptions.kExtraFrontEndOptions,

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -35,7 +35,7 @@ class ConfigCommand extends FlutterCommand {
   final String description =
     'Configure Flutter settings.\n\n'
     'To remove a setting, configure it to an empty string.\n\n'
-    'The Flutter tool anonymously reports feature usage statistics and basic crash reports to help improve\n'
+    'The Flutter tool anonymously reports feature usage statistics and basic crash reports to help improve '
     'Flutter tools over time. See Google\'s privacy policy: https://www.google.com/intl/en/policies/privacy/';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -92,7 +92,7 @@ class CreateCommand extends FlutterCommand {
     argParser.addOption(
       'org',
       defaultsTo: 'com.example',
-      help: 'The organization responsible for your new Flutter project, in reverse domain name notation.\n'
+      help: 'The organization responsible for your new Flutter project, in reverse domain name notation. '
             'This string is used in Java package names and as prefix in the iOS bundle identifier.'
     );
     argParser.addOption(
@@ -174,7 +174,7 @@ class CreateCommand extends FlutterCommand {
     }
 
     if (Cache.flutterRoot == null)
-      throwToolExit('Neither the --flutter-root command line flag nor the FLUTTER_ROOT environment\n'
+      throwToolExit('Neither the --flutter-root command line flag nor the FLUTTER_ROOT environment '
         'variable was specified. Unable to find package:flutter.', exitCode: 2);
 
     await Cache.instance.updateAll();
@@ -230,7 +230,7 @@ class CreateCommand extends FlutterCommand {
         organization = existingOrganizations.first;
       } else if (1 < existingOrganizations.length) {
         throwToolExit(
-          'Ambiguous organization in existing files: $existingOrganizations.\n'
+          'Ambiguous organization in existing files: $existingOrganizations. '
           'The --org command line argument must be specified to recreate project.'
         );
       }
@@ -554,7 +554,7 @@ String _validateProjectName(String projectName) {
 /// if we should disallow the directory name.
 String _validateProjectDir(String dirPath, { String flutterRoot }) {
   if (fs.path.isWithin(flutterRoot, dirPath)) {
-    return 'Cannot create a project within the Flutter SDK.\n'
+    return 'Cannot create a project within the Flutter SDK. '
       "Target directory '$dirPath' is within the Flutter SDK at '$flutterRoot'.";
   }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -749,18 +749,26 @@ class NotifyingLogger extends Logger {
   Stream<LogMessage> get onMessage => _messageController.stream;
 
   @override
-  void printError(String message, { StackTrace stackTrace, bool emphasis = false, TerminalColor color }) {
+  void printError(
+      String message, {
+      StackTrace stackTrace,
+      bool emphasis = false,
+      TerminalColor color,
+      int indent,
+      int hangingIndent,
+    }) {
     _messageController.add(LogMessage('error', message, stackTrace));
   }
 
   @override
   void printStatus(
       String message, {
-        bool emphasis = false,
-        TerminalColor color,
-        bool newline = true,
-        int indent,
-      }) {
+      bool emphasis = false,
+      TerminalColor color,
+      bool newline = true,
+      int indent,
+      int hangingIndent,
+    }) {
     _messageController.add(LogMessage('status', message));
   }
 
@@ -875,9 +883,22 @@ class _AppRunLogger extends Logger {
   int _nextProgressId = 0;
 
   @override
-  void printError(String message, { StackTrace stackTrace, bool emphasis, TerminalColor color}) {
+  void printError(
+      String message, {
+      StackTrace stackTrace,
+      bool emphasis,
+      TerminalColor color,
+      int indent,
+      int hangingIndent,
+    }) {
     if (parent != null) {
-      parent.printError(message, stackTrace: stackTrace, emphasis: emphasis);
+      parent.printError(
+        message,
+        stackTrace: stackTrace,
+        emphasis: emphasis,
+        indent: indent,
+        hangingIndent: hangingIndent,
+      );
     } else {
       if (stackTrace != null) {
         _sendLogEvent(<String, dynamic>{
@@ -897,11 +918,12 @@ class _AppRunLogger extends Logger {
   @override
   void printStatus(
       String message, {
-        bool emphasis = false,
-        TerminalColor color,
-        bool newline = true,
-        int indent,
-      }) {
+      bool emphasis = false,
+      TerminalColor color,
+      bool newline = true,
+      int indent,
+      int hangingIndent,
+    }) {
     if (parent != null) {
       parent.printStatus(
         message,
@@ -909,6 +931,7 @@ class _AppRunLogger extends Logger {
         color: color,
         newline: newline,
         indent: indent,
+        hangingIndent: hangingIndent,
       );
     } else {
       _sendLogEvent(<String, dynamic>{'log': message});

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -33,13 +33,13 @@ class DevicesCommand extends FlutterCommand {
       printStatus(
         'No devices detected.\n\n'
         "Run 'flutter emulators' to list and start any available device emulators.\n\n"
-        'Or, if you expected your device to be detected, please run "flutter doctor" to diagnose\n'
+        'Or, if you expected your device to be detected, please run "flutter doctor" to diagnose '
         'potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');
       final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
       if (diagnostics.isNotEmpty) {
         printStatus('');
         for (String diagnostic in diagnostics) {
-          printStatus('• ${diagnostic.replaceAll('\n', '\n  ')}');
+          printStatus('• $diagnostic', hangingIndent: 2);
         }
       }
     } else {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -45,23 +45,24 @@ class DriveCommand extends RunCommandBase {
       ..addFlag('keep-app-running',
         defaultsTo: null,
         help: 'Will keep the Flutter application running when done testing.\n'
-              'By default, "flutter drive" stops the application after tests are finished,\n'
-              'and --keep-app-running overrides this. On the other hand, if --use-existing-app\n'
-              'is specified, then "flutter drive" instead defaults to leaving the application\n'
+              'By default, "flutter drive" stops the application after tests are finished, '
+              'and --keep-app-running overrides this. On the other hand, if --use-existing-app '
+              'is specified, then "flutter drive" instead defaults to leaving the application '
               'running, and --no-keep-app-running overrides it.',
       )
       ..addOption('use-existing-app',
-        help: 'Connect to an already running instance via the given observatory URL.\n'
-              'If this option is given, the application will not be automatically started,\n'
+        help: 'Connect to an already running instance via the given observatory URL. '
+              'If this option is given, the application will not be automatically started, '
               'and it will only be stopped if --no-keep-app-running is explicitly set.',
         valueHelp: 'url',
       )
       ..addOption('driver',
-        help: 'The test file to run on the host (as opposed to the target file to run on\n'
-              'the device). By default, this file has the same base name as the target\n'
-              'file, but in the "test_driver/" directory instead, and with "_test" inserted\n'
-              'just before the extension, so e.g. if the target is "lib/main.dart", the\n'
-              'driver will be "test_driver/main_test.dart".',
+        help: 'The test file to run on the host (as opposed to the target file to run on '
+              'the device).\n'
+              'By default, this file has the same base name as the target file, but in the '
+              '"test_driver/" directory instead, and with "_test" inserted just before the '
+              'extension, so e.g. if the target is "lib/main.dart", the driver will be '
+              '"test_driver/main_test.dart".',
         valueHelp: 'path',
       );
   }

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -105,10 +105,10 @@ class PackagesTestCommand extends FlutterCommand {
   @override
   String get description {
     return 'Run the "test" package.\n'
-           'This is similar to "flutter test", but instead of hosting the tests in the\n'
-           'flutter environment it hosts the tests in a pure Dart environment. The main\n'
-           'differences are that the "dart:ui" library is not available and that tests\n'
-           'run faster. This is helpful for testing libraries that do not depend on any\n'
+           'This is similar to "flutter test", but instead of hosting the tests in the '
+           'flutter environment it hosts the tests in a pure Dart environment. The main '
+           'differences are that the "dart:ui" library is not available and that tests '
+           'run faster. This is helpful for testing libraries that do not depend on any '
            'packages from the Flutter SDK. It is equivalent to "pub run test".';
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -32,7 +32,7 @@ abstract class RunCommandBase extends FlutterCommand {
       ..addFlag('ipv6',
         hide: true,
         negatable: false,
-        help: 'Binds to IPv6 localhost instead of IPv4 when the flutter tool\n'
+        help: 'Binds to IPv6 localhost instead of IPv4 when the flutter tool '
               'forwards the host port to a device port.',
       )
       ..addOption('route',
@@ -83,27 +83,27 @@ class RunCommand extends RunCommandBase {
       )
       ..addFlag('enable-software-rendering',
         negatable: false,
-        help: 'Enable rendering using the Skia software backend. This is useful\n'
-              'when testing Flutter on emulators. By default, Flutter will\n'
-              'attempt to either use OpenGL or Vulkan and fall back to software\n'
-              'when neither is available.',
+        help: 'Enable rendering using the Skia software backend. '
+              'This is useful when testing Flutter on emulators. By default, '
+              'Flutter will attempt to either use OpenGL or Vulkan and fall back '
+              'to software when neither is available.',
       )
       ..addFlag('skia-deterministic-rendering',
         negatable: false,
-        help: 'When combined with --enable-software-rendering, provides 100%\n'
+        help: 'When combined with --enable-software-rendering, provides 100% '
               'deterministic Skia rendering.',
       )
       ..addFlag('trace-skia',
         negatable: false,
-        help: 'Enable tracing of Skia code. This is useful when debugging\n'
+        help: 'Enable tracing of Skia code. This is useful when debugging '
               'the GPU thread. By default, Flutter will not log skia code.',
       )
       ..addFlag('use-test-fonts',
         negatable: true,
-        help: 'Enable (and default to) the "Ahem" font. This is a special font\n'
-              'used in tests to remove any dependencies on the font metrics. It\n'
-              'is enabled when you use "flutter test". Set this flag when running\n'
-              'a test using "flutter run" for debugging purposes. This flag is\n'
+        help: 'Enable (and default to) the "Ahem" font. This is a special font '
+              'used in tests to remove any dependencies on the font metrics. It '
+              'is enabled when you use "flutter test". Set this flag when running '
+              'a test using "flutter run" for debugging purposes. This flag is '
               'only available when running in debug mode.',
       )
       ..addFlag('build',
@@ -116,19 +116,19 @@ class RunCommand extends RunCommandBase {
       )
       ..addOption('precompile',
         hide: !verboseHelp,
-        help: 'Precompile functions specified in input file. This flag is only\n'
-              'allowed when using --dynamic. It takes a Dart compilation trace\n'
-              'file produced by the training run of the application. With this\n'
-              'flag, instead of using default Dart VM snapshot provided by the\n'
-              'engine, the application will use its own snapshot that includes\n'
+        help: 'Precompile functions specified in input file. This flag is only '
+              'allowed when using --dynamic. It takes a Dart compilation trace '
+              'file produced by the training run of the application. With this '
+              'flag, instead of using default Dart VM snapshot provided by the '
+              'engine, the application will use its own snapshot that includes '
               'additional functions.'
       )
       ..addFlag('hotupdate',
         hide: !verboseHelp,
-        help: 'Build differential snapshot based on the last state of the build\n'
-              'tree and any changes to the application source code since then.\n'
-              'This flag is only allowed when using --dynamic. With this flag,\n'
-              'a partial VM snapshot is generated that is loaded on top of the\n'
+        help: 'Build differential snapshot based on the last state of the build '
+              'tree and any changes to the application source code since then. '
+              'This flag is only allowed when using --dynamic. With this flag, '
+              'a partial VM snapshot is generated that is loaded on top of the '
               'original VM snapshot that contains precompiled code.'
       )
       ..addFlag('track-widget-creation',
@@ -142,7 +142,7 @@ class RunCommand extends RunCommandBase {
       ..addFlag('machine',
         hide: !verboseHelp,
         negatable: false,
-        help: 'Handle machine structured JSON command input and provide output\n'
+        help: 'Handle machine structured JSON command input and provide output '
               'and progress in machine friendly format.',
       )
       ..addFlag('hot',
@@ -151,8 +151,8 @@ class RunCommand extends RunCommandBase {
         help: 'Run with support for hot reloading.',
       )
       ..addOption('pid-file',
-        help: 'Specify a file to write the process id to.\n'
-              'You can send SIGUSR1 to trigger a hot reload\n'
+        help: 'Specify a file to write the process id to. '
+              'You can send SIGUSR1 to trigger a hot reload '
               'and SIGUSR2 to trigger a hot restart.',
       )
       ..addFlag('resident',
@@ -164,9 +164,9 @@ class RunCommand extends RunCommandBase {
       ..addFlag('benchmark',
         negatable: false,
         hide: !verboseHelp,
-        help: 'Enable a benchmarking mode. This will run the given application,\n'
-              'measure the startup time and the app restart time, write the\n'
-              'results out to "refresh_benchmark.json", and exit. This flag is\n'
+        help: 'Enable a benchmarking mode. This will run the given application, '
+              'measure the startup time and the app restart time, write the '
+              'results out to "refresh_benchmark.json", and exit. This flag is '
               'intended for use in generating automated flutter benchmarks.',
       )
       ..addOption(FlutterOptions.kExtraFrontEndOptions, hide: true)

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -33,7 +33,7 @@ class ScreenshotCommand extends FlutterCommand {
       valueHelp: 'port',
       help: 'The observatory port to connect to.\n'
           'This is required when --$_kType is "$_kSkiaType" or "$_kRasterizerType".\n'
-          'To find the observatory port number, use "flutter run --verbose"\n'
+          'To find the observatory port number, use "flutter run --verbose" '
           'and look for "Forwarded host port ... for Observatory" in the output.',
     );
     argParser.addOption(
@@ -42,8 +42,8 @@ class ScreenshotCommand extends FlutterCommand {
       help: 'The type of screenshot to retrieve.',
       allowed: const <String>[_kDeviceType, _kSkiaType, _kRasterizerType],
       allowedHelp: const <String, String>{
-        _kDeviceType: 'Delegate to the device\'s native screenshot capabilities. This\n'
-            'screenshots the entire screen currently being displayed (including content\n'
+        _kDeviceType: 'Delegate to the device\'s native screenshot capabilities. This '
+            'screenshots the entire screen currently being displayed (including content '
             'not rendered by Flutter, like the device status bar).',
         _kSkiaType: 'Render the Flutter app as a Skia picture. Requires --$_kObservatoryPort',
         _kRasterizerType: 'Render the Flutter app using the rasterizer. Requires --$_kObservatoryPort',

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -26,9 +26,9 @@ class ShellCompletionCommand extends FlutterCommand {
 
   @override
   final String description = 'Output command line shell completion setup scripts.\n\n'
-      'This command prints the flutter command line completion setup script for Bash and Zsh. To\n'
-      'use it, specify an output file and follow the instructions in the generated output file to\n'
-      'install it in your shell environment. Once it is sourced, your shell will be able to\n'
+      'This command prints the flutter command line completion setup script for Bash and Zsh. To '
+      'use it, specify an output file and follow the instructions in the generated output file to '
+      'install it in your shell environment. Once it is sourced, your shell will be able to '
       'complete flutter commands and options.';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -35,7 +35,7 @@ class TestCommand extends FlutterCommand {
         negatable: false,
         help: 'Start in a paused mode and wait for a debugger to connect.\n'
               'You must specify a single test file to run, explicitly.\n'
-              'Instructions for connecting with a debugger and printed to the\n'
+              'Instructions for connecting with a debugger and printed to the '
               'console once the test has started.',
       )
       ..addFlag('coverage',
@@ -72,7 +72,7 @@ class TestCommand extends FlutterCommand {
       )
       ..addFlag('update-goldens',
         negatable: false,
-        help: 'Whether matchesGoldenFile() calls within your test methods should\n'
+        help: 'Whether matchesGoldenFile() calls within your test methods should '
               'update the golden files rather than test for an existing match.',
       )
       ..addOption('concurrency',
@@ -94,8 +94,8 @@ class TestCommand extends FlutterCommand {
     if (!fs.isFileSync('pubspec.yaml')) {
       throwToolExit(
         'Error: No pubspec.yaml file found in the current working directory.\n'
-        'Run this command from the root of your project. Test files must be\n'
-        'called *_test.dart and must reside in the package\'s \'test\'\n'
+        'Run this command from the root of your project. Test files must be '
+        'called *_test.dart and must reside in the package\'s \'test\' '
         'directory (or one of its subdirectories).');
     }
   }

--- a/packages/flutter_tools/lib/src/commands/trace.dart
+++ b/packages/flutter_tools/lib/src/commands/trace.dart
@@ -23,7 +23,7 @@ class TraceCommand extends FlutterCommand {
     argParser.addFlag('stop', negatable: false, help: 'Stop tracing. Implied if --start is also omitted.');
     argParser.addOption('duration',
       abbr: 'd',
-      help: 'Time to wait after starting (if --start is specified or implied) and before\n'
+      help: 'Time to wait after starting (if --start is specified or implied) and before '
             'stopping (if --stop is specified or implied).\n'
             'Defaults to ten seconds if --stop is specified or implied, zero otherwise.',
     );
@@ -38,8 +38,8 @@ class TraceCommand extends FlutterCommand {
 
   @override
   final String usageFooter =
-    '\`trace\` called without the --start or --stop flags will automatically start tracing,\n'
-    'delay a set amount of time (controlled by --duration), and stop tracing. To explicitly\n'
+    '\`trace\` called without the --start or --stop flags will automatically start tracing, '
+    'delay a set amount of time (controlled by --duration), and stop tracing. To explicitly '
     'control tracing, call trace with --start and later with --stop.\n'
     'The --debug-port argument is required.';
 

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -25,12 +25,16 @@ void printError(
   StackTrace stackTrace,
   bool emphasis,
   TerminalColor color,
+  int indent,
+  int hangingIndent,
 }) {
   logger.printError(
     message,
     stackTrace: stackTrace,
     emphasis: emphasis ?? false,
     color: color,
+    indent: indent,
+    hangingIndent: hangingIndent,
   );
 }
 
@@ -49,6 +53,7 @@ void printStatus(
   bool newline,
   TerminalColor color,
   int indent,
+  int hangingIndent,
 }) {
   logger.printStatus(
     message,
@@ -56,6 +61,7 @@ void printStatus(
     color: color,
     newline: newline ?? true,
     indent: indent,
+    hangingIndent: hangingIndent,
   );
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -100,7 +100,7 @@ abstract class FlutterCommand extends Command<void> {
       abbr: 't',
       defaultsTo: bundle.defaultMainPath,
       help: 'The main entry-point file of the application, as run on the device.\n'
-            'If the --target option is omitted, but a file name is provided on\n'
+            'If the --target option is omitted, but a file name is provided on '
             'the command line, then that is used instead.',
       valueHelp: 'path');
     _usesTargetOption = true;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -17,11 +17,13 @@ import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/flags.dart';
+import '../base/io.dart' as io;
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
+import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../dart/package_map.dart';
@@ -60,6 +62,16 @@ class FlutterCommandRunner extends CommandRunner<void> {
         negatable: false,
         hide: !verboseHelp,
         help: 'Reduce the amount of output from some commands.');
+    argParser.addFlag('wrap',
+        negatable: true,
+        hide: !verboseHelp,
+        help: 'Toggles output word wrapping, regardless of whether or not the output is a terminal.',
+        defaultsTo: true);
+    argParser.addOption('wrap-column',
+        hide: !verboseHelp,
+        help: 'Sets the output wrap column. If not set, uses the width of the terminal, or 100 if '
+            'the output is not a terminal. Use --no-wrap to turn off wrapping entirely.',
+        defaultsTo: null);
     argParser.addOption('device-id',
         abbr: 'd',
         help: 'Target device id or name (prefixes allowed).');
@@ -73,7 +85,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
     argParser.addFlag('color',
         negatable: true,
         hide: !verboseHelp,
-        help: 'Whether to use terminal colors (requires support for ANSI escape sequences).');
+        help: 'Whether to use terminal colors (requires support for ANSI escape sequences).',
+        defaultsTo: true);
     argParser.addFlag('version-check',
         negatable: true,
         defaultsTo: true,
@@ -103,8 +116,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
     argParser.addOption('flutter-root',
         hide: !verboseHelp,
         help: 'The root directory of the Flutter repository.\n'
-              'Defaults to \$$kFlutterRootEnvironmentVariableName if set, otherwise uses the parent of the\n'
-              'directory that the "flutter" script itself is in.');
+              'Defaults to \$$kFlutterRootEnvironmentVariableName if set, otherwise uses the parent '
+              'of the directory that the "flutter" script itself is in.');
 
     if (verboseHelp)
       argParser.addSeparator('Local build selection options (not normally required):');
@@ -112,9 +125,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
     argParser.addOption('local-engine-src-path',
         hide: !verboseHelp,
         help: 'Path to your engine src directory, if you are building Flutter locally.\n'
-              'Defaults to \$$kFlutterEngineEnvironmentVariableName if set, otherwise defaults to the path given in your pubspec.yaml\n'
-              'dependency_overrides for $kFlutterEnginePackageName, if any, or, failing that, tries to guess at the location\n'
-              'based on the value of the --flutter-root option.');
+              'Defaults to \$$kFlutterEngineEnvironmentVariableName if set, otherwise defaults to '
+              'the path given in your pubspec.yaml dependency_overrides for $kFlutterEnginePackageName, '
+              'if any, or, failing that, tries to guess at the location based on the value of the '
+              '--flutter-root option.');
 
     argParser.addOption('local-engine',
         hide: !verboseHelp,
@@ -127,15 +141,15 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
     argParser.addOption('record-to',
         hide: !verboseHelp,
-        help: 'Enables recording of process invocations (including stdout and stderr of all such invocations),\n'
+        help: 'Enables recording of process invocations (including stdout and stderr of all such invocations), '
               'and file system access (reads and writes).\n'
-              'Serializes that recording to a directory with the path specified in this flag. If the\n'
+              'Serializes that recording to a directory with the path specified in this flag. If the '
               'directory does not already exist, it will be created.');
     argParser.addOption('replay-from',
         hide: !verboseHelp,
-        help: 'Enables mocking of process invocations by replaying their stdout, stderr, and exit code from\n'
-              'the specified recording (obtained via --record-to). The path specified in this flag must refer\n'
-              'to a directory that holds serialized process invocations structured according to the output of\n'
+        help: 'Enables mocking of process invocations by replaying their stdout, stderr, and exit code from '
+              'the specified recording (obtained via --record-to). The path specified in this flag must refer '
+              'to a directory that holds serialized process invocations structured according to the output of '
               '--record-to.');
     argParser.addFlag('show-test-device',
         negatable: false,
@@ -146,11 +160,20 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
   @override
   ArgParser get argParser => _argParser;
-  final ArgParser _argParser = ArgParser(allowTrailingOptions: false);
+  final ArgParser _argParser = ArgParser(
+    allowTrailingOptions: false,
+    usageLineLength: outputPreferences.wrapText ? outputPreferences.wrapColumn : null,
+  );
 
   @override
   String get usageFooter {
-    return 'Run "flutter help -v" for verbose help output, including less commonly used options.';
+    return wrapText('Run "flutter help -v" for verbose help output, including less commonly used options.');
+  }
+
+  @override
+  String get usage {
+    final String usageWithoutDescription = super.usage.substring(description.length + 2);
+    return  '${wrapText(description)}\n\n$usageWithoutDescription';
   }
 
   static String get _defaultFlutterRoot {
@@ -222,6 +245,26 @@ class FlutterCommandRunner extends CommandRunner<void> {
       // Override the logger.
       contextOverrides[Logger] = VerboseLogger(logger);
     }
+
+    int wrapColumn = const io.Stdio().terminalColumns ?? kDefaultTerminalColumns;
+    if (topLevelResults['wrap-column'] != null) {
+      try {
+        wrapColumn = int.parse(topLevelResults['wrap-column']);
+        if (wrapColumn < 0) {
+          throwToolExit('Argument to --wrap-column must be a positive integer. '
+              'You supplied ${topLevelResults['wrap-column']}.');
+        }
+      } on FormatException {
+        throwToolExit('Unable to parse argument '
+            '--wrap-column=${topLevelResults['wrap-column']}. Must be a positive integer.');
+      }
+    }
+
+    contextOverrides[OutputPreferences] = OutputPreferences(
+      wrapText: topLevelResults['wrap'],
+      showColor: topLevelResults['color'],
+      wrapColumn: wrapColumn,
+    );
 
     if (topLevelResults['show-test-device'] ||
         topLevelResults['device-id'] == FlutterTesterDevices.kTesterDeviceId) {
@@ -307,9 +350,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
       body: () async {
         logger.quiet = topLevelResults['quiet'];
 
-        if (topLevelResults.wasParsed('color'))
-          logger.supportsColor = topLevelResults['color'];
-
         if (platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true')
           await Cache.lock();
 
@@ -377,8 +417,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
       if (engineSourcePath == null) {
         throwToolExit('Unable to detect local Flutter engine build directory.\n'
-          'Either specify a dependency_override for the $kFlutterEnginePackageName package in your pubspec.yaml and\n'
-          'ensure --package-root is set if necessary, or set the \$$kFlutterEngineEnvironmentVariableName environment variable, or\n'
+          'Either specify a dependency_override for the $kFlutterEnginePackageName package in your pubspec.yaml and '
+          'ensure --package-root is set if necessary, or set the \$$kFlutterEngineEnvironmentVariableName environment variable, or '
           'use --local-engine-src-path to specify the path to the root of your flutter/engine repository.',
           exitCode: 2);
       }
@@ -386,7 +426,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
     if (engineSourcePath != null && _tryEnginePath(engineSourcePath) == null) {
       throwToolExit('Unable to detect a Flutter engine build directory in $engineSourcePath.\n'
-        'Please ensure that $engineSourcePath is a Flutter engine \'src\' directory and that\n'
+        'Please ensure that $engineSourcePath is a Flutter engine \'src\' directory and that '
         'you have compiled the engine in that directory, which should produce an \'out\' directory',
         exitCode: 2);
     }
@@ -469,7 +509,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
             'Warning: the \'flutter\' tool you are currently running is not the one from the current directory:\n'
             '  running Flutter  : ${Cache.flutterRoot}\n'
             '  current directory: $directory\n'
-            'This can happen when you have multiple copies of flutter installed. Please check your system path to verify\n'
+            'This can happen when you have multiple copies of flutter installed. Please check your system path to verify '
             'that you\'re running the expected version (run \'flutter --version\' to see which flutter is on your path).\n'
           );
         }
@@ -495,25 +535,25 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
         if (!fs.isDirectorySync(flutterPath)) {
           printError(
-            'Warning! This package referenced a Flutter repository via the .packages file that is\n'
-            'no longer available. The repository from which the \'flutter\' tool is currently\n'
+            'Warning! This package referenced a Flutter repository via the .packages file that is '
+            'no longer available. The repository from which the \'flutter\' tool is currently '
             'executing will be used instead.\n'
             '  running Flutter tool: ${Cache.flutterRoot}\n'
             '  previous reference  : $flutterPath\n'
-            'This can happen if you deleted or moved your copy of the Flutter repository, or\n'
-            'if it was on a volume that is no longer mounted or has been mounted at a\n'
-            'different location. Please check your system path to verify that you are running\n'
+            'This can happen if you deleted or moved your copy of the Flutter repository, or '
+            'if it was on a volume that is no longer mounted or has been mounted at a '
+            'different location. Please check your system path to verify that you are running '
             'the expected version (run \'flutter --version\' to see which flutter is on your path).\n'
           );
         } else if (!_compareResolvedPaths(flutterPath, Cache.flutterRoot)) {
           printError(
-            'Warning! The \'flutter\' tool you are currently running is from a different Flutter\n'
-            'repository than the one last used by this package. The repository from which the\n'
+            'Warning! The \'flutter\' tool you are currently running is from a different Flutter '
+            'repository than the one last used by this package. The repository from which the '
             '\'flutter\' tool is currently executing will be used instead.\n'
             '  running Flutter tool: ${Cache.flutterRoot}\n'
             '  previous reference  : $flutterPath\n'
-            'This can happen when you have multiple copies of flutter installed. Please check\n'
-            'your system path to verify that you are running the expected version (run\n'
+            'This can happen when you have multiple copies of flutter installed. Please check '
+            'your system path to verify that you are running the expected version (run '
             '\'flutter --version\' to see which flutter is on your path).\n'
           );
         }

--- a/packages/flutter_tools/test/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/android/android_studio_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/file_system.dart';

--- a/packages/flutter_tools/test/android/android_studio_validator_test.dart
+++ b/packages/flutter_tools/test/android/android_studio_validator_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/android/android_studio_validator.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+const String home = '/home/me';
+
+Platform linuxPlatform() {
+  return FakePlatform.fromPlatform(const LocalPlatform())
+    ..operatingSystem = 'linux'
+    ..environment = <String, String>{'HOME': home};
+}
+
+void main() {
+  group('NoAndroidStudioValidator', () {
+    testUsingContext('shows Android Studio as "not available" when not available.', () async {
+      final NoAndroidStudioValidator validator = NoAndroidStudioValidator();
+      expect((await validator.validate()).type, equals(ValidationType.notAvailable));
+    }, overrides: <Type, Generator>{
+      // Note that custom home paths are not supported on macOS nor Windows yet:
+      Platform: () => linuxPlatform(),
+    });
+  });
+}

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -17,13 +17,13 @@ import '../src/mocks.dart';
 void main() {
   final String red = RegExp.escape(AnsiTerminal.red);
   final String bold = RegExp.escape(AnsiTerminal.bold);
-  final String reset = RegExp.escape(AnsiTerminal.reset);
+  final String resetBold = RegExp.escape(AnsiTerminal.resetBold);
+  final String resetColor = RegExp.escape(AnsiTerminal.resetColor);
 
   group('AppContext', () {
-    test('error', () async {
+    testUsingContext('error', () async {
       final BufferLogger mockLogger = BufferLogger();
       final VerboseLogger verboseLogger = VerboseLogger(mockLogger);
-      verboseLogger.supportsColor = false;
 
       verboseLogger.printStatus('Hey Hey Hey Hey');
       verboseLogger.printTrace('Oooh, I do I do I do');
@@ -33,12 +33,14 @@ void main() {
                                              r'\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] Oooh, I do I do I do\n$'));
       expect(mockLogger.traceText, '');
       expect(mockLogger.errorText, matches( r'^\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] Helpless!\n$'));
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = false,
     });
 
-    test('ANSI colored errors', () async {
+    testUsingContext('ANSI colored errors', () async {
       final BufferLogger mockLogger = BufferLogger();
       final VerboseLogger verboseLogger = VerboseLogger(mockLogger);
-      verboseLogger.supportsColor = true;
 
       verboseLogger.printStatus('Hey Hey Hey Hey');
       verboseLogger.printTrace('Oooh, I do I do I do');
@@ -46,12 +48,15 @@ void main() {
 
       expect(
           mockLogger.statusText,
-          matches(r'^\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] ' '${bold}Hey Hey Hey Hey$reset'
+          matches(r'^\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] ' '${bold}Hey Hey Hey Hey$resetBold'
                   r'\n\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] Oooh, I do I do I do\n$'));
       expect(mockLogger.traceText, '');
       expect(
           mockLogger.errorText,
-          matches('^$red' r'\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] ' '${bold}Helpless!$reset' r'\n$'));
+          matches('^$red' r'\[ (?: {0,2}\+[0-9]{1,3} ms|       )\] ' '${bold}Helpless!$resetBold$resetColor' r'\n$'));
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
     });
   });
 
@@ -109,8 +114,8 @@ void main() {
           ansiSpinner.cancel();
         }, throwsA(isInstanceOf<AssertionError>()));
       }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
         Platform: () => FakePlatform(operatingSystem: testOs),
+        Stdio: () => mockStdio,
       });
 
       testUsingContext('Stdout startProgress handle null inputs on colored terminal for $testOs', () async {
@@ -125,9 +130,10 @@ void main() {
         expect(outputStderr().first, isEmpty);
         expect(lines[0], matches(platform.isWindows ? r'[ ]{64} [\b]-' : r'[ ]{64} [\b]⣾'));
       }, overrides: <Type, Generator>{
+        Logger: () => StdoutLogger(),
+        OutputPreferences: () => OutputPreferences(showColor: true),
+        Platform: () => FakePlatform(operatingSystem: testOs)..stdoutSupportsAnsi = true,
         Stdio: () => mockStdio,
-        Platform: () => FakePlatform(operatingSystem: testOs),
-        Logger: () => StdoutLogger()..supportsColor = true,
       });
 
       testUsingContext('AnsiStatus works when cancelled for $testOs', () async {
@@ -154,8 +160,8 @@ void main() {
         expect(() { ansiStatus.cancel(); }, throwsA(isInstanceOf<AssertionError>()));
         expect(() { ansiStatus.stop(); }, throwsA(isInstanceOf<AssertionError>()));
       }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
         Platform: () => FakePlatform(operatingSystem: testOs),
+        Stdio: () => mockStdio,
       });
 
       testUsingContext('AnsiStatus works when stopped for $testOs', () async {
@@ -183,8 +189,8 @@ void main() {
         expect(() { ansiStatus.stop(); }, throwsA(isInstanceOf<AssertionError>()));
         expect(() { ansiStatus.cancel(); }, throwsA(isInstanceOf<AssertionError>()));
       }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
         Platform: () => FakePlatform(operatingSystem: testOs),
+        Stdio: () => mockStdio,
       });
     }
   });
@@ -218,9 +224,9 @@ void main() {
       expect(lines[2], equals('0123456789' * 4));
       expect(lines[3], equals('0123456789' * 3));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Error logs are wrapped and can be indented.', () async {
@@ -236,9 +242,9 @@ void main() {
       expect(lines[4], equals('     0123456789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Error logs are wrapped and can have hanging indent.', () async {
@@ -254,9 +260,9 @@ void main() {
       expect(lines[4], equals('     56789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Error logs are wrapped, indented, and can have hanging indent.', () async {
@@ -272,9 +278,9 @@ void main() {
       expect(lines[4], equals('         901234567890123456789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Stdout logs are wrapped', () async {
@@ -287,9 +293,9 @@ void main() {
       expect(lines[2], equals('0123456789' * 4));
       expect(lines[3], equals('0123456789' * 3));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Stdout logs are wrapped and can be indented.', () async {
@@ -305,9 +311,9 @@ void main() {
       expect(lines[4], equals('     0123456789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Stdout logs are wrapped and can have hanging indent.', () async {
@@ -323,9 +329,9 @@ void main() {
       expect(lines[4], equals('     56789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Stdout logs are wrapped, indented, and can have hanging indent.', () async {
@@ -341,9 +347,9 @@ void main() {
       expect(lines[4], equals('         901234567890123456789'));
       expect(lines[5], isEmpty);
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40, showColor: false),
       Stdio: () => mockStdio,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Error logs are red', () async {
@@ -351,10 +357,12 @@ void main() {
       final List<String> lines = outputStderr();
       expect(outputStdout().length, equals(1));
       expect(outputStdout().first, isEmpty);
-      expect(lines[0], equals('${AnsiTerminal.red}Pants on fire!${AnsiTerminal.reset}'));
+      expect(lines[0], equals('${AnsiTerminal.red}Pants on fire!${AnsiTerminal.resetColor}'));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = true,
     });
 
     testUsingContext('Stdout logs are not colored', () async {
@@ -364,8 +372,9 @@ void main() {
       expect(outputStderr().first, isEmpty);
       expect(lines[0], equals('All good.'));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: true),
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = true,
     });
 
     testUsingContext('Stdout printStatus handle null inputs on colored terminal', () async {
@@ -375,8 +384,9 @@ void main() {
       expect(outputStderr().first, isEmpty);
       expect(lines[0], equals(''));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: true),
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = true,
     });
 
     testUsingContext('Stdout printStatus handle null inputs on regular terminal', () async {
@@ -386,8 +396,9 @@ void main() {
       expect(outputStderr().first, isEmpty);
       expect(lines[0], equals(''));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: false),
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('Stdout startProgress handle null inputs on regular terminal', () async {
@@ -402,8 +413,9 @@ void main() {
       expect(outputStderr().first, isEmpty);
       expect(lines[0], matches('[ ]{64}'));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: false),
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('SummaryStatus works when cancelled', () async {
@@ -458,8 +470,9 @@ void main() {
       expect(outputStdout()[0], matches(RegExp(r'AAA[ ]{60}[\d ]{3}[\d]ms')));
       expect(outputStdout()[1], matches(RegExp(r'BBB[ ]{60}[\d ]{3}[\d]ms')));
     }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      OutputPreferences: () => OutputPreferences(showColor: false),
       Stdio: () => mockStdio,
-      Logger: () => StdoutLogger()..supportsColor = false,
     });
 
     testUsingContext('sequential startProgress calls with VerboseLogger and StdoutLogger', () async {
@@ -473,8 +486,8 @@ void main() {
         matches(r'^$'),
       ]);
     }, overrides: <Type, Generator>{
-      Stdio: () => mockStdio,
       Logger: () => VerboseLogger(StdoutLogger()),
+      Stdio: () => mockStdio,
     });
 
     testUsingContext('sequential startProgress calls with BufferLogger', () async {

--- a/packages/flutter_tools/test/base/terminal_test.dart
+++ b/packages/flutter_tools/test/base/terminal_test.dart
@@ -4,12 +4,31 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/globals.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
+  group('output preferences', () {
+    testUsingContext('can wrap output', () async {
+      printStatus('0123456789' * 8);
+      expect(testLogger.statusText, equals(('0123456789' * 4 + '\n') * 2));
+    }, overrides: <Type, Generator>{
+      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
+    });
+
+    testUsingContext('can turn off wrapping', () async {
+      final String testString = '0123456789' * 20;
+      printStatus(testString);
+      expect(testLogger.statusText, equals('$testString\n'));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
+    });
+  });
   group('character input prompt', () {
     AnsiTerminal terminalUnderTest;
 
@@ -23,38 +42,34 @@ void main() {
         Future<String>.value('\n'), // Not in accepted list
         Future<String>.value('b'),
       ]).asBroadcastStream();
-      final String choice =
-          await terminalUnderTest.promptForCharInput(
-            <String>['a', 'b', 'c'],
-            prompt: 'Please choose something',
-          );
+      final String choice = await terminalUnderTest.promptForCharInput(
+        <String>['a', 'b', 'c'],
+        prompt: 'Please choose something',
+      );
       expect(choice, 'b');
       expect(
-        testLogger.statusText,
-        'Please choose something [a|b|c]: d\n'
-        'Please choose something [a|b|c]: \n'
-        '\n'
-        'Please choose something [a|b|c]: b\n'
-      );
+          testLogger.statusText,
+          'Please choose something [a|b|c]: d\n'
+          'Please choose something [a|b|c]: \n'
+          '\n'
+          'Please choose something [a|b|c]: b\n');
     });
 
     testUsingContext('default character choice without displayAcceptedCharacters', () async {
       mockStdInStream = Stream<String>.fromFutures(<Future<String>>[
         Future<String>.value('\n'), // Not in accepted list
       ]).asBroadcastStream();
-      final String choice =
-          await terminalUnderTest.promptForCharInput(
-            <String>['a', 'b', 'c'],
-            prompt: 'Please choose something',
-            displayAcceptedCharacters: false,
-            defaultChoiceIndex: 1, // which is b.
-          );
+      final String choice = await terminalUnderTest.promptForCharInput(
+        <String>['a', 'b', 'c'],
+        prompt: 'Please choose something',
+        displayAcceptedCharacters: false,
+        defaultChoiceIndex: 1, // which is b.
+      );
       expect(choice, 'b');
       expect(
-        testLogger.statusText,
-        'Please choose something: \n'
-        '\n'
-      );
+          testLogger.statusText,
+          'Please choose something: \n'
+          '\n');
     });
   });
 }

--- a/packages/flutter_tools/test/base/terminal_test.dart
+++ b/packages/flutter_tools/test/base/terminal_test.dart
@@ -29,6 +29,93 @@ void main() {
       OutputPreferences: () => OutputPreferences(wrapText: false),
     });
   });
+
+  group('ANSI coloring and bold', () {
+    AnsiTerminal terminal;
+
+    setUp(() {
+      terminal = AnsiTerminal();
+    });
+
+    testUsingContext('adding colors works', () {
+      for (TerminalColor color in TerminalColor.values) {
+        expect(
+          terminal.color('output', color),
+          equals('${AnsiTerminal.colorCode(color)}output${AnsiTerminal.resetColor}'),
+        );
+      }
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+
+    testUsingContext('adding bold works', () {
+      expect(
+        terminal.bolden('output'),
+        equals('${AnsiTerminal.bold}output${AnsiTerminal.resetBold}'),
+      );
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+
+    testUsingContext('nesting bold within color works', () {
+      expect(
+        terminal.color(terminal.bolden('output'), TerminalColor.blue),
+        equals('${AnsiTerminal.blue}${AnsiTerminal.bold}output${AnsiTerminal.resetBold}${AnsiTerminal.resetColor}'),
+      );
+      expect(
+        terminal.color('non-bold ${terminal.bolden('output')} also non-bold', TerminalColor.blue),
+        equals('${AnsiTerminal.blue}non-bold ${AnsiTerminal.bold}output${AnsiTerminal.resetBold} also non-bold${AnsiTerminal.resetColor}'),
+      );
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+
+    testUsingContext('nesting color within bold works', () {
+      expect(
+        terminal.bolden(terminal.color('output', TerminalColor.blue)),
+        equals('${AnsiTerminal.bold}${AnsiTerminal.blue}output${AnsiTerminal.resetColor}${AnsiTerminal.resetBold}'),
+      );
+      expect(
+        terminal.bolden('non-color ${terminal.color('output', TerminalColor.blue)} also non-color'),
+        equals('${AnsiTerminal.bold}non-color ${AnsiTerminal.blue}output${AnsiTerminal.resetColor} also non-color${AnsiTerminal.resetBold}'),
+      );
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+
+    testUsingContext('nesting color within color works', () {
+      expect(
+        terminal.color(terminal.color('output', TerminalColor.blue), TerminalColor.magenta),
+        equals('${AnsiTerminal.magenta}${AnsiTerminal.blue}output${AnsiTerminal.resetColor}${AnsiTerminal.magenta}${AnsiTerminal.resetColor}'),
+      );
+      expect(
+        terminal.color('magenta ${terminal.color('output', TerminalColor.blue)} also magenta', TerminalColor.magenta),
+        equals('${AnsiTerminal.magenta}magenta ${AnsiTerminal.blue}output${AnsiTerminal.resetColor}${AnsiTerminal.magenta} also magenta${AnsiTerminal.resetColor}'),
+      );
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+
+    testUsingContext('nesting bold within bold works', () {
+      expect(
+        terminal.bolden(terminal.bolden('output')),
+        equals('${AnsiTerminal.bold}output${AnsiTerminal.resetBold}'),
+      );
+      expect(
+        terminal.bolden('bold ${terminal.bolden('output')} still bold'),
+        equals('${AnsiTerminal.bold}bold output still bold${AnsiTerminal.resetBold}'),
+      );
+    }, overrides: <Type, Generator> {
+      OutputPreferences: () => OutputPreferences(showColor: true),
+      Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+    });
+  });
+
   group('character input prompt', () {
     AnsiTerminal terminalUnderTest;
 

--- a/packages/flutter_tools/test/commands/analyze_once_test.dart
+++ b/packages/flutter_tools/test/commands/analyze_once_test.dart
@@ -41,7 +41,7 @@ void main() {
     testUsingContext('flutter create', () async {
       await runCommand(
         command: CreateCommand(),
-        arguments: <String>['create', projectPath],
+        arguments: <String>['--no-wrap', 'create', projectPath],
         statusTextContains: <String>[
           'All done!',
           'Your application code is in ${fs.path.normalize(fs.path.join(fs.path.relative(projectPath), 'lib', 'main.dart'))}',

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
 import 'package:flutter_tools/src/vscode/vscode_validator.dart';
@@ -132,7 +133,7 @@ void main() {
               '[!] Partial Validator with only a Hint\n'
               '    ! There is a hint here\n'
               '[!] Partial Validator with Errors\n'
-              '    ✗ A error message indicating partial installation\n'
+              '    ✗ An error message indicating partial installation\n'
               '    ! Maybe a hint will help the user\n'
               '[✓] Another Passing Validator (with statusInfo)\n'
               '\n'
@@ -154,7 +155,7 @@ void main() {
               '[!] Partial Validator with only a Hint\n'
               '    ! There is a hint here\n'
               '[!] Partial Validator with Errors\n'
-              '    ✗ A error message indicating partial installation\n'
+              '    ✗ An error message indicating partial installation\n'
               '    ! Maybe a hint will help the user\n'
               '\n'
               '! Doctor found issues in 4 categories.\n'
@@ -183,7 +184,7 @@ void main() {
               '    • But there is no error\n'
               '\n'
               '[!] Partial Validator with Errors\n'
-              '    ✗ A error message indicating partial installation\n'
+              '    ✗ An error message indicating partial installation\n'
               '    ! Maybe a hint will help the user\n'
               '    • An extra message with some verbose details\n'
               '\n'
@@ -191,6 +192,84 @@ void main() {
       ));
     });
   });
+
+  testUsingContext('validate non-verbose output wrapping', () async {
+    expect(await FakeDoctor().diagnose(verbose: false), isFalse);
+    expect(testLogger.statusText, equals(
+        'Doctor summary (to see all\n'
+        'details, run flutter doctor\n'
+        '-v):\n'
+        '[✓] Passing Validator (with\n'
+        '    statusInfo)\n'
+        '[✗] Missing Validator\n'
+        '    ✗ A useful error message\n'
+        '    ! A hint message\n'
+        '[!] Not Available Validator\n'
+        '    ✗ A useful error message\n'
+        '    ! A hint message\n'
+        '[!] Partial Validator with\n'
+        '    only a Hint\n'
+        '    ! There is a hint here\n'
+        '[!] Partial Validator with\n'
+        '    Errors\n'
+        '    ✗ An error message\n'
+        '      indicating partial\n'
+        '      installation\n'
+        '    ! Maybe a hint will help\n'
+        '      the user\n'
+        '\n'
+        '! Doctor found issues in 4\n'
+        '  categories.\n'
+        ''
+    ));
+  }, overrides: <Type, Generator>{
+    OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 30),
+  });
+
+  testUsingContext('validate verbose output wrapping', () async {
+    expect(await FakeDoctor().diagnose(verbose: true), isFalse);
+    expect(testLogger.statusText, equals(
+        '[✓] Passing Validator (with\n'
+        '    statusInfo)\n'
+        '    • A helpful message\n'
+        '    • A second, somewhat\n'
+        '      longer helpful message\n'
+        '\n'
+        '[✗] Missing Validator\n'
+        '    ✗ A useful error message\n'
+        '    • A message that is not an\n'
+        '      error\n'
+        '    ! A hint message\n'
+        '\n'
+        '[!] Not Available Validator\n'
+        '    ✗ A useful error message\n'
+        '    • A message that is not an\n'
+        '      error\n'
+        '    ! A hint message\n'
+        '\n'
+        '[!] Partial Validator with\n'
+        '    only a Hint\n'
+        '    ! There is a hint here\n'
+        '    • But there is no error\n'
+        '\n'
+        '[!] Partial Validator with\n'
+        '    Errors\n'
+        '    ✗ An error message\n'
+        '      indicating partial\n'
+        '      installation\n'
+        '    ! Maybe a hint will help\n'
+        '      the user\n'
+        '    • An extra message with\n'
+        '      some verbose details\n'
+        '\n'
+        '! Doctor found issues in 4\n'
+        '  categories.\n'
+        ''
+    ));
+  }, overrides: <Type, Generator>{
+    OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 30),
+  });
+
 
   group('doctor with grouped validators', () {
     testUsingContext('validate diagnose combines validator output', () async {
@@ -328,7 +407,7 @@ class PartialValidatorWithErrors extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
-    messages.add(ValidationMessage.error('A error message indicating partial installation'));
+    messages.add(ValidationMessage.error('An error message indicating partial installation'));
     messages.add(ValidationMessage.hint('Maybe a hint will help the user'));
     messages.add(ValidationMessage('An extra message with some verbose details'));
     return ValidationResult(ValidationType.partial, messages);

--- a/packages/flutter_tools/test/commands/drive_test.dart
+++ b/packages/flutter_tools/test/commands/drive_test.dart
@@ -123,6 +123,7 @@ void main() {
       final String appFile = fs.path.join(tempDir.dirname, 'other_app', 'app.dart');
       fs.file(appFile).createSync(recursive: true);
       final List<String> args = <String>[
+        '--no-wrap',
         'drive',
         '--target=$appFile',
       ];
@@ -143,6 +144,7 @@ void main() {
       final String appFile = fs.path.join(tempDir.path, 'main.dart');
       fs.file(appFile).createSync(recursive: true);
       final List<String> args = <String>[
+        '--no-wrap',
         'drive',
         '--target=$appFile',
       ];

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -54,7 +55,8 @@ void main() {
       expect(output.outputFilename, equals('/path/to/main.dart.dill'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('single dart failed compilation', () async {
@@ -75,7 +77,8 @@ void main() {
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('single dart abnormal compiler termination', () async {
@@ -98,7 +101,8 @@ void main() {
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
   });
 
@@ -153,7 +157,8 @@ void main() {
       expect(output.outputFilename, equals('/path/to/main.dart.dill'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('single dart compile abnormally terminates', () async {
@@ -167,7 +172,8 @@ void main() {
       expect(output, equals(null));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('compile and recompile', () async {
@@ -191,7 +197,8 @@ void main() {
       ));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('compile and recompile twice', () async {
@@ -220,7 +227,8 @@ void main() {
       ));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
   });
 
@@ -309,7 +317,8 @@ void main() {
 
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
 
     testUsingContext('compile expressions without awaiting', () async {
@@ -371,7 +380,8 @@ void main() {
       expect(await lastExpressionCompleted.future, isTrue);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Logger: () => BufferLogger()..supportsColor = false,
+      OutputPreferences: () => OutputPreferences(showColor: false),
+      Logger: () => BufferLogger(),
     });
   });
 }

--- a/packages/flutter_tools/test/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/ios/code_signing_test.dart
@@ -53,6 +53,8 @@ void main() {
       expect(testLogger.statusText, equals(
         'Automatically signing iOS for device deployment using specified development team in Xcode project: abc\n'
       ));
+    }, overrides: <Type, Generator>{
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('No auto-sign if security or openssl not available', () async {
@@ -88,6 +90,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test single identity and certificate organization works', () async {
@@ -147,6 +150,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test Google cert also manually selects a provisioning profile', () async {
@@ -210,6 +214,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test multiple identity and certificate organization works', () async {
@@ -284,6 +289,7 @@ void main() {
       ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test multiple identity in machine mode works', () async {
@@ -352,6 +358,7 @@ void main() {
       ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test saved certificate used', () async {
@@ -422,6 +429,7 @@ void main() {
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test invalid saved certificate shows error and prompts again', () async {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -76,7 +77,8 @@ void testUsingContext(String description, dynamic testMethod(), {
             when(mock.getAttachedDevices()).thenReturn(<IOSSimulator>[]);
             return mock;
           },
-          Logger: () => BufferLogger()..supportsColor = false,
+          OutputPreferences: () => OutputPreferences(showColor: false),
+          Logger: () => BufferLogger(),
           OperatingSystemUtils: () => MockOperatingSystemUtils(),
           SimControl: () => MockSimControl(),
           Usage: () => MockUsage(),

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 
 import 'src/common.dart';
 
@@ -177,6 +178,145 @@ baz=qux
       expect(snakeCase('AbC'), equals('ab_c'));
       expect(snakeCase('ABc'), equals('a_bc'));
       expect(snakeCase('ABC'), equals('a_b_c'));
+    });
+  });
+
+  group('text wrapping', () {
+    const int _lineLength = 40;
+    const String _longLine = 'This is a long line that needs to be wrapped.';
+    final String _longLineWithNewlines = 'This is a long line with newlines that\n'
+        'needs to be wrapped.\n\n' +
+        '0123456789' * 5;
+    final String _longAnsiLineWithNewlines = '${AnsiTerminal.red}This${AnsiTerminal.reset} is a long line with newlines that\n'
+        'needs to be wrapped.\n\n'
+        '${AnsiTerminal.green}0123456789${AnsiTerminal.reset}' +
+        '0123456789' * 3 +
+        '${AnsiTerminal.green}0123456789${AnsiTerminal.reset}';
+    const String _onlyAnsiSequences = '${AnsiTerminal.red}${AnsiTerminal.reset}';
+    final String _indentedLongLineWithNewlines = '    This is an indented long line with newlines that\n'
+        'needs to be wrapped.\n\tAnd preserves tabs.\n      \n  ' +
+        '0123456789' * 5;
+    const String _shortLine = 'Short line.';
+    const String _indentedLongLine = '    This is an indented long line that needs to be '
+        'wrapped and indentation preserved.';
+
+    test('does not wrap short lines.', () {
+      expect(wrapText(_shortLine, columnWidth: _lineLength), equals(_shortLine));
+    });
+    test('does not wrap at all if not given a length', () {
+      expect(wrapText(_longLine), equals(_longLine));
+    });
+    test('able to wrap long lines', () {
+      expect(wrapText(_longLine, columnWidth: _lineLength), equals('''
+This is a long line that needs to be
+wrapped.'''));
+    });
+    test('wrap long lines with no whitespace', () {
+      expect(wrapText('0123456789' * 5, columnWidth: _lineLength), equals('''
+0123456789012345678901234567890123456789
+0123456789'''));
+    });
+    test('refuses to wrap to a column smaller than 10 characters', () {
+      expect(wrapText('$_longLine ' + '0123456789' * 4, columnWidth: 1), equals('''
+This is a
+long line
+that needs
+to be
+wrapped.
+0123456789
+0123456789
+0123456789
+0123456789'''));
+    });
+    test('preserves indentation', () {
+      expect(wrapText(_indentedLongLine, columnWidth: _lineLength), equals('''
+    This is an indented long line that
+    needs to be wrapped and indentation
+    preserved.'''));
+    });
+    test('preserves indentation and stripping trailing whitespace', () {
+      expect(wrapText('$_indentedLongLine   ', columnWidth: _lineLength), equals('''
+    This is an indented long line that
+    needs to be wrapped and indentation
+    preserved.'''));
+    });
+    test('wraps text with newlines', () {
+      expect(wrapText(_longLineWithNewlines, columnWidth: _lineLength), equals('''
+This is a long line with newlines that
+needs to be wrapped.
+
+0123456789012345678901234567890123456789
+0123456789'''));
+    });
+    test('wraps text with ANSI sequences embedded', () {
+      expect(wrapText(_longAnsiLineWithNewlines, columnWidth: _lineLength), equals('''
+${AnsiTerminal.red}This${AnsiTerminal.reset} is a long line with newlines that
+needs to be wrapped.
+
+${AnsiTerminal.green}0123456789${AnsiTerminal.reset}012345678901234567890123456789
+${AnsiTerminal.green}0123456789${AnsiTerminal.reset}'''));
+    });
+    test('wraps text with only ANSI sequences', () {
+      expect(wrapText(_onlyAnsiSequences, columnWidth: _lineLength),
+          equals('${AnsiTerminal.red}${AnsiTerminal.reset}'));
+    });
+    test('preserves indentation in the presence of newlines', () {
+      expect(wrapText(_indentedLongLineWithNewlines, columnWidth: _lineLength), equals('''
+    This is an indented long line with
+    newlines that
+needs to be wrapped.
+\tAnd preserves tabs.
+
+  01234567890123456789012345678901234567
+  890123456789'''));
+    });
+    test('removes trailing whitespace when wrapping', () {
+      expect(wrapText('$_longLine     \t', columnWidth: _lineLength), equals('''
+This is a long line that needs to be
+wrapped.'''));
+    });
+    test('honors hangingIndent parameter', () {
+      expect(wrapText(_longLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
+This is a long line that needs to be
+      wrapped.'''));
+    });
+    test('handles hangingIndent with a single unwrapped line.', () {
+      expect(wrapText(_shortLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
+Short line.'''));
+    });
+    test('handles hangingIndent with two unwrapped lines and the second is empty.', () {
+      expect(wrapText('$_shortLine\n', columnWidth: _lineLength, hangingIndent: 6), equals('''
+Short line.
+'''));
+    });
+    test('honors hangingIndent parameter on already indented line.', () {
+      expect(wrapText(_indentedLongLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
+    This is an indented long line that
+          needs to be wrapped and
+          indentation preserved.'''));
+    });
+    test('honors hangingIndent and indent parameters at the same time.', () {
+      expect(wrapText(_indentedLongLine, columnWidth: _lineLength, indent: 6, hangingIndent: 6), equals('''
+          This is an indented long line
+                that needs to be wrapped
+                and indentation
+                preserved.'''));
+    });
+    test('honors indent parameter on already indented line.', () {
+      expect(wrapText(_indentedLongLine, columnWidth: _lineLength, indent: 6), equals('''
+          This is an indented long line
+          that needs to be wrapped and
+          indentation preserved.'''));
+    });
+    test('honors hangingIndent parameter on already indented line.', () {
+      expect(wrapText(_indentedLongLineWithNewlines, columnWidth: _lineLength, hangingIndent: 6), equals('''
+    This is an indented long line with
+          newlines that
+needs to be wrapped.
+	And preserves tabs.
+
+  01234567890123456789012345678901234567
+        890123456789'''));
     });
   });
 }

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -187,12 +187,12 @@ baz=qux
     final String _longLineWithNewlines = 'This is a long line with newlines that\n'
         'needs to be wrapped.\n\n' +
         '0123456789' * 5;
-    final String _longAnsiLineWithNewlines = '${AnsiTerminal.red}This${AnsiTerminal.reset} is a long line with newlines that\n'
+    final String _longAnsiLineWithNewlines = '${AnsiTerminal.red}This${AnsiTerminal.resetAll} is a long line with newlines that\n'
         'needs to be wrapped.\n\n'
-        '${AnsiTerminal.green}0123456789${AnsiTerminal.reset}' +
+        '${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}' +
         '0123456789' * 3 +
-        '${AnsiTerminal.green}0123456789${AnsiTerminal.reset}';
-    const String _onlyAnsiSequences = '${AnsiTerminal.red}${AnsiTerminal.reset}';
+        '${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}';
+    const String _onlyAnsiSequences = '${AnsiTerminal.red}${AnsiTerminal.resetAll}';
     final String _indentedLongLineWithNewlines = '    This is an indented long line with newlines that\n'
         'needs to be wrapped.\n\tAnd preserves tabs.\n      \n  ' +
         '0123456789' * 5;
@@ -250,15 +250,15 @@ needs to be wrapped.
     });
     test('wraps text with ANSI sequences embedded', () {
       expect(wrapText(_longAnsiLineWithNewlines, columnWidth: _lineLength), equals('''
-${AnsiTerminal.red}This${AnsiTerminal.reset} is a long line with newlines that
+${AnsiTerminal.red}This${AnsiTerminal.resetAll} is a long line with newlines that
 needs to be wrapped.
 
-${AnsiTerminal.green}0123456789${AnsiTerminal.reset}012345678901234567890123456789
-${AnsiTerminal.green}0123456789${AnsiTerminal.reset}'''));
+${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}012345678901234567890123456789
+${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}'''));
     });
     test('wraps text with only ANSI sequences', () {
       expect(wrapText(_onlyAnsiSequences, columnWidth: _lineLength),
-          equals('${AnsiTerminal.red}${AnsiTerminal.reset}'));
+          equals('${AnsiTerminal.red}${AnsiTerminal.resetAll}'));
     });
     test('preserves indentation in the presence of newlines', () {
       expect(wrapText(_indentedLongLineWithNewlines, columnWidth: _lineLength), equals('''

--- a/packages/flutter_tools/test/utils_test.dart
+++ b/packages/flutter_tools/test/utils_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 
 import 'src/common.dart';
+import 'src/context.dart';
 
 void main() {
   group('SettingsFile', () {
@@ -200,23 +201,37 @@ baz=qux
     const String _indentedLongLine = '    This is an indented long line that needs to be '
         'wrapped and indentation preserved.';
 
-    test('does not wrap short lines.', () {
-      expect(wrapText(_shortLine, columnWidth: _lineLength), equals(_shortLine));
-    });
-    test('does not wrap at all if not given a length', () {
+    void testWrap(String description,  Function body) {
+      testUsingContext(description, body, overrides: <Type, Generator> {
+        OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: _lineLength),
+      });
+    }
+    void testNoWrap(String description,  Function body) {
+      testUsingContext(description, body, overrides: <Type, Generator> {
+        OutputPreferences: () => OutputPreferences(wrapText: false),
+      });
+    }
+
+    test('does not wrap by default in tests', () {
       expect(wrapText(_longLine), equals(_longLine));
     });
-    test('able to wrap long lines', () {
+    testNoWrap('does not wrap at all if not told to wrap', () {
+      expect(wrapText(_longLine), equals(_longLine));
+    });
+    testWrap('does not wrap short lines.', () {
+      expect(wrapText(_shortLine, columnWidth: _lineLength), equals(_shortLine));
+    });
+    testWrap('able to wrap long lines', () {
       expect(wrapText(_longLine, columnWidth: _lineLength), equals('''
 This is a long line that needs to be
 wrapped.'''));
     });
-    test('wrap long lines with no whitespace', () {
+    testWrap('wrap long lines with no whitespace', () {
       expect(wrapText('0123456789' * 5, columnWidth: _lineLength), equals('''
 0123456789012345678901234567890123456789
 0123456789'''));
     });
-    test('refuses to wrap to a column smaller than 10 characters', () {
+    testWrap('refuses to wrap to a column smaller than 10 characters', () {
       expect(wrapText('$_longLine ' + '0123456789' * 4, columnWidth: 1), equals('''
 This is a
 long line
@@ -228,19 +243,19 @@ wrapped.
 0123456789
 0123456789'''));
     });
-    test('preserves indentation', () {
+    testWrap('preserves indentation', () {
       expect(wrapText(_indentedLongLine, columnWidth: _lineLength), equals('''
     This is an indented long line that
     needs to be wrapped and indentation
     preserved.'''));
     });
-    test('preserves indentation and stripping trailing whitespace', () {
+    testWrap('preserves indentation and stripping trailing whitespace', () {
       expect(wrapText('$_indentedLongLine   ', columnWidth: _lineLength), equals('''
     This is an indented long line that
     needs to be wrapped and indentation
     preserved.'''));
     });
-    test('wraps text with newlines', () {
+    testWrap('wraps text with newlines', () {
       expect(wrapText(_longLineWithNewlines, columnWidth: _lineLength), equals('''
 This is a long line with newlines that
 needs to be wrapped.
@@ -248,7 +263,7 @@ needs to be wrapped.
 0123456789012345678901234567890123456789
 0123456789'''));
     });
-    test('wraps text with ANSI sequences embedded', () {
+    testWrap('wraps text with ANSI sequences embedded', () {
       expect(wrapText(_longAnsiLineWithNewlines, columnWidth: _lineLength), equals('''
 ${AnsiTerminal.red}This${AnsiTerminal.resetAll} is a long line with newlines that
 needs to be wrapped.
@@ -256,11 +271,11 @@ needs to be wrapped.
 ${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}012345678901234567890123456789
 ${AnsiTerminal.green}0123456789${AnsiTerminal.resetAll}'''));
     });
-    test('wraps text with only ANSI sequences', () {
+    testWrap('wraps text with only ANSI sequences', () {
       expect(wrapText(_onlyAnsiSequences, columnWidth: _lineLength),
           equals('${AnsiTerminal.red}${AnsiTerminal.resetAll}'));
     });
-    test('preserves indentation in the presence of newlines', () {
+    testWrap('preserves indentation in the presence of newlines', () {
       expect(wrapText(_indentedLongLineWithNewlines, columnWidth: _lineLength), equals('''
     This is an indented long line with
     newlines that
@@ -270,45 +285,45 @@ needs to be wrapped.
   01234567890123456789012345678901234567
   890123456789'''));
     });
-    test('removes trailing whitespace when wrapping', () {
+    testWrap('removes trailing whitespace when wrapping', () {
       expect(wrapText('$_longLine     \t', columnWidth: _lineLength), equals('''
 This is a long line that needs to be
 wrapped.'''));
     });
-    test('honors hangingIndent parameter', () {
+    testWrap('honors hangingIndent parameter', () {
       expect(wrapText(_longLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
 This is a long line that needs to be
       wrapped.'''));
     });
-    test('handles hangingIndent with a single unwrapped line.', () {
+    testWrap('handles hangingIndent with a single unwrapped line.', () {
       expect(wrapText(_shortLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
 Short line.'''));
     });
-    test('handles hangingIndent with two unwrapped lines and the second is empty.', () {
+    testWrap('handles hangingIndent with two unwrapped lines and the second is empty.', () {
       expect(wrapText('$_shortLine\n', columnWidth: _lineLength, hangingIndent: 6), equals('''
 Short line.
 '''));
     });
-    test('honors hangingIndent parameter on already indented line.', () {
+    testWrap('honors hangingIndent parameter on already indented line.', () {
       expect(wrapText(_indentedLongLine, columnWidth: _lineLength, hangingIndent: 6), equals('''
     This is an indented long line that
           needs to be wrapped and
           indentation preserved.'''));
     });
-    test('honors hangingIndent and indent parameters at the same time.', () {
+    testWrap('honors hangingIndent and indent parameters at the same time.', () {
       expect(wrapText(_indentedLongLine, columnWidth: _lineLength, indent: 6, hangingIndent: 6), equals('''
           This is an indented long line
                 that needs to be wrapped
                 and indentation
                 preserved.'''));
     });
-    test('honors indent parameter on already indented line.', () {
+    testWrap('honors indent parameter on already indented line.', () {
       expect(wrapText(_indentedLongLine, columnWidth: _lineLength, indent: 6), equals('''
           This is an indented long line
           that needs to be wrapped and
           indentation preserved.'''));
     });
-    test('honors hangingIndent parameter on already indented line.', () {
+    testWrap('honors hangingIndent parameter on already indented line.', () {
       expect(wrapText(_indentedLongLineWithNewlines, columnWidth: _lineLength, hangingIndent: 6), equals('''
     This is an indented long line with
           newlines that


### PR DESCRIPTION
This attempts to re-land #22656.

There are two changes from the original:
1. I turned off wrapping completely when not sending output to a terminal. Previously I had defaulted to wrapping at and arbitrary 100 chars in that case, just to keep long messages from being too long, but that turns out the be a bad idea because there are tests that are relying on the specific form of the output. It's also pretty arbitrary, and mostly people sending output to a non-terminal will want unwrapped text.

2. I found a better way to terminate ANSI color/bold sequences, so that they can be embedded within each other without needed quite as complex a dance with removing redundant sequences.

As part of these changes, I removed the `Logger.supportsColor` setter so that the one source of truth for color support is in ` AnsiTerminal.supportsColor`.