### PR TITLE
Clarify plugin/example/pubspec.yaml

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -1,5 +1,9 @@
 name: {{projectName}}
 description: {{description}}
+{{#withPluginHook}}
+publish_to: 'none'
+{{/withPluginHook}}
+{{^withPluginHook}}
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -8,6 +12,7 @@ description: {{description}}
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
+{{/withPluginHook}}
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"


### PR DESCRIPTION
The `pubspec.yaml` in the example app for a plugin is not meant to be used for publishing - that is, you wouldn't ordinarily publish your example app to pub by itself.  This clarifies that by removing the version number and specifying `publish_to: 'none'`.

/cc @efortuna 