### PR TITLE
Make progress indicators accessible

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -310,6 +310,9 @@ abstract class MaterialLocalizations {
   /// The label for the [TextField]'s character counter.
   String remainingTextFieldCharacterCount(int remaining);
 
+  /// The default semantics label for a [RefreshIndicator].
+  String get refreshIndicatorSemanticLabel;
+
   /// The `MaterialLocalizations` from the closest [Localizations] instance
   /// that encloses the given context.
   ///
@@ -697,6 +700,9 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
 
   @override
   String get collapsedIconTapHint => 'Expand';
+
+  @override
+  String get refreshIndicatorSemanticLabel => 'Refresh';
 
   /// Creates an object that provides US English resource values for the material
   /// library widgets.

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -34,7 +34,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   ///
   /// {@template flutter.material.progressIndicator.semantics}
   /// ## Accessibility
-  /// 
+  ///
   /// The [semanticsLabel] can be used to identify the purpose of this progress
   /// bar for screen reading software. The [semanticsValue] property may be used
   /// for determinate progress indicators to indicate how much progress has been made.
@@ -88,7 +88,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// screen reading software to identify the widget, and is primarily
   /// intended for use with determinate progress indicators to announce
   /// how far along they are.
-  /// 
+  ///
   /// For determinate progress indicators that have a non-null [semanticsLabel],
   /// this will be defaulted to [value] expressed as a percentage, i.e. `0.1`
   /// will become '10%'.

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -32,21 +32,24 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   ///
-  /// The [semanticsEnabled] argument must not be null. It defaults to false. If
-  /// this widget provides information that should be announced by screen reading
-  /// software, it should be set to true. If it is true, at least one of
-  /// [semanticsLabel] or [semanticsValue] must be specified.
+  /// {@template flutter.material.progressIndicator.semantics}
+  /// The [semanticsLabel] can be used to identify the purpose of this progress
+  /// bar for screen reading software. The [semanticsValue] property may be used
+  /// for determinate progress indicators to indicate how much progress has been made.
+  /// The [semanticsLiveRegion] parameter corresponds to [Semantics.liveRegion],
+  /// and should only be set to true if this progress indicator is a primary item
+  /// on the screen, as it will cause the screen reader to continuously and politely
+  /// read the status of this indicator.
+  /// {@endtemplate}
   const ProgressIndicator({
     Key key,
     this.value,
     this.backgroundColor,
     this.valueColor,
-    this.semanticsEnabled = false,
     this.semanticsLabel,
     this.semanticsValue,
-  }) : assert(semanticsEnabled != null),
-       assert(!semanticsEnabled || semanticsLabel != null || semanticsValue != null),
-       super(key: key);
+    this.semanticsLiveRegion = false,
+  }) : super(key: key);
 
   /// If non-null, the value of this progress indicator with 0.0 corresponding
   /// to no progress having been made and 1.0 corresponding to all the progress
