### PR TITLE
ensure that ScrollPosition._pixels is non-null after construction

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -80,6 +80,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       absorb(oldPosition);
     if (keepScrollOffset)
       restoreScrollOffset();
+    _pixels ??= 0.0;
   }
 
   /// How the scroll position should respond to user input.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -80,7 +80,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       absorb(oldPosition);
     if (keepScrollOffset)
       restoreScrollOffset();
-    _pixels ??= 0.0;
   }
 
   /// How the scroll position should respond to user input.
@@ -659,7 +658,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   @override
   void dispose() {
-    assert(pixels != null);
     activity?.dispose(); // it will be null if it got absorbed by another ScrollPosition
     _activity = null;
     super.dispose();


### PR DESCRIPTION
When an app uses scrollable widgets, but there is no PageStorage in the context, it can happen that `ScrollPosition.pixels` is never initialized, and remains `null`. Later on, if we're running in debug mode, when the widget gets disposed, the following `assert` in `dispose()` gets called, crashing the app.

```
  @override
  void dispose() {
    assert(pixels != null);
    activity?.dispose(); // it will be null if it got absorbed by another ScrollPosition
    _activity = null;
    super.dispose();
  }
```

This patch removes the assert allows `_pixels` to be `null` during dispose. This is needed because:

1. Maybe a ScrollPosition is constructed (with no PageStorage in the context, so `_pixels` is `null`)
2. The intention is to absorb another ScrollPosition into this one. But for some reason, the code never gets there.
3. This ScrollPosition is disposed, and `_pixels` is still `null`. In debug mode, this triggers the assert.

See https://github.com/flutter/flutter/issues/21630 (part 2) for more discussion of this, when the problem shows up, and why I believe this is a good remedy.
