### PR TITLE
Update dartdoc to 0.23.1.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -63,7 +63,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.21.1
+"$PUB" global activate dartdoc 0.23.1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Many changes since 0.21.1, including Dart 2.1-style mixins, @gspencergoog's tool support, and a number of bugfixes.

https://github.com/dart-lang/dartdoc/releases/tag/v0.23.1
https://github.com/dart-lang/dartdoc/releases/tag/v0.23.0
https://github.com/dart-lang/dartdoc/releases/tag/v0.22.0