### PR TITLE
Allows progress indicator height to be controlled by parent

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -221,9 +221,9 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
 
   Widget _buildIndicator(BuildContext context, double animationValue, TextDirection textDirection) {
     return Container(
-      constraints: const BoxConstraints.tightFor(
-        width: double.infinity,
-        height: _kLinearProgressIndicatorHeight,
+      constraints: const BoxConstraints(
+        minWidth: double.infinity,
+        minHeight: _kLinearProgressIndicatorHeight,
       ),
       child: CustomPaint(
         painter: _LinearProgressIndicatorPainter(

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -263,7 +263,7 @@ void main() {
         child: Center(
           child: SizedBox(
             width: 100.0,
-            height: 18.0,
+            height: 12.0,
             child: LinearProgressIndicator(value: 0.25),
           ),
         ),
@@ -272,11 +272,34 @@ void main() {
     expect(
         find.byType(LinearProgressIndicator),
         paints
-          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 100.0, 18.0))
-          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 18.0))
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 100.0, 12.0))
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 12.0))
     );
     expect(tester.binding.transientCallbackCount, 0);
   });
+
+  testWidgets('LinearProgressIndicator with a height less than the minumum', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100.0,
+            height: 3.0,
+            child: LinearProgressIndicator(value: 0.25),
+          ),
+        ),
+      ),
+    );
+    expect(
+        find.byType(LinearProgressIndicator),
+        paints
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 100.0, 3.0))
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 3.0))
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
   testWidgets('LinearProgressIndicator with default height', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -255,4 +255,47 @@ void main() {
     await tester.pump(const Duration(milliseconds: 1));
     expect(tester.hasRunningAnimations, isTrue);
   });
+
+  testWidgets('LinearProgressIndicator with height 12.0', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100.0,
+            height: 18.0,
+            child: LinearProgressIndicator(value: 0.25),
+          ),
+        ),
+      ),
+    );
+    expect(
+        find.byType(LinearProgressIndicator),
+        paints
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 100.0, 18.0))
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 18.0))
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+  testWidgets('LinearProgressIndicator with default height', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100.0,
+            height: 4.0,
+            child: LinearProgressIndicator(value: 0.25),
+          ),
+        ),
+      ),
+    );
+    expect(
+        find.byType(LinearProgressIndicator),
+        paints
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 100.0, 4.0))
+          ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 4.0))
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
 }


### PR DESCRIPTION
Fixes #15282 and addresses #15281, originally debugged by @Phrohdoh.