### PR TITLE
Improve error message when missing curl

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -22,6 +22,24 @@ ENGINE_STAMP="$FLUTTER_ROOT/bin/cache/engine-dart-sdk.stamp"
 ENGINE_VERSION=`cat "$FLUTTER_ROOT/bin/internal/engine.version"`
 
 if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; then
+  command -v curl > /dev/null 2>&1 || {
+    echo
+    echo 'Missing "curl" tool. Unable to download Dart SDK.'
+    case "$(uname -s)" in
+      Darwin)
+        echo 'Consider running "brew install curl".'
+        ;;
+      Linux)
+        echo 'Consider running "sudo apt-get install curl".'
+        ;;
+      *)
+        echo "Please install curl."
+        ;;
+    esac
+    echo
+    exit 1
+  }
+
   echo "Downloading Dart SDK from Flutter engine $ENGINE_VERSION..."
 
   case "$(uname -s)" in


### PR DESCRIPTION
Running `flutter upgrade` will fail if `curl` is missing. It is not installed by default on all platforms, e.g. Ubuntu. It would be helpful to show an informative error message. 

Currently, the error message looks like this:
```
❯ flutter upgrade 
Downloading Dart SDK from Flutter engine 104f0572802c9304b9e0f655b3d44cac5a4f4ca0...
/home/antti/tools/flutter/bin/internal/update_dart_sdk.sh: line 69: curl: command not found

Failed to retrieve the Dart SDK at https://storage.googleapis.com/flutter_infra/flutter/104f0572802c9304b9e0f655b3d44cac5a4f4ca0/dart-sdk-linux-x64.zip
If you're located in China, please follow
https://github.com/flutter/flutter/wiki/Using-Flutter-in-China

```

This PR improves the error message so it looks like this:
```
❯ flutter upgrade 

Missing "curl" tool. Unable to download Dart SDK.
Consider running "sudo apt-get install curl".

```

This error message mimics the one for `lcov` in https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/test/coverage_collector.dart#L127-L135