### PR TITLE
Added '--check-for-remote-artifacts' option for Flutter Doctor.

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -31,7 +31,7 @@ Future<List<int>> fetchUrl(Uri url) async {
 
 /// Check if the given URL points to a valid endpoint.
 Future<bool> doesRemoteFileExist(Uri url) async =>
-  (await _attempt(url, true)) != null;
+  (await _attempt(url, onlyHeaders: true)) != null;
 
 Future<List<int>> _attempt(Uri url, {bool onlyHeaders = false}) async {
   printTrace('Downloading: $url');

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -53,7 +53,7 @@ Future<bool> doesRemoteFileExist(Uri url) async {
     return null;
   }
   final HttpClientResponse response = await request.close();
-  return (response.statusCode == 200);
+  return response.statusCode == 200;
 }
 
 Future<List<int>> _attempt(Uri url) async {

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -31,9 +31,9 @@ Future<List<int>> fetchUrl(Uri url) async {
 
 /// Check if the given URL points to a valid endpoint.
 Future<bool> doesRemoteFileExist(Uri url) async =>
-  (await _attempt(url, true)) as bool;
+  (await _attempt(url, true)) != null;
 
-Future<dynamic> _attempt(Uri url, bool onlyHeaders) async {
+Future<List<int>> _attempt(Uri url, bool onlyHeaders) async {
   printTrace('Downloading: $url');
   HttpClient httpClient;
   if (context[HttpClientFactory] != null) {
@@ -64,7 +64,7 @@ Future<dynamic> _attempt(Uri url, bool onlyHeaders) async {
   // If we're making a HEAD request, we're only checking to see if the URL is
   // valid.
   if (onlyHeaders) {
-    return response.statusCode == 200;
+    return (response.statusCode == 200) ? <int>[] : null;
   }
   if (response.statusCode != 200) {
     if (response.statusCode > 0 && response.statusCode < 500) {

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -19,7 +19,7 @@ Future<List<int>> fetchUrl(Uri url) async {
   int duration = 1;
   while (true) {
     attempts += 1;
-    final List<int> result = await _attempt(url, false);
+    final List<int> result = await _attempt(url);
     if (result != null)
       return result;
     printStatus('Download failed -- attempting retry $attempts in $duration second${ duration == 1 ? "" : "s"}...');

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -29,6 +29,33 @@ Future<List<int>> fetchUrl(Uri url) async {
   }
 }
 
+Future<bool> doesRemoteFileExist(Uri url) async {
+  printTrace('Checking file exists at: $url');
+  HttpClient httpClient;
+  if (context[HttpClientFactory] != null) {
+    httpClient = context[HttpClientFactory]();
+  } else {
+    httpClient = HttpClient();
+  }
+  HttpClientRequest request;
+  try {
+    request = await httpClient.headUrl(url);
+  } on HandshakeException catch (error) {
+    printTrace(error.toString());
+    throwToolExit(
+      'Could not authenticate download server. You may be experiencing a man-in-the-middle attack,\n'
+      'your network may be compromised, or you may have malware installed on your computer.\n'
+      'URL: $url',
+      exitCode: kNetworkProblemExitCode,
+    );
+  } on SocketException catch (error) {
+    printTrace('Request error: $error');
+    return null;
+  }
+  final HttpClientResponse response = await request.close();
+  return (response.statusCode == 200);
+}
+
 Future<List<int>> _attempt(Uri url) async {
   printTrace('Downloading: $url');
   HttpClient httpClient;

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -33,7 +33,7 @@ Future<List<int>> fetchUrl(Uri url) async {
 Future<bool> doesRemoteFileExist(Uri url) async =>
   (await _attempt(url, true)) != null;
 
-Future<List<int>> _attempt(Uri url, bool onlyHeaders) async {
+Future<List<int>> _attempt(Uri url, {bool onlyHeaders = false}) async {
   printTrace('Downloading: $url');
   HttpClient httpClient;
   if (context[HttpClientFactory] != null) {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -510,7 +510,7 @@ class FlutterEngine extends CachedArtifact {
     final bool includeAllPlatformsState = cache.includeAllPlatforms;
     cache.includeAllPlatforms = includeAllPlatforms;
 
-    Future<bool> _areRemoteArtifactsAvailableHelper(String engineVersion) async {
+    Future<bool> checkForArtifacts(String engineVersion) async {
       engineVersion ??= version;
       final String url = '$_storageBaseUrl/flutter_infra/flutter/$engineVersion/';
 
@@ -536,7 +536,7 @@ class FlutterEngine extends CachedArtifact {
       return true;
     }
 
-    final bool result = await _areRemoteArtifactsAvailableHelper(engineVersion);
+    final bool result = await checkForArtifacts(engineVersion);
     cache.includeAllPlatforms = includeAllPlatformsState;
     return result;
   }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -506,18 +506,16 @@ class FlutterEngine extends CachedArtifact {
   }
 
   Future<bool> areRemoteArtifactsAvailable({String engineVersion,
-                                            bool includeAllPlatforms: true}) async {
+                                            bool includeAllPlatforms = true}) async {
     final bool includeAllPlatformsState = cache.includeAllPlatforms;
     cache.includeAllPlatforms = includeAllPlatforms;
-    bool result = await _areRemoteArtifactsAvailableHelper(engineVersion);
+    final bool result = await _areRemoteArtifactsAvailableHelper(engineVersion);
     cache.includeAllPlatforms = includeAllPlatformsState;
     return result;
   }
 
   Future<bool> _areRemoteArtifactsAvailableHelper(String engineVersion) async {
-    if (engineVersion == null) {
-      engineVersion = version;
-    }
+    engineVersion ??= version;
     final String url = '$_storageBaseUrl/flutter_infra/flutter/$engineVersion/';
 
     bool exists = false;
@@ -608,7 +606,7 @@ Future<void> _downloadFile(Uri url, File location) async {
 
 Future<bool> _doesRemoteExist(String message, Uri url) async {
   final Status status = logger.startProgress(message, expectSlowOperation: true);
-  bool exists = await doesRemoteFileExist(url);
+  final bool exists = await doesRemoteFileExist(url);
   status.stop();
   return exists;
 }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -505,6 +505,41 @@ class FlutterEngine extends CachedArtifact {
     }
   }
 
+  Future<bool> areRemoteArtifactsAvailable({String engineVersion,
+                                            bool includeAllPlatforms: true}) async {
+    final bool includeAllPlatformsState = cache.includeAllPlatforms;
+    cache.includeAllPlatforms = includeAllPlatforms;
+    bool result = await _areRemoteArtifactsAvailableHelper(engineVersion);
+    cache.includeAllPlatforms = includeAllPlatformsState;
+    return result;
+  }
+
+  Future<bool> _areRemoteArtifactsAvailableHelper(String engineVersion) async {
+    if (engineVersion == null) {
+      engineVersion = version;
+    }
+    final String url = '$_storageBaseUrl/flutter_infra/flutter/$engineVersion/';
+
+    bool exists = false;
+    for (String pkgName in _getPackageDirs()) {
+      exists = await _doesRemoteExist('Checking package $pkgName is available...', Uri.parse(url + pkgName + '.zip'));
+      if (!exists) {
+        return false;
+      }
+    }
+
+    for (List<String> toolsDir in _getBinaryDirs()) {
+      final String cacheDir = toolsDir[0];
+      final String urlPath = toolsDir[1];
+      exists = await _doesRemoteExist('Checking $cacheDir tools are available...', Uri.parse(url + urlPath));
+      if (!exists) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   void _makeFilesExecutable(Directory dir) {
     for (FileSystemEntity entity in dir.listSync()) {
       if (entity is File) {
@@ -569,6 +604,13 @@ Future<void> _downloadFile(Uri url, File location) async {
   _ensureExists(location.parent);
   final List<int> fileBytes = await fetchUrl(url);
   location.writeAsBytesSync(fileBytes, flush: true);
+}
+
+Future<bool> _doesRemoteExist(String message, Uri url) async {
+  final Status status = logger.startProgress(message, expectSlowOperation: true);
+  bool exists = await doesRemoteFileExist(url);
+  status.stop();
+  return exists;
 }
 
 /// Create the given [directory] and parents, as necessary.

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../base/common.dart';
 import '../doctor.dart';
 import '../runner/flutter_command.dart';
 
@@ -14,6 +15,11 @@ class DoctorCommand extends FlutterCommand {
       negatable: false,
       help: 'Run the Android SDK manager tool to accept the SDK\'s licenses.',
     );
+    argParser.addOption('check-for-remote-artifacts',
+      hide: !verbose,
+      help: 'Used to determine if Flutter engine artifacts for all platforms '
+            'are available for download.',
+      valueHelp: 'engine revision',);
   }
 
   final bool verbose;
@@ -26,6 +32,14 @@ class DoctorCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    final String engineRevision = argResults['check-for-remote-artifacts'];
+    if (engineRevision != null) {
+      final bool success = await doctor.checkRemoteArtifacts(engineRevision);
+      if (!success) {
+        throwToolExit('Artifacts for engine $engineRevision are missing or are '
+            'not yet available.', exitCode: 1);
+      }
+    }
     final bool success = await doctor.diagnose(androidLicenses: argResults['android-licenses'], verbose: verbose);
     return FlutterCommandResult(success ? ExitStatus.success : ExitStatus.warning);
   }

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -19,7 +19,7 @@ class DoctorCommand extends FlutterCommand {
       hide: !verbose,
       help: 'Used to determine if Flutter engine artifacts for all platforms '
             'are available for download.',
-      valueHelp: 'engine revision',);
+      valueHelp: 'engine revision git hash',);
   }
 
   final bool verbose;
@@ -32,12 +32,17 @@ class DoctorCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final String engineRevision = argResults['check-for-remote-artifacts'];
-    if (engineRevision != null) {
-      final bool success = await doctor.checkRemoteArtifacts(engineRevision);
-      if (!success) {
-        throwToolExit('Artifacts for engine $engineRevision are missing or are '
-            'not yet available.', exitCode: 1);
+    if (argResults.wasParsed('check-for-remote-artifacts')) {
+      final String engineRevision = argResults['check-for-remote-artifacts'];
+      if (engineRevision.startsWith(RegExp(r'[a-f0-9]{1,40}'))) {
+        final bool success = await doctor.checkRemoteArtifacts(engineRevision);
+        if (!success) {
+          throwToolExit('Artifacts for engine $engineRevision are missing or are '
+              'not yet available.', exitCode: 1);
+        }
+      } else {
+        throwToolExit('Remote artifact revision $engineRevision is not a valid '
+            'git hash.');
       }
     }
     final bool success = await doctor.diagnose(androidLicenses: argResults['android-licenses'], verbose: verbose);

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -160,6 +160,12 @@ class Doctor {
     return buffer.toString();
   }
 
+  Future<bool> checkRemoteArtifacts(String engineRevision) async {
+    final Cache cache = Cache();
+    final FlutterEngine engine = FlutterEngine(cache);
+    return await engine.areRemoteArtifactsAvailable(engineVersion: engineRevision);
+  }
+
   /// Print information about the state of installed tooling.
   Future<bool> diagnose({ bool androidLicenses = false, bool verbose = true }) async {
     if (androidLicenses)

--- a/packages/flutter_tools/test/base/net_test.dart
+++ b/packages/flutter_tools/test/base/net_test.dart
@@ -103,6 +103,30 @@ void main() {
       const io.HandshakeException('test exception handling'),
     ),
   });
+
+  testUsingContext('remote file non-existant', () async {
+    final Uri invalid = Uri.parse('http://example.invalid/');
+    final bool result = await doesRemoteFileExist(invalid);
+    expect(result, false);
+  }, overrides: <Type, Generator>{
+    HttpClientFactory: () => () => MockHttpClient(404),
+  });
+
+  testUsingContext('remote file server error', () async {
+    final Uri valid = Uri.parse('http://example.valid/');
+    final bool result = await doesRemoteFileExist(valid);
+    expect(result, false);
+  }, overrides: <Type, Generator>{
+    HttpClientFactory: () => () => MockHttpClient(500),
+  });
+
+  testUsingContext('remote file exists', () async {
+    final Uri valid = Uri.parse('http://example.valid/');
+    final bool result = await doesRemoteFileExist(valid);
+    expect(result, true);
+  }, overrides: <Type, Generator>{
+    HttpClientFactory: () => () => MockHttpClient(200),
+  });
 }
 
 class MockHttpClientThrowing implements io.HttpClient {
@@ -128,6 +152,11 @@ class MockHttpClient implements io.HttpClient {
 
   @override
   Future<io.HttpClientRequest> getUrl(Uri url) async {
+    return MockHttpClientRequest(statusCode);
+  }
+
+  @override
+  Future<io.HttpClientRequest> headUrl(Uri url) async {
     return MockHttpClientRequest(statusCode);
   }
 


### PR DESCRIPTION
This option takes a Flutter engine revision and issues HEAD requests to
determine whether or not artifacts for the provided engine revision are
available from cloud storage. This functionality is needed for the Dart
SDK autoroller to avoid creating a PR to roll the engine into the
framework while artifacts haven't finished building, which would cause
Cirrus tests to fail.