### PR TITLE
Remove '' as countryCode in localization tests

### DIFF
--- a/packages/flutter_localizations/test/date_time_test.dart
+++ b/packages/flutter_localizations/test/date_time_test.dart
@@ -49,19 +49,19 @@ void main() {
       });
 
       testWidgets('formats HH', (WidgetTester tester) async {
-        expect(await formatHour(tester, const Locale('de', ''), const TimeOfDay(hour: 9, minute: 0)), '09');
-        expect(await formatHour(tester, const Locale('de', ''), const TimeOfDay(hour: 20, minute: 0)), '20');
+        expect(await formatHour(tester, const Locale('de'), const TimeOfDay(hour: 9, minute: 0)), '09');
+        expect(await formatHour(tester, const Locale('de'), const TimeOfDay(hour: 20, minute: 0)), '20');
 
         expect(await formatHour(tester, const Locale('en', 'GB'), const TimeOfDay(hour: 9, minute: 0)), '09');
         expect(await formatHour(tester, const Locale('en', 'GB'), const TimeOfDay(hour: 20, minute: 0)), '20');
       });
 
       testWidgets('formats H', (WidgetTester tester) async {
-        expect(await formatHour(tester, const Locale('es', ''), const TimeOfDay(hour: 9, minute: 0)), '9');
-        expect(await formatHour(tester, const Locale('es', ''), const TimeOfDay(hour: 20, minute: 0)), '20');
+        expect(await formatHour(tester, const Locale('es'), const TimeOfDay(hour: 9, minute: 0)), '9');
+        expect(await formatHour(tester, const Locale('es'), const TimeOfDay(hour: 20, minute: 0)), '20');
 
-        expect(await formatHour(tester, const Locale('fa', ''), const TimeOfDay(hour: 9, minute: 0)), '۹');
-        expect(await formatHour(tester, const Locale('fa', ''), const TimeOfDay(hour: 20, minute: 0)), '۲۰');
+        expect(await formatHour(tester, const Locale('fa'), const TimeOfDay(hour: 9, minute: 0)), '۹');
+        expect(await formatHour(tester, const Locale('fa'), const TimeOfDay(hour: 20, minute: 0)), '۲۰');
       });
     });
 
