### PR TITLE
RepaintBoundary doesn't throw when getting a new parent after hot reload

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1855,7 +1855,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     }
     assert(() {
       final AbstractNode parent = this.parent;
-      if (parent is RenderObject)
+      if (!isRepaintBoundary && parent is RenderObject)
         return parent._needsCompositing;
       return true;
     }());

--- a/packages/flutter/test/rendering/repaint_boundary_test.dart
+++ b/packages/flutter/test/rendering/repaint_boundary_test.dart
@@ -34,4 +34,23 @@ void main() {
     c.opacity = 0.7;
     pumpFrame(phase: EnginePhase.flushSemantics);
   });
+
+  test('Repaint boundary can get a new parent after a hot reload without crashing', () {
+    // Regression test for https://github.com/flutter/flutter/issues/24029.
+
+    final RenderBox repaintBoundary = RenderRepaintBoundary();
+    layout(repaintBoundary, phase: EnginePhase.flushSemantics);
+
+    // Simulate hot reload.
+    renderer.renderView.reassemble();
+
+    // Give the repaint boundary a new parent.
+    renderer.renderView.dropChild(repaintBoundary);
+    final RenderBox padding = RenderPadding(
+      padding: const EdgeInsets.all(50),
+    );
+    renderer.renderView.adoptChild(padding);
+    padding.adoptChild(repaintBoundary);
+    pumpFrame(phase: EnginePhase.flushSemantics);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/24029.