### PR TITLE
Test `flutter create --offline`

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_create_offline_test_linux.dart
+++ b/dev/devicelab/bin/tasks/flutter_create_offline_test_linux.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/integration_tests.dart';
+
+Future<void> main() async {
+  await task(createFlutterCreateOfflineTest());
+}

--- a/dev/devicelab/bin/tasks/flutter_create_offline_test_mac.dart
+++ b/dev/devicelab/bin/tasks/flutter_create_offline_test_mac.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/integration_tests.dart';
+
+Future<void> main() async {
+  await task(createFlutterCreateOfflineTest());
+}

--- a/dev/devicelab/bin/tasks/flutter_create_offline_test_windows.dart
+++ b/dev/devicelab/bin/tasks/flutter_create_offline_test_windows.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/integration_tests.dart';
+
+Future<void> main() async {
+  await task(createFlutterCreateOfflineTest());
+}

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
+import 'package:path/path.dart' as path;
 import '../framework/adb.dart';
 import '../framework/framework.dart';
 import '../framework/ios.dart';
@@ -57,6 +59,22 @@ TaskFunction createAndroidSemanticsIntegrationTest() {
     '${flutterDirectory.path}/dev/integration_tests/android_semantics_testing',
     'lib/main.dart',
   );
+}
+
+TaskFunction createFlutterCreateOfflineTest() {
+  return () async {
+    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_create_test.');
+    String output;
+    await inDirectory(tempDir, () async {
+      output = await eval(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>['create', '--offline', 'flutter_create_test']);
+    });
+    if (output.contains(RegExp('building flutter tool', caseSensitive: false))) {
+      return TaskResult.failure('`flutter create --offline` should not rebuild flutter tool');
+    } else if (!output.contains('All done!')) {
+      return TaskResult.failure('`flutter create` failed');
+    }
+    return TaskResult.success(null);
+  };
 }
 
 class DriverTest {

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -283,6 +283,27 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
+  flutter_create_offline_test_linux:
+    description: >
+      Tests the `flutter create --offline` command.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
+  flutter_create_offline_test_windows:
+    description: >
+      Tests the `flutter create --offline` command.
+    stage: devicelab
+    required_agent_capabilities: ["windows/android"]
+    flaky: true
+
+  flutter_create_offline_test_mac:
+    description: >
+      Tests the `flutter create --offline` command.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+    flaky: true
+
   # iOS on-device tests
 
   flavors_test_ios:


### PR DESCRIPTION
Verifies that flutter tools isn't rebuilt. Doesn't truly check that the
created output is runnable.