### PR TITLE
Smoke test building IPA and APK on supported platforms

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,8 +114,6 @@ task:
     - name: build_tests-windows
       env:
         SHARD: build_tests
-      test_script:
-        - dart ./dev/bots/test.dart
       container:
         cpu: 4
         memory: 12G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,7 +194,7 @@ task:
       env:
         SHARD: build_tests
         COCOAPODS_DISABLE_STATS: true
-        FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/flutter"
+        FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/flutter/bin/cache/artifacts/engine/ios/"
       container:
         cpu: 4
         memory: 12G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,159 +1,159 @@
 container:
   image: gcr.io/flutter-cirrus/build-flutter-image:latest
 
-task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  env:
-    # Name the SDK directory to include a space so that we constantly
-    # test path names with spaces in them.
-    CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
-    PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
-    ANDROID_HOME: "/opt/android_sdk"
-  git_fetch_script:
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-  flutter_pkg_cache:
-    folder: bin/cache/pkg
-    fingerprint_script: echo $OS; cat bin/internal/engine.version
-  artifacts_cache:
-    folder: bin/cache/artifacts
-    fingerprint_script: echo $OS; cat bin/internal/engine.version
-  setup_script: ./dev/bots/cirrus_setup.sh
-  matrix:
-    - name: docs
-      env:
-        SHARD: docs
-        # For uploading master docs to Firebase master branch staging site
-        FIREBASE_MASTER_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
-        # For uploading beta docs to Firebase public live site
-        FIREBASE_PUBLIC_TOKEN: ENCRYPTED[c422da192f06da7b4449ca8e7aa866dabeb8a0f8d7488497c2e7e447e6fd31d917e6c813db081dc4e2a7a63afdf41864]
-      docs_script: ./dev/bots/docs.sh
-    - name: deploy_gallery
-      only_if: $CIRRUS_BRANCH == 'dev'
-      depends_on:
-        - docs
-        - analyze
-        - tests-linux
-        - tool_tests-linux
-        - build_tests-linux
-      env:
-        SHARD: deploy_gallery
-        GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
-        ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0b3e681b4507aec433ef29c79b715f15f8c75ecd25315ea286b0b2bcb8b28d578634eead5aa2c54086a25e8da1bb219a]
-      test_script: ./dev/bots/deploy_gallery.sh
-    - name: analyze
-      test_script:
-        - dart ./dev/bots/analyze.dart
-    - name: tests-linux
-      env:
-        SHARD: tests
-      test_script:
-        - dart ./dev/bots/test.dart
-      container:
-        cpu: 4
-        memory: 12G
-    - name: tool_tests-linux
-      env:
-        SHARD: tool_tests
-      test_script:
-        - dart ./dev/bots/test.dart
-      container:
-        cpu: 4
-        memory: 12G
-    - name: build_tests-linux
-      env:
-        SHARD: build_tests
-      test_script:
-        - dart ./dev/bots/test.dart
-      container:
-        cpu: 4
-        memory: 12G
-    - name: codelabs-build-test
-      env:
-        SHARD: codelabs-build-test
-      build_test_script: ./dev/bots/codelabs_build_test.sh
+# task:
+#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+#   env:
+#     # Name the SDK directory to include a space so that we constantly
+#     # test path names with spaces in them.
+#     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
+#     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
+#     ANDROID_HOME: "/opt/android_sdk"
+#   git_fetch_script:
+#     - git fetch origin
+#     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+#   pub_cache:
+#     folder: $HOME/.pub-cache
+#     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+#   flutter_pkg_cache:
+#     folder: bin/cache/pkg
+#     fingerprint_script: echo $OS; cat bin/internal/engine.version
+#   artifacts_cache:
+#     folder: bin/cache/artifacts
+#     fingerprint_script: echo $OS; cat bin/internal/engine.version
+#   setup_script: ./dev/bots/cirrus_setup.sh
+#   matrix:
+#     - name: docs
+#       env:
+#         SHARD: docs
+#         # For uploading master docs to Firebase master branch staging site
+#         FIREBASE_MASTER_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
+#         # For uploading beta docs to Firebase public live site
+#         FIREBASE_PUBLIC_TOKEN: ENCRYPTED[c422da192f06da7b4449ca8e7aa866dabeb8a0f8d7488497c2e7e447e6fd31d917e6c813db081dc4e2a7a63afdf41864]
+#       docs_script: ./dev/bots/docs.sh
+#     - name: deploy_gallery
+#       only_if: $CIRRUS_BRANCH == 'dev'
+#       depends_on:
+#         - docs
+#         - analyze
+#         - tests-linux
+#         - tool_tests-linux
+#         - build_tests-linux
+#       env:
+#         SHARD: deploy_gallery
+#         GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
+#         ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0b3e681b4507aec433ef29c79b715f15f8c75ecd25315ea286b0b2bcb8b28d578634eead5aa2c54086a25e8da1bb219a]
+#       test_script: ./dev/bots/deploy_gallery.sh
+#     - name: analyze
+#       test_script:
+#         - dart ./dev/bots/analyze.dart
+#     - name: tests-linux
+#       env:
+#         SHARD: tests
+#       test_script:
+#         - dart ./dev/bots/test.dart
+#       container:
+#         cpu: 4
+#         memory: 12G
+#     - name: tool_tests-linux
+#       env:
+#         SHARD: tool_tests
+#       test_script:
+#         - dart ./dev/bots/test.dart
+#       container:
+#         cpu: 4
+#         memory: 12G
+#     - name: build_tests-linux
+#       env:
+#         SHARD: build_tests
+#       test_script:
+#         - dart ./dev/bots/test.dart
+#       container:
+#         cpu: 4
+#         memory: 12G
+#     - name: codelabs-build-test
+#       env:
+#         SHARD: codelabs-build-test
+#       build_test_script: ./dev/bots/codelabs_build_test.sh
 
 
-task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  windows_container:
-    image: cirrusci/windowsservercore:2016
-    os_version: 2016
-    cpu: 4
-  env:
-    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
-  git_fetch_script:
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-  pub_cache:
-    folder: $APPDATA\Pub\Cache
-    fingerprint_script:
-      - ps:  $Env:OS; Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-  flutter_pkg_cache:
-    folder: bin\cache\pkg
-    fingerprint_script: echo %OS% & type bin\internal\engine.version
-  artifacts_cache:
-    folder: bin\cache\artifacts
-    fingerprint_script: echo %OS% & type bin\internal\engine.version
-  setup_script:
-    - bin\flutter.bat config --no-analytics
-    - bin\flutter.bat update-packages
-    - git fetch origin master
-  test_all_script:
-    - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
-  matrix:
-    - name: tests-windows
-      env:
-        SHARD: tests
-    - name: tool_tests-windows
-      env:
-        SHARD: tool_tests
-    - name: build_tests-windows
-      env:
-        SHARD: build_tests
-      test_script:
-        - dart ./dev/bots/test.dart
-      container:
-        cpu: 4
-        memory: 12G
+# task:
+#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+#   windows_container:
+#     image: cirrusci/windowsservercore:2016
+#     os_version: 2016
+#     cpu: 4
+#   env:
+#     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
+#   git_fetch_script:
+#     - git fetch origin
+#     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+#   pub_cache:
+#     folder: $APPDATA\Pub\Cache
+#     fingerprint_script:
+#       - ps:  $Env:OS; Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+#   flutter_pkg_cache:
+#     folder: bin\cache\pkg
+#     fingerprint_script: echo %OS% & type bin\internal\engine.version
+#   artifacts_cache:
+#     folder: bin\cache\artifacts
+#     fingerprint_script: echo %OS% & type bin\internal\engine.version
+#   setup_script:
+#     - bin\flutter.bat config --no-analytics
+#     - bin\flutter.bat update-packages
+#     - git fetch origin master
+#   test_all_script:
+#     - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
+#   matrix:
+#     - name: tests-windows
+#       env:
+#         SHARD: tests
+#     - name: tool_tests-windows
+#       env:
+#         SHARD: tool_tests
+#     - name: build_tests-windows
+#       env:
+#         SHARD: build_tests
+#       test_script:
+#         - dart ./dev/bots/test.dart
+#       container:
+#         cpu: 4
+#         memory: 12G
 
