### PR TITLE
Fixes gradle error: 'Could not find lint-gradle-api.jar' 

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
-    	  google()
+    	 google()
         jcenter()
     }
     dependencies {

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,10 +18,8 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
+    	google()
         jcenter()
-        maven {
-            url 'https://dl.google.com/dl/android/maven2'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 buildscript {
     repositories {
-    	google()
+    	  google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
dup of https://github.com/flutter/flutter/pull/23397/files needs to be fixed in dev as well 