### PR TITLE
Fix test so it doesn't leak frontend_server process

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -53,6 +53,7 @@ void main() {
       final File pidFile = tempDir.childFile('test.pid');
       await _flutter.run(pidFile: pidFile);
       expect(pidFile.existsSync(), isTrue);
+      await _flutter?.stop();
     });
   }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -52,8 +52,11 @@ void main() {
     test('writes pid-file', () async {
       final File pidFile = tempDir.childFile('test.pid');
       await _flutter.run(pidFile: pidFile);
-      expect(pidFile.existsSync(), isTrue);
-      await _flutter?.stop();
+      try {
+        expect(pidFile.existsSync(), isTrue);
+      } finally {
+        await _flutter.stop();
+      }
     });
   }, timeout: const Timeout.factor(6));
 }


### PR DESCRIPTION
flutter_run_test doesn't stop FlutterTestDriver, which results in frontend_server processes staying running in memory