-task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  name: deploy_gallery-macos
-  only_if: $CIRRUS_BRANCH == 'dev'
-  pub_cache:
-    folder: ~/.pub-cache
-  depends_on:
-    - analyze
-    - tests-macos
-    - tool_tests-macos
-    - build_tests-macos
-  env:
-    # Name the SDK directory to include a space so that we constantly
-    # test path names with spaces in them.
-    CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
-    SHARD: deploy_gallery
-    # Apple Certificates Match Passphrase
-    MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
-    # Apple Fastlane password, ASP, and Session information.
-    FASTLANE_PASSWORD: ENCRYPTED[0bf9bb0cc2cb32a0ed18470cf2c9df0f587cce5f8b04adbd6cff15ca5bde7a74f721ee580227b132ab6b032f08e52ae0]
-    FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ENCRYPTED[b219cc13c757f36cb62bfca5102d6115f1cc283aeb974f20c657bc4991c0cc144e30cf5d8183e41cc1df1668b4d14210]
-    FASTLANE_SESSION: ENCRYPTED[88246e355e55cd5e361a575f5d5b762f5826cb9d5285cb93a263b1cad04ec09bdedb1cbd74df5ec02d6043360fa04acd]
-    # Private repo for publishing certificates.
-    PUBLISHING_MATCH_CERTIFICATE_REPO: git@github.com:flutter/private_publishing_certificates.git
-  osx_instance:
-    image: high-sierra-xcode-9.4.1
-  git_fetch_script:
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD
-  setup_script:
-    - bin/flutter config --no-analytics
-    - bin/flutter update-packages
-  test_all_script:
-    - ./dev/bots/deploy_gallery.sh
+# task:
+#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+#   name: deploy_gallery-macos
+#   only_if: $CIRRUS_BRANCH == 'dev'
+#   pub_cache:
+#     folder: ~/.pub-cache
+#   depends_on:
+#     - analyze
+#     - tests-macos
+#     - tool_tests-macos
+#     - build_tests-macos
+#   env:
+#     # Name the SDK directory to include a space so that we constantly
+#     # test path names with spaces in them.
+#     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
+#     SHARD: deploy_gallery
+#     # Apple Certificates Match Passphrase
+#     MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
+#     # Apple Fastlane password, ASP, and Session information.
+#     FASTLANE_PASSWORD: ENCRYPTED[0bf9bb0cc2cb32a0ed18470cf2c9df0f587cce5f8b04adbd6cff15ca5bde7a74f721ee580227b132ab6b032f08e52ae0]
+#     FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ENCRYPTED[b219cc13c757f36cb62bfca5102d6115f1cc283aeb974f20c657bc4991c0cc144e30cf5d8183e41cc1df1668b4d14210]
+#     FASTLANE_SESSION: ENCRYPTED[88246e355e55cd5e361a575f5d5b762f5826cb9d5285cb93a263b1cad04ec09bdedb1cbd74df5ec02d6043360fa04acd]
+#     # Private repo for publishing certificates.
+#     PUBLISHING_MATCH_CERTIFICATE_REPO: git@github.com:flutter/private_publishing_certificates.git
+#   osx_instance:
+#     image: high-sierra-xcode-9.4.1
+#   git_fetch_script:
+#     - git fetch origin
+#     - git fetch origin master # To set FETCH_HEAD
+#   setup_script:
+#     - bin/flutter config --no-analytics
+#     - bin/flutter update-packages
+#   test_all_script:
+#     - ./dev/bots/deploy_gallery.sh
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
@@ -164,7 +164,7 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
   install_cocoapods_script:
