### PR TITLE
Update dartdoc to 0.24.1

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -63,7 +63,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.24.0
+"$PUB" global activate dartdoc 0.24.1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.24.1

No change to current warnings or doc output.  The most significant change is @gspencergoog 's fix of a bug I accidentally introduced where dartdoc won't hard fail even when errors are detected.