### PR TITLE
Update dartdoc to v0.24.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -63,7 +63,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.23.1
+"$PUB" global activate dartdoc 0.24.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.24.0

In particular, this removes internal uses of the old super-mixin style from dartdoc.