-    - gem install cocoapods
+    - sudo gem install cocoapods
   git_fetch_script:
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
@@ -184,12 +184,12 @@ task:
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart
   matrix:
-    - name: tests-macos
-      env:
-        SHARD: tests
-    - name: tool_tests-macos
-      env:
-        SHARD: tool_tests
+    # - name: tests-macos
+    #   env:
+    #     SHARD: tests
+    # - name: tool_tests-macos
+    #   env:
+    #     SHARD: tool_tests
     - name: build_tests-macos
       env:
         SHARD: build_tests
@@ -199,18 +199,18 @@ task:
         memory: 12G
 
 
-docker_builder:
-  # Only build a new docker image when we tag a release (for dev, beta, or release.)
-  only_if: $CIRRUS_TAG != ''
-  env:
-    GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
-  depends_on:
-    - docs
-    - analyze
-    - tests-linux
-    - tool_tests-linux
-    - build_tests-linux
-  build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
-  login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
-  push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
+# docker_builder:
+#   # Only build a new docker image when we tag a release (for dev, beta, or release.)
+#   only_if: $CIRRUS_TAG != ''
+#   env:
+#     GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
+#   depends_on:
+#     - docs
+#     - analyze
+#     - tests-linux
+#     - tool_tests-linux
+#     - build_tests-linux
+#   build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
+#   login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
+#   push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,7 +163,7 @@ task:
     - analyze
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
-  install_cocoapods:
+  install_cocoapods_script:
     only_if: $SHARD == 'build_tests'
     - gem install cocoapods
   git_fetch_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,159 +1,159 @@
 container:
   image: gcr.io/flutter-cirrus/build-flutter-image:latest
 