@@ -70,24 +73,24 @@ abstract class ProgressIndicator extends StatefulWidget {
 
   /// The [Semantics.label] for this progress indicator.
   ///
-  /// This will be ignored if [semanticsEnabled] is false.
+  /// This value indicates the purpose of the progress bar, and is used
+  /// by screen reading software to identify the widget.
   final String semanticsLabel;
 
   /// The [Semantics.value] for this progress indicator.
   ///
-  /// This will be ignored if [semanticsEnabled] is false.
+  /// This will be used in conjunction with the [semanticsLabel] by
+  /// screen reading software to identify the widget.
   final String semanticsValue;
 
-  /// Whether the indicator will be given its own semantics node in the semantics
-  /// tree. Defaults to false.
-  ///
-  /// This should be set to true if it would be beneficial for accessibility
-  /// users to receive feedback about this indicator. For example, if this
-  /// indicator represents a loading state for a primary action that blocks
-  /// other activity, semantics should be enabled for it; but if it is
-  /// one of many indicators representing multiple images loading in a
-  /// [GridView], it should likely not have semantics enabled.
-  final bool semanticsEnabled;
+  /// The [Semantics.liveRegion] for this progress indicator.
+  /// 
+  /// This value should only be set to true for progress indicators
+  /// that are primary on the screen. For example, a [GridView] of
+  /// progress indicator placeholders should not all be marked as
+  /// live regions, as it would cause the screen reading software
+  /// to continuously read multiple updates at once.
+  final bool semanticsLiveRegion;
 
   Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
   Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
@@ -104,8 +107,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   }) {
     return Semantics(
       container: true,
-      liveRegion: true,
-      enabled: semanticsEnabled,
+      liveRegion: semanticsLiveRegion,
       label: semanticsLabel,
       value: semanticsValue,
       child: child,
@@ -225,10 +227,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   ///
-  /// The [semanticsEnabled] argument must not be null. It defaults to false. If
-  /// this widget provides information that should be announced by screen reading
-  /// software, it should be set to true. If it is `true`, at least one of
-  /// [semanticsLabel] or [semanticsValue] must be specified.
+  /// {@macro flutter.material.progressIndicator.semantics}
   const LinearProgressIndicator({
     Key key,
     double value,
@@ -236,7 +235,7 @@ class LinearProgressIndicator extends ProgressIndicator {
     Animation<Color> valueColor,
     String semanticsLabel,
     String semanticsValue,
-    bool semanticsEnabled = false,
+    bool semanticsLiveRegion = false,
   }) : super(
          key: key,
          value: value,
@@ -244,7 +243,7 @@ class LinearProgressIndicator extends ProgressIndicator {
          valueColor: valueColor,
          semanticsLabel: semanticsLabel,
          semanticsValue: semanticsValue,
-         semanticsEnabled: semanticsEnabled,
+         semanticsLiveRegion: semanticsLiveRegion,
        );
 
   @override
@@ -400,10 +399,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// progress indicator) or non-null (corresponding to a determinate progress
   /// indicator). See [value] for details.
   ///
-  /// The [semanticsEnabled] argument must not be null. It defaults to false. If
-  /// this widget provides information that should be announced by screen reading
-  /// software, it should be set to true. If it is `true`, at least one of
-  /// [semanticsLabel] or [semanticsValue] must be specified.
+  /// {@macro flutter.material.progressIndicator.semantics}
   const CircularProgressIndicator({
     Key key,
     double value,
@@ -412,7 +408,7 @@ class CircularProgressIndicator extends ProgressIndicator {
     this.strokeWidth = 4.0,
     String semanticsLabel,
     String semanticsValue,
-    bool semanticsEnabled = false,
+    bool semanticsLiveRegion,
   }) : super(
          key: key,
          value: value,
@@ -420,7 +416,7 @@ class CircularProgressIndicator extends ProgressIndicator {
          valueColor: valueColor,
          semanticsLabel: semanticsLabel,
          semanticsValue: semanticsValue,
-         semanticsEnabled: semanticsEnabled,
+         semanticsLiveRegion: semanticsLiveRegion,
        );
 
   /// The width of the line used to draw the circle.
@@ -594,28 +590,25 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Rather than creating a refresh progress indicator directly, consider using
   /// a [RefreshIndicator] together with a [Scrollable] widget.
   ///
-  /// The [semanticsEnabled] argument must not be null. It defaults to false. If
-  /// this widget provides information that should be announced by screen reading
-  /// software, it should be set to true. If it is `true`, at least one of
-  /// [semanticsLabel] or [semanticsValue] must be specified.
+  /// {@macro flutter.material.progressIndicator.semantics}
   const RefreshProgressIndicator({
     Key key,
     double value,
     Color backgroundColor,
     Animation<Color> valueColor,
     double strokeWidth = 2.0, // Different default than CircularProgressIndicator.
-    bool semanticsEnabled = false,
     String semanticsLabel,
     String semanticsValue,
+    bool semanticsLiveRegion,
   }) : super(
     key: key,
     value: value,
     backgroundColor: backgroundColor,
     valueColor: valueColor,
     strokeWidth: strokeWidth,
-    semanticsEnabled: semanticsEnabled,
     semanticsLabel: semanticsLabel,
     semanticsValue: semanticsValue,
+    semanticsLiveRegion: semanticsLiveRegion,
   );
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -84,7 +84,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   final String semanticsValue;
 
   /// The [Semantics.liveRegion] for this progress indicator.
-  /// 
+  ///
   /// This value should only be set to true for progress indicators
   /// that are primary on the screen. For example, a [GridView] of
   /// progress indicator placeholders should not all be marked as

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -76,8 +76,9 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@template flutter.material.progressIndicator.semanticsLabel}
   /// The [Semantics.label] for this progress indicator.
   ///
-  /// This value indicates the purpose of the progress bar, and is used
-  /// by screen reading software to identify the widget.
+  /// This value indicates the purpose of the progress bar, and will be
+  /// read out by screen readers to indicate the purpose of this progress
+  /// indicator.
   /// {@endtemplate}
   final String semanticsLabel;
 

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -33,6 +33,8 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// indicator). See [value] for details.
   ///
   /// {@template flutter.material.progressIndicator.semantics}
+  /// ## Accessibility
+  /// 
   /// The [semanticsLabel] can be used to identify the purpose of this progress
   /// bar for screen reading software. The [semanticsValue] property may be used
   /// for determinate progress indicators to indicate how much progress has been made.
@@ -71,16 +73,26 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// [ThemeData.accentColor].
   final Animation<Color> valueColor;
 
+  /// {@template flutter.material.progressIndicator.semanticsLabel}
   /// The [Semantics.label] for this progress indicator.
   ///
   /// This value indicates the purpose of the progress bar, and is used
   /// by screen reading software to identify the widget.
+  /// {@endtemplate}
   final String semanticsLabel;
 
+  /// {@template flutter.material.progressIndicator.semanticsValue}
   /// The [Semantics.value] for this progress indicator.
   ///
   /// This will be used in conjunction with the [semanticsLabel] by
-  /// screen reading software to identify the widget.
+  /// screen reading software to identify the widget, and is primarily
+  /// intended for use with determinate progress indicators to announce
+  /// how far along they are.
+  /// 
+  /// For determinate progress indicators that have a non-null [semanticsLabel],
+  /// this will be defaulted to [value] expressed as a percentage, i.e. `0.1`
+  /// will become '10%'.
+  /// {@endtemplate}
   final String semanticsValue;
 
   /// The [Semantics.liveRegion] for this progress indicator.
@@ -105,11 +117,15 @@ abstract class ProgressIndicator extends StatefulWidget {
     @required BuildContext context,
     @required Widget child,
   }) {
+    String expandedSemanticsValue = semanticsValue;
+    if (semanticsLabel != null && value != null) {
+      expandedSemanticsValue ??= '${(value * 100).round()}%';
+    }
     return Semantics(
       container: true,
       liveRegion: semanticsLiveRegion,
       label: semanticsLabel,
-      value: semanticsValue,
+      value: expandedSemanticsValue,
       child: child,
     );
   }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -108,7 +108,6 @@ abstract class ProgressIndicator extends StatefulWidget {
       expandedSemanticsValue ??= '${(value * 100).round()}%';
     }
     return Semantics(
-      container: true,
       label: semanticsLabel,
       value: expandedSemanticsValue,
       child: child,

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -38,10 +38,6 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// The [semanticsLabel] can be used to identify the purpose of this progress
   /// bar for screen reading software. The [semanticsValue] property may be used
   /// for determinate progress indicators to indicate how much progress has been made.
-  /// The [semanticsLiveRegion] parameter corresponds to [Semantics.liveRegion],
-  /// and should only be set to true if this progress indicator is a primary item
-  /// on the screen, as it will cause the screen reader to continuously and politely
-  /// read the status of this indicator.
   /// {@endtemplate}
   const ProgressIndicator({
     Key key,
@@ -50,7 +46,6 @@ abstract class ProgressIndicator extends StatefulWidget {
     this.valueColor,
     this.semanticsLabel,
     this.semanticsValue,
-    this.semanticsLiveRegion = false,
   }) : super(key: key);
 
   /// If non-null, the value of this progress indicator with 0.0 corresponding
@@ -95,15 +90,6 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@endtemplate}
   final String semanticsValue;
 
-  /// The [Semantics.liveRegion] for this progress indicator.
-  ///
-  /// This value should only be set to true for progress indicators
-  /// that are primary on the screen. For example, a [GridView] of
-  /// progress indicator placeholders should not all be marked as
-  /// live regions, as it would cause the screen reading software
-  /// to continuously read multiple updates at once.
-  final bool semanticsLiveRegion;
-
   Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
   Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
 
@@ -123,7 +109,6 @@ abstract class ProgressIndicator extends StatefulWidget {
     }
     return Semantics(
       container: true,
-      liveRegion: semanticsLiveRegion,
       label: semanticsLabel,
       value: expandedSemanticsValue,
       child: child,
@@ -251,7 +236,6 @@ class LinearProgressIndicator extends ProgressIndicator {
     Animation<Color> valueColor,
     String semanticsLabel,
     String semanticsValue,
-    bool semanticsLiveRegion = false,
   }) : super(
          key: key,
          value: value,
@@ -259,7 +243,6 @@ class LinearProgressIndicator extends ProgressIndicator {
          valueColor: valueColor,
          semanticsLabel: semanticsLabel,
          semanticsValue: semanticsValue,
-         semanticsLiveRegion: semanticsLiveRegion,
        );
 
   @override
@@ -424,7 +407,6 @@ class CircularProgressIndicator extends ProgressIndicator {
     this.strokeWidth = 4.0,
     String semanticsLabel,
     String semanticsValue,
-    bool semanticsLiveRegion,
   }) : super(
          key: key,
          value: value,
@@ -432,7 +414,6 @@ class CircularProgressIndicator extends ProgressIndicator {
          valueColor: valueColor,
          semanticsLabel: semanticsLabel,
          semanticsValue: semanticsValue,
-         semanticsLiveRegion: semanticsLiveRegion,
        );
 
   /// The width of the line used to draw the circle.
@@ -615,7 +596,6 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
     double strokeWidth = 2.0, // Different default than CircularProgressIndicator.
     String semanticsLabel,
     String semanticsValue,
-    bool semanticsLiveRegion,
   }) : super(
     key: key,
     value: value,
@@ -624,7 +604,6 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
     strokeWidth: strokeWidth,
     semanticsLabel: semanticsLabel,
     semanticsValue: semanticsValue,
-    semanticsLiveRegion: semanticsLiveRegion,
   );
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -89,9 +89,8 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// intended for use with determinate progress indicators to announce
   /// how far along they are.
   ///
-  /// For determinate progress indicators that have a non-null [semanticsLabel],
-  /// this will be defaulted to [value] expressed as a percentage, i.e. `0.1`
-  /// will become '10%'.
+  /// For determinate progress indicators, this will be defaulted to [value]
+  /// expressed as a percentage, i.e. `0.1` will become '10%'.
   /// {@endtemplate}
   final String semanticsValue;
 
@@ -118,7 +117,7 @@ abstract class ProgressIndicator extends StatefulWidget {
     @required Widget child,
   }) {
     String expandedSemanticsValue = semanticsValue;
-    if (semanticsLabel != null && value != null) {
+    if (value != null) {
       expandedSemanticsValue ??= '${(value * 100).round()}%';
     }
     return Semantics(

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -87,11 +87,12 @@ class RefreshIndicator extends StatefulWidget {
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
   ///
-  /// The [semanticsEnabled] argument must not be null. It defaults to true.
-  /// It may be set to false if it is used in a way that is primarily meant for
-  /// visual flair and would not add value if read by screen reading software.
-  /// At least one of [semanticsLabel] or [semanticsValue] must be specified if
-  /// [semanticsEnabled] is set to true.
+  /// The [semanticsLabel] is used to specify an accessibility label for this widget.
+  /// If it is null, it will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel].
+  /// An empty string may be passed to avoid having anything read by screen reading software.
+  /// The [semanticsValue] may be used to specify progress on the widget. The
+  /// [semanticsLiveRegion] parameter corresponds to [Semantics.liveRegion], and defaults
+  /// to true, as this widget will normally be a primary indicator for the UI.
   const RefreshIndicator({
     Key key,
     @required this.child,
@@ -100,13 +101,12 @@ class RefreshIndicator extends StatefulWidget {
     this.color,
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
-    this.semanticsEnabled = true,
     this.semanticsLabel,
     this.semanticsValue,
+    this.semanticsLiveRegion = true,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
-       assert(semanticsEnabled != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -144,21 +144,21 @@ class RefreshIndicator extends StatefulWidget {
 
   /// The [Semantics.label] for this indicator.
   ///
-  /// This will be ignored if [semanticsEnabled] is false.
+  /// This will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel]
+  /// if it is null.
   final String semanticsLabel;
 
   /// The [Semantics.value] for this indicator.
-  ///
-  /// This will be ignored if [semanticsEnabled] is false.
   final String semanticsValue;
 
-  /// Whether the indicator will be given its own semantics node in the semantics
-  /// tree.  Defaults to true.
-  ///
-  /// This may be set to false if it would be distracting for a screen reader to
-  /// announce the label and value of this widget, for example if it is used in
-  /// some secondary manner as visual flair.
-  final bool semanticsEnabled;
+  /// The [Semantics.liveRegion] for this indicator.
+  /// 
+  /// This should be set to false if this indicator is being used in
+  /// a way such that it would be undesirable for the screen reader to
+  /// provide live polite updates about its status, e.g. if it is
+  /// one of multiple indicators on the screen and not one that is important
+  /// for users to receive continual updates about.
+  final bool semanticsLiveRegion;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -463,9 +463,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                   animation: _positionController,
                   builder: (BuildContext context, Widget child) {
                     return RefreshProgressIndicator(
-                      semanticsEnabled: widget.semanticsEnabled,
                       semanticsLabel: widget.semanticsLabel ?? MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
                       semanticsValue: widget.semanticsValue,
+                      semanticsLiveRegion: widget.semanticsLiveRegion,
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,
                       backgroundColor: widget.backgroundColor,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import 'material_localizations.dart';
@@ -408,6 +409,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMaterialLocalizations(context));
     final Widget child = NotificationListener<ScrollNotification>(
       key: _key,
       onNotification: _handleScrollNotification,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -85,7 +85,7 @@ class RefreshIndicator extends StatefulWidget {
   /// The [onRefresh], [child], and [notificationPredicate] arguments must be
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
-  ///   
+  ///
   /// The [semanticsEnabled] argument must not be null. It defaults to true.
   /// It may be set to false if it is used in a way that is primarily meant for
   /// visual flair and would not add value if read by screen reading software.

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -142,13 +142,13 @@ class RefreshIndicator extends StatefulWidget {
   /// else for more complicated layouts.
   final ScrollNotificationPredicate notificationPredicate;
 
-  /// The [Semantics.label] for this indicator.
+  /// {@macro flutter.material.progressIndicator.semanticsLabel}
   ///
   /// This will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel]
   /// if it is null.
   final String semanticsLabel;
 
-  /// The [Semantics.value] for this indicator.
+  /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
 
   /// The [Semantics.liveRegion] for this indicator.

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -152,7 +152,7 @@ class RefreshIndicator extends StatefulWidget {
   final String semanticsValue;
 
   /// The [Semantics.liveRegion] for this indicator.
-  /// 
+  ///
   /// This should be set to false if this indicator is being used in
   /// a way such that it would be undesirable for the screen reader to
   /// provide live polite updates about its status, e.g. if it is

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -91,8 +91,6 @@ class RefreshIndicator extends StatefulWidget {
   /// If it is null, it will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel].
   /// An empty string may be passed to avoid having anything read by screen reading software.
   /// The [semanticsValue] may be used to specify progress on the widget. The
-  /// [semanticsLiveRegion] parameter corresponds to [Semantics.liveRegion], and defaults
-  /// to true, as this widget will normally be a primary indicator for the UI.
   const RefreshIndicator({
     Key key,
     @required this.child,
@@ -103,7 +101,6 @@ class RefreshIndicator extends StatefulWidget {
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsLabel,
     this.semanticsValue,
-    this.semanticsLiveRegion = true,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
@@ -150,15 +147,6 @@ class RefreshIndicator extends StatefulWidget {
 
   /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
-
-  /// The [Semantics.liveRegion] for this indicator.
-  ///
-  /// This should be set to false if this indicator is being used in
-  /// a way such that it would be undesirable for the screen reader to
-  /// provide live polite updates about its status, e.g. if it is
-  /// one of multiple indicators on the screen and not one that is important
-  /// for users to receive continual updates about.
-  final bool semanticsLiveRegion;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -465,7 +453,6 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                     return RefreshProgressIndicator(
                       semanticsLabel: widget.semanticsLabel ?? MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
                       semanticsValue: widget.semanticsValue,
-                      semanticsLiveRegion: widget.semanticsLiveRegion,
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,
                       backgroundColor: widget.backgroundColor,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
+import 'material_localizations.dart';
 import 'progress_indicator.dart';
 import 'theme.dart';
 
@@ -100,13 +101,12 @@ class RefreshIndicator extends StatefulWidget {
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsEnabled = true,
-    this.semanticsLabel = 'Refresh',
+    this.semanticsLabel,
     this.semanticsValue,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
        assert(semanticsEnabled != null),
-       assert(!semanticsEnabled || semanticsLabel != null || semanticsValue != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -464,7 +464,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                   builder: (BuildContext context, Widget child) {
                     return RefreshProgressIndicator(
                       semanticsEnabled: widget.semanticsEnabled,
-                      semanticsLabel: widget.semanticsLabel,
+                      semanticsLabel: widget.semanticsLabel ?? MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
                       semanticsValue: widget.semanticsValue,
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -85,6 +85,12 @@ class RefreshIndicator extends StatefulWidget {
   /// The [onRefresh], [child], and [notificationPredicate] arguments must be
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
+  ///   
+  /// The [semanticsEnabled] argument must not be null. It defaults to true.
+  /// It may be set to false if it is used in a way that is primarily meant for
+  /// visual flair and would not add value if read by screen reading software.
+  /// At least one of [semanticsLabel] or [semanticsValue] must be specified if
+  /// [semanticsEnabled] is set to true.
   const RefreshIndicator({
     Key key,
     @required this.child,
@@ -93,9 +99,14 @@ class RefreshIndicator extends StatefulWidget {
     this.color,
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
+    this.semanticsEnabled = true,
+    this.semanticsLabel = 'Refresh',
+    this.semanticsValue,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
+       assert(semanticsEnabled != null),
+       assert(!semanticsEnabled || semanticsLabel != null || semanticsValue != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -130,6 +141,24 @@ class RefreshIndicator extends StatefulWidget {
   /// By default, checks whether `notification.depth == 0`. Set it to something
   /// else for more complicated layouts.
   final ScrollNotificationPredicate notificationPredicate;
+
+  /// The [Semantics.label] for this indicator.
+  ///
+  /// This will be ignored if [semanticsEnabled] is false.
+  final String semanticsLabel;
+
+  /// The [Semantics.value] for this indicator.
+  ///
+  /// This will be ignored if [semanticsEnabled] is false.
+  final String semanticsValue;
+
+  /// Whether the indicator will be given its own semantics node in the semantics
+  /// tree.  Defaults to true.
+  ///
+  /// This may be set to false if it would be distracting for a screen reader to
+  /// announce the label and value of this widget, for example if it is used in
+  /// some secondary manner as visual flair.
+  final bool semanticsEnabled;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -434,6 +463,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                   animation: _positionController,
                   builder: (BuildContext context, Widget child) {
                     return RefreshProgressIndicator(
+                      semanticsEnabled: widget.semanticsEnabled,
+                      semanticsLabel: widget.semanticsLabel,
+                      semanticsValue: widget.semanticsValue,
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,
                       backgroundColor: widget.backgroundColor,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
+import 'debug.dart';
 import 'material_localizations.dart';
 import 'progress_indicator.dart';
 import 'theme.dart';

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -13,7 +13,7 @@ void main() {
   // The "can be constructed" tests that follow are primarily to ensure that any
   // animations started by the progress indicators are stopped at dispose() time.
 
-  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Directionality(
@@ -28,9 +28,7 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
-      isEnabled: false,
-      hasEnabledState: true,
-      isLiveRegion: true,
+      isLiveRegion: false,
     ));
     handle.dispose();
   });
@@ -365,7 +363,6 @@ void main() {
         child: LinearProgressIndicator(
           key: key,
           value: 0.25,
-          semanticsEnabled: true,
           semanticsLabel: label,
           semanticsValue: value,
         ),
@@ -373,9 +370,7 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: true,
-      isEnabled: true,
-      hasEnabledState: true,
+      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,
@@ -395,7 +390,7 @@ void main() {
         child: CircularProgressIndicator(
           key: key,
           value: 0.25,
-          semanticsEnabled: true,
+          semanticsLiveRegion: true,
           semanticsLabel: label,
           semanticsValue: value,
         ),
@@ -404,8 +399,6 @@ void main() {
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
       isLiveRegion: true,
-      isEnabled: true,
-      hasEnabledState: true,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,
@@ -424,7 +417,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: RefreshProgressIndicator(
           key: key,
-          semanticsEnabled: true,
+          semanticsLiveRegion: false,
           semanticsLabel: label,
           semanticsValue: value,
         ),
@@ -432,9 +425,7 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: true,
-      isEnabled: true,
-      hasEnabledState: true,
+      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -13,7 +13,8 @@ void main() {
   // The "can be constructed" tests that follow are primarily to ensure that any
   // animations started by the progress indicators are stopped at dispose() time.
 
-  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -25,9 +26,17 @@ void main() {
         ),
       ),
     );
+
+    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
+      isEnabled: false,
+      hasEnabledState: true,
+      isLiveRegion: true,
+    ));
+    handle.dispose();
   });
 
-  testWidgets('LinearProgressIndicator(value: null) can be constructed', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator(value: null) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.rtl,
@@ -39,6 +48,13 @@ void main() {
         ),
       ),
     );
+
+    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
+      isEnabled: false,
+      hasEnabledState: true,
+      isLiveRegion: true,
+    ));
+    handle.dispose();
   });
 
   testWidgets('LinearProgressIndicator paint (LTR)', (WidgetTester tester) async {
@@ -166,20 +182,36 @@ void main() {
     );
   });
 
-  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Center(
         child: CircularProgressIndicator(value: 0.0)
       )
     );
+
+    expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
+      isEnabled: false,
+      hasEnabledState: true,
+      isLiveRegion: true,
+    ));
+    handle.dispose();
   });
 
-  testWidgets('CircularProgressIndicator(value: null) can be constructed', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: null) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Center(
         child: CircularProgressIndicator(value: null)
       )
     );
+
+    expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
+      isEnabled: false,
+      hasEnabledState: true,
+      isLiveRegion: true,
+    ));
+    handle.dispose();
   });
 
   testWidgets('LinearProgressIndicator causes a repaint when it changes', (WidgetTester tester) async {
@@ -320,5 +352,95 @@ void main() {
           ..rect(rect: Rect.fromLTRB(0.0, 0.0, 25.0, 4.0))
     );
     expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('LinearProgressIndicator can be made accessible', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    const String label = 'Label';
+    const String value = '25%';
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: LinearProgressIndicator(
+          key: key,
+          value: 0.25,
+          semanticsEnabled: true,
+          semanticsLabel: label,
+          semanticsValue: value,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: true,
+      isEnabled: true,
+      hasEnabledState: true,
+      textDirection: TextDirection.ltr,
+      label: label,
+      value: value,
+    ));
+
+    handle.dispose();
+  });
+
+  testWidgets('CircularProgressIndicator can be made accessible', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    const String label = 'Label';
+    const String value = '25%';
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CircularProgressIndicator(
+          key: key,
+          value: 0.25,
+          semanticsEnabled: true,
+          semanticsLabel: label,
+          semanticsValue: value,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: true,
+      isEnabled: true,
+      hasEnabledState: true,
+      textDirection: TextDirection.ltr,
+      label: label,
+      value: value,
+    ));
+
+    handle.dispose();
+  });
+
+  testWidgets('RefreshProgressIndicator can be made accessible', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    const String label = 'Label';
+    const String value = '25%';
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RefreshProgressIndicator(
+          key: key,
+          semanticsEnabled: true,
+          semanticsLabel: label,
+          semanticsValue: value,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: true,
+      isEnabled: true,
+      hasEnabledState: true,
+      textDirection: TextDirection.ltr,
+      label: label,
+      value: value,
+    ));
+
+
+    handle.dispose();
   });
 }

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -373,6 +373,75 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('LinearProgressIndicator that is determinate gets default a11y value', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    const String label = 'Label';
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: LinearProgressIndicator(
+          key: key,
+          value: 0.25,
+          semanticsLabel: label,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: false,
+      textDirection: TextDirection.ltr,
+      label: label,
+      value: '25%',
+    ));
+
+    handle.dispose();
+  });
+
+  testWidgets('LinearProgressIndicator that is determinate does not default a11y value when label is null', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: LinearProgressIndicator(
+          key: key,
+          value: 0.25,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: false,
+    ));
+
+    handle.dispose();
+  });
+
+  testWidgets('LinearProgressIndicator that is indeterminate does not default a11y value', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey key = GlobalKey();
+    const String label = 'Progress';
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: LinearProgressIndicator(
+          key: key,
+          value: 0.25,
+          semanticsLabel: label,
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+      isLiveRegion: false,
+      textDirection: TextDirection.ltr,
+      label: label,
+    ));
+
+    handle.dispose();
+  });
+
   testWidgets('CircularProgressIndicator can be made accessible', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     final GlobalKey key = GlobalKey();

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -48,9 +48,7 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
-      isEnabled: false,
-      hasEnabledState: true,
-      isLiveRegion: true,
+      isLiveRegion: false,
     ));
     handle.dispose();
   });
@@ -180,7 +178,7 @@ void main() {
     );
   });
 
