### PR TITLE
Remove timeout waiting for app to start

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -429,12 +429,7 @@ class AppDomain extends Domain {
     final Completer<void> appStartedCompleter = Completer<void>();
     // We don't want to wait for this future to complete and callbacks won't fail.
     // As it just writes to stdout.
-    appStartedCompleter.future.timeout(const Duration(minutes: 3), onTimeout: () { // ignore: unawaited_futures
-      _sendAppEvent(app, 'log', <String, dynamic>{
-        'log': 'timeout waiting for the application to start',
-        'error': true,
-      });
-    }).then<void>((_) {
+    appStartedCompleter.future.then<void>((_) { // ignore: unawaited_futures
       _sendAppEvent(app, 'started');
     });
 


### PR DESCRIPTION
I know @Hixie is working on removing a lot of timeouts, but since that work (I think) keeps getting blocked, I think it's worth removing this one now because it seems to be causing issues. The problem is that when the code times out, it writes a log but then it also sends the `app.started` event immediately (which is incorrect - the app has not started yet, only the timeout period has elapsed) which results in the IDEs trying to do startup things that they should not (yet)

I think this is safe to do because this timeout was only added fairly recently (https://github.com/flutter/flutter/pull/21696) and I don't think it directly contributed to the issue being fixed in that PR. I did previously increase the timeout (https://github.com/flutter/flutter/pull/22504) but some people still hit it (we could just increase it further, but picking a duration that is long enough for all builds of all apps on all users machines is probably going to effectively be the same as removing it).

Here are some issues I think are caused by (or at least difficult to understand because of) this:

- https://github.com/flutter/flutter/issues/23861
- https://github.com/flutter/flutter/issues/23947
- https://github.com/flutter/flutter/issues/22338
- https://github.com/Dart-Code/Dart-Code/issues/1262

It's possible some of them are hitting the timeout because they're broken, but if so, it'll be easier to track them down when the hang is visible, rather than the IDE continuing to try and launch a debugger and fail further down the line.