### PR TITLE
ensure lastBuildTimestamp is set before early return

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -107,14 +107,16 @@ class _ManifestAssetBundle implements AssetBundle {
     if (flutterManifest == null)
       return 1;
 
+    // If the last build time isn't set before this early return, empty pubspecs will
+    // hang on hot reload, as the incremental dill files will never be copied to the
+    // device.
+    _lastBuildTimestamp = DateTime.now();
     if (flutterManifest.isEmpty) {
       entries[_assetManifestJson] = DevFSStringContent('{}');
       return 0;
     }
 
     final String assetBasePath = fs.path.dirname(fs.path.absolute(manifestPath));
-
-    _lastBuildTimestamp = DateTime.now();
 
     final PackageMap packageMap = PackageMap(packagesPath);
 

--- a/packages/flutter_tools/test/asset_test.dart
+++ b/packages/flutter_tools/test/asset_test.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/run_hot.dart';
 
 import 'src/common.dart';
 import 'src/context.dart';

--- a/packages/flutter_tools/test/asset_test.dart
+++ b/packages/flutter_tools/test/asset_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/run_hot.dart';
 
 import 'src/common.dart';
 import 'src/context.dart';
@@ -41,8 +42,26 @@ void main() {
         await getValueAsString('FontManifest.json', asset),
         '[{"family":"packages/font/test_font","fonts":[{"asset":"packages/font/test_font_file"}]}]',
       );
+      expect(asset.wasBuiltOnce(), true);
     });
 
+    testUsingContext('handles empty pubspec with .packages', () async {
+      final String dataPath = fs.path.join(
+        getFlutterRoot(),
+        'packages',
+        'flutter_tools',
+        'test',
+        'data',
+        'fuchsia_test',
+      );
+      final AssetBundle asset = AssetBundleFactory.instance.createBundle();
+      await asset.build(
+        manifestPath : fs.path.join(dataPath, 'main', 'pubspec.yaml'), // file doesn't exist
+        packagesPath: fs.path.join(dataPath, 'main', '.packages'),
+        includeDefaultFonts: false,
+      );
+      expect(asset.wasBuiltOnce(), true);
+    });
   });
 }
 

--- a/packages/flutter_tools/test/data/fuchsia_test/main/.gitignore
+++ b/packages/flutter_tools/test/data/fuchsia_test/main/.gitignore
@@ -1,0 +1,1 @@
+!.packages

--- a/packages/flutter_tools/test/data/fuchsia_test/main/.packages
+++ b/packages/flutter_tools/test/data/fuchsia_test/main/.packages
@@ -1,0 +1,1 @@
+testo:lib/


### PR DESCRIPTION
If the last build time isn't set before this early return, empty pubspecs will hang on hot reload, as the incremental dill files will never be copied to the device.