### PR TITLE
More detailed doctor message regarding archlinux libstdc installation

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -440,7 +440,7 @@ class _FlutterValidator extends DoctorValidator {
       if (platform.isLinux) {
         buf.writeln('On Debian/Ubuntu/Mint: sudo apt-get install lib32stdc++6');
         buf.writeln('On Fedora: dnf install libstdc++.i686');
-        buf.writeln('On Arch: pacman -S lib32-libstdc++5');
+        buf.writeln('On Arch: pacman -S lib32-libstdc++5 (you need to enable multilib: https://wiki.archlinux.org/index.php/Official_repositories#multilib)');
       }
       messages.add(ValidationMessage.error(buf.toString()));
       valid = ValidationType.partial;


### PR DESCRIPTION
This improves the doctor message regarding a specific scenario for Arch Linux users, adding a bit more of information that is not necessary but can save people some trouble.

I'm not sure this is exactly aligned with Flutter design philosophies, or if it's out of scope, but I personally think it's a harmless bit of additional info that can help some people with a link to more details.

However I agree that a lengthy out-of-scope text could be written in every possible corner of the code and that would not be helpful. Therefore, I completely understand if this is too much for the doctor to do, so feel absolutely free to close the PR if this is not an welcome addition.