### PR TITLE
add explicit const keywords

### DIFF
--- a/dev/devicelab/bin/tasks/named_isolates_test.dart
+++ b/dev/devicelab/bin/tasks/named_isolates_test.dart
@@ -32,7 +32,7 @@ void main() {
     section('Verify all the debug isolate names are set');
     runProcess.stdin.write('l');
     await Future.wait<dynamic>(<Future<dynamic>>[firstNameFound.future, secondNameFound.future])
-                .timeout(Duration(seconds: 1), onTimeout: () => throw 'Isolate names not found.');
+                .timeout(const Duration(seconds: 1), onTimeout: () => throw 'Isolate names not found.');
     await _quitRunner(runProcess);
 
     section('Attach to the second debug isolate');

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
@@ -21,7 +21,7 @@ class CupertinoPickerDemo extends StatefulWidget {
 class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
   int _selectedColorIndex = 0;
 
-  Duration timer = Duration();
+  Duration timer = const Duration();
 
   // Value that is shown in the date picker in date mode.
   DateTime date = DateTime.now();

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -340,7 +340,7 @@ void main() {
       await gesture.up();
     }
 
-    await longPress(kLongPressTimeout + Duration(seconds: 1)); // To make sure the time for long press has occured
+    await longPress(kLongPressTimeout + const Duration(seconds: 1)); // To make sure the time for long press has occurred
     expect(longPressUp, 1);
   });
 }

--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -71,7 +71,7 @@ void main() {
       file.parent.createSync(recursive: true);
       file.writeAsBytesSync(<int>[1, 2, 3]);
 
-      final DateTime fiveSecondsAgo = DateTime.now().subtract(Duration(seconds:5));
+      final DateTime fiveSecondsAgo = DateTime.now().subtract(const Duration(seconds:5));
       expect(content.isModifiedAfter(fiveSecondsAgo), isTrue);
       expect(content.isModifiedAfter(fiveSecondsAgo), isTrue);
       expect(content.isModifiedAfter(null), isTrue);


### PR DESCRIPTION
- add explicit const keywords in 4 places; this will avoid issues with the next dart sdk roll (and issues with the `prefer_const_constructors` lint)

```
info • Prefer const with constant constructors • examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart:24:20 • prefer_const_constructors
```

@scheglov, @ bwilkerson - do you know why these are being reported in the `analyzer` branch of the sdk? Or, is this an issue with auto-const?
