### PR TITLE
Fix multi-step build handling process.

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -255,7 +255,6 @@ BuildApp() {
   StreamOutput " └─Compiling, linking and signing..."
 
   RunCommand popd > /dev/null
-  StreamOutput "all done"
 
   echo "Project ${project_path} built and packaged successfully."
   return 0

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -255,6 +255,7 @@ BuildApp() {
   StreamOutput " └─Compiling, linking and signing..."
 
   RunCommand popd > /dev/null
+  StreamOutput "all done"
 
   echo "Project ${project_path} built and packaged successfully."
   return 0

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -443,9 +443,10 @@ Future<XcodeBuildResult> buildXcodeProject({
   Status initialBuildStatus;
   Directory tempDir;
 
+  File scriptOutputPipeFile;
   if (logger.hasTerminal) {
     tempDir = fs.systemTempDirectory.createTempSync('flutter_build_log_pipe.');
-    final File scriptOutputPipeFile = tempDir.childFile('pipe_to_stdout');
+    scriptOutputPipeFile = tempDir.childFile('pipe_to_stdout');
     os.makePipe(scriptOutputPipeFile.path);
 
     Future<void> listenToScriptOutputLine() async {
@@ -484,6 +485,8 @@ Future<XcodeBuildResult> buildXcodeProject({
     workingDirectory: app.project.hostAppRoot.path,
     allowReentrantFlutter: true
   );
+  // Notifies listener that no more output is coming.
+  scriptOutputPipeFile?.writeAsStringSync('all done');
   buildSubStatus?.stop();
   initialBuildStatus?.cancel();
   buildStopwatch.stop();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -451,10 +451,14 @@ Future<XcodeBuildResult> buildXcodeProject({
     Future<void> listenToScriptOutputLine() async {
       final List<String> lines = await scriptOutputPipeFile.readAsLines();
       for (String line in lines) {
-        if (line == 'done') {
+        if (line == 'done' || line == 'all done') {
           buildSubStatus?.stop();
           buildSubStatus = null;
-          return null;
+          if (line == 'all done') {
+            // Free pipe file.
+            tempDir?.deleteSync(recursive: true);
+            return null;
+          }
         } else {
           initialBuildStatus.cancel();
           buildSubStatus = logger.startProgress(
@@ -483,8 +487,6 @@ Future<XcodeBuildResult> buildXcodeProject({
   buildSubStatus?.stop();
   initialBuildStatus?.cancel();
   buildStopwatch.stop();
-  // Free pipe file.
-  tempDir?.deleteSync(recursive: true);
   printStatus(
     'Xcode build done.'.padRight(kDefaultStatusPadding + 1)
         + '${getElapsedAsSeconds(buildStopwatch.elapsed).padLeft(5)}',


### PR DESCRIPTION
Stop listening for new step updates only after 'all done.' log message that is explicitly added to the file after build process is finished. Make sure that we don't delete file too soon, until listener had a chance to process the 'all done' message.

This is follow-up to https://github.com/flutter/flutter/pull/23932.

Fixes https://github.com/flutter/flutter/issues/18750