### PR TITLE
Revert "Remove mixin so we can roll Google3 (#22819)"

### DIFF
--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -161,7 +161,7 @@ class FlatButton extends MaterialButton {
 ///
 /// This class only exists to give FlatButtons created with [FlatButton.icon]
 /// a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _FlatButtonWithIcon extends FlatButton implements MaterialButtonWithIconMixin {
+class _FlatButtonWithIcon extends FlatButton with MaterialButtonWithIconMixin {
   _FlatButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -279,6 +279,4 @@ class MaterialButton extends StatelessWidget {
 ///
 /// This mixin only exists to give the "label and icon" button widgets a distinct
 /// type for the sake of [ButtonTheme].
-abstract class MaterialButtonWithIconMixin {
-  MaterialButtonWithIconMixin._();
-}
+mixin MaterialButtonWithIconMixin { }

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -185,7 +185,7 @@ class OutlineButton extends MaterialButton {
 //
 // This class only exists to give RaisedButtons created with [RaisedButton.icon]
 // a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _OutlineButtonWithIcon extends OutlineButton implements MaterialButtonWithIconMixin {
+class _OutlineButtonWithIcon extends OutlineButton with MaterialButtonWithIconMixin {
   _OutlineButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -171,7 +171,7 @@ class RaisedButton extends MaterialButton {
 ///
 /// This class only exists to give RaisedButtons created with [RaisedButton.icon]
 /// a distinct class for the sake of [ButtonTheme]. It can not be instantiated.
-class _RaisedButtonWithIcon extends RaisedButton implements MaterialButtonWithIconMixin {
+class _RaisedButtonWithIcon extends RaisedButton with MaterialButtonWithIconMixin {
   _RaisedButtonWithIcon({
     Key key,
     @required VoidCallback onPressed,


### PR DESCRIPTION
This reverts commit c689c97d0579d2a215034359a3cbcdc61173d2ab.

The Dart analyzer in Google3 has been upgraded so we won't need this.