### PR TITLE
covariant

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -594,7 +594,7 @@ abstract class StatelessWidget extends Widget {
   ///
   ///  * The discussion on performance considerations at [StatelessWidget].
   @protected
-  Widget build(BuildContext context);
+  Widget build(covariant BuildContext context);
 }
 
 /// A widget that has mutable state.
@@ -1295,7 +1295,7 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   ///
   ///  * The discussion on performance considerations at [StatefulWidget].
   @protected
-  Widget build(BuildContext context);
+  Widget build(covariant BuildContext context);
 
   /// Called when a dependency of this [State] object changes.
   ///


### PR DESCRIPTION
Made the `build` method of both `StatelessWidget` and `StatefulWidget` covariant. 

This is to allow library creators to subclass these widgets and their respective elements to add public methods on `BuildContext`.

Example:

```dart
abstract class MyBuildContext extends BuildContext { } 
 
class MyElement extends StatelessElement implements MyBuildContext {
  MyElement(MyWidget widget): super(widget);

  @override
  MyWidget get widget => super.widget;
}

abstract class MyWidget extends StatelessWidget {
  @override
  MyElement createElement() => MyElement(this);

  Widget build(MyBuildContext context);
}
```
