### PR TITLE
[frdp] Add configurable timeouts for VM.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -20,7 +20,10 @@ final Logger _log = Logger('DartVm');
 
 /// Signature of an asynchronous function for astablishing a JSON RPC-2
 /// connection to a [Uri].
-typedef RpcPeerConnectionFunction = Future<json_rpc.Peer> Function(Uri uri);
+typedef RpcPeerConnectionFunction = Future<json_rpc.Peer> Function(
+  Uri uri, {
+  Duration timeout,
+});
 
 /// [DartVm] uses this function to connect to the Dart VM on Fuchsia.
 ///
@@ -30,16 +33,18 @@ RpcPeerConnectionFunction fuchsiaVmServiceConnectionFunction = _waitAndConnect;
 
 /// Attempts to connect to a Dart VM service.
 ///
-/// Gives up after `_kConnectTimeout` has elapsed.
-Future<json_rpc.Peer> _waitAndConnect(Uri uri) async {
+/// Gives up after `timeout` has elapsed.
+Future<json_rpc.Peer> _waitAndConnect(
+  Uri uri, {
+  Duration timeout: _kConnectTimeout,
+}) async {
   final Stopwatch timer = Stopwatch()..start();
 
   Future<json_rpc.Peer> attemptConnection(Uri uri) async {
     WebSocket socket;
     json_rpc.Peer peer;
     try {
-      socket =
-          await WebSocket.connect(uri.toString()).timeout(_kConnectTimeout);
+      socket = await WebSocket.connect(uri.toString()).timeout(timeout);
       peer = json_rpc.Peer(IOWebSocketChannel(socket).cast())..listen();
       return peer;
     } on HttpException catch (e) {
@@ -53,7 +58,7 @@ Future<json_rpc.Peer> _waitAndConnect(Uri uri) async {
       // Other unknown errors will be handled with reconnects.
       await peer?.close();
       await socket?.close();
-      if (timer.elapsed < _kConnectTimeout) {
+      if (timer.elapsed < timeout) {
         _log.info('Attempting to reconnect');
         await Future<void>.delayed(_kReconnectAttemptInterval);
         return attemptConnection(uri);
@@ -105,11 +110,15 @@ class DartVm {
   /// Attempts to connect to the given [Uri].
   ///
   /// Throws an error if unable to connect.
-  static Future<DartVm> connect(Uri uri) async {
+  static Future<DartVm> connect(
+    Uri uri, {
+    Duration timeout: _kConnectTimeout,
+  }) async {
     if (uri.scheme == 'http') {
       uri = uri.replace(scheme: 'ws', path: '/ws');
     }
-    final json_rpc.Peer peer = await fuchsiaVmServiceConnectionFunction(uri);
+    final json_rpc.Peer peer =
+        await fuchsiaVmServiceConnectionFunction(uri, timeout: timeout);
     if (peer == null) {
       return null;
     }

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -36,7 +36,7 @@ RpcPeerConnectionFunction fuchsiaVmServiceConnectionFunction = _waitAndConnect;
 /// Gives up after `timeout` has elapsed.
 Future<json_rpc.Peer> _waitAndConnect(
   Uri uri, {
-  Duration timeout: _kConnectTimeout,
+  Duration timeout = _kConnectTimeout,
 }) async {
   final Stopwatch timer = Stopwatch()..start();
 
@@ -112,7 +112,7 @@ class DartVm {
   /// Throws an error if unable to connect.
   static Future<DartVm> connect(
     Uri uri, {
-    Duration timeout: _kConnectTimeout,
+    Duration timeout = _kConnectTimeout,
   }) async {
     if (uri.scheme == 'http') {
       uri = uri.replace(scheme: 'ws', path: '/ws');

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -18,7 +18,7 @@ const Duration _kRpcTimeout = Duration(seconds: 5);
 
 final Logger _log = Logger('DartVm');
 
-/// Signature of an asynchronous function for astablishing a JSON RPC-2
+/// Signature of an asynchronous function for establishing a JSON RPC-2
 /// connection to a [Uri].
 typedef RpcPeerConnectionFunction = Future<json_rpc.Peer> Function(
   Uri uri, {

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -414,7 +414,7 @@ class FuchsiaRemoteConnection {
   /// [TimeoutException], else a [DartVm] instance.
   Future<DartVm> _getDartVm(
     int port, {
-    Duration timeout: _kDartVmConnectionTimeout,
+    Duration timeout = _kDartVmConnectionTimeout,
   }) async {
     if (!_dartVmCache.containsKey(port)) {
       // When raising an HttpException this means that there is no instance of

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -87,7 +87,7 @@ void main() {
       uriConnections = <Uri>[];
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         return Future<json_rpc.Peer>(() async {
           final MockPeer mp = MockPeer();

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -22,8 +22,7 @@ void main() {
       mockRunner = MockSshCommandRunner();
       // Adds some extra junk to make sure the strings will be cleaned up.
       when(mockRunner.run(any)).thenAnswer((_) =>
-          Future<List<String>>.value(
-              <String>['123\n\n\n', '456  ', '789']));
+          Future<List<String>>.value(<String>['123\n\n\n', '456  ', '789']));
       const String address = 'fe80::8eae:4cff:fef4:9247';
       const String interface = 'eno1';
       when(mockRunner.address).thenReturn(address);
@@ -86,7 +85,10 @@ void main() {
 
       mockPeerConnections = <MockPeer>[];
       uriConnections = <Uri>[];
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         return Future<json_rpc.Peer>(() async {
           final MockPeer mp = MockPeer();
           mockPeerConnections.add(mp);

--- a/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
@@ -17,7 +17,10 @@ void main() {
     });
 
     test('null connector', () async {
-      Future<json_rpc.Peer> mockServiceFunction(Uri uri) {
+      Future<json_rpc.Peer> mockServiceFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         return Future<json_rpc.Peer>(() => null);
       }
 
@@ -28,7 +31,10 @@ void main() {
 
     test('disconnect closes peer', () async {
       final MockPeer peer = MockPeer();
-      Future<json_rpc.Peer> mockServiceFunction(Uri uri) {
+      Future<json_rpc.Peer> mockServiceFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         return Future<json_rpc.Peer>(() => peer);
       }
 
@@ -84,7 +90,10 @@ void main() {
         ],
       };
 
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
         return Future<json_rpc.Peer>(() => mockPeer);
@@ -139,7 +148,10 @@ void main() {
         ],
       };
 
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
         return Future<json_rpc.Peer>(() => mockPeer);
@@ -186,7 +198,10 @@ void main() {
         ]
       };
 
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(
                 () => flutterViewCannedResponseMissingId));
@@ -239,7 +254,10 @@ void main() {
         ],
       };
 
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer(
             (_) => Future<Map<String, dynamic>>(() => vmCannedResponse));
         return Future<json_rpc.Peer>(() => mockPeer);
@@ -278,7 +296,10 @@ void main() {
         ],
       };
 
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(
                 () => flutterViewCannedResponseMissingIsolateName));
@@ -311,7 +332,10 @@ void main() {
 
     test('verify timeout fires', () async {
       const Duration timeoutTime = Duration(milliseconds: 100);
-      Future<json_rpc.Peer> mockVmConnectionFunction(Uri uri) {
+      Future<json_rpc.Peer> mockVmConnectionFunction(
+        Uri uri, {
+        Duration timeout = null,
+      }) {
         // Return a command that will never complete.
         when(mockPeer.sendRequest(any, any))
             .thenAnswer((_) => Completer<Map<String, dynamic>>().future);

--- a/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/dart/dart_vm_test.dart
@@ -19,7 +19,7 @@ void main() {
     test('null connector', () async {
       Future<json_rpc.Peer> mockServiceFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         return Future<json_rpc.Peer>(() => null);
       }
@@ -33,7 +33,7 @@ void main() {
       final MockPeer peer = MockPeer();
       Future<json_rpc.Peer> mockServiceFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         return Future<json_rpc.Peer>(() => peer);
       }
@@ -92,7 +92,7 @@ void main() {
 
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
@@ -150,7 +150,7 @@ void main() {
 
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(() => flutterViewCannedResponses));
@@ -200,7 +200,7 @@ void main() {
 
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(
@@ -256,7 +256,7 @@ void main() {
 
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer(
             (_) => Future<Map<String, dynamic>>(() => vmCannedResponse));
@@ -298,7 +298,7 @@ void main() {
 
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         when(mockPeer.sendRequest(any, any)).thenAnswer((_) =>
             Future<Map<String, dynamic>>(
@@ -334,7 +334,7 @@ void main() {
       const Duration timeoutTime = Duration(milliseconds: 100);
       Future<json_rpc.Peer> mockVmConnectionFunction(
         Uri uri, {
-        Duration timeout = null,
+        Duration timeout,
       }) {
         // Return a command that will never complete.
         when(mockPeer.sendRequest(any, any))


### PR DESCRIPTION
This adds configurable timeouts for the Dart VM. Due to some testing
machines running things quite slowly, this is becoming more necessary.

This change also includes some logging additions for easier debugging.