### PR TITLE
Back swipe hero

### DIFF
--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -7,6 +7,7 @@ import 'dart:developer';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import 'backdrop.dart';
@@ -320,6 +321,8 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
 
   @override
   Widget build(BuildContext context) {
+    debugPrintBeginFrameBanner = true;
+    debugPrintEndFrameBanner = true;
     final ThemeData theme = Theme.of(context);
     final bool isDark = theme.brightness == Brightness.dark;
     final MediaQueryData media = MediaQuery.of(context);

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -7,7 +7,6 @@ import 'dart:developer';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import 'backdrop.dart';
@@ -321,8 +320,6 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
 
   @override
   Widget build(BuildContext context) {
-    debugPrintBeginFrameBanner = true;
-    debugPrintEndFrameBanner = true;
     final ThemeData theme = Theme.of(context);
     final bool isDark = theme.brightness == Brightness.dark;
     final MediaQueryData media = MediaQuery.of(context);

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -402,7 +402,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
-      transitionForUserGestures: true,
+      transitionOnUserGestures: true,
       child: _TransitionableNavigationBar(
         componentsKeys: keys,
         backgroundColor: widget.backgroundColor,
@@ -737,7 +737,7 @@ class _LargeTitleNavigationBarSliverDelegate
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
-      transitionForUserGestures: true,
+      transitionOnUserGestures: true,
       // This is all the way down here instead of being at the top level of
       // CupertinoSliverNavigationBar like CupertinoNavigationBar because it
       // needs to wrap the top level RenderBox rather than a RenderSliver.

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -398,6 +398,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
+      userGestureTransitions: true,
       child: _TransitionableNavigationBar(
         componentsKeys: keys,
         backgroundColor: widget.backgroundColor,
@@ -732,6 +733,7 @@ class _LargeTitleNavigationBarSliverDelegate
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
+      userGestureTransitions: true,
       // This is all the way down here instead of being at the top level of
       // CupertinoSliverNavigationBar like CupertinoNavigationBar because it
       // needs to wrap the top level RenderBox rather than a RenderSliver.
@@ -1439,6 +1441,7 @@ class _NavigationBarTransition extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('builds transition nav bar');
     final List<Widget> children = <Widget>[
       // Draw an empty navigation bar box with changing shape behind all the
       // moving components without any components inside it itself.

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -316,6 +316,10 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// to also has a [CupertinoNavigationBar] or a [CupertinoSliverNavigationBar]
   /// with [transitionBetweenRoutes] set to true.
   ///
+  /// This transition will also occur on edge back swipe gestures like on iOS
+  /// but only if the previous page below has `maintainState` set to true on the
+  /// [PageRoute].
+  ///
   /// When set to true, only one navigation bar can be present per route unless
   /// [heroTag] is also set.
   ///
@@ -398,7 +402,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
-      userGestureTransitions: true,
+      transitionForUserGestures: true,
       child: _TransitionableNavigationBar(
         componentsKeys: keys,
         backgroundColor: widget.backgroundColor,
@@ -733,7 +737,7 @@ class _LargeTitleNavigationBarSliverDelegate
       createRectTween: _linearTranslateWithLargestRectSizeTween,
       flightShuttleBuilder: _navBarHeroFlightShuttleBuilder,
       placeholderBuilder: _navBarHeroLaunchPadBuilder,
-      userGestureTransitions: true,
+      transitionForUserGestures: true,
       // This is all the way down here instead of being at the top level of
       // CupertinoSliverNavigationBar like CupertinoNavigationBar because it
       // needs to wrap the top level RenderBox rather than a RenderSliver.
@@ -1441,7 +1445,6 @@ class _NavigationBarTransition extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print('builds transition nav bar');
     final List<Widget> children = <Widget>[
       // Draw an empty navigation bar box with changing shape behind all the
       // moving components without any components inside it itself.

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 const double _kBackGestureWidth = 20.0;
@@ -254,7 +253,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   }
 
   // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
-  // gesture is detected. The returned controller handles all of the subsquent
+  // gesture is detected. The returned controller handles all of the subsequent
   // drag events.
   static _CupertinoBackGestureController<T> _startPopGesture<T>(PageRoute<T> route) {
     assert(!_popGestureInProgress.contains(route));
@@ -477,14 +476,12 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
   void _handleDragStart(DragStartDetails details) {
     assert(mounted);
     assert(_backGestureController == null);
-    print('gesture start');
     _backGestureController = widget.onStartPopGesture();
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
     assert(mounted);
     assert(_backGestureController != null);
-    print('move');
     _backGestureController.dragUpdate(_convertToLogical(details.primaryDelta / context.size.width));
   }
 
@@ -504,7 +501,6 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
   }
 
   void _handlePointerDown(PointerDownEvent event) {
-    print('pointer down');
     if (widget.enabledCallback())
       _recognizer.addPointer(event);
   }
@@ -564,12 +560,6 @@ class _CupertinoBackGestureController<T> {
   }) : assert(navigator != null),
        assert(controller != null),
        assert(onEnded != null) {
-    print('tell navigator');
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      print('first back gesture controller detected frame');
-      _drewOneFrame = true;
-    });
-    SchedulerBinding.instance.scheduleFrame();
     navigator.didStartUserGesture();
   }
 
@@ -584,15 +574,10 @@ class _CupertinoBackGestureController<T> {
 
   bool _animating = false;
 
-  bool _drewOneFrame = false;
-
   /// The drag gesture has changed by [fractionalDelta]. The total range of the
   /// drag should be 0.0 to 1.0.
   void dragUpdate(double delta) {
-    // if (_drewOneFrame) {
-      controller.value -= delta;
-      print('controller update animation value to ${controller.value}');
-    // }
+    controller.value -= delta;
   }
 
   /// The drag gesture has ended with a horizontal motion of

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 const double _kBackGestureWidth = 20.0;
@@ -476,12 +477,14 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
   void _handleDragStart(DragStartDetails details) {
     assert(mounted);
     assert(_backGestureController == null);
+    print('gesture start');
     _backGestureController = widget.onStartPopGesture();
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
     assert(mounted);
     assert(_backGestureController != null);
+    print('move');
     _backGestureController.dragUpdate(_convertToLogical(details.primaryDelta / context.size.width));
   }
 
@@ -501,6 +504,7 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
   }
 
   void _handlePointerDown(PointerDownEvent event) {
+    print('pointer down');
     if (widget.enabledCallback())
       _recognizer.addPointer(event);
   }
@@ -560,6 +564,12 @@ class _CupertinoBackGestureController<T> {
   }) : assert(navigator != null),
        assert(controller != null),
        assert(onEnded != null) {
+    print('tell navigator');
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      print('first back gesture controller detected frame');
+      _drewOneFrame = true;
+    });
+    SchedulerBinding.instance.scheduleFrame();
     navigator.didStartUserGesture();
   }
 
