### PR TITLE
Allow snippets tool to be run from arbitrary CWDs

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -206,7 +206,7 @@ class SampleChecker {
     if (_snippetsSnapshotPath == null) {
       _snippetsSnapshotPath = '$_snippetsExecutable.snapshot';
       return Process.runSync(
-        path.absolute(Platform.executable),
+        Platform.executable,
         <String>[
           '--snapshot=$_snippetsSnapshotPath',
           '--snapshot-kind=app-jit',
@@ -216,7 +216,7 @@ class SampleChecker {
       );
     } else {
       return Process.runSync(
-        path.absolute(Platform.executable),
+        Platform.executable,
         <String>[path.absolute(_snippetsSnapshotPath)]..addAll(args),
         workingDirectory: workingDirectory,
       );

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -124,7 +124,7 @@ class SampleChecker {
 
   /// Finds the location of the snippets script.
   String get _snippetsExecutable {
-    final String platformScriptPath = path.dirname(Platform.script.toFilePath());
+    final String platformScriptPath = path.dirname(path.fromUri(Platform.script));
     return path.canonicalize(path.join(platformScriptPath, '..', 'snippets', 'lib', 'main.dart'));
   }
 

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -206,18 +206,18 @@ class SampleChecker {
     if (_snippetsSnapshotPath == null) {
       _snippetsSnapshotPath = '$_snippetsExecutable.snapshot';
       return Process.runSync(
-        Platform.executable,
+        path.canonicalize(Platform.executable),
         <String>[
           '--snapshot=$_snippetsSnapshotPath',
           '--snapshot-kind=app-jit',
-          path.absolute(_snippetsExecutable),
+          path.canonicalize(_snippetsExecutable),
         ]..addAll(args),
         workingDirectory: workingDirectory,
       );
     } else {
       return Process.runSync(
-        Platform.executable,
-        <String>[path.absolute(_snippetsSnapshotPath)]..addAll(args),
+        path.canonicalize(Platform.executable),
+        <String>[path.canonicalize(_snippetsSnapshotPath)]..addAll(args),
         workingDirectory: workingDirectory,
       );
     }

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -31,7 +31,7 @@ class SnippetGenerator {
   SnippetGenerator({Configuration configuration})
       : configuration = configuration ??
             // Flutter's root is four directories up from this script.
-            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(path.dirname(Platform.script.path), '..', '..', '..')))) {
+            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(path.dirname(path.fromUri(Platform.script)), '..', '..', '..')))) {
     this.configuration.createOutputDirectory();
   }
 

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -31,7 +31,7 @@ class SnippetGenerator {
   SnippetGenerator({Configuration configuration})
       : configuration = configuration ??
             // Flutter's root is four directories up from this script.
-            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(Platform.script.path, '..', '..', '..', '..')))) {
+            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(path.dirname(Platform.script.path), '..', '..', '..')))) {
     this.configuration.createOutputDirectory();
   }
 

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -30,8 +30,8 @@ class _ComponentTuple {
 class SnippetGenerator {
   SnippetGenerator({Configuration configuration})
       : configuration = configuration ??
-           // This script must be run from dev/docs, so the root is up two levels.
-            Configuration(flutterRoot: Directory(path.canonicalize(path.join('..', '..')))) {
+            // Flutter's root is four directories up from this script.
+            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(Platform.script.path, '..', '..', '..', '..')))) {
     this.configuration.createOutputDirectory();
   }
 


### PR DESCRIPTION
This fixes a problem where dartdoc is unable to run tools when documenting flutter plugins.