### PR TITLE
Add support for leading parameter in TextStyle

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -241,6 +241,7 @@ class TextStyle extends Diagnosticable {
     this.wordSpacing,
     this.textBaseline,
     this.height,
+    this.leading,
     this.locale,
     this.foreground,
     this.background,
@@ -313,12 +314,19 @@ class TextStyle extends Diagnosticable {
   /// parent text span, or, for the root text spans, with the line box.
   final TextBaseline textBaseline;
 
-  /// The height of this text span, as a multiple of the font size.
+  /// The height of this text span, as a multiple of the sum of font size and leading.
   ///
   /// If applied to the root [TextSpan], this value sets the line height, which
   /// is the minimum distance between subsequent text baselines, as multiple of
   /// the font size.
   final double height;
+
+  /// Custom leading to use instead of the font-provided leading as a multiple
+  /// of font size.
+  ///
+  /// When null, default font leading will be used. Leading is the additional
+  /// spacing between lines.
+  final double leading;
 
   /// The locale used to select region-specific glyphs.
   ///
@@ -399,6 +407,7 @@ class TextStyle extends Diagnosticable {
     double wordSpacing,
     TextBaseline textBaseline,
     double height,
+    double leading,
     Locale locale,
     Paint foreground,
     Paint background,
@@ -426,6 +435,7 @@ class TextStyle extends Diagnosticable {
       wordSpacing: wordSpacing ?? this.wordSpacing,
       textBaseline: textBaseline ?? this.textBaseline,
       height: height ?? this.height,
+      leading: leading ?? this.leading,
       locale: locale ?? this.locale,
       foreground: foreground ?? this.foreground,
       background: background ?? this.background,
@@ -478,6 +488,8 @@ class TextStyle extends Diagnosticable {
     double wordSpacingDelta = 0.0,
     double heightFactor = 1.0,
     double heightDelta = 0.0,
+    double leadingFactor = 1.0,
+    double leadingDelta = 0.0,
   }) {
     assert(fontSizeFactor != null);
     assert(fontSizeDelta != null);
@@ -512,6 +524,7 @@ class TextStyle extends Diagnosticable {
       wordSpacing: wordSpacing == null ? null : wordSpacing * wordSpacingFactor + wordSpacingDelta,
       textBaseline: textBaseline,
       height: height == null ? null : height * heightFactor + heightDelta,
+      leading: leading == null ? null : leading * leadingFactor + leadingDelta,
       locale: locale,
       foreground: foreground != null ? foreground : null,
       background: background,
@@ -563,6 +576,7 @@ class TextStyle extends Diagnosticable {
       wordSpacing: other.wordSpacing,
       textBaseline: other.textBaseline,
       height: other.height,
+      leading: other.leading,
       locale: other.locale,
       foreground: other.foreground,
       background: other.background,
@@ -608,6 +622,7 @@ class TextStyle extends Diagnosticable {
         wordSpacing: t < 0.5 ? null : b.wordSpacing,
         textBaseline: t < 0.5 ? null : b.textBaseline,
         height: t < 0.5 ? null : b.height,
+        leading: t < 0.5 ? null : b.leading,
         locale: t < 0.5 ? null : b.locale,
         foreground: t < 0.5 ? null : b.foreground,
         background: t < 0.5 ? null : b.background,
@@ -631,6 +646,7 @@ class TextStyle extends Diagnosticable {
         wordSpacing: t < 0.5 ? a.wordSpacing : null,
         textBaseline: t < 0.5 ? a.textBaseline : null,
         height: t < 0.5 ? a.height : null,
+        leading: t < 0.5 ? a.leading : null,
         locale: t < 0.5 ? a.locale : null,
         foreground: t < 0.5 ? a.foreground : null,
         background: t < 0.5 ? a.background : null,
@@ -653,6 +669,7 @@ class TextStyle extends Diagnosticable {
       wordSpacing: ui.lerpDouble(a.wordSpacing ?? b.wordSpacing, b.wordSpacing ?? a.wordSpacing, t),
       textBaseline: t < 0.5 ? a.textBaseline : b.textBaseline,
       height: ui.lerpDouble(a.height ?? b.height, b.height ?? a.height, t),
+      leading: ui.lerpDouble(a.leading ?? b.leading, b.leading ?? a.leading, t),
       locale: t < 0.5 ? a.locale : b.locale,
       foreground: (a.foreground != null || b.foreground != null)
         ? t < 0.5
@@ -683,6 +700,7 @@ class TextStyle extends Diagnosticable {
       letterSpacing: letterSpacing,
       wordSpacing: wordSpacing,
       height: height,
+      leading: leading,
       locale: locale,
       foreground: foreground,
       background: background,
@@ -740,6 +758,7 @@ class TextStyle extends Diagnosticable {
         wordSpacing != other.wordSpacing ||
         textBaseline != other.textBaseline ||
         height != other.height ||
+        leading != other.leading ||
         locale != other.locale ||
         foreground != other.foreground ||
         background != other.background ||
@@ -770,6 +789,7 @@ class TextStyle extends Diagnosticable {
            wordSpacing == typedOther.wordSpacing &&
            textBaseline == typedOther.textBaseline &&
            height == typedOther.height &&
+           leading == typedOther.leading &&
            locale == typedOther.locale &&
            foreground == typedOther.foreground &&
            background == typedOther.background &&
@@ -792,6 +812,7 @@ class TextStyle extends Diagnosticable {
       wordSpacing,
       textBaseline,
       height,
+      leading,
       locale,
       foreground,
       background,
@@ -861,6 +882,7 @@ class TextStyle extends Diagnosticable {
     styles.add(DoubleProperty('${prefix}wordSpacing', wordSpacing, defaultValue: null));
     styles.add(EnumProperty<TextBaseline>('${prefix}baseline', textBaseline, defaultValue: null));
     styles.add(DoubleProperty('${prefix}height', height, unit: 'x', defaultValue: null));
+    styles.add(DoubleProperty('${prefix}leading', height, unit: 'x', defaultValue: null));
     styles.add(DiagnosticsProperty<Locale>('${prefix}locale', locale, defaultValue: null));
     styles.add(DiagnosticsProperty<Paint>('${prefix}foreground', foreground, defaultValue: null));
     styles.add(DiagnosticsProperty<Paint>('${prefix}background', background, defaultValue: null));

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1796,7 +1796,7 @@ void main() {
     ).toString();
 
     // Spot check
-    expect(debugString, contains('labelStyle: TextStyle(inherit: true, height: 1.0x)'));
+    expect(debugString, contains('labelStyle: TextStyle(inherit: true, height: 1.0x, leading: 1.0x)'));
     expect(debugString, contains('isDense: true'));
     expect(debugString, contains('fillColor: Color(0x0000000a)'));
     expect(debugString, contains('errorBorder: UnderlineInputBorder()'));

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -453,6 +453,7 @@ class _TextStyleProxy implements TextStyle {
   @override FontStyle get fontStyle => _delegate.fontStyle;
   @override FontWeight get fontWeight => _delegate.fontWeight;
   @override double get height => _delegate.height;
+  @override double get leading => _delegate.leading;
   @override Locale get locale => _delegate.locale;
   @override ui.Paint get foreground => _delegate.foreground;
   @override ui.Paint get background => _delegate.background;
@@ -477,7 +478,7 @@ class _TextStyleProxy implements TextStyle {
   }
 
   @override
-  TextStyle apply({Color color, TextDecoration decoration, Color decorationColor, TextDecorationStyle decorationStyle, String fontFamily, double fontSizeFactor = 1.0, double fontSizeDelta = 0.0, int fontWeightDelta = 0, double letterSpacingFactor = 1.0, double letterSpacingDelta = 0.0, double wordSpacingFactor = 1.0, double wordSpacingDelta = 0.0, double heightFactor = 1.0, double heightDelta = 0.0}) {
+  TextStyle apply({Color color, TextDecoration decoration, Color decorationColor, TextDecorationStyle decorationStyle, String fontFamily, double fontSizeFactor = 1.0, double fontSizeDelta = 0.0, int fontWeightDelta = 0, double letterSpacingFactor = 1.0, double letterSpacingDelta = 0.0, double wordSpacingFactor = 1.0, double wordSpacingDelta = 0.0, double heightFactor = 1.0, double heightDelta = 0.0, double leadingFactor = 1.0, double leadingDelta = 0.0}) {
     throw UnimplementedError();
   }
 
@@ -487,7 +488,7 @@ class _TextStyleProxy implements TextStyle {
   }
 
   @override
-  TextStyle copyWith({Color color, String fontFamily, double fontSize, FontWeight fontWeight, FontStyle fontStyle, double letterSpacing, double wordSpacing, TextBaseline textBaseline, double height, Locale locale, ui.Paint foreground, ui.Paint background, List<Shadow> shadows, TextDecoration decoration, Color decorationColor, TextDecorationStyle decorationStyle, String debugLabel}) {
+  TextStyle copyWith({Color color, String fontFamily, double fontSize, FontWeight fontWeight, FontStyle fontStyle, double letterSpacing, double wordSpacing, TextBaseline textBaseline, double height, double leading, Locale locale, ui.Paint foreground, ui.Paint background, List<Shadow> shadows, TextDecoration decoration, Color decorationColor, TextDecorationStyle decorationStyle, String debugLabel}) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -166,7 +166,7 @@ void main() {
     expect(ts5.toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, leading: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
     final ui.TextStyle ts2 = s2.getTextStyle();
     expect(ts2, equals(ui.TextStyle(color: const Color(0xFF00FF00), fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0)));
-    expect(ts2.toString(), 'TextStyle(color: Color(0xff00ff00), decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 10.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 100.0x, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
+    expect(ts2.toString(), 'TextStyle(color: Color(0xff00ff00), decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 10.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 100.0x, leading: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
 
     final ui.ParagraphStyle ps2 = s2.getParagraphStyle(textAlign: TextAlign.center);
     expect(ps2, equals(ui.ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, lineHeight: 100.0)));

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -30,7 +30,7 @@ void main() {
     expect(s1, equals(s1));
     expect(
       s1.toString(),
-      equals('TextStyle(inherit: true, size: 10.0, weight: 800, height: 123.0x)'),
+      equals('TextStyle(inherit: true, size: 10.0, weight: 800, height: 123.0x, leading: 123.0x)'),
     );
 
     final TextStyle s2 = s1.copyWith(color: const Color(0xFF00FF00), height: 100.0);
@@ -48,7 +48,7 @@ void main() {
     expect(
       s2.toString(),
       equals(
-        'TextStyle(inherit: true, color: Color(0xff00ff00), size: 10.0, weight: 800, height: 100.0x)',
+        'TextStyle(inherit: true, color: Color(0xff00ff00), size: 10.0, weight: 800, height: 100.0x, leading: 100.0x)',
       ),
     );
 
@@ -163,7 +163,7 @@ void main() {
 
     final ui.TextStyle ts5 = s5.getTextStyle();
     expect(ts5, equals(ui.TextStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0)));
-    expect(ts5.toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
+    expect(ts5.toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, leading: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
     final ui.TextStyle ts2 = s2.getTextStyle();
     expect(ts2, equals(ui.TextStyle(color: const Color(0xFF00FF00), fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0)));
     expect(ts2.toString(), 'TextStyle(color: Color(0xff00ff00), decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontSize: 10.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 100.0x, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
@@ -189,11 +189,11 @@ void main() {
   test('TextStyle using package font', () {
     const TextStyle s6 = TextStyle(fontFamily: 'test');
     expect(s6.fontFamily, 'test');
-    expect(s6.getTextStyle().toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: test, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
+    expect(s6.getTextStyle().toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: test, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leading: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
 
     const TextStyle s7 = TextStyle(fontFamily: 'test', package: 'p');
     expect(s7.fontFamily, 'packages/p/test');
-    expect(s7.getTextStyle().toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: packages/p/test, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
+    expect(s7.getTextStyle().toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: packages/p/test, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leading: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified)');
   });
 
   test('TextStyle.debugLabel', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -63,6 +63,7 @@ void main() {
         '   ║   family: Ahem\n'
         '   ║   size: 10.0\n'
         '   ║   height: 1.0x\n'
+        '   ║   leading: 1.0x\n'
         '   ║   "12345"\n'
         '   ╚═══════════\n'
       ),


### PR DESCRIPTION
This enables leading as a TextStyle parameter to non-breaking-ly allow users to adjust the line spacing without changing the overall height of the text span and the metrics surrounding it.

Requires an engine roll with the LibTxt changes.

See https://github.com/flutter/flutter/issues/23875.