### PR TITLE
Remove TextField.noMaxLength, use maxLength = -1 instead

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -251,7 +251,7 @@ class TextField extends StatefulWidget {
   ///
   /// This value must be either null, [TextField.noMaxLength], or greater than 0.
   /// If null (the default) then there is no limit to the number of characters
-  /// that can be entered. If set to [TextField.noMaxLength], then no limit will 
+  /// that can be entered. If set to [TextField.noMaxLength], then no limit will
   /// be enforced, but the number of characters entered will still be displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -249,10 +249,10 @@ class TextField extends StatefulWidget {
   /// enforces the length with a [LengthLimitingTextInputFormatter], which is
   /// evaluated after the supplied [inputFormatters], if any.
   ///
-  /// This value must be either null, [TextField.noMaxLength], or greater than 0. If set to null
-  /// (the default), there is no limit to the number of characters allowed.
-  /// If set to [TextField.noMaxLength], then no limit will be enforced, but the number of
-  /// characters entered will still be displayed.
+  /// This value must be either null, [TextField.noMaxLength], or greater than 0.
+  /// If null (the default) then there is no limit to the number of characters
+  /// that can be entered. If set to [TextField.noMaxLength], then no limit will 
+  /// be enforced, but the number of characters entered will still be displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the
   /// character count.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -247,7 +247,7 @@ class TextField extends StatefulWidget {
   ///
   /// This value must be either null, greater than 0, or -1 (negative one). If set to null
   /// (the default), there is no limit to the number of characters allowed. If set to -1,
-  /// then no limit will be enforce, but the display of how many characters have been
+  /// then no limit will be enforced, but the display of how many characters have been
   /// entered is still displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -415,7 +415,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       counterText += '/${widget.maxLength}';
       final int remaining = (widget.maxLength - currentLength).clamp(0, widget.maxLength);
       semanticCounterText = localizations.remainingTextFieldCharacterCount(remaining);
-  
+
       // Handle length exceeds maxLength
       if (_effectiveController.value.text.runes.length > widget.maxLength) {
         final ThemeData themeData = Theme.of(context);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -80,7 +80,7 @@ class TextField extends StatefulWidget {
   /// field showing how many characters have been entered. If the value is
   /// set to a positive integer it will also display the maximum allowed
   /// number of characters to be entered.  If the value is set to -1 then
-  /// only the current length is displatyed.
+  /// only the current length is displayed.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
@@ -245,7 +245,7 @@ class TextField extends StatefulWidget {
   /// enforces the length with a [LengthLimitingTextInputFormatter], which is
   /// evaluated after the supplied [inputFormatters], if any.
   ///
-  /// This value must be either null, greater than 0, or -1 (negative one). If set to null
+  /// This value must be either null, -1, or greater than 0. If set to null
   /// (the default), there is no limit to the number of characters allowed. If set to -1,
   /// then no limit will be enforced, but the display of how many characters have been
   /// entered is still displayed.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -79,8 +79,8 @@ class TextField extends StatefulWidget {
   /// [maxLength] is set a character counter will be displayed below the
   /// field showing how many characters have been entered. If the value is
   /// set to a positive integer it will also display the maximum allowed
-  /// number of characters to be entered.  If the value is set to -1 then
-  /// only the current length is displayed.
+  /// number of characters to be entered.  If the value is set to
+  /// [TextField.noMaxLength] then only the current length is displayed.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
@@ -136,7 +136,7 @@ class TextField extends StatefulWidget {
        assert(maxLengthEnforced != null),
        assert(scrollPadding != null),
        assert(maxLines == null || maxLines > 0),
-       assert(maxLength == null || maxLength == -1 || maxLength > 0),
+       assert(maxLength == null || maxLength == TextField.noMaxLength || maxLength > 0),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        assert(enableInteractiveSelection != null),
        super(key: key);
@@ -232,22 +232,26 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.maxLines}
   final int maxLines;
 
+  /// If [maxLength] is set to this value, only the "current input length"
+  /// part of the character counter is shown.
+  static const int noMaxLength = -1;
+
   /// The maximum number of characters (Unicode scalar values) to allow in the
   /// text field.
   ///
   /// If set, a character counter will be displayed below the
   /// field showing how many characters have been entered. If set to a number
   /// greather than 0, it will also display the maximum number allowed. If set
-  /// to -1 then only the current character count is displayed.
+  /// to [TextField.noMaxLength] then only the current character count is displayed.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
   /// enforces the length with a [LengthLimitingTextInputFormatter], which is
   /// evaluated after the supplied [inputFormatters], if any.
   ///
-  /// This value must be either null, -1, or greater than 0. If set to null
+  /// This value must be either null, [TextField.noMaxLength], or greater than 0. If set to null
   /// (the default), there is no limit to the number of characters allowed.
-  /// If set to -1, then no limit will be enforced, but the number of
+  /// If set to [TextField.noMaxLength], then no limit will be enforced, but the number of
   /// characters entered will still be displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -237,9 +237,9 @@ class TextField extends StatefulWidget {
   ///
   /// If set, a character counter will be displayed below the
   /// field showing how many characters have been entered. If set to a number
-  /// greather than 0, it will also display the maximum number allowed. If set 
+  /// greather than 0, it will also display the maximum number allowed. If set
   /// to -1 then only the current character count is displayed.
-  /// 
+  ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
   /// enforces the length with a [LengthLimitingTextInputFormatter], which is
@@ -415,7 +415,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       counterText += '/${widget.maxLength}';
       final int remaining = (widget.maxLength - currentLength).clamp(0, widget.maxLength);
       semanticCounterText = localizations.remainingTextFieldCharacterCount(remaining);
-    
+  
       // Handle length exceeds maxLength
       if (_effectiveController.value.text.runes.length > widget.maxLength) {
         final ThemeData themeData = Theme.of(context);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -246,9 +246,9 @@ class TextField extends StatefulWidget {
   /// evaluated after the supplied [inputFormatters], if any.
   ///
   /// This value must be either null, -1, or greater than 0. If set to null
-  /// (the default), there is no limit to the number of characters allowed. If set to -1,
-  /// then no limit will be enforced, but the display of how many characters have been
-  /// entered is still displayed.
+  /// (the default), there is no limit to the number of characters allowed.
+  /// If set to -1, then no limit will be enforced, but the number of
+  /// characters entered will still be displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the
   /// character count.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -76,10 +76,11 @@ class TextField extends StatefulWidget {
   ///
   /// The [maxLength] property is set to null by default, which means the
   /// number of characters allowed in the text field is not restricted. If
-  /// [maxLength] is set, a character counter will be displayed below the
-  /// field, showing how many characters have been entered and how many are
-  /// allowed unless the value is set to [noMaxLength] in which case only the
-  /// current length is displayed.
+  /// [maxLength] is set a character counter will be displayed below the
+  /// field showing how many characters have been entered. If the value is
+  /// set to a positive integer it will also display the maximum allowed
+  /// number of characters to be entered.  If the value is set to -1 then
+  /// only the current length is displatyed.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
@@ -135,7 +136,7 @@ class TextField extends StatefulWidget {
        assert(maxLengthEnforced != null),
        assert(scrollPadding != null),
        assert(maxLines == null || maxLines > 0),
-       assert(maxLength == null || maxLength > 0),
+       assert(maxLength == null || maxLength == -1 || maxLength > 0),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        assert(enableInteractiveSelection != null),
        super(key: key);
@@ -231,22 +232,23 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.maxLines}
   final int maxLines;
 
-  /// If [maxLength] is set to this value, only the "current input length"
-  /// part of the character counter is shown.
-  static const int noMaxLength = 9007199254740992; // math.pow(2, 53);
-
   /// The maximum number of characters (Unicode scalar values) to allow in the
   /// text field.
   ///
   /// If set, a character counter will be displayed below the
-  /// field, showing how many characters have been entered and how many are
-  /// allowed. After [maxLength] characters have been input, additional input
+  /// field showing how many characters have been entered. If set to a number
+  /// greather than 0, it will also display the maximum number allowed. If set 
+  /// to -1 then only the current character count is displayed.
+  /// 
+  /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforced] is set to false. The TextField
   /// enforces the length with a [LengthLimitingTextInputFormatter], which is
   /// evaluated after the supplied [inputFormatters], if any.
   ///
-  /// This value must be either null or greater than zero. If set to null
-  /// (the default), there is no limit to the number of characters allowed.
+  /// This value must be either null, greater than 0, or -1 (negative one). If set to null
+  /// (the default), there is no limit to the number of characters allowed. If set to -1,
+  /// then no limit will be enforce, but the display of how many characters have been
+  /// entered is still displayed.
   ///
   /// Whitespace characters (e.g. newline, space, tab) are included in the
   /// character count.
@@ -407,23 +409,26 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     String counterText = '$currentLength';
     String semanticCounterText = '';
 
-    if (widget.maxLength != TextField.noMaxLength) {
+    // Handle a real maxLength (positive number)
+    if (widget.maxLength > 0) {
+      // Show the maxLength in the counter
       counterText += '/${widget.maxLength}';
       final int remaining = (widget.maxLength - currentLength).clamp(0, widget.maxLength);
       semanticCounterText = localizations.remainingTextFieldCharacterCount(remaining);
+    
+      // Handle length exceeds maxLength
+      if (_effectiveController.value.text.runes.length > widget.maxLength) {
+        final ThemeData themeData = Theme.of(context);
+        return effectiveDecoration.copyWith(
+          errorText: effectiveDecoration.errorText ?? '',
+          counterStyle: effectiveDecoration.errorStyle
+            ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor),
+          counterText: counterText,
+          semanticCounterText: semanticCounterText,
+        );
+      }
     }
 
-    // Handle length exceeds maxLength
-    if (_effectiveController.value.text.runes.length > widget.maxLength) {
-      final ThemeData themeData = Theme.of(context);
-      return effectiveDecoration.copyWith(
-        errorText: effectiveDecoration.errorText ?? '',
-        counterStyle: effectiveDecoration.errorStyle
-          ?? themeData.textTheme.caption.copyWith(color: themeData.errorColor),
-        counterText: counterText,
-        semanticCounterText: semanticCounterText,
-      );
-    }
     return effectiveDecoration.copyWith(
       counterText: counterText,
       semanticCounterText: semanticCounterText,

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -134,10 +134,10 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
   /// Creates a formatter that prevents the insertion of more characters than a
   /// limit.
   ///
-  /// The [maxLength] must be null or greater than zero. If it is null, then no
-  /// limit is enforced.
+  /// The [maxLength] must be null, -1 or greater than zero. If it is null or -1
+  /// then no limit is enforced.
   LengthLimitingTextInputFormatter(this.maxLength)
-    : assert(maxLength == null || maxLength > 0);
+    : assert(maxLength == null || maxLength == -1 || maxLength > 0);
 
   /// The limit on the number of characters (i.e. Unicode scalar values) this formatter
   /// will allow.
@@ -171,7 +171,7 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
     TextEditingValue oldValue, // unused.
     TextEditingValue newValue,
   ) {
-    if (maxLength != null && newValue.text.runes.length > maxLength) {
+    if (maxLength != null && maxLength > 0 && newValue.text.runes.length > maxLength) {
       final TextSelection newSelection = newValue.selection.copyWith(
           baseOffset: math.min(newValue.selection.start, maxLength),
           extentOffset: math.min(newValue.selection.end, maxLength),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1810,13 +1810,13 @@ void main() {
   });
 
   testWidgets(
-      'setting maxLength to TextField.noMaxLength shows only entered length',
+      'setting maxLength to -1 shows only entered length',
       (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
-              maxLength: TextField.noMaxLength,
+              maxLength: -1,
             ),
           ),
         ),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1810,13 +1810,13 @@ void main() {
   });
 
   testWidgets(
-      'setting maxLength to -1 shows only entered length',
+      'setting maxLength to TextField.noMaxLength shows only entered length',
       (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
-              maxLength: -1,
+              maxLength: TextField.noMaxLength,
             ),
           ),
         ),


### PR DESCRIPTION
As per a discussion the value of the maxLength to cause it to not display is now -1 instead of a very large int. This should be reviewed by @Hixie and @HansMuller as they are familiar with the discussion.

Cheers!
