### PR TITLE
Adds support for floating cursor

### DIFF
--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -272,8 +272,8 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../../../Flutter/flutter/engine/src/out/ios_debug_unopt/Flutter.framework",
-			);
+                "${PODS_ROOT}/../../../../bin/cache/artifacts/engine/ios/Flutter.framework",
+            );
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",

--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -181,7 +181,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = S8QB4VV633;
 					};
 				};
 			};
@@ -273,7 +272,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../../Flutter/engine/src/out/ios_debug_unopt/Flutter.framework",
+				"${PODS_ROOT}/../../../../../../../Flutter/flutter/engine/src/out/ios_debug_unopt/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -372,7 +371,6 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -496,7 +494,6 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -518,7 +515,6 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -272,8 +272,8 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-                "${PODS_ROOT}/../../../../bin/cache/artifacts/engine/ios/Flutter.framework",
-            );
+				"${PODS_ROOT}/../../../../bin/cache/artifacts/engine/ios/Flutter.framework",
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",

--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = S8QB4VV633;
 					};
 				};
 			};
@@ -272,7 +273,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../bin/cache/artifacts/engine/ios/Flutter.framework",
+				"${PODS_ROOT}/../../../../../../Flutter/engine/src/out/ios_debug_unopt/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -371,6 +372,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -494,6 +496,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -515,6 +518,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -672,6 +672,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
           cursorWidth: widget.cursorWidth,
           cursorRadius: widget.cursorRadius,
           cursorColor: widget.cursorColor,