@@ -90,21 +90,21 @@ void main() {
       }
 
       testWidgets('formats ${TimeOfDayFormat.h_colon_mm_space_a}', (WidgetTester tester) async {
-        expect(await formatTimeOfDay(tester, const Locale('en', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32 AM');
-        expect(await formatTimeOfDay(tester, const Locale('en', ''), const TimeOfDay(hour: 20, minute: 32)), '8:32 PM');
+        expect(await formatTimeOfDay(tester, const Locale('en'), const TimeOfDay(hour: 9, minute: 32)), '9:32 AM');
+        expect(await formatTimeOfDay(tester, const Locale('en'), const TimeOfDay(hour: 20, minute: 32)), '8:32 PM');
       });
 
       testWidgets('formats ${TimeOfDayFormat.HH_colon_mm}', (WidgetTester tester) async {
-        expect(await formatTimeOfDay(tester, const Locale('de', ''), const TimeOfDay(hour: 9, minute: 32)), '09:32');
+        expect(await formatTimeOfDay(tester, const Locale('de'), const TimeOfDay(hour: 9, minute: 32)), '09:32');
         expect(await formatTimeOfDay(tester, const Locale('en', 'ZA'), const TimeOfDay(hour: 9, minute: 32)), '09:32');
       });
 
       testWidgets('formats ${TimeOfDayFormat.H_colon_mm}', (WidgetTester tester) async {
-        expect(await formatTimeOfDay(tester, const Locale('es', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32');
-        expect(await formatTimeOfDay(tester, const Locale('es', ''), const TimeOfDay(hour: 20, minute: 32)), '20:32');
+        expect(await formatTimeOfDay(tester, const Locale('es'), const TimeOfDay(hour: 9, minute: 32)), '9:32');
+        expect(await formatTimeOfDay(tester, const Locale('es'), const TimeOfDay(hour: 20, minute: 32)), '20:32');
 
-        expect(await formatTimeOfDay(tester, const Locale('ja', ''), const TimeOfDay(hour: 9, minute: 32)), '9:32');
-        expect(await formatTimeOfDay(tester, const Locale('ja', ''), const TimeOfDay(hour: 20, minute: 32)), '20:32');
+        expect(await formatTimeOfDay(tester, const Locale('ja'), const TimeOfDay(hour: 9, minute: 32)), '9:32');
+        expect(await formatTimeOfDay(tester, const Locale('ja'), const TimeOfDay(hour: 20, minute: 32)), '20:32');
       });
 
       testWidgets('formats ${TimeOfDayFormat.frenchCanadian}', (WidgetTester tester) async {
@@ -112,7 +112,7 @@ void main() {
       });
 
       testWidgets('formats ${TimeOfDayFormat.a_space_h_colon_mm}', (WidgetTester tester) async {
-        expect(await formatTimeOfDay(tester, const Locale('zh', ''), const TimeOfDay(hour: 9, minute: 32)), '上午 9:32');
+        expect(await formatTimeOfDay(tester, const Locale('zh'), const TimeOfDay(hour: 9, minute: 32)), '上午 9:32');
       });
     });
 
@@ -140,7 +140,7 @@ void main() {
       }
 
       testWidgets('formats dates in English', (WidgetTester tester) async {
-       final Map<DateType, String> formatted = await formatDate(tester, const Locale('en', ''), DateTime(2018, 8, 1));
+       final Map<DateType, String> formatted = await formatDate(tester, const Locale('en'), DateTime(2018, 8, 1));
        expect(formatted[DateType.year], '2018');
        expect(formatted[DateType.medium], 'Wed, Aug 1');
        expect(formatted[DateType.full], 'Wednesday, August 1, 2018');
@@ -148,7 +148,7 @@ void main() {
       });
 
       testWidgets('formats dates in German', (WidgetTester tester) async {
-        final Map<DateType, String> formatted = await formatDate(tester, const Locale('de', ''), DateTime(2018, 8, 1));
+        final Map<DateType, String> formatted = await formatDate(tester, const Locale('de'), DateTime(2018, 8, 1));
         expect(formatted[DateType.year], '2018');
         expect(formatted[DateType.medium], 'Mi., 1. Aug.');
         expect(formatted[DateType.full], 'Mittwoch, 1. August 2018');

--- a/packages/flutter_localizations/test/override_test.dart
+++ b/packages/flutter_localizations/test/override_test.dart
@@ -176,9 +176,9 @@ void main() {
           const FooMaterialLocalizationsDelegate(supportedLanguage: 'de', backButtonTooltip: 'DE'),
         ],
         supportedLocales: const <Locale>[
-          Locale('en', ''),
-          Locale('fr', ''),
-          Locale('de', ''),
+          Locale('en'),
+          Locale('fr'),
+          Locale('de'),
         ],
         buildContent: (BuildContext context) {
           return Text(

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   for (String language in kSupportedLanguages) {
     testWidgets('translations exist for $language', (WidgetTester tester) async {
-      final Locale locale = Locale(language, '');
+      final Locale locale = Locale(language);
 
       expect(GlobalMaterialLocalizations.delegate.isSupported(locale), isTrue);
 
@@ -78,7 +78,7 @@ void main() {
   }
 
   testWidgets('spot check selectedRowCount translations', (WidgetTester tester) async {
-    MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en', ''));
+    MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en'));
     expect(localizations.selectedRowCountTitle(0), 'No items selected');
     expect(localizations.selectedRowCountTitle(1), '1 item selected');
     expect(localizations.selectedRowCountTitle(2), '2 items selected');
@@ -91,7 +91,7 @@ void main() {
     expect(localizations.selectedRowCountTitle(10019), '10,019 items selected');
     expect(localizations.selectedRowCountTitle(123456789), '123,456,789 items selected');
 
-    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('es', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('es'));
     expect(localizations.selectedRowCountTitle(0), 'No se han seleccionado elementos');
     expect(localizations.selectedRowCountTitle(1), '1 elemento seleccionado');
     expect(localizations.selectedRowCountTitle(2), '2 elementos seleccionados');
@@ -104,7 +104,7 @@ void main() {
     expect(localizations.selectedRowCountTitle(10019), '10.019 elementos seleccionados');
     expect(localizations.selectedRowCountTitle(123456789), '123.456.789 elementos seleccionados');
 
-    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('ro', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('ro'));
     expect(localizations.selectedRowCountTitle(0), 'Nu există elemente selectate');
     expect(localizations.selectedRowCountTitle(1), 'Un articol selectat');
     expect(localizations.selectedRowCountTitle(2), '2 articole selectate');
@@ -117,7 +117,7 @@ void main() {
     expect(localizations.selectedRowCountTitle(10019), '10.019 articole selectate');
     expect(localizations.selectedRowCountTitle(123456789), '123.456.789 de articole selectate');
 
-    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('km', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('km'));
     expect(localizations.selectedRowCountTitle(0), 'បាន​ជ្រើស​រើស​ធាតុ 0');
     expect(localizations.selectedRowCountTitle(1), 'បាន​ជ្រើស​រើស​ធាតុ 1');
     expect(localizations.selectedRowCountTitle(2), 'បាន​ជ្រើស​រើស​ធាតុ 2');
@@ -126,7 +126,7 @@ void main() {
   });
 
   testWidgets('spot check formatMediumDate(), formatFullDate() translations', (WidgetTester tester) async {
-    MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en', ''));
+    MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('en'));
     expect(localizations.formatMediumDate(DateTime(2015, 7, 23)), 'Thu, Jul 23');
     expect(localizations.formatFullDate(DateTime(2015, 7, 23)), 'Thursday, July 23, 2015');
 
@@ -134,11 +134,11 @@ void main() {
     expect(localizations.formatMediumDate(DateTime(2015, 7, 23)), 'Thu 23 Jul');
     expect(localizations.formatFullDate(DateTime(2015, 7, 23)), 'Thursday, 23 July 2015');
 
-    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('es', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('es'));
     expect(localizations.formatMediumDate(DateTime(2015, 7, 23)), 'jue., 23 jul.');
     expect(localizations.formatFullDate(DateTime(2015, 7, 23)), 'jueves, 23 de julio de 2015');
 
-    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('de', ''));
+    localizations = await GlobalMaterialLocalizations.delegate.load(const Locale('de'));
     expect(localizations.formatMediumDate(DateTime(2015, 7, 23)), 'Do., 23. Juli');
     expect(localizations.formatFullDate(DateTime(2015, 7, 23)), 'Donnerstag, 23. Juli 2015');
   });


### PR DESCRIPTION
The countryCode should not be able to be ''. See https://github.com/flutter/engine/pull/6693