### PR TITLE
Log received messages for exceptions as well as timeouts

### DIFF
--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -355,7 +355,9 @@ class FlutterTestDriver {
 
     return f().timeout(timeout ?? defaultTimeout, onTimeout: () {
       logMessage('<timed out>');
-      throw '$message\nReceived:\n${messages.toString()}';
+      throw '$message';
+    }).catchError((dynamic error) {
+      throw '$error\nReceived:\n${messages.toString()}';
     }).whenComplete(() => sub.cancel());
   }
 


### PR DESCRIPTION
The code previously only included the recent messages received in the error message for a timeout. This changes it to output for all exceptions to make it easier to understand errors like https://github.com/flutter/flutter/issues/19273#issuecomment-431171632.

**Before**:

```
00:19 +0 -1: hot reload works without error [E]                                                                                                                
  Received app.stop event while waiting for app.started event.
  
  test/integration/test_driver.dart 362:7   FlutterTestDriver._timeoutWithMessages.<fn>
  ===== asynchronous gap ===========================
  dart:async                                Future.catchError
  test/integration/test_driver.dart 361:8   FlutterTestDriver._timeoutWithMessages
  test/integration/test_driver.dart 339:12  FlutterTestDriver._waitFor
  ===== asynchronous gap ===========================
  dart:async                                _asyncThenWrapperHelper
  test/integration/test_driver.dart         FlutterTestDriver._setupProcess
  test/integration/test_driver.dart 60:11   FlutterTestDriver.run
```

**After:**

```
00:19 +0 -1: hot reload works without error [E]                                                                                                                
  Received app.stop event while waiting for app.started event.
  
  
  Received:
  [+   195] [{"event":"app.start","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab","deviceId":"flutter-tester","directory":"/private/var/folders/8r/5r4vmgn94h9fy343vxdvr4_r00hbgw/T/flutter_hot_reload_test_app.ZvM5t6","supportsRestart":true}}]
  [+   793] Launching lib/main.dart on Flutter test device in debug mode...
  [+  5152] topLevelFunction
  [+  5244] [{"event":"app.debugPort","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab","port":50874,"wsUri":"ws://127.0.0.1:50874/ws","baseUri":"file:///var/folders/8r/5r4vmgn94h9fy343vxdvr4_r00hbgw/T/flutter_hot_reload_test_app.ZvM5t6uKdtGb/flutter_hot_reload_test_app.ZvM5t6/"}}]
  [+  5289] [{"event":"app.progress","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab","id":"0","progressId":null,"message":"Syncing files to device Flutter test device..."}}]
  [+  8861] [{"event":"app.progress","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab","id":"0","progressId":null,"finished":true}}]
  [+  8870] [{"event":"app.started","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab"}}]
  [+ 10445] Lost connection to device.
  [+ 10709] [{"event":"app.stop","params":{"appId":"81a63a61-3820-4cf1-b7ad-7df5fe0f74ab"}}]
  
  test/integration/test_driver.dart 362:7   FlutterTestDriver._timeoutWithMessages.<fn>
  ===== asynchronous gap ===========================
  dart:async                                Future.catchError
  test/integration/test_driver.dart 361:8   FlutterTestDriver._timeoutWithMessages
  test/integration/test_driver.dart 339:12  FlutterTestDriver._waitFor
  ===== asynchronous gap ===========================
  dart:async                                _asyncThenWrapperHelper
  test/integration/test_driver.dart         FlutterTestDriver._setupProcess
  test/integration/test_driver.dart 60:11   FlutterTestDriver.run
```