### PR TITLE
Add a delay to the Gallery navigation memory test to give Dart an opportunity to GC

### DIFF
--- a/examples/flutter_gallery/test_memory/memory_nav.dart
+++ b/examples/flutter_gallery/test_memory/memory_nav.dart
@@ -79,6 +79,7 @@ Future<void> main() async {
     debugPrint('Backing out...');
     await controller.tap(find.byTooltip('Back'));
     await endOfAnimation();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
   }
 
   debugPrint('==== MEMORY BENCHMARK ==== DONE ====');


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/23171