-# task:
-#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-#   env:
-#     # Name the SDK directory to include a space so that we constantly
-#     # test path names with spaces in them.
-#     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
-#     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
-#     ANDROID_HOME: "/opt/android_sdk"
-#   git_fetch_script:
-#     - git fetch origin
-#     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-#   pub_cache:
-#     folder: $HOME/.pub-cache
-#     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-#   flutter_pkg_cache:
-#     folder: bin/cache/pkg
-#     fingerprint_script: echo $OS; cat bin/internal/engine.version
-#   artifacts_cache:
-#     folder: bin/cache/artifacts
-#     fingerprint_script: echo $OS; cat bin/internal/engine.version
-#   setup_script: ./dev/bots/cirrus_setup.sh
-#   matrix:
-#     - name: docs
-#       env:
-#         SHARD: docs
-#         # For uploading master docs to Firebase master branch staging site
-#         FIREBASE_MASTER_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
-#         # For uploading beta docs to Firebase public live site
-#         FIREBASE_PUBLIC_TOKEN: ENCRYPTED[c422da192f06da7b4449ca8e7aa866dabeb8a0f8d7488497c2e7e447e6fd31d917e6c813db081dc4e2a7a63afdf41864]
-#       docs_script: ./dev/bots/docs.sh
-#     - name: deploy_gallery
-#       only_if: $CIRRUS_BRANCH == 'dev'
-#       depends_on:
-#         - docs
-#         - analyze
-#         - tests-linux
-#         - tool_tests-linux
-#         - build_tests-linux
-#       env:
-#         SHARD: deploy_gallery
-#         GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
-#         ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0b3e681b4507aec433ef29c79b715f15f8c75ecd25315ea286b0b2bcb8b28d578634eead5aa2c54086a25e8da1bb219a]
-#       test_script: ./dev/bots/deploy_gallery.sh
-#     - name: analyze
-#       test_script:
-#         - dart ./dev/bots/analyze.dart
-#     - name: tests-linux
-#       env:
-#         SHARD: tests
-#       test_script:
-#         - dart ./dev/bots/test.dart
-#       container:
-#         cpu: 4
-#         memory: 12G
-#     - name: tool_tests-linux
-#       env:
-#         SHARD: tool_tests
-#       test_script:
-#         - dart ./dev/bots/test.dart
-#       container:
-#         cpu: 4
-#         memory: 12G
-#     - name: build_tests-linux
-#       env:
-#         SHARD: build_tests
-#       test_script:
-#         - dart ./dev/bots/test.dart
-#       container:
-#         cpu: 4
-#         memory: 12G
-#     - name: codelabs-build-test
-#       env:
-#         SHARD: codelabs-build-test
-#       build_test_script: ./dev/bots/codelabs_build_test.sh
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  env:
+    # Name the SDK directory to include a space so that we constantly
+    # test path names with spaces in them.
+    CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
+    PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
+    ANDROID_HOME: "/opt/android_sdk"
+  git_fetch_script:
+    - git fetch origin
+    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+  flutter_pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
+  artifacts_cache:
+    folder: bin/cache/artifacts
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
+  setup_script: ./dev/bots/cirrus_setup.sh
+  matrix:
+    - name: docs
+      env:
+        SHARD: docs
+        # For uploading master docs to Firebase master branch staging site
+        FIREBASE_MASTER_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
+        # For uploading beta docs to Firebase public live site
+        FIREBASE_PUBLIC_TOKEN: ENCRYPTED[c422da192f06da7b4449ca8e7aa866dabeb8a0f8d7488497c2e7e447e6fd31d917e6c813db081dc4e2a7a63afdf41864]
+      docs_script: ./dev/bots/docs.sh
+    - name: deploy_gallery
+      only_if: $CIRRUS_BRANCH == 'dev'
+      depends_on:
+        - docs
+        - analyze
+        - tests-linux
+        - tool_tests-linux
+        - build_tests-linux
+      env:
+        SHARD: deploy_gallery
+        GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
+        ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0b3e681b4507aec433ef29c79b715f15f8c75ecd25315ea286b0b2bcb8b28d578634eead5aa2c54086a25e8da1bb219a]
+      test_script: ./dev/bots/deploy_gallery.sh
+    - name: analyze
+      test_script:
+        - dart ./dev/bots/analyze.dart
+    - name: tests-linux
+      env:
+        SHARD: tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: tool_tests-linux
+      env:
+        SHARD: tool_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: build_tests-linux
+      env:
+        SHARD: build_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: codelabs-build-test
+      env:
+        SHARD: codelabs-build-test
+      build_test_script: ./dev/bots/codelabs_build_test.sh
 
 
-# task:
-#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-#   windows_container:
-#     image: cirrusci/windowsservercore:2016
-#     os_version: 2016
-#     cpu: 4
-#   env:
-#     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
-#   git_fetch_script:
-#     - git fetch origin
-#     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-#   pub_cache:
-#     folder: $APPDATA\Pub\Cache
-#     fingerprint_script:
-#       - ps:  $Env:OS; Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-#   flutter_pkg_cache:
-#     folder: bin\cache\pkg
-#     fingerprint_script: echo %OS% & type bin\internal\engine.version
-#   artifacts_cache:
-#     folder: bin\cache\artifacts
-#     fingerprint_script: echo %OS% & type bin\internal\engine.version
-#   setup_script:
-#     - bin\flutter.bat config --no-analytics
-#     - bin\flutter.bat update-packages
-#     - git fetch origin master
-#   test_all_script:
-#     - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
-#   matrix:
-#     - name: tests-windows
-#       env:
-#         SHARD: tests
-#     - name: tool_tests-windows
-#       env:
-#         SHARD: tool_tests
-#     - name: build_tests-windows
-#       env:
-#         SHARD: build_tests
-#       test_script:
-#         - dart ./dev/bots/test.dart
-#       container:
-#         cpu: 4
-#         memory: 12G
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  windows_container:
+    image: cirrusci/windowsservercore:2016
+    os_version: 2016
+    cpu: 4
+  env:
+    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\flutter sdk"
+  git_fetch_script:
+    - git fetch origin
+    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+  pub_cache:
+    folder: $APPDATA\Pub\Cache
+    fingerprint_script:
+      - ps:  $Env:OS; Get-ChildItem -Path "$Env:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+  flutter_pkg_cache:
+    folder: bin\cache\pkg
+    fingerprint_script: echo %OS% & type bin\internal\engine.version
+  artifacts_cache:
+    folder: bin\cache\artifacts
+    fingerprint_script: echo %OS% & type bin\internal\engine.version
+  setup_script:
+    - bin\flutter.bat config --no-analytics
+    - bin\flutter.bat update-packages
+    - git fetch origin master
+  test_all_script:
+    - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
+  matrix:
+    - name: tests-windows
+      env:
+        SHARD: tests
+    - name: tool_tests-windows
+      env:
+        SHARD: tool_tests
+    - name: build_tests-windows
+      env:
+        SHARD: build_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
 
