### PR TITLE
Addition of `shouldRebuild` to `StatelessWidget`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Felix Schmidt <felix.free@gmx.de>
 Artur Rymarz <artur.rymarz@gmail.com>
 Stefan Mitev <mr.mitew@gmail.com>
 Mattijs Fuijkschot <mattijs.fuijkschot@gmail.com>
+Simon Lightfoot <simon@devangels.london>

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -598,6 +598,18 @@ abstract class StatelessWidget extends Widget {
   ///  * The discussion on performance considerations at [StatelessWidget].
   @protected
   Widget build(BuildContext context);
+
+  /// Called whenever the widget configuration is updated.
+  ///
+  /// If the new instance represents different information than the old
+  /// instance, then the method should return true, otherwise it should
+  /// return false.
+  ///
+  /// If the method returns false, then the widget will not get rebuilt.
+  ///
+  /// The `oldWidget` argument will never be null.
+  @protected
+  bool shouldRebuild(covariant StatelessWidget oldWidget) => true;
 }
 
 /// A widget that has mutable state.
@@ -3775,10 +3787,13 @@ class StatelessElement extends ComponentElement {
 
   @override
   void update(StatelessWidget newWidget) {
+    final StatelessWidget oldWidget = widget;
     super.update(newWidget);
     assert(widget == newWidget);
-    _dirty = true;
-    rebuild();
+    if(widget.shouldRebuild(oldWidget)){
+      _dirty = true;
+      rebuild();
+    }
   }
 }
 

--- a/packages/flutter/test/widgets/stateful_component_test.dart
+++ b/packages/flutter/test/widgets/stateful_component_test.dart
@@ -56,11 +56,12 @@ void main() {
   });
 
   testWidgets('Don\'t rebuild subwidgets', (WidgetTester tester) async {
+    TestBuildCounter.buildCount = 0;
     await tester.pumpWidget(
-      FlipWidget(
-        key: const Key('rebuild test'),
+      const FlipWidget(
+        key: Key('rebuild test'),
         left: TestBuildCounter(),
-        right: const DecoratedBox(decoration: kBoxDecorationB)
+        right: DecoratedBox(decoration: kBoxDecorationB)
       )
     );
 

--- a/packages/flutter/test/widgets/stateless_component_test.dart
+++ b/packages/flutter/test/widgets/stateless_component_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_widgets.dart';
+
+void main() {
+  testWidgets('Stateless widget smoke test', (WidgetTester tester) async {
+    TestBuildCounter.buildCount = 0;
+
+    await tester.pumpWidget(const TestBuildCounter());
+
+    expect(TestBuildCounter.buildCount, equals(1));
+  });
+
+  testWidgets('Stateless shouldRebuild test', (WidgetTester tester) async {
+    TestBuildCounter.buildCount = 0;
+
+    await tester.pumpWidget(const TestBuildCounterValue(1000)); // Built 1st time
+    await tester.pumpWidget(const TestBuildCounterValue(1000)); // same parameter, no rebuild
+    await tester.pumpWidget(const TestBuildCounterValue(1000)); // same parameter, no rebuild
+    await tester.pumpWidget(const TestBuildCounterValue(1000)); // same parameter, no rebuild
+    expect(TestBuildCounter.buildCount, equals(1));
+
+    await tester.pumpWidget(const TestBuildCounterValue(1234)); // change parameter, rebuilt 2nd
+    await tester.pumpWidget(const TestBuildCounterValue(5678)); // change parameter, rebuilt 3rd
+    await tester.pumpWidget(const TestBuildCounterValue(9876)); // change parameter, rebuilt 4th
+    expect(TestBuildCounter.buildCount, equals(4));
+  });
+}
+
+class TestBuildCounterValue extends TestBuildCounter {
+  const TestBuildCounterValue(this.value);
+
+  final int value;
+
+  @override
+  bool shouldRebuild(TestBuildCounterValue oldWidget) => value != oldWidget.value;
+}

--- a/packages/flutter/test/widgets/test_widgets.dart
+++ b/packages/flutter/test/widgets/test_widgets.dart
@@ -19,6 +19,8 @@ const BoxDecoration kBoxDecorationC = BoxDecoration(
 );
 
 class TestBuildCounter extends StatelessWidget {
+  const TestBuildCounter();
+
   static int buildCount = 0;
 
   @override


### PR DESCRIPTION
Addition of `shouldRebuild` to `StatelessWidget` to allow widgets to decide when they should be rebuilt. For instance if the constructor parameters differ. This operates like CustomPainter.shouldRepaint and CustomClipper.shouldReclip.

__Over simplified example__
```
class MyCoolWidget extends StatelessWidget {
  const MyCoolWidget(this.value);
  
  final int value;

  @override
  Widget build(BuildContext context) {
    return Text('$value');
  }
  
  @override
  bool shouldRebuild(MyCoolWidget oldWidget) => value != oldWidget.value;
}
```