### PR TITLE
Add a profile build type to the app template

### DIFF
--- a/packages/flutter_tools/templates/application/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/application/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -14,6 +14,9 @@ android {
     }
 
     buildTypes {
+        profile {
+            initWith debug
+        }
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.


### PR DESCRIPTION
This is required in order to support "flutter run --profile"