### PR TITLE
[Material] Added support to has no control (continue/cancel button) in Stepper Widget

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -141,6 +141,7 @@ class Stepper extends StatefulWidget {
     this.onStepContinue,
     this.onStepCancel,
     this.controlsBuilder,
+    this.useControl,
   }) : assert(steps != null),
        assert(type != null),
        assert(currentStep != null),
@@ -221,6 +222,11 @@ class Stepper extends StatefulWidget {
   /// )
   /// ```
   final ControlsWidgetBuilder controlsBuilder;
+
+  /// The configuration to determine whether Stepper has default controlls.
+  ///
+  /// If true, the 'continue' and 'cancel' button will be build.
+  final bool useControl;
 
   @override
   _StepperState createState() => _StepperState();
@@ -547,10 +553,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               bottom: 24.0,
             ),
             child: Column(
-              children: <Widget>[
-                widget.steps[index].content,
-                _buildVerticalControls(),
-              ],
+              children: _buildVerticalControlsBody(index),
             ),
           ),
           firstCurve: const Interval(0.0, 0.6, curve: Curves.fastOutSlowIn),
@@ -561,6 +564,12 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         ),
       ],
     );
+  }
+
+  List<Widget> _buildVerticalControlsBody(int index) {
+    return widget.useControl
+        ? <Widget>[widget.steps[index].content, _buildVerticalControls()]
+        : <Widget>[Row(children: <Widget>[Container(child: widget.steps[index].content)])];
   }
 
   Widget _buildVertical() {
@@ -652,19 +661,28 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         Expanded(
           child: ListView(
             padding: const EdgeInsets.all(24.0),
-            children: <Widget>[
-              AnimatedSize(
-                curve: Curves.fastOutSlowIn,
-                duration: kThemeAnimationDuration,
-                vsync: this,
-                child: widget.steps[widget.currentStep].content,
-              ),
-              _buildVerticalControls(),
-            ],
+            children: _buildHorizontalBody(),
           ),
         ),
       ],
     );
+  }
+
+  List<Widget> _buildHorizontalBody() {
+    final List<Widget> horizontalBody = <Widget>[
+      AnimatedSize(
+        curve: Curves.fastOutSlowIn,
+        duration: kThemeAnimationDuration,
+        vsync: this,
+        child: widget.steps[widget.currentStep].content,
+      )
+    ];
+
+    if (widget.useControl) {
+      horizontalBody.add(_buildVerticalControls());
+    }
+
+    return horizontalBody;
   }
 
   @override

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -375,10 +375,10 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   }
 
   List<Widget> _buildStepContent(Widget stepContent) {
-    final Widget verticalControls = _buildVerticalControls();
-    return verticalControls == null 
+    final Widget verticalControl = _buildVerticalControls();
+    return verticalControl == null 
       ? <Widget>[Row(children: <Widget>[stepContent])]
-      : <Widget>[stepContent, verticalControls];
+      : <Widget>[stepContent, verticalControl];
   }
   
   Widget _buildVerticalControls() {

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -223,7 +223,7 @@ class Stepper extends StatefulWidget {
   /// ```
   final ControlsWidgetBuilder controlsBuilder;
 
-  /// The configuration to determine whether Stepper has default controlls.
+  /// The configuration to define whether Stepper has the default 'continue' and 'cancel' control.
   ///
   /// If true, the 'continue' and 'cancel' button will be build.
   final bool useControl;

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -141,7 +141,7 @@ class Stepper extends StatefulWidget {
     this.onStepContinue,
     this.onStepCancel,
     this.controlsBuilder,
-    this.useControl,
+    this.useControl = true,
   }) : assert(steps != null),
        assert(type != null),
        assert(currentStep != null),

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -141,7 +141,6 @@ class Stepper extends StatefulWidget {
     this.onStepContinue,
     this.onStepCancel,
     this.controlsBuilder,
-    this.useControl = true,
   }) : assert(steps != null),
        assert(type != null),
        assert(currentStep != null),
@@ -222,11 +221,6 @@ class Stepper extends StatefulWidget {
   /// )
   /// ```
   final ControlsWidgetBuilder controlsBuilder;
-
-  /// The configuration to define whether Stepper has the default 'continue' and 'cancel' control.
-  ///
-  /// If true, the 'continue' and 'cancel' button will be build.
-  final bool useControl;
 
   @override
   _StepperState createState() => _StepperState();
@@ -380,6 +374,13 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     }
   }
 
+  List<Widget> _buildStepContent(Widget stepContent) {
+    final Widget verticalControls = _buildVerticalControls();
+    return verticalControls == null 
+      ? <Widget>[Row(children: <Widget>[stepContent])]
+      : <Widget>[stepContent, verticalControls];
+  }
+  
   Widget _buildVerticalControls() {
     if (widget.controlsBuilder != null)
       return widget.controlsBuilder(context, onStepContinue: widget.onStepContinue, onStepCancel: widget.onStepCancel);
@@ -553,7 +554,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               bottom: 24.0,
             ),
             child: Column(
-              children: _buildVerticalControlsBody(index),
+              children: _buildStepContent(widget.steps[index].content),
             ),
           ),
           firstCurve: const Interval(0.0, 0.6, curve: Curves.fastOutSlowIn),
