### PR TITLE
Add some a basic debug stepping tests

### DIFF
--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+
+import '../src/common.dart';
+import 'test_data/stepping_project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  group('debugger', () {
+    Directory tempDir;
+    final SteppingProject _project = SteppingProject();
+    FlutterRunTestDriver _flutter;
+
+    setUp(() async {
+      tempDir = createResolvedTempDirectorySync();
+      await _project.setUpIn(tempDir);
+      _flutter = FlutterRunTestDriver(tempDir);
+    });
+
+    tearDown(() async {
+      await _flutter.stop();
+      tryToDelete(tempDir);
+    });
+
+    test('can step over statements', () async {
+      await _flutter.run(withDebugger: true);
+
+      // Stop at the initial breakpoint that the expected steps are based on.
+      await _flutter.breakAt(_project.breakpointUri, _project.breakpointLine, restart: true);
+
+      // Issue 5 steps, ensuring that we end up on the annotated lines each time.
+      for (int i = 1; i <= _project.numberOfSteps; i++) {
+        await _flutter.stepOverOrOverAsyncSuspension();
+        final SourcePosition location = await _flutter.getSourceLocation();
+        final int actualLine = location.line;
+        
+        // Get the line we're expected to stop at by searching for the comment
+        // within the source code.
+        final int expectedLine = _project.lineForStep(i);
+
+        expect(actualLine, equals(expectedLine),
+          reason: 'After $i steps, debugger should stop at $expectedLine but stopped at $actualLine');
+      }
+    });
+  }, timeout: const Timeout.factor(3));
+}

--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -38,7 +38,7 @@ void main() {
         await _flutter.stepOverOrOverAsyncSuspension();
         final SourcePosition location = await _flutter.getSourceLocation();
         final int actualLine = location.line;
-        
+
         // Get the line we're expected to stop at by searching for the comment
         // within the source code.
         final int expectedLine = _project.lineForStep(i);

--- a/packages/flutter_tools/test/integration/test_data/stepping_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/stepping_project.dart
@@ -5,7 +5,6 @@
 import 'project.dart';
 
 class SteppingProject extends Project {
-
   @override
   final String pubspec = '''
   name: test

--- a/packages/flutter_tools/test/integration/test_data/stepping_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/stepping_project.dart
@@ -1,0 +1,58 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'project.dart';
+
+class SteppingProject extends Project {
+
+  @override
+  final String pubspec = '''
+  name: test
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'''
+  import 'dart:async';
+
+  import 'package:flutter/material.dart';
+
+  void main() => runApp(new MyApp());
+
+  class MyApp extends StatefulWidget {
+    @override
+    _MyAppState createState() => _MyAppState();
+  }
+
+  class _MyAppState extends State<MyApp> {
+    @override
+    void initState() {
+      doAsyncStuff();
+      super.initState();
+    }
+
+    Future<void> doAsyncStuff() async {
+      print("test"); // BREAKPOINT
+      await new Future.value(true); // STEP 1
+      await new Future.microtask(() => true); // STEP 2 // STEP 3
+      await new Future.delayed(const Duration(milliseconds: 1)); // STEP 4 // STEP 5
+      print("done!"); // STEP 6
+    }
+
+    @override
+    Widget build(BuildContext context) {
+      return new MaterialApp(
+        title: 'Flutter Demo',
+        home: new Container(),
+      );
+    }
+  }
+  ''';
+
+  int lineForStep(int i) => lineContaining(main, '// STEP $i');
+
+  final int numberOfSteps = 6;
+}


### PR DESCRIPTION
A re-take of #18878. This adds a test that hits a breakpoint and then steps over some `await`s and ensures we step to the correct locations. This was added because we had issues with this previously (#18877).