### PR TITLE
Remove color command from flutter_console.bat

### DIFF
--- a/flutter_console.bat
+++ b/flutter_console.bat
@@ -4,7 +4,6 @@ REM Use of this source code is governed by a BSD-style license that can be
 REM found in the LICENSE file.
 
 TITLE Flutter Console
-COLOR 3f
 
 echo.
 echo          ######## ##       ##     ## ######## ######## ######## ########


### PR DESCRIPTION
The current Windows command prompt batch file changes the color of the command window. I think this is driven by an attempt to differentiate between this and other command prompts, but unfortunately the upshot is that the new color output of Flutter has poor contrast, as shown by the screenshot below. 
![image](https://user-images.githubusercontent.com/2319867/47931619-90260a80-de8c-11e8-86e4-0fceb14b99b6.png)

Windows now has more flexibility to control color schemes, which means that this may not be the worst case scenario. But in general, I suspect we should probably leave color schemes to the user's taste rather than embedding them in our scripts. 

This PR removes the `COLOR` command, which means that Flutter commands will now default to running on a black background. This looks like the following:
![image](https://user-images.githubusercontent.com/2319867/47932032-c021dd80-de8d-11e8-9447-07a58f38e594.png)