### PR TITLE
Add flutter_shared assets to module artifact

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -375,7 +375,7 @@ class FlutterPlugin implements Plugin<Project> {
             Task copySharedFlutterAssetsTask = project.tasks.create(name: "copySharedFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 from(project.zipTree(releaseFlutterJar))
                 include 'assets/flutter_shared/*'
-                into 'src/main'
+                into "src/${variant.name}"
             }
             Task copyFlutterAssetsTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn flutterTask

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -278,6 +278,22 @@ class FlutterPlugin implements Plugin<Project> {
         return "release"
     }
 
+    /**
+     * Returns a Flutter Jar file path suitable for the specified Android buildMode.
+     */
+    private File flutterJarFor(buildMode) {
+        if (buildMode == "profile") {
+            return profileFlutterJar
+        } else if (buildMode == "dynamicProfile") {
+            return dynamicProfileFlutterJar
+        } else if (buildMode == "dynamicRelease") {
+            return dynamicReleaseFlutterJar
+        } else if (buildMode == "debug") {
+            return debugFlutterJar
+        }
+        return releaseFlutterJar
+    }
+
     private void addFlutterTask(Project project) {
         if (project.state.failure) {
             return
@@ -372,8 +388,9 @@ class FlutterPlugin implements Plugin<Project> {
             // We know that the flutter app is a subproject in another Android app when these tasks exist.
             Task packageAssets = project.tasks.findByPath(":flutter:package${variant.name.capitalize()}Assets")
             Task cleanPackageAssets = project.tasks.findByPath(":flutter:cleanPackage${variant.name.capitalize()}Assets")
+            File chosenFlutterJar = flutterJarFor(flutterBuildMode)
             Task copySharedFlutterAssetsTask = project.tasks.create(name: "copySharedFlutterAssets${variant.name.capitalize()}", type: Copy) {
-                from(project.zipTree(releaseFlutterJar))
+                from(project.zipTree(chosenFlutterJar))
                 include 'assets/flutter_shared/*'
                 into "src/${variant.name}"
             }

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,13 +372,20 @@ class FlutterPlugin implements Plugin<Project> {
             // We know that the flutter app is a subproject in another Android app when these tasks exist.
             Task packageAssets = project.tasks.findByPath(":flutter:package${variant.name.capitalize()}Assets")
             Task cleanPackageAssets = project.tasks.findByPath(":flutter:cleanPackage${variant.name.capitalize()}Assets")
+            Task copySharedFlutterAssetsTask = project.tasks.create(name: "copySharedFlutterAssets${variant.name.capitalize()}", type: Copy) {
+                from(project.zipTree(releaseFlutterJar))
+                include 'assets/flutter_shared/*'
+                into 'src/main'
+            }
             Task copyFlutterAssetsTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn flutterTask
+                dependsOn copySharedFlutterAssetsTask
                 dependsOn packageAssets ? packageAssets : variant.mergeAssets
                 dependsOn cleanPackageAssets ? cleanPackageAssets : "clean${variant.mergeAssets.name.capitalize()}"
                 into packageAssets ? packageAssets.outputDir : variant.mergeAssets.outputDir
                 with flutterTask.assets
             }
+
             if (packageAssets) {
                 // Only include configurations that exist in parent project.
                 Task mergeAssets = project.tasks.findByPath(":app:merge${variant.name.capitalize()}Assets")


### PR DESCRIPTION
Currently, when using Flutter from module template, `assets/flutter_shared` folder is not merged when compiling the project into a library (AAR). This is caused by the way gradle works: only classes and library binaries are merged into an AAR from a JAR file.

As the `flutter_shared` folder currently lives inside `flutter.jar`, when compiling the module as a library, it gets missing from the generated AAR, causing the final app to crash with the `"Can't find icudtl.dat"` error.

We commented an example reproduction repository and two proposed solutions [here](https://github.com/flutter/flutter/issues/18025#issuecomment-434435454) and this PR implements the second one, which we thought it was cleaner and shouldn't cause any compatibility issues.

Solves https://github.com/flutter/flutter/issues/21107