### PR TITLE
Make host app test actually test host app

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -137,8 +137,7 @@ Future<void> main() async {
       final Directory hostApp = Directory(path.join(tempDir.path, 'hello_host_app'));
       mkdir(hostApp);
       recursiveCopy(
-        Directory(path.join(
-            flutterDirectory.path, 'dev', 'integration_tests', 'ios_host_app')),
+        Directory(path.join(flutterDirectory.path, 'dev', 'integration_tests', 'ios_host_app')),
         hostApp,
       );
 

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -14,7 +14,6 @@ import 'package:path/path.dart' as path;
 /// adding Flutter to an existing iOS app.
 Future<void> main() async {
   await task(() async {
-
     section('Create Flutter module project');
 
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_module_test.');
@@ -23,7 +22,12 @@ Future<void> main() async {
       await inDirectory(tempDir, () async {
         await flutter(
           'create',
-          options: <String>['--org', 'io.flutter.devicelab', '--template=module', 'hello'],
+          options: <String>[
+            '--org',
+            'io.flutter.devicelab',
+            '--template=module',
+            'hello'
+          ],
         );
       });
       await prepareProvisioningCertificates(projectDir.path);
@@ -127,11 +131,53 @@ Future<void> main() async {
       if (!editableHostAppBuilt) {
         return TaskResult.failure('Failed to build editable host .app');
       }
+
+      section('Add to existing iOS app');
+
+      final Directory hostApp =
+          Directory(path.join(tempDir.path, 'hello_host_app'));
+      mkdir(hostApp);
+      recursiveCopy(
+        Directory(path.join(
+            flutterDirectory.path, 'dev', 'integration_tests', 'ios_host_app')),
+        hostApp,
+      );
+
+      await inDirectory(hostApp, () async {
+        await exec('pod', <String>['install']);
+        await exec(
+          'xcodebuild',
+          <String>[
+            '-workspace',
+            'Host.xcworkspace',
+            '-scheme',
+            'Host',
+            '-configuration',
+            'Debug',
+            'CODE_SIGNING_ALLOWED=NO',
+            'CODE_SIGNING_REQUIRED=NO',
+            'CODE_SIGNING_IDENTITY=""',
+            'EXPANDED_CODE_SIGN_IDENTITY=""',
+            'CONFIGURATION_BUILD_DIR=${tempDir.path}',
+          ],
+        );
+      });
+
+      final bool existingAppBuilt = exists(File(path.join(
+        tempDir.path,
+        'Host.app',
+        'Host',
+      )));
+
+      if (!existingAppBuilt) {
+        return TaskResult.failure('Failed to build existing app .app');
+      }
+
       return TaskResult.success(null);
     } catch (e) {
       return TaskResult.failure(e.toString());
     } finally {
-      //rmTree(tempDir);
+      rmTree(tempDir);
     }
   });
 }

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -134,8 +134,7 @@ Future<void> main() async {
 
       section('Add to existing iOS app');
 
-      final Directory hostApp =
-          Directory(path.join(tempDir.path, 'hello_host_app'));
+      final Directory hostApp = Directory(path.join(tempDir.path, 'hello_host_app'));
       mkdir(hostApp);
       recursiveCopy(
         Directory(path.join(

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -326,6 +326,7 @@ tasks:
       Checks that the module project template works and supports add2app on iOS.
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
+    flaky: true
 
   external_ui_integration_test_ios:
     description: >

--- a/dev/integration_tests/ios_host_app/Host.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_host_app/Host.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+			shellScript = "\"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n\"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed\n";
 		};
 		EDACAC7378E52BD5BBDB34D5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/dev/integration_tests/ios_host_app/README.md
+++ b/dev/integration_tests/ios_host_app/README.md
@@ -1,0 +1,8 @@
+# iOS host app
+
+iOS host app for a Flutter module created using
+```
+$ flutter create -t module hello
+```
+and placed in a sibling folder to (a clone of) the host app.
+Used by the `module_test_ios.dart` device lab test.

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -367,9 +367,10 @@ EmbedFlutterFrameworks() {
   
   # Sign the binaries we moved.
   local identity="${EXPANDED_CODE_SIGN_IDENTITY_NAME:-$CODE_SIGN_IDENTITY}"
-
-  RunCommand codesign --force --verbose --sign "${identity}" -- "${xcode_frameworks_dir}/App.framework/App"
-  RunCommand codesign --force --verbose --sign "${identity}" -- "${xcode_frameworks_dir}/Flutter.framework/Flutter"
+  if (${identity} != ""); then
+    RunCommand codesign --force --verbose --sign "${identity}" -- "${xcode_frameworks_dir}/App.framework/App"
+    RunCommand codesign --force --verbose --sign "${identity}" -- "${xcode_frameworks_dir}/Flutter.framework/Flutter"
+  fi
 }
 
 # Main entry point.

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -68,7 +68,7 @@ post_install do |installer|
             config.build_settings['ENABLE_BITCODE'] = 'NO'
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|
-                file.puts "#include \"#{File.join(framework_dir, 'Generated.xcconfig')}\""
+                file.puts "#include \"#{File.realpath(File.join(framework_dir, 'Generated.xcconfig'))}\""
             end
         end
     end


### PR DESCRIPTION
This is _not_ the full Add2App test, but rather something I noticed/rememebred when going to work on that.

The `module_test_ios` test was never fully wired up to actually embed the module into a host app and try to build it.  This fixes that.

In the course of wiring this up, I discovered https://github.com/flutter/flutter/issues/24124 - this fixes that as well.  It also fixes an issue where `xcode_backend.sh` would try to sign things even if the signing variables indicated we shouldn't be (this does not generate a signed app).

/cc @mravn just FYI in case there's anything obvious being missed here.  

Fixes #24124 