### PR TITLE
TextTheme.apply() should not assume non-null TextStyle fields

### DIFF
--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -331,7 +331,7 @@ class TextTheme extends Diagnosticable {
     TextDecorationStyle decorationStyle,
   }) {
     return TextTheme(
-      display4: display4.apply(
+      display4: display4?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -340,7 +340,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display3: display3.apply(
+      display3: display3?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -349,7 +349,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display2: display2.apply(
+      display2: display2?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -358,7 +358,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display1: display1.apply(
+      display1: display1?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -367,7 +367,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline: headline.apply(
+      headline: headline?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -376,7 +376,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      title: title.apply(
+      title: title?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -385,7 +385,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      subhead: subhead.apply(
+      subhead: subhead?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -394,7 +394,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      body2: body2.apply(
+      body2: body2?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -403,7 +403,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      body1: body1.apply(
+      body1: body1?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -412,7 +412,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      caption: caption.apply(
+      caption: caption?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -421,7 +421,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      button: button.apply(
+      button: button?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -430,7 +430,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      subtitle: subtitle.apply(
+      subtitle: subtitle?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -439,7 +439,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      overline: overline.apply(
+      overline: overline?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -6,11 +6,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('TextTheme copyWith apply, merge basics', () {
+  test('TextTheme copyWith apply, merge basics with const TextTheme()', () {
+    expect(const TextTheme(), equals(const TextTheme().copyWith()));
+    expect(const TextTheme(), equals(const TextTheme().apply()));
+    expect(const TextTheme(), equals(const TextTheme().merge(null)));
+    expect(const TextTheme().hashCode, equals(const TextTheme().copyWith().hashCode));
+    expect(const TextTheme(), equals(const TextTheme().copyWith()));
+  });
+
+  test('TextTheme copyWith apply, merge basics with Typography.black', () {
     final Typography typography = Typography(platform: TargetPlatform.android);
     expect(typography.black, equals(typography.black.copyWith()));
     expect(typography.black, equals(typography.black.apply()));
     expect(typography.black, equals(typography.black.merge(null)));
+    expect(typography.black, equals(const TextTheme().merge(typography.black)));
     expect(typography.black, equals(typography.black.merge(typography.black)));
     expect(typography.white, equals(typography.black.merge(typography.white)));
     expect(typography.black.hashCode, equals(typography.black.copyWith().hashCode));


### PR DESCRIPTION
TextTheme() has never required non-null TextStyle fields but TextTheme.apply() has always assumed that all of the TextTheme fields are non-null.

Changed TextTheme.apply to use `fooTextStyle?.apply(...)` instead of `fooTextStyle.apply()`.
