### PR TITLE
Temporarily add back filtered bintray ExoPlayer repository

### DIFF
--- a/examples/flutter_gallery/android/build.gradle
+++ b/examples/flutter_gallery/android/build.gradle
@@ -13,6 +13,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://google.bintray.com/exoplayer/'
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #25145

It's not a Flutter issue since vanilla gradle seems to not be able to depend on ExoPlayer either

https://github.com/google/ExoPlayer/issues/5225

Seems like there was a miscommunication about mirroring google hosted dependencies on jcenter etc https://issuetracker.google.com/issues/120759347
