### PR TITLE
Implement handling for `setInitialRoute`

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -98,6 +98,7 @@ class CupertinoApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.onSetInitialRoute,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -107,6 +108,9 @@ class CupertinoApp extends StatefulWidget {
        assert(showSemanticsDebugger != null),
        assert(debugShowCheckedModeBanner != null),
        super(key: key);
+
+  /// {@macro flutter.widgets.widgetsApp.onSetInitialRoute}
+  final ValueChanged<String> onSetInitialRoute;
 
   /// {@macro flutter.widgets.widgetsApp.navigatorKey}
   final GlobalKey<NavigatorState> navigatorKey;
@@ -308,6 +312,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
             onPressed: onPressed,
           );
         },
+        onSetInitialRoute: widget.onSetInitialRoute,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -107,6 +107,7 @@ class MaterialApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.onSetInitialRoute,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -117,6 +118,9 @@ class MaterialApp extends StatefulWidget {
        assert(showSemanticsDebugger != null),
        assert(debugShowCheckedModeBanner != null),
        super(key: key);
+
+  /// {@macro flutter.widgets.widgetsApp.onSetInitialRoute}
+  final ValueChanged<String> onSetInitialRoute;
 
   /// {@macro flutter.widgets.widgetsApp.navigatorKey}
   final GlobalKey<NavigatorState> navigatorKey;
@@ -443,6 +447,7 @@ class _MaterialAppState extends State<MaterialApp> {
             mini: true,
           );
         },
