### PR TITLE
Add ChangeNotifier.isDisposed

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -115,6 +115,12 @@ class ChangeNotifier implements Listenable {
     return true;
   }
 
+  /// Whether the resources held by this object have been disposed.
+  ///
+  /// This can be used to check if it is safe to continue using the object in
+  /// circumstances where the lifecycle is dynamic.
+  bool get isDisposed => _listeners == null;
+
   /// Whether any listeners are currently registered.
   ///
   /// Clients should not depend on this value for their behavior, because having

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -202,11 +202,13 @@ void main() {
 
   test('Cannot use a disposed ChangeNotifier', () {
     final TestNotifier source = TestNotifier();
+    expect(source.isDisposed, false);
     source.dispose();
     expect(() { source.addListener(null); }, throwsFlutterError);
     expect(() { source.removeListener(null); }, throwsFlutterError);
     expect(() { source.dispose(); }, throwsFlutterError);
     expect(() { source.notify(); }, throwsFlutterError);
+    expect(source.isDisposed, true);
   });
 
   test('Value notifier', () {


### PR DESCRIPTION
This resolves an issue discovered in https://github.com/flutter/flutter/pull/24753. With a ChangeNotifier children have to release their resources (removeListener) before their parents do (dispose). However `didUpdateWidget` progresses from parent to child, so this cannot be used to release a resource which is held by both. 

One solution is to allow children to check if the resource has already been disposed. Another would be to place the call to dispose in a microtask.

