### PR TITLE
Support ANDROID_SDK_ROOT in addition to ANDROID_HOME

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     # test path names with spaces in them.
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
-    ANDROID_HOME: "/opt/android_sdk"
+    ANDROID_SDK_ROOT: "/opt/android_sdk"
   git_fetch_script:
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work

--- a/dev/bots/deploy_gallery.sh
+++ b/dev/bots/deploy_gallery.sh
@@ -34,7 +34,7 @@ if [[ "$SHARD" = "deploy_gallery" ]]; then
     fi
     set -x
 
-    # ANDROID_HOME must be set in the env.
+    # ANDROID_SDK_ROOT must be set in the env.
     (
       cd examples/flutter_gallery
       flutter build apk --release -t lib/main_publish.dart

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -184,7 +184,9 @@ Future<void> _flutterBuildAot(String relativePathToApplication) async {
 
 Future<void> _flutterBuildApk(String relativePathToApplication) async {
   // TODO(dnfield): See if we can get Android SDK on all Cirrus platforms.
-  if (Platform.environment['ANDROID_HOME']?.isEmpty ?? true) {
+  if (
+        (Platform.environment['ANDROID_HOME']?.isEmpty ?? true) &&
+        (Platform.environment['ANDROID_SDK_ROOT']?.isEmpty ?? true)) {
     return;
   }
   print('Running APK build tests...');

--- a/dev/devicelab/README.md
+++ b/dev/devicelab/README.md
@@ -102,9 +102,9 @@ reproduce a CI test failure locally.
 
 ## Prerequisites
 
-You must set the `ANDROID_HOME` environment variable to run tests on Android. If
-you have a local build of the Flutter engine, then you have a copy of the
-Android SDK at `.../engine/src/third_party/android_tools/sdk`.
+You must set the `ANDROID_HOME` or `ANDROID_SDK_ROOT` environment variable to run
+tests on Android. If you have a local build of the Flutter engine, then you have
+a copy of the Android SDK at `.../engine/src/third_party/android_tools/sdk`.
 
 You can find where your Android SDK is using `flutter doctor`.
 

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -461,7 +461,6 @@ class IosDevice implements Device {
 
 /// Path to the `adb` executable.
 String get adbPath {
-  
   final String androidHome =
       Platform.environment['ANDROID_HOME'] != null
           ? Platform.environment['ANDROID_HOME']

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -467,8 +467,9 @@ String get adbPath {
           : Platform.environment['ANDROID_SDK_ROOT'];
 
   if (androidHome == null)
-    throw 'The ANDROID_SDK_ROOT and ANDROID_HOME environment variables are missing. At least one of these variables must '
-        'point to the Android SDK directory containing platform-tools.';
+    throw 'The ANDROID_SDK_ROOT and ANDROID_HOME environment variables are '
+        'missing. At least one of these variables must point to the Android '
+        'SDK directory containing platform-tools.';
 
   final String adbPath = path.join(androidHome, 'platform-tools/adb');
 

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -467,7 +467,7 @@ String get adbPath {
           : Platform.environment['ANDROID_SDK_ROOT'];
 
   if (androidHome == null)
-    throw 'ANDROID_SDK_ROOT environment variable missing. This variable must '
+    throw 'The ANDROID_SDK_ROOT and ANDROID_HOME environment variables are missing. At least one of these variables must '
         'point to the Android SDK directory containing platform-tools.';
 
   final String adbPath = path.join(androidHome, 'platform-tools/adb');

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -461,10 +461,14 @@ class IosDevice implements Device {
 
 /// Path to the `adb` executable.
 String get adbPath {
-  final String androidHome = Platform.environment['ANDROID_HOME'];
+  
+  final String androidHome =
+      Platform.environment['ANDROID_HOME'] != null
+          ? Platform.environment['ANDROID_HOME']
+          : Platform.environment['ANDROID_SDK_ROOT'];
 
   if (androidHome == null)
-    throw 'ANDROID_HOME environment variable missing. This variable must '
+    throw 'ANDROID_SDK_ROOT environment variable missing. This variable must '
         'point to the Android SDK directory containing platform-tools.';
 
   final String adbPath = path.join(androidHome, 'platform-tools/adb');

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -21,6 +21,7 @@ import 'android_studio.dart' as android_studio;
 AndroidSdk get androidSdk => context[AndroidSdk];
 
 const String kAndroidHome = 'ANDROID_HOME';
+const String kAndroidSdkRoot = 'ANDROID_SDK_ROOT';
 
 // Android SDK layout:
 
@@ -243,6 +244,8 @@ class AndroidSdk {
         androidHomeDir = config.getValue('android-sdk');
       } else if (platform.environment.containsKey(kAndroidHome)) {
         androidHomeDir = platform.environment[kAndroidHome];
+      } else if (platform.environment.containsKey(kAndroidSdkRoot)) {
+        androidHomeDir = platform.environment[kAndroidSdkRoot];
       } else if (platform.isLinux) {
         if (homeDirPath != null)
           androidHomeDir = fs.path.join(homeDirPath, 'Android', 'Sdk');

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -125,6 +125,10 @@ class AndroidValidator extends DoctorValidator {
       final String androidHomeDir = platform.environment[kAndroidHome];
       messages.add(ValidationMessage('$kAndroidHome = $androidHomeDir'));
     }
+    if (platform.environment.containsKey(kAndroidSdkRoot)) {
+      final String androidSdkRoot = platform.environment[kAndroidSdkRoot];
+      messages.add(ValidationMessage('$kAndroidSdkRoot = $androidSdkRoot'));
+    }
 
     final List<String> validationResult = androidSdk.validateSdkWellFormed();
 

--- a/packages/flutter_tools/lib/src/android/apk.dart
+++ b/packages/flutter_tools/lib/src/android/apk.dart
@@ -30,7 +30,7 @@ Future<void> buildApk({
 
   // Validate that we can find an android sdk.
   if (androidSdk == null)
-    throwToolExit('No Android SDK found. Try setting the ANDROID_HOME environment variable.');
+    throwToolExit('No Android SDK found. Try setting the ANDROID_SDK_ROOT environment variable.');
 
   final List<String> validationResult = androidSdk.validateSdkWellFormed();
   if (validationResult.isNotEmpty) {


### PR DESCRIPTION
I don't know if we need changes outside of this repo, but this should address #15114 which relates to our use of ANDROID_HOME which is now deprecated.

The change currently still prefers ANDROID_HOME since that's what the SDK appears to do:

https://developer.android.com/studio/command-line/variables

> If *ANDROID_HOME* is defined and contains a valid SDK installation, its value is used instead of the value in *ANDROID_SDK_ROOT*.

The `flutter doctor` output will list both variables, so aid troubleshooting if something seems wrong.

Note: This changes the Cirrus script to set *ANDROID_SDK_ROOT* since that's now our "preferred" option (even if we check the other first) - everything seems to pass on my fork, but I don't know if there are any other implications of no longer having ANDROID_HOME set (for ex. in anything that only runs on certain branches).

(cc @dnfield since your name is on a comment about ANDROID_HOME in here!)