### PR TITLE
Remove optimization that was trying to bypass build process for iOS sim.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -360,22 +360,9 @@ class IOSSimulator extends Device {
     }
   }
 
-  Future<bool> _applicationIsInstalledAndRunning(ApplicationPackage app) async {
-    final List<bool> criteria = await Future.wait<bool>(<Future<bool>>[
-      isAppInstalled(app),
-      exitsHappyAsync(<String>['/usr/bin/killall', 'Runner']),
-    ]);
-    return criteria.reduce((bool a, bool b) => a && b);
-  }
-
   Future<void> _setupUpdatedApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
     await _sideloadUpdatedAssetsForInstalledApplicationBundle(app, buildInfo, mainPath);
 
-    if (!await _applicationIsInstalledAndRunning(app))
-      return _buildAndInstallApplicationBundle(app, buildInfo, mainPath, usesTerminalUi);
-  }
-
-  Future<void> _buildAndInstallApplicationBundle(ApplicationPackage app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
     // Step 1: Build the Xcode project.
     // The build mode for the simulator is always debug.
 


### PR DESCRIPTION
This optimization resulted in app still running with old kernel file.

Fixes another source of https://github.com/flutter/flutter/issues/16604

cc @devoncarew 