### PR TITLE
update android-kotlin templates

### DIFF
--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -60,7 +60,7 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.60'
     repositories {
         google()
         jcenter()

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -2,7 +2,7 @@ group '{{androidIdentifier}}'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.60'
     repositories {
         google()
         jcenter()
@@ -40,5 +40,5 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
@@ -16,7 +16,7 @@ class {{pluginClass}}(): MethodCallHandler {
   }
 
   override fun onMethodCall(call: MethodCall, result: Result): Unit {
-    if (call.method.equals("getPlatformVersion")) {
+    if (call.method == "getPlatformVersion") {
       result.success("Android ${android.os.Build.VERSION.RELEASE}")
     } else {
       result.notImplemented()


### PR DESCRIPTION
update android-kotlin templates:
1.*org.jetbrains.kotlin:kotlin-stdlib-jre7* is deprecated, use *org.jetbrains.kotlin:kotlin-stdlib-jdk7* instead.
2.Gernate a kotlin-style code such as  *"call.method == "getPlatformVersion"*.
3.Use *kotlin-1.2.60* as default in order to support *kotlinx.coroutines*.