### PR TITLE
Make FlutterTestDriver.stop() safe to call if it didn't spawn a process

### DIFF
--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -25,6 +25,7 @@ void main() {
     });
 
     tearDown(() async {
+      await _flutter.stop();
       tryToDelete(tempDir);
     });
 
@@ -52,11 +53,7 @@ void main() {
     test('writes pid-file', () async {
       final File pidFile = tempDir.childFile('test.pid');
       await _flutter.run(pidFile: pidFile);
-      try {
-        expect(pidFile.existsSync(), isTrue);
-      } finally {
-        await _flutter.stop();
-      }
+      expect(pidFile.existsSync(), isTrue);
     });
   }, timeout: const Timeout.factor(6));
 }

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -220,8 +220,11 @@ class FlutterTestDriver {
       );
       _currentRunningAppId = null;
     }
-    _debugPrint('Waiting for process to end');
-    return _proc.exitCode.timeout(quitTimeout, onTimeout: _killGracefully);
+    if (_proc != null) {
+      _debugPrint('Waiting for process to end');
+      return _proc.exitCode.timeout(quitTimeout, onTimeout: _killGracefully);
+    }
+    return 0;
   }
 
   Future<int> quit() => _killGracefully();


### PR DESCRIPTION
This means we can just always add it to test teardowns without having to add try/catches if there are any tests that don't spawn a process.