### PR TITLE
Run dartdocs on analysis task

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -230,7 +230,7 @@ Future<EvalResult> _evalCommand(String executable, List<String> arguments, {
 Future<void> _runFlutterAnalyze(String workingDirectory, {
   List<String> options = const <String>[]
 }) {
-  return runCommand(flutter, <String>['analyze']..addAll(options),
+  return runCommand(flutter, <String>['analyze', '--dartdocs']..addAll(options),
     workingDirectory: workingDirectory,
   );
 }


### PR DESCRIPTION
When running `flutter analyze` without the `--dartdocs` flag, missing public member documentation errors are discarded.  However we also run a devicelab task which verifies that all public members have documentation, putting us in the odd position of failing in a postsubmit would could be a presubmit.

Fixes https://github.com/flutter/flutter/issues/24128