### PR TITLE
Fix flutter root error message string interpolation

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -23,7 +23,7 @@ end
 def flutter_root(f)
     generated_xcode_build_settings = parse_KV_file(File.join(f, File.join('.ios', 'Flutter', 'Generated.xcconfig')))
     if generated_xcode_build_settings.empty?
-        puts "Generated.xcconfig must exist. Make sure `flutter packages get` is executed in ${f}."
+        puts "Generated.xcconfig must exist. Make sure `flutter packages get` is executed in #{f}."
         exit
     end
     generated_xcode_build_settings.map { |p|


### PR DESCRIPTION
The variable isn't interpolating because it's using "${}" when ruby uses "#{}".