### PR TITLE
add an analysis_options excludes for the build/ dir

### DIFF
--- a/dev/tools/mega_gallery.dart
+++ b/dev/tools/mega_gallery.dart
@@ -83,6 +83,9 @@ void main(List<String> args) {
   pubspec = pubspec.replaceAll('../../packages/flutter', '../../../packages/flutter');
   _file(out, 'pubspec.yaml').writeAsStringSync(pubspec);
 
+  // Remove the (flutter_gallery specific) analysis_options.yaml file.
+  _file(out, 'analysis_options.yaml').deleteSync();
+
   _file(out, '.dartignore').writeAsStringSync('');
 
   // Count source lines and number of files; tell how to run it.

--- a/examples/flutter_gallery/analysis_options.yaml
+++ b/examples/flutter_gallery/analysis_options.yaml
@@ -1,0 +1,8 @@
+# Take our settings from the repo's main analysis_options.yaml file, but add
+# an exclude for the build directory.
+
+include: ../../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - build/**


### PR DESCRIPTION
- add an analysis_options excludes for the build/ dir

When running `flutter analyze --flutter-repo`, I noticed that older dart source in the `flutter_gallery/build/` directory was being included in the analysis.

```
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:18:1 • unnecessary_new
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:35:1 • unnecessary_new
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:46:1 • unnecessary_new
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:63:1 • unnecessary_new
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:74:1 • unnecessary_new
   info • Unnecessary new keyword • examples/flutter_gallery/build/flutter_assets/lib/gallery/example_code.dart:96:1 • unnecessary_new
```

@HansMuller 