### PR TITLE
Override FLUTTER_BUILD_MODE for Add2App

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -69,6 +69,9 @@ post_install do |installer|
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|
                 file.puts "#include \"#{File.join(framework_dir, 'Generated.xcconfig')}\""
+                if config.name == 'Release'
+                    file.puts "FLUTTER_BUILD_MODE=release"
+                end
             end
         end
     end


### PR DESCRIPTION
Flutter tooling creates a `Generated.xcconfig` file and sets a `FLUTTER_BUILD_MODE=debug/release/profile` as approrpiate.  In an add to app scenario, we want this to be driven by the Xcode build mode.  Current instructions tell users to create and update xcconfig files manually - this change will let Cocoapods take care of it for them.