### PR TITLE
Throw a better error when old test versions are loaded.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -426,7 +426,7 @@ class _FlutterPlatform extends PlatformPlugin {
       if (err.toString().contains('type \'Declarer\' is not a subtype of type \'Declarer\'')) {
         throw UnsupportedError('Package incompatibility between flutter and test packages:\n'
           '  * flutter is incompatible with test <1.4.0.\n'
-          '  * flutter is incompatible with mockito <1.4.0\n'
+          '  * flutter is incompatible with mockito <4.0.0\n'
           'To fix this error, update test to at least \'^1.4.0\' and mockito to at least \'^4.0.0\'\n'
         );
       }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -414,10 +414,25 @@ class _FlutterPlatform extends PlatformPlugin {
   ) async {
     // loadChannel may throw an exception. That's fine; it will cause the
     // LoadSuite to emit an error, which will be presented to the user.
-    final StreamChannel<dynamic> channel = loadChannel(path, platform);
-    final RunnerSuiteController controller = deserializeSuite(path, platform,
+    // Except for the Declarer error, which is a specific test incompatibility
+    // error we need to catch.
+    try {
+      final StreamChannel<dynamic> channel = loadChannel(path, platform);
+      final RunnerSuiteController controller = deserializeSuite(path, platform,
         suiteConfig, const PluginEnvironment(), channel, message);
-    return await controller.suite;
+      return await controller.suite;
+    } catch (err) {
+      /// Rethrow a less confusing error if it is a test incompatibility.
+      if (err.toString().contains('type \'Declarer\' is not a subtype of type \'Declarer\'')) {
+        throw UnsupportedError('Package incompatibility between flutter and test packages:\n'
+          '  * flutter is incompatible with test <1.4.0.\n'
+          '  * flutter is incompatible with mockito <1.4.0\n'
+          'To fix this error, update test to at least \'^1.4.0\' and mockito to at least \'^4.0.0\'\n'
+        );
+      }
+      // Guess it was a different error.
+      rethrow;
+    }
   }
 
   @override


### PR DESCRIPTION
Since flutter_test no longer depends on test and older test versions do not use test_api, version solving can give us incompatible test packages. Since we can't go back and time and make all versions of test have a test_api dependency, we can instead catch this specific error and explain how to fix it.

Before:
```
  type 'Declarer' is not a subtype of type 'Declarer' in type cast where
    Declarer is from package:test_api/src/backend/declarer.dart
    Declarer is from package:test/src/backend/declarer.dart
  
  package:test                                                                                       test
  broken_test.dart 4:3                                                                               main
  ===== asynchronous gap ===========================
```

After:

```
  Unsupported operation: Package incompatibility between flutter and test packages:
    * flutter is incompatible with test <1.4.0.
    * flutter is incompatible with mockito <4.0.0
  To fix this error, update test to at least '^1.4.0' and mockito to at least '^4.0.0'
```

Fixes https://github.com/flutter/flutter/issues/24136