### PR TITLE
Datepicker: fix out of range date after year changed (#17309)

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -895,6 +895,10 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
   }
 
   void _handleYearChanged(DateTime value) {
+    if (value.isBefore(widget.firstDate))
+      value = widget.firstDate;
+    else if (value.isAfter(widget.lastDate))
+      value = widget.lastDate;
     _vibrate();
     setState(() {
       _mode = DatePickerMode.day;


### PR DESCRIPTION
This fix the bug reported in issue #17309

This make sure the picked date stay in the given range after year changed (firstDate < pickedDate < lastDate).

Without this check, when you change the year by tapping on the header of the datepicker, it change the year but keep the same month and day, which mean it can easily go out of range.