### PR TITLE
Refactor Test Driver in preparation for `flutter test` integration tests

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -15,15 +15,15 @@ import 'test_driver.dart';
 import 'test_utils.dart';
 
 void main() {
-  group('expression evaluation', () {
+  group('flutter run expression evaluation', () {
     Directory tempDir;
     final BasicProject _project = BasicProject();
-    FlutterTestDriver _flutter;
+    FlutterRunTestDriver _flutter;
 
     setUp(() async {
       tempDir = createResolvedTempDirectorySync();
       await _project.setUpIn(tempDir);
-      _flutter = FlutterTestDriver(tempDir);
+      _flutter = FlutterRunTestDriver(tempDir);
     });
 
     tearDown(() async {
@@ -43,70 +43,70 @@ void main() {
           _project.topLevelFunctionBreakpointLine);
     }
 
-    Future<void> evaluateTrivialExpressions() async {
-      InstanceRef res;
-
-      res = await _flutter.evaluateInFrame('"test"');
-      expect(res.kind == InstanceKind.kString && res.valueAsString == 'test', isTrue);
-
-      res = await _flutter.evaluateInFrame('1');
-      expect(res.kind == InstanceKind.kInt && res.valueAsString == 1.toString(), isTrue);
-
-      res = await _flutter.evaluateInFrame('true');
-      expect(res.kind == InstanceKind.kBool && res.valueAsString == true.toString(), isTrue);
-    }
-
-    Future<void> evaluateComplexExpressions() async {
-      final InstanceRef res = await _flutter.evaluateInFrame('new DateTime.now().year');
-      expect(res.kind == InstanceKind.kInt && res.valueAsString == DateTime.now().year.toString(), isTrue);
-    }
-
-    Future<void> evaluateComplexReturningExpressions() async {
-      final DateTime now = DateTime.now();
-      final InstanceRef resp = await _flutter.evaluateInFrame('new DateTime.now()');
-      expect(resp.classRef.name, equals('DateTime'));
-      // Ensure we got a reasonable approximation. The more accurate we try to
-      // make this, the more likely it'll fail due to differences in the time
-      // in the remote VM and the local VM at the time the code runs.
-      final InstanceRef res = await _flutter.evaluate(resp.id, r'"$year-$month-$day"');
-      expect(res.valueAsString,
-          equals('${now.year}-${now.month}-${now.day}'));
-    }
-
     test('can evaluate trivial expressions in top level function', () async {
       await _flutter.run(withDebugger: true);
       await breakInTopLevelFunction(_flutter);
-      await evaluateTrivialExpressions();
+      await evaluateTrivialExpressions(_flutter);
     });
 
     test('can evaluate trivial expressions in build method', () async {
       await _flutter.run(withDebugger: true);
       await breakInBuildMethod(_flutter);
-      await evaluateTrivialExpressions();
+      await evaluateTrivialExpressions(_flutter);
     });
 
     test('can evaluate complex expressions in top level function', () async {
       await _flutter.run(withDebugger: true);
       await breakInTopLevelFunction(_flutter);
-      await evaluateComplexExpressions();
+      await evaluateComplexExpressions(_flutter);
     });
 
     test('can evaluate complex expressions in build method', () async {
       await _flutter.run(withDebugger: true);
       await breakInBuildMethod(_flutter);
-      await evaluateComplexExpressions();
+      await evaluateComplexExpressions(_flutter);
     });
 
     test('can evaluate expressions returning complex objects in top level function', () async {
       await _flutter.run(withDebugger: true);
       await breakInTopLevelFunction(_flutter);
-      await evaluateComplexReturningExpressions();
+      await evaluateComplexReturningExpressions(_flutter);
     });
 
     test('can evaluate expressions returning complex objects in build method', () async {
       await _flutter.run(withDebugger: true);
       await breakInBuildMethod(_flutter);
-      await evaluateComplexReturningExpressions();
+      await evaluateComplexReturningExpressions(_flutter);
     });
   }, timeout: const Timeout.factor(6));
+}
+
+Future<void> evaluateTrivialExpressions(FlutterTestDriver flutter) async {
+  InstanceRef res;
+
+  res = await flutter.evaluateInFrame('"test"');
+  expect(res.kind == InstanceKind.kString && res.valueAsString == 'test', isTrue);
+
+  res = await flutter.evaluateInFrame('1');
+  expect(res.kind == InstanceKind.kInt && res.valueAsString == 1.toString(), isTrue);
+
+  res = await flutter.evaluateInFrame('true');
+  expect(res.kind == InstanceKind.kBool && res.valueAsString == true.toString(), isTrue);
+}
+
+Future<void> evaluateComplexExpressions(FlutterTestDriver flutter) async {
+  final InstanceRef res = await flutter.evaluateInFrame('new DateTime.now().year');
+    expect(res.kind == InstanceKind.kInt && res.valueAsString == DateTime.now().year.toString(), isTrue);
+}
+
+Future<void> evaluateComplexReturningExpressions(FlutterTestDriver flutter) async {
+  final DateTime now = DateTime.now();
+    final InstanceRef resp = await flutter.evaluateInFrame('new DateTime.now()');
+    expect(resp.classRef.name, equals('DateTime'));
+    // Ensure we got a reasonable approximation. The more accurate we try to
+    // make this, the more likely it'll fail due to differences in the time
+    // in the remote VM and the local VM at the time the code runs.
+    final InstanceRef res = await flutter.evaluate(resp.id, r'"$year-$month-$day"');
+    expect(res.valueAsString,
+        equals('${now.year}-${now.month}-${now.day}'));
 }

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -11,15 +11,15 @@ import 'test_driver.dart';
 import 'test_utils.dart';
 
 void main() {
-  FlutterTestDriver _flutterRun, _flutterAttach;
+  FlutterRunTestDriver _flutterRun, _flutterAttach;
   final BasicProject _project = BasicProject();
   Directory tempDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync();
     await _project.setUpIn(tempDir);
-    _flutterRun = FlutterTestDriver(tempDir, logPrefix: 'RUN');
-    _flutterAttach = FlutterTestDriver(tempDir, logPrefix: 'ATTACH');
+    _flutterRun = FlutterRunTestDriver(tempDir, logPrefix: 'RUN');
+    _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH');
   });
 
   tearDown(() async {
@@ -54,7 +54,7 @@ void main() {
       await _flutterRun.run(withDebugger: true);
       await _flutterAttach.attach(_flutterRun.vmServicePort);
       await _flutterAttach.quit();
-      _flutterAttach = FlutterTestDriver(tempDir, logPrefix: 'ATTACH-2');
+      _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH-2');
       await _flutterAttach.attach(_flutterRun.vmServicePort);
       await _flutterAttach.hotReload();
     });

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -16,12 +16,12 @@ void main() {
   group('flutter_run', () {
     Directory tempDir;
     final BasicProject _project = BasicProject();
-    FlutterTestDriver _flutter;
+    FlutterRunTestDriver _flutter;
 
     setUp(() async {
       tempDir = createResolvedTempDirectorySync();
       await _project.setUpIn(tempDir);
-      _flutter = FlutterTestDriver(tempDir);
+      _flutter = FlutterRunTestDriver(tempDir);
     });
 
     tearDown(() async {

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -17,12 +17,12 @@ void main() {
   group('hot', () {
     Directory tempDir;
     final HotReloadProject _project = HotReloadProject();
-    FlutterTestDriver _flutter;
+    FlutterRunTestDriver _flutter;
 
     setUp(() async {
       tempDir = createResolvedTempDirectorySync();
       await _project.setUpIn(tempDir);
-      _flutter = FlutterTestDriver(tempDir);
+      _flutter = FlutterRunTestDriver(tempDir);
     });
 
     tearDown(() async {

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -20,13 +20,13 @@ const Duration requiredLifespan = Duration(seconds: 5);
 void main() {
   group('flutter run', () {
     final BasicProject _project = BasicProject();
-    FlutterTestDriver _flutter;
+    FlutterRunTestDriver _flutter;
     Directory tempDir;
 
     setUp(() async {
       tempDir = createResolvedTempDirectorySync();
       await _project.setUpIn(tempDir);
-      _flutter = FlutterTestDriver(tempDir);
+      _flutter = FlutterRunTestDriver(tempDir);
     });
 
     tearDown(() async {

--- a/packages/flutter_tools/test/integration/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/basic_project.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'test_project.dart';
+import 'project.dart';
 
-class BasicProject extends TestProject {
+class BasicProject extends Project {
 
   @override
   final String pubspec = '''

--- a/packages/flutter_tools/test/integration/test_data/hot_reload_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/hot_reload_project.dart
@@ -5,9 +5,9 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 
 import '../test_utils.dart';
-import 'test_project.dart';
+import 'project.dart';
 
-class HotReloadProject extends TestProject {
+class HotReloadProject extends Project {
   @override
   final String pubspec = '''
   name: test

--- a/packages/flutter_tools/test/integration/test_data/project.dart
+++ b/packages/flutter_tools/test/integration/test_data/project.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 
 import '../test_utils.dart';
 
-abstract class TestProject {
+abstract class Project {
   Directory dir;
 
   String get pubspec;
@@ -22,7 +22,9 @@ abstract class TestProject {
   Future<void> setUpIn(Directory dir) async {
     this.dir = dir;
     writeFile(fs.path.join(dir.path, 'pubspec.yaml'), pubspec);
+    if (main != null) {
     writeFile(fs.path.join(dir.path, 'lib', 'main.dart'), main);
+    }
     await getPackages(dir.path);
   }
 

--- a/packages/flutter_tools/test/integration/test_data/project.dart
+++ b/packages/flutter_tools/test/integration/test_data/project.dart
@@ -23,7 +23,7 @@ abstract class Project {
     this.dir = dir;
     writeFile(fs.path.join(dir.path, 'pubspec.yaml'), pubspec);
     if (main != null) {
-    writeFile(fs.path.join(dir.path, 'lib', 'main.dart'), main);
+      writeFile(fs.path.join(dir.path, 'lib', 'main.dart'), main);
     }
     await getPackages(dir.path);
   }


### PR DESCRIPTION
I've written some simple expression evaluation integration tests for `flutter test` due to #23409 but it required splitting FlutterTestDriver up to be able to share the debugger code without needing to share the daemon protocol (`flutter test` talks its own protocol).

To simplify the test PR, this is a PR just for the refactor. It splits the `FlutterTestDriver` class into a base (that has functionality common to `flutter run` and `flutter test`) and `FlutterRunTestDriver` that has the `flutter run`(/`attach`)-specific bits.

It also renames `TestProject` - the base type for projects used in tests - just to `Project` because the `flutter test` tests have a `TestProject` that is a project with tests.

(@aam @devoncarew)

(Edit: It also extracts the expression evaluation functions further in the test, since they're reusable with the `flutter test` tests)