### PR TITLE
Update pubspec SDK constraints to >=2.1.0-dev.5.0.

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,6 +3,10 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
+
 dependencies:
   args: 1.5.1
   file: 5.0.6

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,10 +3,6 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
-environment:
-  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.1.0-dev.5.0 <3.0.0"
-
 dependencies:
   args: 1.5.1
   file: 5.0.6

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/flutter
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
 
 dependencies:
   args: 1.5.1

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,10 +3,6 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.io
 
-environment:
-  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.1.0-dev.5.0 <3.0.0"
-
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   collection: 1.14.11

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,6 +3,10 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.io
 
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
+
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   collection: 1.14.11

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://flutter.io
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,9 +1,5 @@
 name: flutter_test
 
-environment:
-  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.1.0-dev.5.0 <3.0.0"
-
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,5 +1,9 @@
 name: flutter_test
 
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
+
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,6 +3,10 @@ description: Tools for building Flutter applications
 homepage: https://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
+
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   analyzer: 0.33.3

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,10 +3,6 @@ description: Tools for building Flutter applications
 homepage: https://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
-environment:
-  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.1.0-dev.5.0 <3.0.0"
-
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   analyzer: 0.33.3

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -5,7 +5,7 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0-dev.5.0 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".


### PR DESCRIPTION
In Dart SDK version 2.1.0-dev.5.0, dart:core was modified so that it
exports the classes Future and Stream.  (Previously these classes were
only available via an import of dart:async).  Some of the useages of
Future and Stream in Flutter fail to import dart:async, therefore in
order to work correctly Flutter requires Dart SDK version
2.1.0-dev.5.0 or later.

The Dart analyzer team is in the process of implementing a hint to
help users remember to update their pubspecs when using Future or
Stream and not importing dart:async
(https://github.com/dart-lang/sdk/issues/35162).  In order to avoid
Flutter failing this hint when it lands, we need to update the
pubspecs now.