### PR TITLE
Make examples/catalog instructions a bit less confusing

### DIFF
--- a/examples/catalog/README.md
+++ b/examples/catalog/README.md
@@ -3,11 +3,19 @@ Samples Catalog
 
 A collection of sample apps that demonstrate how Flutter can be used.
 
-Each sample app is contained in a single `.dart` file and they're all found in
-the lib directory.
+Each sample app is contained in a single `.dart` file located in the `lib`
+directory. To run each sample app, specify the corresponding file on the
+`flutter run` command line, for example:
+
+```
+flutter run lib/animated_list.dart
+flutter run lib/app_bar_bottom.dart
+flutter run lib/basic_app_bar.dart
+...
+```
 
 The apps are intended to be short and easily understood. Classes that represent
-the sample's focus are at the top of the file, data and support classes follow.
+the sample's focus are at the top of the file; data and support classes follow.
 
 Each sample app contains a comment (usually at the end) which provides some
 standard documentation that also appears in the web view of the catalog.
@@ -21,8 +29,8 @@ and saved in the `.generated` directory. The markdown file contains
 the text taken from the Sample Catalog comment found in the app's source
 file, followed by the source code itself.
 
-This sample_page.dart command line app must be run from the examples/catalog
-directory. It relies on templates also found in the bin directory and it
+This `sample_page.dart` command line app must be run from the `examples/catalog`
+directory. It relies on templates also found in the bin directory, and it
 generates and executes `test_driver` apps to collect the screenshots:
 
 ```

--- a/examples/catalog/lib/main.dart
+++ b/examples/catalog/lib/main.dart
@@ -6,10 +6,10 @@ import 'package:flutter/widgets.dart';
 
 void main() {
   runApp(
-    const Directionality(
-      textDirection: TextDirection.ltr,
-      child: Center(
-        child: Text('flutter run -t lib/xxx.dart'),
+    const Center(
+      child: Text(
+        'Instead run:\nflutter run lib/xxx.dart',
+        textDirection: TextDirection.ltr,
       ),
     ),
   );

--- a/examples/layers/lib/main.dart
+++ b/examples/layers/lib/main.dart
@@ -4,4 +4,13 @@
 
 import 'package:flutter/widgets.dart';
 
-void main() => runApp(const Center(child: Text('flutter run -t xxx/yyy.dart', textDirection: TextDirection.ltr)));
+void main() {
+  runApp(
+    const Center(
+      child: Text(
+        'Instead run:\nflutter run xxx/yyy.dart',
+        textDirection: TextDirection.ltr,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Make the examples/catalog instructions a bit less confusing:
* Make the README.md file provide explicit instructions about how to
  run each example.
* Try to clarify that the lib/main.dart message is instructional and
  not an error message.

Additionally, adjust examples/layers/lib/main.dart to be consistent
with examples/catalog/lib/main.dart.

Fixes #22640.

Testing Done:
* Ran `flutter run` from examples/catalog and from examples/layers,
  saw the updated message.