### PR TITLE
WIP clear inherited dependencies before rebuild

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3530,6 +3530,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (_dependencies != null && _dependencies.isNotEmpty) {
       for (InheritedElement dependency in _dependencies)
         dependency._dependents.remove(this);
+      _dependencies.clear();
     }
 
     performRebuild();

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4076,6 +4076,12 @@ class InheritedElement extends ProxyElement {
   }
 
   @override
+  void rebuild() {
+    _dependents.clear();
+    super.rebuild();
+  }
+
+  @override
   void debugDeactivated() {
     assert(() {
       assert(_dependents.isEmpty);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -21,7 +21,6 @@ export 'package:flutter/foundation.dart' show
   protected,
   required,
   visibleForTesting;
-
 export 'package:flutter/foundation.dart' show FlutterError, debugPrint, debugPrintStack;
 export 'package:flutter/foundation.dart' show VoidCallback, ValueChanged, ValueGetter, ValueSetter;
 export 'package:flutter/foundation.dart' show DiagnosticLevel;
@@ -3527,6 +3526,12 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       owner._debugCurrentBuildTarget = this;
       return true;
     }());
+
+    if (_dependencies != null && _dependencies.isNotEmpty) {
+      for (InheritedElement dependency in _dependencies)
+        dependency._dependents.remove(this);
+    }
+
     performRebuild();
     assert(() {
       assert(owner._debugCurrentBuildTarget == this);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4076,12 +4076,6 @@ class InheritedElement extends ProxyElement {
   }
 
   @override
-  void rebuild() {
-    _dependents.clear();
-    super.rebuild();
-  }
-
-  @override
   void debugDeactivated() {
     assert(() {
       assert(_dependents.isEmpty);


### PR DESCRIPTION
Related: https://github.com/flutter/flutter/issues/21967


> Consider a widget that conditionally depends on an InheritedModel aspect:
>
> ```dart
> if (foo) {
>   return Text("Foo", MyModel.of(context, aspect: MyAspect));
> }
> ```
> It seems that if foo requirement is met once. Then even if that condition fails in the future; the widget will stay dependent on the MyModel.
> 
> This leads to unnecessary builds. I'd expect the list of dependencies to be cleared before build call



This seems to fix the problem (at least for my use-case).
But I'm likely to be missing something. 

I don't know how to evaluate the performance impact.
Although considering how minor the modification is (Only InheritedWidgets are impacted), I doupt it changes much.

I'll add tests when it has been confirmed that this is a correct solution

