### PR TITLE
[ci] add more memory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,7 @@ task:
         - dart ./dev/bots/test.dart
       container:
         cpu: 4
-        memory: 8G
+        memory: 12G
     - name: tool_tests-linux
       env:
         SHARD: tool_tests
@@ -61,7 +61,7 @@ task:
         - dart ./dev/bots/test.dart
       container:
         cpu: 4
-        memory: 8G
+        memory: 12G
     - name: aot_build_tests-linux
       env:
         SHARD: aot_build_tests
@@ -69,7 +69,7 @@ task:
         - dart ./dev/bots/test.dart
       container:
         cpu: 4
-        memory: 8G
+        memory: 12G
     - name: codelabs-build-test
       env:
         SHARD: codelabs-build-test


### PR DESCRIPTION
While investigating reports from @gspencergoog about unexpectedly failing tasks I've found out that `tool_tests` sometimes fails with Out Of Memory errors. I've also added detection of such issues to Cirrus CI so in future you'll see something like:

<img width="1009" alt="screen shot 2018-11-16 at 2 28 55 pm" src="https://user-images.githubusercontent.com/989066/48643825-d01ddf00-e9ae-11e8-8cf8-6f6f8aa5b848.png">