-  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Center(
@@ -189,14 +187,12 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
-      isEnabled: false,
-      hasEnabledState: true,
-      isLiveRegion: true,
+      isLiveRegion: false,
     ));
     handle.dispose();
   });
 
-  testWidgets('CircularProgressIndicator(value: null) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: null) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Center(
@@ -205,9 +201,7 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
-      isEnabled: false,
-      hasEnabledState: true,
-      isLiveRegion: true,
+      isLiveRegion: false,
     ));
     handle.dispose();
   });

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -13,7 +13,7 @@ void main() {
   // The "can be constructed" tests that follow are primarily to ensure that any
   // animations started by the progress indicators are stopped at dispose() time.
 
-  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator(value: 0.0) can be constructed and has empty semantics by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Directionality(
@@ -27,13 +27,11 @@ void main() {
       ),
     );
 
-    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
-      isLiveRegion: false,
-    ));
+    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics());
     handle.dispose();
   });
 
-  testWidgets('LinearProgressIndicator(value: null) can be constructed and has disabled semantics by default', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator(value: null) can be constructed and has empty semantics by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Directionality(
@@ -47,9 +45,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics(
-      isLiveRegion: false,
-    ));
+    expect(tester.getSemantics(find.byType(LinearProgressIndicator)), matchesSemantics());
     handle.dispose();
   });
 
