### PR TITLE
Don't include toString method bodies in release mode

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show VoidCallback;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'tween.dart';
 
 // Examples can assume:
@@ -162,7 +163,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
 
   @override
   String toString() {
-    return '${describeIdentity(this)}(${toStringDetails()})';
+    return assertionsEnabled ? '${describeIdentity(this)}(${toStringDetails()})' : super.toString();
   }
 
   /// Provides a string describing the status of this object, but not including

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show VoidCallback;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'animation.dart';
 import 'curves.dart';
 import 'listener_helpers.dart';
@@ -233,9 +234,12 @@ class ProxyAnimation extends Animation<double>
 
   @override
   String toString() {
-    if (parent == null)
-      return '$runtimeType(null; ${super.toStringDetails()} ${value.toStringAsFixed(3)})';
-    return '$parent\u27A9$runtimeType';
+    if (assertionsEnabled) {
+      if (parent == null)
+        return '$runtimeType(null; ${super.toStringDetails()} ${value.toStringAsFixed(3)})';
+      return '$parent\u27A9$runtimeType';
+    }
+    return super.toString();
   }
 }
 
@@ -311,7 +315,7 @@ class ReverseAnimation extends Animation<double>
 
   @override
   String toString() {
-    return '$parent\u27AA$runtimeType';
+    return assertionsEnabled ? '$parent\u27AA$runtimeType' : super.toString();
   }
 }
 
@@ -453,11 +457,14 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
 
   @override
   String toString() {
-    if (reverseCurve == null)
-      return '$parent\u27A9$curve';
-    if (_useForwardCurve)
-      return '$parent\u27A9$curve\u2092\u2099/$reverseCurve';
-    return '$parent\u27A9$curve/$reverseCurve\u2092\u2099';
+    if (assertionsEnabled) {
+      if (reverseCurve == null)
+        return '$parent\u27A9$curve';
+      if (_useForwardCurve)
+        return '$parent\u27A9$curve\u2092\u2099/$reverseCurve';
+      return '$parent\u27A9$curve/$reverseCurve\u2092\u2099';
+    }
+    return super.toString();
   }
 }
 
@@ -589,9 +596,12 @@ class TrainHoppingAnimation extends Animation<double>
 
   @override
   String toString() {
-    if (_nextTrain != null)
-      return '$currentTrain\u27A9$runtimeType(next: $_nextTrain)';
-    return '$currentTrain\u27A9$runtimeType(no next)';
+    if (assertionsEnabled) {
+      if (_nextTrain != null)
+        return '$currentTrain\u27A9$runtimeType(next: $_nextTrain)';
+      return '$currentTrain\u27A9$runtimeType(no next)';
+    }
+    return super.toString();
   }
 }
 
@@ -651,7 +661,7 @@ abstract class CompoundAnimation<T> extends Animation<T>
 
   @override
   String toString() {
-    return '$runtimeType($first, $next)';
+    return assertionsEnabled ? '$runtimeType($first, $next)' : super.toString();
   }
 
   AnimationStatus _lastStatus;

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -6,6 +6,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 /// An easing curve, i.e. a mapping of the unit interval to the unit interval.
 ///
 /// Easing curves are used to adjust the rate of change of an animation over
@@ -52,7 +54,7 @@ abstract class Curve {
 
   @override
   String toString() {
-    return '$runtimeType';
+    return assertionsEnabled ? '$runtimeType' : super.toString();
   }
 }
 
@@ -92,7 +94,7 @@ class SawTooth extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($count)';
+    return assertionsEnabled ? '$runtimeType($count)' : super.toString();
   }
 }
 
@@ -145,9 +147,12 @@ class Interval extends Curve {
 
   @override
   String toString() {
-    if (curve is! _Linear)
-      return '$runtimeType($begin\u22EF$end)\u27A9$curve';
-    return '$runtimeType($begin\u22EF$end)';
+    if (assertionsEnabled) {
+      if (curve is! _Linear)
+        return '$runtimeType($begin\u22EF$end)\u27A9$curve';
+      return '$runtimeType($begin\u22EF$end)';
+    }
+    return super.toString();
   }
 }
 
@@ -255,7 +260,10 @@ class Cubic extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType(${a.toStringAsFixed(2)}, ${b.toStringAsFixed(2)}, ${c.toStringAsFixed(2)}, ${d.toStringAsFixed(2)})';
+    if (assertionsEnabled) {
+      return '$runtimeType(${a.toStringAsFixed(2)}, ${b.toStringAsFixed(2)}, ${c.toStringAsFixed(2)}, ${d.toStringAsFixed(2)})';
+    }
+    return super.toString();
   }
 }
 
@@ -291,7 +299,10 @@ class FlippedCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($curve)';
+    if (assertionsEnabled) {
+      return '$runtimeType($curve)';
+    }
+    return super.toString();
   }
 }
 
@@ -403,7 +414,7 @@ class ElasticInCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return assertionsEnabled ? '$runtimeType($period)' : super.toString();
   }
 }
 
@@ -431,7 +442,7 @@ class ElasticOutCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return assertionsEnabled ? '$runtimeType($period)' : super.toString();
   }
 }
 
@@ -464,7 +475,7 @@ class ElasticInOutCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return assertionsEnabled ? '$runtimeType($period)' : super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show Color, Size, Rect;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'animation.dart';
 import 'animations.dart';
 import 'curves.dart';
@@ -88,7 +89,7 @@ class _AnimatedEvaluation<T> extends Animation<T> with AnimationWithParentMixin<
 
   @override
   String toString() {
-    return '$parent\u27A9$_evaluatable\u27A9$value';
+    return assertionsEnabled ? '$parent\u27A9$_evaluatable\u27A9$value' : super.toString();
   }
 
   @override
@@ -110,7 +111,7 @@ class _ChainedEvaluation<T> extends Animatable<T> {
 
   @override
   String toString() {
-    return '$_parent\u27A9$_evaluatable';
+    return assertionsEnabled ? '$_parent\u27A9$_evaluatable' : super.toString();
   }
 }
 
@@ -258,7 +259,7 @@ class Tween<T extends dynamic> extends Animatable<T> {
   }
 
   @override
-  String toString() => '$runtimeType($begin \u2192 $end)';
+  String toString() => assertionsEnabled ? '$runtimeType($begin \u2192 $end)' : super.toString();
 }
 
 /// A [Tween] that evaluates its [parent] in reverse.
@@ -396,7 +397,7 @@ class ConstantTween<T> extends Tween<T> {
   T lerp(double t) => begin;
 
   @override
-  String toString() => '$runtimeType(value: begin)';
+  String toString() => assertionsEnabled ? '$runtimeType(value: begin)' : super.toString();
 }
 
 /// Transforms the value of the given animation by the given curve.
@@ -444,5 +445,5 @@ class CurveTween extends Animatable<double> {
   }
 
   @override
-  String toString() => '$runtimeType(curve: $curve)';
+  String toString() => assertionsEnabled ? '$runtimeType(curve: $curve)' : super.toString();
 }

--- a/packages/flutter/lib/src/animation/tween_sequence.dart
+++ b/packages/flutter/lib/src/animation/tween_sequence.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'animation.dart';
 import 'tween.dart';
 
@@ -128,5 +129,5 @@ class _Interval {
   double value(double t) => (t - start) / (end - start);
 
   @override
-  String toString() => '<$start, $end>';
+  String toString() => assertionsEnabled ? '<$start, $end>' : super.toString();
 }

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'button.dart';
 import 'colors.dart';
 import 'icons.dart';