-# task:
-#   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-#   name: deploy_gallery-macos
-#   only_if: $CIRRUS_BRANCH == 'dev'
-#   pub_cache:
-#     folder: ~/.pub-cache
-#   depends_on:
-#     - analyze
-#     - tests-macos
-#     - tool_tests-macos
-#     - build_tests-macos
-#   env:
-#     # Name the SDK directory to include a space so that we constantly
-#     # test path names with spaces in them.
-#     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
-#     SHARD: deploy_gallery
-#     # Apple Certificates Match Passphrase
-#     MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
-#     # Apple Fastlane password, ASP, and Session information.
-#     FASTLANE_PASSWORD: ENCRYPTED[0bf9bb0cc2cb32a0ed18470cf2c9df0f587cce5f8b04adbd6cff15ca5bde7a74f721ee580227b132ab6b032f08e52ae0]
-#     FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ENCRYPTED[b219cc13c757f36cb62bfca5102d6115f1cc283aeb974f20c657bc4991c0cc144e30cf5d8183e41cc1df1668b4d14210]
-#     FASTLANE_SESSION: ENCRYPTED[88246e355e55cd5e361a575f5d5b762f5826cb9d5285cb93a263b1cad04ec09bdedb1cbd74df5ec02d6043360fa04acd]
-#     # Private repo for publishing certificates.
-#     PUBLISHING_MATCH_CERTIFICATE_REPO: git@github.com:flutter/private_publishing_certificates.git
-#   osx_instance:
-#     image: high-sierra-xcode-9.4.1
-#   git_fetch_script:
-#     - git fetch origin
-#     - git fetch origin master # To set FETCH_HEAD
-#   setup_script:
-#     - bin/flutter config --no-analytics
-#     - bin/flutter update-packages
-#   test_all_script:
-#     - ./dev/bots/deploy_gallery.sh
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  name: deploy_gallery-macos
+  only_if: $CIRRUS_BRANCH == 'dev'
+  pub_cache:
+    folder: ~/.pub-cache
+  depends_on:
+    - analyze
+    - tests-macos
+    - tool_tests-macos
+    - build_tests-macos
+  env:
+    # Name the SDK directory to include a space so that we constantly
+    # test path names with spaces in them.
+    CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
+    SHARD: deploy_gallery
+    # Apple Certificates Match Passphrase
+    MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
+    # Apple Fastlane password, ASP, and Session information.
+    FASTLANE_PASSWORD: ENCRYPTED[0bf9bb0cc2cb32a0ed18470cf2c9df0f587cce5f8b04adbd6cff15ca5bde7a74f721ee580227b132ab6b032f08e52ae0]
+    FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ENCRYPTED[b219cc13c757f36cb62bfca5102d6115f1cc283aeb974f20c657bc4991c0cc144e30cf5d8183e41cc1df1668b4d14210]
+    FASTLANE_SESSION: ENCRYPTED[88246e355e55cd5e361a575f5d5b762f5826cb9d5285cb93a263b1cad04ec09bdedb1cbd74df5ec02d6043360fa04acd]
+    # Private repo for publishing certificates.
+    PUBLISHING_MATCH_CERTIFICATE_REPO: git@github.com:flutter/private_publishing_certificates.git
+  osx_instance:
+    image: high-sierra-xcode-9.4.1
+  git_fetch_script:
+    - git fetch origin
+    - git fetch origin master # To set FETCH_HEAD
+  setup_script:
+    - bin/flutter config --no-analytics
+    - bin/flutter update-packages
+  test_all_script:
+    - ./dev/bots/deploy_gallery.sh
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
@@ -184,12 +184,12 @@ task:
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     bin/cache/dart-sdk/bin/dart -c dev/bots/test.dart
   matrix:
