### PR TITLE
Fix hanging of flutter run when running on more than one simulator.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -441,6 +441,7 @@ Future<XcodeBuildResult> buildXcodeProject({
         if (line == 'done') {
           buildSubStatus?.stop();
           buildSubStatus = null;
+          return null;
         } else {
           initialBuildStatus.cancel();
           buildSubStatus = logger.startProgress(


### PR DESCRIPTION
This stops reading from pipe-to-file log after the build is completed. Attempting to read from pipe-to-file keeps open blocked because nobody is going to write into that pipe.

Fixes https://github.com/flutter/flutter/issues/23931