### PR TITLE
Remove extraneous flags from dartdoc invocation

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -134,16 +134,8 @@ Future<void> main(List<String> arguments) async {
   'package:Flutter/temp_doc.dart,package:http/browser_client.dart,package:intl/intl_browser.dart,package:matcher/mirror_matchers.dart,package:quiver/mirrors.dart,package:quiver/io.dart,package:vm_service_client/vm_service_client.dart,package:web_socket_channel/html.dart',
     '--favicon=favicon.ico',
     '--package-order', 'flutter,Dart,flutter_test,flutter_driver',
-    '--show-warnings',
     '--auto-include-dependencies',
   ]);
-
-  // Explicitly list all the packages in //flutter/packages/* that are
-  // not listed 'nodoc' in their pubspec.yaml.
-  for (String libraryRef in libraryRefs(diskPath: true)) {
-    dartdocArgs.add('--include-external');
-    dartdocArgs.add(libraryRef);
-  }
 
   String quote(String arg) => arg.contains(' ') ? "'$arg'" : arg;
   print('Executing: (cd dev/docs ; $pubExecutable ${dartdocArgs.map<String>(quote).join(' ')})');
@@ -162,7 +154,6 @@ Future<void> main(List<String> arguments) async {
   );
   printStream(process.stderr, prefix: args['json'] ? '' : 'dartdoc:stderr: ',
     filter: args['verbose'] ? const <Pattern>[] : <Pattern>[
-      RegExp(r'^[ ]+warning: generic type handled as HTML:'), // https://github.com/dart-lang/dartdoc/issues/1475
       RegExp(r'^ warning: .+: \(.+/\.pub-cache/hosted/pub.dartlang.org/.+\)'), // packages outside our control
     ],
   );
@@ -321,29 +312,19 @@ List<FileSystemEntity> findPackages() {
 }
 
 /// Returns import or on-disk paths for all libraries in the Flutter SDK.
-///
-/// diskPath toggles between import paths vs. disk paths.
-Iterable<String> libraryRefs({ bool diskPath = false }) sync* {
+Iterable<String> libraryRefs() sync* {
   for (Directory dir in findPackages()) {
     final String dirName = path.basename(dir.path);
     for (FileSystemEntity file in Directory('${dir.path}/lib').listSync()) {
       if (file is File && file.path.endsWith('.dart')) {
-        if (diskPath)
-          yield '$dirName/lib/${path.basename(file.path)}';
-        else
-          yield '$dirName/${path.basename(file.path)}';
-       }
+        yield '$dirName/${path.basename(file.path)}';
+      }
     }
   }
 
   // Add a fake package for platform integration APIs.
-  if (diskPath) {
-    yield 'platform_integration/lib/android.dart';
-    yield 'platform_integration/lib/ios.dart';
-  } else {
-    yield 'platform_integration/android.dart';
-    yield 'platform_integration/ios.dart';
-  }
+  yield 'platform_integration/android.dart';
+  yield 'platform_integration/ios.dart';
 }
 
 void printStream(Stream<List<int>> stream, { String prefix = '', List<Pattern> filter = const <Pattern>[] }) {


### PR DESCRIPTION
Dartdoc's --include-external flag has apparently been a noop for some time (see dart-lang/dartdoc#1790 for changes), and the only purpose of --show-warnings is to display warnings that are known to be buggy anyway (which the tool then promptly filters out).  Verified by comparing the outputted documentation.

Remove those flags and simplify the helper script in flutter just a bit.