### PR TITLE
Do not ignore pubspec.lock in project templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Miscellaneous
 *.class
-*.lock
 *.log
 *.pyc
 *.swp

--- a/dev/tools/vitool/.gitignore
+++ b/dev/tools/vitool/.gitignore
@@ -3,8 +3,6 @@
 .packages
 .pub/
 build/
-# Remove the following pattern if you wish to check in your lock file
-pubspec.lock
 
 # Directory created by dartdoc
 doc/api/

--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -1,6 +1,5 @@
 # Miscellaneous
 *.class
-*.lock
 *.log
 *.pyc
 *.swp

--- a/packages/flutter_tools/templates/plugin/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/plugin/.gitignore.tmpl
@@ -3,6 +3,5 @@
 
 .packages
 .pub/
-pubspec.lock
 
 build/

--- a/packages/flutter_tools/test/data/asset_test/main/.gitignore
+++ b/packages/flutter_tools/test/data/asset_test/main/.gitignore
@@ -1,2 +1,1 @@
 .packages
-pubspec.lock


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/14768, it has been decided to inlucde ```pubspec.lock``` into git. But it looks like the project created by ```flutter create <projectname>``` still ignore this file. This PR fixes this.