### PR TITLE
Fix heroes transition when initial route is not '/'

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -599,14 +599,14 @@ class HeroController extends NavigatorObserver {
       final Animation<double> animation = (flightType == HeroFlightDirection.push) ? to.animation : from.animation;
 
       // A user gesture may have already completed the pop, or we might be the initial route
-      switch(flightType) {
+      switch (flightType) {
         case HeroFlightDirection.pop:
-          if (animation.isDismissed) {
+          if (animation.value == 0.0) {
             return;
           }
           break;
         case HeroFlightDirection.push:
-          if (animation.isCompleted) {
+          if (animation.value == 1.0) {
             return;
           }
           break;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -598,9 +598,18 @@ class HeroController extends NavigatorObserver {
       final PageRoute<dynamic> to = toRoute;
       final Animation<double> animation = (flightType == HeroFlightDirection.push) ? to.animation : from.animation;
 
-      // A user gesture may have already completed the pop.
-      if (flightType == HeroFlightDirection.pop && animation.status == AnimationStatus.dismissed) {
-        return;
+      // A user gesture may have already completed the pop, or we might be the initial route
+      switch(flightType) {
+        case HeroFlightDirection.pop:
+          if (animation.isDismissed) {
+            return;
+          }
+          break;
+        case HeroFlightDirection.push:
+          if (animation.isCompleted) {
+            return;
+          }
+          break;
       }
 
       // For pop transitions driven by a user gesture: if the "to" page has

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1437,4 +1437,12 @@ void main() {
     expect(find.byKey(firstKey), isInCard);
     expect(find.byKey(secondKey), findsNothing);
   });
+
+  testWidgets('Handles transitions when a non-default initial route is set', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      routes: routes,
+      initialRoute: '/two',
+    ));
+    expect(find.text('two'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
The current implementation for heroes transitions throws an assertion when a non-default initial route is set, which prints an error message to the console that is likely to confuse users.  The animation ends up being completed by https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/pages.dart#L41-L42

This updates the logic to add another early return for that case, plus a test.

I discovered this when working on the fix for https://github.com/flutter/flutter/issues/23736

/cc @HansMuller (fyi)