### PR TITLE
Scrollbar fix for iOS

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -598,6 +598,12 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// True if the navigation bar's background color has no transparency.
   bool get opaque => backgroundColor.alpha == 0xFF;
 
+  /// The height of the persistent component of the nav bar.
+  static const double navBarPersistentHeight = _kNavBarPersistentHeight;
+
+  /// The dynamic height extension of the nav bar.
+  static const double navBarHeightExtension = _kNavBarLargeTitleHeightExtension;
+
   @override
   _CupertinoSliverNavigationBarState createState() => _CupertinoSliverNavigationBarState();
 }

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -39,6 +39,7 @@ class CupertinoScrollbar extends StatefulWidget {
   const CupertinoScrollbar({
     Key key,
     @required this.child,
+    this.padding,
   }) : super(key: key);
 
   /// The subtree to place inside the [CupertinoScrollbar].
@@ -46,6 +47,9 @@ class CupertinoScrollbar extends StatefulWidget {
   /// This should include a source of [ScrollNotification] notifications,
   /// typically a [Scrollable] widget.
   final Widget child;
+
+  ///
+  final EdgeInsets padding;
 
   @override
   _CupertinoScrollbarState createState() => _CupertinoScrollbarState();
@@ -91,6 +95,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
       radius: _kScrollbarRadius,
       minLength: _kScrollbarMinLength,
       minOverscrollLength: _kScrollbarMinOverscrollLength,
+      padding: widget.padding,
     );
   }
 

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -39,7 +39,8 @@ class CupertinoScrollbar extends StatefulWidget {
   const CupertinoScrollbar({
     Key key,
     @required this.child,
-    this.padding,
+    this.dynamicNavBarPersistentHeight,
+    this.dynamicNavBarHeightExtension,
   }) : super(key: key);
 
   /// The subtree to place inside the [CupertinoScrollbar].
@@ -48,8 +49,16 @@ class CupertinoScrollbar extends StatefulWidget {
   /// typically a [Scrollable] widget.
   final Widget child;
 
+  /// In the case of a dynamic nav bar, the height of the persistent component
+  /// of the nav bar.
   ///
-  final EdgeInsets padding;
+  /// Should be left to null for static nav bars.
+  final double dynamicNavBarPersistentHeight;
+
+  /// In the case of a dynamic nav bar, the height extension of the nav bar.
+  ///
+  /// Should be left to null for static nav bars.
+  final double dynamicNavBarHeightExtension;
 
   @override
   _CupertinoScrollbarState createState() => _CupertinoScrollbarState();
@@ -74,6 +83,8 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
       parent: _fadeoutAnimationController,
       curve: Curves.fastOutSlowIn
     );
+    if (widget.dynamicNavBarHeightExtension != null)
+      assert (widget.dynamicNavBarHeightExtension > 0);
   }
 
   @override
@@ -85,6 +96,8 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
 
   /// Returns a [ScrollbarPainter] visually styled like the iOS scrollbar.
   ScrollbarPainter _buildCupertinoScrollbarPainter() {
+    final double topPadding = MediaQuery.of(context).padding.top;
+    final double dynamicNavBarPersistentHeight = widget.dynamicNavBarPersistentHeight ?? 0;
     return ScrollbarPainter(
       color: _kScrollbarColor,
       textDirection: _textDirection,
@@ -95,7 +108,9 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
       radius: _kScrollbarRadius,
       minLength: _kScrollbarMinLength,
       minOverscrollLength: _kScrollbarMinOverscrollLength,
-      padding: widget.padding,
+      navBarMinExtent: dynamicNavBarPersistentHeight + topPadding,
+      navBarHeightExtension: widget.dynamicNavBarHeightExtension,
+      bottomExtent: MediaQuery.of(context).padding.bottom,
     );
   }
 
@@ -106,7 +121,6 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
       if (_fadeoutAnimationController.status != AnimationStatus.forward) {
         _fadeoutAnimationController.forward();
       }
-
       _fadeoutTimer?.cancel();
       _painter.update(notification.metrics, notification.metrics.axisDirection);
     } else if (notification is ScrollEndNotification) {

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -104,6 +104,8 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
         textDirection: _textDirection,
         thickness: _kScrollbarThickness,
         fadeoutOpacityAnimation: _fadeoutOpacityAnimation,
+        navBarMinExtent: 0,
+        bottomExtent: 0,
       );
   }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -48,6 +48,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     this.radius,
     this.minLength = _kMinThumbExtent,
     this.minOverscrollLength = _kMinThumbExtent,
