### PR TITLE
Don't require the AVD folder to exist in order to run `flutter emulators`

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -43,7 +43,7 @@ class AndroidWorkflow implements Workflow {
   bool get canLaunchDevices => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
 
   @override
-  bool get canListEmulators => getEmulatorPath(androidSdk) != null && getAvdPath() != null;
+  bool get canListEmulators => getEmulatorPath(androidSdk) != null;
 }
 
 class AndroidValidator extends DoctorValidator {


### PR DESCRIPTION
Fixes #24750. We were unnecessarily checking the AVD folder existed before allowing listing/creating of emulators - but this is normal if the user has never run `emulator` before and doesn't have any AVDs. Both creating and listing work find without this check (listing returns no emulators, and create works successfully) so it's unnecessary and stops people from creating their first emulator with Flutter.