### PR TITLE
Null check in locale resolution

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -678,6 +678,9 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
   Locale _locale;
 
   Locale _resolveLocale(Locale newLocale, Iterable<Locale> supportedLocales) {
+    if (newLocale == null) {
+      return supportedLocales.first;
+    }
     if (widget.localeResolutionCallback != null) {
       final Locale locale = widget.localeResolutionCallback(newLocale, widget.supportedLocales);
       if (locale != null)


### PR DESCRIPTION
Dart intl.dart in the observatory expects null locales as the default empty locale, so we should check for the same thing.