### PR TITLE
Fix project directory has spaces lead to compile error

### DIFF
--- a/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
@@ -1,6 +1,6 @@
 // Generated file. Do not edit.
 
-def scriptFile = getClass().protectionDomain.codeSource.location.path
+def scriptFile = getClass().protectionDomain.codeSource.location.toURI()
 def flutterProjectRoot = new File(scriptFile).parentFile.parentFile
 
 gradle.include ':flutter'


### PR DESCRIPTION
### Steps to Reproduce:

1. I use 'flutter create -t module module_test' command in directory 'flutter test' 

2. Opened this project using android studio

3. FAILURE: Build failed with an exception

### Logs：

Could not determine the dependencies of task ':app:lintVitalRelease'.
> Could not resolve all task dependencies for configuration ':app:releaseRuntimeClasspath'.
   > Could not resolve project :flutter.
     Required by:
         project :app
      > Unable to find a matching configuration of project :flutter: None of the consumable configurations have attributes.
