### PR TITLE
make LocalHistoryRoute a proper super-mixin

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -306,16 +306,14 @@ class LocalHistoryEntry {
   }
 }
 
-/// A route that can handle back navigations internally by popping a list.
+/// A mixin used by routes to handle back navigations internally by popping a list.
 ///
 /// When a [Navigator] is instructed to pop, the current route is given an
-/// opportunity to handle the pop internally. A LocalHistoryRoute handles the
+/// opportunity to handle the pop internally. A `LocalHistoryRoute` handles the
 /// pop internally if its list of local history entries is non-empty. Rather
 /// than being removed as the current route, the most recent [LocalHistoryEntry]
 /// is removed from the list and its [LocalHistoryEntry.onRemove] is called.
-///
-/// This class is typically used as a mixin.
-abstract class LocalHistoryRoute<T> extends Route<T> {
+mixin LocalHistoryRoute<T> on Route<T> {
   List<LocalHistoryEntry> _localHistory;
 
   /// Adds a local history entry to this route.

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -12,7 +12,7 @@ final List<String> results = <String>[];
 
 Set<TestRoute> routes = HashSet<TestRoute>();
 
-class TestRoute extends LocalHistoryRoute<String> {
+class TestRoute extends Route<String> with LocalHistoryRoute<String> {
   TestRoute(this.name);
   final String name;
 


### PR DESCRIPTION
It is a super-mixin and therefore must be declared using `mixin` and must not allow extensions.

/cc @leafpetersen 