### PR TITLE
update cirrus git_fetch_script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ task:
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
     ANDROID_HOME: "/opt/android_sdk"
   git_fetch_script:
-    - git fetch origin
+    - git fetch origin --tags
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
   pub_cache:
     folder: $HOME/.pub-cache


### PR DESCRIPTION
This might fix cirrus CI not finding the tags on dev/beta rolls.