### PR TITLE
Use constant durations in more places

### DIFF
--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -113,7 +113,7 @@ void main() {
 
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 10));
+    await tester.pump(const Duration(milliseconds: 10));
     expect(tester.hasRunningAnimations, isTrue);
 
     await tester.pumpAndSettle();
@@ -126,7 +126,7 @@ void main() {
 
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 10));
+    await tester.pump(const Duration(milliseconds: 10));
     expect(tester.hasRunningAnimations, isTrue);
 
     await tester.pumpAndSettle();
@@ -149,25 +149,25 @@ void main() {
     // Icon starts to rotate down.
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
     expect(tester.hasRunningAnimations, isTrue);
 
     // Icon starts to rotate up mid animation.
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
     expect(tester.hasRunningAnimations, isTrue);
 
     // Icon starts to rotate down again still mid animation.
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
     expect(tester.hasRunningAnimations, isTrue);
 
     // Icon starts to rotate up to its original position mid animation.
     await tester.tap(find.byType(Icon));
     await tester.pump();
-    await tester.pump(Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
     expect(tester.hasRunningAnimations, isTrue);
 
     await tester.pumpAndSettle();

--- a/packages/flutter_tools/test/time_test.dart
+++ b/packages/flutter_tools/test/time_test.dart
@@ -15,7 +15,7 @@ void main() {
 
     test('can find a time ago', () {
       final SystemClock clock = SystemClock.fixed(DateTime(1991, 8, 23));
-      expect(clock.ago(Duration(days: 10)), DateTime(1991, 8, 13));
+      expect(clock.ago(const Duration(days: 10)), DateTime(1991, 8, 13));
     });
   });
 }


### PR DESCRIPTION
These were discovered by prefer_const_constructors when run against the version of the SDK on the 'analyzer' branch.