-    # - name: tests-macos
-    #   env:
-    #     SHARD: tests
-    # - name: tool_tests-macos
-    #   env:
-    #     SHARD: tool_tests
+    - name: tests-macos
+      env:
+        SHARD: tests
+    - name: tool_tests-macos
+      env:
+        SHARD: tool_tests
     - name: build_tests-macos
       env:
         SHARD: build_tests
@@ -200,18 +200,18 @@ task:
         memory: 12G
 
 
-# docker_builder:
-#   # Only build a new docker image when we tag a release (for dev, beta, or release.)
-#   only_if: $CIRRUS_TAG != ''
-#   env:
-#     GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
-#   depends_on:
-#     - docs
-#     - analyze
-#     - tests-linux
-#     - tool_tests-linux
-#     - build_tests-linux
-#   build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
-#   login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
-#   push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
+docker_builder:
+  # Only build a new docker image when we tag a release (for dev, beta, or release.)
+  only_if: $CIRRUS_TAG != ''
+  env:
+    GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
+  depends_on:
+    - docs
+    - analyze
+    - tests-linux
+    - tool_tests-linux
+    - build_tests-linux
+  build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
+  login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
+  push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,7 +194,7 @@ task:
       env:
         SHARD: build_tests
         COCOAPODS_DISABLE_STATS: true
-        FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/flutter/bin/cache/artifacts/engine/ios/"
+        FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/bin/cache/artifacts/engine/ios/"
       container:
         cpu: 4
         memory: 12G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,6 +38,7 @@ task:
         - analyze
         - tests-linux
         - tool_tests-linux
+        - build_tests-linux
       env:
         SHARD: deploy_gallery
         GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
@@ -62,9 +63,9 @@ task:
       container:
         cpu: 4
         memory: 12G
-    - name: aot_build_tests-linux
+    - name: build_tests-linux
       env:
-        SHARD: aot_build_tests
+        SHARD: build_tests
       test_script:
         - dart ./dev/bots/test.dart
       container:
@@ -110,6 +111,14 @@ task:
     - name: tool_tests-windows
       env:
         SHARD: tool_tests
+    - name: build_tests-windows
+      env:
+        SHARD: build_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
@@ -121,6 +130,7 @@ task:
     - analyze
     - tests-macos
     - tool_tests-macos
+    - build_tests-macos
   env:
     # Name the SDK directory to include a space so that we constantly
     # test path names with spaces in them.
@@ -178,6 +188,14 @@ task:
     - name: tool_tests-macos
       env:
         SHARD: tool_tests
+    - name: build_tests-macos
+      env:
+        SHARD: build_tests
+      test_script:
+        - dart ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
 
 
 docker_builder:
@@ -190,6 +208,7 @@ docker_builder:
     - analyze
     - tests-linux
     - tool_tests-linux
+    - build_tests-linux
   build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
   login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
   push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,6 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
   install_cocoapods_script:
-    only_if: $SHARD == 'build_tests'
     - gem install cocoapods
   git_fetch_script:
     - git fetch origin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,6 +194,7 @@ task:
       env:
         SHARD: build_tests
         COCOAPODS_DISABLE_STATS: true
+        FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/flutter"
       container:
         cpu: 4
         memory: 12G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,6 +163,9 @@ task:
     - analyze
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
+  install_cocoapods:
+    only_if: $SHARD == 'build_tests'
+    - gem install cocoapods
   git_fetch_script:
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
@@ -192,8 +195,6 @@ task:
       env:
         SHARD: build_tests
         COCOAPODS_DISABLE_STATS: true
-      test_script:
-        - dart ./dev/bots/test.dart
       container:
         cpu: 4
         memory: 12G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -191,6 +191,7 @@ task:
     - name: build_tests-macos
       env:
         SHARD: build_tests
