### PR TITLE
Remove deprecated lint "prefer_bool_in_asserts".

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -114,7 +114,6 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors


### PR DESCRIPTION
In Dart 2, asserts no longer accept non-bool values so this rule is
made redundant by the Dart analyzer's basic checks and is no longer
necessary.

The rule will be removed in a future Linter release.