### PR TITLE
Include frameworkVersion in JSON version output.

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -108,6 +108,7 @@ class FlutterVersion {
   }
 
   Map<String, Object> toJson() => <String, Object>{
+        'frameworkVersion': frameworkVersion ?? 'unknown',
         'channel': channel,
         'repositoryUrl': repositoryUrl ?? 'unknown source',
         'frameworkRevision': frameworkRevision,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/23098