### PR TITLE
Handle escaped spaces in deps-file.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -581,9 +581,13 @@ class FlutterTask extends BaseFlutterTask {
         if (dependenciesFile.exists()) {
             try {
                 // Dependencies file has Makefile syntax:
-                //   <target> <files>: <source> <files> <separated> <by> <space>
+                //   <target> <files>: <source> <files> <separated> <by> <non-escaped space>
                 String depText = dependenciesFile.text
-                return project.files(depText.split(': ')[1].split())
+                // So we split list of files by non-escaped(by backslash) space,
+                def matcher = depText.split(': ')[1] =~ /(\\ |[^\s])+/
+                // then we replace all escaped spaces with regular spaces
+                def depList = matcher.collect{it[0].replaceAll("\\\\ ", " ")}
+                return project.files(depList)
             } catch (Exception e) {
                 logger.error("Error reading dependency file ${dependenciesFile}: ${e}")
             }


### PR DESCRIPTION
Handle escaped spaces in deps-file.

This is reland of 617e8f65b97013c5876cef9236582dffcbe2a469 with fix for removing all backslashes, that breaks things on Windows.

Fixes https://github.com/flutter/flutter/issues/23236