### PR TITLE
Add new benchmark to track cost of dependencies to a User

### DIFF
--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -95,12 +95,12 @@ Future<void> main() async {
       <String, dynamic>{
         _kCostBenchmarkKey: await findCostsForRepo(),
         _kNumberOfDependenciesKey: await countDependencies(),
-	_kNumberOfConsumerDependenciesKey: await countConsumerDependencies(),
+        _kNumberOfConsumerDependenciesKey: await countConsumerDependencies(),
       },
       benchmarkScoreKeys: <String>[
         _kCostBenchmarkKey,
         _kNumberOfDependenciesKey,
-	_kNumberOfConsumerDependenciesKey,
+        _kNumberOfConsumerDependenciesKey,
       ],
     );
   });

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -75,15 +75,14 @@ Future<int> countDependencies() async {
 
 Future<int> countConsumerDependencies() async {
   final List<String> lines = (await evalFlutter(
-    'update-packages',   
+    'update-packages',
     options: <String>['--transitive-closure', '--consumer-only'],
-  )).split('\n');        
+  )).split('\n');
   final int count = lines.where((String line) => line.contains('->')).length;
   if (count < 2) // we'll always have flutter and flutter_test, at least...
-    throw Exception('"flutter update-packages --transitive-closure" returned bogus output:\n${lines.join("\n")}');                       
-  return count;          
-}      
-
+    throw Exception('"flutter update-packages --transitive-closure" returned bogus output:\n${lines.join("\n")}');
+  return count;
+}
 
 const String _kCostBenchmarkKey = 'technical_debt_in_dollars';
 const String _kNumberOfDependenciesKey = 'dependencies_count';

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -73,8 +73,21 @@ Future<int> countDependencies() async {
   return count;
 }
 
+Future<int> countConsumerDependencies() async {
+  final List<String> lines = (await evalFlutter(
+    'update-packages',   
+    options: <String>['--transitive-closure', '--consumer-only'],
+  )).split('\n');        
+  final int count = lines.where((String line) => line.contains('->')).length;
+  if (count < 2) // we'll always have flutter and flutter_test, at least...
+    throw Exception('"flutter update-packages --transitive-closure" returned bogus output:\n${lines.join("\n")}');                       
+  return count;          
+}      
+
+
 const String _kCostBenchmarkKey = 'technical_debt_in_dollars';
 const String _kNumberOfDependenciesKey = 'dependencies_count';