+    this.padding,
   }) : assert(color != null),
        assert(textDirection != null),
        assert(thickness != null),
@@ -94,6 +95,12 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// The smallest size the scrollbar can shrink to when viewport is
   /// overscrolled. Mustn't be null.
   final double minOverscrollLength;
+
+  /// Padding applied to the scrollbar from all edges of the screen.
+  ///
+  /// Primarily used to account for the possibility of tab bars and navigation
+  /// bars lying on top of scroll views.
+  final EdgeInsets padding;
 
   ScrollMetrics _lastMetrics;
   AxisDirection _lastAxisDirection;
@@ -158,6 +165,22 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   ) {
     // Establish the minimum size possible.
     double thumbExtent = math.min(viewport, minOverscrollLength);
+
+//    double _mainAxisMargin = mainAxisMargin;
+//    switch(_lastAxisDirection) {
+//      case AxisDirection.up:
+//        _mainAxisMargin = padding?.top;
+//        break;
+//      case AxisDirection.down:
+//        _mainAxisMargin = padding?.bottom;
+//        break;
+//      case AxisDirection.left:
+//        _mainAxisMargin = padding?.left;
+//        break;
+//      case AxisDirection.right:
+//        _mainAxisMargin = padding?.right;
+//        break;
+//    }
 
     if (before + inside + after > 0.0) {
       // Thumb extent reflects fraction of content visible, as long as this
@@ -243,6 +266,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         || mainAxisMargin != old.mainAxisMargin
         || crossAxisMargin != old.crossAxisMargin
         || radius != old.radius
+        || padding != old.padding
         || minLength != old.minLength;
   }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' as ui;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -11,11 +11,14 @@ void main() {
   testWidgets('Paints iOS spec', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
-      child: CupertinoScrollbar(
-        child: SingleChildScrollView(
-          child: SizedBox(width: 4000.0, height: 4000.0),
+      child: MediaQuery(
+        data: MediaQueryData(padding: EdgeInsets.fromLTRB(0, 0, 0, 0)),
+        child: CupertinoScrollbar(
+          child: SingleChildScrollView(
+            child: SizedBox(width: 4000.0, height: 4000.0),
+          ),
         ),
-      ),
+      )
     ));
     expect(find.byType(CupertinoScrollbar), isNot(paints..rrect()));
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(SingleChildScrollView)));

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -11,9 +11,12 @@ void main() {
   testWidgets('Scrollbar never goes away until finger lift', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
-      child: CupertinoScrollbar(
-        child: SingleChildScrollView(
-          child: SizedBox(width: 4000.0, height: 4000.0),
+      child: MediaQuery(
+        data: MediaQueryData(padding: EdgeInsets.fromLTRB(0, 40, 0, 60)), 
+        child: CupertinoScrollbar(
+          child: SingleChildScrollView(
+            child: SizedBox(width: 4000.0, height: 4000.0),
+          ),
         ),
       ),
     ));
@@ -47,9 +50,12 @@ void main() {
           (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
-      child: CupertinoScrollbar(
-        child: SingleChildScrollView(
-          child: SizedBox(width: 800.0, height: 20000.0),
+      child: MediaQuery(
+        data: MediaQueryData(padding: EdgeInsets.fromLTRB(0, 0, 0, 0)),
+        child: CupertinoScrollbar(
+          child: SingleChildScrollView(
+            child: SizedBox(width: 800.0, height: 20000.0),
+          ),
         ),
       ),
     ));

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -109,13 +109,16 @@ void main() {
     Widget viewWithScroll(TargetPlatform platform) {
       return Directionality(
         textDirection: TextDirection.ltr,
-        child: Theme(
-          data: ThemeData(
-            platform: platform
-          ),
-          child: const Scrollbar(
-            child: SingleChildScrollView(
-              child: SizedBox(width: 4000.0, height: 4000.0),
+        child: MediaQuery(
+          data: const MediaQueryData(padding: EdgeInsets.fromLTRB(0, 0, 0, 0)),
+          child: Theme(
+            data: ThemeData(
+              platform: platform
+            ),
+            child: const Scrollbar(
+              child: SingleChildScrollView(
+                child: SizedBox(width: 4000.0, height: 4000.0),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Fixes the scrollbar height rendering for iOS. Static nav bar scrollbar rendering works by default, to enable scrollbar functionality for dynamic navbars, the persistent nav bar height and height extent of the nav bar must be passed in to the scrollbar's constructor.