+          backgroundCursorColor: CupertinoColors.inactiveGray,
           scrollPadding: widget.scrollPadding,
           keyboardAppearance: keyboardAppearance,
         ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -608,7 +608,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
 
         // First add the explicit suffix if the suffix visibility mode matches.
         if (_showSuffixWidget(text)) {
-          rowChildren.add(Align(alignment: FractionalOffset.bottomRight, child: widget.suffix));
+          rowChildren.add(widget.suffix);
         // Otherwise, try to show a clear button if its visibility mode matches.
         } else if (_showClearButton(text)) {
           rowChildren.add(

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -608,7 +608,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
 
         // First add the explicit suffix if the suffix visibility mode matches.
         if (_showSuffixWidget(text)) {
-          rowChildren.add(widget.suffix);
+          rowChildren.add(Align(alignment: FractionalOffset.bottomRight, child: widget.suffix));
         // Otherwise, try to show a clear button if its visibility mode matches.
         } else if (_showClearButton(text)) {
           rowChildren.add(

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -606,6 +606,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         cursorWidth: widget.cursorWidth,
         cursorRadius: widget.cursorRadius,
         cursorColor: widget.cursorColor ?? Theme.of(context).cursorColor,
+        backgroundCursorColor: CupertinoColors.inactiveGray,
         scrollPadding: widget.scrollPadding,
         keyboardAppearance: keyboardAppearance,
         enableInteractiveSelection: widget.enableInteractiveSelection,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1313,6 +1313,7 @@ class RenderEditable extends RenderBox {
     final Rect caretRect = caretPrototype.shift(effectiveOffset);
     const Radius floatingCursorRadius = Radius.circular(_kFloatingCaretRadius);
     final RRect caretRRect = RRect.fromRectAndRadius(caretRect, floatingCursorRadius);
+    print(caretRRect.left.toString() + ' and ' + caretRRect.top.toString() + ' and ' + caretRRect.right.toString() + ' and ' + caretRRect.bottom.toString() + ' and ' + caretRRect.brRadius.toString());
     canvas.drawRRect(caretRRect, paint);
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1235,7 +1235,7 @@ class RenderEditable extends RenderBox {
   Offset get boundedCursorOffset {
     // Painting requires an offset of - preferredLineHeight / 2 so we need to add it back
     // so that the offset used to determine the text position is calculated correctly.
-    final Offset offset = Offset(_floatingCursorOffset.dx, math.max(0, _floatingCursorOffset.dy + preferredLineHeight / 2));
+    final Offset offset = Offset(_floatingCursorOffset.dx, _floatingCursorOffset.dy + preferredLineHeight / 2);
     return offset;
   }
 
@@ -1253,7 +1253,8 @@ class RenderEditable extends RenderBox {
       _resetOriginOnBottom = false;
     }
     _floatingCursorOn = action != TextCursorAction.End;
-    _floatingCursorOffset = _calculateBoundedCursorOffset(rawCursorOffset);
+    if(_floatingCursorOn)
+      _floatingCursorOffset = _calculateBoundedCursorOffset(rawCursorOffset);
   }
 
   void _paintFloatingCaret(Canvas canvas, Offset effectiveOffset) {
@@ -1261,44 +1262,12 @@ class RenderEditable extends RenderBox {
     final Paint paint = Paint()
       ..color = _cursorColor;
 
-//    Offset deltaPosition = const Offset(0, 0);
-//    if (_previousOffset != null)
-//      deltaPosition = effectiveOffset - _previousOffset;
-//
-//    // We are off the left end of text field.
-//    if (_resetOriginOnLeft && deltaPosition.dx > 0 || _resetOriginOnRight && deltaPosition.dx < 0) {
-//      _relativeOrigin = Offset(effectiveOffset.dx, _relativeOrigin.dy);
-//      _resetOriginOnLeft = false;
-//      _resetOriginOnRight = false;
-//    }
-//    if (_resetOriginOnTop && deltaPosition.dy > 0 || _resetOriginOnBottom && deltaPosition.dy < 0) {
-//      _relativeOrigin = Offset(_relativeOrigin.dx, effectiveOffset.dy);
-//      _resetOriginOnBottom = false;
-//      _resetOriginOnTop = false;
-//    }
-//
-//    final double currentX = effectiveOffset.dx - _relativeOrigin.dx;
-//    final double currentY = effectiveOffset.dy - _relativeOrigin.dy - preferredLineHeight / 2;
-//    final double adjustedX = math.min(math.max(currentX, 0), _textPainter.width);
-//    final double adjustedY = math.min(math.max(currentY, 0), _textPainter.height);
-//    final Offset adjustedOffset = Offset(adjustedX, adjustedY);
-//
-//    if (currentX < 0 && deltaPosition.dx < 0)
-//      _resetOriginOnLeft = true;
-//    else if(currentX > 0 && deltaPosition.dx > 0)
-//      _resetOriginOnRight = true;
-//    if (currentY < 0 && deltaPosition.dy < 0)
-//      _resetOriginOnTop = true;
-//    else if (currentY > 0 && deltaPosition.dy > 0)
-//      _resetOriginOnBottom = true;
-
     final Rect caretPrototype = Rect.fromLTRB(_caretPrototype.left, _caretPrototype.top - 2, _caretPrototype.right, _caretPrototype.bottom + 2);
     final Rect caretRect = caretPrototype.shift(effectiveOffset);
 
     const Radius floatingCursorRadius = Radius.circular(3);
     final RRect caretRRect = RRect.fromRectAndRadius(caretRect, floatingCursorRadius);
     canvas.drawRRect(caretRRect, paint);
-//    _previousOffset = effectiveOffset;
   }
 
   Offset _relativeOrigin = const Offset(0, 0);
@@ -1313,7 +1282,6 @@ class RenderEditable extends RenderBox {
     if (_previousOffset != null)
       deltaPosition = rawCursorOffset - _previousOffset;
 
-    print(_resetOriginOnLeft.toString() + ' and ' + _resetOriginOnRight.toString());
     // We are off the left end of text field.
     if (_resetOriginOnLeft && deltaPosition.dx > 0) {
       _relativeOrigin = Offset(rawCursorOffset.dx, _relativeOrigin.dy);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -20,6 +20,7 @@ import 'viewport_offset.dart';
 const double _kCaretGap = 1.0; // pixels
 const double _kCaretHeightOffset = 2.0; // pixels
 const Offset _kFloatingCaretSizeOffset = Offset(0.5, 2.0); // pixels
+const double _kFloatingCaretRadius = 1.0; // pixels
 
 /// Signature for the callback that reports when the user changes the selection
 /// (including the cursor location).
@@ -1277,8 +1278,7 @@ class RenderEditable extends RenderBox {
                                               _caretPrototype.right + _kFloatingCaretSizeOffset.dx,
                                               _caretPrototype.bottom + _kFloatingCaretSizeOffset.dy);
     final Rect caretRect = caretPrototype.shift(effectiveOffset);
-
-    const Radius floatingCursorRadius = Radius.circular(3);
+    const Radius floatingCursorRadius = Radius.circular(_kFloatingCaretRadius);
     final RRect caretRRect = RRect.fromRectAndRadius(caretRect, floatingCursorRadius);
     canvas.drawRRect(caretRRect, paint);
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -144,6 +144,7 @@ class RenderEditable extends RenderBox {
     double cursorWidth = 1.0,
     Radius cursorRadius,
     bool enableInteractiveSelection = true,
+    TextEditingPoint textEditingPoint,
     @required this.textSelectionDelegate,
   }) : assert(textAlign != null),
        assert(textDirection != null, 'RenderEditable created without a textDirection.'),
@@ -169,6 +170,7 @@ class RenderEditable extends RenderBox {
        _selection = selection,
        _offset = offset,
        _cursorWidth = cursorWidth,
+       _textEditingPoint = textEditingPoint,
        _cursorRadius = cursorRadius,
        _enableInteractiveSelection = enableInteractiveSelection,
        _obscureText = obscureText {
@@ -215,6 +217,8 @@ class RenderEditable extends RenderBox {
   /// It must not be null. It will make cut, copy and paste functionality work
   /// with the most recently set [TextSelectionDelegate].
   TextSelectionDelegate textSelectionDelegate;
+
+  TextEditingPoint _textEditingPoint;
 
   Rect _lastCaretRect;
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -702,7 +702,7 @@ FloatingCursorEditingPoint _toTextPoint(FloatingCursorDragState state, Map<Strin
   assert(encoded['X'] != null, 'You must provide a value for the horizontal location of the floating cursor.');
   assert(encoded['Y'] != null, 'You must provide a value for the vertical location of the floating cursor.');
   final Offset offset = state == FloatingCursorDragState.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
-  return FloatingCursorEditingPoint(point: offset, state: state);
+  return FloatingCursorEditingPoint(offset: offset, state: state);
 }
 
 class _TextInputClientHandler {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -458,14 +458,16 @@ class FloatingCursorEditingPoint {
   /// Creates information for setting the position and state of a floating
   /// cursor.
   ///
-  /// [state] must not be null.
-  const FloatingCursorEditingPoint({
-    this.point = const Offset(0, 0),
+  /// [state] must not be null and [offset] must not be null if the state is
+  /// [FloatingCursorDragState.Update].
+  FloatingCursorEditingPoint({
+    this.offset,
     @required this.state,
-  }) : assert(state != null);
+  }) : assert(state != null),
+       assert(state == FloatingCursorDragState.Update ? offset != null : true);
 
   /// The raw position of the floating cursor as determined by the iOS sdk.
-  final Offset point;
+  final Offset offset;
 
   /// The state of the floating cursor.
   final FloatingCursorDragState state;

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -454,13 +454,13 @@ enum FloatingCursorDragState {
 }
 
 /// The current state and position of the floating cursor.
-class FloatingCursorEditingPoint {
+class RawFloatingCursorPoint {
   /// Creates information for setting the position and state of a floating
   /// cursor.
   ///
   /// [state] must not be null and [offset] must not be null if the state is
   /// [FloatingCursorDragState.Update].
-  FloatingCursorEditingPoint({
+  RawFloatingCursorPoint({
     this.offset,
     @required this.state,
   }) : assert(state != null),
@@ -602,7 +602,7 @@ abstract class TextInputClient {
   void performAction(TextInputAction action);
 
   /// Updates the floating cursor position and state.
-  void updateFloatingCursor(FloatingCursorEditingPoint point);
+  void updateFloatingCursor(RawFloatingCursorPoint point);
 }
 
 /// An interface for interacting with a text input control.
@@ -697,12 +697,12 @@ FloatingCursorDragState _toTextCursorAction(String state) {
   throw FlutterError('Unknown text cursor action: $state');
 }
 
-FloatingCursorEditingPoint _toTextPoint(FloatingCursorDragState state, Map<String, dynamic> encoded) {
+RawFloatingCursorPoint _toTextPoint(FloatingCursorDragState state, Map<String, dynamic> encoded) {
   assert(state != null, 'You must provide a state to set a new editing point.');
   assert(encoded['X'] != null, 'You must provide a value for the horizontal location of the floating cursor.');
   assert(encoded['Y'] != null, 'You must provide a value for the vertical location of the floating cursor.');
   final Offset offset = state == FloatingCursorDragState.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
-  return FloatingCursorEditingPoint(offset: offset, state: state);
+  return RawFloatingCursorPoint(offset: offset, state: state);
 }
 
 class _TextInputClientHandler {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -440,7 +440,7 @@ TextAffinity _toTextAffinity(String affinity) {
 }
 
 ///
-enum TextCursorAction {
+enum TextCursorState {
   ///
   Start,
 
@@ -456,14 +456,14 @@ class TextEditingPoint {
   ///
   const TextEditingPoint({
     this.point = const Offset(0, 0),
-    this.action,
+    this.state,
   }) : assert(point != null);
 
   ///
   final Offset point;
 
   ///
-  final TextCursorAction action;
+  final TextCursorState state;
 }
 
 /// The current text, selection, and composing state for editing a run of text.
@@ -678,21 +678,21 @@ TextInputAction _toTextInputAction(String action) {
   throw FlutterError('Unknown text input action: $action');
 }
 
-TextCursorAction _toTextCursorAction(String action) {
-  switch (action) {
-    case 'TextCursorAction.start':
-      return TextCursorAction.Start;
-    case 'TextCursorAction.update':
-      return TextCursorAction.Update;
-    case 'TextCursorAction.end':
-      return TextCursorAction.End;
+TextCursorState _toTextCursorAction(String state) {
+  switch (state) {
+    case 'TextCursorState.start':
+      return TextCursorState.Start;
+    case 'TextCursorState.update':
+      return TextCursorState.Update;
+    case 'TextCursorState.end':
+      return TextCursorState.End;
   }
-  throw FlutterError('Unknown text cursor action: $action');
+  throw FlutterError('Unknown text cursor action: $state');
 }
 
-TextEditingPoint _toTextPoint(TextCursorAction action, Map<String, dynamic> encoded) {
-  final Offset offset = action == TextCursorAction.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
-  return TextEditingPoint(point: offset, action: action);
+TextEditingPoint _toTextPoint(TextCursorState state, Map<String, dynamic> encoded) {
+  final Offset offset = state == TextCursorState.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
+  return TextEditingPoint(point: offset, state: state);
 }
 
 class _TextInputClientHandler {
@@ -718,7 +718,7 @@ class _TextInputClientHandler {
       case 'TextInputClient.performAction':
         _currentConnection._client.performAction(_toTextInputAction(args[1]));
         break;
-      case 'TextInputClient.updateCursor':
+      case 'TextInputClient.updateFloatingCursor':
         _currentConnection._client.updateCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
         break;
       default:

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -685,11 +685,11 @@ TextInputAction _toTextInputAction(String action) {
 
 FloatingCursorDragState _toTextCursorAction(String state) {
   switch (state) {
-    case 'TextCursorState.start':
+    case 'FloatingCursorDragState.start':
       return FloatingCursorDragState.Start;
-    case 'TextCursorState.update':
+    case 'FloatingCursorDragState.update':
       return FloatingCursorDragState.Update;
-    case 'TextCursorState.end':
+    case 'FloatingCursorDragState.end':
       return FloatingCursorDragState.End;
   }
   throw FlutterError('Unknown text cursor action: $state');

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -441,7 +441,7 @@ TextAffinity _toTextAffinity(String affinity) {
 
 /// A floating cursor state the user has induced by force pressing an iOS
 /// keyboard.
-enum TextCursorState {
+enum FloatingCursorDragState {
   /// A user has just activated a floating cursor.
   Start,
 
@@ -454,12 +454,12 @@ enum TextCursorState {
 }
 
 /// The current state and position of the floating cursor.
-class TextEditingPoint {
+class FloatingCursorEditingPoint {
   /// Creates information for setting the position and state of a floating
   /// cursor.
   ///
   /// [state] must not be null.
-  const TextEditingPoint({
+  const FloatingCursorEditingPoint({
     this.point = const Offset(0, 0),
     @required this.state,
   }) : assert(state != null);
@@ -468,7 +468,7 @@ class TextEditingPoint {
   final Offset point;
 
   /// The state of the floating cursor.
-  final TextCursorState state;
+  final FloatingCursorDragState state;
 }
 
 /// The current text, selection, and composing state for editing a run of text.
@@ -600,7 +600,7 @@ abstract class TextInputClient {
   void performAction(TextInputAction action);
 
   /// Updates the floating cursor position and state.
-  void updateFloatingCursor(TextEditingPoint point);
+  void updateFloatingCursor(FloatingCursorEditingPoint point);
 }
 
 /// An interface for interacting with a text input control.
@@ -683,21 +683,24 @@ TextInputAction _toTextInputAction(String action) {
   throw FlutterError('Unknown text input action: $action');
 }
 
-TextCursorState _toTextCursorAction(String state) {
+FloatingCursorDragState _toTextCursorAction(String state) {
   switch (state) {
     case 'TextCursorState.start':
-      return TextCursorState.Start;
+      return FloatingCursorDragState.Start;
     case 'TextCursorState.update':
-      return TextCursorState.Update;
+      return FloatingCursorDragState.Update;
     case 'TextCursorState.end':
-      return TextCursorState.End;
+      return FloatingCursorDragState.End;
   }
   throw FlutterError('Unknown text cursor action: $state');
 }
 
-TextEditingPoint _toTextPoint(TextCursorState state, Map<String, dynamic> encoded) {
-  final Offset offset = state == TextCursorState.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
-  return TextEditingPoint(point: offset, state: state);
+FloatingCursorEditingPoint _toTextPoint(FloatingCursorDragState state, Map<String, dynamic> encoded) {
+  assert(state != null, 'You must provide a state to set a new editing point.');
+  assert(encoded['X'] != null, 'You must provide a value for the horizontal location of the floating cursor.');
+  assert(encoded['Y'] != null, 'You must provide a value for the vertical location of the floating cursor.');
+  final Offset offset = state == FloatingCursorDragState.Update ? Offset(encoded['X'], encoded['Y']) : const Offset(0, 0);
+  return FloatingCursorEditingPoint(point: offset, state: state);
 }
 
 class _TextInputClientHandler {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -439,19 +439,20 @@ TextAffinity _toTextAffinity(String affinity) {
   return null;
 }
 
-///
+/// A floating cursor state the user has induced by force pressing an iOS
+/// keyboard.
 enum TextCursorState {
-  ///
+  /// A user has just activated a floating cursor.
   Start,
 
-  ///
+  /// A user is dragging a floating cursor.
   Update,
 
-  ///
+  /// A user has lifted their finger off the screen after using a floating cursor.
   End,
 }
 
-///
+/// The current state and position of the floating cursor.
 class TextEditingPoint {
   ///
   const TextEditingPoint({
@@ -459,10 +460,10 @@ class TextEditingPoint {
     this.state,
   }) : assert(point != null);
 
-  ///
+  /// The raw position of the floating cursor as determined by the iOS sdk.
   final Offset point;
 
-  ///
+  /// The state of the floating cursor.
   final TextCursorState state;
 }
 
@@ -594,8 +595,8 @@ abstract class TextInputClient {
   /// Requests that this client perform the given action.
   void performAction(TextInputAction action);
 
-  ///
-  void updateCursor(TextEditingPoint point);
+  /// Updates the floating cursor position and state.
+  void updateFloatingCursor(TextEditingPoint point);
 }
 
 /// An interface for interacting with a text input control.
@@ -719,7 +720,7 @@ class _TextInputClientHandler {
         _currentConnection._client.performAction(_toTextInputAction(args[1]));
         break;
       case 'TextInputClient.updateFloatingCursor':
-        _currentConnection._client.updateCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
+        _currentConnection._client.updateFloatingCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
         break;
       default:
         throw MissingPluginException();

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -448,17 +448,21 @@ enum TextCursorState {
   /// A user is dragging a floating cursor.
   Update,
 
-  /// A user has lifted their finger off the screen after using a floating cursor.
+  /// A user has lifted their finger off the screen after using a floating
+  /// cursor.
   End,
 }
 
 /// The current state and position of the floating cursor.
 class TextEditingPoint {
+  /// Creates information for setting the position and state of a floating
+  /// cursor.
   ///
+  /// [state] must not be null.
   const TextEditingPoint({
     this.point = const Offset(0, 0),
-    this.state,
-  }) : assert(point != null);
+    @required this.state,
+  }) : assert(state != null);
 
   /// The raw position of the floating cursor as determined by the iOS sdk.
   final Offset point;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -632,7 +632,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   Offset get _floatingCursorOffset => Offset(0, renderEditable.preferredLineHeight / 2);
 
   @override
-  void updateFloatingCursor(FloatingCursorEditingPoint point) {
+  void updateFloatingCursor(RawFloatingCursorPoint point) {
     switch(point.state){
       case FloatingCursorDragState.Start:
         final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -612,7 +612,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   Offset _pointOffsetOrigin;
   Offset _lastBoundedOffset;
   AnimationController _floatingCursorController;
-  bool _hasRenderedFinalFrame = false;
 
   // Because the center of the cursor is preferredLineHeight / 2 below the touch
   // origin, but the touch origin is used to determine which line the cursor is

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -606,28 +606,32 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   @override
   void updateFloatingCursor(TextEditingPoint point) {
-    if (point.state == TextCursorState.Start) {
-      final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
-       _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
-       _pointOffsetOrigin = null;
-       renderEditable.setFloatingCursor(point.state, _startCaretRect.center - _floatingCursorOffset, currentTextPosition);
-    } else if (point.state == TextCursorState.Update) {
-      // We want to send in points that are centered around a (0,0) origin, so we cache
-      // position on the first update call.
-      if (_pointOffsetOrigin != null) {
-        final Offset centeredPoint = point.point - _pointOffsetOrigin;
-        final Offset rawCursorOffset = _startCaretRect.center + centeredPoint - _floatingCursorOffset;
-        final Offset boundedOffset = renderEditable.calculateBoundedCursorOffset(rawCursorOffset);
-        _lastTextPosition = renderEditable.getPositionForPoint(renderEditable.localToGlobal(boundedOffset + _floatingCursorOffset));
-        renderEditable.setFloatingCursor(point.state, boundedOffset, _lastTextPosition);
-      } else {
-        _pointOffsetOrigin = point.point;
-      }
-    } else {
-      if (_lastTextPosition.offset != renderEditable.selection.baseOffset)
-        _handleSelectionChanged(TextSelection.collapsed(offset: _lastTextPosition.offset), renderEditable, SelectionChangedCause.tap);
-      renderEditable.setFloatingCursor(point.state, null, null);
-      renderEditable.markNeedsPaint();
+    switch(point.state){
+      case TextCursorState.Start:
+        final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
+        _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
+        _pointOffsetOrigin = null;
+        renderEditable.setFloatingCursor(point.state, _startCaretRect.center - _floatingCursorOffset, currentTextPosition);
+        break;
+      case TextCursorState.Update:
+        // We want to send in points that are centered around a (0,0) origin, so we cache
+        // position on the first update call.
+        if (_pointOffsetOrigin != null) {
+          final Offset centeredPoint = point.point - _pointOffsetOrigin;
+          final Offset rawCursorOffset = _startCaretRect.center + centeredPoint - _floatingCursorOffset;
+          final Offset boundedOffset = renderEditable.calculateBoundedCursorOffset(rawCursorOffset);
+          _lastTextPosition = renderEditable.getPositionForPoint(renderEditable.localToGlobal(boundedOffset + _floatingCursorOffset));
+          renderEditable.setFloatingCursor(point.state, boundedOffset, _lastTextPosition);
+        } else {
+          _pointOffsetOrigin = point.point;
+        }
+        break;
+      case TextCursorState.End:
+        if (_lastTextPosition.offset != renderEditable.selection.baseOffset)
+          _handleSelectionChanged(TextSelection.collapsed(offset: _lastTextPosition.offset), renderEditable, SelectionChangedCause.tap);
+        renderEditable.setFloatingCursor(point.state, null, null);
+        renderEditable.markNeedsPaint();
+        break;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -8,7 +8,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart' show TickerProviderStateMixin;
 
 import 'automatic_keep_alive.dart';
 import 'basic.dart';
@@ -22,6 +21,7 @@ import 'scroll_controller.dart';
 import 'scroll_physics.dart';
 import 'scrollable.dart';
 import 'text_selection.dart';
+import 'ticker_provider.dart';
 
 export 'package:flutter/services.dart' show TextEditingValue, TextSelection, TextInputType;
 export 'package:flutter/rendering.dart' show SelectionChangedCause;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' show TickerProviderStateMixin;
 
 import 'automatic_keep_alive.dart';
 import 'basic.dart';

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -599,13 +599,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   TextPosition _lastTextPosition;
   Offset _pointOffsetOrigin;
 
-  // Painting requires an offset of - preferredLineHeight / 2 so we need to add it back
-  // so that the offset used to determine the text position is calculated correctly.
+  // Because the center of the cursor is preferredLineHeight / 2 below the touch
+  // origin, but the touch origin is used to determine which line the cursor is
+  // on, we need this offset to correctly render and move the cursor.
   Offset get _floatingCursorOffset { return Offset(0, renderEditable.preferredLineHeight / 2); }
 
   @override
-  void updateCursor(TextEditingPoint point) {
-//    print('editing point ' + point.point.toString());
+  void updateFloatingCursor(TextEditingPoint point) {
     if (point.state == TextCursorState.Start) {
       final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
        _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
@@ -625,8 +625,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       }
     } else {
       if (_lastTextPosition.offset != renderEditable.selection.baseOffset)
-        _handleSelectionChanged(TextSelection.collapsed(offset: _lastTextPosition.offset), renderEditable,
-          SelectionChangedCause.tap);
+        _handleSelectionChanged(TextSelection.collapsed(offset: _lastTextPosition.offset), renderEditable, SelectionChangedCause.tap);
       renderEditable.setFloatingCursor(point.state, null, null);
       renderEditable.markNeedsPaint();
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -609,7 +609,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (point.state == TextCursorState.Start) {
       final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
        _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
-       _pointOffsetOrigin = null;
+      _pointOffsetOrigin = null;
        renderEditable.setFloatingCursor(point.state, _startCaretRect.center - _floatingCursorOffset, currentTextPosition);
     } else if (point.state == TextCursorState.Update) {
       // We want to send in points that are centered around a (0,0) origin, so we cache

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -498,6 +498,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   TextInputConnection _textInputConnection;
   TextSelectionOverlay _selectionOverlay;
+  TextEditingPoint _textEditingPoint;
 
   final ScrollController _scrollController = ScrollController();
   final LayerLink _layerLink = LayerLink();
@@ -593,6 +594,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _finalizeEditing(false);
         break;
     }
+  }
+
+  @override
+  void updateCursor(TextEditingPoint point) {
+    print(point.action.toString() + ' ' + point.point.toString());
+    _textEditingPoint = point;
   }
 
   void _finalizeEditing(bool shouldUnfocus) {
@@ -987,6 +994,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               cursorRadius: widget.cursorRadius,
               enableInteractiveSelection: widget.enableInteractiveSelection,
               textSelectionDelegate: this,
+              textEditingPoint: _textEditingPoint,
             ),
           ),
         );
@@ -1052,6 +1060,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.cursorRadius,
     this.enableInteractiveSelection = true,
     this.textSelectionDelegate,
+    this.textEditingPoint,
   }) : assert(textDirection != null),
        assert(rendererIgnoresPointer != null),
        assert(enableInteractiveSelection != null),
@@ -1078,6 +1087,7 @@ class _Editable extends LeafRenderObjectWidget {
   final Radius cursorRadius;
   final bool enableInteractiveSelection;
   final TextSelectionDelegate textSelectionDelegate;
+  final TextEditingPoint textEditingPoint;
 
   @override
   RenderEditable createRenderObject(BuildContext context) {
@@ -1102,6 +1112,7 @@ class _Editable extends LeafRenderObjectWidget {
       cursorRadius: cursorRadius,
       enableInteractiveSelection: enableInteractiveSelection,
       textSelectionDelegate: textSelectionDelegate,
+      textEditingPoint: textEditingPoint,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -193,7 +193,7 @@ class EditableText extends StatefulWidget {
     this.autocorrect = true,
     @required this.style,
     @required this.cursorColor,
-    @required this.backgroundCursorColor,
+    this.backgroundCursorColor = const Color(0xFF8E8E93),
     this.textAlign = TextAlign.start,
     this.textDirection,
     this.locale,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -609,7 +609,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (point.state == TextCursorState.Start) {
       final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
        _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
-      _pointOffsetOrigin = null;
+       _pointOffsetOrigin = null;
        renderEditable.setFloatingCursor(point.state, _startCaretRect.center - _floatingCursorOffset, currentTextPosition);
     } else if (point.state == TextCursorState.Update) {
       // We want to send in points that are centered around a (0,0) origin, so we cache

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -138,8 +138,8 @@ void main() {
     editable.selection = const TextSelection(baseOffset: 29, extentOffset: 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
       offset: const Offset(20, 20)));
     await tester.pump();
 
@@ -148,14 +148,14 @@ void main() {
     );
 
     // Moves the cursor right a few characters.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
       offset: const Offset(-250, 20)));
 
     expect(find.byType(EditableText), paints..rrect(
       rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
     );
 
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -28,9 +28,7 @@ class FakeEditableTextState extends TextSelectionDelegate {
 void main() {
 
   final TextEditingController controller = TextEditingController();
-  final FocusScopeNode focusScopeNode = FocusScopeNode();
   const TextStyle textStyle = TextStyle();
-
 
   test('editable intrinsics', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
@@ -147,7 +145,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(EditableText), paints..rrect(
-        rrect: RRect.fromRectAndRadius(Rect.fromLTRB(406.5, 0.0, 409.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(406.5, 0.0, 409.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
     );
 
     // Moves the cursor right a few characters.
@@ -155,7 +153,7 @@ void main() {
       point: Offset(-250, 20)));
 
     expect(find.byType(EditableText), paints..rrect(
-        rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0.0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0.0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
     );
 
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1,10 +1,12 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+ // Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 import '../rendering/mock_canvas.dart';
 import '../rendering/recording_canvas.dart';
@@ -24,6 +26,12 @@ class FakeEditableTextState extends TextSelectionDelegate {
 }
 
 void main() {
+
+  final TextEditingController controller = TextEditingController();
+  final FocusScopeNode focusScopeNode = FocusScopeNode();
+  const TextStyle textStyle = TextStyle();
+
+
   test('editable intrinsics', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final RenderEditable editable = RenderEditable(
@@ -90,5 +98,70 @@ void main() {
       (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
       paints..clipRect(rect: Rect.fromLTRB(0.0, 0.0, 1000.0, 10.0))
     );
+  });
+
+  RenderEditable findRenderEditable(WidgetTester tester) {
+    final RenderObject root = tester.renderObject(find.byType(EditableText));
+    expect(root, isNotNull);
+
+    RenderEditable renderEditable;
+    void recursiveFinder(RenderObject child) {
+      if (child is RenderEditable) {
+        renderEditable = child;
+        return;
+      }
+      child.visitChildren(recursiveFinder);
+    }
+    root.visitChildren(recursiveFinder);
+    expect(renderEditable, isNotNull);
+    return renderEditable;
+  }
+
+  testWidgets('Floating cursor is painted', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    const String text = 'hello world this is fun and cool and awesome!';
+    controller.text = text;
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(
+            controller: controller,
+            focusNode: focusNode,
+            style: textStyle,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    final RenderEditable editable = findRenderEditable(tester);
+    editable.selection = const TextSelection(baseOffset: 29, extentOffset: 29);
+
+
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      point: Offset(20, 20)));
+    await tester.pump();
+
+    expect(find.byType(EditableText), paints..rrect(
+        rrect: RRect.fromRectAndRadius(Rect.fromLTRB(406.5, 0.0, 409.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+    );
+
+    // Moves the cursor right a few characters.
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      point: Offset(-250, 20)));
+
+    expect(find.byType(EditableText), paints..rrect(
+        rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0.0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+    );
+
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+
+    await tester.pumpAndSettle();
+
+    debugDefaultTargetPlatformOverride = null;
   });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -137,7 +137,6 @@ void main() {
     final RenderEditable editable = findRenderEditable(tester);
     editable.selection = const TextSelection(baseOffset: 29, extentOffset: 29);
 
-
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -138,24 +138,24 @@ void main() {
     editable.selection = const TextSelection(baseOffset: 29, extentOffset: 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-      point: Offset(20, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      offset: const Offset(20, 20)));
     await tester.pump();
 
     expect(find.byType(EditableText), paints..rrect(
-      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(406.5, 0.0, 409.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(406.5, 0, 409.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
     );
 
     // Moves the cursor right a few characters.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-      point: Offset(-250, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      offset: const Offset(-250, 20)));
 
     expect(find.byType(EditableText), paints..rrect(
-      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0.0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
+      rrect: RRect.fromRectAndRadius(Rect.fromLTRB(136.5, 0, 139.5, 14.0), const Radius.circular(1.0)), color: const Color(0xff4285f4))
     );
 
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1024,16 +1024,49 @@ class _RectPaintPredicate extends _OneParameterPaintPredicate<Rect> {
   );
 }
 
-class _RRectPaintPredicate extends _OneParameterPaintPredicate<RRect> {
-  _RRectPaintPredicate({ RRect rrect, Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style }) : super(
+class _RRectPaintPredicate extends _DrawCommandPaintPredicate {
+  _RRectPaintPredicate({ this.rrect, Color color, double strokeWidth, bool hasMaskFilter, PaintingStyle style }) : super(
     #drawRRect,
     'a rounded rectangle',
-    expected: rrect,
+    2,
+    1,
     color: color,
     strokeWidth: strokeWidth,
     hasMaskFilter: hasMaskFilter,
-    style: style,
+    style: style
   );
+
+  final RRect rrect;
+
+  @override
+  void verifyArguments(List<dynamic> arguments) {
+    super.verifyArguments(arguments);
+    const double eps = .0001;
+    final RRect actual = arguments[0];
+    if (rrect != null &&
+       ((actual.left - rrect.left).abs() > eps ||
+        (actual.right - rrect.right).abs() > eps ||
+        (actual.top - rrect.top).abs() > eps ||
+        (actual.bottom - rrect.bottom).abs() > eps ||
+        (actual.blRadiusX - rrect.blRadiusX).abs() > eps ||
+        (actual.blRadiusY - rrect.blRadiusX).abs() > eps ||
+        (actual.brRadiusX - rrect.blRadiusX).abs() > eps ||
+        (actual.brRadiusY - rrect.blRadiusX).abs() > eps ||
+        (actual.tlRadiusX - rrect.blRadiusX).abs() > eps ||
+        (actual.tlRadiusY - rrect.blRadiusX).abs() > eps ||
+        (actual.trRadiusX - rrect.blRadiusX).abs() > eps ||
+        (actual.trRadiusY - rrect.blRadiusX).abs() > eps)) {
+      throw 'It called $methodName with RRect, $actual, which was not exactly the expected RRect ($rrect).';
+    }
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (rrect != null) {
+      description.add('RRect: $rrect');
+    }
+  }
 }
 
 class _DRRectPaintPredicate extends _TwoParameterPaintPredicate<RRect, RRect> {

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1049,13 +1049,13 @@ class _RRectPaintPredicate extends _DrawCommandPaintPredicate {
         (actual.top - rrect.top).abs() > eps ||
         (actual.bottom - rrect.bottom).abs() > eps ||
         (actual.blRadiusX - rrect.blRadiusX).abs() > eps ||
-        (actual.blRadiusY - rrect.blRadiusX).abs() > eps ||
-        (actual.brRadiusX - rrect.blRadiusX).abs() > eps ||
-        (actual.brRadiusY - rrect.blRadiusX).abs() > eps ||
-        (actual.tlRadiusX - rrect.blRadiusX).abs() > eps ||
-        (actual.tlRadiusY - rrect.blRadiusX).abs() > eps ||
-        (actual.trRadiusX - rrect.blRadiusX).abs() > eps ||
-        (actual.trRadiusY - rrect.blRadiusX).abs() > eps)) {
+        (actual.blRadiusY - rrect.blRadiusY).abs() > eps ||
+        (actual.brRadiusX - rrect.brRadiusX).abs() > eps ||
+        (actual.brRadiusY - rrect.brRadiusY).abs() > eps ||
+        (actual.tlRadiusX - rrect.tlRadiusX).abs() > eps ||
+        (actual.tlRadiusY - rrect.tlRadiusY).abs() > eps ||
+        (actual.trRadiusX - rrect.trRadiusX).abs() > eps ||
+        (actual.trRadiusY - rrect.trRadiusY).abs() > eps)) {
       throw 'It called $methodName with RRect, $actual, which was not exactly the expected RRect ($rrect).';
     }
   }

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -26,6 +26,7 @@ void main() {
             controller: scrollController,
             children: <Widget>[
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -67,6 +68,7 @@ void main() {
                 height: 200.0,
               ),
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 scrollPadding: const EdgeInsets.all(50.0),
                 controller: controller,
                 focusNode: focusNode,
@@ -112,6 +114,7 @@ void main() {
                 height: 350.0,
               ),
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -161,6 +164,7 @@ void main() {
                 height: 350.0,
               ),
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -247,6 +251,7 @@ void main() {
             controller: scrollController,
             children: <Widget>[
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 maxLines: null, // multi-line
                 controller: controller,
                 focusNode: focusNode,
@@ -302,6 +307,7 @@ void main() {
                 height: 200.0,
               ),
               EditableText(
+                backgroundCursorColor: Colors.grey,
                 scrollPadding: const EdgeInsets.only(bottom: 300.0),
                 controller: controller,
                 focusNode: focusNode,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1834,24 +1834,24 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
       offset: const Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor right a few characters.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
       offset: const Offset(-250, 20)));
 
     // But we have not yet set the offset because the user is not done placing the cursor.
     expect(controller.selection.baseOffset, 29);
 
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
     // The cursor has been set.
@@ -1887,52 +1887,52 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor super far right
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(2090, 20)));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(2100, 20)));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(2090, 20)));
 
     // After peaking the cursor, we move in the opposite direction.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(1400, 20)));
 
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
     // The cursor has been set.
     expect(controller.selection.baseOffset, 8);
 
     // Go in the other direction.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Start));
     // Sets the origin.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(20, 20)));
 
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(-5000, 20)));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(-5010, 20)));
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(-5000, 20)));
 
     // Move back in the opposite direction only a few hundred.
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Update,
         offset: const Offset(-4850, 20)));
 
-    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -42,6 +42,7 @@ void main() {
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             textInputAction: action,
@@ -67,6 +68,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: EditableText(
           controller: controller,
+          backgroundCursorColor: Colors.grey,
           focusNode: focusNode,
           style: textStyle,
           cursorColor: cursorColor,
@@ -87,6 +89,7 @@ void main() {
     await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,
         child: EditableText(
+          backgroundCursorColor: Colors.grey,
           controller: controller,
           focusNode: focusNode,
           style: textStyle,
@@ -111,6 +114,7 @@ void main() {
           autofocus: true,
           child: EditableText(
             controller: controller,
+            backgroundCursorColor: Colors.grey,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
@@ -272,6 +276,7 @@ void main() {
           autofocus: true,
           child: EditableText(
             controller: controller,
+            backgroundCursorColor: Colors.grey,
             focusNode: focusNode,
             keyboardType: TextInputType.multiline,
             style: textStyle,
@@ -301,6 +306,7 @@ void main() {
           autofocus: true,
           child: EditableText(
             controller: controller,
+            backgroundCursorColor: Colors.grey,
             focusNode: focusNode,
             maxLines: null,
             style: textStyle,
@@ -329,6 +335,7 @@ void main() {
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             maxLines: null,
@@ -361,6 +368,7 @@ void main() {
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             keyboardType: TextInputType.phone,
@@ -392,6 +400,7 @@ void main() {
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             maxLines: 3, // Sets multiline keyboard implicitly.
@@ -422,6 +431,7 @@ void main() {
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             maxLines: 1, // Sets text keyboard implicitly.
@@ -451,6 +461,7 @@ void main() {
     String changedValue;
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: FocusNode(),
@@ -494,6 +505,7 @@ void main() {
       home: RepaintBoundary(
         key: const ValueKey<int>(1),
         child: EditableText(
+          backgroundCursorColor: Colors.grey,
           key: editableTextKey,
           controller: TextEditingController(),
           focusNode: FocusNode(),
@@ -544,6 +556,7 @@ void main() {
       home: RepaintBoundary(
         key: const ValueKey<int>(1),
         child: EditableText(
+          backgroundCursorColor: Colors.grey,
           key: editableTextKey,
           controller: TextEditingController(),
           focusNode: FocusNode(),
@@ -594,6 +607,7 @@ void main() {
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -628,6 +642,7 @@ void main() {
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -669,6 +684,7 @@ void main() {
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -713,6 +729,7 @@ void main() {
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -757,6 +774,7 @@ void main() {
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -801,6 +819,7 @@ testWidgets(
 
     final Widget widget = MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         key: editableTextKey,
         controller: TextEditingController(),
         focusNode: focusNode,
@@ -853,6 +872,7 @@ testWidgets(
             child: Center(
               child: Material(
                 child: EditableText(
+                  backgroundCursorColor: Colors.grey,
                   key: editableTextKey,
                   controller: currentController,
                   focusNode: FocusNode(),
@@ -912,6 +932,7 @@ testWidgets(
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             style: textStyle,
@@ -952,6 +973,7 @@ testWidgets(
         child: FocusScope(
           node: focusScopeNode,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             style: textStyle,
@@ -992,6 +1014,7 @@ testWidgets(
     await tester.pumpWidget(
       MaterialApp(
         home: EditableText(
+          backgroundCursorColor: Colors.grey,
           controller: controller,
           selectionControls: materialTextSelectionControls,
           focusNode: focusNode,
@@ -1034,6 +1057,7 @@ testWidgets(
 
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1109,6 +1133,7 @@ testWidgets(
 
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1198,6 +1223,7 @@ testWidgets(
 
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1297,6 +1323,7 @@ testWidgets(
 
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1395,6 +1422,7 @@ testWidgets(
 
       await tester.pumpWidget(MaterialApp(
         home: EditableText(
+          backgroundCursorColor: Colors.grey,
           controller: controller,
           focusNode: focusNode,
           style: textStyle,
@@ -1490,6 +1518,7 @@ testWidgets(
 
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
+        backgroundCursorColor: Colors.grey,
         obscureText: true,
         controller: controller,
         focusNode: focusNode,
@@ -1536,6 +1565,7 @@ testWidgets(
         MockTextSelectionControls controls, WidgetTester tester) {
       return tester.pumpWidget(MaterialApp(
         home: EditableText(
+          backgroundCursorColor: Colors.grey,
           controller: controller,
           focusNode: focusNode,
           style: textStyle,
@@ -1743,6 +1773,7 @@ testWidgets(
         node: focusScopeNode,
         autofocus: true,
         child: EditableText(
+          backgroundCursorColor: Colors.grey,
           controller: controller,
           focusNode: focusNode,
           autofocus: true,
@@ -1786,6 +1817,7 @@ testWidgets(
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             style: textStyle,
@@ -1802,24 +1834,24 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-                                                                  point: Offset(20, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      offset: const Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor right a few characters.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-                                                                  point: Offset(-250, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+      offset: const Offset(-250, 20)));
 
     // But we have not yet set the offset because the user is not done placing the cursor.
     expect(controller.selection.baseOffset, 29);
 
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
     // The cursor has been set.
@@ -1838,6 +1870,7 @@ testWidgets(
           node: focusScopeNode,
           autofocus: true,
           child: EditableText(
+            backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
             style: textStyle,
@@ -1854,52 +1887,52 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(20, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor super far right
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(2090, 20)));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(2100, 20)));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(2090, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(2090, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(2100, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(2090, 20)));
 
     // After peaking the cursor, we move in the opposite direction.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(1400, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(1400, 20)));
 
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
     // The cursor has been set.
     expect(controller.selection.baseOffset, 8);
 
     // Go in the other direction.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(20, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(20, 20)));
 
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(-5000, 20)));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(-5010, 20)));
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(-5000, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(-5000, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(-5010, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(-5000, 20)));
 
     // Move back in the opposite direction only a few hundred.
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
-        point: Offset(-4850, 20)));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
+        offset: const Offset(-4850, 20)));
 
-    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+    editableTextState.updateFloatingCursor(FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     await tester.pumpAndSettle();
 
@@ -1918,6 +1951,7 @@ class CustomStyleEditableText extends EditableText {
   }) : super(
           controller: controller,
           cursorColor: cursorColor,
+          backgroundCursorColor: Colors.grey,
           focusNode: focusNode,
           style: style,
         );

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1821,6 +1821,7 @@ testWidgets(
 
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
+    await tester.pumpAndSettle();
     // The cursor has been set.
     expect(controller.selection.baseOffset, 10);
   });
@@ -1877,6 +1878,7 @@ testWidgets(
 
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
+    await tester.pumpAndSettle();
     // The cursor has been set.
     expect(controller.selection.baseOffset, 8);
 
@@ -1898,6 +1900,8 @@ testWidgets(
         point: Offset(-4850, 20)));
 
     editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
+
+    await tester.pumpAndSettle();
 
     expect(controller.selection.baseOffset, 11);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1802,24 +1802,24 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Start));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
                                                                   point: Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor right a few characters.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
                                                                   point: Offset(-250, 20)));
 
     // But we have not yet set the offset because the user is not done placing the cursor.
     expect(controller.selection.baseOffset, 29);
 
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.End));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     // The cursor has been set.
     expect(controller.selection.baseOffset, 10);
@@ -1853,51 +1853,51 @@ testWidgets(
     expect(controller.selection.baseOffset, 29);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Start));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
 
     expect(controller.selection.baseOffset, 29);
 
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(20, 20)));
 
     expect(controller.selection.baseOffset, 29);
 
     // Moves the cursor super far right
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(2090, 20)));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(2100, 20)));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(2090, 20)));
 
     // After peaking the cursor, we move in the opposite direction.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(1400, 20)));
 
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.End));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     // The cursor has been set.
     expect(controller.selection.baseOffset, 8);
 
     // Go in the other direction.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Start));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Start));
     // Sets the origin.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(20, 20)));
 
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(-5000, 20)));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(-5010, 20)));
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(-5000, 20)));
 
     // Move back in the opposite direction only a few hundred.
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.Update,
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.Update,
         point: Offset(-4850, 20)));
 
-    editableTextState.updateFloatingCursor(const TextEditingPoint(state: TextCursorState.End));
+    editableTextState.updateFloatingCursor(const FloatingCursorEditingPoint(state: FloatingCursorDragState.End));
 
     expect(controller.selection.baseOffset, 11);
   });


### PR DESCRIPTION
Adds framework support for the floating cursor for text editing on iOS. It can be triggered by either a force press on the keyboard or (on iOS 12) by long pressing the spacebar. Fixes #17030 (#5445). 