### PR TITLE
Add a check for build methods that return context.widget

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -37,8 +37,8 @@ enum _SwitchType { material, adaptive }
 ///
 /// If the [onChanged] callback is null, then the switch will be disabled (it
 /// will not respond to input). A disabled switch's thumb and track are rendered
-/// in shades of grey by default. The appearance of a disabled switch can be
-/// overridden with [inactiveThumbColor] and [inactiveTrackColor].
+/// in shades of grey by default. The default appearance of a disabled switch
+/// can be overridden with [inactiveThumbColor] and [inactiveTrackColor].
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -35,6 +35,11 @@ enum _SwitchType { material, adaptive }
 /// that use a switch will listen for the [onChanged] callback and rebuild the
 /// switch with a new [value] to update the visual appearance of the switch.
 ///
+/// If the [onChanged] callback is null, then the switch will be disabled (it
+/// will not respond to input). A disabled switch's thumb and track are rendered
+/// in shades of grey by default. The appearance of a disabled switch can be
+/// overridden with [inactiveThumbColor] and [inactiveTrackColor].
+///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
 /// See also:
@@ -505,8 +510,7 @@ class _RenderSwitch extends RenderToggleable {
   @override
   void paint(PaintingContext context, Offset offset) {
     final Canvas canvas = context.canvas;
-
-    final bool isActive = onChanged != null;
+    final bool isEnabled = onChanged != null;
     final double currentValue = position.value;
 
     double visualPosition;
@@ -519,7 +523,17 @@ class _RenderSwitch extends RenderToggleable {
         break;
     }
 
-    final Color trackColor = isActive ? Color.lerp(inactiveTrackColor, activeTrackColor, currentValue) : inactiveTrackColor;
+    final Color trackColor = isEnabled
+      ? Color.lerp(inactiveTrackColor, activeTrackColor, currentValue)
+      : inactiveTrackColor;
+
+    final Color thumbColor = isEnabled
+      ? Color.lerp(inactiveColor, activeColor, currentValue)
+      : inactiveColor;
+
+    final ImageProvider thumbImage = isEnabled
+      ? (currentValue < 0.5 ? inactiveThumbImage : activeThumbImage)
+      : inactiveThumbImage;
 
     // Paint the track
     final Paint paint = Paint()
@@ -544,8 +558,6 @@ class _RenderSwitch extends RenderToggleable {
     try {
       _isPainting = true;
       BoxPainter thumbPainter;
-      final Color thumbColor = isActive ? Color.lerp(inactiveColor, activeColor, currentValue) : inactiveColor;
-      final ImageProvider thumbImage = isActive ? (currentValue < 0.5 ? inactiveThumbImage : activeThumbImage) : inactiveThumbImage;
       if (_cachedThumbPainter == null || thumbColor != _cachedThumbColor || thumbImage != _cachedThumbImage) {
         _cachedThumbColor = thumbColor;
         _cachedThumbImage = thumbImage;

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -275,6 +275,14 @@ void debugWidgetBuilderValue(Widget widget, Widget built) {
         'To return an empty space that takes as little room as possible, return "new Container(width: 0.0, height: 0.0)".'
       );
     }
+    if (widget == built) {
+      throw FlutterError(
+        'A build function returned context.widget.\n'
+        'The offending widget is: $widget\n'
+        'Build functions must never return their BuildContext parameter\'s widget or a child that contains "context.widget". '
+        'Doing so introduces a loop in the widget tree that can cause the app to crash.'
+      );
+    }
     return true;
   }());
 }

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -42,7 +42,7 @@ Future<void> main() async {
     final GlobalKey key = GlobalKey();
     final Completer<void> completer = Completer<void>();
     await tester.pumpWidget(
-      KeyedSubtree(
+       KeyedSubtree(
         key: key,
         child: DecoratedBox(
           decoration: BoxDecoration(

--- a/packages/flutter/test/widgets/build_fail_test.dart
+++ b/packages/flutter/test/widgets/build_fail_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+Future<void> main() async {
+  testWidgets('Build method that returns context.widget throws FlutterError', (WidgetTester tester) async {
+    // Regression test for: https://github.com/flutter/flutter/issues/25041
+    await tester.pumpWidget(
+      Builder(builder: (BuildContext context) => context.widget)
+    );
+    expect(tester.takeException(), isFlutterError);
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/25041

Extend `debugWidgetBuilderValue`: throw an error if the built widget is the same as the builder itself.
```
void main() { runApp(Builder(builder: (context) => context.widget)); } // error
```

Widget tree build loops can be introduced in various ways, see https://github.com/flutter/flutter/issues/25041#issuecomment-444973851. This change only detects the most obvious case.
