### PR TITLE
Replace Android-specific check with switch

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -247,8 +247,14 @@ class RenderEditable extends RenderBox {
 
   // TODO(goderbauer): doesn't handle extended grapheme clusters with more than one Unicode scalar value (https://github.com/flutter/flutter/issues/13404).
   void _handleKeyEvent(RawKeyEvent keyEvent) {
-    if (defaultTargetPlatform != TargetPlatform.android)
-      return;
+    // Only handle key events on Android.
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        break;
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        return;
+    }
 
     if (keyEvent is RawKeyUpEvent)
       return;


### PR DESCRIPTION
Generally, we should always use default-less switches for
platform-specific behaviour so we're forced to make a conscious decision
on each instance of such behaviour any time we add support for a new
platform.