@@ -74,7 +75,7 @@ class _HeroTag {
 
   // Let the Hero tag be described in tree dumps.
   @override
-  String toString() => 'Default Hero tag for Cupertino navigation bars with navigator $navigator';
+  String toString() => assertionsEnabled ? 'Default Hero tag for Cupertino navigation bars with navigator $navigator' : super.toString();
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'print.dart';
 
@@ -143,34 +144,37 @@ class FlutterErrorDetails {
 
   @override
   String toString() {
-    final StringBuffer buffer = StringBuffer();
-    if ((library != null && library != '') || (context != null && context != '')) {
-      if (library != null && library != '') {
-        buffer.write('Error caught by $library');
+    if (assertionsEnabled) {
+      final StringBuffer buffer = StringBuffer();
+      if ((library != null && library != '') || (context != null && context != '')) {
+        if (library != null && library != '') {
+          buffer.write('Error caught by $library');
+          if (context != null && context != '')
+            buffer.write(', ');
+        } else {
+          buffer.writeln('Exception ');
+        }
         if (context != null && context != '')
-          buffer.write(', ');
+          buffer.write('thrown $context');
+        buffer.writeln('.');
       } else {
-        buffer.writeln('Exception ');
+        buffer.write('An error was caught.');
       }
-      if (context != null && context != '')
-        buffer.write('thrown $context');
-      buffer.writeln('.');
-    } else {
-      buffer.write('An error was caught.');
-    }
-    buffer.writeln(exceptionAsString());
-    if (informationCollector != null)
-      informationCollector(buffer);
-    if (stack != null) {
-      Iterable<String> stackLines = stack.toString().trimRight().split('\n');
-      if (stackFilter != null) {
-        stackLines = stackFilter(stackLines);
-      } else {
-        stackLines = FlutterError.defaultStackFilter(stackLines);
+      buffer.writeln(exceptionAsString());
+      if (informationCollector != null)
+        informationCollector(buffer);
+      if (stack != null) {
+        Iterable<String> stackLines = stack.toString().trimRight().split('\n');
+        if (stackFilter != null) {
+          stackLines = stackFilter(stackLines);
+        } else {
+          stackLines = FlutterError.defaultStackFilter(stackLines);
+        }
+        buffer.writeAll(stackLines, '\n');
       }
-      buffer.writeAll(stackLines, '\n');
+      return buffer.toString().trimRight();
     }
-    return buffer.toString().trimRight();
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:collection';
 
+import '../util.dart';
+
 // COMMON SIGNATURES
 
 export 'dart:ui' show VoidCallback;
@@ -296,7 +298,7 @@ class Factory<T> {
 
   @override
   String toString() {
-    return 'Factory(type: $type)';
+    return assertionsEnabled ? 'Factory(type: $type)' : super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -9,6 +9,7 @@ import 'dart:io' show exit;
 
 import 'package:meta/meta.dart';
 
+import '../util.dart';
 import 'assertions.dart';
 import 'basic_types.dart';
 import 'debug.dart';
@@ -463,7 +464,7 @@ abstract class BindingBase {
   }
 
   @override
-  String toString() => '<$runtimeType>';
+  String toString() => assertionsEnabled ? '<$runtimeType>' : super.toString();
 }
 
 /// Terminate the Flutter application.

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import '../util.dart';
 import 'assertions.dart';
 import 'basic_types.dart';
 import 'diagnostics.dart';
@@ -240,7 +241,10 @@ class _MergingListenable extends ChangeNotifier {
 
   @override
   String toString() {
-    return 'Listenable.merge([${_children.join(", ")}])';
+    if (assertionsEnabled) {
+      return 'Listenable.merge([${_children.join(", ")}])';
+    }
+    return super.toString();
   }
 }
 
@@ -265,5 +269,5 @@ class ValueNotifier<T> extends ChangeNotifier implements ValueListenable<T> {
   }
 
   @override
-  String toString() => '${describeIdentity(this)}($value)';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}($value)' : super.toString();
 }

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import '../util.dart';
 import 'print.dart';
 
 // Examples can assume:
@@ -619,7 +620,7 @@ class _PrefixedStringBuilder {
   }
 
   @override
-  String toString() => _buffer.toString();
+  String toString() => assertionsEnabled ? _buffer.toString() : super.toString();
 }
 
 class _NoDefaultValue {
@@ -789,18 +790,21 @@ abstract class DiagnosticsNode {
     TextTreeConfiguration parentConfiguration,
     DiagnosticLevel minLevel = DiagnosticLevel.info,
   }) {
-    assert(style != null);
-    assert(minLevel != null);
-    if (style == DiagnosticsTreeStyle.singleLine)
-      return toStringDeep(parentConfiguration: parentConfiguration, minLevel: minLevel);
+    if (assertionsEnabled) {
+      assert(style != null);
+      assert(minLevel != null);
+      if (style == DiagnosticsTreeStyle.singleLine)
+        return toStringDeep(parentConfiguration: parentConfiguration, minLevel: minLevel);
 
-    final String description = toDescription(parentConfiguration: parentConfiguration);
+      final String description = toDescription(parentConfiguration: parentConfiguration);
 
-    if (name == null || name.isEmpty || !showName)
-      return description;
+      if (name == null || name.isEmpty || !showName)
+        return description;
 
-    return description.contains('\n') ? '$name$_separator\n$description'
-                                      : '$name$_separator $description';
+      return description.contains('\n') ? '$name$_separator\n$description'
+                                        : '$name$_separator $description';
+    }
+    return super.toString();
   }
 
   /// Returns a configuration specifying how this object should be rendered
@@ -2123,7 +2127,10 @@ abstract class Diagnosticable {
 
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.debug }) {
-    return toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
+    if (assertionsEnabled) {
+      return toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
+    }
+    return super.toString();
   }
 
   /// Returns a debug representation of the object that is used by debugging
@@ -2465,7 +2472,10 @@ abstract class DiagnosticableTree extends Diagnosticable {
 mixin DiagnosticableTreeMixin implements DiagnosticableTree {
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.debug }) {
-    return toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
+    if (assertionsEnabled) {
+      return toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
+    }
+    return super.toString();
   }
 
   @override

--- a/packages/flutter/lib/src/foundation/key.dart
+++ b/packages/flutter/lib/src/foundation/key.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show hashValues;
 
 import 'package:meta/meta.dart';
 
+import '../util.dart';
+
 /// A [Key] is an identifier for [Widget]s, [Element]s and [SemanticsNode]s.
 ///
 /// A new widget will only be used to update an existing element if its key is
@@ -74,12 +76,15 @@ class ValueKey<T> extends LocalKey {
 
   @override
   String toString() {
-    final String valueString = T == String ? '<\'$value\'>' : '<$value>';
-    // The crazy on the next line is a workaround for
-    // https://github.com/dart-lang/sdk/issues/33297
-    if (runtimeType == _TypeLiteral<ValueKey<T>>().type)
-      return '[$valueString]';
-    return '[$T $valueString]';
+    if (assertionsEnabled) {
+      final String valueString = T == String ? '<\'$value\'>' : '<$value>';
+      // The crazy on the next line is a workaround for
+      // https://github.com/dart-lang/sdk/issues/33297
+      if (runtimeType == _TypeLiteral<ValueKey<T>>().type)
+        return '[$valueString]';
+      return '[$T $valueString]';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'debug.dart';
 
 /// Whether the gesture was accepted or rejected.
@@ -72,23 +73,26 @@ class _GestureArena {
 
   @override
   String toString() {
-    final StringBuffer buffer = StringBuffer();
-    if (members.isEmpty) {
-      buffer.write('<empty>');
-    } else {
-      buffer.write(members.map<String>((GestureArenaMember member) {
-        if (member == eagerWinner)
-          return '$member (eager winner)';
-        return '$member';
-      }).join(', '));
+    if (assertionsEnabled) {
+      final StringBuffer buffer = StringBuffer();
+      if (members.isEmpty) {
+        buffer.write('<empty>');
+      } else {
+        buffer.write(members.map<String>((GestureArenaMember member) {
+          if (member == eagerWinner)
+            return '$member (eager winner)';
+          return '$member';
+        }).join(', '));
+      }
+      if (isOpen)
+        buffer.write(' [open]');
+      if (isHeld)
+        buffer.write(' [held]');
+      if (hasPendingSweep)
+        buffer.write(' [hasPendingSweep]');
+      return buffer.toString();
     }
-    if (isOpen)
-      buffer.write(' [open]');
-    if (isHeld)
-      buffer.write(' [held]');
-    if (hasPendingSweep)
-      buffer.write(' [hasPendingSweep]');
-    return buffer.toString();
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui show PointerData, PointerChange;
 
+import '../util.dart';
 import 'events.dart';
 
 class _PointerState {
@@ -32,7 +33,10 @@ class _PointerState {
 
   @override
   String toString() {
-    return '_PointerState(pointer: $pointer, down: $down, lastPosition: $lastPosition)';
+    if (assertionsEnabled) {
+      return '_PointerState(pointer: $pointer, down: $down, lastPosition: $lastPosition)';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show Offset;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'velocity_tracker.dart';
 
 /// Details object for callbacks that use [GestureDragDownCallback].
@@ -29,7 +30,7 @@ class DragDownDetails {
   final Offset globalPosition;
 
   @override
-  String toString() => '$runtimeType($globalPosition)';
+  String toString() => assertionsEnabled ? '$runtimeType($globalPosition)' : super.toString();
 }
 
 /// Signature for when a pointer has contacted the screen and might begin to
@@ -71,7 +72,7 @@ class DragStartDetails {
   // instead).
 
   @override
-  String toString() => '$runtimeType($globalPosition)';
+  String toString() => assertionsEnabled ? '$runtimeType($globalPosition)' : super.toString();
 }
 
 /// Signature for when a pointer has contacted the screen and has begun to move.
@@ -140,7 +141,7 @@ class DragUpdateDetails {
   final Offset globalPosition;
 
   @override
-  String toString() => '$runtimeType($delta)';
+  String toString() => assertionsEnabled ? '$runtimeType($delta)' : super.toString();
 }
 
 /// Signature for when a pointer that is in contact with the screen and moving
@@ -190,5 +191,5 @@ class DragEndDetails {
   final double primaryVelocity;
 
   @override
-  String toString() => '$runtimeType($velocity)';
+  String toString() => assertionsEnabled ? '$runtimeType($velocity)' : super.toString();
 }

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show Offset, PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 export 'dart:ui' show Offset, PointerDeviceKind;
 
 /// The bit of [PointerEvent.buttons] that corresponds to the primary mouse button.
@@ -258,7 +260,7 @@ abstract class PointerEvent {
   final bool synthesized;
 
   @override
-  String toString() => '$runtimeType($position)';
+  String toString() => assertionsEnabled ? '$runtimeType($position)' : super.toString();
 
   /// Returns a complete textual description of this event.
   String toStringFull() {

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
 import 'events.dart';
 
 /// An object that can hit-test pointers.
@@ -49,7 +50,7 @@ class HitTestEntry {
   final HitTestTarget target;
 
   @override
-  String toString() => '$target';
+  String toString() => assertionsEnabled ? '$target' : super.toString();
 }
 
 /// The result of performing a hit test.
@@ -79,5 +80,7 @@ class HitTestResult {
   }
 
   @override
-  String toString() => 'HitTestResult(${_path.isEmpty ? "<empty path>" : _path.join(", ")})';
+  String toString() => assertionsEnabled
+    ? 'HitTestResult(${_path.isEmpty ? "<empty path>" : _path.join(", ")})'
+    : super.toString();
 }

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import '../util.dart';
 import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
@@ -42,7 +43,7 @@ class ScaleStartDetails {
   final Offset focalPoint;
 
   @override
-  String toString() => 'ScaleStartDetails(focalPoint: $focalPoint)';
+  String toString() => assertionsEnabled ? 'ScaleStartDetails(focalPoint: $focalPoint)' : super.toString();
 }
 
 /// Details for [GestureScaleUpdateCallback].
@@ -72,7 +73,9 @@ class ScaleUpdateDetails {
   final double rotation;
 
   @override
-  String toString() => 'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, rotation: $rotation)';
+  String toString() => assertionsEnabled
+    ? 'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, rotation: $rotation)'
+    : super.toString();
 }
 
 /// Details for [GestureScaleEndCallback].
@@ -87,7 +90,7 @@ class ScaleEndDetails {
   final Velocity velocity;
 
   @override
-  String toString() => 'ScaleEndDetails(velocity: $velocity)';
+  String toString() => assertionsEnabled ? 'ScaleEndDetails(velocity: $velocity)' : super.toString();
 }
 
 /// Signature for when the pointers in contact with the screen have established

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show Offset;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'lsq_solver.dart';
 
 export 'dart:ui' show Offset;
@@ -73,7 +74,9 @@ class Velocity {
   int get hashCode => pixelsPerSecond.hashCode;
 
   @override
-  String toString() => 'Velocity(${pixelsPerSecond.dx.toStringAsFixed(1)}, ${pixelsPerSecond.dy.toStringAsFixed(1)})';
+  String toString() => assertionsEnabled
+    ? 'Velocity(${pixelsPerSecond.dx.toStringAsFixed(1)}, ${pixelsPerSecond.dy.toStringAsFixed(1)})'
+    : super.toString();
 }
 
 /// A two dimensional velocity estimate.
@@ -121,7 +124,9 @@ class VelocityEstimate {
   final Offset offset;
 
   @override
-  String toString() => 'VelocityEstimate(${pixelsPerSecond.dx.toStringAsFixed(1)}, ${pixelsPerSecond.dy.toStringAsFixed(1)}; offset: $offset, duration: $duration, confidence: ${confidence.toStringAsFixed(1)})';
+  String toString() => assertionsEnabled
+    ? 'VelocityEstimate(${pixelsPerSecond.dx.toStringAsFixed(1)}, ${pixelsPerSecond.dy.toStringAsFixed(1)}; offset: $offset, duration: $duration, confidence: ${confidence.toStringAsFixed(1)})'
+    : super.toString();
 }
 
 class _PointAtTime {
@@ -133,7 +138,7 @@ class _PointAtTime {
   final Offset point;
 
   @override
-  String toString() => '_PointAtTime($point at $time)';
+  String toString() => assertionsEnabled ? '_PointAtTime($point at $time)' : super.toString();
 }
 
 /// Computes a pointer's velocity based on data from [PointerMoveEvent]s.

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'back_button.dart';
 import 'constants.dart';
 import 'debug.dart';
@@ -701,7 +702,10 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   String toString() {
-    return '${describeIdentity(this)}(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
+    if (assertionsEnabled) {
+      return '${describeIdentity(this)}(topPadding: ${topPadding.toStringAsFixed(1)}, bottomHeight: ${_bottomHeight.toStringAsFixed(1)}, ...)';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -8,6 +8,8 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/animation.dart';
 import 'package:flutter/painting.dart';
 
+import '../util.dart';
+
 // How close the begin and end points must be to an axis to be considered
 // vertical or horizontal.
 const double _kOnAxisDelta = 2.0;
@@ -169,7 +171,10 @@ class MaterialPointArcTween extends Tween<Offset> {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; center=$center, radius=$radius, beginAngle=$beginAngle, endAngle=$endAngle)';
+    if (assertionsEnabled) {
+      return '$runtimeType($begin \u2192 $end; center=$center, radius=$radius, beginAngle=$beginAngle, endAngle=$endAngle)';
+    }
+    return super.toString();
   }
 }
 
@@ -324,7 +329,10 @@ class MaterialRectArcTween extends RectTween {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
+    if (assertionsEnabled) {
+      return '$runtimeType($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
+    }
+    return super.toString();
   }
 }
 
@@ -410,6 +418,9 @@ class MaterialRectCenterArcTween extends RectTween {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; centerArc=$centerArc)';
+    if (assertionsEnabled) {
+      return '$runtimeType($begin \u2192 $end; centerArc=$centerArc)';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'expand_icon.dart';
 import 'mergeable_material.dart';
 import 'theme.dart';
@@ -32,9 +33,12 @@ class _SaltedKey<S, V> extends LocalKey {
 
   @override
   String toString() {
-    final String saltString = S == String ? '<\'$salt\'>' : '<$salt>';
-    final String valueString = V == String ? '<\'$value\'>' : '<$value>';
-    return '[$saltString $valueString]';
+    if (assertionsEnabled) {
+      final String saltString = S == String ? '<\'$salt\'>' : '<$salt>';
+      final String valueString = V == String ? '<\'$value\'>' : '<$value>';
+      return '[$saltString $valueString]';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'scaffold.dart';
 
 // TODO(hmuller): should be device dependent.
@@ -90,7 +91,7 @@ abstract class FloatingActionButtonLocation {
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 class _CenterFloatFabLocation extends FloatingActionButtonLocation {
@@ -311,7 +312,7 @@ abstract class FloatingActionButtonAnimator {
   double getAnimationRestart(double previousValue) => 0.0;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 class _ScalingFabMotionAnimator extends FloatingActionButtonAnimator {

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'colors.dart';
 import 'input_border.dart';
 import 'theme.dart';
@@ -2604,68 +2605,71 @@ class InputDecoration {
 
   @override
   String toString() {
-    final List<String> description = <String>[];
-    if (icon != null)
-      description.add('icon: $icon');
-    if (labelText != null)
-      description.add('labelText: "$labelText"');
-    if (helperText != null)
-      description.add('helperText: "$helperText"');
-    if (hintText != null)
-      description.add('hintText: "$hintText"');
-    if (errorText != null)
-      description.add('errorText: "$errorText"');
-    if (errorStyle != null)
-      description.add('errorStyle: "$errorStyle"');
-    if (errorMaxLines != null)
-      description.add('errorMaxLines: "$errorMaxLines"');
-    if (isDense ?? false)
-      description.add('isDense: $isDense');
-    if (contentPadding != null)
-      description.add('contentPadding: $contentPadding');
-    if (isCollapsed)
-      description.add('isCollapsed: $isCollapsed');
-    if (prefixIcon != null)
-      description.add('prefixIcon: $prefixIcon');
-    if (prefix != null)
-      description.add('prefix: $prefix');
-    if (prefixText != null)
-      description.add('prefixText: $prefixText');
-    if (prefixStyle != null)
-      description.add('prefixStyle: $prefixStyle');
-    if (suffixIcon != null)
-      description.add('suffixIcon: $suffixIcon');
-    if (suffix != null)
-      description.add('suffix: $suffix');
-    if (suffixText != null)
-      description.add('suffixText: $suffixText');
-    if (suffixStyle != null)
-      description.add('suffixStyle: $suffixStyle');
-    if (counterText != null)
-      description.add('counterText: $counterText');
-    if (counterStyle != null)
-      description.add('counterStyle: $counterStyle');
-    if (filled == true) // filled == null same as filled == false
-      description.add('filled: true');
-    if (fillColor != null)
-      description.add('fillColor: $fillColor');
-    if (errorBorder != null)
-      description.add('errorBorder: $errorBorder');
-    if (focusedBorder != null)
-      description.add('focusedBorder: $focusedBorder');
-    if (focusedErrorBorder != null)
-      description.add('focusedErrorBorder: $focusedErrorBorder');
-    if (disabledBorder != null)
-      description.add('disabledBorder: $disabledBorder');
-    if (enabledBorder != null)
-      description.add('enabledBorder: $enabledBorder');
-    if (border != null)
-      description.add('border: $border');
-    if (!enabled)
-      description.add('enabled: false');
-    if (semanticCounterText != null)
-      description.add('semanticCounterText: $semanticCounterText');
-    return 'InputDecoration(${description.join(', ')})';
+    if (assertionsEnabled) {
+      final List<String> description = <String>[];
+      if (icon != null)
+        description.add('icon: $icon');
+      if (labelText != null)
+        description.add('labelText: "$labelText"');
+      if (helperText != null)
+        description.add('helperText: "$helperText"');
+      if (hintText != null)
+        description.add('hintText: "$hintText"');
+      if (errorText != null)
+        description.add('errorText: "$errorText"');
+      if (errorStyle != null)
+        description.add('errorStyle: "$errorStyle"');
+      if (errorMaxLines != null)
+        description.add('errorMaxLines: "$errorMaxLines"');
+      if (isDense ?? false)
+        description.add('isDense: $isDense');
+      if (contentPadding != null)
+        description.add('contentPadding: $contentPadding');
+      if (isCollapsed)
+        description.add('isCollapsed: $isCollapsed');
+      if (prefixIcon != null)
+        description.add('prefixIcon: $prefixIcon');
+      if (prefix != null)
+        description.add('prefix: $prefix');
+      if (prefixText != null)
+        description.add('prefixText: $prefixText');
+      if (prefixStyle != null)
+        description.add('prefixStyle: $prefixStyle');
+      if (suffixIcon != null)
+        description.add('suffixIcon: $suffixIcon');
+      if (suffix != null)
+        description.add('suffix: $suffix');
+      if (suffixText != null)
+        description.add('suffixText: $suffixText');
+      if (suffixStyle != null)
+        description.add('suffixStyle: $suffixStyle');
+      if (counterText != null)
+        description.add('counterText: $counterText');
+      if (counterStyle != null)
+        description.add('counterStyle: $counterStyle');
+      if (filled == true) // filled == null same as filled == false
+        description.add('filled: true');
+      if (fillColor != null)
+        description.add('fillColor: $fillColor');
+      if (errorBorder != null)
+        description.add('errorBorder: $errorBorder');
+      if (focusedBorder != null)
+        description.add('focusedBorder: $focusedBorder');
+      if (focusedErrorBorder != null)
+        description.add('focusedErrorBorder: $focusedErrorBorder');
+      if (disabledBorder != null)
+        description.add('disabledBorder: $disabledBorder');
+      if (enabledBorder != null)
+        description.add('enabledBorder: $enabledBorder');
+      if (border != null)
+        description.add('border: $border');
+      if (!enabled)
+        description.add('enabled: false');
+      if (semanticCounterText != null)
+        description.add('semanticCounterText: $semanticCounterText');
+      return 'InputDecoration(${description.join(', ')})';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'constants.dart';
 import 'theme.dart';
 
@@ -570,7 +571,7 @@ abstract class InkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform);
 
   @override
-  String toString() => describeIdentity(this);
+  String toString() => assertionsEnabled ? describeIdentity(this) : super.toString();
 }
 
 /// An interpolation between two [ShapeBorder]s.

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'divider.dart';
 import 'material.dart';
 import 'shadows.dart';
@@ -51,7 +52,10 @@ class MaterialSlice extends MergeableMaterialItem {
 
   @override
   String toString() {
-    return 'MergeableSlice(key: $key, child: $child)';
+    if (assertionsEnabled) {
+      return 'MergeableSlice(key: $key, child: $child)';
+    }
+    return super.toString();
   }
 }
 
@@ -72,7 +76,10 @@ class MaterialGap extends MergeableMaterialItem {
 
   @override
   String toString() {
-    return 'MaterialGap(key: $key, child: $size)';
+    if (assertionsEnabled) {
+      return 'MaterialGap(key: $key, child: $size)';
+    }
+    return super.toString();
   }
 }
 
@@ -639,7 +646,10 @@ class _MergeableMaterialSliceKey extends GlobalKey {
 
   @override
   String toString() {
-    return '_MergeableMaterialSliceKey($value)';
+    if (assertionsEnabled) {
+      return '_MergeableMaterialSliceKey($value)';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'app_bar.dart';
 import 'bottom_sheet.dart';
 import 'button_bar.dart';
@@ -162,7 +163,10 @@ class _TransitionSnapshotFabLocation extends FloatingActionButtonLocation {
 
   @override
   String toString() {
-    return '$runtimeType(begin: $begin, end: $end, progress: $progress)';
+    if (assertionsEnabled) {
+      return '$runtimeType(begin: $begin, end: $end, progress: $progress)';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show hashValues;
 
 import 'package:flutter/widgets.dart';
 
+import '../util.dart';
 import 'debug.dart';
 import 'material_localizations.dart';
 
@@ -122,16 +123,19 @@ class TimeOfDay {
 
   @override
   String toString() {
-    String _addLeadingZeroIfNeeded(int value) {
-      if (value < 10)
-        return '0$value';
-      return value.toString();
+    if (assertionsEnabled) {
+      String _addLeadingZeroIfNeeded(int value) {
+        if (value < 10)
+          return '0$value';
+        return value.toString();
+      }
+
+      final String hourLabel = _addLeadingZeroIfNeeded(hour);
+      final String minuteLabel = _addLeadingZeroIfNeeded(minute);
+
+      return '$TimeOfDay($hourLabel:$minuteLabel)';
     }
-
-    final String hourLabel = _addLeadingZeroIfNeeded(hour);
-    final String minuteLabel = _addLeadingZeroIfNeeded(minute);
-
-    return '$TimeOfDay($hourLabel:$minuteLabel)';
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 
 /// Base class for [Alignment] that allows for text-direction aware
@@ -118,11 +119,14 @@ abstract class AlignmentGeometry {
 
   @override
   String toString() {
-    if (_start == 0.0)
-      return Alignment._stringify(_x, _y);
-    if (_x == 0.0)
-      return AlignmentDirectional._stringify(_start, _y);
-    return Alignment._stringify(_x, _y) + ' + ' + AlignmentDirectional._stringify(_start, 0.0);
+    if (assertionsEnabled) {
+      if (_start == 0.0)
+        return Alignment._stringify(_x, _y);
+      if (_x == 0.0)
+        return AlignmentDirectional._stringify(_start, _y);
+      return Alignment._stringify(_x, _y) + ' + ' + AlignmentDirectional._stringify(_start, 0.0);
+    }
+    return super.toString();
   }
 
   @override
@@ -363,7 +367,7 @@ class Alignment extends AlignmentGeometry {
   }
 
   @override
-  String toString() => _stringify(x, y);
+  String toString() => assertionsEnabled ? _stringify(x, y) : super.toString();
 }
 
 /// An offset that's expressed as a fraction of a [Size], but whose horizontal
@@ -553,7 +557,7 @@ class AlignmentDirectional extends AlignmentGeometry {
   }
 
   @override
-  String toString() => _stringify(start, y);
+  String toString() => assertionsEnabled ? _stringify(start, y) : super.toString();
 }
 
 class _MixedAlignment extends AlignmentGeometry {

--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -146,6 +147,6 @@ class BeveledRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side, $borderRadius)';
+    return assertionsEnabled ? '$runtimeType($side, $borderRadius)' : super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 
 /// Base class for [BorderRadius] that allows for text-direction aware resolution.
@@ -150,6 +151,10 @@ abstract class BorderRadiusGeometry {
 
   @override
   String toString() {
+    if (!assertionsEnabled) {
+      return super.toString();
+    }
+
     String visual, logical;
     if (_topLeft == _topRight &&
         _topRight == _bottomLeft &&

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -7,6 +7,7 @@ import 'dart:ui' as ui show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'edge_insets.dart';
 
@@ -257,7 +258,9 @@ class BorderSide {
   int get hashCode => hashValues(color, width, style);
 
   @override
-  String toString() => '$runtimeType($color, ${width.toStringAsFixed(1)}, $style)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType($color, ${width.toStringAsFixed(1)}, $style)'
+    : super.toString();
 }
 
 /// Base class for shape outlines.
@@ -467,7 +470,7 @@ abstract class ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType()';
+    return assertionsEnabled ? '$runtimeType()' : super.toString();
   }
 }
 
@@ -615,11 +618,14 @@ class _CompoundBorder extends ShapeBorder {
 
   @override
   String toString() {
-    // We list them in reverse order because when adding two borders they end up
-    // in the list in the opposite order of what the source looks like: a + b =>
-    // [b, a]. We do this to make the painting code more optimal, and most of
-    // the rest of the code doesn't care, except toString() (for debugging).
-    return borders.reversed.map<String>((ShapeBorder border) => border.toString()).join(' + ');
+    if (assertionsEnabled) {
+      // We list them in reverse order because when adding two borders they end up
+      // in the list in the opposite order of what the source looks like: a + b =>
+      // [b, a]. We do this to make the painting code more optimal, and most of
+      // the rest of the code doesn't care, except toString() (for debugging).
+      return borders.reversed.map<String>((ShapeBorder border) => border.toString()).join(' + ');
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -512,18 +513,21 @@ class Border extends BoxBorder {
 
   @override
   String toString() {
-    if (isUniform)
-      return '$runtimeType.all($top)';
-    final List<String> arguments = <String>[];
-    if (top != BorderSide.none)
-      arguments.add('top: $top');
-    if (right != BorderSide.none)
-      arguments.add('right: $right');
-    if (bottom != BorderSide.none)
-      arguments.add('bottom: $bottom');
-    if (left != BorderSide.none)
-      arguments.add('left: $left');
-    return '$runtimeType(${arguments.join(", ")})';
+    if (assertionsEnabled) {
+      if (isUniform)
+        return '$runtimeType.all($top)';
+      final List<String> arguments = <String>[];
+      if (top != BorderSide.none)
+        arguments.add('top: $top');
+      if (right != BorderSide.none)
+        arguments.add('right: $right');
+      if (bottom != BorderSide.none)
+        arguments.add('bottom: $bottom');
+      if (left != BorderSide.none)
+        arguments.add('left: $left');
+      return '$runtimeType(${arguments.join(", ")})';
+    }
+    return super.toString();
   }
 }
 
@@ -817,15 +821,18 @@ class BorderDirectional extends BoxBorder {
 
   @override
   String toString() {
-    final List<String> arguments = <String>[];
-    if (top != BorderSide.none)
-      arguments.add('top: $top');
-    if (start != BorderSide.none)
-      arguments.add('start: $start');
-    if (end != BorderSide.none)
-      arguments.add('end: $end');
-    if (bottom != BorderSide.none)
-      arguments.add('bottom: $bottom');
-    return '$runtimeType(${arguments.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> arguments = <String>[];
+      if (top != BorderSide.none)
+        arguments.add('top: $top');
+      if (start != BorderSide.none)
+        arguments.add('start: $start');
+      if (end != BorderSide.none)
+        arguments.add('end: $end');
+      if (bottom != BorderSide.none)
+        arguments.add('bottom: $bottom');
+      return '$runtimeType(${arguments.join(", ")})';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'box_border.dart';
@@ -429,6 +430,9 @@ class _BoxDecorationPainter extends BoxPainter {
 
   @override
   String toString() {
-    return 'BoxPainter for $_decoration';
+    if (assertionsEnabled) {
+      return 'BoxPainter for $_decoration';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/box_shadow.dart
+++ b/packages/flutter/lib/src/painting/box_shadow.dart
@@ -7,6 +7,7 @@ import 'dart:ui' as ui show Shadow, lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'debug.dart';
 
@@ -131,5 +132,7 @@ class BoxShadow extends ui.Shadow {
   int get hashCode => hashValues(color, offset, blurRadius, spreadRadius);
 
   @override
-  String toString() => 'BoxShadow($color, $offset, $blurRadius, $spreadRadius)';
+  String toString() => assertionsEnabled
+    ? 'BoxShadow($color, $offset, $blurRadius, $spreadRadius)'
+    : super.toString();
 }

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
@@ -93,6 +94,6 @@ class CircleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side)';
+    return assertionsEnabled ? '$runtimeType($side)' : super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -7,6 +7,8 @@ import 'dart:ui' show Color, lerpDouble, hashValues;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 double _getHue(double red, double green, double blue, double max, double delta) {
   double hue;
   if (max == 0.0) {
@@ -230,7 +232,9 @@ class HSVColor {
   int get hashCode => hashValues(alpha, hue, saturation, value);
 
   @override
-  String toString() => '$runtimeType($alpha, $hue, $saturation, $value)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType($alpha, $hue, $saturation, $value)'
+    : super.toString();
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [lightness].
@@ -416,7 +420,9 @@ class HSLColor {
   int get hashCode => hashValues(alpha, hue, saturation, lightness);
 
   @override
-  String toString() => '$runtimeType($alpha, $hue, $saturation, $lightness)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType($alpha, $hue, $saturation, $lightness)'
+    : super.toString();
 }
 
 /// A color that has a small table of related colors called a "swatch".
@@ -458,5 +464,7 @@ class ColorSwatch<T> extends Color {
   int get hashCode => hashValues(runtimeType, value, _swatch);
 
   @override
-  String toString() => '$runtimeType(primary value: ${super.toString()})';
+  String toString() => assertionsEnabled
+    ? '$runtimeType(primary value: ${super.toString()})'
+    : super.toString();
 }

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show Image;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'alignment.dart';
 import 'basic_types.dart';
 import 'borders.dart';
@@ -156,22 +157,25 @@ class DecorationImage {
 
   @override
   String toString() {
-    final List<String> properties = <String>[];
-    properties.add('$image');
-    if (colorFilter != null)
-      properties.add('$colorFilter');
-    if (fit != null &&
-        !(fit == BoxFit.fill && centerSlice != null) &&
-        !(fit == BoxFit.scaleDown && centerSlice == null))
-      properties.add('$fit');
-    properties.add('$alignment');
-    if (centerSlice != null)
-      properties.add('centerSlice: $centerSlice');
-    if (repeat != ImageRepeat.noRepeat)
-      properties.add('$repeat');
-    if (matchTextDirection)
-      properties.add('match text direction');
-    return '$runtimeType(${properties.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> properties = <String>[];
+      properties.add('$image');
+      if (colorFilter != null)
+        properties.add('$colorFilter');
+      if (fit != null &&
+          !(fit == BoxFit.fill && centerSlice != null) &&
+          !(fit == BoxFit.scaleDown && centerSlice == null))
+        properties.add('$fit');
+      properties.add('$alignment');
+      if (centerSlice != null)
+        properties.add('centerSlice: $centerSlice');
+      if (repeat != ImageRepeat.noRepeat)
+        properties.add('$repeat');
+      if (matchTextDirection)
+        properties.add('match text direction');
+      return '$runtimeType(${properties.join(", ")})';
+    }
+    return super.toString();
   }
 }
 
@@ -289,7 +293,10 @@ class DecorationImagePainter {
 
   @override
   String toString() {
-    return '$runtimeType(stream: $_imageStream, image: $_image) for $_details';
+    if (assertionsEnabled) {
+      return '$runtimeType(stream: $_imageStream, image: $_image) for $_details';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show lerpDouble, WindowPadding;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 
 /// Base class for [EdgeInsets] that allows for text-direction aware
@@ -226,6 +227,10 @@ abstract class EdgeInsetsGeometry {
 
   @override
   String toString() {
+    if (!assertionsEnabled) {
+      return super.toString();
+    }
+
     if (_start == 0.0 && _end == 0.0) {
       if (_left == 0.0 && _right == 0.0 && _top == 0.0 && _bottom == 0.0)
         return 'EdgeInsets.zero';

--- a/packages/flutter/lib/src/painting/fractional_offset.dart
+++ b/packages/flutter/lib/src/painting/fractional_offset.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'alignment.dart';
 import 'basic_types.dart';
 
@@ -192,7 +193,10 @@ class FractionalOffset extends Alignment {
 
   @override
   String toString() {
-    return 'FractionalOffset(${dx.toStringAsFixed(1)}, '
-                            '${dy.toStringAsFixed(1)})';
+    if (assertionsEnabled) {
+      return 'FractionalOffset(${dx.toStringAsFixed(1)}, '
+                              '${dy.toStringAsFixed(1)})';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -7,6 +7,7 @@ import 'dart:ui' as ui show Gradient, lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'alignment.dart';
 import 'basic_types.dart';
 
@@ -420,7 +421,10 @@ class LinearGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($begin, $end, $colors, $stops, $tileMode)';
+    if (assertionsEnabled) {
+      return '$runtimeType($begin, $end, $colors, $stops, $tileMode)';
+    }
+    return super.toString();
   }
 }
 
@@ -692,7 +696,10 @@ class RadialGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($center, $radius, $colors, $stops, $tileMode, $focal, $focalRadius)';
+    if (assertionsEnabled) {
+      return '$runtimeType($center, $radius, $colors, $stops, $tileMode, $focal, $focalRadius)';
+    }
+    return super.toString();
   }
 }
 
@@ -919,6 +926,9 @@ class SweepGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($center, $startAngle, $endAngle, $colors, $stops, $tileMode)';
+    if (assertionsEnabled) {
+      return '$runtimeType($center, $startAngle, $endAngle, $colors, $stops, $tileMode)';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -11,6 +11,7 @@ import 'dart:ui' show Size, Locale, TextDirection, hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'image_cache.dart';
 import 'image_stream.dart';
@@ -106,6 +107,10 @@ class ImageConfiguration {
 
   @override
   String toString() {
+    if (!assertionsEnabled) {
+      return super.toString();
+    }
+
     final StringBuffer result = StringBuffer();
     result.write('ImageConfiguration(');
     bool hasArguments = false;
@@ -346,7 +351,7 @@ abstract class ImageProvider<T> {
   ImageStreamCompleter load(T key);
 
   @override
-  String toString() => '$runtimeType()';
+  String toString() => assertionsEnabled ? '$runtimeType()' : super.toString();
 }
 
 /// Key for the image obtained by an [AssetImage] or [ExactAssetImage].
@@ -392,7 +397,9 @@ class AssetBundleImageKey {
   int get hashCode => hashValues(bundle, name, scale);
 
   @override
-  String toString() => '$runtimeType(bundle: $bundle, name: "$name", scale: $scale)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType(bundle: $bundle, name: "$name", scale: $scale)'
+    : super.toString();
 }
 
 /// A subclass of [ImageProvider] that knows about [AssetBundle]s.
@@ -509,7 +516,9 @@ class NetworkImage extends ImageProvider<NetworkImage> {
   int get hashCode => hashValues(url, scale);
 
   @override
-  String toString() => '$runtimeType("$url", scale: $scale)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType("$url", scale: $scale)'
+    : super.toString();
 }
 
 /// Decodes the given [File] object as an image, associating it with the given
@@ -571,7 +580,9 @@ class FileImage extends ImageProvider<FileImage> {
   int get hashCode => hashValues(file?.path, scale);
 
   @override
-  String toString() => '$runtimeType("${file?.path}", scale: $scale)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType("${file?.path}", scale: $scale)'
+    : super.toString();
 }
 
 /// Decodes the given [Uint8List] buffer as an image, associating it with the
@@ -632,7 +643,9 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   int get hashCode => hashValues(bytes.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${describeIdentity(bytes)}, scale: $scale)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType(${describeIdentity(bytes)}, scale: $scale)'
+    : super.toString();
 }
 
 /// Fetches an image from an [AssetBundle], associating it with the given scale.
@@ -769,5 +782,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
   int get hashCode => hashValues(keyName, scale, bundle);
 
   @override
-  String toString() => '$runtimeType(name: "$keyName", scale: $scale, bundle: $bundle)';
+  String toString() => assertionsEnabled
+    ? '$runtimeType(name: "$keyName", scale: $scale, bundle: $bundle)'
+    : super.toString();
 }

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -11,6 +11,7 @@ import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../util.dart';
 import 'image_provider.dart';
 
 const String _kAssetManifestFileName = 'AssetManifest.json';
@@ -287,5 +288,7 @@ class AssetImage extends AssetBundleImageProvider {
   int get hashCode => hashValues(keyName, bundle);
 
   @override
-  String toString() => '$runtimeType(bundle: $bundle, name: "$keyName")';
+  String toString() => assertionsEnabled
+    ? '$runtimeType(bundle: $bundle, name: "$keyName")'
+    : super.toString();
 }

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -9,6 +9,8 @@ import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
+import '../util.dart';
+
 /// A [dart:ui.Image] object with its corresponding scale.
 ///
 /// ImageInfo objects are used by [ImageStream] objects to represent the
@@ -41,7 +43,7 @@ class ImageInfo {
   final double scale;
 
   @override
-  String toString() => '$image @ ${scale}x';
+  String toString() => assertionsEnabled ? '$image @ ${scale}x' : super.toString();
 
   @override
   int get hashCode => hashValues(image, scale);

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -136,7 +137,10 @@ class RoundedRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side, $borderRadius)';
+    if (assertionsEnabled) {
+      return '$runtimeType($side, $borderRadius)';
+    }
+    return super.toString();
   }
 }
 
@@ -296,6 +300,9 @@ class _RoundedRectangleToCircleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return 'RoundedRectangleBorder($side, $borderRadius, ${(circleness * 100).toStringAsFixed(1)}% of the way to being a CircleBorder)';
+    if (assertionsEnabled) {
+      return 'RoundedRectangleBorder($side, $borderRadius, ${(circleness * 100).toStringAsFixed(1)}% of the way to being a CircleBorder)';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/painting/stadium_border.dart
+++ b/packages/flutter/lib/src/painting/stadium_border.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui show lerpDouble;
 
+import '../util.dart';
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -122,7 +123,7 @@ class StadiumBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side)';
+    return assertionsEnabled ? '$runtimeType($side)' : super.toString();
   }
 }
 
@@ -270,8 +271,11 @@ class _StadiumToCircleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return 'StadiumBorder($side, ${(circleness * 100).toStringAsFixed(1)}% '
-           'of the way to being a CircleBorder)';
+    if (assertionsEnabled) {
+      return 'StadiumBorder($side, ${(circleness * 100).toStringAsFixed(1)}% '
+            'of the way to being a CircleBorder)';
+    }
+    return super.toString();
   }
 }
 
@@ -413,8 +417,11 @@ class _StadiumToRoundedRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return 'StadiumBorder($side, $borderRadius, '
-           '${(rectness * 100).toStringAsFixed(1)}% of the way to being a '
-           'RoundedRectangleBorder)';
+    if (assertionsEnabled) {
+      return 'StadiumBorder($side, $borderRadius, '
+            '${(rectness * 100).toStringAsFixed(1)}% of the way to being a '
+            'RoundedRectangleBorder)';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/physics/simulation.dart
+++ b/packages/flutter/lib/src/physics/simulation.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
 import 'tolerance.dart';
 
 /// The base class for all simulations.
@@ -52,5 +53,5 @@ abstract class Simulation {
   Tolerance tolerance;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import '../util.dart';
 import 'simulation.dart';
 import 'tolerance.dart';
 import 'utils.dart';
@@ -55,7 +56,7 @@ class SpringDescription {
   final double damping;
 
   @override
-  String toString() => '$runtimeType(mass: ${mass.toStringAsFixed(1)}, stiffness: ${stiffness.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})';
+  String toString() => assertionsEnabled ? '$runtimeType(mass: ${mass.toStringAsFixed(1)}, stiffness: ${stiffness.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})' : super.toString();
 }
 
 /// The kind of spring solution that the [SpringSimulation] is using to simulate the spring.
@@ -119,7 +120,7 @@ class SpringSimulation extends Simulation {
   }
 
   @override
-  String toString() => '$runtimeType(end: $_endPosition, $type)';
+  String toString() => assertionsEnabled ? '$runtimeType(end: $_endPosition, $type)' : super.toString();
 }
 
 /// A SpringSimulation where the value of [x] is guaranteed to have exactly the

--- a/packages/flutter/lib/src/physics/tolerance.dart
+++ b/packages/flutter/lib/src/physics/tolerance.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
+
 /// Structure that specifies maximum allowable magnitudes for distances,
 /// durations, and velocity differences to be considered equal.
 class Tolerance {
@@ -42,5 +44,5 @@ class Tolerance {
   final double velocity;
 
   @override
-  String toString() => 'Tolerance(distance: ±$distance, time: ±$time, velocity: ±$velocity)';
+  String toString() => assertionsEnabled ? 'Tolerance(distance: ±$distance, time: ±$time, velocity: ±$velocity)' : super.toString();
 }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -10,6 +10,7 @@ import 'package:flutter/gestures.dart';
 
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'debug.dart';
 import 'object.dart';
 
@@ -592,20 +593,23 @@ class BoxConstraints extends Constraints {
 
   @override
   String toString() {
-    final String annotation = isNormalized ? '' : '; NOT NORMALIZED';
-    if (minWidth == double.infinity && minHeight == double.infinity)
-      return 'BoxConstraints(biggest$annotation)';
-    if (minWidth == 0 && maxWidth == double.infinity &&
-        minHeight == 0 && maxHeight == double.infinity)
-      return 'BoxConstraints(unconstrained$annotation)';
-    String describe(double min, double max, String dim) {
-      if (min == max)
-        return '$dim=${min.toStringAsFixed(1)}';
-      return '${min.toStringAsFixed(1)}<=$dim<=${max.toStringAsFixed(1)}';
+    if (assertionsEnabled) {
+      final String annotation = isNormalized ? '' : '; NOT NORMALIZED';
+      if (minWidth == double.infinity && minHeight == double.infinity)
+        return 'BoxConstraints(biggest$annotation)';
+      if (minWidth == 0 && maxWidth == double.infinity &&
+          minHeight == 0 && maxHeight == double.infinity)
+        return 'BoxConstraints(unconstrained$annotation)';
+      String describe(double min, double max, String dim) {
+        if (min == max)
+          return '$dim=${min.toStringAsFixed(1)}';
+        return '${min.toStringAsFixed(1)}<=$dim<=${max.toStringAsFixed(1)}';
+      }
+      final String width = describe(minWidth, maxWidth, 'w');
+      final String height = describe(minHeight, maxHeight, 'h');
+      return 'BoxConstraints($width, $height$annotation)';
     }
-    final String width = describe(minWidth, maxWidth, 'w');
-    final String height = describe(minHeight, maxHeight, 'h');
-    return 'BoxConstraints($width, $height$annotation)';
+    return super.toString();
   }
 }
 
@@ -625,7 +629,7 @@ class BoxHitTestEntry extends HitTestEntry {
   final Offset localPosition;
 
   @override
-  String toString() => '${describeIdentity(target)}@$localPosition';
+  String toString() => assertionsEnabled ? '${describeIdentity(target)}@$localPosition' : super.toString();
 }
 
 /// Parent data used by [RenderBox] and its subclasses.
@@ -634,7 +638,7 @@ class BoxParentData extends ParentData {
   Offset offset = Offset.zero;
 
   @override
-  String toString() => 'offset=$offset';
+  String toString() => assertionsEnabled ? 'offset=$offset' : super.toString();
 }
 
 /// Abstract ParentData subclass for RenderBox subclasses that want the

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 
@@ -15,7 +16,7 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
   Object id;
 
   @override
-  String toString() => '${super.toString()}; id=$id';
+  String toString() => assertionsEnabled ? '${super.toString()}; id=$id' : super.toString();
 }
 
 /// A delegate that controls the layout of multiple children.
@@ -267,7 +268,7 @@ abstract class MultiChildLayoutDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 /// Defers the layout of multiple children to a delegate.

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -9,6 +9,7 @@ import 'package:flutter/semantics.dart';
 
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 import 'proxy_box.dart';
@@ -260,7 +261,7 @@ abstract class CustomPainter extends Listenable {
   bool hitTest(Offset position) => null;
 
   @override
-  String toString() => '${describeIdentity(this)}(${ _repaint?.toString() ?? "" })';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}(${ _repaint?.toString() ?? "" })' : super.toString();
 }
 
 /// Contains properties describing information drawn in a rectangle contained by

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -12,6 +12,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 import 'viewport_offset.dart';
@@ -69,13 +70,16 @@ class TextSelectionPoint {
 
   @override
   String toString() {
-    switch (direction) {
-      case TextDirection.ltr:
-        return '$point-ltr';
-      case TextDirection.rtl:
-        return '$point-rtl';
+    if (assertionsEnabled) {
+      switch (direction) {
+        case TextDirection.ltr:
+          return '$point-ltr';
+        case TextDirection.rtl:
+          return '$point-rtl';
+      }
+      return '$point';
     }
-    return '$point';
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'debug_overflow_indicator.dart';
 import 'object.dart';
@@ -51,7 +52,7 @@ class FlexParentData extends ContainerBoxParentData<RenderBox> {
   FlexFit fit;
 
   @override
-  String toString() => '${super.toString()}; flex=$flex; fit=$fit';
+  String toString() => assertionsEnabled ? '${super.toString()}; flex=$flex; fit=$fit' : super.toString();
 }
 
 /// How much space should be occupied in the main axis.

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 
@@ -131,7 +132,7 @@ abstract class FlowDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 int _getAlphaFromOpacity(double opacity) => (opacity * 255).round();

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'debug.dart';
 
 /// A composited layer.
@@ -1392,7 +1393,7 @@ class LayerLink {
   LeaderLayer _leader;
 
   @override
-  String toString() => '${describeIdentity(this)}(${ _leader != null ? "<linked>" : "<dangling>" })';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}(${ _leader != null ? "<linked>" : "<dangling>" })' : super.toString();
 }
 
 /// A composited layer that can be followed by a [FollowerLayer].

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -13,6 +13,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'debug.dart';
 import 'layer.dart';
@@ -33,7 +34,7 @@ class ParentData {
   void detach() { }
 
   @override
-  String toString() => '<none>';
+  String toString() => assertionsEnabled ? '<none>' : super.toString();
 }
 
 /// Signature for painting into a [PaintingContext].
@@ -495,7 +496,7 @@ class PaintingContext extends ClipContext {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)';
+  String toString() => assertionsEnabled ? '$runtimeType#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)' : super.toString();
 }
 
 /// An abstract set of layout constraints.
@@ -2564,7 +2565,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   }
 
   @override
-  String toString({ DiagnosticLevel minLevel }) => toStringShort();
+  String toString({ DiagnosticLevel minLevel }) => assertionsEnabled ? toStringShort() : super.toString();
 
   /// Returns a description of the tree rooted at this node.
   /// If the prefix argument is provided, then every line in the output

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -14,6 +14,7 @@ import 'package:flutter/semantics.dart';
 
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'layer.dart';
 import 'object.dart';
@@ -1090,7 +1091,7 @@ abstract class CustomClipper<T> {
   bool shouldReclip(covariant CustomClipper<T> oldClipper);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 /// A [CustomClipper] that clips to the outer path of a [ShapeBorder].

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'debug.dart';
@@ -456,19 +457,22 @@ class SliverConstraints extends Constraints {
 
   @override
   String toString() {
-    return 'SliverConstraints('
-             '$axisDirection, '
-             '$growthDirection, '
-             '$userScrollDirection, '
-             'scrollOffset: ${scrollOffset.toStringAsFixed(1)}, '
-             'remainingPaintExtent: ${remainingPaintExtent.toStringAsFixed(1)}, ' +
-             (overlap != 0.0 ? 'overlap: ${overlap.toStringAsFixed(1)}, ' : '') +
-             'crossAxisExtent: ${crossAxisExtent.toStringAsFixed(1)}, '
-             'crossAxisDirection: $crossAxisDirection, '
-             'viewportMainAxisExtent: ${viewportMainAxisExtent.toStringAsFixed(1)}, '
-             'remainingCacheExtent: ${remainingCacheExtent.toStringAsFixed(1)} '
-             'cacheOrigin: ${cacheOrigin.toStringAsFixed(1)} '
-           ')';
+    if (assertionsEnabled) {
+      return 'SliverConstraints('
+              '$axisDirection, '
+              '$growthDirection, '
+              '$userScrollDirection, '
+              'scrollOffset: ${scrollOffset.toStringAsFixed(1)}, '
+              'remainingPaintExtent: ${remainingPaintExtent.toStringAsFixed(1)}, ' +
+              (overlap != 0.0 ? 'overlap: ${overlap.toStringAsFixed(1)}, ' : '') +
+              'crossAxisExtent: ${crossAxisExtent.toStringAsFixed(1)}, '
+              'crossAxisDirection: $crossAxisDirection, '
+              'viewportMainAxisExtent: ${viewportMainAxisExtent.toStringAsFixed(1)}, '
+              'remainingCacheExtent: ${remainingCacheExtent.toStringAsFixed(1)} '
+              'cacheOrigin: ${cacheOrigin.toStringAsFixed(1)} '
+            ')';
+    }
+    return super.toString();
   }
 }
 
@@ -771,7 +775,7 @@ class SliverHitTestEntry extends HitTestEntry {
   final double crossAxisPosition;
 
   @override
-  String toString() => '${target.runtimeType}@(mainAxis: $mainAxisPosition, crossAxis: $crossAxisPosition)';
+  String toString() => assertionsEnabled ? '${target.runtimeType}@(mainAxis: $mainAxisPosition, crossAxis: $crossAxisPosition)' : super.toString();
 }
 
 /// Parent data structure used by parents of slivers that position their
@@ -791,7 +795,7 @@ class SliverLogicalParentData extends ParentData {
   double layoutOffset = 0.0;
 
   @override
-  String toString() => 'layoutOffset=${layoutOffset.toStringAsFixed(1)}';
+  String toString() => assertionsEnabled ? 'layoutOffset=${layoutOffset.toStringAsFixed(1)}' : super.toString();
 }
 
 /// Parent data for slivers that have multiple children and that position their
@@ -823,7 +827,7 @@ class SliverPhysicalParentData extends ParentData {
   }
 
   @override
-  String toString() => 'paintOffset=$paintOffset';
+  String toString() => assertionsEnabled ? 'paintOffset=$paintOffset' : super.toString();
 }
 
 /// Parent data for slivers that have multiple children and that position their

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -71,12 +72,15 @@ class SliverGridGeometry {
 
   @override
   String toString() {
-    return 'SliverGridGeometry('
-      'scrollOffset: $scrollOffset, '
-      'crossAxisOffset: $crossAxisOffset, '
-      'mainAxisExtent: $mainAxisExtent, '
-      'crossAxisExtent: $crossAxisExtent'
-    ')';
+    if (assertionsEnabled) {
+      return 'SliverGridGeometry('
+        'scrollOffset: $scrollOffset, '
+        'crossAxisOffset: $crossAxisOffset, '
+        'mainAxisExtent: $mainAxisExtent, '
+        'crossAxisExtent: $crossAxisExtent'
+      ')';
+    }
+    return super.toString();
   }
 }
 
@@ -456,7 +460,7 @@ class SliverGridParentData extends SliverMultiBoxAdaptorParentData {
   double crossAxisOffset;
 
   @override
-  String toString() => 'crossAxisOffset=$crossAxisOffset; ${super.toString()}';
+  String toString() => assertionsEnabled ? 'crossAxisOffset=$crossAxisOffset; ${super.toString()}' : super.toString();
 }
 
 /// A sliver that places multiple box children in a two dimensional arrangement.

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
@@ -136,7 +137,7 @@ class SliverMultiBoxAdaptorParentData extends SliverLogicalParentData with Conta
   bool _keptAlive = false;
 
   @override
-  String toString() => 'index=$index; ${keepAlive == true ? "keepAlive; " : ""}${super.toString()}';
+  String toString() => assertionsEnabled ? 'index=$index; ${keepAlive == true ? "keepAlive; " : ""}${super.toString()}' : super.toString();
 }
 
 /// A sliver with multiple box children.

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show lerpDouble, hashValues;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 
@@ -167,7 +168,7 @@ class RelativeRect {
   int get hashCode => hashValues(left, top, right, bottom);
 
   @override
-  String toString() => 'RelativeRect.fromLTRB(${left?.toStringAsFixed(1)}, ${top?.toStringAsFixed(1)}, ${right?.toStringAsFixed(1)}, ${bottom?.toStringAsFixed(1)})';
+  String toString() => assertionsEnabled ? 'RelativeRect.fromLTRB(${left?.toStringAsFixed(1)}, ${top?.toStringAsFixed(1)}, ${right?.toStringAsFixed(1)}, ${bottom?.toStringAsFixed(1)})' : super.toString();
 }
 
 /// Parent data for use with [RenderStack].
@@ -213,23 +214,26 @@ class StackParentData extends ContainerBoxParentData<RenderBox> {
 
   @override
   String toString() {
-    final List<String> values = <String>[];
-    if (top != null)
-      values.add('top=$top');
-    if (right != null)
-      values.add('right=$right');
-    if (bottom != null)
-      values.add('bottom=$bottom');
-    if (left != null)
-      values.add('left=$left');
-    if (width != null)
-      values.add('width=$width');
-    if (height != null)
-      values.add('height=$height');
-    if (values.isEmpty)
-      values.add('not positioned');
-    values.add(super.toString());
-    return values.join('; ');
+    if (assertionsEnabled) {
+      final List<String> values = <String>[];
+      if (top != null)
+        values.add('top=$top');
+      if (right != null)
+        values.add('right=$right');
+      if (bottom != null)
+        values.add('bottom=$bottom');
+      if (left != null)
+        values.add('left=$left');
+      if (width != null)
+        values.add('width=$width');
+      if (height != null)
+        values.add('height=$height');
+      if (values.isEmpty)
+        values.add('not positioned');
+      values.add(super.toString());
+      return values.join('; ');
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'box.dart';
 import 'object.dart';
 import 'table_border.dart';
@@ -23,7 +24,7 @@ class TableCellParentData extends BoxParentData {
   int y;
 
   @override
-  String toString() => '${super.toString()}; ${verticalAlignment == null ? "default vertical alignment" : "$verticalAlignment"}';
+  String toString() => assertionsEnabled ? '${super.toString()}; ${verticalAlignment == null ? "default vertical alignment" : "$verticalAlignment"}' : super.toString();
 }
 
 /// Base class to describe how wide a column in a [RenderTable] should be.
@@ -76,7 +77,7 @@ abstract class TableColumnWidth {
   double flex(Iterable<RenderBox> cells) => null;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 /// Sizes the column according to the intrinsic dimensions of all the
@@ -115,7 +116,7 @@ class IntrinsicColumnWidth extends TableColumnWidth {
   double flex(Iterable<RenderBox> cells) => _flex;
 
   @override
-  String toString() => '$runtimeType(flex: ${_flex?.toStringAsFixed(1)})';
+  String toString() => assertionsEnabled ? '$runtimeType(flex: ${_flex?.toStringAsFixed(1)})' : super.toString();
 }
 
 /// Sizes the column to a specific number of pixels.
@@ -141,7 +142,7 @@ class FixedColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($value)';
+  String toString() => assertionsEnabled ? '$runtimeType($value)' : super.toString();
 }
 
 /// Sizes the column to a fraction of the table's constraints' maxWidth.
@@ -173,7 +174,7 @@ class FractionColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($value)';
+  String toString() => assertionsEnabled ? '$runtimeType($value)' : super.toString();
 }
 
 /// Sizes the column by taking a part of the remaining space once all
@@ -210,7 +211,7 @@ class FlexColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($value)';
+  String toString() => assertionsEnabled ? '$runtimeType($value)' : super.toString();
 }
 
 /// Sizes the column such that it is the size that is the maximum of
@@ -261,7 +262,7 @@ class MaxColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($a, $b)';
+  String toString() => assertionsEnabled ? '$runtimeType($a, $b)' : super.toString();
 }
 
 /// Sizes the column such that it is the size that is the minimum of
@@ -312,7 +313,7 @@ class MinColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($a, $b)';
+  String toString() => assertionsEnabled ? '$runtimeType($a, $b)' : super.toString();
 }
 
 /// Vertical alignment options for cells in [RenderTable] objects.

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' hide Border;
 
+import '../util.dart';
+
 /// Border specification for [Table] widgets.
 ///
 /// This is like [Border], with the addition of two sides: the inner horizontal
@@ -276,5 +278,5 @@ class TableBorder {
   int get hashCode => hashValues(top, right, bottom, left, horizontalInside, verticalInside);
 
   @override
-  String toString() => 'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside)';
+  String toString() => assertionsEnabled ? 'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside)' : super.toString();
 }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'debug.dart';
@@ -39,7 +40,7 @@ class ViewConfiguration {
   }
 
   @override
-  String toString() => '$size at ${devicePixelRatio}x';
+  String toString() => assertionsEnabled ? '$size at ${devicePixelRatio}x' : super.toString();
 }
 
 /// The root of the render tree.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -10,6 +10,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
@@ -128,7 +129,7 @@ class RevealedOffset {
 
   @override
   String toString() {
-    return '$runtimeType(offset: $offset, rect: $rect)';
+    return assertionsEnabled ? '$runtimeType(offset: $offset, rect: $rect)' : super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 /// The direction of a scroll, relative to the positive scroll offset axis given
 /// by an [AxisDirection] and a [GrowthDirection].
 ///
@@ -206,9 +208,12 @@ abstract class ViewportOffset extends ChangeNotifier {
 
   @override
   String toString() {
-    final List<String> description = <String>[];
-    debugFillDescription(description);
-    return '${describeIdentity(this)}(${description.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> description = <String>[];
+      debugFillDescription(description);
+      return '${describeIdentity(this)}(${description.join(", ")})';
+    }
+    return super.toString();
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'binding.dart';
 
 /// Signature for the callback passed to the [Ticker] class's constructor.
@@ -312,22 +313,25 @@ class Ticker {
 
   @override
   String toString({ bool debugIncludeStack = false }) {
-    final StringBuffer buffer = StringBuffer();
-    buffer.write('$runtimeType(');
-    assert(() {
-      buffer.write(debugLabel ?? '');
-      return true;
-    }());
-    buffer.write(')');
-    assert(() {
-      if (debugIncludeStack) {
-        buffer.writeln();
-        buffer.writeln('The stack trace when the $runtimeType was actually created was:');
-        FlutterError.defaultStackFilter(_debugCreationStack.toString().trimRight().split('\n')).forEach(buffer.writeln);
-      }
-      return true;
-    }());
-    return buffer.toString();
+    if (assertionsEnabled) {
+      final StringBuffer buffer = StringBuffer();
+      buffer.write('$runtimeType(');
+      assert(() {
+        buffer.write(debugLabel ?? '');
+        return true;
+      }());
+      buffer.write(')');
+      assert(() {
+        if (debugIncludeStack) {
+          buffer.writeln();
+          buffer.writeln('The stack trace when the $runtimeType was actually created was:');
+          FlutterError.defaultStackFilter(_debugCreationStack.toString().trimRight().split('\n')).forEach(buffer.writeln);
+        }
+        return true;
+      }());
+      return buffer.toString();
+    }
+    return super.toString();
   }
 }
 
@@ -439,7 +443,7 @@ class TickerFuture implements Future<void> {
   }
 
   @override
-  String toString() => '${describeIdentity(this)}(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}(${ _completed == null ? "active" : _completed ? "complete" : "canceled" })' : super.toString();
 }
 
 /// Exception thrown by [Ticker] objects on the [TickerFuture.orCancel] future
@@ -456,8 +460,11 @@ class TickerCanceled implements Exception {
 
   @override
   String toString() {
-    if (ticker != null)
-      return 'This ticker was canceled: $ticker';
-    return 'The ticker was canceled before the "orCancel" property was first used.';
+    if (assertionsEnabled) {
+      if (ticker != null)
+        return 'This ticker was canceled: $ticker';
+      return 'The ticker was canceled before the "orCancel" property was first used.';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -13,6 +13,7 @@ import 'package:flutter/painting.dart' show MatrixUtils, TransformProperty;
 import 'package:flutter/services.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../util.dart';
 import 'semantics_event.dart';
 
 export 'dart:ui' show SemanticsAction;
@@ -66,7 +67,7 @@ class SemanticsTag {
   final String name;
 
   @override
-  String toString() => '$runtimeType($name)';
+  String toString() => assertionsEnabled ? '$runtimeType($name)' : super.toString();
 }
 
 /// An identifier of a custom semantics action.
@@ -136,7 +137,7 @@ class CustomSemanticsAction {
 
   @override
   String toString() {
-    return 'CustomSemanticsAction(${_ids[this]}, label:$label, hint:$hint, action:$action)';
+    return assertionsEnabled ? 'CustomSemanticsAction(${_ids[this]}, label:$label, hint:$hint, action:$action)' : super.toString();
   }
 
   // Logic to assign a unique id to each custom action without requiring
@@ -2438,7 +2439,7 @@ class SemanticsOwner extends ChangeNotifier {
   }
 
   @override
-  String toString() => describeIdentity(this);
+  String toString() => assertionsEnabled ? describeIdentity(this) : super.toString();
 }
 
 /// Describes the semantic information associated with the owning

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/painting.dart';
 
+import '../util.dart';
+
 /// An event sent by the application to notify interested listeners that
 /// something happened to the user interface (e.g. a view scrolled).
 ///
@@ -43,12 +45,15 @@ abstract class SemanticsEvent {
 
   @override
   String toString() {
-    final List<String> pairs = <String>[];
-    final Map<String, dynamic> dataMap = getDataMap();
-    final List<String> sortedKeys = dataMap.keys.toList()..sort();
-    for (String key in sortedKeys)
-      pairs.add('$key: ${dataMap[key]}');
-    return '$runtimeType(${pairs.join(', ')})';
+    if (assertionsEnabled) {
+      final List<String> pairs = <String>[];
+      final Map<String, dynamic> dataMap = getDataMap();
+      final List<String> sortedKeys = dataMap.keys.toList()..sort();
+      for (String key in sortedKeys)
+        pairs.add('$key: ${dataMap[key]}');
+      return '$runtimeType(${pairs.join(', ')})';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'platform_messages.dart';
 
 /// A collection of resources used by the application.
@@ -92,7 +93,7 @@ abstract class AssetBundle {
   void evict(String key) { }
 
   @override
-  String toString() => '${describeIdentity(this)}()';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}()' : super.toString();
 }
 
 /// An [AssetBundle] that loads resources over the network.
@@ -140,7 +141,7 @@ class NetworkAssetBundle extends AssetBundle {
   // should implement evict().
 
   @override
-  String toString() => '${describeIdentity(this)}($_baseUrl)';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}($_baseUrl)' : super.toString();
 }
 
 /// An [AssetBundle] that permanently caches string and structured resources

--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'platform_channel.dart';
 
 export 'dart:typed_data' show ByteData;
@@ -48,7 +49,7 @@ class MethodCall {
   final dynamic arguments;
 
   @override
-  String toString() => '$runtimeType($method, $arguments)';
+  String toString() => assertionsEnabled ? '$runtimeType($method, $arguments)' : super.toString();
 }
 
 /// A codec for method calls and enveloped results.
@@ -118,7 +119,7 @@ class PlatformException implements Exception {
   final dynamic details;
 
   @override
-  String toString() => 'PlatformException($code, $message, $details)';
+  String toString() => assertionsEnabled ? 'PlatformException($code, $message, $details)' : super.toString();
 }
 
 /// Thrown to indicate that a platform interaction failed to find a handling
@@ -140,5 +141,5 @@ class MissingPluginException implements Exception {
   final String message;
 
   @override
-  String toString() => 'MissingPluginException($message)';
+  String toString() => assertionsEnabled ? 'MissingPluginException($message)' : super.toString();
 }

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'message_codec.dart';
 import 'system_channels.dart';
 
@@ -172,7 +173,7 @@ class AndroidPointerProperties {
 
   @override
   String toString() {
-    return 'AndroidPointerProperties(id: $id, toolType: $toolType)';
+    return assertionsEnabled ? 'AndroidPointerProperties(id: $id, toolType: $toolType)' : super.toString();
   }
 }
 
@@ -256,7 +257,7 @@ class AndroidPointerCoords {
 
   @override
   String toString() {
-    return 'AndroidPointerCoords(orientation: $orientation, pressure: $pressure, size: $size, toolMajor: $toolMajor, toolMinor: $toolMinor, touchMajor: $touchMajor, touchMinor: $touchMinor, x: $x, y: $y)';
+    return assertionsEnabled ? 'AndroidPointerCoords(orientation: $orientation, pressure: $pressure, size: $size, toolMajor: $toolMajor, toolMinor: $toolMinor, touchMajor: $touchMajor, touchMinor: $touchMinor, x: $x, y: $y)' : super.toString();
   }
 }
 
@@ -383,7 +384,7 @@ class AndroidMotionEvent {
 
   @override
   String toString() {
-    return 'AndroidPointerEvent(downTime: $downTime, eventTime: $eventTime, action: $action, pointerCount: $pointerCount, pointerProperties: $pointerProperties, pointerCoords: $pointerCoords, metaState: $metaState, buttonState: $buttonState, xPrecision: $xPrecision, yPrecision: $yPrecision, deviceId: $deviceId, edgeFlags: $edgeFlags, source: $source, flags: $flags)';
+    return assertionsEnabled ? 'AndroidPointerEvent(downTime: $downTime, eventTime: $eventTime, action: $action, pointerCount: $pointerCount, pointerProperties: $pointerProperties, pointerCoords: $pointerCoords, metaState: $metaState, buttonState: $buttonState, xPrecision: $xPrecision, yPrecision: $yPrecision, deviceId: $deviceId, edgeFlags: $edgeFlags, source: $source, flags: $flags)' : super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -7,6 +7,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'system_channels.dart';
 
 /// Specifies a particular device orientation.
@@ -172,7 +173,7 @@ class SystemUiOverlayStyle {
   }
 
   @override
-  String toString() => _toMap().toString();
+  String toString() => assertionsEnabled ? _toMap().toString() : super.toString();
 
   /// Creates a copy of this theme with the given fields replaced with new values.
   SystemUiOverlayStyle copyWith({

--- a/packages/flutter/lib/src/services/text_editing.dart
+++ b/packages/flutter/lib/src/services/text_editing.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show hashValues, TextAffinity, TextPosition;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 export 'dart:ui' show TextAffinity, TextPosition;
 
 /// A range of characters in a string of text.
@@ -90,7 +92,7 @@ class TextRange {
   );
 
   @override
-  String toString() => 'TextRange(start: $start, end: $end)';
+  String toString() => assertionsEnabled ? 'TextRange(start: $start, end: $end)' : super.toString();
 }
 
 /// A range of text that represents a selection.
@@ -176,7 +178,10 @@ class TextSelection extends TextRange {
 
   @override
   String toString() {
-    return '$runtimeType(baseOffset: $baseOffset, extentOffset: $extentOffset, affinity: $affinity, isDirectional: $isDirectional)';
+    if (assertionsEnabled) {
+      return '$runtimeType(baseOffset: $baseOffset, extentOffset: $extentOffset, affinity: $affinity, isDirectional: $isDirectional)';
+    }
+    return super.toString();
   }
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -8,6 +8,7 @@ import 'dart:ui' show TextAffinity, hashValues;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'message_codec.dart';
 import 'system_channels.dart';
 import 'system_chrome.dart';
@@ -115,10 +116,13 @@ class TextInputType {
 
   @override
   String toString() {
-    return '$runtimeType('
-        'name: $_name, '
-        'signed: $signed, '
-        'decimal: $decimal)';
+    if (assertionsEnabled) {
+      return '$runtimeType('
+          'name: $_name, '
+          'signed: $signed, '
+          'decimal: $decimal)';
+    }
+    return super.toString();
   }
 
   @override
@@ -512,7 +516,7 @@ class TextEditingValue {
   }
 
   @override
-  String toString() => '$runtimeType(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
+  String toString() => assertionsEnabled ? '$runtimeType(text: \u2524$text\u251C, selection: $selection, composing: $composing)' : super.toString();
 
   @override
   bool operator ==(dynamic other) {

--- a/packages/flutter/lib/src/util.dart
+++ b/packages/flutter/lib/src/util.dart
@@ -1,0 +1,20 @@
+/// Use this function to guard debugging code. When Dart is compiled in
+/// production mode, the code guarded using this function will be tree
+/// shaken away, reducing code size.
+///
+/// WARNING: DO NOT CHANGE THIS METHOD! This method is designed to have no
+/// more AST nodes than the maximum allowed by dart2js to inline it. In
+/// addition, the use of `assert` allows the compiler to statically compute
+/// the value returned by this function and tree shake conditions guarded by
+/// it.
+///
+/// Example:
+///
+/// if (assertionsEnabled) {
+///   ...code here is tree shaken away in prod mode...
+/// }
+bool get assertionsEnabled {
+  bool k = false;
+  assert(k = true);
+  return k;
+}

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'ticker_provider.dart';
@@ -40,7 +41,7 @@ class _ChildEntry {
   Widget widgetChild;
 
   @override
-  String toString() => 'Entry#${shortHash(this)}($widgetChild)';
+  String toString() => assertionsEnabled ? 'Entry#${shortHash(this)}($widgetChild)' : super.toString();
 }
 
 /// Signature for builders used to generate custom transitions for

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -8,6 +8,7 @@
 
 import 'dart:async' show Future, Stream, StreamSubscription;
 
+import '../util.dart';
 import 'framework.dart';
 
 // Examples can assume:
@@ -262,7 +263,7 @@ class AsyncSnapshot<T> {
   bool get hasError => error != null;
 
   @override
-  String toString() => '$runtimeType($connectionState, $data, $error)';
+  String toString() => assertionsEnabled ? '$runtimeType($connectionState, $data, $error)' : super.toString();
 
   @override
   bool operator ==(dynamic other) {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 /// A leaf node in the focus tree that can receive focus.
 ///
 /// The focus tree keeps track of which widget is the user's current focus. The
@@ -104,7 +106,7 @@ class FocusNode extends ChangeNotifier {
   }
 
   @override
-  String toString() => '${describeIdentity(this)}${hasFocus ? '(FOCUSED)' : ''}';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}${hasFocus ? '(FOCUSED)' : ''}' : super.toString();
 }
 
 /// An interior node in the focus tree.
@@ -452,10 +454,13 @@ class FocusManager {
 
   @override
   String toString() {
-    final String status = _haveScheduledUpdate ? ' UPDATE SCHEDULED' : '';
-    const String indent = '  ';
-    return '${describeIdentity(this)}$status\n'
-      '${indent}currentFocus: $_currentFocus\n'
-      '${rootScope.toStringDeep(prefixLineOne: indent, prefixOtherLines: indent)}';
+    if (assertionsEnabled) {
+      final String status = _haveScheduledUpdate ? ' UPDATE SCHEDULED' : '';
+      const String indent = '  ';
+      return '${describeIdentity(this)}$status\n'
+        '${indent}currentFocus: $_currentFocus\n'
+        '${rootScope.toStringDeep(prefixLineOne: indent, prefixOtherLines: indent)}';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -9,6 +9,7 @@ import 'dart:developer';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '../util.dart';
 import 'debug.dart';
 import 'focus_manager.dart';
 
@@ -54,7 +55,7 @@ class UniqueKey extends LocalKey {
   UniqueKey();
 
   @override
-  String toString() => '[#${shortHash(this)}]';
+  String toString() => assertionsEnabled ? '[#${shortHash(this)}]' : super.toString();
 }
 
 /// A key that takes its identity from the object used as its value.
@@ -83,9 +84,12 @@ class ObjectKey extends LocalKey {
 
   @override
   String toString() {
-    if (runtimeType == ObjectKey)
-      return '[${describeIdentity(value)}]';
-    return '[$runtimeType ${describeIdentity(value)}]';
+    if (assertionsEnabled) {
+      if (runtimeType == ObjectKey)
+        return '[${describeIdentity(value)}]';
+      return '[$runtimeType ${describeIdentity(value)}]';
+    }
+    return super.toString();
   }
 }
 
@@ -271,10 +275,13 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
 
   @override
   String toString() {
-    final String label = _debugLabel != null ? ' $_debugLabel' : '';
-    if (runtimeType == LabeledGlobalKey)
-      return '[GlobalKey#${shortHash(this)}$label]';
-    return '[${describeIdentity(this)}$label]';
+    if (assertionsEnabled) {
+      final String label = _debugLabel != null ? ' $_debugLabel' : '';
+      if (runtimeType == LabeledGlobalKey)
+        return '[GlobalKey#${shortHash(this)}$label]';
+      return '[${describeIdentity(this)}$label]';
+    }
+    return super.toString();
   }
 }
 
@@ -321,15 +328,18 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
 
   @override
   String toString() {
-    String selfType = runtimeType.toString();
-    // const GlobalObjectKey().runtimeType.toString() returns 'GlobalObjectKey<State<StatefulWidget>>'
-    // because GlobalObjectKey is instantiated to its bounds. To avoid cluttering the output
-    // we remove the suffix.
-    const String suffix = '<State<StatefulWidget>>';
-    if (selfType.endsWith(suffix)) {
-      selfType = selfType.substring(0, selfType.length - suffix.length);
+    if (assertionsEnabled) {
+      String selfType = runtimeType.toString();
+      // const GlobalObjectKey().runtimeType.toString() returns 'GlobalObjectKey<State<StatefulWidget>>'
+      // because GlobalObjectKey is instantiated to its bounds. To avoid cluttering the output
+      // we remove the suffix.
+      const String suffix = '<State<StatefulWidget>>';
+      if (selfType.endsWith(suffix)) {
+        selfType = selfType.substring(0, selfType.length - suffix.length);
+      }
+      return '[$selfType ${describeIdentity(value)}]';
     }
-    return '[$selfType ${describeIdentity(value)}]';
+    return super.toString();
   }
 }
 
@@ -4950,7 +4960,7 @@ class _DebugCreator {
   _DebugCreator(this.element);
   final RenderObjectElement element;
   @override
-  String toString() => element.debugGetCreatorChain(12);
+  String toString() => assertionsEnabled ? element.debugGetCreatorChain(12) : super.toString();
 }
 
 FlutterErrorDetails _debugReportException(

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'framework.dart';
@@ -315,8 +316,11 @@ class _HeroFlightManifest {
 
   @override
   String toString() {
-    return '_HeroFlightManifest($type tag: $tag from route: ${fromRoute.settings} '
-        'to route: ${toRoute.settings} with hero: $fromHero to $toHero)';
+    if (assertionsEnabled) {
+      return '_HeroFlightManifest($type tag: $tag from route: ${fromRoute.settings} '
+          'to route: ${toRoute.settings} with hero: $fromHero to $toHero)';
+    }
+    return super.toString();
   }
 }
 
@@ -537,10 +541,13 @@ class _HeroFlight {
 
   @override
   String toString() {
-    final RouteSettings from = manifest.fromRoute.settings;
-    final RouteSettings to = manifest.toRoute.settings;
-    final Object tag = manifest.tag;
-    return 'HeroFlight(for: $tag, from: $from, to: $to ${_proxyAnimation.parent})';
+    if (assertionsEnabled) {
+      final RouteSettings from = manifest.fromRoute.settings;
+      final RouteSettings to = manifest.toRoute.settings;
+      final Object tag = manifest.tag;
+      return 'HeroFlight(for: $tag, from: $from, to: $to ${_proxyAnimation.parent})';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show hashValues;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
+
 /// A description of an icon fulfilled by a font glyph.
 ///
 /// See [Icons] for a number of predefined icons available for material
@@ -64,5 +66,5 @@ class IconData {
   int get hashCode => hashValues(codePoint, fontFamily, fontPackage, matchTextDirection);
 
   @override
-  String toString() => 'IconData(U+${codePoint.toRadixString(16).toUpperCase().padLeft(5, '0')})';
+  String toString() => assertionsEnabled ? 'IconData(U+${codePoint.toRadixString(16).toUpperCase().padLeft(5, '0')})' : super.toString();
 }

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show Locale;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'container.dart';
@@ -134,7 +135,7 @@ abstract class LocalizationsDelegate<T> {
   Type get type => T;
 
   @override
-  String toString() => '$runtimeType[$type]';
+  String toString() => assertionsEnabled ? '$runtimeType[$type]' : super.toString();
 }
 
 /// Interface for localized resource values for the lowest levels of the Flutter

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'framework.dart';
 
@@ -313,18 +314,21 @@ class MediaQueryData {
 
   @override
   String toString() {
-    return '$runtimeType('
-             'size: $size, '
-             'devicePixelRatio: ${devicePixelRatio.toStringAsFixed(1)}, '
-             'textScaleFactor: ${textScaleFactor.toStringAsFixed(1)}, '
-             'padding: $padding, '
-             'viewInsets: $viewInsets, '
-             'alwaysUse24HourFormat: $alwaysUse24HourFormat, '
-             'accessibleNavigation: $accessibleNavigation'
-             'disableAnimations: $disableAnimations'
-             'invertColors: $invertColors'
-             'boldText: $boldText'
-           ')';
+    if (assertionsEnabled) {
+      return '$runtimeType('
+              'size: $size, '
+              'devicePixelRatio: ${devicePixelRatio.toStringAsFixed(1)}, '
+              'textScaleFactor: ${textScaleFactor.toStringAsFixed(1)}, '
+              'padding: $padding, '
+              'viewInsets: $viewInsets, '
+              'alwaysUse24HourFormat: $alwaysUse24HourFormat, '
+              'accessibleNavigation: $accessibleNavigation'
+              'disableAnimations: $disableAnimations'
+              'invertColors: $invertColors'
+              'boldText: $boldText'
+            ')';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -8,6 +8,7 @@ import 'dart:developer' as developer;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'focus_manager.dart';
@@ -314,7 +315,7 @@ class RouteSettings {
   final bool isInitialRoute;
 
   @override
-  String toString() => '"$name"';
+  String toString() => assertionsEnabled ? '"$name"' : super.toString();
 }
 
 /// An interface for observing the behavior of a [Navigator].

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -11,6 +11,7 @@ import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'primary_scroll_controller.dart';
@@ -830,7 +831,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
   }
 
   @override
-  String toString() => '$runtimeType(outer=$_outerController; inner=$_innerController)';
+  String toString() => assertionsEnabled ? '$runtimeType(outer=$_outerController; inner=$_innerController)' : super.toString();
 }
 
 class _NestedScrollController extends ScrollController {
@@ -1210,7 +1211,10 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
 
   @override
   String toString() {
-    return '$runtimeType(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
+    if (assertionsEnabled) {
+      return '$runtimeType(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
+    }
+    return super.toString();
   }
 }
 
@@ -1283,19 +1287,22 @@ class SliverOverlapAbsorberHandle extends ChangeNotifier {
 
   @override
   String toString() {
-    String extra;
-    switch (_writers) {
-      case 0:
-        extra = ', orphan';
-        break;
-      case 1:
-        // normal case
-        break;
-      default:
-        extra = ', $_writers WRITERS ASSIGNED';
-        break;
+    if (assertionsEnabled) {
+      String extra;
+      switch (_writers) {
+        case 0:
+          extra = ', orphan';
+          break;
+        case 1:
+          // normal case
+          break;
+        default:
+          extra = ', $_writers WRITERS ASSIGNED';
+          break;
+      }
+      return '$runtimeType($layoutExtent$extra)';
     }
-    return '$runtimeType($layoutExtent$extra)';
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
 import 'framework.dart';
 
 /// Signature for [Notification] listeners.
@@ -61,9 +62,12 @@ abstract class Notification {
 
   @override
   String toString() {
-    final List<String> description = <String>[];
-    debugFillDescription(description);
-    return '$runtimeType(${description.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> description = <String>[];
+      debugFillDescription(description);
+      return '$runtimeType(${description.join(", ")})';
+    }
+    return super.toString();
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
@@ -150,7 +151,7 @@ class OverlayEntry {
   }
 
   @override
-  String toString() => '${describeIdentity(this)}(opaque: $opaque; maintainState: $maintainState)';
+  String toString() => assertionsEnabled ? '${describeIdentity(this)}(opaque: $opaque; maintainState: $maintainState)' : super.toString();
 }
 
 class _OverlayEntry extends StatefulWidget {

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../util.dart';
 import 'framework.dart';
 
 /// A [ValueKey] that defines where [PageStorage] values will be saved.
@@ -61,7 +62,10 @@ class _StorageEntryIdentifier {
 
   @override
   String toString() {
-    return 'StorageEntryIdentifier(${keys?.join(":")})';
+    if (assertionsEnabled) {
+      return 'StorageEntryIdentifier(${keys?.join(":")})';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
@@ -281,7 +282,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   String get debugLabel => '$runtimeType';
 
   @override
-  String toString() => '$runtimeType(animation: $_controller)';
+  String toString() => assertionsEnabled ? '$runtimeType(animation: $_controller)' : super.toString();
 }
 
 /// An entry in the history of a [LocalHistoryRoute].
@@ -1227,7 +1228,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
-  String toString() => '$runtimeType($settings, animation: $_animation)';
+  String toString() => assertionsEnabled ? '$runtimeType($settings, animation: $_animation)' : super.toString();
 }
 
 /// A modal route that overlays a widget over the current route.

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -11,6 +11,7 @@ import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
@@ -131,7 +132,7 @@ abstract class ScrollActivity {
   }
 
   @override
-  String toString() => describeIdentity(this);
+  String toString() => assertionsEnabled ? describeIdentity(this) : super.toString();
 }
 
 /// A scroll activity that does nothing.
@@ -409,7 +410,7 @@ class ScrollDragController implements Drag {
   dynamic _lastDetails;
 
   @override
-  String toString() => describeIdentity(this);
+  String toString() => assertionsEnabled ? describeIdentity(this) : super.toString();
 }
 
 /// The activity a scroll view performs when a the user drags their finger
@@ -480,7 +481,10 @@ class DragScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${describeIdentity(this)}($_controller)';
+    if (assertionsEnabled) {
+      return '${describeIdentity(this)}($_controller)';
+    }
+    return super.toString();
   }
 }
 
@@ -570,7 +574,10 @@ class BallisticScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${describeIdentity(this)}($_controller)';
+    if (assertionsEnabled) {
+      return '${describeIdentity(this)}($_controller)';
+    }
+    return super.toString();
   }
 }
 
@@ -654,6 +661,9 @@ class DrivenScrollActivity extends ScrollActivity {
 
   @override
   String toString() {
-    return '${describeIdentity(this)}($_controller)';
+    if (assertionsEnabled) {
+      return '${describeIdentity(this)}($_controller)';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '../util.dart';
 import 'framework.dart';
 import 'overscroll_indicator.dart';
 import 'scroll_physics.dart';
@@ -75,7 +76,7 @@ class ScrollBehavior {
   bool shouldNotify(covariant ScrollBehavior oldDelegate) => false;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => assertionsEnabled ? '$runtimeType' : super.toString();
 }
 
 /// Controls how [Scrollable] widgets behave in a subtree.

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
+import '../util.dart';
 import 'scroll_context.dart';
 import 'scroll_physics.dart';
 import 'scroll_position.dart';
@@ -241,9 +242,12 @@ class ScrollController extends ChangeNotifier {
 
   @override
   String toString() {
-    final List<String> description = <String>[];
-    debugFillDescription(description);
-    return '${describeIdentity(this)}(${description.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> description = <String>[];
+      debugFillDescription(description);
+      return '${describeIdentity(this)}(${description.join(", ")})';
+    }
+    return super.toString();
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -7,6 +7,8 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '../util.dart';
+
 /// A description of a [Scrollable]'s contents, useful for modeling the state
 /// of its viewport.
 ///
@@ -142,6 +144,9 @@ class FixedScrollMetrics extends ScrollMetrics {
 
   @override
   String toString() {
-    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
+    if (assertionsEnabled) {
+      return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
+    }
+    return super.toString();
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 
+import '../util.dart';
 import 'overscroll_indicator.dart';
 import 'scroll_metrics.dart';
 import 'scroll_simulation.dart';
@@ -236,9 +237,12 @@ class ScrollPhysics {
 
   @override
   String toString() {
-    if (parent == null)
-      return runtimeType.toString();
-    return '$runtimeType -> $parent';
+    if (assertionsEnabled) {
+      if (parent == null)
+        return runtimeType.toString();
+      return '$runtimeType -> $parent';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -7,6 +7,8 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
 
+import '../util.dart';
+
 /// An implementation of scroll physics that matches iOS.
 ///
 /// See also:
@@ -123,7 +125,10 @@ class BouncingScrollSimulation extends Simulation {
 
   @override
   String toString() {
-    return '$runtimeType(leadingExtent: $leadingExtent, trailingExtent: $trailingExtent)';
+    if (assertionsEnabled) {
+      return '$runtimeType(leadingExtent: $leadingExtent, trailingExtent: $trailingExtent)';
+    }
+    return super.toString();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -7,6 +7,7 @@ import 'dart:collection' show SplayTreeMap, HashMap;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '../util.dart';
 import 'automatic_keep_alive.dart';
 import 'basic.dart';
 import 'framework.dart';
@@ -176,9 +177,12 @@ abstract class SliverChildDelegate {
 
   @override
   String toString() {
-    final List<String> description = <String>[];
-    debugFillDescription(description);
-    return '${describeIdentity(this)}(${description.join(", ")})';
+    if (assertionsEnabled) {
+      final List<String> description = <String>[];
+      debugFillDescription(description);
+      return '${describeIdentity(this)}(${description.join(", ")})';
+    }
+    return super.toString();
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import '../util.dart';
 import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
@@ -53,21 +54,24 @@ class TableRow {
 
   @override
   String toString() {
-    final StringBuffer result = StringBuffer();
-    result.write('TableRow(');
-    if (key != null)
-      result.write('$key, ');
-    if (decoration != null)
-      result.write('$decoration, ');
-    if (children == null) {
-      result.write('child list is null');
-    } else if (children.isEmpty) {
-      result.write('no children');
-    } else {
-      result.write('$children');
+    if (assertionsEnabled) {
+      final StringBuffer result = StringBuffer();
+      result.write('TableRow(');
+      if (key != null)
+        result.write('$key, ');
+      if (decoration != null)
+        result.write('$decoration, ');
+      if (children == null) {
+        result.write('child list is null');
+      } else if (children.isEmpty) {
+        result.write('no children');
+      } else {
+        result.write('$children');
+      }
+      result.write(')');
+      return result.toString();
     }
-    result.write(')');
-    return result.toString();
+    return super.toString();
   }
 }
 


### PR DESCRIPTION
Guarding all the bodies of `toString` methods by `assertionsEnabled` helps reduce the binary size. Here are the results I got by running `flutter build apk` on the following projects under `examples/`:

* **catalog**: _-4168_
* **flutter_gallery**: _-37956_
* **flutter_view**: _-22684_
* **hello_world**: _-4204_
* **layers**: _-4204_
* **platform_channel**: _-17924_
* **platform_view**: _-19864_
* **stocks**: _-27104_

The numbers represent the reduction in apk sizes in bytes.