### PR TITLE
Added google maven repository for fix gradle build error

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven {
             url 'https://dl.google.com/dl/android/maven2'

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,11 +18,10 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
-        google()
-        jcenter()
         maven {
             url 'https://dl.google.com/dl/android/maven2'
         }
+	jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'


### PR DESCRIPTION
Some developers are using Android Studio to build,
but they can encounter error "could not find lint-gradle-api-26.1.2.jar."

The reason for this error is that the flutter grade does not include the
google maven repository, which is why it can not find lint-gradle-api.

Of course developers can add it by self like stackoverflow below,
But.. I think the google maven repository should be included by default.

Please refer to stackoverflow issue.
https://stackoverflow.com/questions/52945041/couldnt-locate-lint-gradle-api-26-1-2-jar-for-flutter-project