### PR TITLE
Print .packages / pubspec.lock only with --verbose

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -43,7 +43,7 @@ abstract class BuildSubCommand extends FlutterCommand {
   @override
   @mustCallSuper
   Future<FlutterCommandResult> runCommand() async {
-    if (isRunningOnBot) {
+    if (isRunningOnBot && logger.isVerbose) {
       final File dotPackages = fs.file('.packages');
       printStatus('Contents of .packages:');
       if (dotPackages.existsSync())


### PR DESCRIPTION
Tested with:

```shell
$ BOT=true ~/src/flutter/flutter/bin/flutter build apk --debug

$ BOT=true ~/src/flutter/flutter/bin/flutter --verbose build apk --debug
```