### PR TITLE
Change engine merge method back to squash

### DIFF
--- a/bin/internal/engine.merge_method
+++ b/bin/internal/engine.merge_method
@@ -1,1 +1,1 @@
-rebase
+squash


### PR DESCRIPTION
We need to wait the fix in
https://skia-review.googlesource.com/c/buildbot/+/169724
to land in order to enable the rebase merge method again.

TBR: goderbauer