### PR TITLE
Handle a missing ListView separator as an error

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -889,9 +889,28 @@ class ListView extends BoxScrollView {
        childrenDelegate = SliverChildBuilderDelegate(
          (BuildContext context, int index) {
            final int itemIndex = index ~/ 2;
-           return index.isEven
-             ? itemBuilder(context, itemIndex)
-             : separatorBuilder(context, itemIndex);
+           if (index.isEven) {
+             return itemBuilder(context, itemIndex);
+           } else {
+             Widget separator;
+             try {
+               separator = separatorBuilder(context, itemIndex);
+               if (separator == null) {
+                 throw FlutterError('separatorBuilder cannot return null.');
+               }
+             } catch (exception, stack) {
+               final FlutterErrorDetails details = FlutterErrorDetails(
+                 exception: exception,
+                 stack: stack,
+                 library: 'widgets library',
+                 context: 'building',
+                 informationCollector: null,
+               );
+               FlutterError.reportError(details);
+               separator = ErrorWidget.builder(details);
+             }
+             return separator;
+           }
          },
          childCount: _computeSemanticChildCount(itemCount),
          addAutomaticKeepAlives: addAutomaticKeepAlives,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -894,9 +894,12 @@ class ListView extends BoxScrollView {
              widget = itemBuilder(context, itemIndex);
            } else {
              widget = separatorBuilder(context, itemIndex);
-             if (widget == null) {
-               throw FlutterError('separatorBuilder cannot return null.');
-             }
+             assert(() {
+               if (widget == null) {
+                 throw FlutterError('separatorBuilder cannot return null.');
+               }
+               return true;
+             }());
            }
            return widget;
          },

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -890,20 +890,14 @@ class ListView extends BoxScrollView {
          (BuildContext context, int index) {
            final int itemIndex = index ~/ 2;
            Widget widget;
-           try {
-             if (index.isEven) {
-               widget = itemBuilder(context, itemIndex);
-             } else {
-               widget = separatorBuilder(context, itemIndex);
-               if (widget == null) {
-                 throw FlutterError('separatorBuilder cannot return null.');
-               }
+           if (index.isEven) {
+             widget = itemBuilder(context, itemIndex);
+           } else {
+             widget = separatorBuilder(context, itemIndex);
+             if (widget == null) {
+               throw FlutterError('separatorBuilder cannot return null.');
              }
-           } catch (exception) {
-             // If there was an error, use an ErrorWidget
-             widget = _createErrorWidget(exception);
            }
-
            return widget;
          },
          childCount: _computeSemanticChildCount(itemCount),
@@ -1401,25 +1395,4 @@ class GridView extends BoxScrollView {
       gridDelegate: gridDelegate,
     );
   }
-}
-
-// Return an ErrorWidget for the given Exception
-ErrorWidget _createErrorWidget(dynamic exception) {
-  // Get the stack trace by throwing
-  StackTrace stackTrace;
-  try {
-    throw exception;
-  } catch(thrownException, thrownStackTrace) {
-    stackTrace = thrownStackTrace;
-  }
-
-  final FlutterErrorDetails details = FlutterErrorDetails(
-    exception: exception,
-    stack: stackTrace,
-    library: 'widgets library',
-    context: 'building',
-    informationCollector: null,
-  );
-  FlutterError.reportError(details);
-  return ErrorWidget.builder(details);
 }

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -889,28 +889,22 @@ class ListView extends BoxScrollView {
        childrenDelegate = SliverChildBuilderDelegate(
          (BuildContext context, int index) {
            final int itemIndex = index ~/ 2;
-           if (index.isEven) {
-             return itemBuilder(context, itemIndex);
-           } else {
-             Widget separator;
-             try {
-               separator = separatorBuilder(context, itemIndex);
-               if (separator == null) {
+           Widget widget;
+           try {
+             if (index.isEven) {
+               widget = itemBuilder(context, itemIndex);
+             } else {
+               widget = separatorBuilder(context, itemIndex);
+               if (widget == null) {
                  throw FlutterError('separatorBuilder cannot return null.');
                }
-             } catch (exception, stack) {
-               final FlutterErrorDetails details = FlutterErrorDetails(
-                 exception: exception,
-                 stack: stack,
-                 library: 'widgets library',
-                 context: 'building',
-                 informationCollector: null,
-               );
-               FlutterError.reportError(details);
-               separator = ErrorWidget.builder(details);
              }
-             return separator;
+           } catch (exception) {
+             // If there was an error, use an ErrorWidget
+             widget = _createErrorWidget(exception);
            }
+
+           return widget;
          },
          childCount: _computeSemanticChildCount(itemCount),
          addAutomaticKeepAlives: addAutomaticKeepAlives,
@@ -1407,4 +1401,25 @@ class GridView extends BoxScrollView {
       gridDelegate: gridDelegate,
     );
   }
+}
+
+// Return an ErrorWidget for the given Exception
+ErrorWidget _createErrorWidget(dynamic exception) {
+  // Get the stack trace by throwing
+  StackTrace stackTrace;
+  try {
+    throw exception;
+  } catch(thrownException, thrownStackTrace) {
+    stackTrace = thrownStackTrace;
+  }
+
+  final FlutterErrorDetails details = FlutterErrorDetails(
+    exception: exception,
+    stack: stackTrace,
+    library: 'widgets library',
+    context: 'building',
+    informationCollector: null,
+  );
+  FlutterError.reportError(details);
+  return ErrorWidget.builder(details);
 }

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -392,7 +392,12 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
     assert(builder != null);
     if (index < 0 || (childCount != null && index >= childCount))
       return null;
-    Widget child = builder(context, index);
+    Widget child;
+    try {
+      child = builder(context, index);
+    } catch (exception, stackTrace) {
+      child = _createErrorWidget(exception, stackTrace);
+    }
     if (child == null)
       return null;
     if (addRepaintBoundaries)
@@ -1266,4 +1271,17 @@ class KeepAlive extends ParentDataWidget<SliverMultiBoxAdaptorWidget> {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<bool>('keepAlive', keepAlive));
   }
+}
+
+// Return an ErrorWidget for the given Exception
+ErrorWidget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
+  final FlutterErrorDetails details = FlutterErrorDetails(
+    exception: exception,
+    stack: stackTrace,
+    library: 'widgets library',
+    context: 'building',
+    informationCollector: null,
+  );
+  FlutterError.reportError(details);
+  return ErrorWidget.builder(details);
 }

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -413,18 +413,14 @@ void main() {
   });
 
   testWidgets('separatorBuilder must return something', (WidgetTester tester) async {
-    final List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
+    const List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
 
     Widget buildFrame(Widget firstSeparator) {
       return MaterialApp(
         home: Material(
           child: ListView.separated(
             itemBuilder: (BuildContext context, int index) {
-              return ListTile(
-                title: Text(
-                  listOfValues[index],
-                ),
-              );
+              return Text(listOfValues[index]);
             },
             separatorBuilder: (BuildContext context, int index) {
               if (index == 0) {
@@ -446,31 +442,24 @@ void main() {
     // A separatorBuilder that returns null throws a FlutterError
     await tester.pumpWidget(buildFrame(null));
     expect(tester.takeException(), isInstanceOf<FlutterError>());
+    expect(find.byType(ErrorWidget), findsOneWidget);
   });
 
   testWidgets('itemBuilder can return null', (WidgetTester tester) async {
-    final List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
+    const List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
     const Key key = Key('list');
-    const int RENDER_NULL_AT = 2;
+    const int RENDER_NULL_AT = 2; // only render the first 2 values
 
     Widget buildFrame() {
       return MaterialApp(
         home: Material(
-          child: ListView.separated(
+          child: ListView.builder(
             key: key,
             itemBuilder: (BuildContext context, int index) {
               if (index == RENDER_NULL_AT) {
                 return null;
-              } else  {
-                return ListTile(
-                  title: Text(
-                    listOfValues[index],
-                  ),
-                );
               }
-            },
-            separatorBuilder: (BuildContext context, int index) {
-              return const Divider();
+              return Text(listOfValues[index]);
             },
             itemCount: listOfValues.length,
           ),
@@ -478,43 +467,26 @@ void main() {
       );
     }
 
-    // An itemBuilder that returns null stops rendering items, but it does not
-    // throw an error or render an ErrorWidget
+    // The length of a list is itemCount or the index of the first itemBuilder
+    // that returns null, whichever is smaller
     await tester.pumpWidget(buildFrame());
     expect(tester.takeException(), isNull);
-    final Finder errorFinder = find.descendant(
-      of: find.byKey(key),
-      matching: find.byType(ErrorWidget),
-    );
-    expect(errorFinder, findsNothing);
-    final Finder itemFinder = find.descendant(
-      of: find.byKey(key),
-      matching: find.byType(ListTile),
-    );
-    expect(itemFinder, findsNWidgets(RENDER_NULL_AT));
+    expect(find.byType(ErrorWidget), findsNothing);
+    expect(find.byType(Text), findsNWidgets(RENDER_NULL_AT));
   });
 
   testWidgets('when itemBuilder throws, creates Error Widget', (WidgetTester tester) async {
-    final List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
-    const Key key = Key('list');
+    const List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
 
     Widget buildFrame(bool throwOnFirstItem) {
       return MaterialApp(
         home: Material(
-          child: ListView.separated(
-            key: key,
+          child: ListView.builder(
             itemBuilder: (BuildContext context, int index) {
               if (index == 0 && throwOnFirstItem) {
                 throw Exception('itemBuilder fail');
               }
-              return ListTile(
-                title: Text(
-                  listOfValues[index],
-                ),
-              );
-            },
-            separatorBuilder: (BuildContext context, int index) {
-              return const Divider();
+              return Text(listOfValues[index]);
             },
             itemCount: listOfValues.length,
           ),
@@ -525,11 +497,8 @@ void main() {
     // When itemBuilder doesn't throw, no ErrorWidget
     await tester.pumpWidget(buildFrame(false));
     expect(tester.takeException(), isNull);
-    final Finder finder = find.descendant(
-      of: find.byKey(key),
-      matching: find.byType(ErrorWidget),
-    );
-    expect(finder, findsNothing);
+    final Finder finder = find.byType(ErrorWidget);
+    expect(find.byType(ErrorWidget), findsNothing);
 
     // When it does throw, one error widget is rendered in the item's place
     await tester.pumpWidget(buildFrame(true));
@@ -538,7 +507,7 @@ void main() {
   });
 
   testWidgets('when separatorBuilder throws, creates ErrorWidget', (WidgetTester tester) async {
-    final List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
+    const List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
     const Key key = Key('list');
 
     Widget buildFrame(bool throwOnFirstSeparator) {
@@ -547,11 +516,7 @@ void main() {
           child: ListView.separated(
             key: key,
             itemBuilder: (BuildContext context, int index) {
-              return ListTile(
-                title: Text(
-                  listOfValues[index],
-                ),
-              );
+              return Text(listOfValues[index]);
             },
             separatorBuilder: (BuildContext context, int index) {
               if (index == 0 && throwOnFirstSeparator) {
@@ -568,11 +533,8 @@ void main() {
     // When separatorBuilder doesn't throw, no ErrorWidget
     await tester.pumpWidget(buildFrame(false));
     expect(tester.takeException(), isNull);
-    final Finder finder = find.descendant(
-      of: find.byKey(key),
-      matching: find.byType(ErrorWidget),
-    );
-    expect(finder, findsNothing);
+    final Finder finder = find.byType(ErrorWidget);
+    expect(find.byType(ErrorWidget), findsNothing);
 
     // When it does throw, one error widget is rendered in the separator's place
     await tester.pumpWidget(buildFrame(true));

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import 'states.dart';
 
@@ -409,5 +410,42 @@ void main() {
     );
     await tester.dragFrom(const Offset(100.0, 100.0), const Offset(0.0, 100.0));
     expect(scrolled, isFalse);
+  });
+
+  testWidgets('separatorBuilder must return something', (WidgetTester tester) async {
+    final List<String> listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
+
+    Widget buildFrame(Widget firstSeparator) {
+      return MaterialApp(
+        home: Material(
+          child: ListView.separated(
+            itemBuilder: (BuildContext context, int index) {
+              return ListTile(
+                title: Text(
+                  listOfValues[index],
+                  textAlign: TextAlign.center,
+                ),
+              );
+            },
+            separatorBuilder: (BuildContext context, int index) {
+              if (index == 0) {
+                return firstSeparator;
+              } else  {
+                return const Divider();
+              }
+            },
+            itemCount: listOfValues.length,
+          ),
+        ),
+      );
+    }
+
+    // A separatorBuilder that always returns a Divider is fine
+    await tester.pumpWidget(buildFrame(const Divider()));
+    expect(tester.takeException(), isNull);
+
+    // A separatorBuilder that returns null throws a FlutterError
+    await tester.pumpWidget(buildFrame(null));
+    expect(tester.takeException(), isInstanceOf<FlutterError>());
   });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/23515

Now a `separatorBuilder` that returns null looks like this:
![screenshot_20181113-154845](https://user-images.githubusercontent.com/389558/48450796-7e7e1600-e75c-11e8-83df-7a651da73fa6.png)
