### PR TITLE
fix devicelab

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -154,8 +154,8 @@ Future<void> main() async {
             'Debug',
             'CODE_SIGNING_ALLOWED=NO',
             'CODE_SIGNING_REQUIRED=NO',
-            'CODE_SIGN_IDENTITY=',
-            'EXPANDED_CODE_SIGN_IDENTITY=',
+            'CODE_SIGN_IDENTITY=-',
+            'EXPANDED_CODE_SIGN_IDENTITY=-',
             'CONFIGURATION_BUILD_DIR=${tempDir.path}',
           ],
         );


### PR DESCRIPTION
I __believe__ this will fix the devicelab - it passes locally, but so does my previous attempt.

I'm unable to test it on the boxes themselves, I keep getting kicked off.

Based on what I've seen in https://github.com/CocoaPods/CocoaPods/issues/7708