### PR TITLE
Fix Podfile issue #24342

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -65,8 +65,8 @@ plugin_pods.map { |r|
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
-            next if  config.base_configuration_reference == nil
             config.build_settings['ENABLE_BITCODE'] = 'NO'
+            next if  config.base_configuration_reference == nil
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|
                 file.puts "#include \"#{File.realpath(File.join(framework_dir, 'Generated.xcconfig'))}\""

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -65,6 +65,7 @@ plugin_pods.map { |r|
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
+            next if  config.base_configuration_reference == nil
             config.build_settings['ENABLE_BITCODE'] = 'NO'
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|


### PR DESCRIPTION
Sometimes base configurations  (config.base_configuration_reference) can be nil, which leads to undefined method `real_path' for nil:NilClass.