### PR TITLE
Update pubspec template docs for module/plugin

### DIFF
--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -78,6 +78,8 @@ flutter:
   # embedding in a native host app.  These identifiers should _not_ be
   # changed after generation - they are used to ensure that the tooling can
   # maintain consistency when adding or modifying assets and plugins.
+  # They also do not have any bearing on your native host application's
+  # identifiers, which may be completely independent or the same as these.
   module:
     androidPackage: {{androidIdentifier}}
     iosBundleIdentifier: {{iosIdentifier}}

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -75,8 +75,8 @@ flutter:
 
 
   # This section identifies your Flutter project as a module meant for
-  # embedding in a native host app.  These identifiers should _not_ be
-  # changed after generation - they are used to ensure that the tooling can
+  # embedding in a native host app.  These identifiers should _not_ ordinarily
+  # be changed after generation - they are used to ensure that the tooling can
   # maintain consistency when adding or modifying assets and plugins.
   # They also do not have any bearing on your native host application's
   # identifiers, which may be completely independent or the same as these.

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -1,5 +1,16 @@
 name: {{projectName}}
 description: {{description}}
+
+# The following defines the version and build number for your application.
+# A version number is three numbers separated by dots, like 1.2.43
+# followed by an optional build number separated by a +.
+# Both the version and the builder number may be overridden in flutter
+# build by specifying --build-name and --build-number, respectively.
+# Read more about versioning at semver.org.
+#
+# This version is used _only_ for the Runner app, which is used if you just do
+# a `flutter run` or a `flutter make-host-app-editable`. It has no impact
+# on any other native host app that you embed your Flutter project into.
 version: 1.0.0+1
 
 environment:
@@ -9,6 +20,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # The following adds the Cupertino Icons font to your application.
+  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
 dev_dependencies:
@@ -19,9 +32,52 @@ dev_dependencies:
     sdk: flutter
 {{/withDriverTest}}
 
+# For information on the generic Dart part of this file, see the
+# following page: https://www.dartlang.org/tools/pub/pubspec
 
 flutter:
+  # The following line ensures that the Material Icons font is
+  # included with your application, so that you can use the icons in
+  # the material Icons class.
   uses-material-design: true
+
+  # To add Flutter specific assets to your application, add an assets section, 
+  # like this:
+  # assets:
+  #  - images/a_dot_burr.jpeg
+  #  - images/a_dot_ham.jpeg
+
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.io/assets-and-images/#resolution-aware.
+
+  # For details regarding adding assets from package dependencies, see
+  # https://flutter.io/assets-and-images/#from-packages
+
+  # To add Flutter specific custom fonts to your application, add a fonts
+  # section here, in this "flutter" section. Each entry in this list should
+  # have a "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts from package dependencies,
+  # see https://flutter.io/custom-fonts/#from-packages
+
+
+  # This section identifies your Flutter project as a module meant for
+  # embedding in a native host app.  These identifiers should _not_ be
+  # changed after generation - they are used to ensure that the tooling can
+  # maintain consistency when adding or modifying assets and plugins.
   module:
     androidPackage: {{androidIdentifier}}
     iosBundleIdentifier: {{iosIdentifier}}

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -16,6 +16,10 @@ dependencies:
 
 # The following section is specific to Flutter.
 flutter:
+  # This section identifies this Flutter project as a plugin project.
+  # The androidPackage and pluginClass identifiers should not be modified.
+  # They are used by the tooling to maintain consistency when adding or
+  # updating assets for this project.
   plugin:
     androidPackage: {{androidIdentifier}}
     pluginClass: {{pluginClass}}

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -17,9 +17,9 @@ dependencies:
 # The following section is specific to Flutter.
 flutter:
   # This section identifies this Flutter project as a plugin project.
-  # The androidPackage and pluginClass identifiers should not be modified.
-  # They are used by the tooling to maintain consistency when adding or
-  # updating assets for this project.
+  # The androidPackage and pluginClass identifiers should not ordinarily
+  # be modified. They are used by the tooling to maintain consistency when
+  # adding or updating assets for this project.
   plugin:
     androidPackage: {{androidIdentifier}}
     pluginClass: {{pluginClass}}


### PR DESCRIPTION
Fixes #23954 (the remainder of it anyway)

Pubspec.yaml is missing docs in the module templates.  I also noticed that there's a bit missing in the Plugins template.

I question whether we really should be storing the bundle identifiers in pubspec.yaml - they're meant to be one-way only, and we have no real way to prevent users from modifying them.  That said, it might be helpful to modify them if a user for some reason went and modified it everywhere else in their project structure and wants to keep things consistent.

/cc @matthew-carroll  @mit-mit @gspencergoog 