### PR TITLE
Update coverage, linter to latest releases

### DIFF
--- a/examples/flutter_gallery/pubspec.yaml
+++ b/examples/flutter_gallery/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   intl: 0.15.7
   connectivity: 0.3.2
   string_scanner: 1.0.4
-  url_launcher: 3.0.3
+  url_launcher: 4.0.1
   cupertino_icons: 0.1.2
-  video_player: 0.6.5
+  video_player: 0.7.2
 
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets: 0.1.6
@@ -196,4 +196,4 @@ flutter:
         - asset: packages/flutter_gallery_assets/fonts/private/googlesans/GoogleSansDisplay-Regular.ttf
           weight: 400
 
-# PUBSPEC CHECKSUM: 3ed5
+# PUBSPEC CHECKSUM: 0fd2

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,14 +14,14 @@ dependencies:
   args: 1.5.0
   cli_util: 0.1.3+2
   completion: 0.2.1+1
-  coverage: 0.12.2
+  coverage: 0.12.3
   crypto: 2.0.6
   file: 5.0.6
   http: 0.12.0
   intl: 0.15.7
   json_rpc_2: 2.0.9
   json_schema: 1.0.10
-  linter: 0.1.68
+  linter: 0.1.70
   meta: 1.1.6
   mustache: 1.0.2
   package_config: 1.0.5
@@ -90,4 +90,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: d5fc
+# PUBSPEC CHECKSUM: c4f6


### PR DESCRIPTION
Coverage 0.12.3 includes a fix for dart-lang/tools#437, which was
causing errors on the flutter build bots.

Linter was updated automatically as a side effect of running
`flutter update-packages --force-upgrade`.