### PR TITLE
#23811 fix android versioning

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -243,10 +243,10 @@ void updateLocalProperties({
   changeIfNecessary('flutter.sdk', escapePath(Cache.flutterRoot));
   if (buildInfo != null) {
     changeIfNecessary('flutter.buildMode', buildInfo.modeName);
-    final String buildName = buildInfo?.buildName ?? manifest.buildName;
+    final String buildName = buildInfo.buildName ?? manifest.buildName;
     if (buildName != null)
       changeIfNecessary('flutter.versionName', buildName);
-    final int buildNumber = buildInfo?.buildNumber ?? manifest.buildNumber;
+    final int buildNumber = buildInfo.buildNumber ?? manifest.buildNumber;
     if (buildNumber != null)
       changeIfNecessary('flutter.versionCode', '$buildNumber');
   }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -241,14 +241,15 @@ void updateLocalProperties({
   if (androidSdk != null)
     changeIfNecessary('sdk.dir', escapePath(androidSdk.directory));
   changeIfNecessary('flutter.sdk', escapePath(Cache.flutterRoot));
-  if (buildInfo != null)
+  if (buildInfo != null) {
     changeIfNecessary('flutter.buildMode', buildInfo.modeName);
-  final String buildName = buildInfo?.buildName ?? manifest.buildName;
-  if (buildName != null)
-    changeIfNecessary('flutter.versionName', buildName);
-  final int buildNumber = buildInfo?.buildNumber ?? manifest.buildNumber;
-  if (buildNumber != null)
-    changeIfNecessary('flutter.versionCode', '$buildNumber');
+    final String buildName = buildInfo?.buildName ?? manifest.buildName;
+    if (buildName != null)
+      changeIfNecessary('flutter.versionName', buildName);
+    final int buildNumber = buildInfo?.buildNumber ?? manifest.buildNumber;
+    if (buildNumber != null)
+      changeIfNecessary('flutter.versionCode', '$buildNumber');
+  }
 
   if (changed)
     settings.writeContents(localProperties);


### PR DESCRIPTION
The updateLocalProperties method is called multiple times,
sometimes without providing a buildInfo.

If it is called without buildInfo it uses the buildName / buildVersion
from the manifest and overrides the result of the earlier call with buildInfo.