### PR TITLE
Correctly throw when MaterialPageRoute's builder returns null

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -82,12 +82,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   }
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    final Widget result = Semantics(
-      scopesRoute: true,
-      explicitChildNodes: true,
-      child: builder(context),
-    );
+  Widget buildPage(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation) {
+    final Widget result = builder(context);
     assert(() {
       if (result == null) {
         throw FlutterError(
@@ -97,7 +94,11 @@ class MaterialPageRoute<T> extends PageRoute<T> {
       }
       return true;
     }());
-    return result;
+    return Semantics(
+      scopesRoute: true,
+      explicitChildNodes: true,
+      child: result,
+    );
   }
 
   @override

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -452,4 +452,22 @@ void main() {
     // Page 1 is back where it started.
     expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
   });
+
+  testWidgets('throws when builder returns null', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Text('Home'),
+    ));
+    // No exceptions yet.
+    expect(tester.takeException(), isNull);
+
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(MaterialPageRoute<void>(
+          settings: const RouteSettings(name: 'broken'),
+          builder: (BuildContext context) => null,
+        ));
+    await tester.pumpAndSettle();
+    // An exception should've been thrown because the `builder` returned null.
+    expect(tester.takeException(), isInstanceOf<FlutterError>());
+  });
 }


### PR DESCRIPTION
This logic became broken as of: https://github.com/flutter/flutter/commit/034a663d33f23a549895ecc750997ddda42282f3#diff-4b673411bff408351f353abf1b412f0fR154