### PR TITLE
call hapticFunction directly

### DIFF
--- a/packages/flutter/test/services/haptic_feedback_test.dart
+++ b/packages/flutter/test/services/haptic_feedback_test.dart
@@ -27,7 +27,7 @@ void main() {
         log.add(methodCall);
       });
 
-      await Function.apply(hapticFunction, null);
+      await hapticFunction();
       expect(log, hasLength(1));
       expect(
         log.last,


### PR DESCRIPTION
There doesn't seem to be a need for the `Function.apply` awkwardness.