@@ -574,10 +584,15 @@ class _CupertinoBackGestureController<T> {
 
   bool _animating = false;
 
+  bool _drewOneFrame = false;
+
   /// The drag gesture has changed by [fractionalDelta]. The total range of the
   /// drag should be 0.0 to 1.0.
   void dragUpdate(double delta) {
-    controller.value -= delta;
+    // if (_drewOneFrame) {
+      controller.value -= delta;
+      print('controller update animation value to ${controller.value}');
+    // }
   }
 
   /// The drag gesture has ended with a horizontal motion of

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -429,7 +429,7 @@ class _HeroFlight {
       assert(type != null);
       switch (type) {
         case HeroFlightDirection.pop:
-          // Pops may be driven by a user gesture that manually drives the
+          // Pops may be initiated by a user gesture that manually drives the
           // AnimationController without being in any particular animation states.
           return initial.value == 1.0;
         case HeroFlightDirection.push:
@@ -553,7 +553,7 @@ class HeroController extends NavigatorObserver {
   /// linear [Tween<Rect>].
   HeroController({ this.createRectTween });
 
-  /// Used to create [RectTween]s that interpolate the position of heros in flight.
+  /// Used to create [RectTween]s that interpolate the position of heroes in flight.
   ///
   /// If null, the controller uses a linear [RectTween].
   final CreateRectTween createRectTween;
@@ -602,7 +602,7 @@ class HeroController extends NavigatorObserver {
       }
 
       // For gesture driven pops into a page that maintainState, let the
-      // heros be measured and the overlay built right away since the previous
+      // heroes be measured and the overlay built right away since the previous
       // both routes' render objects are already present and laid out.
       if (fromGesture && flightType == HeroFlightDirection.pop && to.maintainState) {
         _startHeroTransition(from, to, animation, flightType, fromGesture);
@@ -623,7 +623,7 @@ class HeroController extends NavigatorObserver {
     }
   }
 
-  // Find the matching pairs of heros in from and to and either start or a new
+  // Find the matching pairs of heroes in from and to and either start or a new
   // hero flight, or divert an existing one.
   void _startHeroTransition(
     PageRoute<dynamic> from,

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -348,10 +348,13 @@ class NavigatorObserver {
   /// The [Navigator] replaced `oldRoute` with `newRoute`.
   void didReplace({ Route<dynamic> newRoute, Route<dynamic> oldRoute }) { }
 
-  /// The [Navigator]'s routes are being moved by a user gesture.
+  /// The [Navigator]'s route `route` is being moved by a user gesture.
   ///
-  /// For example, this is called when an iOS back gesture starts, and is used
-  /// to disabled hero animations during such interactions.
+  /// For example, this is called when an iOS back gesture starts.
+  ///
+  /// If present, the route immediately below `route` is `previousRoute`.
+  /// Though the gesture may not necessarily conclude at `previousRoute` if
+  /// canceled.
   void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute) { }
 
   /// User gesture is no longer controlling the [Navigator].

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -352,9 +352,13 @@ class NavigatorObserver {
   ///
   /// For example, this is called when an iOS back gesture starts.
   ///
+  /// Paired with a call to [didStopUserGesture] when the route is no longer
+  /// being manipulated via user gesture.
+  ///
   /// If present, the route immediately below `route` is `previousRoute`.
   /// Though the gesture may not necessarily conclude at `previousRoute` if
-  /// canceled.
+  /// the gesture is canceled. In that case, [didStopUserGesture] is still
+  /// called but a follow-up [didPop] is not.
   void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute) { }
 
   /// User gesture is no longer controlling the [Navigator].
@@ -1915,11 +1919,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     _userGesturesInProgress += 1;
     if (_userGesturesInProgress == 1) {
       final Route<dynamic> route = _history.last;
-      final Route<dynamic> previousRoute = route.willHandlePopInternally
-          ? null
-          : _history.length > 1
-              ? _history[_history.length - 2]
-              : null;
+      final Route<dynamic> previousRoute = !route.willHandlePopInternally && _history.length > 1
+          ? _history[_history.length - 2]
+          : null;
       // Don't operate the _history list since the gesture may be cancelled.
       // In case of a back swipe, the gesture controller will call .pop() itself.
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1911,15 +1911,17 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   void didStartUserGesture() {
     _userGesturesInProgress += 1;
     if (_userGesturesInProgress == 1) {
-      final Route<dynamic> currentRoute = _history.last;
-      final Route<dynamic> nextRoute = currentRoute.willHandlePopInternally
+      final Route<dynamic> route = _history.last;
+      final Route<dynamic> previousRoute = route.willHandlePopInternally
           ? null
           : _history.length > 1
               ? _history[_history.length - 2]
               : null;
+      // Don't operate the _history list since the gesture may be cancelled.
+      // In case of a back swipe, the gesture controller will call .pop() itself.
 
       for (NavigatorObserver observer in widget.observers)
-        observer.didStartUserGesture(currentRoute, nextRoute);
+        observer.didStartUserGesture(route, previousRoute);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -352,7 +352,7 @@ class NavigatorObserver {
   ///
   /// For example, this is called when an iOS back gesture starts, and is used
   /// to disabled hero animations during such interactions.
-  void didStartUserGesture() { }
+  void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute) { }
 
   /// User gesture is no longer controlling the [Navigator].
   ///
@@ -1911,8 +1911,15 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   void didStartUserGesture() {
     _userGesturesInProgress += 1;
     if (_userGesturesInProgress == 1) {
+      final Route<dynamic> currentRoute = _history.last;
+      final Route<dynamic> nextRoute = currentRoute.willHandlePopInternally
+          ? null
+          : _history.length > 1
+              ? _history[_history.length - 2]
+              : null;
+
       for (NavigatorObserver observer in widget.observers)
-        observer.didStartUserGesture();
+        observer.didStartUserGesture(currentRoute, nextRoute);
     }
   }
 

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -808,4 +808,34 @@ void main() {
     expect(bottomBuildTimes, 2);
     expect(topBuildTimes, 3);
   });
+
+  testWidgets('Back swipe gesture transitions',
+      (WidgetTester tester) async {
+    await startTransitionBetween(
+      tester,
+      fromTitle: 'Page 1',
+      toTitle: 'Page 2',
+    );
+
+    // Go to the next page.
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Start the gesture at the edge of the screen.
+    final TestGesture gesture =  await tester.startGesture(const Offset(5.0, 200.0));
+    // Trigger the swipe.
+    await gesture.moveBy(const Offset(100.0, 0.0));
+
+    // Back gestures should trigger and draw the hero transition in the very same
+    // frame (since the "from" route has already moved to reveal the "to" route).
+    await tester.pump();
+
+    // Page 2, which is the middle of the top route, start to fly back to the right.
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(352.5802058875561, 13.5),
+    );
+
+    debugDumpApp();
+    expect(find.text('Page 1'), findsNWidgets(2));
+  });
 }

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -835,7 +835,83 @@ void main() {
       const Offset(352.5802058875561, 13.5),
     );
 
-    debugDumpApp();
-    expect(find.text('Page 1'), findsNWidgets(2));
+    // Page 1 is in transition in 2 places. Once as the top back label and once
+    // as the bottom middle.
+    expect(flying(tester, find.text('Page 1')), findsNWidgets(2));
+
+    // Past the halfway point now.
+    await gesture.moveBy(const Offset(500.0, 0.0));
+    await gesture.up();
+
+    await tester.pump();
+
+    // Transition continues.
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(654.2055835723877, 13.5),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(720.8727767467499, 13.5),
+    );
+
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Cleans up properly
+    expect(() => flying(tester, find.text('Page 1')), throwsAssertionError);
+    expect(() => flying(tester, find.text('Page 2')), throwsAssertionError);
+    // Just the bottom route's middle now.
+    expect(find.text('Page 1'), findsOneWidget);
+  });
+
+  testWidgets('Back swipe gesture cancels properly with transition',
+      (WidgetTester tester) async {
+    await startTransitionBetween(
+      tester,
+      fromTitle: 'Page 1',
+      toTitle: 'Page 2',
+    );
+
+    // Go to the next page.
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Start the gesture at the edge of the screen.
+    final TestGesture gesture =  await tester.startGesture(const Offset(5.0, 200.0));
+    // Trigger the swipe.
+    await gesture.moveBy(const Offset(100.0, 0.0));
+
+    // Back gestures should trigger and draw the hero transition in the very same
+    // frame (since the "from" route has already moved to reveal the "to" route).
+    await tester.pump();
+
+    // Page 2, which is the middle of the top route, start to fly back to the right.
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(352.5802058875561, 13.5),
+    );
+
+    await gesture.up();
+    await tester.pump();
+
+    // Transition continues from the point we let off.
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(352.5802058875561, 13.5),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      tester.getTopLeft(flying(tester, find.text('Page 2'))),
+      const Offset(350.00985169410706, 13.5),
+    );
+
+    // Finish the snap back animation.
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Cleans up properly
+    expect(() => flying(tester, find.text('Page 1')), throwsAssertionError);
+    expect(() => flying(tester, find.text('Page 2')), throwsAssertionError);
+    // Back to page 2.
+    expect(find.text('Page 2'), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -24,7 +24,7 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
         Container(height: 100.0, width: 100.0),
         Card(child: Hero(
           tag: 'a',
-          transitionForUserGestures: transitionFromUserGestures,
+          transitionOnUserGestures: transitionFromUserGestures,
           child: Container(height: 100.0, width: 100.0, key: firstKey),
         )),
         Container(height: 100.0, width: 100.0),
@@ -50,7 +50,7 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
         Container(height: 150.0, width: 150.0),
         Card(child: Hero(
           tag: 'a',
-          transitionForUserGestures: transitionFromUserGestures,
+          transitionOnUserGestures: transitionFromUserGestures,
           child: Container(height: 150.0, width: 150.0, key: secondKey),
         )),
         Container(height: 150.0, width: 150.0),
@@ -79,7 +79,7 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
             padding: const EdgeInsets.only(left: 50.0),
             child: Hero(
               tag: 'a',
-              transitionForUserGestures: transitionFromUserGestures,
+              transitionOnUserGestures: transitionFromUserGestures,
               child: Container(height: 150.0, width: 150.0, key: secondKey),
             )
           ),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -14,13 +14,19 @@ Key homeRouteKey = const Key('homeRoute');
 Key routeTwoKey = const Key('routeTwo');
 Key routeThreeKey = const Key('routeThree');
 
+bool transitionFromUserGestures = false;
+
 final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
   '/': (BuildContext context) => Material(
     child: ListView(
       key: homeRouteKey,
       children: <Widget>[
         Container(height: 100.0, width: 100.0),
-        Card(child: Hero(tag: 'a', child: Container(height: 100.0, width: 100.0, key: firstKey))),
+        Card(child: Hero(
+          tag: 'a',
+          transitionForUserGestures: transitionFromUserGestures,
+          child: Container(height: 100.0, width: 100.0, key: firstKey),
+        )),
         Container(height: 100.0, width: 100.0),
         FlatButton(
           child: const Text('two'),
@@ -42,7 +48,11 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
           onPressed: () { Navigator.pop(context); }
         ),
         Container(height: 150.0, width: 150.0),
-        Card(child: Hero(tag: 'a', child: Container(height: 150.0, width: 150.0, key: secondKey))),
+        Card(child: Hero(
+          tag: 'a',
+          transitionForUserGestures: transitionFromUserGestures,
+          child: Container(height: 150.0, width: 150.0, key: secondKey),
+        )),
         Container(height: 150.0, width: 150.0),
         FlatButton(
           child: const Text('three'),
@@ -67,7 +77,11 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
         Card(
           child: Padding(
             padding: const EdgeInsets.only(left: 50.0),
-            child: Hero(tag: 'a', child: Container(height: 150.0, width: 150.0, key: secondKey))
+            child: Hero(
+              tag: 'a',
+              transitionForUserGestures: transitionFromUserGestures,
+              child: Container(height: 150.0, width: 150.0, key: secondKey),
+            )
           ),
         ),
         Container(height: 150.0, width: 150.0),
@@ -78,7 +92,6 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       ]
     )
   ),
-
 };
 
 class ThreeRoute extends MaterialPageRoute<void> {
@@ -121,6 +134,10 @@ class MyStatefulWidgetState extends State<MyStatefulWidget> {
 }
 
 void main() {
+  setUp(() {
+    transitionFromUserGestures = false;
+  });
+
   testWidgets('Heroes animate', (WidgetTester tester) async {
 
     await tester.pumpWidget(MaterialApp(routes: routes));
@@ -1334,5 +1351,90 @@ void main() {
     expect(find.text('Wolverine'), findsOneWidget);
     expect(find.text('Venom'), findsOneWidget);
     expect(find.text('Joker'), findsOneWidget);
+  });
+
+  testWidgets('Heroes do not transition on back gestures by default', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        platform: TargetPlatform.iOS,
+      ),
+      routes: routes,
+    ));
+
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), findsNothing);
+
+    await tester.tap(find.text('two'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byKey(firstKey), findsNothing);
+    expect(find.byKey(secondKey), isOnstage);
+    expect(find.byKey(secondKey), isInCard);
+
+    final TestGesture gesture = await tester.startGesture(const Offset(5.0, 200.0));
+    await gesture.moveBy(const Offset(200.0, 0.0));
+
+    await tester.pump();
+
+    // Both Heros exist and seated in their normal parents.
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), isOnstage);
+    expect(find.byKey(secondKey), isInCard);
+
+    // To make sure the hero had all chances of starting.
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), isOnstage);
+    expect(find.byKey(secondKey), isInCard);
+  });
+
+  testWidgets('Heroes can transition on gesture in one frame', (WidgetTester tester) async {
+    transitionFromUserGestures = true;
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        platform: TargetPlatform.iOS,
+      ),
+      routes: routes,
+    ));
+
+    await tester.tap(find.text('two'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byKey(firstKey), findsNothing);
+    expect(find.byKey(secondKey), isOnstage);
+    expect(find.byKey(secondKey), isInCard);
+
+    final TestGesture gesture = await tester.startGesture(const Offset(5.0, 200.0));
+    await gesture.moveBy(const Offset(200.0, 0.0));
+    await tester.pump();
+
+    // We're going to page 1 so page 1's Hero is lifted into flight.
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isNotInCard);
+    expect(find.byKey(secondKey), findsNothing);
+
+    // Move further along.
+    await gesture.moveBy(const Offset(500.0, 0.0));
+    await tester.pump();
+
+    // Same results.
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isNotInCard);
+    expect(find.byKey(secondKey), findsNothing);
+
+    await gesture.up();
+    // Finish transition.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Hero A is back in the card.
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), findsNothing);
   });
 }


### PR DESCRIPTION
Fixes #9446

Lets Heroes be initiated from a back swipe gesture. 
Changes signature for NavigatorObserver.didStartUserGesture from

```dart
void didStartUserGesture();
```

to

```dart
void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute);
```

Measures and inserts hero flight into overlay on first frame. 
Use in Cupertino nav bars.

![giphy-8](https://user-images.githubusercontent.com/156888/47249410-f9574980-d3c7-11e8-8ffa-ea11d868655f.gif)

Breaking signature announce: https://groups.google.com/forum/#!topic/flutter-dev/SBAlcp6W_3g