### PR TITLE
Remove snippets snapshotting hack from dartdoc generation.

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -4,8 +4,8 @@ dartdoc:
   # The dev/tools/dartdoc.dart script does this automatically.
   tools:
     snippet:
-      command: ["bin/cache/dart-sdk/bin/dart", "../../bin/cache/snippets.snapshot", "--type=application"]
+      command: ["dev/snippets/lib/main.dart", "--type=application"]
       description: "Creates application sample code documentation output from embedded documentation samples."
     sample:
-      command: ["bin/cache/dart-sdk/bin/dart", "../../bin/cache/snippets.snapshot", "--type=sample"]
+      command: ["dev/snippets/lib/main.dart", "--type=sample"]
       description: "Creates sample code documentation output from embedded documentation samples."


### PR DESCRIPTION
Now that dartdoc automatically generates snapshots for external dart tools, I can remove my path hack from the `dartdoc_options.yaml` file.

This will allow other packages to again build dartdocs (e.g. plugins) that link to Flutter's dartdocs, and allow me to re-enable dartdoc's cross-linking test that was disabled because of this hack.