### PR TITLE
Implement didUpdateWidget for DefaultTabController

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
@@ -286,7 +287,7 @@ class DefaultTabController extends StatefulWidget {
   _DefaultTabControllerState createState() => _DefaultTabControllerState();
 }
 
-class _DefaultTabControllerState extends State<DefaultTabController> with SingleTickerProviderStateMixin {
+class _DefaultTabControllerState extends State<DefaultTabController> with TickerProviderStateMixin {
   TabController _controller;
 
   @override
@@ -297,6 +298,19 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Single
       length: widget.length,
       initialIndex: widget.initialIndex,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant DefaultTabController oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.length != oldWidget.length) {
+      final int oldIndex = _controller._index;
+      _controller = TabController(
+        vsync: this,
+        length: widget.length,
+        initialIndex: math.min(oldIndex, widget.length - 1),
+      );
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -304,12 +304,19 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Ticker
   void didUpdateWidget(covariant DefaultTabController oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.length != oldWidget.length) {
+      final TabController oldController = _controller;
       final int oldIndex = _controller._index;
       _controller = TabController(
         vsync: this,
         length: widget.length,
         initialIndex: math.min(oldIndex, widget.length - 1),
       );
+      // This has to be done in a microtask since child widgets will attempt
+      // to remove their listeners in the didUpdateWidget method. This will fail
+      // if the controller has already been disposed.
+      scheduleMicrotask(() {
+        oldController.dispose();
+      });
     }
   }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1917,7 +1917,7 @@ void main() {
                 ),
               ),
               body: TabBarView(
-                children: tabs.take(tabCount).map((Tab tab) => Center(child: Text(tab.text))).toList(),    
+                children: tabs.take(tabCount).map((Tab tab) => Center(child: Text(tab.text))).toList(),
               ),
             ),
           );

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1895,4 +1895,44 @@ void main() {
     expect(find.text(AlwaysKeepAliveWidget.text, skipOffstage: false), findsOneWidget);
     expect(find.text('4'), findsOneWidget);
   });
+
+  testWidgets('The number of tabs can be updated', (WidgetTester tester) async {
+    Function _setState;
+    int tabCount = 3;
+    const List<Tab> tabs = <Tab>[
+      Tab(text: 'LEFT'),
+      Tab(text: 'MIDDLE'),
+      Tab(text: 'RIGHT'),
+    ];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(builder: (BuildContext context, Function setState) {
+          _setState = setState;
+          return DefaultTabController(
+            length: tabCount,
+            child: Scaffold(
+              appBar: AppBar(
+                bottom: TabBar(
+                  tabs: tabs.take(tabCount).toList(),
+                ),
+              ),
+              body: TabBarView(
+                children: tabs.take(tabCount).map((Tab tab) => Center(child: Text(tab.text))).toList(),    
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+    await tester.tap(find.text('RIGHT'));
+    // Without the additional logic in _DefaultTabControllerState.didUpdateWidget, this
+    // will throw an index out of bounds error.
+    await tester.pumpAndSettle();
+    _setState(() {
+      tabCount = 2;
+    });
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(find.text('MIDDLE'), findsNWidgets(2));
+  });
 }


### PR DESCRIPTION
Fixes flutter#20292
Fixes flutter#18686

Currently trying to update the number of tabs without forcing the state object to be destroyed via a ValueKey (or similar) can cause index out of bounds or related errors when the child tabs try to render