### PR TITLE
Make FlexibleSpaceBar offset configurable

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -47,7 +47,8 @@ class FlexibleSpaceBar extends StatefulWidget {
     this.title,
     this.background,
     this.centerTitle,
-    this.collapseMode = CollapseMode.parallax
+    this.collapseMode = CollapseMode.parallax,
+    this.titleStartOffset = 72.0
   }) : assert(collapseMode != null),
        super(key: key);
 
@@ -70,6 +71,11 @@ class FlexibleSpaceBar extends StatefulWidget {
   ///
   /// Defaults to [CollapseMode.parallax].
   final CollapseMode collapseMode;
+
+  /// Offset from the start (if [title] is not centered).
+  ///
+  /// Defaults to 72.0
+  final double titleStartOffset;
 
   /// Wraps a widget that contains an [AppBar] to convey sizing information down
   /// to the [FlexibleSpaceBar].
@@ -212,7 +218,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);
         children.add(Container(
           padding: EdgeInsetsDirectional.only(
-            start: effectiveCenterTitle ? 0.0 : 72.0,
+            start: effectiveCenterTitle ? 0.0 : widget.titleStartOffset,
             bottom: 16.0
           ),
           child: Transform(

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -114,6 +114,50 @@ void main() {
 
     expect(clipRect.size.height, minExtent);
   });
+
+  testWidgets('FlexibleSpaceBar has default titleStartOffset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: Scaffold(
+          appBar: AppBar(
+            flexibleSpace: const FlexibleSpaceBar(
+              title: Text('X')
+            )
+          )
+        )
+      )
+    );
+
+    final Finder title = find.text('X');
+    final Offset topLeft = tester.getTopLeft(title);
+
+    expect(topLeft.dx, equals(72.0));
+  });
+
+  testWidgets('FlexibleSpaceBar has defined titleStartOffset', (WidgetTester tester) async {
+    const double definedOffset = 24.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: Scaffold(
+          appBar: AppBar(
+            flexibleSpace: const FlexibleSpaceBar(
+              title: Text('X'),
+              titleStartOffset: definedOffset
+            )
+          )
+        )
+      )
+    );
+
+    final Finder title = find.text('X');
+    final Offset topLeft = tester.getTopLeft(title);
+
+    expect(topLeft.dx, equals(definedOffset));
+  });
+
 }
 
 class TestDelegate extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
In the current implementation, the offset from the start is a hardcoded value (72.0). In the app I am developing, I need to change this and I see no easy way to do it. I propose to make it configurable but to maintain the current 72.0 as a default (not to break existing apps).

There is already old PR with the same change #22548 but currently seems forgotten and has merge conflicts.