### PR TITLE
Add dashing config file for generating docset from flutter docs

### DIFF
--- a/dev/docs/dashing.json
+++ b/dev/docs/dashing.json
@@ -1,0 +1,105 @@
+{
+  "name": "flutter",
+  "package": "flutter",
+  "version": "{{VERSION}}",
+  "author": {
+    "name": "The Flutter Team",
+    "link": "https://flutter.io"
+  },
+  "index": "index.html",
+  "icon32x32": "flutter/static-assets/favicon.png",
+  "allowJS": true,
+  "ExternalURL": "https://docs.flutter.io",
+  "selectors": {
+
+    "#exceptions span.name a": {
+      "type": "Exception"
+    },
+
+    "body > main > div.col-xs-12.col-sm-9.col-md-8.main-content > h1": {
+      "requiretext": " library",
+      "type": "Library",
+      "regexp": " library",
+      "replacement": ""
+    },
+
+    "body > main > div.col-xs-12.col-sm-9.main-content > h1": {
+      "requiretext": " class",
+      "type": "Class",
+      "regexp": " class",
+      "replacement": ""
+    },
+
+    "body > main > div.col-xs-12.col-md-8.main-content > h1": {
+      "requiretext": " function",
+      "type": "Function",
+      "regexp": " function",
+      "replacement": ""
+    },
+
+    "body > main > div.col-sm-9.col-md-8.main-content > h1": {
+      "requiretext": " typedef",
+      "type": "Type",
+      "regexp": " typedef",
+      "replacement": ""
+    },
+
+    "body > main > .col-xs-12.col-sm-9.col-md-8.main-content > h1": {
+      "requiretext": " enum",
+      "type": "Enum",
+      "regexp": " enum",
+      "replacement": ""
+    },
+
+    "body > main > .col-md-8.main-content > h1": {
+      "requiretext": " constant",
+      "type": "Constant",
+      "regexp": " constant",
+      "replacement": ""
+    },
+
+    "body > main > div.col-xs-12.col-sm-9 > h1": {
+      "requiretext": " method",
+      "type": "Method",
+      "regexp": " method",
+      "replacement": ""
+    },
+
+    ".callables .callable .name a": {
+      "type": "Method"
+    },
+
+    "body > main > .col-xs-12.col-sm-9.col-md-8 > h1": {
+      "requiretext": " property",
+      "type": "Property",
+      "regexp": " property",
+      "replacement": ""
+    },
+
+    "body > main > .col-xs-12.col-md-8 > h1": {
+      "requiretext": " constructor",
+      "type": "Constructor",
+      "regexp": " constructor",
+      "replacement": ""
+    },
+
+    "body > main > .col-xs-12.col-sm-9.main-content > h1": {
+      "requiretext": "operator ",
+      "type": "Operator",
+      "regexp": "operator ",
+      "replacement": ""
+    },
+
+    ".callables .callable": {
+      "requiretext": "operator ",
+      "type": "Operator",
+      "regexp": "operator ",
+      "replacement": ""
+    }
+
+
+  },
+  "ignore": [
+    "ABOUT"
+  ]
+}


### PR DESCRIPTION
The aim of this PR is to introduce `.docset` for Flutter APIs in relation to #9955.

A brief description about building this docset:

## Prerequisites

1. A clone of the Flutter repository
2. Installed [technosophos/dashing](https://github.com/imWildCat/flutter-docset)

## Docset building procedure

1. Run the script `dev/bots/docs.sh` to build Flutter docs.
2. Execute `dashing build --source ./doc --config dashing.json` to build the docset.

## Issues of this configuration file

1. There is no configuration field for the version number in the requirements of `dashing.json`. The version number could be specified at a 'Dash documentation feeds' file. For more details, please read: [https://kapeli.com/docsets#dashdocsetfeed](https://kapeli.com/docsets#dashdocsetfeed). In addition, here is my minimal example: [https://github.com/imWildCat/flutter-docset/blob/master/flutter.xml](https://github.com/imWildCat/flutter-docset/blob/master/flutter.xml).

2. As for `icon32x32` in `dashing.json`, `dev/docs/doc/flutter/static-assets/favicon.png` is used currently. This icon image works well in the Dash.app though this image is actually '64x64'.
3. The selectors of different [entry types](entries) should be improved for better doc navigation.

## References

1. Supported Entry Types - Docset Generation Guide: [https://kapeli.com/docsets#supportedentrytypes](https://kapeli.com/docsets#supportedentrytypes)
2. technosophos/dashing: A Dash Generator Script for Any HTML: [https://github.com/technosophos/dashing](https://github.com/technosophos/dashing)