### PR TITLE
Move the Android INTERNET permission into the debug build.

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- The INTERNET permission is required for development. Specifically,
+            flutter needs it to communicate with the running application
+            to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+</manifest>

--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
@@ -1,12 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{androidIdentifier}}">
 
-    <!-- The INTERNET permission is required for development. Specifically,
-         flutter needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
-
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/debug/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/debug/AndroidManifest.xml.tmpl
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- The INTERNET permission is required for development. Specifically,
+            flutter needs it to communicate with the running application
+            to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+</manifest>

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
@@ -2,12 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="{{androidIdentifier}}.host">
 
-    <!-- The INTERNET permission is required for development. Specifically,
-         flutter needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
-
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/debug/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/debug/AndroidManifest.xml.tmpl
@@ -1,0 +1,10 @@
+<!-- Generated file. Do not edit. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- The INTERNET permission is required for development. Specifically,
+          flutter needs it to communicate with the running application
+          to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+</manifest>

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/AndroidManifest.xml.tmpl
@@ -1,5 +1,3 @@
 <!-- Generated file. Do not edit. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{androidIdentifier}}">
-  <uses-permission android:name="android.permission.INTERNET"/>
-</manifest>
+    package="{{androidIdentifier}}" />


### PR DESCRIPTION
Fixes #20789.

This is based on the assumption that Flutter Apps MAY but not MUST have a requirement for internet access / communication. It's a little hard to believe these days, yet IMHO the App developer should make the decision, not the framework. 