### PR TITLE
Added google()

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
+    	google()
         jcenter()
         maven {
             url 'https://dl.google.com/dl/android/maven2'


### PR DESCRIPTION
Added google() to solve Could not find lint-gradle-api.jar
In the project, modify



  
Dependencies {
         Classpath 'com.android.tools.build:gradle:3.2.1'
}



distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip