### PR TITLE
mark integration_ui_ios as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -405,6 +405,7 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
     timeout_in_minutes: 20
+    flaky: true
 
   ios_sample_catalog_generator:
     description: >


### PR DESCRIPTION
Example log on device lab with flake: https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahNzfmZsdXR0ZXItZGFzaGJvYXJkclgLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci8zYmJiMzA4MmI4OWFkYTRiMGM0NDM5NjE0OGYzYzJkZTczMWQxYzZkDAsSBFRhc2sYgICAgIDkyQoM

Looking at https://flutter-dashboard.appspot.com/build.html every other run is failing.