### PR TITLE
Include error message in crash reports

### DIFF
--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -107,6 +107,7 @@ class CrashReportSender {
       req.fields['osVersion'] = os.name; // this actually includes version
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
+      req.fields['error_message'] = '$error';
 
       final String stackTraceWithRelativePaths = Chain.parse(stackTrace.toString()).terse.toString();
       req.files.add(http.MultipartFile.fromString(

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -107,6 +107,7 @@ void main() {
       expect(fields['osVersion'], 'fake OS name and version');
       expect(fields['type'], 'DartError');
       expect(fields['error_runtime_type'], 'StateError');
+      expect(fields['error_message'], 'Bad state: Test bad state error');
 
       final BufferLogger logger = context[Logger];
       expect(logger.statusText, 'Sending crash report to Google.\n'


### PR DESCRIPTION
This modifies our flutter_tools crash reports to include the error
message. This error message may contain personally identifying
information (PII), such as a file system path on the developer's
local machine that may contain user names, project code names,
etc. To disable crash reporting, the developer can run the
following command:

    flutter config --no-analytics