### PR TITLE
deflake the dartdocs test

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -459,7 +459,6 @@ tasks:
       Tracks how many members are still lacking documentation.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_test_performance:
     description: >


### PR DESCRIPTION
It's been fixed by the latest Dart SDK roll.