### PR TITLE
[Material] Theme-able elevation on dialogs.

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -54,17 +54,16 @@ class Dialog extends StatelessWidget {
   ///
   /// This sets the [Material.color] on this [Dialog]'s [Material].
   ///
-  /// If `null`, [ThemeData.cardColor] is used (this is the default for
-  /// [MaterialType.card]).
+  /// If `null`, [ThemeData.cardColor] is used.
   /// {@endtemplate}
   final Color backgroundColor;
 
+  /// {@template flutter.material.dialog.elevation}
   /// The z-coordinate of this [Dialog].
   ///
-  /// If this is `null`, [DialogTheme.elevation] will be used, if
-  /// [DialogTheme.elevation] is not set, the default value [_defaultElevation]
-  /// is used.
-  ///
+  /// If null then [DialogTheme.elevation] is used, and if that's null then the
+  /// dialog's elevation is 24.0.
+  /// {@endtemplate}
   /// {@macro flutter.material.material.elevation}
   final double elevation;
 
@@ -94,10 +93,6 @@ class Dialog extends StatelessWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
-  Color _getColor(BuildContext context, DialogTheme dialogTheme) {
-    return backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor;
-  }
-
   // TODO(johnsonmh): Update default dialog border radius to 4.0 to match material spec.
   static const RoundedRectangleBorder _defaultDialogShape =
     RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
@@ -120,7 +115,7 @@ class Dialog extends StatelessWidget {
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 280.0),
             child: Material(
-              color: _getColor(context, dialogTheme),
+              color: backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor,
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,
               shape: shape ?? dialogTheme.shape ?? _defaultDialogShape,
               type: MaterialType.card,
@@ -269,13 +264,7 @@ class AlertDialog extends StatelessWidget {
   /// {@macro flutter.material.dialog.backgroundColor}
   final Color backgroundColor;
 
-  /// The z-coordinate of this [Dialog].
-  ///
-  /// If this is `null`, [DialogTheme.elevation] will be used, if
-  /// [DialogTheme.elevation] is not set, the default value
-  /// [Dialog._defaultElevation] is used.
-  ///
-  ///
+  /// {@macro flutter.material.dialog.elevation}
   /// {@macro flutter.material.material.elevation}
   final double elevation;
 
@@ -554,12 +543,7 @@ class SimpleDialog extends StatelessWidget {
   /// {@macro flutter.material.dialog.backgroundColor}
   final Color backgroundColor;
 
-  /// The z-coordinate of this [Dialog].
-  ///
-  /// If this is `null`, [DialogTheme.elevation] will be used, if
-  /// [DialogTheme.elevation] is not set, the default value
-  /// [Dialog._defaultElevation] is used.
-  ///
+  /// {@macro flutter.material.dialog.elevation}
   /// {@macro flutter.material.material.elevation}
   final double elevation;
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -41,19 +41,29 @@ class Dialog extends StatelessWidget {
   /// Typically used in conjunction with [showDialog].
   const Dialog({
     Key key,
-    this.child,
+    this.backgroundColor,
     this.elevation,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
     this.shape,
+    this.child,
   }) : super(key: key);
 
-  /// The widget below this widget in the tree.
+  /// {@template flutter.material.dialog.backgroundColor}
+  /// The background color of the surface of this [Dialog].
   ///
-  /// {@macro flutter.widgets.child}
-  final Widget child;
+  /// This sets the [Material.color] on this [Dialog]'s [Material].
+  ///
+  /// If `null`, [ThemeData.cardColor] is used (this is the default for
+  /// [MaterialType.card]).
+  /// {@endtemplate}
+  final Color backgroundColor;
 
   /// The z-coordinate of this [Dialog].
+  ///
+  /// If this is `null`, [DialogTheme.elevation] will be used, if
+  /// [DialogTheme.elevation] is not set, the default value [_defaultElevation]
+  /// is used.
   ///
   /// {@macro flutter.material.material.elevation}
   final double elevation;
@@ -79,8 +89,13 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final ShapeBorder shape;
 
-  Color _getColor(BuildContext context) {
-    return Theme.of(context).dialogBackgroundColor;
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.child}
+  final Widget child;
+
+  Color _getColor(BuildContext context, DialogTheme dialogTheme) {
+    return backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor;
   }
 
   // TODO(johnsonmh): Update default dialog border radius to 4.0 to match material spec.
@@ -105,11 +120,11 @@ class Dialog extends StatelessWidget {
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 280.0),
             child: Material(
-              child: child,
-              color: _getColor(context),
+              color: _getColor(context, dialogTheme),
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,
               shape: shape ?? dialogTheme.shape ?? _defaultDialogShape,
               type: MaterialType.card,
+              child: child,
             ),
           ),
         ),
@@ -197,6 +212,7 @@ class AlertDialog extends StatelessWidget {
     this.content,
     this.contentPadding = const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
     this.actions,
+    this.backgroundColor,
     this.elevation,
     this.semanticLabel,
     this.shape,
@@ -250,7 +266,15 @@ class AlertDialog extends StatelessWidget {
   /// from the [actions].
   final List<Widget> actions;
 
+  /// {@macro flutter.material.dialog.backgroundColor}
+  final Color backgroundColor;
+
   /// The z-coordinate of this [Dialog].
+  ///
+  /// If this is `null`, [DialogTheme.elevation] will be used, if
+  /// [DialogTheme.elevation] is not set, the default value
+  /// [Dialog._defaultElevation] is used.
+  ///
   ///
   /// {@macro flutter.material.material.elevation}
   final double elevation;
@@ -331,7 +355,12 @@ class AlertDialog extends StatelessWidget {
         child: dialogChild
       );
 
-    return Dialog(child: dialogChild, elevation: elevation, shape: shape);
+    return Dialog(
+      backgroundColor: backgroundColor,
+      elevation: elevation,
+      shape: shape,
+      child: dialogChild,
+    );
   }
 }
 
@@ -477,6 +506,7 @@ class SimpleDialog extends StatelessWidget {
     this.titlePadding = const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 0.0),
     this.children,
     this.contentPadding = const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 16.0),
+    this.backgroundColor,
     this.elevation,
     this.semanticLabel,
     this.shape,
@@ -521,7 +551,14 @@ class SimpleDialog extends StatelessWidget {
   /// the top padding ends up being 24 pixels.
   final EdgeInsetsGeometry contentPadding;
 
+  /// {@macro flutter.material.dialog.backgroundColor}
+  final Color backgroundColor;
+
   /// The z-coordinate of this [Dialog].
+  ///
+  /// If this is `null`, [DialogTheme.elevation] will be used, if
+  /// [DialogTheme.elevation] is not set, the default value
+  /// [Dialog._defaultElevation] is used.
   ///
   /// {@macro flutter.material.material.elevation}
   final double elevation;
@@ -594,7 +631,12 @@ class SimpleDialog extends StatelessWidget {
         label: label,
         child: dialogChild,
       );
-    return Dialog(child: dialogChild, elevation: elevation, shape: shape);
+    return Dialog(
+      backgroundColor: backgroundColor,
+      elevation: elevation,
+      shape: shape,
+      child: dialogChild,
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -42,6 +42,7 @@ class Dialog extends StatelessWidget {
   const Dialog({
     Key key,
     this.child,
+    this.elevation,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
     this.shape,
@@ -51,6 +52,11 @@ class Dialog extends StatelessWidget {
   ///
   /// {@macro flutter.widgets.child}
   final Widget child;
+
+  /// The z-coordinate of this [Dialog].
+  ///
+  /// {@macro flutter.material.material.elevation}
+  final double elevation;
 
   /// The duration of the animation to show when the system keyboard intrudes
   /// into the space that the dialog is placed in.
@@ -80,6 +86,7 @@ class Dialog extends StatelessWidget {
   // TODO(johnsonmh): Update default dialog border radius to 4.0 to match material spec.
   static const RoundedRectangleBorder _defaultDialogShape =
     RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
+  static const double _defaultElevation = 24.0;
 
   @override
   Widget build(BuildContext context) {
@@ -98,11 +105,11 @@ class Dialog extends StatelessWidget {
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 280.0),
             child: Material(
-              elevation: 24.0,
-              color: _getColor(context),
-              type: MaterialType.card,
               child: child,
+              color: _getColor(context),
+              elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,
               shape: shape ?? dialogTheme.shape ?? _defaultDialogShape,
+              type: MaterialType.card,
             ),
           ),
         ),
@@ -190,6 +197,7 @@ class AlertDialog extends StatelessWidget {
     this.content,
     this.contentPadding = const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
     this.actions,
+    this.elevation,
     this.semanticLabel,
     this.shape,
   }) : assert(contentPadding != null),
@@ -241,6 +249,11 @@ class AlertDialog extends StatelessWidget {
   /// pixels of padding is added above the [ButtonBar] to separate the [title]
   /// from the [actions].
   final List<Widget> actions;
+
+  /// The z-coordinate of this [Dialog].
+  ///
+  /// {@macro flutter.material.material.elevation}
+  final double elevation;
 
   /// The semantic label of the dialog used by accessibility frameworks to
   /// announce screen transitions when the dialog is opened and closed.
@@ -318,7 +331,7 @@ class AlertDialog extends StatelessWidget {
         child: dialogChild
       );
 
-    return Dialog(child: dialogChild, shape: shape);
+    return Dialog(child: dialogChild, elevation: elevation, shape: shape);
   }
 }
 
@@ -464,6 +477,7 @@ class SimpleDialog extends StatelessWidget {
     this.titlePadding = const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 0.0),
     this.children,
     this.contentPadding = const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 16.0),
+    this.elevation,
     this.semanticLabel,
     this.shape,
   }) : assert(titlePadding != null),
@@ -506,6 +520,11 @@ class SimpleDialog extends StatelessWidget {
   /// If there is no [title], the [contentPadding] should be adjusted so that
   /// the top padding ends up being 24 pixels.
   final EdgeInsetsGeometry contentPadding;
+
+  /// The z-coordinate of this [Dialog].
+  ///
+  /// {@macro flutter.material.material.elevation}
+  final double elevation;
 
   /// The semantic label of the dialog used by accessibility frameworks to
   /// announce screen transitions when the dialog is opened and closed.
@@ -575,7 +594,7 @@ class SimpleDialog extends StatelessWidget {
         label: label,
         child: dialogChild,
       );
-    return Dialog(child: dialogChild, shape: shape);
+    return Dialog(child: dialogChild, elevation: elevation, shape: shape);
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
@@ -23,15 +25,23 @@ import 'theme.dart';
 ///    application.
 class DialogTheme extends Diagnosticable {
   /// Creates a dialog theme that can be used for [ThemeData.dialogTheme].
-  const DialogTheme({ this.shape });
+  const DialogTheme({ this.elevation, this.shape });
+
+  /// Default value for [Dialog.elevation].
+  ///
+  /// If null, the [Dialog] elevation defaults to `24.0`.
+  final double elevation;
 
   /// Default value for [Dialog.shape].
   final ShapeBorder shape;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
-  DialogTheme copyWith({ ShapeBorder shape }) {
-    return DialogTheme(shape: shape ?? this.shape);
+  DialogTheme copyWith({ double elevation, ShapeBorder shape }) {
+    return DialogTheme(
+      elevation: elevation ?? this.elevation,
+      shape: shape ?? this.shape,
+    );
   }
 
   /// The data from the closest [DialogTheme] instance given the build context.
@@ -47,7 +57,8 @@ class DialogTheme extends Diagnosticable {
   static DialogTheme lerp(DialogTheme a, DialogTheme b, double t) {
     assert(t != null);
     return DialogTheme(
-        shape: ShapeBorder.lerp(a?.shape, b?.shape, t)
+      elevation: lerpDouble(a?.elevation, b?.elevation, t),
+      shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
     );
   }
 
@@ -61,12 +72,14 @@ class DialogTheme extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final DialogTheme typedOther = other;
-    return typedOther.shape == shape;
+    return typedOther.elevation == elevation
+        && typedOther.shape == shape;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
+    properties.add(DiagnosticsProperty<double>('elevation', elevation));
   }
 }

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -25,7 +25,10 @@ import 'theme.dart';
 ///    application.
 class DialogTheme extends Diagnosticable {
   /// Creates a dialog theme that can be used for [ThemeData.dialogTheme].
-  const DialogTheme({ this.elevation, this.shape });
+  const DialogTheme({ this.backgroundColor, this.elevation, this.shape });
+
+  /// Default value for [Dialog.backgroundColor].
+  final Color backgroundColor;
 
   /// Default value for [Dialog.elevation].
   ///
@@ -37,8 +40,9 @@ class DialogTheme extends Diagnosticable {
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
-  DialogTheme copyWith({ double elevation, ShapeBorder shape }) {
+  DialogTheme copyWith({ Color backgroundColor, double elevation, ShapeBorder shape }) {
     return DialogTheme(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
       elevation: elevation ?? this.elevation,
       shape: shape ?? this.shape,
     );
@@ -57,6 +61,7 @@ class DialogTheme extends Diagnosticable {
   static DialogTheme lerp(DialogTheme a, DialogTheme b, double t) {
     assert(t != null);
     return DialogTheme(
+      backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
     );
@@ -72,13 +77,15 @@ class DialogTheme extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final DialogTheme typedOther = other;
-    return typedOther.elevation == elevation
+    return typedOther.backgroundColor == backgroundColor
+        && typedOther.elevation == elevation
         && typedOther.shape == shape;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Color>('backgroundColor', backgroundColor));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation));
   }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -194,6 +194,7 @@ class Material extends StatefulWidget {
   /// the shape is rectangular, and the default color.
   final MaterialType type;
 
+  /// {@template flutter.material.material.elevation}
   /// The z-coordinate at which to place this material. This controls the size
   /// of the shadow below the material.
   ///
@@ -202,6 +203,7 @@ class Material extends StatefulWidget {
   ///
   /// Defaults to 0. Changing this value will cause the shadow to animate over
   /// [animationDuration].
+  /// {@endtemplate}
   final double elevation;
 
   /// The color to paint the material.

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -42,6 +42,25 @@ Material _getMaterialFromDialog(WidgetTester tester) {
 const ShapeBorder _defaultDialogShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
 
 void main() {
+  testWidgets('Dialog implements debugFillDescription', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    AlertDialog(
+      title: Text('Title'),
+      content: Text('Y'),
+      actions: <Widget>[ ],
+    ).debugFillProperties(builder);
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode n) => n.toString()).toList();
+    expect(description, <String>[
+      'textColor: Color(0xff00ff00)',
+      'disabledTextColor: Color(0xffff0000)',
+      'color: Color(0xff000000)',
+      'highlightColor: Color(0xff1565c0)',
+      'splashColor: Color(0xff9e9e9e)',
+    ]);
+  });
+
   testWidgets('Dialog is scrollable', (WidgetTester tester) async {
     bool didPressOk = false;
     final AlertDialog dialog = AlertDialog(
@@ -69,7 +88,7 @@ void main() {
     expect(didPressOk, true);
   });
 
-  testWidgets('Dialog background color from theme', (WidgetTester tester) async {
+  testWidgets('Dialog background color from AlertDialog', (WidgetTester tester) async {
     const Color customColor = Colors.pink;
     const AlertDialog dialog = AlertDialog(
       backgroundColor: customColor,

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -36,9 +36,7 @@ MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeD
 }
 
 Material _getMaterialFromDialog(WidgetTester tester) {
-  final StatefulElement widget = tester.element(
-      find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-  return widget.state.widget;
+  return tester.widget<Material>(find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
 }
 
 const ShapeBorder _defaultDialogShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
@@ -86,7 +84,7 @@ void main() {
     expect(materialWidget.color, customColor);
   });
 
-  testWidgets('Dialog background color', (WidgetTester tester) async {
+  testWidgets('Dialog Defaults', (WidgetTester tester) async {
     const AlertDialog dialog = AlertDialog(
       title: Text('Title'),
       content: Text('Y'),
@@ -100,6 +98,7 @@ void main() {
     final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.color, Colors.grey[800]);
     expect(materialWidget.shape, _defaultDialogShape);
+    expect(materialWidget.elevation, 24.0);
   });
 
   testWidgets('Custom dialog elevation', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -42,25 +42,6 @@ Material _getMaterialFromDialog(WidgetTester tester) {
 const ShapeBorder _defaultDialogShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
 
 void main() {
-  testWidgets('Dialog implements debugFillDescription', (WidgetTester tester) async {
-    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    AlertDialog(
-      title: Text('Title'),
-      content: Text('Y'),
-      actions: <Widget>[ ],
-    ).debugFillProperties(builder);
-    final List<String> description = builder.properties
-        .where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info))
-        .map((DiagnosticsNode n) => n.toString()).toList();
-    expect(description, <String>[
-      'textColor: Color(0xff00ff00)',
-      'disabledTextColor: Color(0xffff0000)',
-      'color: Color(0xff000000)',
-      'highlightColor: Color(0xff1565c0)',
-      'splashColor: Color(0xff9e9e9e)',
-    ]);
-  });
-
   testWidgets('Dialog is scrollable', (WidgetTester tester) async {
     bool didPressOk = false;
     final AlertDialog dialog = AlertDialog(

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -35,6 +35,12 @@ MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeD
   );
 }
 
+Material _getMaterialFromDialog(WidgetTester tester) {
+  final StatefulElement widget = tester.element(
+      find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
+  return widget.state.widget;
+}
+
 const ShapeBorder _defaultDialogShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
 
 void main() {
@@ -58,12 +64,26 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
     expect(didPressOk, false);
     await tester.tap(find.text('OK'));
     expect(didPressOk, true);
+  });
+
+  testWidgets('Dialog background color from theme', (WidgetTester tester) async {
+    const Color customColor = Colors.pink;
+    const AlertDialog dialog = AlertDialog(
+      backgroundColor: customColor,
+      actions: <Widget>[ ],
+    );
+    await tester.pumpWidget(_appWithAlertDialog(tester, dialog, theme: ThemeData(brightness: Brightness.dark)));
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Material materialWidget = _getMaterialFromDialog(tester);
+    expect(materialWidget.color, customColor);
   });
 
   testWidgets('Dialog background color', (WidgetTester tester) async {
@@ -75,12 +95,9 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog, theme: ThemeData(brightness: Brightness.dark)));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.color, Colors.grey[800]);
     expect(materialWidget.shape, _defaultDialogShape);
   });
@@ -94,12 +111,9 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.elevation, customElevation);
   });
 
@@ -113,12 +127,9 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.shape, customBorder);
   });
 
@@ -130,12 +141,9 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.shape, _defaultDialogShape);
   });
 
@@ -148,12 +156,9 @@ void main() {
     await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.shape, customBorder);
   });
 
@@ -424,8 +429,7 @@ void main() {
     )));
 
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
     expect(semantics, includesNodeWith(
       label: 'Title',

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -85,6 +85,24 @@ void main() {
     expect(materialWidget.shape, _defaultDialogShape);
   });
 
+  testWidgets('Custom dialog elevation', (WidgetTester tester) async {
+    const double customElevation = 12.0;
+    const AlertDialog dialog = AlertDialog(
+      actions: <Widget>[ ],
+      elevation: customElevation,
+    );
+    await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1));
+
+    final StatefulElement widget = tester.element(
+        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
+    final Material materialWidget = widget.state.widget;
+    expect(materialWidget.elevation, customElevation);
+  });
+
   testWidgets('Custom dialog shape', (WidgetTester tester) async {
     const RoundedRectangleBorder customBorder =
       RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -35,9 +35,7 @@ MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeD
 final Key _painterKey = UniqueKey();
 
 Material _getMaterialFromDialog(WidgetTester tester) {
-  final StatefulElement widget = tester.element(
-      find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-  return widget.state.widget;
+  return tester.widget<Material>(find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
 }
 
 void main() {

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeData theme}) {
@@ -39,6 +40,22 @@ Material _getMaterialFromDialog(WidgetTester tester) {
 }
 
 void main() {
+  testWidgets('Dialog Theme implements debugFillDescription', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const DialogTheme(
+      backgroundColor: Color(0xff123456),
+      elevation: 8.0,
+      shape: null,
+    ).debugFillProperties(builder);
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode n) => n.toString()).toList();
+    expect(description, <String>[
+      'backgroundColor: Color(0xff123456)',
+      'elevation: 8.0'
+    ]);
+  });
+
   testWidgets('Dialog background color', (WidgetTester tester) async {
     const Color customColor = Colors.pink;
     const AlertDialog dialog = AlertDialog(

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -35,6 +35,27 @@ MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeD
 final Key _painterKey = UniqueKey();
 
 void main() {
+  testWidgets('Custom dialog elevation', (WidgetTester tester) async {
+    const double customElevation = 12.0;
+    const AlertDialog dialog = AlertDialog(
+      title: Text('Title'),
+      actions: <Widget>[ ],
+    );
+    final ThemeData theme = ThemeData(dialogTheme: const DialogTheme(elevation: customElevation));
+
+    await tester.pumpWidget(
+        _appWithAlertDialog(tester, dialog, theme: theme)
+    );
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(seconds: 1));
+
+    final StatefulElement widget = tester.element(
+        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
+    final Material materialWidget = widget.state.widget;
+    expect(materialWidget.elevation, customElevation);
+  });
+
   testWidgets('Custom dialog shape', (WidgetTester tester) async {
     const RoundedRectangleBorder customBorder =
       RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -34,7 +34,29 @@ MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, {ThemeD
 
 final Key _painterKey = UniqueKey();
 
+Material _getMaterialFromDialog(WidgetTester tester) {
+  final StatefulElement widget = tester.element(
+      find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
+  return widget.state.widget;
+}
+
 void main() {
+  testWidgets('Dialog background color', (WidgetTester tester) async {
+    const Color customColor = Colors.pink;
+    const AlertDialog dialog = AlertDialog(
+      title: Text('Title'),
+      actions: <Widget>[ ],
+    );
+    final ThemeData theme = ThemeData(dialogTheme: const DialogTheme(backgroundColor: customColor));
+
+    await tester.pumpWidget(_appWithAlertDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Material materialWidget = _getMaterialFromDialog(tester);
+    expect(materialWidget.color, customColor);
+  });
+
   testWidgets('Custom dialog elevation', (WidgetTester tester) async {
     const double customElevation = 12.0;
     const AlertDialog dialog = AlertDialog(
@@ -47,12 +69,9 @@ void main() {
         _appWithAlertDialog(tester, dialog, theme: theme)
     );
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.elevation, customElevation);
   });
 
@@ -69,12 +88,9 @@ void main() {
       _appWithAlertDialog(tester, dialog, theme: theme)
     );
     await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final StatefulElement widget = tester.element(
-        find.descendant(of: find.byType(AlertDialog), matching: find.byType(Material)));
-    final Material materialWidget = widget.state.widget;
+    final Material materialWidget = _getMaterialFromDialog(tester);
     expect(materialWidget.shape, customBorder);
   });
 


### PR DESCRIPTION
This PR adds two new customizable properties to `Dialog`s in the `material` library: 
1. `backgroundColor`
1. `elevation`

Both of these fields were also added to `DialogTheme` to allow for more descriptive theming. 

Note: This change is backwards compatible. 