+const String _kNumberOfConsumerDependenciesKey = 'consumer_dependencies_count';
 
 Future<void> main() async {
   await task(() async {
@@ -82,10 +95,12 @@ Future<void> main() async {
       <String, dynamic>{
         _kCostBenchmarkKey: await findCostsForRepo(),
         _kNumberOfDependenciesKey: await countDependencies(),
+	_kNumberOfConsumerDependenciesKey: await countConsumerDependencies(),
       },
       benchmarkScoreKeys: <String>[
         _kCostBenchmarkKey,
         _kNumberOfDependenciesKey,
+	_kNumberOfConsumerDependenciesKey,
       ],
     );
   });

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -117,8 +117,7 @@ class UpdatePackagesCommand extends FlutterCommand {
     final bool isVerifyOnly = argResults['verify-only'];
     final bool isConsumerOnly = argResults['consumer-only'];
 
-    // "consumer" packages are those our users are likely to rely on, and represents
-    // a specific subset of our SDK.
+    // "consumer" packages are those that constitute our public API (e.g. flutter, flutter_test, flutter_driver, flutter_localizations).
     if (isConsumerOnly) {
       if (!isPrintTransitiveClosure) {
         throwToolExit(

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -66,6 +66,14 @@ class UpdatePackagesCommand extends FlutterCommand {
         negatable: false,
       )
       ..addFlag(
+        'consumer-only',
+        help: 'Only prints the dependency graph that is the transitive closure'
+              'that a consumer of the Flutter SDK will observe (When combined '
+              'with transitive-closure)',
+        defaultsTo: false,
+        negatable: true,
+      )
+      ..addFlag(
         'verify-only',
         help: 'verifies the package checksum without changing or updating deps',
         defaultsTo: false,
@@ -107,6 +115,26 @@ class UpdatePackagesCommand extends FlutterCommand {
     final bool isPrintPaths = argResults['paths'];
     final bool isPrintTransitiveClosure = argResults['transitive-closure'];
     final bool isVerifyOnly = argResults['verify-only'];
+    final bool isConsumerOnly = argResults['consumer-only'];
+
+    // "consumer" packages are those our users are likely to rely on, and represents
+    // a specific subset of our SDK.
+    if (isConsumerOnly) {
+      // Only retain flutter, flutter_test, flutter_driver, and flutter_localizations.
+      const List<String> consumerPackages = <String>['flutter', 'flutter_test', 'flutter_driver', 'flutter_localizations'];
+      if (!isPrintTransitiveClosure) {
+        throwToolExit(
+          '--consumer-only and --no-consumer-only can only be used'
+          'with the --verify-only flag'
+        );
+      }
+      // ensure we only get flutter/packages
+      packages.retainWhere((Directory directory) {
+        return consumerPackages.any((String package) {
+          return directory.path.endsWith('packages${fs.path.separator}$package');
+        });
+      });
+    }
 
     // The dev/integration_tests/android_views integration test depends on an assets
     // package that is in the goldens repository. We need to make sure that the goldens

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -71,7 +71,7 @@ class UpdatePackagesCommand extends FlutterCommand {
               'that a consumer of the Flutter SDK will observe (When combined '
               'with transitive-closure)',
         defaultsTo: false,
-        negatable: true,
+        negatable: false,
       )
       ..addFlag(
         'verify-only',
@@ -120,14 +120,13 @@ class UpdatePackagesCommand extends FlutterCommand {
     // "consumer" packages are those our users are likely to rely on, and represents
     // a specific subset of our SDK.
     if (isConsumerOnly) {
-      // Only retain flutter, flutter_test, flutter_driver, and flutter_localizations.
-      const List<String> consumerPackages = <String>['flutter', 'flutter_test', 'flutter_driver', 'flutter_localizations'];
       if (!isPrintTransitiveClosure) {
         throwToolExit(
-          '--consumer-only and --no-consumer-only can only be used'
-          'with the --verify-only flag'
+          '--consumer-only can only be used with the --transitive-closure flag'
         );
       }
+      // Only retain flutter, flutter_test, flutter_driver, and flutter_localizations.
+      const List<String> consumerPackages = <String>['flutter', 'flutter_test', 'flutter_driver', 'flutter_localizations'];
       // ensure we only get flutter/packages
       packages.retainWhere((Directory directory) {
         return consumerPackages.any((String package) {


### PR DESCRIPTION
While the dependencies_count benchmark is great for tracking the overall health of the repo, it doesn't specifically measure the costs of dependencies on our users (nor does the technical debt benchmark). This is important because while our dependencies have a cost to developers on the framework, they can have an even larger cost to our users.

Specific Examples:
- A new user is introduced to Flutter and looks up a tutorial on the internet. They follow the directions exactly which includes adding a new dependency on `package:http` to the pubspec. The version of Flutter they use has a dependency that is incompatible with it. Frustrated and without enough knowledge of the pub ecosystem to resolve it, they move on.

- A Dart power user has written a new code generation package and wants to make sure as many developers can use it as possible. The package must depend on `package:analyzer` and they know that Flutter has a pinned version.  So they spend extra time each week making sure it is compatible, instead of responding to issues or addressing new feature requests.

This is also important to track separately from the overall dependency count. A certain refactor which drastically reduces the dependencies of users (cough cough) may increase the overall dependency count of the repo, by splitting a single package up.