### PR TITLE
Adding relative position support to Stack widget

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -194,6 +194,9 @@ class StackParentData extends ContainerBoxParentData<RenderBox> {
   /// Ignored if both top and bottom are non-null.
   double height;
 
+  /// Whether the postioned values are considered as a fraction of the [Stack] size.
+  bool isRelative;
+
   /// Get or set the current values in terms of a RelativeRect object.
   RelativeRect get rect => RelativeRect.fromLTRB(left, top, right, bottom);
   set rect(RelativeRect value) {
@@ -210,6 +213,24 @@ class StackParentData extends ContainerBoxParentData<RenderBox> {
   /// of the stack but are instead placed relative to the non-positioned
   /// children in the stack.
   bool get isPositioned => top != null || right != null || bottom != null || left != null || width != null || height != null;
+
+  void _resolve(Size size){
+    if (isRelative){
+      if (top != null)
+        top *= size.height;
+      if (right != null)
+        right *= size.width;
+      if (bottom != null)
+        bottom *= size.height;
+      if (left != null)
+        left *= size.width;
+      if (width != null)
+        width *= size.width;
+      if (height != null)
+        height *= size.height;
+      isRelative = false;
+    }
+  }
 
   @override
   String toString() {
@@ -312,8 +333,8 @@ enum Overflow {
 ///
 /// Once the child is laid out, the stack positions the child
 /// according to the top, right, bottom, and left properties of their
-/// [StackParentData]. For example, if the bottom value is 10.0, the
-/// bottom edge of the child will be inset 10.0 pixels from the bottom
+/// [StackParentData]. For example, if the bottom value is 10.0 and isRelative
+/// is false, the bottom edge of the child will be inset 10.0 pixels from the bottom
 /// edge of the stack. If the child extends beyond the bounds of the
 /// stack, the stack will clip the child's painting to the bounds of
 /// the stack.
@@ -534,6 +555,7 @@ class RenderStack extends RenderBox
       if (!childParentData.isPositioned) {
         childParentData.offset = _resolvedAlignment.alongOffset(size - child.size);
       } else {
+        childParentData._resolve(size);
         BoxConstraints childConstraints = const BoxConstraints();
 
         if (childParentData.left != null && childParentData.right != null)

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -215,6 +215,7 @@ class StackParentData extends ContainerBoxParentData<RenderBox> {
   bool get isPositioned => top != null || right != null || bottom != null || left != null || width != null || height != null;
 
   void _resolve(Size size){
+    assert(isRelative != null);
     if (isRelative){
       if (top != null)
         top *= size.height;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2776,7 +2776,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 /// If you want to lay a number of children out in a particular pattern, or if
 /// you want to make a custom layout manager, you probably want to use
 /// [CustomMultiChildLayout] instead. In particular, when using a [Stack] you
-/// can't position children relative to their size or the stack's own size.
+/// can't position children relative to their size.
 ///
 /// See also:
 ///
@@ -2943,6 +2943,9 @@ class IndexedStack extends Stack {
 /// If all six values are null, the child is a non-positioned child. The [Stack]
 /// uses only the non-positioned children to size itself.
 ///
+/// If [isRelative] is true, the child will be positioned relatively to the
+/// [Stack]'s size.
+///
 /// See also:
 ///
 ///  * [PositionedDirectional], which adapts to the ambient [Directionality].
@@ -2968,6 +2971,7 @@ class Positioned extends ParentDataWidget<Stack> {
     this.bottom,
     this.width,
     this.height,
+    this.isRelative = false,
     @required Widget child,
   }) : assert(left == null || right == null || width == null),
        assert(top == null || bottom == null || height == null),
@@ -2981,6 +2985,7 @@ class Positioned extends ParentDataWidget<Stack> {
   Positioned.fromRect({
     Key key,
     Rect rect,
+    this.isRelative = false,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,
@@ -2997,6 +3002,7 @@ class Positioned extends ParentDataWidget<Stack> {
   Positioned.fromRelativeRect({
     Key key,
     RelativeRect rect,
+    this.isRelative = false,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,
@@ -3014,6 +3020,7 @@ class Positioned extends ParentDataWidget<Stack> {
     this.top = 0.0,
     this.right = 0.0,
     this.bottom = 0.0,
+    this.isRelative = false,
     @required Widget child,
   }) : width = null,
        height = null,
@@ -3046,6 +3053,7 @@ class Positioned extends ParentDataWidget<Stack> {
     double bottom,
     double width,
     double height,
+    bool isRelative = false,
     @required Widget child,
   }) {
     assert(textDirection != null);
@@ -3069,6 +3077,7 @@ class Positioned extends ParentDataWidget<Stack> {
       bottom: bottom,
       width: width,
       height: height,
+      isRelative: isRelative,
       child: child,
     );
   }
@@ -3127,6 +3136,15 @@ class Positioned extends ParentDataWidget<Stack> {
   /// vertically.
   final double height;
 
+  /// Whether the child is positioned relatively to the [Stack]'s size.
+  /// 
+  /// For example if the [Stack]'s width is 200.0 pixels, [left] is 0.25
+  /// and [isRelative] is true, then the left edge of the child will be inset
+  /// 50.0 pixels from the left edge of the [Stack].
+  /// 
+  /// Defaults to false.
+  final bool isRelative;
+
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is StackParentData);
@@ -3163,6 +3181,11 @@ class Positioned extends ParentDataWidget<Stack> {
       needsLayout = true;
     }
 
+    if (parentData.isRelative != isRelative) {
+      parentData.isRelative = isRelative;
+      needsLayout = true;
+    }
+
     if (needsLayout) {
       final AbstractNode targetParent = renderObject.parent;
       if (targetParent is RenderObject)
@@ -3179,6 +3202,7 @@ class Positioned extends ParentDataWidget<Stack> {
     properties.add(DoubleProperty('bottom', bottom, defaultValue: null));
     properties.add(DoubleProperty('width', width, defaultValue: null));
     properties.add(DoubleProperty('height', height, defaultValue: null));
+    properties.add(FlagProperty('isRelative', value:isRelative, ifTrue: 'enabled', ifFalse: 'disabled', showName: true, defaultValue: false));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3137,11 +3137,11 @@ class Positioned extends ParentDataWidget<Stack> {
   final double height;
 
   /// Whether the child is positioned relatively to the [Stack]'s size.
-  /// 
+  ///
   /// For example if the [Stack]'s width is 200.0 pixels, [left] is 0.25
   /// and [isRelative] is true, then the left edge of the child will be inset
   /// 50.0 pixels from the left edge of the [Stack].
-  /// 
+  ///
   /// Defaults to false.
   final bool isRelative;
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -491,6 +491,7 @@ class PositionedTransition extends AnimatedWidget {
     Key key,
     @required Animation<RelativeRect> rect,
     @required this.child,
+    this.isRelative = false,
   }) : super(key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
@@ -501,11 +502,17 @@ class PositionedTransition extends AnimatedWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
+  /// Whether the child is positioned relatively to the [Stack]'s size.
+  ///
+  /// Defaults to false.
+  final bool isRelative;
+
   @override
   Widget build(BuildContext context) {
     return Positioned.fromRelativeRect(
       rect: rect.value,
       child: child,
+      isRelative: isRelative,
     );
   }
 }
@@ -543,6 +550,7 @@ class RelativePositionedTransition extends AnimatedWidget {
     @required Animation<Rect> rect,
     @required this.size,
     @required this.child,
+    this.isRelative = false,
   }) : super(key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
@@ -559,6 +567,11 @@ class RelativePositionedTransition extends AnimatedWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
+  /// Whether the child is positioned relatively to the [Stack]'s size.
+  ///
+  /// Defaults to false.
+  final bool isRelative;
+
   @override
   Widget build(BuildContext context) {
     final RelativeRect offsets = RelativeRect.fromSize(rect.value, size);
@@ -568,6 +581,7 @@ class RelativePositionedTransition extends AnimatedWidget {
       bottom: offsets.bottom,
       left: offsets.left,
       child: child,
+      isRelative: isRelative,
     );
   }
 }

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -35,7 +35,8 @@ void main() {
       ..top = 0.0
       ..right = 0.0
       ..bottom = 0.0
-      ..left = 0.0;
+      ..left = 0.0
+      ..isRelative = false;
 
     layout(stack, constraints: const BoxConstraints());
 

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -130,4 +130,80 @@ void main() {
     await tester.pump();
     expect(completer.isCompleted, isTrue);
   });
+
+  testWidgets('Can animate relative position data', (WidgetTester tester) async {
+    final RelativeRectTween rect = RelativeRectTween(
+      begin: RelativeRect.fromRect(
+        Rect.fromLTRB(0.0, 0.0, 0.5, 0.5),
+        Rect.fromLTRB(0.0, 0.0, 1.0, 1.0),
+      ),
+      end: RelativeRect.fromRect(
+        Rect.fromLTRB(0.5, 0.5, 1.0, 1.0),
+        Rect.fromLTRB(0.0, 0.0, 1.0, 1.0),
+      )
+    );
+    final AnimationController controller = AnimationController(
+      duration: const Duration(seconds: 10),
+      vsync: tester,
+    );
+    final List<Size> sizes = <Size>[];
+    final List<Offset> positions = <Offset>[];
+    final GlobalKey key = GlobalKey();
+
+    void recordMetrics() {
+      final RenderBox box = key.currentContext.findRenderObject();
+      final BoxParentData boxParentData = box.parentData;
+      sizes.add(box.size);
+      positions.add(boxParentData.offset);
+    }
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Container(
+            height: 100.0,
+            width: 100.0,
+            child: Stack(
+              children: <Widget>[
+                PositionedTransition(
+                  rect: rect.animate(controller),
+                  isRelative: true,
+                  child: Container(
+                    key: key,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ); // t=0
+    recordMetrics();
+    final Completer<void> completer = Completer<void>();
+    controller.forward().whenComplete(completer.complete);
+    expect(completer.isCompleted, isFalse);
+    await tester.pump(); // t=0 again
+    expect(completer.isCompleted, isFalse);
+    recordMetrics();
+    await tester.pump(const Duration(seconds: 1)); // t=1
+    expect(completer.isCompleted, isFalse);
+    recordMetrics();
+    await tester.pump(const Duration(seconds: 1)); // t=2
+    expect(completer.isCompleted, isFalse);
+    recordMetrics();
+    await tester.pump(const Duration(seconds: 3)); // t=5
+    expect(completer.isCompleted, isFalse);
+    recordMetrics();
+    await tester.pump(const Duration(seconds: 5)); // t=10
+    expect(completer.isCompleted, isFalse);
+    recordMetrics();
+
+    expect(sizes, equals(<Size>[const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0)]));
+    expect(positions, equals(<Offset>[const Offset(0.0, 10.0), const Offset(0.0, 10.0), const Offset(5.0, 5.0), const Offset(10.0, 10.0), const Offset(25.0, 25.0), const Offset(50.0, 50.0)]));
+
+    controller.stop(canceled: false);
+    await tester.pump();
+    expect(completer.isCompleted, isTrue);
+  });
 }

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -200,7 +200,7 @@ void main() {
     recordMetrics();
 
     expect(sizes, equals(<Size>[const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0), const Size(50.0, 50.0)]));
-    expect(positions, equals(<Offset>[const Offset(0.0, 10.0), const Offset(0.0, 10.0), const Offset(5.0, 5.0), const Offset(10.0, 10.0), const Offset(25.0, 25.0), const Offset(50.0, 50.0)]));
+    expect(positions, equals(<Offset>[const Offset(0.0, 0.0), const Offset(0.0, 0.0), const Offset(5.0, 5.0), const Offset(10.0, 10.0), const Offset(25.0, 25.0), const Offset(50.0, 50.0)]));
 
     controller.stop(canceled: false);
     await tester.pump();

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -646,19 +646,27 @@ void main() {
             PositionedDirectional(end: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(top: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(bottom: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(bottom: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
           ],
         ),
       ),
     );
-    expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(350.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(3)), Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(4)), Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(5)), Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(6)), Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(7)), Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(8)), Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(0)),  Rect.fromLTWH(350.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(1)),  Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(2)),  Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(3)),  Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(4)),  Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(5)),  Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(6)),  Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(7)),  Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(8)),  Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(9)),  Rect.fromLTWH(200.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(10)), Rect.fromLTWH(500.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(11)), Rect.fromLTWH(350.0, 150.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(12)), Rect.fromLTWH(350.0, 350.0, 100.0, 100.0));
 
     await tester.pumpWidget(
       Directionality(
@@ -675,19 +683,27 @@ void main() {
             PositionedDirectional(end: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(top: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(bottom: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(bottom: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
           ],
         ),
       ),
     );
-    expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(350.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(3)), Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(4)), Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(5)), Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(6)), Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(7)), Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(8)), Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(0)),  Rect.fromLTWH(350.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(1)),  Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(2)),  Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(3)),  Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(4)),  Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(5)),  Rect.fromLTWH(0.0,   250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(6)),  Rect.fromLTWH(700.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(7)),  Rect.fromLTWH(350.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(8)),  Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(9)),  Rect.fromLTWH(200.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(10)), Rect.fromLTWH(500.0, 250.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(11)), Rect.fromLTWH(350.0, 150.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(12)), Rect.fromLTWH(350.0, 350.0, 100.0, 100.0));
 
     await tester.pumpWidget(
       Directionality(
@@ -704,19 +720,27 @@ void main() {
             PositionedDirectional(end: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(top: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(bottom: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(bottom: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
           ],
         ),
       ),
     );
-    expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(3)), Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(4)), Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(5)), Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(6)), Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(7)), Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(8)), Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(0)),  Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(1)),  Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(2)),  Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(3)),  Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(4)),  Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(5)),  Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(6)),  Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(7)),  Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(8)),  Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(9)),  Rect.fromLTWH(200.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(10)), Rect.fromLTWH(500.0, 500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(11)), Rect.fromLTWH(700.0, 150.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(12)), Rect.fromLTWH(700.0, 350.0, 100.0, 100.0));
 
     await tester.pumpWidget(
       Directionality(
@@ -733,18 +757,52 @@ void main() {
             PositionedDirectional(end: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(top: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             PositionedDirectional(bottom: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(bottom: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
           ],
         ),
       ),
     );
-    expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(3)), Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(4)), Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(5)), Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(6)), Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(7)), Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
-    expect(tester.getRect(find.byType(SizedBox).at(8)), Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(0)),  Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(1)),  Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(2)),  Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(3)),  Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(4)),  Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(5)),  Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(6)),  Rect.fromLTWH(700.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(7)),  Rect.fromLTWH(0.0,   0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(8)),  Rect.fromLTWH(0.0,   500.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(9)),  Rect.fromLTWH(200.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(10)), Rect.fromLTWH(500.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(11)), Rect.fromLTWH(0.0, 150.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(12)), Rect.fromLTWH(0.0, 350.0,   100.0, 100.0));
+  });
+
+  testWidgets('Relative positioned children', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: Stack(
+          alignment: Alignment.topLeft,
+          children: const <Widget>[            
+            Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(bottom: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
+            Positioned(left: 0.25, width: 0.5, isRelative: true, child: SizedBox()),
+            Positioned(top: 0.25, height: 0.5, isRelative: true, child: SizedBox()),
+          ],
+        ),
+      ),
+    );
+    
+    expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(200.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(500.0, 0.0,   100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(0.0,   150.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(3)), Rect.fromLTWH(0.0,   350.0, 100.0, 100.0));
+    expect(tester.getRect(find.byType(SizedBox).at(4)), Rect.fromLTWH(200.0, 0.0,   400.0, 0.0  ));
+    expect(tester.getRect(find.byType(SizedBox).at(5)), Rect.fromLTWH(0.0,   150.0, 0.0,   300.0));
   });
 }

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -797,7 +797,7 @@ void main() {
         ),
       ),
     );
-    
+
     expect(tester.getRect(find.byType(SizedBox).at(0)), Rect.fromLTWH(200.0, 0.0,   100.0, 100.0));
     expect(tester.getRect(find.byType(SizedBox).at(1)), Rect.fromLTWH(500.0, 0.0,   100.0, 100.0));
     expect(tester.getRect(find.byType(SizedBox).at(2)), Rect.fromLTWH(0.0,   150.0, 100.0, 100.0));

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -786,7 +786,7 @@ void main() {
         textDirection: TextDirection.rtl,
         child: Stack(
           alignment: Alignment.topLeft,
-          children: const <Widget>[            
+          children: const <Widget>[
             Positioned(left: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(top: 0.25, isRelative: true, child: SizedBox(width: 100.0, height: 100.0)),


### PR DESCRIPTION
In some cases it can be helpful to position a widget inside a `Stack` relatively to the size of the `Stack`.

This PR adds a way to do this by setting a new value of the `Positioned` widget (`isRelative`) to true.