### PR TITLE
Fix text field clipping when erasing rapidly.

### DIFF
--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -104,8 +104,7 @@ class _TextSelectionToolbarLayout extends SingleChildLayoutDelegate {
   }
 }
 
-/// Draws a single text selection handle. The [type] determines where the handle
-/// points (e.g. the [left] handle points up and to the right).
+/// Draws a single text selection handle which points up and to the left.
 class _TextSelectionHandlePainter extends CustomPainter {
   _TextSelectionHandlePainter({ this.color });
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -925,7 +925,7 @@ class RenderEditable extends RenderBox {
 
     // We need to check the paint offset here because during animation, the start of
     // the text may position outside the visible region even when the text fits.
-  bool get hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
+  bool get _hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
   /// Returns the local coordinates of the endpoints of the given selection.
   ///
@@ -1204,14 +1204,14 @@ class RenderEditable extends RenderBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     _layoutText(constraints.maxWidth);
-    if (hasVisualOverflow)
+    if (_hasVisualOverflow)
       context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents);
     else
       _paintContents(context, offset);
   }
 
   @override
-  Rect describeApproximatePaintClip(RenderObject child) => hasVisualOverflow ? Offset.zero & size : null;
+  Rect describeApproximatePaintClip(RenderObject child) => _hasVisualOverflow ? Offset.zero & size : null;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -923,8 +923,8 @@ class RenderEditable extends RenderBox {
 
   double _maxScrollExtent = 0;
 
-    // We need to check the paint offset here because during animation, the start of
-    // the text may position outside the visible region even when the text fits.
+  // We need to check the paint offset here because during animation, the start of
+  // the text may position outside the visible region even when the text fits.
   bool get _hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
   /// Returns the local coordinates of the endpoints of the given selection.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -921,7 +921,11 @@ class RenderEditable extends RenderBox {
     return null;
   }
 
-  bool _hasVisualOverflow = false;
+  double _maxScrollExtent = 0;
+
+    // We need to check the paint offset here because during animation, the start of
+    // the text may position outside the visible region even when the text fits.
+  bool get hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
   /// Returns the local coordinates of the endpoints of the given selection.
   ///
@@ -1146,8 +1150,7 @@ class RenderEditable extends RenderBox {
     final Size textPainterSize = _textPainter.size;
     size = Size(constraints.maxWidth, constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
     final Size contentSize = Size(textPainterSize.width + _kCaretGap + cursorWidth, textPainterSize.height);
-    final double _maxScrollExtent = _getMaxScrollExtent(contentSize);
-    _hasVisualOverflow = _maxScrollExtent > 0.0;
+    _maxScrollExtent = _getMaxScrollExtent(contentSize);
     offset.applyViewportDimension(_viewportExtent);
     offset.applyContentDimensions(0.0, _maxScrollExtent);
   }
@@ -1201,14 +1204,14 @@ class RenderEditable extends RenderBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     _layoutText(constraints.maxWidth);
-    if (_hasVisualOverflow)
+    if (hasVisualOverflow)
       context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents);
     else
       _paintContents(context, offset);
   }
 
   @override
-  Rect describeApproximatePaintClip(RenderObject child) => _hasVisualOverflow ? Offset.zero & size : null;
+  Rect describeApproximatePaintClip(RenderObject child) => hasVisualOverflow ? Offset.zero & size : null;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1333,7 +1333,11 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// The layout constraints most recently supplied by the parent.
   @protected
   Constraints get constraints => _constraints;
-  Constraints _constraints;
+  Constraints __constraints;
+  Constraints get _constraints => __constraints;
+  Constraints set _constraints(Constraints value) {
+    __constraints = value;
+  }
 
   /// Verify that the object's constraints are being met. Override
   /// this function in a subclass to verify that your state matches

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1333,11 +1333,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// The layout constraints most recently supplied by the parent.
   @protected
   Constraints get constraints => _constraints;
-  Constraints __constraints;
-  Constraints get _constraints => __constraints;
-  Constraints set _constraints(Constraints value) {
-    __constraints = value;
-  }
+  Constraints _constraints;
 
   /// Verify that the object's constraints are being met. Override
   /// this function in a subclass to verify that your state matches

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -6,6 +6,9 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 
+import '../rendering/mock_canvas.dart';
+import '../rendering/recording_canvas.dart';
+
 class FakeEditableTextState extends TextSelectionDelegate {
   @override
   TextEditingValue get textEditingValue { return const TextEditingValue(); }
@@ -83,6 +86,9 @@ void main() {
       textSelectionDelegate: delegate,
     );
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
-    expect(editable.hasVisualOverflow, true);
+    expect(
+      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      paints..clipRect(rect: Rect.fromLTRB(0.0, 0.0, 1000.0, 10.0))
+    );
   });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -65,4 +65,24 @@ void main() {
       ),
     );
   });
+
+  // Test that clipping will be used even when the text fits within the visible
+  // region if the start position of the text is offset (e.g. during scrolling
+  // animation).
+  test('correct clipping', () {
+    final TextSelectionDelegate delegate = FakeEditableTextState();
+    final RenderEditable editable = RenderEditable(
+      text: const TextSpan(
+        style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+        text: 'A',
+      ),
+      textAlign: TextAlign.start,
+      textDirection: TextDirection.ltr,
+      locale: const Locale('en', 'US'),
+      offset: ViewportOffset.fixed(10.0),
+      textSelectionDelegate: delegate,
+    );
+    editable.layout(BoxConstraints.loose(Size(1000.0, 1000.0)));
+    expect(editable.hasVisualOverflow, true);
+  });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -82,7 +82,7 @@ void main() {
       offset: ViewportOffset.fixed(10.0),
       textSelectionDelegate: delegate,
     );
-    editable.layout(BoxConstraints.loose(Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
     expect(editable.hasVisualOverflow, true);
   });
 }


### PR DESCRIPTION
`RenderEditable.paint` assumes that if the length of the text fits within the
visible region, then the text will be rendered at the start of the region and be
completely visible. This is not always true, since the text may still be
rendered at an offset if an animation is ongoing when the text begins to fit.

This fixes #22288 and #14121 