### PR TITLE
Warn about supported locales that lack localizations

### DIFF
--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -213,6 +213,9 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
 
   @override
   bool shouldReload(_CupertinoLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'DefaultCupertinoLocalizations.delegate(en_US)';
 }
 
 /// US English strings for the cupertino widgets.

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -338,6 +338,9 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
 
   @override
   bool shouldReload(_MaterialLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'DefaultMaterialLocalizations.delegate(en_US)';
 }
 
 /// US English strings for the material widgets.

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -4,11 +4,13 @@
 
 import 'dart:ui' show hashValues;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
 import 'material_localizations.dart';
 
+import 'debug.dart';
 
 /// Whether the [TimeOfDay] is before or after noon.
 enum DayPeriod {

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -4,13 +4,11 @@
 
 import 'dart:ui' show hashValues;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
 import 'material_localizations.dart';
 
-import 'debug.dart';
 
 /// Whether the [TimeOfDay] is before or after noon.
 enum DayPeriod {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -802,7 +802,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
         if (unsupportedType.toString() == 'CupertinoLocalizations')
           continue;
         message.writeln(
-          '> A delegate that supports $unsupportedType was not found.'
+          '> A $unsupportedType delegate that supports the $appLocale locale was not found.'
         );
       }
       message.writeln(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:ui' as ui show window;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'banner.dart';
@@ -769,6 +770,53 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
 
   // BUILDER
 
+  bool _debugCheckLocalizations(Locale appLocale) {
+    assert(() {
+      final Set<Type> unsupportedTypes =
+        _localizationsDelegates.map<Type>((LocalizationsDelegate<dynamic> delegate) => delegate.type).toSet();
+      for (LocalizationsDelegate<dynamic> delegate in _localizationsDelegates) {
+        if (!unsupportedTypes.contains(delegate.type))
+          continue;
+        if (delegate.isSupported(appLocale))
+          unsupportedTypes.remove(delegate.type);
+      }
+      if (unsupportedTypes.isEmpty)
+        return true;
+
+      // Currently the Cupertino library only provides english localizations.
+      // Remove this when https://github.com/flutter/flutter/issues/23847
+      // is fixed.
+      if (listEquals(unsupportedTypes.map((Type type) => type.toString()).toList(), <String>['CupertinoLocalizations']))
+        return true;
+
+      final StringBuffer message = StringBuffer();
+      message.writeln('\u2550' * 8);
+      message.writeln(
+        'Warning: This application\'s locale, $appLocale, is not supported by all of its\n'
+        'localization delegates.'
+      );
+      for (Type unsupportedType in unsupportedTypes) {
+        // Currently the Cupertino library only provides english localizations.
+        // Remove this when https://github.com/flutter/flutter/issues/23847
+        // is fixed.
+        if (unsupportedType.toString() == 'CupertinoLocalizations')
+          continue;
+        message.writeln(
+          '> A delegate that supports $unsupportedType was not found.'
+        );
+      }
+      message.writeln(
+        'See https://flutter.io/tutorials/internationalization/ for more\n'
+        'information about configuring an app\'s locale, supportedLocales,\n'
+        'and localizationsDelegates parameters.'
+      );
+      message.writeln('\u2550' * 8);
+      debugPrint(message.toString());
+      return true;
+    }());
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget navigator;
@@ -874,12 +922,16 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
       );
     }
 
+    final Locale appLocale = widget.locale != null
+      ? _resolveLocale(widget.locale, widget.supportedLocales)
+      : _locale;
+
+    assert(_debugCheckLocalizations(appLocale));
+
     return MediaQuery(
       data: MediaQueryData.fromWindow(ui.window),
       child: Localizations(
-        locale: widget.locale != null
-          ? _resolveLocale(widget.locale, widget.supportedLocales)
-          : _locale,
+        locale: appLocale,
         delegates: _localizationsDelegates.toList(),
         child: title,
       ),

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -181,6 +181,9 @@ class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliz
 
   @override
   bool shouldReload(_WidgetsLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'DefaultWidgetsLocalizations.delegate(en_US)';
 }
 
 /// US English localizations for the widgets library.

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -641,4 +641,7 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
 
   @override
   bool shouldReload(_MaterialLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'GlobalMaterialLocalizations.delegate(${kSupportedLanguages.length} locales)';
 }

--- a/packages/flutter_localizations/lib/src/widgets_localizations.dart
+++ b/packages/flutter_localizations/lib/src/widgets_localizations.dart
@@ -74,4 +74,7 @@ class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliz
 
   @override
   bool shouldReload(_WidgetsLocalizationsDelegate old) => false;
+
+  @override
+  String toString() => 'GlobalWidgetsLocalizations.delegate(all locales)';
 }


### PR DESCRIPTION
Fixes #13482, #14890, #22205

Added a check to WidgetsApp that prints a warning if the app's resolved locale isn't supported by all of the LocalizationsDelegate types specified by `localizationDelegates`.

For example if a MaterialApp was configured like this:

```
MaterialApp(
  localizationsDelegates: [
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
  ],
  supportedLocales: const <Locale>[Locale('foo', 'BAR')],
  locale: Locale('foo', 'BAR'),
  // ...
)
```

The following console warning would appear.

```
════════
Warning: This application's locale, foo_BAR, is not supported by all of its
localization delegates.
> A MaterialLocalizations delegate that supports the foo_BAR locale was not found.
See https://flutter.io/tutorials/internationalization/ for more
information about configuring an app's locale, supportedLocales,
and localizationsDelegates parameters.
════════
```

This is only a warning because an app configured this way could still run correctly, if it didn't create any widgets that depended on MaterialLocalizations.


