### PR TITLE
Make `titleStartOffset` a parameter in FlexibleSpaceBar

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -47,7 +47,8 @@ class FlexibleSpaceBar extends StatefulWidget {
     this.title,
     this.background,
     this.centerTitle,
-    this.collapseMode = CollapseMode.parallax
+    this.collapseMode = CollapseMode.parallax,
+    this.titleStartOffset = 72.0
   }) : assert(collapseMode != null),
        super(key: key);
 
@@ -70,6 +71,11 @@ class FlexibleSpaceBar extends StatefulWidget {
   ///
   /// Defaults to [CollapseMode.parallax].
   final CollapseMode collapseMode;
+
+  /// Offset from the start (if [title] is not centered).
+  ///
+  /// Defaults to 72.0
+  final double titleStartOffset;
 
   /// Wraps a widget that contains an [AppBar] to convey sizing information down
   /// to the [FlexibleSpaceBar].
@@ -199,7 +205,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);
         children.add(Container(
           padding: EdgeInsetsDirectional.only(
-            start: effectiveCenterTitle ? 0.0 : 72.0,
+            start: effectiveCenterTitle ? 0.0 : widget.titleStartOffset,
             bottom: 16.0
           ),
           child: Transform(


### PR DESCRIPTION
In the current implementation, the offset from the start is a hardcoded value (`72.0`). In the app I am developing, I need to change this and I see no easy way to do it. I propose to make it configurable but to maintain the current `72.0` as a default (not to break existing apps).