### PR TITLE
remove unnecessary overrides

### DIFF
--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -156,11 +156,6 @@ class _TestAppState extends State<TestApp> {
   Future<TestStepResult> _result;
   int _step = 0;
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
   void _executeNextStep() {
     setState(() {
       if (_step < steps.length)

--- a/dev/integration_tests/platform_interaction/lib/main.dart
+++ b/dev/integration_tests/platform_interaction/lib/main.dart
@@ -27,11 +27,6 @@ class _TestAppState extends State<TestApp> {
   Future<TestStepResult> _result;
   int _step = 0;
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
   void _executeNextStep() {
     setState(() {
       if (_step < steps.length)

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -62,11 +62,6 @@ class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {
   }
 
   @override
-  ImageStream resolve(ImageConfiguration configuration) {
-    return super.resolve(configuration);
-  }
-
-  @override
   ImageStreamCompleter load(DelayedImageProvider key) {
     return OneFrameImageStreamCompleter(_completer.future);
   }


### PR DESCRIPTION
- remove 3 unnecessary overrides

These would cause issues with the next dart sdk roll - this lint may have gotten more precise?

```
Don't override a method to do a super method invocation with the same parameters • dev/integration_tests/channels/lib/main.dart:160:8 • unnecessary_overrides
```
