### PR TITLE
[frdp] Add `includeNonFlutterIsolates` flag.

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -287,10 +287,14 @@ class FuchsiaRemoteConnection {
   /// If there are no live Dart VM's or the Isolate cannot be found, waits until
   /// either `timeout` is reached, or a Dart VM starts up with a name that
   /// matches `pattern`.
+  ///
+  /// `includeNonFlutterIsolates` can be set to true to include all isolates
+  /// found instead of just Flutter Isolates.
   Future<List<IsolateRef>> getMainIsolatesByPattern(
     Pattern pattern, {
     Duration timeout = _kIsolateFindTimeout,
     Duration vmConnectionTimeout = _kDartVmConnectionTimeout,
+    bool includeNonFlutterIsolates = false,
   }) async {
     // If for some reason there are no Dart VM's that are alive, wait for one to
     // start with the Isolate in question.
@@ -309,7 +313,10 @@ class FuchsiaRemoteConnection {
       if (vmService == null) {
         continue;
       }
-      isolates.add(vmService.getMainIsolatesByPattern(pattern));
+      isolates.add(vmService.getMainIsolatesByPattern(
+        pattern,
+        includeNonFlutterIsolates: includeNonFlutterIsolates,
+      ));
     }
     final List<IsolateRef> result =
         await Future.wait<List<IsolateRef>>(isolates)


### PR DESCRIPTION
Previously there was no way to add this flag when searching for
Isolates.