### PR TITLE
bugfix: Text overflow does not work correctly in Sized widgets

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -273,9 +273,10 @@ class RenderParagraph extends RenderBox {
     // Other _textPainter state like didExceedMaxLines will also be affected.
     // See also RenderEditable which has a similar issue.
     final Size textSize = _textPainter.size;
-    final bool didOverflowHeight = _textPainter.didExceedMaxLines;
     size = constraints.constrain(textSize);
 
+    final bool didOverflowHeight =
+      _textPainter.didExceedMaxLines || size.height < textSize.height;
     final bool didOverflowWidth = size.width < textSize.width;
     // TODO(abarth): We're only measuring the sizes of the line boxes here. If
     // the glyphs draw outside the line boxes, we might think that there isn't


### PR DESCRIPTION
fixes #25025