### PR TITLE
CupertinoTheme et al

### DIFF
--- a/packages/flutter/lib/cupertino.dart
+++ b/packages/flutter/lib/cupertino.dart
@@ -30,5 +30,6 @@ export 'src/cupertino/tab_scaffold.dart';
 export 'src/cupertino/tab_view.dart';
 export 'src/cupertino/text_field.dart';
 export 'src/cupertino/text_selection.dart';
+export 'src/cupertino/theme.dart';
 export 'src/cupertino/thumb_painter.dart';
 export 'widgets.dart';

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/widgets.dart';
+
+class CupertinoDialogTheme {
+  const CupertinoDialogTheme({
+    this.color,
+    this.pressedColor,
+    this.buttonDividerColor,
+  });
+
+  final Color color;
+  final Color pressedColor;
+  final Color buttonDividerColor;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    final CupertinoDialogTheme typedOther = other;
+    return typedOther.color == color
+        && typedOther.pressedColor == pressedColor
+        && typedOther.buttonDividerColor == buttonDividerColor;
+  }
+
+  @override
+  int get hashCode => hashValues(color, pressedColor, buttonDividerColor);
+
+  static CupertinoDialogTheme lerp(CupertinoDialogTheme a, CupertinoDialogTheme b, double t) {
+    assert(t != null);
+    return CupertinoDialogTheme(
+      color: Color.lerp(a?.color, b?.color, t),
+      pressedColor: Color.lerp(a?.pressedColor, b?.pressedColor, t),
+      buttonDividerColor: Color.lerp(a?.buttonDividerColor, b?.buttonDividerColor, t),
+    );
+  }
+}
+
+class CupertinoThemeData {
+  const CupertinoThemeData({
+    this.dialogTheme = const CupertinoDialogTheme(),
+  });
+
+  final CupertinoDialogTheme dialogTheme;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    final CupertinoThemeData typedOther = other;
+    return typedOther.dialogTheme == dialogTheme;
+  }
+
+  @override
+  int get hashCode => dialogTheme.hashCode;
+
+  static CupertinoThemeData lerp(CupertinoThemeData a, CupertinoThemeData b, double t) {
+    assert(a != null);
+    assert(b != null);
+    assert(t != null);
+    return CupertinoThemeData(
+      dialogTheme: CupertinoDialogTheme.lerp(a.dialogTheme, b.dialogTheme, t),
+    );
+  }
+}
+
+class CupertinoTheme extends InheritedModel<Type> {
+  const CupertinoTheme({
+    Key key,
+    this.data = const CupertinoThemeData(),
+    Widget child,
+  }) : super(key: key, child: child);
+
+  final CupertinoThemeData data;
+
+  @override
+  bool updateShouldNotify(CupertinoTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+
+  @override
+  bool updateShouldNotifyDependent(CupertinoTheme oldWidget, Set<Type> dependencies) {
+    return dependencies.contains(CupertinoDialogTheme) && data.dialogTheme != oldWidget.data.dialogTheme;
+  }
+
+  static CupertinoDialogTheme dialogThemeOf(BuildContext context) {
+    final CupertinoTheme theme = InheritedModel.inheritFrom<CupertinoTheme>(context, aspect: CupertinoDialogTheme);
+    return theme.data.dialogTheme;
+  }
+}

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
@@ -143,7 +144,11 @@ class Theme extends StatelessWidget {
       theme: this,
       child: IconTheme(
         data: data.iconTheme,
-        child: child,
+        child: CupertinoTheme(
+          // Could merge CupertinoThemeData with values from this.data here.
+          data: data.cupertinoTheme,
+          child: child,
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' show Color, hashValues;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -151,6 +152,7 @@ class ThemeData extends Diagnosticable {
     PageTransitionsTheme pageTransitionsTheme,
     ColorScheme colorScheme,
     Typography typography,
+    CupertinoThemeData cupertinoTheme,
   }) {
     brightness ??= Brightness.light;
     final bool isDark = brightness == Brightness.dark;
@@ -243,6 +245,7 @@ class ThemeData extends Diagnosticable {
       brightness: brightness,
       labelStyle: textTheme.body2,
     );
+    cupertinoTheme ??= const CupertinoThemeData();
 
     return ThemeData.raw(
       brightness: brightness,
@@ -290,6 +293,7 @@ class ThemeData extends Diagnosticable {
       pageTransitionsTheme: pageTransitionsTheme,
       colorScheme: colorScheme,
       typography: typography,
+      cupertinoTheme: cupertinoTheme,
     );
   }
 
@@ -348,6 +352,7 @@ class ThemeData extends Diagnosticable {
     @required this.pageTransitionsTheme,
     @required this.colorScheme,
     @required this.typography,
+    @required this.cupertinoTheme,
   }) : assert(brightness != null),
        assert(primaryColor != null),
        assert(primaryColorBrightness != null),
@@ -391,7 +396,8 @@ class ThemeData extends Diagnosticable {
        assert(materialTapTargetSize != null),
        assert(pageTransitionsTheme != null),
        assert(colorScheme != null),
-       assert(typography != null);
+       assert(typography != null),
+       assert(cupertinoTheme != null);
 
   // Warning: make sure these properties are in the exact same order as in
   // hashValues() and in the raw constructor and in the order of fields in
@@ -621,6 +627,8 @@ class ThemeData extends Diagnosticable {
   /// [primaryTextTheme], and [accentTextTheme].
   final Typography typography;
 
+  final CupertinoThemeData cupertinoTheme;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ThemeData copyWith({
     Brightness brightness,
@@ -668,6 +676,7 @@ class ThemeData extends Diagnosticable {
     PageTransitionsTheme pageTransitionsTheme,
     ColorScheme colorScheme,
     Typography typography,
+    CupertinoThemeData cupertinoTheme,
   }) {
     return ThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -715,6 +724,7 @@ class ThemeData extends Diagnosticable {
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       colorScheme: colorScheme ?? this.colorScheme,
       typography: typography ?? this.typography,
+      cupertinoTheme: cupertinoTheme ?? this.cupertinoTheme,
     );
   }
 
@@ -841,6 +851,7 @@ class ThemeData extends Diagnosticable {
       pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
       colorScheme: ColorScheme.lerp(a.colorScheme, b.colorScheme, t),
       typography: Typography.lerp(a.typography, b.typography, t),
+      cupertinoTheme: CupertinoThemeData.lerp(a.cupertinoTheme, b.cupertinoTheme, t),
     );
   }
 
@@ -896,7 +907,8 @@ class ThemeData extends Diagnosticable {
            (otherData.materialTapTargetSize == materialTapTargetSize) &&
            (otherData.pageTransitionsTheme == pageTransitionsTheme) &&
            (otherData.colorScheme == colorScheme) &&
-           (otherData.typography == typography);
+           (otherData.typography == typography) &&
+           (otherData.cupertinoTheme == cupertinoTheme);
   }
 
   @override
@@ -953,6 +965,7 @@ class ThemeData extends Diagnosticable {
           pageTransitionsTheme,
           colorScheme,
           typography,
+          cupertinoTheme,
         ),
       ),
     );
@@ -1004,6 +1017,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
     properties.add(DiagnosticsProperty<ColorScheme>('colorScheme', colorScheme, defaultValue: defaultData.colorScheme));
     properties.add(DiagnosticsProperty<Typography>('typography', typography, defaultValue: defaultData.typography));
+    properties.add(DiagnosticsProperty<CupertinoThemeData>('cupertinoTheme', cupertinoTheme, defaultValue: defaultData.cupertinoTheme));
   }
 }
 


