### PR TITLE
Add cupertino_icons dependency to module pubspec template

### DIFF
--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -9,6 +9,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  cupertino_icons: ^0.1.2
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/23954

Since the module template has `uses-material-design: true`, make it equivalent on iOS