+        onSetInitialRoute: widget.onSetInitialRoute,
       )
     );
 

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -22,10 +22,16 @@ class SystemChannels {
   ///  * `pushRoute`, which is called with a single string argument when the
   ///    operating system instructs the application to open a particular page.
   ///
+  ///  * `setInitialRoute`, which is called with a single string argument when
+  ///    the system wants the routing state to be reset to a specific. The last
+  ///    call made to this before the Dart Isolate started running is available
+  ///    as the [dart:ui.Window.defaultRouteName] property.
+  ///
   /// See also:
   ///
-  ///  * [WidgetsBindingObserver.didPopRoute] and
-  ///    [WidgetsBindingObserver.didPushRoute], which expose this channel's
+  ///  * [WidgetsBindingObserver.didPopRoute],
+  ///    [WidgetsBindingObserver.didPushRoute], and
+  ///    [WidgetsBindingObserver.didSetInitialRoute] which expose this channel's
   ///    methods.
   static const MethodChannel navigation = MethodChannel(
       'flutter/navigation',

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -139,6 +139,9 @@ class WidgetsApp extends StatefulWidget {
   ///
   /// The `supportedLocales` argument must be a list of one or more elements.
   /// By default supportedLocales is `[const Locale('en', 'US')]`.
+  ///
+  /// The `onSetInitialRoute` argument can be used to handle the `setInitialRoute` message
+  /// on the [SystemChannels.navigation] channel.
   WidgetsApp({ // can't be const because the asserts use methods on Iterable :-(
     Key key,
     this.navigatorKey,
@@ -166,6 +169,7 @@ class WidgetsApp extends StatefulWidget {
     this.debugShowWidgetInspector = false,
     this.debugShowCheckedModeBanner = true,
     this.inspectorSelectButtonBuilder,
+    this.onSetInitialRoute,
   }) : assert(navigatorObservers != null),
        assert(routes != null),
        assert(
@@ -224,6 +228,15 @@ class WidgetsApp extends StatefulWidget {
        assert(debugShowCheckedModeBanner != null),
        assert(debugShowWidgetInspector != null),
        super(key: key);
+
+  /// {@template flutter.widgets.widgetsApp.onSetInitialRoute}
+  /// The callback to invoke when the `setInitialRoute` method is
+  /// invoked on the [SystemChannels.navigation] channel. Calls to
+  /// that method made before the current isolate starts will be
+  /// available on [ui.window.defaultRouteName]. Listeners interested
+  /// in calls after that point should set a callback here.
+  /// {@endtemplate}
+  final ValueChanged<String> onSetInitialRoute;
 
   /// {@template flutter.widgets.widgetsApp.navigatorKey}
   /// A key to use when building the [Navigator].
@@ -793,6 +806,15 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
       return false;
     navigator.pushNamed(route);
     return true;
+  }
+
+  @override
+  Future<bool> didSetInitialRoute(String route) async {
+    if (widget.onSetInitialRoute != null) {
+      widget.onSetInitialRoute(route);
+      return true;
+    }
+    return false;
   }
 
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -105,6 +105,17 @@ abstract class WidgetsBindingObserver {
   /// [SystemChannels.navigation].
   Future<bool> didPushRoute(String route) => Future<bool>.value(false);
 
+  /// Called when the host tells the app to reset navigation state to the
+  /// specified route.
+  ///
+  /// Observers are expected to return true if they were able to
+  /// handle the notification. Observers are notified in registration
+  /// order until one returns true.
+  ///
+  /// This method exposes the `didSetInitialRoute` notification from
+  /// [SystemChannels.navigation].
+  Future<bool> didSetInitialRoute(String route) => Future<bool>.value(false);
+
   /// Called when the application's dimensions change. For example,
   /// when a phone is rotated.
   ///
@@ -484,12 +495,35 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
     }
   }
 
+  /// Called when the host tells the app to reset navigation state to the specified
+  /// route.
+  ///
+  /// This notifies the binding observers (using
+  /// [WidgetsBindingObserver.didSetInitialRoute]), in registration order, until one
+  /// returns true, meaning that it was able to handle the request (e.g. rebuilding the
+  /// app at the specified route). If none return true, then nothing happens.
+  ///
+  /// This method exposes the `setInitialRoute` notification from
+  /// [SystemChannels.navigation].
+  @protected
+  @mustCallSuper
+  @visibleForTesting
+  Future<void> handleSetInitialRoute(String route) async {
+    for (WidgetsBindingObserver observer in List<WidgetsBindingObserver>.from(_observers)) {
+      if (await observer.didSetInitialRoute(route))
+        return;
+    }
+  }
+
   Future<dynamic> _handleNavigationInvocation(MethodCall methodCall) {
+    print('setting nav $methodCall');
     switch (methodCall.method) {
       case 'popRoute':
         return handlePopRoute();
       case 'pushRoute':
         return handlePushRoute(methodCall.arguments);
+      case 'setInitialRoute':
+        return handleSetInitialRoute(methodCall.arguments);
     }
     return Future<dynamic>.value();
   }

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -15,4 +15,24 @@ void main() {
     );
     expect(find.byKey(key), findsOneWidget);
   });
+
+  testWidgets('WidgetsApp can be notified of setInitialRoute changes', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    String initialRouteName = '/';
+    await tester.pumpWidget(
+      WidgetsApp(
+        key: key,
+        builder: (BuildContext context, Widget child) {
+          return const Placeholder();
+        },
+        onSetInitialRoute: (String name) => initialRouteName = name,
+        color: const Color(0xFF123456),
+      ),
+    );
+    expect(find.byKey(key), findsOneWidget);
+    expect(initialRouteName, equals('/'));
+
+    tester.binding.handleSetInitialRoute('/another');
+    expect(initialRouteName, equals('/another'));
+  });
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_mr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mr.arb
@@ -51,5 +51,6 @@
   "collapsedIconTapHint": "विस्तृत",
   "remainingTextFieldCharacterCountZero": "कोणतेही वर्ण शिल्लक नाहीत",
   "remainingTextFieldCharacterCountOne": "1 वर्ण उर्वरित",
-  "remainingTextFieldCharacterCountOther": "$remainingCount वर्ण उर्वरित"
+  "remainingTextFieldCharacterCountOther": "$remainingCount वर्ण उर्वरित",
+  "refreshIndicatorSemanticLabel": "TBD"
 }


### PR DESCRIPTION
The engine special cases the `setInitialRoute` platform message and stores it in `dart:ui.Window.defaultRouteName`.  However, this variable will only be set if `setInitialRoute` is called in the embedding __before__ the engine starts running.  Otherwise it's sent to the Flutter side, but not handled currently.  This is a source of confusion for Add2App customers, who have expected `setInitialRoute` to work at various stages and don't have a good way to inform the Flutter app that they want to just throw away all current nav state and reset to a new route (so not `pushRoute` - in particular, there are use cases where we don't want to see routes animating, and we don't want a back button to get us anywhere in Flutter, they really want something like just calling `runApp` all over again).

This adds handling logic for the method by exposing a `ValueChange<String>` callback on `WidgetsApp`, `MaterialApp`, and `CupertinoApp`.  The `onSetInitialRoute` callback can be implemented in such a way that it results in calling `runApp` again, or otherwise clearing out state that the user no longer is interested in (without resetting the whole Dart isolate).