### PR TITLE
Include empty config message in 'flutter config' output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -50,10 +50,10 @@ class ConfigCommand extends FlutterCommand {
     String values = config.keys.map<String>((String key) {
       return '  $key: ${config.getValue(key)}';
     }).join('\n');
-    if (values.isNotEmpty)
-      values = '\nSettings:\n$values\n\n';
+    if (values.isEmpty)
+      values = '  No settings have been configured.';
     return
-      '$values'
+      '\nSettings:\n$values\n\n'
       'Analytics reporting is currently ${flutterUsage.enabled ? 'enabled' : 'disabled'}.';
   }
 


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/5869

When the flutter config is empty, the output for `flutter config` command does not make it clear that this is the case. This change stops hiding the `Settings` section of the command output and adds a new message `No settings have been configured.` for clarity.

### New output
```
$ flutter config
Configure Flutter settings.

To remove a setting, configure it to an empty string.

The Flutter tool anonymously reports feature usage statistics and basic crash
reports to help improve Flutter tools over time. See Google's privacy policy:
https://www.google.com/intl/en/policies/privacy/

Usage: flutter config [arguments]
-h, --help                      Print this usage information.
    --[no-]analytics            Enable or disable reporting anonymously tool
    usage statistics and crash reports.
    --clear-ios-signing-cert    Clear the saved development certificate choice
    used to sign apps for iOS device deployment.
    --gradle-dir                The gradle install directory.
    --android-sdk               The Android SDK directory.
    --android-studio-dir        The Android Studio install directory.

Run "flutter help" to see global options.

Settings:
  No settings have been configured.

Analytics reporting is currently disabled.
```

The settings section looks similar to the when a setting has been configured e.g.
```
Settings:
  android-sdk: /path/to/android/sdk
```

