### PR TITLE
Fixes a bug when resolving locales using 'localeResolutionCallback'.

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -810,9 +810,10 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     }
     // localeListResolutionCallback failed, falling back to localeResolutionCallback.
     if (widget.localeResolutionCallback != null) {
-      final Locale locale = preferredLocales != null && preferredLocales.isNotEmpty
-        ? widget.localeResolutionCallback(preferredLocales.first, widget.supportedLocales)
-        : widget.localeResolutionCallback(null, widget.supportedLocales);
+      final Locale locale = widget.localeResolutionCallback(
+        preferredLocales != null && preferredLocales.isNotEmpty ? preferredLocales.first : null,
+        widget.supportedLocales,
+      );
       if (locale != null)
         return locale;
     }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -809,8 +809,10 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
         return locale;
     }
     // localeListResolutionCallback failed, falling back to localeResolutionCallback.
-    if (widget.localeResolutionCallback != null && preferredLocales != null && preferredLocales.isNotEmpty) {
-      final Locale locale = widget.localeResolutionCallback(preferredLocales.first, widget.supportedLocales);
+    if (widget.localeResolutionCallback != null) {
+      final Locale locale = preferredLocales != null && preferredLocales.isNotEmpty
+        ? widget.localeResolutionCallback(preferredLocales.first, widget.supportedLocales)
+        : widget.localeResolutionCallback(null, widget.supportedLocales);
       if (locale != null)
         return locale;
     }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -809,7 +809,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
         return locale;
     }
     // localeListResolutionCallback failed, falling back to localeResolutionCallback.
-    if (widget.localeResolutionCallback != null) {
+    if (widget.localeResolutionCallback != null && preferredLocales != null && preferredLocales.isNotEmpty) {
       final Locale locale = widget.localeResolutionCallback(preferredLocales.first, widget.supportedLocales);
       if (locale != null)
         return locale;

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -1414,4 +1414,41 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('en_CA'), findsOneWidget);
   });
+
+  testWidgets('WidgetsApp invalid preferredLocales', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildFrame(
+        supportedLocales: const <Locale>[
+          Locale('zh', 'CN'),
+          Locale('en', 'CA'),
+          Locale('en', 'US'),
+          Locale('en', 'AU'),
+          Locale('de', 'DE'),
+        ],
+        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
+          if (locale == null)
+            return Locale('und', 'US');
+          return Locale('en', 'US');
+        },
+        buildContent: (BuildContext context) {
+          final Locale locale = Localizations.localeOf(context);
+          return Text('$locale');
+        }
+      )
+    );
+
+    await tester.binding.setLocales(const <Locale>[
+      Locale.fromSubtags(languageCode: 'en', countryCode: 'US'),]
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('en_US'), findsOneWidget);
+
+    await tester.binding.setLocales(null);
+    await tester.pumpAndSettle();
+    expect(find.text('und_US'), findsOneWidget);
+
+    await tester.binding.setLocales(const <Locale>[]);
+    await tester.pumpAndSettle();
+    expect(find.text('und_US'), findsOneWidget);
+  });
 }

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -1427,8 +1427,8 @@ void main() {
         ],
         localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
           if (locale == null)
-            return Locale('und', 'US');
-          return Locale('en', 'US');
+            return const Locale('und', 'US');
+          return const Locale('en', 'US');
         },
         buildContent: (BuildContext context) {
           final Locale locale = Localizations.localeOf(context);


### PR DESCRIPTION
This resolves a bug introduced with a recent Flutter update, which caused numerous problems for resolving locales. In particular, the `_resolveLocales()` method in `lib/src/widgets/app.dart` wasn't checking for a `null` value for `preferredLocales` parameter, even though the doc. specifically says that this parameter might be null and user apps must take care to check for null.

See also:
https://github.com/flutter/flutter/issues/24064
https://github.com/flutter/flutter/issues/24288