### PR TITLE
TextTheme.apply() corrections

### DIFF
--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -368,7 +368,7 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       headline: headline.apply(
-        color: displayColor,
+        color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -377,7 +377,7 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       title: title.apply(
-        color: displayColor,
+        color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -386,7 +386,7 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       subhead: subhead.apply(
-        color: displayColor,
+        color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -395,7 +395,7 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       body2: body2.apply(
-        color: displayColor,
+        color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -404,7 +404,7 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       body1: body1.apply(
-        color: displayColor,
+        color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -65,10 +65,10 @@ void main() {
     // The `displayColor` is applied to [display4], [display3], [display2],
     // [display1], and [caption]. The `bodyColor` is applied to the remaining
     // text styles.
-    const Color displayColor = const Color(1);
-    const Color bodyColor = const Color(2);
+    const Color displayColor = Color(1);
+    const Color bodyColor = Color(2);
     const String fontFamily = 'fontFamily';
-    const Color decorationColor = const Color(3);
+    const Color decorationColor = Color(3);
     const TextDecorationStyle decorationStyle = TextDecorationStyle.dashed;
     final TextDecoration decoration = TextDecoration.combine(<TextDecoration>[
       TextDecoration.underline,

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -1,0 +1,146 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('TextTheme copyWith apply, merge basics', () {
+    final Typography typography = Typography(platform: TargetPlatform.android);
+    expect(typography.black, equals(typography.black.copyWith()));
+    expect(typography.black, equals(typography.black.apply()));
+    expect(typography.black, equals(typography.black.merge(null)));
+    expect(typography.black, equals(typography.black.merge(typography.black)));
+    expect(typography.white, equals(typography.black.merge(typography.white)));
+    expect(typography.black.hashCode, equals(typography.black.copyWith().hashCode));
+    expect(typography.black, isNot(equals(typography.white)));
+  });
+
+  test('TextTheme copyWith', () {
+    final Typography typography = Typography(platform: TargetPlatform.android);
+    final TextTheme whiteCopy = typography.black.copyWith(
+      display4: typography.white.display4,
+      display3: typography.white.display3,
+      display2: typography.white.display2,
+      display1: typography.white.display1,
+      headline: typography.white.headline,
+      title: typography.white.title,
+      subhead: typography.white.subhead,
+      body2: typography.white.body2,
+      body1: typography.white.body1,
+      caption: typography.white.caption,
+      button: typography.white.button,
+      subtitle: typography.white.subtitle,
+      overline: typography.white.overline,
+    );
+    expect(typography.white, equals(whiteCopy));
+  });
+
+
+  test('TextTheme merges properly in the presence of null fields.', () {
+    const TextTheme partialTheme = TextTheme(title: TextStyle(color: Color(0xcafefeed)));
+    final TextTheme fullTheme = ThemeData.fallback().textTheme.merge(partialTheme);
+    expect(fullTheme.title.color, equals(partialTheme.title.color));
+
+    const TextTheme onlyHeadlineAndTitle = TextTheme(
+      headline: TextStyle(color: Color(0xcafefeed)),
+      title: TextStyle(color: Color(0xbeefcafe)),
+    );
+    const TextTheme onlyBody1AndTitle = TextTheme(
+      body1: TextStyle(color: Color(0xfeedfeed)),
+      title: TextStyle(color: Color(0xdeadcafe)),
+    );
+    TextTheme merged = onlyHeadlineAndTitle.merge(onlyBody1AndTitle);
+    expect(merged.body2, isNull);
+    expect(merged.body1.color, equals(onlyBody1AndTitle.body1.color));
+    expect(merged.headline.color, equals(onlyHeadlineAndTitle.headline.color));
+    expect(merged.title.color, equals(onlyBody1AndTitle.title.color));
+
+    merged = onlyHeadlineAndTitle.merge(null);
+    expect(merged, equals(onlyHeadlineAndTitle));
+  });
+
+  test('TextTheme apply', () {
+    // The `displayColor` is applied to [display4], [display3], [display2],
+    // [display1], and [caption]. The `bodyColor` is applied to the remaining
+    // text styles.
+    const Color displayColor = const Color(1);
+    const Color bodyColor = const Color(2);
+    const String fontFamily = 'fontFamily';
+    const Color decorationColor = const Color(3);
+    const TextDecorationStyle decorationStyle = TextDecorationStyle.dashed;
+    final TextDecoration decoration = TextDecoration.combine(<TextDecoration>[
+      TextDecoration.underline,
+      TextDecoration.lineThrough
+    ]);
+
+    final Typography typography = Typography(platform: TargetPlatform.android);
+    final TextTheme theme = typography.black.apply(
+      fontFamily: fontFamily,
+      displayColor: displayColor,
+      bodyColor: bodyColor,
+      decoration: decoration,
+      decorationColor: decorationColor,
+      decorationStyle: decorationStyle,
+    );
+
+    expect(theme.display4.color, displayColor);
+    expect(theme.display3.color, displayColor);
+    expect(theme.display2.color, displayColor);
+    expect(theme.display1.color, displayColor);
+    expect(theme.caption.color, displayColor);
+    expect(theme.headline.color, bodyColor);
+    expect(theme.title.color, bodyColor);
+    expect(theme.subhead.color, bodyColor);
+    expect(theme.body2.color, bodyColor);
+    expect(theme.body1.color, bodyColor);
+    expect(theme.button.color, bodyColor);
+    expect(theme.subtitle.color, bodyColor);
+    expect(theme.overline.color, bodyColor);
+
+    final List<TextStyle> themeStyles = <TextStyle>[
+      theme.display4,
+      theme.display3,
+      theme.display2,
+      theme.display1,
+      theme.caption,
+      theme.headline,
+      theme.title,
+      theme.subhead,
+      theme.body2,
+      theme.body1,
+      theme.button,
+      theme.subtitle,
+      theme.overline,
+    ];
+    expect(themeStyles.every((TextStyle style) => style.fontFamily == fontFamily), true);
+    expect(themeStyles.every((TextStyle style) => style.decorationColor == decorationColor), true);
+    expect(themeStyles.every((TextStyle style) => style.decorationStyle == decorationStyle), true);
+    expect(themeStyles.every((TextStyle style) => style.decoration == decoration), true);
+  });
+
+  test('TextTheme apply fontSizeFactor fontSizeDelta', () {
+    final Typography typography = Typography(platform: TargetPlatform.android);
+    final TextTheme baseTheme = Typography.englishLike2014.merge(typography.black);
+    final TextTheme sizeTheme = baseTheme.apply(
+      fontSizeFactor: 2.0,
+      fontSizeDelta: 5.0,
+    );
+
+    expect(sizeTheme.display4.fontSize, baseTheme.display4.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.display3.fontSize, baseTheme.display3.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.display2.fontSize, baseTheme.display2.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.display1.fontSize, baseTheme.display1.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.caption.fontSize, baseTheme.caption.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.headline.fontSize, baseTheme.headline.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.title.fontSize, baseTheme.title.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.subhead.fontSize, baseTheme.subhead.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.body2.fontSize, baseTheme.body2.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.body1.fontSize, baseTheme.body1.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.button.fontSize, baseTheme.button.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.subtitle.fontSize, baseTheme.subtitle.fontSize * 2.0 + 5.0);
+    expect(sizeTheme.overline.fontSize, baseTheme.overline.fontSize * 2.0 + 5.0);
+  });
+
+}

--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -6,14 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('TextTheme control test', () {
-    final Typography typography = Typography(platform: TargetPlatform.android);
-    expect(typography.black, equals(typography.black.copyWith()));
-    expect(typography.black, equals(typography.black.apply()));
-    expect(typography.black.hashCode, equals(typography.black.copyWith().hashCode));
-    expect(typography.black, isNot(equals(typography.white)));
-  });
-
   test('Typography is defined for all target platforms', () {
     for (TargetPlatform platform in TargetPlatform.values) {
       final Typography typography = Typography(platform: platform);
@@ -21,29 +13,6 @@ void main() {
       expect(typography.black, isNotNull, reason: 'null black typography for $platform');
       expect(typography.white, isNotNull, reason: 'null white typography for $platform');
     }
-  });
-
-  test('TextTheme merges properly in the presence of null fields.', () {
-    const TextTheme partialTheme = TextTheme(title: TextStyle(color: Color(0xcafefeed)));
-    final TextTheme fullTheme = ThemeData.fallback().textTheme.merge(partialTheme);
-    expect(fullTheme.title.color, equals(partialTheme.title.color));
-
-    const TextTheme onlyHeadlineAndTitle = TextTheme(
-      headline: TextStyle(color: Color(0xcafefeed)),
-      title: TextStyle(color: Color(0xbeefcafe)),
-    );
-    const TextTheme onlyBody1AndTitle = TextTheme(
-      body1: TextStyle(color: Color(0xfeedfeed)),
-      title: TextStyle(color: Color(0xdeadcafe)),
-    );
-    TextTheme merged = onlyHeadlineAndTitle.merge(onlyBody1AndTitle);
-    expect(merged.body2, isNull);
-    expect(merged.body1.color, equals(onlyBody1AndTitle.body1.color));
-    expect(merged.headline.color, equals(onlyHeadlineAndTitle.headline.color));
-    expect(merged.title.color, equals(onlyBody1AndTitle.title.color));
-
-    merged = onlyHeadlineAndTitle.merge(null);
-    expect(merged, equals(onlyHeadlineAndTitle));
   });
 
   test('Typography on Android, Fuchsia defaults to Roboto', () {


### PR DESCRIPTION
TextTheme.apply was incorrectly applying displayColor to the TextTheme's headline, title, subhead, body1, and body2 TextStyle colors. In all cases it should have been bodyColor.

This was a regression introduced by https://github.com/flutter/flutter/pull/22330.
