### PR TITLE
Use new `mixin` syntax for super-mixins

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,8 +19,6 @@
 # Android Studio, and the `flutter analyze` command.
 
 analyzer:
-  language:
-    enableSuperMixins: true
   strong-mode:
     implicit-dynamic: false
   errors:
@@ -134,6 +132,7 @@ linter:
     - prefer_is_empty
     - prefer_is_not_empty
     - prefer_iterable_whereType
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     - prefer_single_quotes
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null

--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   intl: 0.15.7
   connectivity: 0.3.2
   string_scanner: 1.0.4
-  url_launcher: 4.0.0
+  url_launcher: 3.0.3
   cupertino_icons: 0.1.2
   video_player: 0.6.5
 
@@ -196,4 +196,4 @@ flutter:
         - asset: packages/flutter_gallery_assets/fonts/private/googlesans/GoogleSansDisplay-Regular.ttf
           weight: 400
 
-# PUBSPEC CHECKSUM: 46d3
+# PUBSPEC CHECKSUM: 3ed5

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -21,8 +21,6 @@
 # When editing, make sure you keep this and /analysis_options.yaml consistent.
 
 analyzer:
-  language:
-    enableSuperMixins: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
@@ -66,6 +64,7 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_is_not_empty
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     # - public_member_api_docs
     - slash_for_doc_comments
     # - sort_constructors_first

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -120,11 +120,7 @@ class AlwaysStoppedAnimation<T> extends Animation<T> {
 ///
 /// To define a mapping from values in the range 0..1, consider subclassing
 /// [Tween] instead.
-abstract class AnimationWithParentMixin<T> {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AnimationWithParentMixin._() => null;
-
+mixin AnimationWithParentMixin<T> {
   /// The animation whose value this animation will proxy.
   ///
   /// This animation must remain the same for the lifetime of this object. If

--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -13,11 +13,7 @@ import 'animation.dart';
 /// This mixin provides implementations of [didRegisterListener] and [didUnregisterListener],
 /// and therefore can be used in conjunction with mixins that require these methods,
 /// [AnimationLocalListenersMixin] and [AnimationLocalStatusListenersMixin].
-abstract class AnimationLazyListenerMixin {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AnimationLazyListenerMixin._() => null;
-
+mixin AnimationLazyListenerMixin {
   int _listenerCounter = 0;
 
   /// Calls [didStartListening] every time a registration of a listener causes
@@ -66,11 +62,7 @@ abstract class AnimationLazyListenerMixin {
 /// This mixin provides implementations of [didRegisterListener] and [didUnregisterListener],
 /// and therefore can be used in conjunction with mixins that require these methods,
 /// [AnimationLocalListenersMixin] and [AnimationLocalStatusListenersMixin].
-abstract class AnimationEagerListenerMixin {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AnimationEagerListenerMixin._() => null;
-
+mixin AnimationEagerListenerMixin {
   /// This implementation ignores listener registrations.
   void didRegisterListener() { }
 
@@ -89,11 +81,7 @@ abstract class AnimationEagerListenerMixin {
 /// This mixin requires that the mixing class provide methods [didRegisterListener]
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
-abstract class AnimationLocalListenersMixin {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AnimationLocalListenersMixin._() => null;
-
+mixin AnimationLocalListenersMixin {
   final ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
 
   /// Called immediately before a listener is added via [addListener].
@@ -157,11 +145,7 @@ abstract class AnimationLocalListenersMixin {
 /// This mixin requires that the mixing class provide methods [didRegisterListener]
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
-abstract class AnimationLocalStatusListenersMixin {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AnimationLocalStatusListenersMixin._() => null;
-
+mixin AnimationLocalStatusListenersMixin {
   final ObserverList<AnimationStatusListener> _statusListeners = ObserverList<AnimationStatusListener>();
 
   /// Called immediately before a status listener is added via [addStatusListener].

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -27,7 +27,7 @@ typedef ServiceExtensionCallback = Future<Map<String, dynamic>> Function(Map<Str
 /// Base class for mixins that provide singleton services (also known as
 /// "bindings").
 ///
-/// To use this class in a mixin, inherit from it and implement
+/// To use this class in an `on` clause of a mixin, inherit from it and implement
 /// [initInstances()]. The mixin is guaranteed to only be constructed once in
 /// the lifetime of the app (more precisely, it will assert if constructed twice
 /// in checked mode).

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2355,8 +2355,7 @@ abstract class Diagnosticable {
 ///
 /// See also:
 ///
-///  * [DiagnosticableTreeMixin], which provides a mixin that implements this
-///    class.
+///  * [DiagnosticableTreeMixin], a mixin that implements this class.
 ///  * [Diagnosticable], which should be used instead of this class to provide
 ///    diagnostics for objects without children.
 abstract class DiagnosticableTree extends Diagnosticable {
@@ -2455,16 +2454,10 @@ abstract class DiagnosticableTree extends Diagnosticable {
   List<DiagnosticsNode> debugDescribeChildren() => const <DiagnosticsNode>[];
 }
 
-/// A class that can be used as a mixin that helps dump string and
-/// [DiagnosticsNode] representations of trees.
+/// A mixin that helps dump string and [DiagnosticsNode] representations of trees.
 ///
-/// This class is identical to DiagnosticableTree except that it can be used as
-/// a mixin.
-abstract class DiagnosticableTreeMixin implements DiagnosticableTree {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory DiagnosticableTreeMixin._() => null;
-
+/// This mixin is identical to class [DiagnosticableTree].
+mixin DiagnosticableTreeMixin implements DiagnosticableTree {
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.debug }) {
     return toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -16,11 +16,7 @@ import 'hit_test.dart';
 import 'pointer_router.dart';
 
 /// A binding for the gesture subsystem.
-abstract class GestureBinding extends BindingBase with HitTestable, HitTestDispatcher, HitTestTarget {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory GestureBinding._() => null;
-
+mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, HitTestTarget {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -16,11 +16,7 @@ const double _kDefaultDecodedCacheRatioCap = 25.0;
 /// Hooks into the cache eviction logic to clear the image cache.
 ///
 /// Requires the [ServicesBinding] to be mixed in earlier.
-abstract class PaintingBinding extends BindingBase with ServicesBinding {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory PaintingBinding._() => null;
-
+mixin PaintingBinding on BindingBase, ServicesBinding {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -21,11 +21,7 @@ import 'view.dart';
 export 'package:flutter/gestures.dart' show HitTestResult;
 
 /// The glue between the render tree and the Flutter engine.
-abstract class RendererBinding extends BindingBase with ServicesBinding, SchedulerBinding, SemanticsBinding, HitTestable {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory RendererBinding._() => null;
-
+mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, SemanticsBinding, HitTestable {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2178,11 +2178,7 @@ abstract class RenderBox extends RenderObject {
 /// By convention, this class doesn't override any members of the superclass.
 /// Instead, it provides helpful functions that subclasses can call as
 /// appropriate.
-abstract class RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataType extends ContainerBoxParentData<ChildType>> implements ContainerRenderObjectMixin<ChildType, ParentDataType> {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory RenderBoxContainerDefaultsMixin._() => null;
-
+mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataType extends ContainerBoxParentData<ChildType>> implements ContainerRenderObjectMixin<ChildType, ParentDataType> {
   /// Returns the baseline of the first child with a baseline.
   ///
   /// Useful when the children are displayed vertically in the same order they

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -86,11 +86,7 @@ class _OverflowRegionData {
 ///
 ///   * The code for [RenderUnconstrainedBox] and [RenderFlex] for examples of
 ///     classes that use this indicator mixin.
-abstract class DebugOverflowIndicatorMixin extends RenderObject {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory DebugOverflowIndicatorMixin._() => null;
-
+mixin DebugOverflowIndicatorMixin on RenderObject {
   static const Color _black = Color(0xBF000000);
   static const Color _yellow = Color(0xBFFFFF00);
   // The fraction of the container that the indicator covers.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2670,10 +2670,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 /// Generic mixin for render objects with one child.
 ///
 /// Provides a child model for a render object subclass that has a unique child.
-abstract class RenderObjectWithChildMixin<ChildType extends RenderObject> extends RenderObject {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory RenderObjectWithChildMixin._() => null;
+mixin RenderObjectWithChildMixin<ChildType extends RenderObject> on RenderObject {
 
   /// Checks whether the given render object has the correct [runtimeType] to be
   /// a child of this render object.
@@ -2749,11 +2746,7 @@ abstract class RenderObjectWithChildMixin<ChildType extends RenderObject> extend
 }
 
 /// Parent data to support a doubly-linked list of children.
-abstract class ContainerParentDataMixin<ChildType extends RenderObject> extends ParentData {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory ContainerParentDataMixin._() => null;
-
+mixin ContainerParentDataMixin<ChildType extends RenderObject> on ParentData {
   /// The previous sibling in the parent's child list.
   ChildType previousSibling;
   /// The next sibling in the parent's child list.
@@ -2784,11 +2777,7 @@ abstract class ContainerParentDataMixin<ChildType extends RenderObject> extends 
 ///
 /// Provides a child model for a render object subclass that has a doubly-linked
 /// list of children.
-abstract class ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType extends ContainerParentDataMixin<ChildType>> extends RenderObject {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory ContainerRenderObjectMixin._() => null;
-
+mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType extends ContainerParentDataMixin<ChildType>> on RenderObject {
   bool _debugUltimatePreviousSiblingOf(ChildType child, { ChildType equals }) {
     ParentDataType childParentData = child.parentData;
     while (childParentData.previousSibling != null) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -49,16 +49,12 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 
 /// Implementation of [RenderProxyBox].
 ///
-/// This class can be used as a mixin for situations where the proxying behavior
+/// Use this mixin in situations where the proxying behavior
 /// of [RenderProxyBox] is desired but inheriting from [RenderProxyBox] is
 /// impractical (e.g. because you want to mix in other classes as well).
 // TODO(ianh): Remove this class once https://github.com/dart-lang/sdk/issues/31543 is fixed
 @optionalTypeArgs
-abstract class RenderProxyBoxMixin<T extends RenderBox> extends RenderBox with RenderObjectWithChildMixin<T> {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory RenderProxyBoxMixin._() => null;
-
+mixin RenderProxyBoxMixin<T extends RenderBox> on RenderBox, RenderObjectWithChildMixin<T> {
   @override
   void setupParentData(RenderObject child) {
     // We don't actually use the offset argument in BoxParentData, so let's

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -186,11 +186,7 @@ enum SchedulerPhase {
 /// * Non-rendering tasks, to be run between frames. These are given a
 ///   priority and are executed in priority order according to a
 ///   [schedulingStrategy].
-abstract class SchedulerBinding extends BindingBase with ServicesBinding {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory SchedulerBinding._() => null;
-
+mixin SchedulerBinding on BindingBase, ServicesBinding {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -12,11 +12,7 @@ export 'dart:ui' show AccessibilityFeatures;
 
 /// The glue between the semantics layer and the Flutter engine.
 // TODO(jonahwilliams): move the remaining semantic related bindings here.
-class SemanticsBinding extends BindingBase {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory SemanticsBinding._() => null;
-
+mixin SemanticsBinding on BindingBase {
   /// The current [SemanticsBinding], if one has been created.
   static SemanticsBinding get instance => _instance;
   static SemanticsBinding _instance;

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -16,11 +16,7 @@ import 'platform_messages.dart';
 /// the licenses found in the `LICENSE` file stored at the root of the asset
 /// bundle, and implements the `ext.flutter.evict` service extension (see
 /// [evict]).
-abstract class ServicesBinding extends BindingBase {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory ServicesBinding._() => null;
-
+mixin ServicesBinding on BindingBase {
   @override
   void initInstances() {
     super.initInstances();

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -341,11 +341,7 @@ class KeepAliveHandle extends ChangeNotifier {
 ///  * [AutomaticKeepAlive], which listens to messages from this mixin.
 ///  * [KeepAliveNotification], the notifications sent by this mixin.
 @optionalTypeArgs
-abstract class AutomaticKeepAliveClientMixin<T extends StatefulWidget> extends State<T> {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory AutomaticKeepAliveClientMixin._() => null;
-
+mixin AutomaticKeepAliveClientMixin<T extends StatefulWidget> on State<T> {
   KeepAliveHandle _keepAliveHandle;
 
   void _ensureKeepAlive() {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -23,6 +23,8 @@ export 'dart:ui' show AppLifecycleState, Locale;
 
 /// Interface for classes that register with the Widgets layer binding.
 ///
+/// When used as a mixin, provides noop method implementations.
+///
 /// See [WidgetsBinding.addObserver] and [WidgetsBinding.removeObserver].
 ///
 /// This class can be extended directly, to get default behaviors for all of the
@@ -239,11 +241,7 @@ abstract class WidgetsBindingObserver {
 }
 
 /// The glue between the widgets layer and the Flutter engine.
-abstract class WidgetsBinding extends BindingBase with SchedulerBinding, GestureBinding, RendererBinding {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory WidgetsBinding._() => null;
-
+mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererBinding, SemanticsBinding {
   @override
   void initInstances() {
     super.initInstances();
@@ -925,6 +923,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
 }
 
 /// A concrete binding for applications based on the Widgets framework.
+///
 /// This is the glue that binds the framework to the Flutter engine.
 class WidgetsFlutterBinding extends BindingBase with GestureBinding, ServicesBinding, SchedulerBinding, PaintingBinding, SemanticsBinding, RendererBinding, WidgetsBinding {
 

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -13,11 +13,7 @@ import 'scroll_metrics.dart';
 /// have bubbled through.
 ///
 /// This is used by [ScrollNotification] and [OverscrollIndicatorNotification].
-abstract class ViewportNotificationMixin extends Notification {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory ViewportNotificationMixin._() => null;
-
+mixin ViewportNotificationMixin on Notification {
   /// The number of viewports that this notification has bubbled through.
   ///
   /// Typically listeners only respond to notifications with a [depth] of zero.

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -251,11 +251,7 @@ abstract class _SliverPersistentHeaderRenderObjectWidget extends RenderObjectWid
   }
 }
 
-abstract class _RenderSliverPersistentHeaderForWidgetsMixin extends RenderSliverPersistentHeader {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory _RenderSliverPersistentHeaderForWidgetsMixin._() => null;
-
+mixin _RenderSliverPersistentHeaderForWidgetsMixin on RenderSliverPersistentHeader {
   _SliverPersistentHeaderElement _element;
 
   @override

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -74,11 +74,7 @@ class TickerMode extends InheritedWidget {
 /// [AnimationController] objects over the lifetime of the [State], use a full
 /// [TickerProviderStateMixin] instead.
 @optionalTypeArgs
-abstract class SingleTickerProviderStateMixin<T extends StatefulWidget> extends State<T> implements TickerProvider {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory SingleTickerProviderStateMixin._() => null;
-
+mixin SingleTickerProviderStateMixin<T extends StatefulWidget> on State<T> implements TickerProvider {
   Ticker _ticker;
 
   @override
@@ -156,11 +152,7 @@ abstract class SingleTickerProviderStateMixin<T extends StatefulWidget> extends 
 /// [AnimationController]) for the lifetime of your [State], then using a
 /// [SingleTickerProviderStateMixin] is more efficient. This is the common case.
 @optionalTypeArgs
-abstract class TickerProviderStateMixin<T extends StatefulWidget> extends State<T> implements TickerProvider {
-  // This class is intended to be used as a mixin, and should not be
-  // extended directly.
-  factory TickerProviderStateMixin._() => null;
-
+mixin TickerProviderStateMixin<T extends StatefulWidget> on State<T> implements TickerProvider {
   Set<Ticker> _tickers;
 
   @override

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -712,8 +712,8 @@ class _SerializeConfig {
   final bool expandPropertyValues;
 }
 
-class _WidgetInspectorService extends Object with WidgetInspectorService {
-}
+// Production implementation of [WidgetInspectorService].
+class _WidgetInspectorService = Object with WidgetInspectorService;
 
 /// Service used by GUI tools to interact with the [WidgetInspector].
 ///
@@ -735,11 +735,7 @@ class _WidgetInspectorService extends Object with WidgetInspectorService {
 /// widget inspector support still works with the changes.
 ///
 /// All methods returning String values return JSON.
-class WidgetInspectorService {
-  // This class is usable as a mixin for test purposes and as a singleton
-  // [instance] for production purposes.
-  factory WidgetInspectorService._() => _WidgetInspectorService();
-
+mixin WidgetInspectorService {
   /// Ring of cached JSON values to prevent json from being garbage
   /// collected before it can be requested over the Observatory protocol.
   final List<String> _serializeRing = List<String>(20);
@@ -747,7 +743,7 @@ class WidgetInspectorService {
 
   /// The current [WidgetInspectorService].
   static WidgetInspectorService get instance => _instance;
-  static WidgetInspectorService _instance = WidgetInspectorService._();
+  static WidgetInspectorService _instance = _WidgetInspectorService();
   @protected
   static set instance(WidgetInspectorService instance) {
     _instance = instance;

--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -5,10 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import '../painting/image_data.dart';
 
-class PaintingBindingSpy extends BindingBase with PaintingBinding {
+class PaintingBindingSpy extends BindingBase with ServicesBinding, PaintingBinding {
   int counter = 0;
   int get instantiateImageCodecCalledCount => counter;
 

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-class MemoryPressureObserver extends WidgetsBindingObserver {
+class MemoryPressureObserver with WidgetsBindingObserver {
   bool sawMemoryPressure = false;
 
   @override
@@ -17,7 +17,7 @@ class MemoryPressureObserver extends WidgetsBindingObserver {
   }
 }
 
-class AppLifecycleStateObserver extends WidgetsBindingObserver {
+class AppLifecycleStateObserver with WidgetsBindingObserver {
   AppLifecycleState lifecycleState;
 
   @override
@@ -26,7 +26,7 @@ class AppLifecycleStateObserver extends WidgetsBindingObserver {
   }
 }
 
-class PushRouteObserver extends WidgetsBindingObserver {
+class PushRouteObserver with WidgetsBindingObserver {
   String pushedRoute;
 
   @override

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -74,4 +74,4 @@ dev_dependencies:
   mockito: 3.0.0
   quiver: 2.0.0+1
 
-# PUBSPEC CHECKSUM: 23ea
+# PUBSPEC CHECKSUM: 11e5

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -74,4 +74,4 @@ dev_dependencies:
   mockito: 3.0.0
   quiver: 2.0.0+1
 
-# PUBSPEC CHECKSUM: 11e5
+# PUBSPEC CHECKSUM: 23ea

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -84,11 +84,11 @@ const Size _kDefaultTestViewportSize = Size(800.0, 600.0);
 /// When using these bindings, certain features are disabled. For
 /// example, [timeDilation] is reset to 1.0 on initialization.
 abstract class TestWidgetsFlutterBinding extends BindingBase
-  with SchedulerBinding,
+  with ServicesBinding,
+       SchedulerBinding,
        GestureBinding,
        SemanticsBinding,
        RendererBinding,
-       ServicesBinding,
        PaintingBinding,
        WidgetsBinding {
 

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -52,13 +52,6 @@ class AnalysisServer {
         _process.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter());
     inStream.listen(_handleServerResponse);
 
-    // Available options (many of these are obsolete):
-    //   enableAsync, enableDeferredLoading, enableEnums, enableNullAwareOperators,
-    //   enableSuperMixins, generateDart2jsHints, generateHints, generateLints
-    _sendCommand('analysis.updateOptions', <String, dynamic>{
-      'options': <String, dynamic>{'enableSuperMixins': true}
-    });
-
     _sendCommand('server.setSubscriptions', <String, dynamic>{
       'subscriptions': <String>['STATUS']
     });

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   intl: 0.15.7
   json_rpc_2: 2.0.9
   json_schema: 1.0.10
-  linter: 0.1.65
+  linter: 0.1.68
   meta: 1.1.6
   mustache: 1.0.2
   package_config: 1.0.5
@@ -90,4 +90,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 39f9
+# PUBSPEC CHECKSUM: d5fc


### PR DESCRIPTION
This re-lands https://github.com/flutter/flutter/commit/3c56e6c77dc5c351d610d5c2a11d86e8be88519f on top of a new Dart SDK that contains new `mixin` syntax fixes.
