### PR TITLE
fix #25035

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -450,7 +450,7 @@ class _FlutterValidator extends DoctorValidator {
       if (platform.isLinux) {
         buf.writeln('On Debian/Ubuntu/Mint: sudo apt-get install lib32stdc++6');
         buf.writeln('On Fedora: dnf install libstdc++.i686');
-        buf.writeln('On Arch: pacman -S lib32-libstdc++5');
+        buf.writeln('On Arch: Install the AUR package from https://aur.archlinux.org/packages/lib32-libstdc++5');
       }
       messages.add(ValidationMessage.error(buf.toString()));
       valid = ValidationType.partial;


### PR DESCRIPTION
replace instruction ```pacman -S lib32-libstdc++5``` with ```Install the AUR package from https://aur.archlinux.org/packages/lib32-libstdc++5```