+        COCOAPODS_DISABLE_STATS: true
       test_script:
         - dart ./dev/bots/test.dart
       container:

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -184,7 +184,7 @@ Future<void> _flutterBuildAot(String relativePathToApplication) async {
 
 Future<void> _flutterBuildApk(String relativePathToApplication) async {
   // TODO(dnfield): See if we can get Android SDK on all Cirrus platforms.
-  if (Platform.environment['ANDROID_HOME'] == null || Platform.environment['ANDROID_HOME'] == '') {
+  if (Platform.environment['ANDROID_HOME']?.isEmpty ?? true) {
     return;
   }
   print('Running APK build tests...');

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -206,8 +206,8 @@ Future<void> _flutterBuildIpa(String relativePathToApplication) async {
   // and build ios doesn't take care of it automatically.
   final File podfile = File(path.join(flutterRoot, relativePathToApplication, 'ios', 'Podfile'));
   if (podfile.existsSync()) {
-    await runCommand(flutter,
-      <String>['pod', 'install'],
+    await runCommand('pod',
+      <String>['install'],
       workingDirectory: path.join(flutterRoot, relativePathToApplication),
       expectNonZeroExit: false,
       timeout: _kShortTimeout,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -21,7 +21,7 @@ final List<String> flutterTestArgs = <String>[];
 const Map<String, ShardRunner> _kShards = <String, ShardRunner>{
   'tests': _runTests,
   'tool_tests': _runToolTests,
-  'aot_build_tests': _runAotBuildTests,
+  'build_tests': _runBuildTests,
   'coverage': _runCoverage,
 };
 
@@ -150,16 +150,25 @@ Future<void> _runToolTests() async {
   print('${bold}DONE: All tests successful.$reset');
 }
 
-/// Verifies that AOT builds of some examples apps finish
-/// without crashing. It does not actually launch the AOT-built
-/// apps. That happens later in the devicelab. This is just
-/// a smoke-test.
-Future<void> _runAotBuildTests() async {
-  await _flutterBuildAot(path.join('examples', 'hello_world'));
-  await _flutterBuildAot(path.join('examples', 'flutter_gallery'));
-  await _flutterBuildAot(path.join('examples', 'flutter_view'));
+/// Verifies that AOT, APK, and IPA (if on macOS) builds of some
+/// examples apps finish without crashing. It does not actually
+/// launch the apps. That happens later in the devicelab. This is
+/// just a smoke-test. In particular, this will verify we can build
+/// when there are spaces in the path name for the Flutter SDK and
+/// target app.
+Future<void> _runBuildTests() async {
+  final List<String> paths = <String>[
+    path.join('examples', 'hello_world'),
+    path.join('examples', 'flutter_gallery'),
+    path.join('examples', 'flutter_view'),
+  ];
+  for (String path in paths) {
+    await _flutterBuildAot(path);
+    await _flutterBuildApk(path);
+    await _flutterBuildIpa(path);
+  }
 
-  print('${bold}DONE: All AOT build tests successful.$reset');
+  print('${bold}DONE: All build tests successful.$reset');
 }
 
 Future<void> _flutterBuildAot(String relativePathToApplication) {
@@ -169,6 +178,26 @@ Future<void> _flutterBuildAot(String relativePathToApplication) {
     expectNonZeroExit: false,
     timeout: _kShortTimeout,
   );
+}
+
+Future<void> _flutterBuildApk(String relativePathToApplication) {
+  return runCommand(flutter,
+    <String>['build', 'apk', '--debug'],
+    workingDirectory: path.join(flutterRoot, relativePathToApplication),
+    expectNonZeroExit: false,
+    timeout: _kShortTimeout,
+  );
+}
+
+Future<void> _flutterBuildIpa(String relativePathToApplication) {
+  if (Platform.isMacOS) {
+    return runCommand(flutter,
+      <String>['build', 'ios', '--no-codesign', '--debug'],
+      workingDirectory: path.join(flutterRoot, relativePathToApplication),
+      expectNonZeroExit: false,
+      timeout: _kShortTimeout,
+    );
+  }
 }
 
 Future<void> _runTests() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -181,6 +181,10 @@ Future<void> _flutterBuildAot(String relativePathToApplication) async {
 }
 
 Future<void> _flutterBuildApk(String relativePathToApplication) async {
+  // TODO(dnfield): See if we can get Android SDK on all Cirrus platforms.
+  if (Platform.environment['ANDROID_HOME'] == null || Platform.environment['ANDROID_HOME'] == '') {
+    return;
+  }
   await runCommand(flutter,
     <String>['build', 'apk', '--debug'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -198,6 +198,7 @@ Future<void> _flutterBuildIpa(String relativePathToApplication) {
       timeout: _kShortTimeout,
     );
   }
+  return null;
 }
 
 Future<void> _runTests() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -172,12 +172,14 @@ Future<void> _runBuildTests() async {
 }
 
 Future<void> _flutterBuildAot(String relativePathToApplication) async {
+  print('Running AOT build tests...');
   await runCommand(flutter,
-    <String>['build', 'aot'],
+    <String>['build', 'aot', '-v'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
     expectNonZeroExit: false,
     timeout: _kShortTimeout,
   );
+  print('Done.');
 }
 
 Future<void> _flutterBuildApk(String relativePathToApplication) async {
@@ -185,24 +187,39 @@ Future<void> _flutterBuildApk(String relativePathToApplication) async {
   if (Platform.environment['ANDROID_HOME'] == null || Platform.environment['ANDROID_HOME'] == '') {
     return;
   }
+  print('Running APK build tests...');
   await runCommand(flutter,
-    <String>['build', 'apk', '--debug'],
+    <String>['build', 'apk', '--debug', '-v'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
     expectNonZeroExit: false,
     timeout: _kShortTimeout,
   );
+  print('Done.');
 }
 
 Future<void> _flutterBuildIpa(String relativePathToApplication) async {
   if (!Platform.isMacOS) {
     return;
   }
+  print('Running IPA build tests...');
+  // Install Cocoapods.  We don't have these checked in for the examples,
+  // and build ios doesn't take care of it automatically.
+  final File podfile = File(path.join(flutterRoot, relativePathToApplication, 'ios', 'Podfile');
+  if (podfile.existsSync()) {
+    await runCommand(flutter,
+      <String>['pod', 'install'],
+      workingDirectory: path.join(flutterRoot, relativePathToApplication),
+      expectNonZeroExit: false,
+      timeout: _kShortTimeout,
+    );
+  }
   await runCommand(flutter,
-    <String>['build', 'ios', '--no-codesign', '--debug'],
+    <String>['build', 'ios', '--no-codesign', '--debug', '-v'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
     expectNonZeroExit: false,
     timeout: _kShortTimeout,
   );
+  print('Done.');
 }
 
 Future<void> _runTests() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -208,7 +208,7 @@ Future<void> _flutterBuildIpa(String relativePathToApplication) async {
   if (podfile.existsSync()) {
     await runCommand('pod',
       <String>['install'],
-      workingDirectory: path.join(flutterRoot, relativePathToApplication),
+      workingDirectory: podfile.parent.path,
       expectNonZeroExit: false,
       timeout: _kShortTimeout,
     );

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -171,8 +171,8 @@ Future<void> _runBuildTests() async {
   print('${bold}DONE: All build tests successful.$reset');
 }
 
-Future<void> _flutterBuildAot(String relativePathToApplication) {
-  return runCommand(flutter,
+Future<void> _flutterBuildAot(String relativePathToApplication) async {
+  await runCommand(flutter,
     <String>['build', 'aot'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
     expectNonZeroExit: false,
@@ -180,8 +180,8 @@ Future<void> _flutterBuildAot(String relativePathToApplication) {
   );
 }
 
-Future<void> _flutterBuildApk(String relativePathToApplication) {
-  return runCommand(flutter,
+Future<void> _flutterBuildApk(String relativePathToApplication) async {
+  await runCommand(flutter,
     <String>['build', 'apk', '--debug'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
     expectNonZeroExit: false,
@@ -189,16 +189,16 @@ Future<void> _flutterBuildApk(String relativePathToApplication) {
   );
 }
 
-Future<void> _flutterBuildIpa(String relativePathToApplication) {
-  if (Platform.isMacOS) {
-    return runCommand(flutter,
-      <String>['build', 'ios', '--no-codesign', '--debug'],
-      workingDirectory: path.join(flutterRoot, relativePathToApplication),
-      expectNonZeroExit: false,
-      timeout: _kShortTimeout,
-    );
+Future<void> _flutterBuildIpa(String relativePathToApplication) async {
+  if (!Platform.isMacOS) {
+    return;
   }
-  return null;
+  await runCommand(flutter,
+    <String>['build', 'ios', '--no-codesign', '--debug'],
+    workingDirectory: path.join(flutterRoot, relativePathToApplication),
+    expectNonZeroExit: false,
+    timeout: _kShortTimeout,
+  );
 }
 
 Future<void> _runTests() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -204,7 +204,7 @@ Future<void> _flutterBuildIpa(String relativePathToApplication) async {
   print('Running IPA build tests...');
   // Install Cocoapods.  We don't have these checked in for the examples,
   // and build ios doesn't take care of it automatically.
-  final File podfile = File(path.join(flutterRoot, relativePathToApplication, 'ios', 'Podfile');
+  final File podfile = File(path.join(flutterRoot, relativePathToApplication, 'ios', 'Podfile'));
   if (podfile.existsSync()) {
     await runCommand(flutter,
       <String>['pod', 'install'],


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/24591 fixed a regression that only showed up for people with a space in the Flutter SDK directory on macOS.  Although Cirrus is set up to have a space in the SDK root, it isn't actually testing a build today except in the deploy gallery shard - which unfortunately only happens on the dev branch and is broken for other reasons presently.

This repurposes the existing AOT smoke test to also test builds for APK and IPA (if on macOS), on Linux, Mac and Windows.