### PR TITLE
[Material] Create TabBarTheme.of constructor

### DIFF
--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -3,8 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import 'tabs.dart';
+import 'theme.dart';
 
 /// Defines a theme for [TabBar] widgets.
 ///

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -6,16 +6,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-import 'tabs.dart';
-
 /// Defines a theme for [TabBar] widgets.
 ///
 /// A tab bar theme describes the color of the tab label and the size/shape of
 /// the [TabBar.indicator].
 ///
 /// Descendant widgets obtain the current theme's [TabBarTheme] object using
-/// `TabBarTheme.of(context)`. Instances of [TabBarTheme] can be customized by
-/// copying it (using [TabBarTheme.copyWith]).
+/// `TabBarTheme.of(context)`. Instances of [TabBarTheme] can be customized with
+/// [TabBarTheme.copyWith].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 import 'tabs.dart';
@@ -13,9 +14,8 @@ import 'tabs.dart';
 /// the [TabBar.indicator].
 ///
 /// Descendant widgets obtain the current theme's [TabBarTheme] object using
-/// `Theme.of(context).tabBarTheme`.
-/// [ThemeData.tabBarTheme] can be customized by copying it (using
-/// [TabBarTheme.copyWith]).
+/// `TabBarTheme.of(context)`. Instances of [TabBarTheme] can be customized by
+/// copying it (using [TabBarTheme.copyWith]).
 ///
 /// See also:
 ///
@@ -57,6 +57,11 @@ class TabBarTheme extends Diagnosticable {
         labelColor: labelColor ?? this.labelColor,
         unselectedLabelColor: unselectedLabelColor ?? this.unselectedLabelColor
     );
+  }
+
+  /// The data from the closest [TabBarTheme] instance given the build context.
+  static TabBarTheme of(BuildContext context) {
+    return Theme.of(context).tabBarTheme;
   }
 
   /// Linearly interpolate between two tab bar themes.

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -150,7 +150,7 @@ class _TabStyle extends AnimatedWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final TabBarTheme tabBarTheme = themeData.tabBarTheme;
+    final TabBarTheme tabBarTheme = TabBarTheme.of(context);
 
     final TextStyle defaultStyle = labelStyle ?? themeData.primaryTextTheme.body2;
     final TextStyle defaultUnselectedStyle = unselectedLabelStyle ?? labelStyle ?? themeData.primaryTextTheme.body2;
@@ -513,7 +513,7 @@ class _TabBarScrollController extends ScrollController {
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
-/// Uses values from [ThemeData.tabBarTheme] if it is set in the current context.
+/// Uses values from [TabBarTheme] if it is set in the current context.
 ///
 /// See also:
 ///
@@ -698,11 +698,11 @@ class _TabBarState extends State<TabBar> {
   Decoration get _indicator {
     if (widget.indicator != null)
       return widget.indicator;
-    final ThemeData themeData = Theme.of(context);
-    if (themeData.tabBarTheme.indicator != null)
-      return themeData.tabBarTheme.indicator;
+    final TabBarTheme tabBarTheme = TabBarTheme.of(context);
+    if (tabBarTheme.indicator != null)
+      return tabBarTheme.indicator;
 
-    Color color = widget.indicatorColor ?? themeData.indicatorColor;
+    Color color = widget.indicatorColor ?? Theme.of(context).indicatorColor;
     // ThemeData tries to avoid this by having indicatorColor avoid being the
     // primaryColor. However, it's possible that the tab bar is on a
     // Material that isn't the primaryColor. In that case, if the indicator
@@ -755,7 +755,7 @@ class _TabBarState extends State<TabBar> {
     _indicatorPainter = _controller == null ? null : _IndicatorPainter(
       controller: _controller,
       indicator: _indicator,
-      indicatorSize: widget.indicatorSize ?? Theme.of(context).tabBarTheme.indicatorSize,
+      indicatorSize: widget.indicatorSize ?? TabBarTheme.of(context).indicatorSize,
       tabKeys: _tabKeys,
       old: _indicatorPainter,
     );


### PR DESCRIPTION
* Widget themes should have `of(context)` constructor.
* The underlying widgets should get the themes from the of(context) constructors.

## Do
### tab_bar_theme.dart
```dart
static TabBarTheme of(BuildContext build) { ... }
```
### tabs.dart
```dart
TabBarTheme tabBarTheme = TabBarTheme.of(context);
```

## Don't
### tabs.dart
```dart
TabBarTheme tabBarTheme = Theme.of(context).tabBarTheme;
```