@@ -178,21 +174,25 @@ void main() {
     );
   });
 
-  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: 0.0) can be constructed and has value semantics by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
-      const Center(
-        child: CircularProgressIndicator(value: 0.0)
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CircularProgressIndicator(value: 0.0)
+        )
       )
     );
 
     expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
-      isLiveRegion: false,
+      value: '0%',
+      textDirection: TextDirection.ltr,
     ));
     handle.dispose();
   });
 
-  testWidgets('CircularProgressIndicator(value: null) can be constructed and has disabled liveRegion by default', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator(value: null) can be constructed and has empty semantics by default', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       const Center(
@@ -200,9 +200,7 @@ void main() {
       )
     );
 
-    expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics(
-      isLiveRegion: false,
-    ));
+    expect(tester.getSemantics(find.byType(CircularProgressIndicator)), matchesSemantics());
     handle.dispose();
   });
 
@@ -364,7 +362,6 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,
@@ -389,7 +386,6 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
       value: '25%',
@@ -411,9 +407,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: false,
-    ));
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics());
 
     handle.dispose();
   });
@@ -434,7 +428,6 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
     ));
@@ -453,7 +446,6 @@ void main() {
         child: CircularProgressIndicator(
           key: key,
           value: 0.25,
-          semanticsLiveRegion: true,
           semanticsLabel: label,
           semanticsValue: value,
         ),
@@ -461,7 +453,6 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: true,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,
@@ -480,7 +471,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: RefreshProgressIndicator(
           key: key,
-          semanticsLiveRegion: false,
           semanticsLabel: label,
           semanticsValue: value,
         ),
@@ -488,7 +478,6 @@ void main() {
     );
 
     expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
-      isLiveRegion: false,
       textDirection: TextDirection.ltr,
       label: label,
       value: value,

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -23,6 +23,7 @@ Future<void> holdRefresh() {
 void main() {
   testWidgets('RefreshIndicator', (WidgetTester tester) async {
     refreshCalled = false;
+    final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
@@ -42,10 +43,19 @@ void main() {
 
     await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
     await tester.pump();
+
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      isEnabled: true,
+      isLiveRegion: true,
+      hasEnabledState: true,
+      label: 'Refresh',
+    ));
+
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator hide animation
     expect(refreshCalled, true);
+    handle.dispose();
   });
 
   testWidgets('Refresh Indicator - nested', (WidgetTester tester) async {

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -45,9 +45,7 @@ void main() {
     await tester.pump();
 
     expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
-      isEnabled: true,
       isLiveRegion: true,
-      hasEnabledState: true,
       label: 'Refresh',
     ));
 

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -45,7 +45,6 @@ void main() {
     await tester.pump();
 
     expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
-      isLiveRegion: true,
       label: 'Refresh',
     ));
 

--- a/packages/flutter_localizations/lib/src/l10n/localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/localizations.dart
@@ -132,6 +132,9 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'الصفحة السابقة';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'$remainingCount أحرف متبقية';
 
   @override
@@ -331,6 +334,9 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Предишната страница';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -534,6 +540,9 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Prethodna stranica';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
 
   @override
@@ -733,6 +742,9 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Pàgina anterior';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -936,6 +948,9 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Předchozí stránka';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Zbývají $remainingCount znaky';
 
   @override
@@ -1137,6 +1152,9 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Forrige side';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -1336,6 +1354,9 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Vorherige Seite';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -1569,6 +1590,9 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Προηγούμενη σελίδα';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -1768,6 +1792,9 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Previous page';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'Refresh';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -2272,6 +2299,9 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -4098,6 +4128,9 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Eelmine leht';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -4297,6 +4330,9 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'صفحه قبل';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -4500,6 +4536,9 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Edellinen sivu';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -4701,6 +4740,9 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Nakaraang page';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -4900,6 +4942,9 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Page précédente';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -5130,6 +5175,9 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Vorherige Seite';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -5329,6 +5377,9 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'הדף הקודם';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -5532,6 +5583,9 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'पिछला पेज';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -5731,6 +5785,9 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
@@ -5934,6 +5991,9 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Előző oldal';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -6133,6 +6193,9 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -6336,6 +6399,9 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Pagina precedente';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -6535,6 +6601,9 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'前のページ';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -6738,6 +6807,9 @@ class MaterialLocalizationKm extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'ទំព័រមុន';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -6937,6 +7009,9 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'이전 페이지';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -7140,6 +7215,9 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Ankstesnis puslapis';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Liko $remainingCount simboliai';
 
   @override
@@ -7339,6 +7417,9 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Iepriekšējā lapa';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -7542,6 +7623,9 @@ class MaterialLocalizationMn extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Өмнөх хуудас';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -7741,6 +7825,9 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Halaman sebelumnya';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -7944,6 +8031,9 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Forrige side';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -8143,6 +8233,9 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Vorige pagina';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -8346,6 +8439,9 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Poprzednia strona';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Jeszcze $remainingCount znaki';
 
   @override
@@ -8547,6 +8643,9 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'مخکینی مخ';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -8746,6 +8845,9 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Página anterior';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -9033,6 +9135,9 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Pagina anterioară';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'$remainingCount caractere rămase';
 
   @override
@@ -9232,6 +9337,9 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Предыдущая страница';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => r'Осталось $remainingCount символа';
@@ -9435,6 +9543,9 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Predchádzajúca stránka';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Zostávajú $remainingCount znaky';
 
   @override
@@ -9636,6 +9747,9 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Prejšnja stran';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Še $remainingCount znaki';
 
   @override
@@ -9835,6 +9949,9 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Претходна страница';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => r'Преостала су $remainingCount знака';
@@ -10239,6 +10356,9 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Föregående sida';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -10438,6 +10558,9 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'หน้าก่อน';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -10641,6 +10764,9 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Nakaraang page';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -10840,6 +10966,9 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'Önceki sayfa';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -11043,6 +11172,9 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Попередня сторінка';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => r'Залишилося $remainingCount символи';
 
   @override
@@ -11242,6 +11374,9 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'گزشتہ صفحہ';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;
@@ -11445,6 +11580,9 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   String get previousPageTooltip => r'Trang trước';
 
   @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
+
+  @override
   String get remainingTextFieldCharacterCountFew => null;
 
   @override
@@ -11644,6 +11782,9 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
 
   @override
   String get previousPageTooltip => r'上一页';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'TBD';
 
   @override
   String get remainingTextFieldCharacterCountFew => null;

--- a/packages/flutter_localizations/lib/src/l10n/material_ar.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ar.arb
@@ -57,5 +57,6 @@
   "collapsedIconTapHint": "توسيع",
   "remainingTextFieldCharacterCountZero": "لا أحرف متبقية",
   "remainingTextFieldCharacterCountOne": "حرف واحد متبقٍ",
-  "remainingTextFieldCharacterCountOther": "$remainingCount حرف متبقٍ"
+  "remainingTextFieldCharacterCountOther": "$remainingCount حرف متبقٍ",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_bg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bg.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Разгъване",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Остава 1 знак",
-  "remainingTextFieldCharacterCountOther": "Остават $remainingCount знака"
+  "remainingTextFieldCharacterCountOther": "Остават $remainingCount знака",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_bs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bs.arb
@@ -52,5 +52,6 @@
   "collapsedIconTapHint": "Proširi",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Preostao je 1 znak",
-  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova"
+  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ca.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ca.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Desplega",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 caràcter",
-  "remainingTextFieldCharacterCountOther": "Queden $remainingCount caràcters"
+  "remainingTextFieldCharacterCountOther": "Queden $remainingCount caràcters",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_cs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_cs.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Rozbalit",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Zbývá 1 znak",
-  "remainingTextFieldCharacterCountOther": "Zbývá $remainingCount znaků"
+  "remainingTextFieldCharacterCountOther": "Zbývá $remainingCount znaků",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_da.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_da.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Udvid",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Ét tegn tilbage",
-  "remainingTextFieldCharacterCountOther": "$remainingCount tegn tilbage"
+  "remainingTextFieldCharacterCountOther": "$remainingCount tegn tilbage",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Maximieren",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Noch 1 Zeichen",
-  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen"
+  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_de_CH.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Maximieren",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Noch 1 Zeichen",
-  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen"
+  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_el.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_el.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Ανάπτυξη",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "απομένει 1 χαρακτήρας",
-  "remainingTextFieldCharacterCountOther": "απομένουν $remainingCount χαρακτήρες"
+  "remainingTextFieldCharacterCountOther": "απομένουν $remainingCount χαρακτήρες",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -254,5 +254,10 @@
   "@remainingTextFieldCharacterCount": {
     "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
     "plural": "remainingCount"
+  },
+
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
   }
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_CA.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_GB.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IE.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_IN.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_SG.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "Refresh"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Mostrar",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter.",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_419.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_AR.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_BO.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CL.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CO.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_CR.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_DO.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_EC.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_GT.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_HN.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_MX.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_NI.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PA.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PE.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PR.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_PY.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_SV.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_US.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_UY.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_es_VE.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Queda 1 carácter",
-  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres"
+  "remainingTextFieldCharacterCountOther": "Quedan $remainingCount caracteres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_et.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_et.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Laienda",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Jäänud on 1 tähemärk",
-  "remainingTextFieldCharacterCountOther": "Jäänud on $remainingCount tähemärki"
+  "remainingTextFieldCharacterCountOther": "Jäänud on $remainingCount tähemärki",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fa.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fa.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "بزرگ کردن",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "۱ نویسه باقی مانده است",
-  "remainingTextFieldCharacterCountOther": "$remainingCount نویسه باقی مانده است"
+  "remainingTextFieldCharacterCountOther": "$remainingCount نویسه باقی مانده است",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fi.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Laajenna",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 merkki jäljellä",
-  "remainingTextFieldCharacterCountOther": "$remainingCount merkkiä jäljellä"
+  "remainingTextFieldCharacterCountOther": "$remainingCount merkkiä jäljellä",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fil.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fil.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "I-expand",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 character ang natitira",
-  "remainingTextFieldCharacterCountOther": "$remainingCount na character ang natitira"
+  "remainingTextFieldCharacterCountOther": "$remainingCount na character ang natitira",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_fr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fr.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Développer",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 caractère restant",
-  "remainingTextFieldCharacterCountOther": "$remainingCount caractères restants"
+  "remainingTextFieldCharacterCountOther": "$remainingCount caractères restants",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gsw.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Maximieren",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Noch 1 Zeichen",
-  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen"
+  "remainingTextFieldCharacterCountOther": "Noch $remainingCount Zeichen",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_he.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_he.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "הרחבה",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "נותר תו אחד",
-  "remainingTextFieldCharacterCountOther": "נותרו $remainingCount תווים"
+  "remainingTextFieldCharacterCountOther": "נותרו $remainingCount תווים",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hi.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "बड़ा करें",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "एक वर्ण अाैर डाला जा सकता है",
-  "remainingTextFieldCharacterCountOther": "$remainingCount वर्ण अाैर डाले जा सकते हैं"
+  "remainingTextFieldCharacterCountOther": "$remainingCount वर्ण अाैर डाले जा सकते हैं",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hr.arb
@@ -52,5 +52,6 @@
   "collapsedIconTapHint": "Proširi",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Preostao je 1 znak",
-  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova"
+  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_hu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hu.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Kibontás",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 karakter maradt",
-  "remainingTextFieldCharacterCountOther": "$remainingCount karakter maradt"
+  "remainingTextFieldCharacterCountOther": "$remainingCount karakter maradt",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_id.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_id.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Luaskan",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Sisa 1 karakter",
-  "remainingTextFieldCharacterCountOther": "Sisa $remainingCount karakter"
+  "remainingTextFieldCharacterCountOther": "Sisa $remainingCount karakter",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_it.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_it.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Espandi",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 carattere rimanente",
-  "remainingTextFieldCharacterCountOther": "$remainingCount caratteri rimanenti"
+  "remainingTextFieldCharacterCountOther": "$remainingCount caratteri rimanenti",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ja.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ja.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "展開",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "残り 1 文字（半角相当）",
-  "remainingTextFieldCharacterCountOther": "残り $remainingCount 文字（半角相当）"
+  "remainingTextFieldCharacterCountOther": "残り $remainingCount 文字（半角相当）",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_km.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_km.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "ពង្រីក",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "នៅសល់​ 1 តួ​ទៀត",
-  "remainingTextFieldCharacterCountOther": "នៅសល់ $remainingCount តួ​ទៀត"
+  "remainingTextFieldCharacterCountOther": "នៅសល់ $remainingCount តួ​ទៀត",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ko.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ko.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "펼치기",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1자 남음",
-  "remainingTextFieldCharacterCountOther": "$remainingCount자 남음"
+  "remainingTextFieldCharacterCountOther": "$remainingCount자 남음",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_lt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lt.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Išskleisti",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Liko 1 simbolis",
-  "remainingTextFieldCharacterCountOther": "Liko $remainingCount simbolių"
+  "remainingTextFieldCharacterCountOther": "Liko $remainingCount simbolių",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_lv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lv.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Izvērst",
   "remainingTextFieldCharacterCountZero": "Nav atlikusi neviena rakstzīme.",
   "remainingTextFieldCharacterCountOne": "Atlikusi 1 rakstzīme.",
-  "remainingTextFieldCharacterCountOther": "Atlikušas $remainingCount rakstzīmes."
+  "remainingTextFieldCharacterCountOther": "Atlikušas $remainingCount rakstzīmes.",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_mn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mn.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Expand",
   "remainingTextFieldCharacterCountZero": "No characters remaining",
   "remainingTextFieldCharacterCountOne": "1 character remaining",
-  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining"
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ms.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ms.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "Kembangkan",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 aksara lagi",
-  "remainingTextFieldCharacterCountOther": "$remainingCount aksara lagi"
+  "remainingTextFieldCharacterCountOther": "$remainingCount aksara lagi",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nb.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Vis",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 tegn gjenstår",
-  "remainingTextFieldCharacterCountOther": "$remainingCount tegn gjenstår"
+  "remainingTextFieldCharacterCountOther": "$remainingCount tegn gjenstår",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_nl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nl.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Uitvouwen",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 teken resterend",
-  "remainingTextFieldCharacterCountOther": "$remainingCount tekens resterend"
+  "remainingTextFieldCharacterCountOther": "$remainingCount tekens resterend",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pl.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Rozwiń",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Jeszcze 1 znak",
-  "remainingTextFieldCharacterCountOther": "Jeszcze $remainingCount znaku"
+  "remainingTextFieldCharacterCountOther": "Jeszcze $remainingCount znaku",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ps.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ps.arb
@@ -49,5 +49,6 @@
   "collapsedIconTapHint": "TBD",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "TBD",
-  "remainingTextFieldCharacterCountOther": "TBD"
+  "remainingTextFieldCharacterCountOther": "TBD",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt.arb
@@ -52,5 +52,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 caractere restante",
-  "remainingTextFieldCharacterCountOther": "$remainingCount caracteres restantes"
+  "remainingTextFieldCharacterCountOther": "$remainingCount caracteres restantes",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pt_PT.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Expandir",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Resta 1 caráter",
-  "remainingTextFieldCharacterCountOther": "Restam $remainingCount carateres"
+  "remainingTextFieldCharacterCountOther": "Restam $remainingCount carateres",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ro.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ro.arb
@@ -53,5 +53,6 @@
   "collapsedIconTapHint": "Extindeți",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "un caracter rămas",
-  "remainingTextFieldCharacterCountOther": "$remainingCount de caractere rămase"
+  "remainingTextFieldCharacterCountOther": "$remainingCount de caractere rămase",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ru.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ru.arb
@@ -55,5 +55,6 @@
   "collapsedIconTapHint": "Развернуть",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Остался 1 символ",
-  "remainingTextFieldCharacterCountOther": "Осталось $remainingCount символа"
+  "remainingTextFieldCharacterCountOther": "Осталось $remainingCount символа",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sk.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Rozbaliť",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Zostáva 1 znak",
-  "remainingTextFieldCharacterCountOther": "Zostáva $remainingCount znakov"
+  "remainingTextFieldCharacterCountOther": "Zostáva $remainingCount znakov",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sl.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Razširiti",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Še 1 znak",
-  "remainingTextFieldCharacterCountOther": "Še $remainingCount znakov"
+  "remainingTextFieldCharacterCountOther": "Še $remainingCount znakov",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sr.arb
@@ -52,5 +52,6 @@
   "collapsedIconTapHint": "Прошири",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Преостао је 1 знак",
-  "remainingTextFieldCharacterCountOther": "Преостало је $remainingCount знакова"
+  "remainingTextFieldCharacterCountOther": "Преостало је $remainingCount знакова",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sr_Latn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sr_Latn.arb
@@ -52,5 +52,6 @@
   "collapsedIconTapHint": "Proširi",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Preostao je 1 znak",
-  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova"
+  "remainingTextFieldCharacterCountOther": "Preostalo je $remainingCount znakova",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_sv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sv.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Utöka",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 tecken kvar",
-  "remainingTextFieldCharacterCountOther": "$remainingCount tecken kvar"
+  "remainingTextFieldCharacterCountOther": "$remainingCount tecken kvar",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_th.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_th.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "ขยาย",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "เหลือ 1 อักขระ",
-  "remainingTextFieldCharacterCountOther": "เหลือ $remainingCount อักขระ"
+  "remainingTextFieldCharacterCountOther": "เหลือ $remainingCount อักขระ",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_tl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tl.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "I-expand",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 character ang natitira",
-  "remainingTextFieldCharacterCountOther": "$remainingCount na character ang natitira"
+  "remainingTextFieldCharacterCountOther": "$remainingCount na character ang natitira",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_tr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tr.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Genişlet",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 karakter kaldı",
-  "remainingTextFieldCharacterCountOther": "$remainingCount karakter kaldı"
+  "remainingTextFieldCharacterCountOther": "$remainingCount karakter kaldı",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_uk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_uk.arb
@@ -54,5 +54,6 @@
   "collapsedIconTapHint": "Розгорнути",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Залишився 1 символ",
-  "remainingTextFieldCharacterCountOther": "Залишилося $remainingCount символу"
+  "remainingTextFieldCharacterCountOther": "Залишилося $remainingCount символу",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_ur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ur.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "پھیلائیں",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "1 حرف باقی ہے",
-  "remainingTextFieldCharacterCountOther": "$remainingCount حروف باقی ہیں"
+  "remainingTextFieldCharacterCountOther": "$remainingCount حروف باقی ہیں",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_vi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_vi.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "Mở rộng",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "Còn lại 1 ký tự",
-  "remainingTextFieldCharacterCountOther": "Còn lại $remainingCount ký tự"
+  "remainingTextFieldCharacterCountOther": "Còn lại $remainingCount ký tự",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "展开",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "还可输入 1 个字符",
-  "remainingTextFieldCharacterCountOther": "还可输入 $remainingCount 个字符"
+  "remainingTextFieldCharacterCountOther": "还可输入 $remainingCount 个字符",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_HK.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "展開",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "還可輸入 1 個字元",
-  "remainingTextFieldCharacterCountOther": "還可輸入 $remainingCount 個字元"
+  "remainingTextFieldCharacterCountOther": "還可輸入 $remainingCount 個字元",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh_TW.arb
@@ -50,5 +50,6 @@
   "collapsedIconTapHint": "展開",
   "remainingTextFieldCharacterCountZero": "TBD",
   "remainingTextFieldCharacterCountOne": "還可輸入 1 個字元",
-  "remainingTextFieldCharacterCountOther": "還可輸入 $remainingCount 個字元"
+  "remainingTextFieldCharacterCountOther": "還可輸入 $remainingCount 個字元",
+  "refreshIndicatorSemanticLabel": "TBD"
 }

--- a/packages/flutter_localizations/test/translations_test.dart
+++ b/packages/flutter_localizations/test/translations_test.dart
@@ -40,6 +40,7 @@ void main() {
       expect(localizations.alertDialogLabel, isNotNull);
       expect(localizations.collapsedIconTapHint, isNotNull);
       expect(localizations.expandedIconTapHint, isNotNull);
+      expect(localizations.refreshIndicatorSemanticLabel, isNotNull);
 
       expect(localizations.remainingTextFieldCharacterCount(0), isNotNull);
       expect(localizations.remainingTextFieldCharacterCount(1), isNotNull);


### PR DESCRIPTION
Fixes #14465 

Android does not make progress indicators announce anything by default - we're immitating that here by making it opt in (but still making it easier by providing a default implementation that can be easily used).

RefreshIndicator is made enabled by default because this should normally be a one at a time widget, and is indicating some kind of modal-like activity.

I'd appreciate feedback from people using these in accessible apps for sure!

Note that this does not address making the "swipe to refresh" action accessible.