### PR TITLE
Fixes gradle error: 'Could not find lint-gradle-api.jar' (#23095)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Christian Mürtz <teraarts@t-online.de>
 Lukasz Piliszczuk <lukasz@intheloup.io>
 Felix Schmidt <felix.free@gmx.de>
 Artur Rymarz <artur.rymarz@gmail.com>
+Stefan Mitev <mr.mitew@gmail.com>

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven {
             url 'https://dl.google.com/dl/android/maven2'

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -20,9 +20,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://dl.google.com/dl/android/maven2'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'


### PR DESCRIPTION
Fixes gradle error:

Could not resolve all files for configuration 'classpath'.
Could not find lint-gradle-api.jar (com.android.tools.lint:lint-gradle-api:26.1.2).
Searched in the following locations:
https://jcenter.bintray.com/com/android/tools/lint/lint-gradle-api/26.1.2/lint-gradle-api-26.1.2.jar