### PR TITLE
Fix bug where gradle build rule would rerun when turning off --track-widget-creation flag.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -418,7 +418,7 @@ abstract class BaseFlutterTask extends DefaultTask {
     String[] fileSystemRoots
     @Optional @Input
     String fileSystemScheme
-    @Optional @Input
+    @Input
     Boolean trackWidgetCreation
     @Optional @Input
     String compilationTraceFilePath

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -365,8 +365,8 @@ Future<void> _buildGradleProjectV2(
   if (target != null) {
     command.add('-Ptarget=$target');
   }
-  if (buildInfo.trackWidgetCreation)
-    command.add('-Ptrack-widget-creation=true');
+  assert(buildInfo.trackWidgetCreation != null);
+  command.add('-Ptrack-widget-creation=${buildInfo.trackWidgetCreation}');
   if (buildInfo.compilationTraceFilePath != null)
     command.add('-Pprecompile=${buildInfo.compilationTraceFilePath}');
   if (buildInfo.buildHotUpdate)


### PR DESCRIPTION
Going from
--track-widget-creation=false to
--track-widget-creation=true
would cause gradle to rerun but

going from
--track-widget-creation=true
to
--track-widget-creation=false

would not due to the counterintuitive behavior of Gradle @Optional inputs.
