### PR TITLE
Run flutter tests with --track-widget-creation as part of the build.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -176,6 +176,11 @@ Future<void> _runTests() async {
   await _runSmokeTests();
 
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter'));
+  // Only packages/flutter/test/widgets/widget_inspector_test.dart really
+  // needs to be run with --track-widget-creation but it is nice to run
+  // all of the tests in package:flutter with the flag to ensure that
+  // the Dart kernel transformer triggered by the flag does not break anything.
+  await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter'), options: <String>['--track-widget-creation']);
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_localizations'));
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_driver'));
   await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_test'));
@@ -189,6 +194,9 @@ Future<void> _runTests() async {
   await _runFlutterTest(path.join(flutterRoot, 'examples', 'layers'));
   await _runFlutterTest(path.join(flutterRoot, 'examples', 'stocks'));
   await _runFlutterTest(path.join(flutterRoot, 'examples', 'flutter_gallery'));
+  // Regression test to ensure that code outside of package:flutter can run
+  // with --track-widget-creation.
+  await _runFlutterTest(path.join(flutterRoot, 'examples', 'flutter_gallery'), options: <String>['--track-widget-creation']);
   await _runFlutterTest(path.join(flutterRoot, 'examples', 'catalog'));
 
   print('${bold}DONE: All tests successful.$reset');

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -677,23 +677,23 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       // would make this test fragile.
       expect(lineA + 1, equals(lineB));
       // Column numbers are more stable than line numbers.
-      expect(columnA, equals(21));
+      expect(columnA, equals(15));
       expect(columnA, equals(columnB));
       expect(parameterLocationsA.length, equals(1));
       final Map<String, Object> paramA = parameterLocationsA[0];
       expect(paramA['name'], equals('data'));
       expect(paramA['line'], equals(lineA));
-      expect(paramA['column'], equals(26));
+      expect(paramA['column'], equals(20));
 
       expect(parameterLocationsB.length, equals(2));
       final Map<String, Object> paramB1 = parameterLocationsB[0];
       expect(paramB1['name'], equals('data'));
       expect(paramB1['line'], equals(lineB));
-      expect(paramB1['column'], equals(26));
+      expect(paramB1['column'], equals(20));
       final Map<String, Object> paramB2 = parameterLocationsB[1];
       expect(paramB2['name'], equals('textDirection'));
       expect(paramB2['line'], equals(lineB));
-      expect(paramB2['column'], equals(31));
+      expect(paramB2['column'], equals(25));
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // Test requires --track-widget-creation flag.
 
     testWidgets('WidgetInspectorService setPubRootDirectories', (WidgetTester tester) async {
@@ -1203,23 +1203,23 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       // would make this test fragile.
       expect(lineA + 1, equals(lineB));
       // Column numbers are more stable than line numbers.
-      expect(columnA, equals(21));
+      expect(columnA, equals(15));
       expect(columnA, equals(columnB));
       expect(parameterLocationsA.length, equals(1));
       final Map<String, Object> paramA = parameterLocationsA[0];
       expect(paramA['name'], equals('data'));
       expect(paramA['line'], equals(lineA));
-      expect(paramA['column'], equals(26));
+      expect(paramA['column'], equals(20));
 
       expect(parameterLocationsB.length, equals(2));
       final Map<String, Object> paramB1 = parameterLocationsB[0];
       expect(paramB1['name'], equals('data'));
       expect(paramB1['line'], equals(lineB));
-      expect(paramB1['column'], equals(26));
+      expect(paramB1['column'], equals(20));
       final Map<String, Object> paramB2 = parameterLocationsB[1];
       expect(paramB2['name'], equals('textDirection'));
       expect(paramB2['line'], equals(lineB));
-      expect(paramB2['column'], equals(31));
+      expect(paramB2['column'], equals(25));
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // Test requires --track-widget-creation flag.
 
     testWidgets('ext.flutter.inspector.setPubRootDirectories', (WidgetTester tester) async {


### PR DESCRIPTION
This CL was previously landed and reverted because of an issue with reusing --track-widget-creation dill files in a non --track-widget-creation build. 
That issue was fixed by 
https://github.com/flutter/flutter/commit/f5f70f0c9930585d0eac1ac1288cc3d0abc29630
so this cl should be good to land again.