### PR TITLE
Throw flutter error if bottom nav bar items length is mutated

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -373,6 +373,11 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
   // Last splash circle's color, and the final color of the control after
   // animation is complete.
   Color _backgroundColor;
+  // Assert that list of bottom navigation bar items is not mutated.
+  int _debugLastLength;
+  // Errors thrown during didUpdateWidget do not cause the widget to become an
+  // error widget.
+  FlutterError _debugCapturedFlutterError;
 
   static final Animatable<double> _flexTween = Tween<double>(begin: 1.0, end: 1.5);
 
@@ -396,6 +401,10 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         reverseCurve: Curves.fastOutSlowIn.flipped,
       );
     });
+    assert(() {
+      _debugLastLength = widget.items.length;
+      return true;
+    }());
     _controllers[widget.currentIndex].value = 1.0;
     _backgroundColor = widget.items[widget.currentIndex].backgroundColor;
   }
@@ -456,6 +465,20 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
   @override
   void didUpdateWidget(BottomNavigationBar oldWidget) {
     super.didUpdateWidget(oldWidget);
+    assert(() {
+      if (_debugLastLength != oldWidget.items.length) {
+        _debugCapturedFlutterError = FlutterError(
+          'The list of BottomNavigationBarItems was mutated by a parent widget. '
+          'Ensure that if the number of items in the BottomNavigationBar is changed, '
+          'a new List of items is passed in.'
+        );
+      }
+      return true;
+    }());
+    assert(() {
+      _debugLastLength = widget.items.length;
+      return true;
+    }());
 
     // No animated segue if the length of the items list changes.
     if (widget.items.length != oldWidget.items.length) {
@@ -555,6 +578,12 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
   Widget build(BuildContext context) {
     assert(debugCheckHasDirectionality(context));
     assert(debugCheckHasMaterialLocalizations(context));
+    assert(() {
+      if (_debugCapturedFlutterError != null) {
+        throw _debugCapturedFlutterError;
+      }
+      return true;
+    }());
 
     // Labels apply up to _bottomMargin padding. Remainder is media padding.
     final double additionalBottomPadding = math.max(MediaQuery.of(context).padding.bottom - _kBottomMargin, 0.0);

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -834,7 +834,7 @@ void main() {
   });
 
   testWidgets('mutating the list of BottomNavigationBarItems throws a FluterError', (WidgetTester tester) async {
-    final List<BottomNavigationBarItem> items = [
+    final List<BottomNavigationBarItem> items = <BottomNavigationBarItem>[
       const BottomNavigationBarItem(
         title: Text('Red'),
         backgroundColor: Colors.red,

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -833,6 +833,50 @@ void main() {
     }
   });
 
+  testWidgets('mutating the list of BottomNavigationBarItems throws a FluterError', (WidgetTester tester) async {
+    final List<BottomNavigationBarItem> items = [
+      const BottomNavigationBarItem(
+        title: Text('Red'),
+        backgroundColor: Colors.red,
+        icon: Icon(Icons.dashboard),
+      ),
+      const BottomNavigationBarItem(
+        title: Text('Green'),
+        backgroundColor: Colors.green,
+        icon: Icon(Icons.menu),
+      ),
+    ];
+    Function _setState;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            _setState = setState;
+            return Scaffold(
+              bottomNavigationBar: RepaintBoundary(
+                child: BottomNavigationBar(
+                  type: BottomNavigationBarType.shifting,
+                  currentIndex: 0,
+                  onTap: (int index) {},
+                  items: items,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    _setState(() {
+      items.add(const BottomNavigationBarItem(
+        title: Text('Blue'),
+        backgroundColor: Colors.purple,
+        icon: Icon(Icons.adb)
+      ));
+    });
+    await tester.pump();
+    expect(tester.takeException(), isInstanceOf<FlutterError>());
+  });
+
   testWidgets('BottomNavigationBar item title should not be nullable',
       (WidgetTester tester) async {
     expect(() {


### PR DESCRIPTION
Instead of erroring out with an index out of bounds, we can throw an error.

Fixes https://github.com/flutter/flutter/issues/22500