### PR TITLE
Register expression compiler in flutter test setting.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -25,6 +24,7 @@ import '../bundle.dart';
 import '../compile.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
+import '../vmservice.dart';
 import 'watcher.dart';
 
 /// The timeout we give the test process to connect to the test harness
@@ -419,7 +419,7 @@ class _FlutterPlatform extends PlatformPlugin {
       String libraryUri, String klass, bool isStatic,
       ) async {
     if (compiler == null || compiler.compiler == null) {
-      throw "Compiler is not set up properly to compile $expression";
+      throw 'Compiler is not set up properly to compile $expression';
     }
     final CompilerOutput compilerOutput =
       await compiler.compiler.compileExpression(expression, definitions,
@@ -546,8 +546,8 @@ class _FlutterPlatform extends PlatformPlugin {
 
           {
             printTrace('Connecting to service protocol: $processObservatoryUri');
-            Future<VMService> localVmService = VMService.connect(processObservatoryUri,
-                compileExpression: _compileExpressionService);
+            final Future<VMService> localVmService = VMService.connect(processObservatoryUri,
+              compileExpression: _compileExpressionService);
             localVmService.then((VMService vmservice) {
               printTrace('Successfully connected to service protocol: $processObservatoryUri');
             });

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -413,6 +414,22 @@ class _FlutterPlatform extends PlatformPlugin {
     return remoteChannel;
   }
 
+  Future<String> _compileExpressionService(String isolateId, String expression,
+      List<String> definitions, List<String> typeDefinitions,
+      String libraryUri, String klass, bool isStatic,
+      ) async {
+    if (compiler == null || compiler.compiler == null) {
+      throw "Compiler is not set up properly to compile $expression";
+    }
+    final CompilerOutput compilerOutput =
+      await compiler.compiler.compileExpression(expression, definitions,
+        typeDefinitions, libraryUri, klass, isStatic);
+    if (compilerOutput != null && compilerOutput.outputFilename != null) {
+      return base64.encode(fs.file(compilerOutput.outputFilename).readAsBytesSync());
+    }
+    throw 'Failed to compile $expression';
+  }
+
   Future<_AsyncError> _startTest(
     String testPath,
     StreamChannel<dynamic> controller,
@@ -526,6 +543,16 @@ class _FlutterPlatform extends PlatformPlugin {
             printTrace('test $ourTestCount: using observatory uri $detectedUri from pid ${process.pid}');
           }
           processObservatoryUri = detectedUri;
+
+          {
+            printTrace('Connecting to service protocol: $processObservatoryUri');
+            Future<VMService> localVmService = VMService.connect(processObservatoryUri,
+                compileExpression: _compileExpressionService);
+            localVmService.then((VMService vmservice) {
+              printTrace('Successfully connected to service protocol: $processObservatoryUri');
+            });
+          }
+
           gotProcessObservatoryUri.complete();
           watcher?.handleStartedProcess(ProcessEvent(ourTestCount, process, processObservatoryUri));
         },


### PR DESCRIPTION
This is needed so that expression evaluation works when debugging `flutter test` tests.