### PR TITLE
Don't consider a timestamp "newer" when equal

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -89,6 +89,9 @@ GOTO :after_subroutine
   SET pubspec_yaml_path=%flutter_tools_dir%\pubspec.yaml
   SET pubspec_lock_path=%flutter_tools_dir%\pubspec.lock
   FOR /F %%i IN ('DIR /B /O:D "%pubspec_yaml_path%" "%pubspec_lock_path%"') DO SET newer_file=%%i
+  FOR %%i IN (%pubspec_yaml_path%) DO SET pubspec_yaml_timestamp=%%~ti
+  FOR %%i IN (%pubspec_lock_path%) DO SET pubspec_lock_timestamp=%%~ti
+  IF "%pubspec_yaml_timestamp%" == "%pubspec_lock_timestamp%" SET newer_file=""
   IF "%newer_file%" EQU "pubspec.yaml" GOTO do_snapshot
 
   REM Everything is uptodate - exit subroutine


### PR DESCRIPTION
The problem was that the timestamps were still being considered newer based on order, which lead to `yaml` being considered the "newer" one despite having the same timestamp. Add a check to make sure that the yaml and lock actually have different timestamps before considering yaml the newer one.

Fixes flutter/flutter#22062