### PR TITLE
Ignore unreachable iOS devices in IOSDevice.getAttachedDevices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Lukasz Piliszczuk <lukasz@intheloup.io>
 Felix Schmidt <felix.free@gmx.de>
 Artur Rymarz <artur.rymarz@gmail.com>
 Stefan Mitev <mr.mitew@gmail.com>
+Mattijs Fuijkschot <mattijs.fuijkschot@gmail.com>

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -149,9 +149,13 @@ class IOSDevice extends Device {
       if (id.isEmpty)
         continue;
 
-      final String deviceName = await iMobileDevice.getInfoForDevice(id, 'DeviceName');
-      final String sdkVersion = await iMobileDevice.getInfoForDevice(id, 'ProductVersion');
-      devices.add(IOSDevice(id, name: deviceName, sdkVersion: sdkVersion));
+      try {
+        final String deviceName = await iMobileDevice.getInfoForDevice(id, 'DeviceName');
+        final String sdkVersion = await iMobileDevice.getInfoForDevice(id, 'ProductVersion');
+        devices.add(IOSDevice(id, name: deviceName, sdkVersion: sdkVersion));
+      } catch (_) {
+        // Unable to get device info. Possibly a network device.
+      }
     }
     return devices;
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -153,8 +153,8 @@ class IOSDevice extends Device {
         final String deviceName = await iMobileDevice.getInfoForDevice(id, 'DeviceName');
         final String sdkVersion = await iMobileDevice.getInfoForDevice(id, 'ProductVersion');
         devices.add(IOSDevice(id, name: deviceName, sdkVersion: sdkVersion));
-      } catch (_) {
-        // Unable to get device info. Possibly a network device.
+      } on IOSDeviceNotFoundError catch (_) {
+        // Unable to find device with given udid. Possibly a network device.
       }
     }
     return devices;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -153,8 +153,9 @@ class IOSDevice extends Device {
         final String deviceName = await iMobileDevice.getInfoForDevice(id, 'DeviceName');
         final String sdkVersion = await iMobileDevice.getInfoForDevice(id, 'ProductVersion');
         devices.add(IOSDevice(id, name: deviceName, sdkVersion: sdkVersion));
-      } on IOSDeviceNotFoundError catch (_) {
+      } on IOSDeviceNotFoundError catch (error) {
         // Unable to find device with given udid. Possibly a network device.
+        printTrace('Error getting attached iOS device: $error');
       }
     }
     return devices;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -83,6 +83,17 @@ class PropertyList {
   }
 }
 
+/// Specialized exception for expected situations where the ideviceinfo
+/// tool responds with exit code 255 / 'No device found' message
+class IOSDeviceNotFoundError implements Exception {
+  IOSDeviceNotFoundError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 class IMobileDevice {
   const IMobileDevice();
 
@@ -118,6 +129,8 @@ class IMobileDevice {
   Future<String> getInfoForDevice(String deviceID, String key) async {
     try {
       final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key, '--simple']);
+      if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
+        throw IOSDeviceNotFoundError('idevice_id returned an error:\n${result.stdout}');
       if (result.exitCode != 0)
         throw ToolExit('ideviceinfo returned an error:\n${result.stderr}');
       return result.stdout.trim();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -119,10 +119,10 @@ class IMobileDevice {
     try {
       final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key, '--simple']);
       if (result.exitCode != 0)
-        throw ToolExit('idevice_id returned an error:\n${result.stderr}');
+        throw ToolExit('ideviceinfo returned an error:\n${result.stderr}');
       return result.stdout.trim();
     } on ProcessException {
-      throw ToolExit('Failed to invoke idevice_id. Run flutter doctor.');
+      throw ToolExit('Failed to invoke ideviceinfo. Run flutter doctor.');
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -130,7 +130,7 @@ class IMobileDevice {
     try {
       final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key, '--simple']);
       if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
-        throw IOSDeviceNotFoundError('idevice_id returned an error:\n${result.stdout}');
+        throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}');
       if (result.exitCode != 0)
         throw ToolExit('ideviceinfo returned an error:\n${result.stderr}');
       return result.stdout.trim();

--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -77,6 +77,25 @@ f577a7903cc54959be2e34bc4f7f80b7009efcf4
     }, overrides: <Type, Generator>{
       IMobileDevice: () => mockIMobileDevice,
     });
+
+    testUsingContext('returns attached devices and ignores devices that cannot be found by ideviceinfo', () async {
+      when(iMobileDevice.isInstalled).thenReturn(true);
+      when(iMobileDevice.getAvailableDeviceIDs())
+          .thenAnswer((Invocation invocation) => Future<String>.value('''
+98206e7a4afd4aedaff06e687594e089dede3c44
+f577a7903cc54959be2e34bc4f7f80b7009efcf4
+'''));
+      when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
+          .thenAnswer((_) => Future<String>.value('La tele me regarde'));
+      when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
+          .thenThrow(IOSDeviceNotFoundError('Device not found'));
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
+      expect(devices, hasLength(1));
+      expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
+      expect(devices[0].name, 'La tele me regarde');
+    }, overrides: <Type, Generator>{
+      IMobileDevice: () => mockIMobileDevice,
+    });
   });
 
   group('decodeSyslog', () {

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -122,7 +122,7 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when idevice_id returns specific error code and message', () async {
+    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when ideviceinfo returns specific error code and message', () async {
       when(mockProcessManager.run(<String>['ideviceinfo', '-u', 'foo', '-k', 'bar', '--simple']))
           .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 255, 'No device found with udid foo, is it plugged in?', '')));
       expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotFoundError>()));

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -122,6 +122,14 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when idevice_id returns specific error code and message', () async {
+      when(mockProcessManager.run(<String>['ideviceinfo', '-u', 'foo', '-k', 'bar', '--simple']))
+          .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 255, 'No device found with udid foo, is it plugged in?', '')));
+      expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotFoundError>()));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
     group('screenshot', () {
       final String outputPath = fs.path.join('some', 'test', 'path', 'image.png');
       MockProcessManager mockProcessManager;


### PR DESCRIPTION
Fixes #23341

Related:
- https://github.com/libimobiledevice/libimobiledevice/issues/152
- https://github.com/libimobiledevice/libusbmuxd/pull/53#issuecomment-425673643

> The usbmuxd ("USB multiplexer daemon") daemon manages the list of devices and facilitates communication with them. When Apple added support for WiFi backups and syncing, they did so by extending usbmuxd, so it is very much an intended behavior. I would like to see your proposed patch to usbmuxd_get_device_list as a configuration option, though. It would also be useful if the APIs in libimobiledevice allowed restricting connects to USB so it could selected per-connection.

In practice this means that `idevice_id -l` also lists udid's that are not actually attached via usb and have no debugging capabilities. When flutter tries to get device meta information using `ideviceinfo -u UDID` it returns an exit code 255 causing `fluttor doctor` and other flutter devices related API's to produce errors even though there are other attached devices / simulators that work fine.

This PR basically ignores devices for which `ideviceinfo` fails to receive meta information but still allow devices that do provide meta information to be included.