### PR TITLE
Push breakpoint URIs to Project and remove unused string paths

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -33,13 +33,13 @@ void main() {
 
     Future<VMIsolate> breakInBuildMethod(FlutterTestDriver flutter) async {
       return _flutter.breakAt(
-          Uri.parse('package:test/main.dart'),
+          _project.buildMethodBreakpointUri,
           _project.buildMethodBreakpointLine);
     }
 
     Future<VMIsolate> breakInTopLevelFunction(FlutterTestDriver flutter) async {
       return _flutter.breakAt(
-          Uri.parse('package:test/main.dart'),
+          _project.topLevelFunctionBreakpointUri,
           _project.topLevelFunctionBreakpointLine);
     }
 

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -41,7 +41,7 @@ void main() {
     test('reload hits breakpoints after reload', () async {
       await _flutter.run(withDebugger: true);
       final VMIsolate isolate = await _flutter.breakAt(
-          Uri.parse('package:test/main.dart'),
+          _project.breakpointUri,
           _project.breakpointLine);
       expect(isolate.pauseEvent, isInstanceOf<VMPauseBreakpointEvent>());
     });

--- a/packages/flutter_tools/test/integration/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/basic_project.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/file_system.dart';
-
 import 'test_project.dart';
 
 class BasicProject extends TestProject {
@@ -41,9 +39,9 @@ class BasicProject extends TestProject {
   }
   ''';
 
-  String get buildMethodBreakpointFile => breakpointFile;
+  Uri get buildMethodBreakpointUri => breakpointUri;
   int get buildMethodBreakpointLine => breakpointLine;
 
-  String get topLevelFunctionBreakpointFile => fs.path.join(dir.path, 'lib', 'main.dart');
+  Uri get topLevelFunctionBreakpointUri => breakpointUri;
   int get topLevelFunctionBreakpointLine => lineContaining(main, '// TOP LEVEL BREAKPOINT');
 }

--- a/packages/flutter_tools/test/integration/test_data/test_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/test_project.dart
@@ -16,8 +16,7 @@ abstract class TestProject {
   String get main;
 
   // Valid locations for a breakpoint for tests that just need to break somewhere.
-  String get breakpointFile => fs.path.join(
-      dir.path, 'lib', 'main.dart');
+  Uri get breakpointUri => Uri.parse('package:test/main.dart');
   int get breakpointLine => lineContaining(main, '// BREAKPOINT');
 
   Future<void> setUpIn(Directory dir) async {


### PR DESCRIPTION
This just pushes the URIs added in #23384/#23357/#23346 into the Project classes and removes the string paths that are no longer used.

@aam @dnfield @jason-simmons