### PR TITLE
Switch engine.merge_method back to squash

### DIFF
--- a/bin/internal/engine.merge_method
+++ b/bin/internal/engine.merge_method
@@ -1,1 +1,1 @@
-rebase
+squash


### PR DESCRIPTION
Unfortunately, device lab does not have the capacity for merge method `rebase`. It's essentially DoSing device lab: The last engine `rebase` has been processing for over 6h now and it is still not done :(