### PR DESCRIPTION
This is a WIP, it's not for review.

Requirements:

- CupertinoTheme clients should benefit from the performance advantages of an InheritedModel.
- CupertinoTheme clients should be insulated from InheritedModel "aspect" values (and any other inherited widget/model implementation details).
- CupertinoTheme values are always available in Cupertino library.
- CupertinoTheme clients based on the Cupertino library should not incur a Material library dependency.
- CupertinoTheme values are always available in Material library apps.
- CupertinoThemeData can be specified when constructing a MaterialApp.
- CupertinoTheme values can defer to MaterialThemeData properties.
- CupertinoTheme values should be exposed via BuildContext based APIs that are as narrowly scoped as is practical.

This is a partially complete version of a CupertinoTheme that demonstrates how it would work with MaterialApp and the Material Theme.

CupertinoTheme is an InheritedModel. Like Theme, the values it provides are defined by CupertinoThemeData.

Only one set of CupertinoTheme values are supported, a few colors that could be used by the CupertinoDialog widget: CupertinoDialogTheme. That's enough to demonstrate how things fit together.

The CupertinoDialog widget would lookup its visual properties with `CupertinoTheme.dialogThemeOf(context)`. Eventually, the returned CupertinoDialogTheme value would contain all of the visual (themeable) properties needed to build a CupertinoDialog.

CupertinoDialogTheme is one part or "aspect" of CupertinoThemeData. Eventually all of the themeable properties or groups of properties would be part of CupertinoThemeData. And there would be a static lookup method like `CupertinoTheme.dialogThemeOf(context)` for each of them.

Material's ThemeData now includes a CupertinoThemeData value. Theme uses it to build a CupertinoTheme below the Material Theme itself. Theme's build method could use its ThemeData to merge Theme values with the CupertinoThemeData.

Currently IconTheme is handled this way as well. It's rather odd that _only_ IconTheme is currently handled this way. Eventually more of the subordinate ThemeData themes should be.



