### PR TITLE
Fix text selection handles showing outside the visible text region

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -258,9 +258,9 @@ class RenderEditable extends RenderBox {
   /// Track whether position of the start of the selected text is within the viewport.
   ///
   /// For example, if the text contains "Hello World", and the user selects
-  /// "Hello", then scrolls so only "World" is visible, this will become
-  /// 'false'. If the user scrolls back so that the "H" is visible again, this
-  /// will become 'true'.
+  /// "Hello", then scrolls so only "World" is visible, this will become false.
+  /// If the user scrolls back so that the "H" is visible again, this will
+  /// become true.
   ///
   /// This bool indicates whether the text is scrolled so that the handle is
   /// inside the text field viewport, as opposed to whether it is actually

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -255,6 +255,50 @@ class RenderEditable extends RenderBox {
 
   Rect _lastCaretRect;
 
+  /// Track whether position of the start of the selected text is within the viewport.
+  ///
+  /// For example, if the text contains "Hello World", and the user selects
+  /// "Hello", then scrolls so only "World" is visible, this will become
+  /// 'false'. If the user scrolls back so that the "H" is visible again, this
+  /// will become 'true'.
+  ///
+  /// This bool indicates whether the text is scrolled so that the handle is
+  /// inside the text field viewport, as opposed to whether it is actually
+  /// visible on the screen.
+  ValueListenable<bool> get selectionStartInViewport => _selectionStartInViewport;
+  final ValueNotifier<bool> _selectionStartInViewport = ValueNotifier<bool>(true);
+
+  /// Track whether position of the end of the selected text is within the viewport.
+  ///
+  /// For example, if the text contains "Hello World", and the user selects
+  /// "World", then scrolls so only "Hello" is visible, this will become
+  /// 'false'. If the user scrolls back so that the "d" is visible again, this
+  /// will become 'true'.
+  ///
+  /// This bool indicates whether the text is scrolled so that the handle is
+  /// inside the text field viewport, as opposed to whether it is actually
+  /// visible on the screen.
+  ValueListenable<bool> get selectionEndInViewport => _selectionEndInViewport;
+  final ValueNotifier<bool> _selectionEndInViewport = ValueNotifier<bool>(true);
+
+  void _updateSelectionExtentsVisibility(Offset effectiveOffset) {
+    final Rect visibleRegion = Offset.zero & size;
+
+    final Offset startOffset = _textPainter.getOffsetForCaret(
+      TextPosition(offset: _selection.start, affinity: _selection.affinity),
+      Rect.zero
+    );
+
+    _selectionStartInViewport.value = visibleRegion.contains(startOffset + effectiveOffset);
+
+    final Offset endOffset =  _textPainter.getOffsetForCaret(
+      TextPosition(offset: _selection.end, affinity: _selection.affinity),
+      Rect.zero
+    );
+
+    _selectionEndInViewport.value = visibleRegion.contains(endOffset + effectiveOffset);
+  }
+
   static const int _kLeftArrowCode = 21;
   static const int _kRightArrowCode = 22;
   static const int _kUpArrowCode = 19;
@@ -1570,6 +1614,7 @@ class RenderEditable extends RenderBox {
         showCaret = true;
       else if (!_selection.isCollapsed && _selectionColor != null)
         showSelection = true;
+      _updateSelectionExtentsVisibility(effectiveOffset);
     }
 
     if (showSelection) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -605,8 +605,8 @@ class _TextSelectionHandleOverlayState
 
     final Size viewport = widget.renderObject.size;
     point = Offset(
-        point.dx.clamp(0.0, viewport.width),
-        point.dy.clamp(0.0, viewport.height)
+      point.dx.clamp(0.0, viewport.width),
+      point.dy.clamp(0.0, viewport.height),
     );
 
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -604,12 +604,11 @@ class _TextSelectionHandleOverlayState
     }
 
     final Size viewport = widget.renderObject.size;
-    if (!viewport.contains(point)) {
-      point = Offset(
+    point = Offset(
         point.dx.clamp(0.0, viewport.width),
-        point.dy.clamp(0.0, viewport.height),
-      );
-    }
+        point.dy.clamp(0.0, viewport.height)
+    );
+
 
     return CompositedTransformFollower(
       link: widget.layerLink,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1997,6 +1997,140 @@ void main() {
     expect(renderEditable.text.text, 'text composing text');
     expect(renderEditable.text.style.decoration, isNull);
   });
+
+  testWidgets('text selection handle visibility', (WidgetTester tester) async {
+    final GlobalKey<EditableTextState> editableTextKey =
+        GlobalKey<EditableTextState>();
+
+    const String testText = 'XXXXX          XXXXX';
+    final TextEditingController controller = TextEditingController(text: testText);
+
+    final Widget widget = MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: EditableText(
+            key: editableTextKey,
+            controller: controller,
+            focusNode: FocusNode(),
+            style: Typography(platform: TargetPlatform.android).black.subhead,
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+
+    final EditableTextState state =
+        tester.state<EditableTextState>(find.byType(EditableText));
+
+    bool leftVisibleBefore = false;
+    bool rightVisibleBefore = false;
+
+    Future<void> verifyVisibility(
+      bool leftVisible,
+      Symbol leftPosition,
+      bool rightVisible,
+      Symbol rightPosition,
+    ) async {
+      await tester.pump();
+
+      // Check the signal from RenderEditable about whether they're within the
+      // viewport.
+
+      final RenderEditable renderObject = state.selectionOverlay.renderObject;
+      expect(renderObject.selectionStartInViewport.value, equals(leftVisible));
+      expect(renderObject.selectionEndInViewport.value, equals(rightVisible));
+
+      // Check that the animations are functional and going in the right
+      // direction.
+
+      final List<Widget> transitions =
+        find.byType(FadeTransition).evaluate().map((Element e) => e.widget).toList();
+      final FadeTransition left = transitions[1];
+      final FadeTransition right = transitions[2];
+
+      if (leftVisibleBefore)
+        expect(left.opacity.value, equals(1.0));
+      if (rightVisibleBefore)
+        expect(right.opacity.value, equals(1.0));
+
+      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+
+      if (leftVisible != leftVisibleBefore)
+        expect(left.opacity.value, equals(0.5));
+      if (rightVisible != rightVisibleBefore)
+        expect(right.opacity.value, equals(0.5));
+
+      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+
+      if (leftVisible)
+        expect(left.opacity.value, equals(1.0));
+      if (rightVisible)
+        expect(right.opacity.value, equals(1.0));
+
+      leftVisibleBefore = leftVisible;
+      rightVisibleBefore = rightVisible;
+
+      // Check that the handles' positions are correct (clamped within the
+      // viewport but not stuck).
+
+      final List<Positioned> positioned =
+        find.byType(Positioned).evaluate().map((Element e) => e.widget).cast<Positioned>().toList();
+
+      final Size viewport = renderObject.size;
+
+      void testPosition(double pos, Symbol expected) {
+        if (expected == #left)
+          expect(pos, equals(0.0));
+        if (expected == #right)
+          expect(pos, equals(viewport.width));
+        if (expected == #middle)
+          expect(pos, inExclusiveRange(0.0, viewport.width));
+      }
+
+      testPosition(positioned[0].left, leftPosition);
+      testPosition(positioned[1].left, rightPosition);
+    }
+
+    // Select the first word. Both handles should be visible.
+    await tester.longPressAt(const Offset(20, 10));
+    await verifyVisibility(true, #left, true, #middle);
+
+    // Drag the text slightly so the first word is partially visible. Only the
+    // right handle should be visible.
+    await tester.drag(find.byKey(editableTextKey), const Offset(-20, 0));
+    await verifyVisibility(false, #left, true, #middle);
+
+    // Drag the text all the way to the left so the first word is not visible at
+    // all (and the second word is fully visible). Both handles should be
+    // invisible now.
+    await tester.drag(find.byKey(editableTextKey), const Offset(-400, 0));
+    await verifyVisibility(false, #left, false, #left);
+
+    // Tap to unselect.
+    await tester.tap(find.byKey(editableTextKey));
+    await tester.pump();
+
+    // Now that the second word has been dragged fully into view, select it.
+    await tester.longPressAt(const Offset(80, 10));
+    await verifyVisibility(true, #middle, true, #middle);
+
+    // Drag the text slightly to the right. Only the left handle should be
+    // visible.
+    await tester.drag(find.byKey(editableTextKey), const Offset(20, 0));
+    await verifyVisibility(true, #middle, false, #right);
+
+    // Drag the text all the way to the right, so the second word is not visible
+    // at all. Again, both handles should be invisible.
+    await tester.drag(find.byKey(editableTextKey), const Offset(400, 0));
+    await verifyVisibility(false, #right, false, #right);
+  });
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {}


### PR DESCRIPTION
This follows the Android behavior that the text selection handles fade in and out when they enter/leave the viewport of the text, remaining clamped within the viewport and not drawing outside of it.

This also fixes an issue with gestures being incorrectly shifted after scrolling.

fixes #24214