@@ -564,12 +565,6 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         ),
       ],
     );
-  }
-
-  List<Widget> _buildVerticalControlsBody(int index) {
-    return widget.useControl
-        ? <Widget>[widget.steps[index].content, _buildVerticalControls()]
-        : <Widget>[Row(children: <Widget>[Container(child: widget.steps[index].content)])];
   }
 
   Widget _buildVertical() {
@@ -661,28 +656,16 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         Expanded(
           child: ListView(
             padding: const EdgeInsets.all(24.0),
-            children: _buildHorizontalBody(),
+            children: _buildStepContent(AnimatedSize(
+                curve: Curves.fastOutSlowIn,
+                duration: kThemeAnimationDuration,
+                vsync: this,
+                child: widget.steps[widget.currentStep].content,
+              )),
           ),
         ),
       ],
     );
-  }
-
-  List<Widget> _buildHorizontalBody() {
-    final List<Widget> horizontalBody = <Widget>[
-      AnimatedSize(
-        curve: Curves.fastOutSlowIn,
-        duration: kThemeAnimationDuration,
-        vsync: this,
-        child: widget.steps[widget.currentStep].content,
-      )
-    ];
-
-    if (widget.useControl) {
-      horizontalBody.add(_buildVerticalControls());
-    }
-
-    return horizontalBody;
   }
 
   @override

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -182,6 +182,57 @@ void main() {
     expect(find.text('B'), findsOneWidget);
   });
 
+
+  testWidgets('Stepper control visibility test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            useControl: false,
+            type: StepperType.horizontal,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 1'),
+                content: Text('A'),
+              ),
+              Step(
+                title: Text('Step 2'),
+                content: Text('B'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('CONTINUE'), findsNothing);
+    expect(find.text('CANCEL'), findsNothing);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            currentStep: 1,
+            type: StepperType.horizontal,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 1'),
+                content: Text('A'),
+              ),
+              Step(
+                title: Text('Step 2'),
+                content: Text('B'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('CONTINUE'), findsOneWidget);
+    expect(find.text('CANCEL'), findsOneWidget);
+  });
+
   testWidgets('Stepper button test', (WidgetTester tester) async {
     bool continuePressed = false;
     bool cancelPressed = false;

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -182,57 +182,6 @@ void main() {
     expect(find.text('B'), findsOneWidget);
   });
 
-
-  testWidgets('Stepper control visibility test', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Stepper(
-            useControl: false,
-            type: StepperType.horizontal,
-            steps: const <Step>[
-              Step(
-                title: Text('Step 1'),
-                content: Text('A'),
-              ),
-              Step(
-                title: Text('Step 2'),
-                content: Text('B'),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    expect(find.text('CONTINUE'), findsNothing);
-    expect(find.text('CANCEL'), findsNothing);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Stepper(
-            currentStep: 1,
-            type: StepperType.horizontal,
-            steps: const <Step>[
-              Step(
-                title: Text('Step 1'),
-                content: Text('A'),
-              ),
-              Step(
-                title: Text('Step 2'),
-                content: Text('B'),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    expect(find.text('CONTINUE'), findsOneWidget);
-    expect(find.text('CANCEL'), findsOneWidget);
-  });
-
   testWidgets('Stepper button test', (WidgetTester tester) async {
     bool continuePressed = false;
     bool cancelPressed = false;
@@ -503,6 +452,60 @@ void main() {
     expect(canceledPressed, isTrue);
     expect(continuePressed, isTrue);
   });
+
+  testWidgets('Stepper control visibility test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            controlsBuilder: (BuildContext context,
+                {VoidCallback onStepContinue, VoidCallback onStepCancel}) {
+              return null;
+            },
+            type: StepperType.horizontal,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 1'),
+                content: Text('A'),
+              ),
+              Step(
+                title: Text('Step 2'),
+                content: Text('B'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('CONTINUE'), findsNothing);
+    expect(find.text('CANCEL'), findsNothing);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            currentStep: 1,
+            type: StepperType.horizontal,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 1'),
+                content: Text('A'),
+              ),
+              Step(
+                title: Text('Step 2'),
+                content: Text('B'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('CONTINUE'), findsOneWidget);
+    expect(find.text('CANCEL'), findsOneWidget);
+  });
+
 
   testWidgets('Stepper error test', (WidgetTester tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
Flutter stepper widget does not allow to has no control button (continue/cancel).

Solution: I have created a `bool useControl` property to allow developer choose between use or not control's button.

Case of use: Product delivery stepper is not controlled by users, the app/system controls it's delivery.