### PR TITLE
Run dartfmt on all flutter examples

### DIFF
--- a/examples/catalog/bin/sample_page.dart
+++ b/examples/catalog/bin/sample_page.dart
@@ -29,8 +29,13 @@ Directory sampleDirectory;
 Directory testDirectory;
 Directory driverDirectory;
 
-void logMessage(String s) { print(s); }
-void logError(String s) { print(s); }
+void logMessage(String s) {
+  print(s);
+}
+
+void logError(String s) {
+  print(s);
+}
 
 File inputFile(String dir, String name) {
   return File(dir + Platform.pathSeparator + name);
@@ -54,8 +59,9 @@ String expandTemplate(String template, Map<String, String> values) {
   // Matches @(foo), match[1] == 'foo'
   final RegExp tokenRE = RegExp(r'@\(([\w ]+)\)', multiLine: true);
   return template.replaceAllMapped(tokenRE, (Match match) {
-    if (match.groupCount != 1)
+    if (match.groupCount != 1) {
       throw SampleError('bad template keyword $match[0]');
+    }
     final String keyword = match[1];
     return values[keyword] ?? '';
   });
@@ -87,8 +93,9 @@ class SampleInfo {
   // The value of the 'Classes:' comment as a list of class names.
   Iterable<String> get highlightedClasses {
     final String classNames = commentValues['classes'];
-    if (classNames == null)
+    if (classNames == null) {
       return const <String>[];
+    }
     return classNames.split(',').map<String>((String s) => s.trim()).where((String s) => s.isNotEmpty);
   }
 
@@ -105,23 +112,27 @@ class SampleInfo {
     final RegExp startRE = RegExp(r'^/\*\s+^Sample\s+Catalog', multiLine: true);
     final RegExp endRE = RegExp(r'^\*/', multiLine: true);
     final Match startMatch = startRE.firstMatch(contents);
-    if (startMatch == null)
+    if (startMatch == null) {
       return false;
+    }
 
     final int startIndex = startMatch.end;
     final Match endMatch = endRE.firstMatch(contents.substring(startIndex));
-    if (endMatch == null)
+    if (endMatch == null) {
       return false;
+    }
 
     final String comment = contents.substring(startIndex, startIndex + endMatch.start);
     sourceCode = contents.substring(0, startMatch.start) + contents.substring(startIndex + endMatch.end);
-    if (sourceCode.trim().isEmpty)
+    if (sourceCode.trim().isEmpty) {
       throw SampleError('did not find any source code in $sourceFile');
+    }
 
     final RegExp keywordsRE = RegExp(sampleCatalogKeywords, multiLine: true);
     final List<Match> keywordMatches = keywordsRE.allMatches(comment).toList();
-    if (keywordMatches.isEmpty)
+    if (keywordMatches.isEmpty) {
       throw SampleError('did not find any keywords in the Sample Catalog comment in $sourceFile');
+    }
 
     commentValues = <String, String>{};
     for (int i = 0; i < keywordMatches.length; i += 1) {
@@ -136,7 +147,8 @@ class SampleInfo {
     commentValues['path'] = 'examples/catalog/${sourceFile.path}';
     commentValues['source'] = sourceCode.trim();
     commentValues['link'] = link;
-    commentValues['android screenshot'] = 'https://storage.googleapis.com/flutter-catalog/$commit/${sourceName}_small.png';
+    commentValues['android screenshot'] =
+        'https://storage.googleapis.com/flutter-catalog/$commit/${sourceName}_small.png';
 
     return true;
   }
@@ -149,8 +161,10 @@ void generate(String commit) {
   for (FileSystemEntity entity in sampleDirectory.listSync()) {
     if (entity is File && entity.path.endsWith('.dart')) {
       final SampleInfo sample = SampleInfo(entity, commit);
-      if (sample.initialize()) // skip files that lack the Sample Catalog comment
+      if (sample.initialize()) {
+        // skip files that lack the Sample Catalog comment
         samples.add(sample);
+      }
     }
   }
 
@@ -215,12 +229,18 @@ void generate(String commit) {
     outputFile('screenshot.dart', driverDirectory),
     inputFile('bin', 'screenshot.dart.template').readAsStringSync(),
     <String, String>{
-      'imports': samples.map<String>((SampleInfo page) {
-        return "import '${page.importPath}' show ${page.sampleClass};\n";
-      }).toList().join(),
-      'widgets': samples.map<String>((SampleInfo sample) {
-        return 'new ${sample.sampleClass}(),\n';
-      }).toList().join(),
+      'imports': samples
+        .map<String>((SampleInfo page) {
+          return "import '${page.importPath}' show ${page.sampleClass};\n";
+        })
+        .toList()
+        .join(),
+      'widgets': samples
+        .map<String>((SampleInfo sample) {
+          return 'new ${sample.sampleClass}(),\n';
+        })
+        .toList()
+        .join(),
     },
   );
 
@@ -230,23 +250,25 @@ void generate(String commit) {
     outputFile('screenshot_test.dart', driverDirectory),
     inputFile('bin', 'screenshot_test.dart.template').readAsStringSync(),
     <String, String>{
-      'paths': samples.map<String>((SampleInfo sample) {
-        return "'${outputFile(sample.sourceName + '.png').path}'";
-      }).toList().join(',\n'),
+      'paths': samples
+        .map<String>((SampleInfo sample) {
+          return "'${outputFile(sample.sourceName + '.png').path}'";
+        })
+        .toList()
+        .join(',\n'),
     },
   );
 
   // For now, the website's index.json file must be updated by hand.
   logMessage('The following entries must appear in _data/catalog/widgets.json');
-  for (String className in classToSamples.keys)
-    logMessage('"sample": "${className}_index"');
+  for (String className in classToSamples.keys) logMessage('"sample": "${className}_index"');
 }
 
 void main(List<String> args) {
   if (args.length != 1) {
     logError(
       'Usage (cd examples/catalog/; dart bin/sample_page.dart commit)\n'
-      'The flutter commit hash locates screenshots on storage.googleapis.com/flutter-catalog/'
+          'The flutter commit hash locates screenshots on storage.googleapis.com/flutter-catalog/',
     );
     exit(255);
   }
@@ -255,8 +277,8 @@ void main(List<String> args) {
   } catch (error) {
     logError(
       'Error: sample_page.dart failed: $error\n'
-      'This sample_page.dart app expects to be run from the examples/catalog directory. '
-      'More information can be found in examples/catalog/README.md.'
+          'This sample_page.dart app expects to be run from the examples/catalog directory. '
+          'More information can be found in examples/catalog/README.md.',
     );
     exit(255);
   }

--- a/examples/catalog/lib/animated_list.dart
+++ b/examples/catalog/lib/animated_list.dart
@@ -117,9 +117,9 @@ class ListModel<E> {
     @required this.listKey,
     @required this.removedItemBuilder,
     Iterable<E> initialItems,
-  })  : assert(listKey != null),
-        assert(removedItemBuilder != null),
-        _items = List<E>.from(initialItems ?? <E>[]);
+  }) : assert(listKey != null),
+       assert(removedItemBuilder != null),
+       _items = List<E>.from(initialItems ?? <E>[]);
 
   final GlobalKey<AnimatedListState> listKey;
   final dynamic removedItemBuilder;
@@ -158,10 +158,10 @@ class CardItem extends StatelessWidget {
     this.onTap,
     @required this.item,
     this.selected = false,
-  })  : assert(animation != null),
-        assert(item != null && item >= 0),
-        assert(selected != null),
-        super(key: key);
+  }) : assert(animation != null),
+       assert(item != null && item >= 0),
+       assert(selected != null),
+       super(key: key);
 
   final Animation<double> animation;
   final VoidCallback onTap;

--- a/examples/catalog/lib/animated_list.dart
+++ b/examples/catalog/lib/animated_list.dart
@@ -117,9 +117,9 @@ class ListModel<E> {
     @required this.listKey,
     @required this.removedItemBuilder,
     Iterable<E> initialItems,
-  }) : assert(listKey != null),
-       assert(removedItemBuilder != null),
-       _items = List<E>.from(initialItems ?? <E>[]);
+  })  : assert(listKey != null),
+        assert(removedItemBuilder != null),
+        _items = List<E>.from(initialItems ?? <E>[]);
 
   final GlobalKey<AnimatedListState> listKey;
   final dynamic removedItemBuilder;
@@ -157,11 +157,11 @@ class CardItem extends StatelessWidget {
     @required this.animation,
     this.onTap,
     @required this.item,
-    this.selected = false
-  }) : assert(animation != null),
-       assert(item != null && item >= 0),
-       assert(selected != null),
-       super(key: key);
+    this.selected = false,
+  })  : assert(animation != null),
+        assert(item != null && item >= 0),
+        assert(selected != null),
+        super(key: key);
 
   final Animation<double> animation;
   final VoidCallback onTap;
@@ -171,8 +171,9 @@ class CardItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TextStyle textStyle = Theme.of(context).textTheme.display1;
-    if (selected)
+    if (selected) {
       textStyle = textStyle.copyWith(color: Colors.lightGreenAccent[400]);
+    }
     return Padding(
       padding: const EdgeInsets.all(2.0),
       child: SizeTransition(

--- a/examples/catalog/lib/app_bar_bottom.dart
+++ b/examples/catalog/lib/app_bar_bottom.dart
@@ -26,8 +26,9 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
 
   void _nextPage(int delta) {
     final int newIndex = _tabController.index + delta;
-    if (newIndex < 0 || newIndex >= _tabController.length)
+    if (newIndex < 0 || newIndex >= _tabController.length) {
       return;
+    }
     _tabController.animateTo(newIndex);
   }
 
@@ -40,13 +41,17 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
           leading: IconButton(
             tooltip: 'Previous choice',
             icon: const Icon(Icons.arrow_back),
-            onPressed: () { _nextPage(-1); },
+            onPressed: () {
+              _nextPage(-1);
+            },
           ),
           actions: <Widget>[
             IconButton(
               icon: const Icon(Icons.arrow_forward),
               tooltip: 'Next choice',
-              onPressed: () { _nextPage(1); },
+              onPressed: () {
+                _nextPage(1);
+              },
             ),
           ],
           bottom: PreferredSize(
@@ -76,7 +81,7 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
   final String title;
   final IconData icon;
 }
@@ -91,7 +96,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/lib/app_bar_bottom.dart
+++ b/examples/catalog/lib/app_bar_bottom.dart
@@ -81,7 +81,7 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
 }
 
 class Choice {
-  const Choice({this.title, this.icon});
+  const Choice({ this.title, this.icon });
   final String title;
   final IconData icon;
 }
@@ -96,7 +96,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({Key key, this.choice}) : super(key: key);
+  const ChoiceCard({ Key key, this.choice }) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/lib/basic_app_bar.dart
+++ b/examples/catalog/lib/basic_app_bar.dart
@@ -14,7 +14,8 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
   Choice _selectedChoice = choices[0]; // The app's "state".
 
   void _select(Choice choice) {
-    setState(() { // Causes the app to rebuild with the new _selectedChoice.
+    setState(() {
+      // Causes the app to rebuild with the new _selectedChoice.
       _selectedChoice = choice;
     });
   }
@@ -26,15 +27,22 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
         appBar: AppBar(
           title: const Text('Basic AppBar'),
           actions: <Widget>[
-            IconButton( // action button
+            IconButton(
+              // action button
               icon: Icon(choices[0].icon),
-              onPressed: () { _select(choices[0]); },
+              onPressed: () {
+                _select(choices[0]);
+              },
             ),
-            IconButton( // action button
+            IconButton(
+              // action button
               icon: Icon(choices[1].icon),
-              onPressed: () { _select(choices[1]); },
+              onPressed: () {
+                _select(choices[1]);
+              },
             ),
-            PopupMenuButton<Choice>( // overflow menu
+            PopupMenuButton<Choice>(
+              // overflow menu
               onSelected: _select,
               itemBuilder: (BuildContext context) {
                 return choices.skip(2).map<PopupMenuItem<Choice>>((Choice choice) {
@@ -57,7 +65,7 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
   final String title;
   final IconData icon;
 }
@@ -72,7 +80,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/lib/basic_app_bar.dart
+++ b/examples/catalog/lib/basic_app_bar.dart
@@ -65,7 +65,7 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
 }
 
 class Choice {
-  const Choice({this.title, this.icon});
+  const Choice({ this.title, this.icon });
   final String title;
   final IconData icon;
 }
@@ -80,7 +80,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({Key key, this.choice}) : super(key: key);
+  const ChoiceCard({ Key key, this.choice }) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/lib/custom_a11y_traversal.dart
+++ b/examples/catalog/lib/custom_a11y_traversal.dart
@@ -48,7 +48,7 @@ import 'package:flutter/semantics.dart';
 ///  * [SemanticSortKey] for the base class of all semantic sort keys.
 ///  * [OrdinalSortKey] for a concrete sort key that sorts based on the given ordinal.
 class RowColumnTraversal extends StatelessWidget {
-  const RowColumnTraversal({this.rowOrder, this.columnOrder, this.child});
+  const RowColumnTraversal({ this.rowOrder, this.columnOrder, this.child });
 
   final int rowOrder;
   final int columnOrder;
@@ -92,7 +92,7 @@ class RowColumnTraversal extends StatelessWidget {
 /// set its traversal order.
 class SpinnerButton extends StatelessWidget {
   const SpinnerButton(
-      {Key key, this.onPressed, this.icon, this.rowOrder, this.columnOrder, this.field, this.increment})
+      { Key key, this.onPressed, this.icon, this.rowOrder, this.columnOrder, this.field, this.increment })
       : super(key: key);
 
   final VoidCallback onPressed;

--- a/examples/catalog/lib/custom_a11y_traversal.dart
+++ b/examples/catalog/lib/custom_a11y_traversal.dart
@@ -92,13 +92,8 @@ class RowColumnTraversal extends StatelessWidget {
 /// set its traversal order.
 class SpinnerButton extends StatelessWidget {
   const SpinnerButton(
-      {Key key,
-      this.onPressed,
-      this.icon,
-      this.rowOrder,
-      this.columnOrder,
-      this.field,
-      this.increment}) : super(key: key);
+      {Key key, this.onPressed, this.icon, this.rowOrder, this.columnOrder, this.field, this.increment})
+      : super(key: key);
 
   final VoidCallback onPressed;
   final IconData icon;
@@ -213,7 +208,12 @@ class CustomTraversalExampleState extends State<CustomTraversalExample> {
     );
   }
 
-  Widget _makeSpinnerButton(int rowOrder, int columnOrder, Field field, {bool increment = true}) {
+  Widget _makeSpinnerButton(
+    int rowOrder,
+    int columnOrder,
+    Field field, {
+    bool increment = true,
+  }) {
     return SpinnerButton(
       rowOrder: rowOrder,
       columnOrder: columnOrder,

--- a/examples/catalog/lib/custom_semantics.dart
+++ b/examples/catalog/lib/custom_semantics.dart
@@ -58,7 +58,7 @@ class AdjustableDropdownListTile extends StatelessWidget {
             }).toList(),
           ),
         ),
-      )
+      ),
     );
   }
 
@@ -85,14 +85,7 @@ class AdjustableDropdownExample extends StatefulWidget {
 }
 
 class AdjustableDropdownExampleState extends State<AdjustableDropdownExample> {
-
-  final List<String> items = <String>[
-    '1 second',
-    '5 seconds',
-    '15 seconds',
-    '30 seconds',
-    '1 minute'
-  ];
+  final List<String> items = <String>['1 second', '5 seconds', '15 seconds', '30 seconds', '1 minute'];
   String timeout;
 
   @override

--- a/examples/catalog/lib/expansion_tile_sample.dart
+++ b/examples/catalog/lib/expansion_tile_sample.dart
@@ -30,9 +30,11 @@ class Entry {
 
 // The entire multilevel list displayed by this app.
 final List<Entry> data = <Entry>[
-  Entry('Chapter A',
+  Entry(
+    'Chapter A',
     <Entry>[
-      Entry('Section A0',
+      Entry(
+        'Section A0',
         <Entry>[
           Entry('Item A0.1'),
           Entry('Item A0.2'),
@@ -43,17 +45,20 @@ final List<Entry> data = <Entry>[
       Entry('Section A2'),
     ],
   ),
-  Entry('Chapter B',
+  Entry(
+    'Chapter B',
     <Entry>[
       Entry('Section B0'),
       Entry('Section B1'),
     ],
   ),
-  Entry('Chapter C',
+  Entry(
+    'Chapter C',
     <Entry>[
       Entry('Section C0'),
       Entry('Section C1'),
-      Entry('Section C2',
+      Entry(
+        'Section C2',
         <Entry>[
           Entry('Item C2.0'),
           Entry('Item C2.1'),
@@ -73,8 +78,9 @@ class EntryItem extends StatelessWidget {
   final Entry entry;
 
   Widget _buildTiles(Entry root) {
-    if (root.children.isEmpty)
+    if (root.children.isEmpty) {
       return ListTile(title: Text(root.title));
+    }
     return ExpansionTile(
       key: PageStorageKey<Entry>(root),
       title: Text(root.title),

--- a/examples/catalog/lib/tabbed_app_bar.dart
+++ b/examples/catalog/lib/tabbed_app_bar.dart
@@ -38,7 +38,7 @@ class TabbedAppBarSample extends StatelessWidget {
 }
 
 class Choice {
-  const Choice({this.title, this.icon});
+  const Choice({ this.title, this.icon });
   final String title;
   final IconData icon;
 }
@@ -53,7 +53,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({Key key, this.choice}) : super(key: key);
+  const ChoiceCard({ Key key, this.choice }) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/lib/tabbed_app_bar.dart
+++ b/examples/catalog/lib/tabbed_app_bar.dart
@@ -38,7 +38,7 @@ class TabbedAppBarSample extends StatelessWidget {
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
   final String title;
   final IconData icon;
 }
@@ -53,7 +53,7 @@ const List<Choice> choices = <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/examples/catalog/test/custom_semantics_test.dart
+++ b/examples/catalog/test/custom_semantics_test.dart
@@ -19,11 +19,11 @@ void main() {
 
     // Verify it correctly exposes its semantics.
     // TODO(goderbauer): Use `SemanticsTester` after https://github.com/flutter/flutter/issues/12286.
-    final SemanticsNode semantics = tester
-        .renderObject(find.byType(AdjustableDropdownListTile))
-        .debugSemantics;
+    final SemanticsNode semantics =
+        tester.renderObject(find.byType(AdjustableDropdownListTile)).debugSemantics;
 
-    expectAdjustable(semantics,
+    expectAdjustable(
+      semantics,
       hasIncreaseAction: true,
       hasDecreaseAction: true,
       label: 'Timeout',
@@ -36,7 +36,8 @@ void main() {
     semanticsOwner.performAction(semantics.id, SemanticsAction.increase);
     await tester.pump();
 
-    expectAdjustable(semantics,
+    expectAdjustable(
+      semantics,
       hasIncreaseAction: true,
       hasDecreaseAction: true,
       label: 'Timeout',
@@ -49,7 +50,8 @@ void main() {
     semanticsOwner.performAction(semantics.id, SemanticsAction.increase);
     await tester.pump();
 
-    expectAdjustable(semantics,
+    expectAdjustable(
+      semantics,
       hasIncreaseAction: false,
       hasDecreaseAction: true,
       label: 'Timeout',
@@ -61,7 +63,8 @@ void main() {
     semanticsOwner.performAction(semantics.id, SemanticsAction.decrease);
     await tester.pump();
 
-    expectAdjustable(semantics,
+    expectAdjustable(
+      semantics,
       hasIncreaseAction: true,
       hasDecreaseAction: true,
       label: 'Timeout',
@@ -78,7 +81,8 @@ void main() {
     semanticsOwner.performAction(semantics.id, SemanticsAction.decrease);
     await tester.pump();
 
-    expectAdjustable(semantics,
+    expectAdjustable(
+      semantics,
       hasIncreaseAction: true,
       hasDecreaseAction: false,
       label: 'Timeout',
@@ -91,7 +95,8 @@ void main() {
   });
 }
 
-void expectAdjustable(SemanticsNode node, {
+void expectAdjustable(
+  SemanticsNode node, {
   bool hasIncreaseAction = true,
   bool hasDecreaseAction = true,
   String label = '',
@@ -102,10 +107,12 @@ void expectAdjustable(SemanticsNode node, {
   final SemanticsData semanticsData = node.getSemanticsData();
 
   int actions = 0;
-  if (hasIncreaseAction)
+  if (hasIncreaseAction) {
     actions |= SemanticsAction.increase.index;
-  if (hasDecreaseAction)
+  }
+  if (hasDecreaseAction) {
     actions |= SemanticsAction.decrease.index;
+  }
 
   expect(semanticsData.actions, actions);
   expect(semanticsData.label, label);

--- a/examples/catalog/test/custom_semantics_test.dart
+++ b/examples/catalog/test/custom_semantics_test.dart
@@ -19,8 +19,9 @@ void main() {
 
     // Verify it correctly exposes its semantics.
     // TODO(goderbauer): Use `SemanticsTester` after https://github.com/flutter/flutter/issues/12286.
-    final SemanticsNode semantics =
-        tester.renderObject(find.byType(AdjustableDropdownListTile)).debugSemantics;
+    final SemanticsNode semantics = tester
+      .renderObject(find.byType(AdjustableDropdownListTile))
+      .debugSemantics;
 
     expectAdjustable(
       semantics,

--- a/examples/catalog/test/expansion_tile_sample_test.dart
+++ b/examples/catalog/test/expansion_tile_sample_test.dart
@@ -17,8 +17,7 @@ void main() {
       expect(find.text(chapter.title), findsOneWidget);
       for (Entry section in chapter.children) {
         expect(find.text(section.title), findsNothing);
-        for (Entry item in section.children)
-          expect(find.text(item.title), findsNothing);
+        for (Entry item in section.children) expect(find.text(item.title), findsNothing);
       }
     }
 
@@ -34,16 +33,14 @@ void main() {
 
     // Expand the chapters. Now the chapter and sections, but not the
     // items, should be present.
-    for (Entry chapter in expansion_tile_sample.data.reversed)
-      await tapEntry(chapter.title);
+    for (Entry chapter in expansion_tile_sample.data.reversed) await tapEntry(chapter.title);
 
     for (Entry chapter in expansion_tile_sample.data) {
       expect(find.text(chapter.title), findsOneWidget);
       for (Entry section in chapter.children) {
         expect(find.text(section.title), findsOneWidget);
         await scrollUpOneEntry();
-        for (Entry item in section.children)
-          expect(find.text(item.title), findsNothing);
+        for (Entry item in section.children) expect(find.text(item.title), findsNothing);
       }
       await scrollUpOneEntry();
     }
@@ -69,8 +66,7 @@ void main() {
       expect(find.text(chapter.title), findsOneWidget);
       for (Entry section in chapter.children.reversed) {
         expect(find.text(section.title), findsOneWidget);
-        for (Entry item in section.children.reversed)
-          expect(find.text(item.title), findsOneWidget);
+        for (Entry item in section.children.reversed) expect(find.text(item.title), findsOneWidget);
         await tapEntry(section.title); // close the section
       }
       await tapEntry(chapter.title); // close the chapter
@@ -81,10 +77,8 @@ void main() {
       expect(find.text(chapter.title), findsOneWidget);
       for (Entry section in chapter.children) {
         expect(find.text(section.title), findsNothing);
-        for (Entry item in section.children)
-          expect(find.text(item.title), findsNothing);
+        for (Entry item in section.children) expect(find.text(item.title), findsNothing);
       }
     }
-
   });
 }

--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -34,18 +34,19 @@ class _RenderStatusBarPaddingSliver extends RenderSliver {
   _RenderStatusBarPaddingSliver({
     @required double maxHeight,
     @required double scrollFactor,
-  }) : assert(maxHeight != null && maxHeight >= 0.0),
-       assert(scrollFactor != null && scrollFactor >= 1.0),
-       _maxHeight = maxHeight,
-       _scrollFactor = scrollFactor;
+  })  : assert(maxHeight != null && maxHeight >= 0.0),
+        assert(scrollFactor != null && scrollFactor >= 1.0),
+        _maxHeight = maxHeight,
+        _scrollFactor = scrollFactor;
 
   // The height of the status bar
   double get maxHeight => _maxHeight;
   double _maxHeight;
   set maxHeight(double value) {
     assert(maxHeight != null && maxHeight >= 0.0);
-    if (_maxHeight == value)
+    if (_maxHeight == value) {
       return;
+    }
     _maxHeight = value;
     markNeedsLayout();
   }
@@ -56,8 +57,9 @@ class _RenderStatusBarPaddingSliver extends RenderSliver {
   double _scrollFactor;
   set scrollFactor(double value) {
     assert(scrollFactor != null && scrollFactor >= 1.0);
-    if (_scrollFactor == value)
+    if (_scrollFactor == value) {
       return;
+    }
     _scrollFactor = value;
     markNeedsLayout();
   }
@@ -78,9 +80,9 @@ class _StatusBarPaddingSliver extends SingleChildRenderObjectWidget {
     Key key,
     @required this.maxHeight,
     this.scrollFactor = 5.0,
-  }) : assert(maxHeight != null && maxHeight >= 0.0),
-       assert(scrollFactor != null && scrollFactor >= 1.0),
-       super(key: key);
+  })  : assert(maxHeight != null && maxHeight >= 0.0),
+        assert(scrollFactor != null && scrollFactor >= 1.0),
+        super(key: key);
 
   final double maxHeight;
   final double scrollFactor;
@@ -119,8 +121,10 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final double maxHeight;
   final Widget child;
 
-  @override double get minExtent => minHeight;
-  @override double get maxExtent => math.max(maxHeight, minHeight);
+  @override
+  double get minExtent => minHeight;
+  @override
+  double get maxExtent => math.max(maxHeight, minHeight);
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
@@ -129,9 +133,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   bool shouldRebuild(_SliverAppBarDelegate oldDelegate) {
-    return maxHeight != oldDelegate.maxHeight
-        || minHeight != oldDelegate.minHeight
-        || child != oldDelegate.child;
+    return maxHeight != oldDelegate.maxHeight ||
+        minHeight != oldDelegate.minHeight ||
+        child != oldDelegate.child;
   }
 
   @override
@@ -200,15 +204,14 @@ class _AllSectionsLayout extends MultiChildLayoutDelegate {
     // When tCollapsed > 0, the indicators move closer together
     //final double rowIndicatorWidth = 48.0 + (1.0 - tCollapsed) * (rowTitleWidth - 48.0);
     const double paddedSectionIndicatorWidth = kSectionIndicatorWidth + 8.0;
-    final double rowIndicatorWidth = paddedSectionIndicatorWidth +
-      (1.0 - tCollapsed) * (rowTitleWidth - paddedSectionIndicatorWidth);
+    final double rowIndicatorWidth =
+        paddedSectionIndicatorWidth + (1.0 - tCollapsed) * (rowTitleWidth - paddedSectionIndicatorWidth);
     double rowIndicatorX = (size.width - rowIndicatorWidth) / 2.0 - selectedIndex * rowIndicatorWidth;
 
     // Compute the size and origin of each card, title, and indicator for the maxHeight
     // "column" layout, and the midHeight "row" layout. The actual layout is just the
     // interpolated value between the column and row layouts for t.
     for (int index = 0; index < cardCount; index++) {
-
       // Layout the card for index.
       final Rect columnCardRect = Rect.fromLTWH(columnCardX, columnCardY, columnCardWidth, columnCardHeight);
       final Rect rowCardRect = Rect.fromLTWH(rowCardX, 0.0, rowCardWidth, size.height);
@@ -250,9 +253,9 @@ class _AllSectionsLayout extends MultiChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_AllSectionsLayout oldDelegate) {
-    return tColumnToRow != oldDelegate.tColumnToRow
-      || cardCount != oldDelegate.cardCount
-      || selectedIndex != oldDelegate.selectedIndex;
+    return tColumnToRow != oldDelegate.tColumnToRow ||
+        cardCount != oldDelegate.cardCount ||
+        selectedIndex != oldDelegate.selectedIndex;
   }
 }
 
@@ -266,13 +269,13 @@ class _AllSectionsView extends AnimatedWidget {
     this.midHeight,
     this.maxHeight,
     this.sectionCards = const <Widget>[],
-  }) : assert(sections != null),
-       assert(sectionCards != null),
-       assert(sectionCards.length == sections.length),
-       assert(sectionIndex >= 0 && sectionIndex < sections.length),
-       assert(selectedIndex != null),
-       assert(selectedIndex.value >= 0.0 && selectedIndex.value < sections.length.toDouble()),
-       super(key: key, listenable: selectedIndex);
+  })  : assert(sections != null),
+        assert(sectionCards != null),
+        assert(sectionCards.length == sections.length),
+        assert(sectionIndex >= 0 && sectionIndex < sections.length),
+        assert(selectedIndex != null),
+        assert(selectedIndex.value >= 0.0 && selectedIndex.value < sections.length.toDouble()),
+        super(key: key, listenable: selectedIndex);
 
   final int sectionIndex;
   final List<Section> sections;
@@ -292,17 +295,12 @@ class _AllSectionsView extends AnimatedWidget {
     // The layout's progress from from a column to a row. Its value is
     // 0.0 when size.height equals the maxHeight, 1.0 when the size.height
     // equals the midHeight.
-    final double tColumnToRow =
-      1.0 - ((size.height - midHeight) /
-             (maxHeight - midHeight)).clamp(0.0, 1.0);
-
+    final double tColumnToRow = 1.0 - ((size.height - midHeight) / (maxHeight - midHeight)).clamp(0.0, 1.0);
 
     // The layout's progress from from the midHeight row layout to
     // a minHeight row layout. Its value is 0.0 when size.height equals
     // midHeight and 1.0 when size.height equals minHeight.
-    final double tCollapsed =
-      1.0 - ((size.height - minHeight) /
-             (midHeight - minHeight)).clamp(0.0, 1.0);
+    final double tCollapsed = 1.0 - ((size.height - minHeight) / (midHeight - minHeight)).clamp(0.0, 1.0);
 
     double _indicatorOpacity(int index) {
       return 1.0 - _selectedIndexDelta(index) * 0.5;
@@ -364,8 +362,8 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
   const _SnappingScrollPhysics({
     ScrollPhysics parent,
     @required this.midScrollOffset,
-  }) : assert(midScrollOffset != null),
-       super(parent: parent);
+  })  : assert(midScrollOffset != null),
+        super(parent: parent);
 
   final double midScrollOffset;
 
@@ -395,29 +393,34 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
       // then snap it there. Similarly if the simulation is headed down past
       // midScrollOffset but will not reach zero, then snap it to zero.
       final double simulationEnd = simulation.x(double.infinity);
-      if (simulationEnd >= midScrollOffset)
+      if (simulationEnd >= midScrollOffset) {
         return simulation;
-      if (dragVelocity > 0.0)
+      }
+      if (dragVelocity > 0.0) {
         return _toMidScrollOffsetSimulation(offset, dragVelocity);
-      if (dragVelocity < 0.0)
+      }
+      if (dragVelocity < 0.0) {
         return _toZeroScrollOffsetSimulation(offset, dragVelocity);
+      }
     } else {
       // The user ended the drag with little or no velocity. If they
       // didn't leave the offset above midScrollOffset, then
       // snap to midScrollOffset if they're more than halfway there,
       // otherwise snap to zero.
       final double snapThreshold = midScrollOffset / 2.0;
-      if (offset >= snapThreshold && offset < midScrollOffset)
+      if (offset >= snapThreshold && offset < midScrollOffset) {
         return _toMidScrollOffsetSimulation(offset, dragVelocity);
-      if (offset > 0.0 && offset < snapThreshold)
+      }
+      if (offset > 0.0 && offset < snapThreshold) {
         return _toZeroScrollOffsetSimulation(offset, dragVelocity);
+      }
     }
     return simulation;
   }
 }
 
 class AnimationDemoHome extends StatefulWidget {
-  const AnimationDemoHome({ Key key }) : super(key: key);
+  const AnimationDemoHome({Key key}) : super(key: key);
 
   static const String routeName = '/animation';
 
@@ -444,10 +447,11 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
   }
 
   void _handleBackButton(double midScrollOffset) {
-    if (_scrollController.offset >= midScrollOffset)
+    if (_scrollController.offset >= midScrollOffset) {
       _scrollController.animateTo(0.0, curve: _kScrollCurve, duration: _kScrollDuration);
-    else
+    } else {
       Navigator.maybePop(context);
+    }
   }
 
   // Only enable paging for the heading when the user has scrolled to midScrollOffset.
@@ -455,8 +459,8 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
   bool _handleScrollNotification(ScrollNotification notification, double midScrollOffset) {
     if (notification.depth == 0 && notification is ScrollUpdateNotification) {
       final ScrollPhysics physics = _scrollController.position.pixels >= midScrollOffset
-       ? const PageScrollPhysics()
-       : const NeverScrollableScrollPhysics();
+          ? const PageScrollPhysics()
+          : const NeverScrollableScrollPhysics();
       if (physics != _headingScrollPhysics) {
         setState(() {
           _headingScrollPhysics = physics;
@@ -480,11 +484,13 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
     }
   }
 
-  bool _handlePageNotification(ScrollNotification notification, PageController leader, PageController follower) {
+  bool _handlePageNotification(
+      ScrollNotification notification, PageController leader, PageController follower) {
     if (notification.depth == 0 && notification is ScrollUpdateNotification) {
       selectedIndex.value = leader.page;
-      if (follower.page != leader.page)
-        follower.position.jumpToWithoutSettling(leader.position.pixels); // ignore: deprecated_member_use
+      if (follower.page != leader.page) {
+        follower.position.jumpToWithoutSettling(leader.position.pixels);
+      } // ignore: deprecated_member_use
     }
     return false;
   }
@@ -509,14 +515,15 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
             setState(() {
               _maybeScroll(midScrollOffset, index, xOffset);
             });
-          }
+          },
         ),
       ));
     }
 
     final List<Widget> headings = <Widget>[];
     for (int index = 0; index < allSections.length; index++) {
-      headings.add(Container(
+      headings.add(
+        Container(
           color: _kAppBackgroundColor,
           child: ClipRect(
             child: _AllSectionsView(
@@ -529,7 +536,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
               sectionCards: sectionCards,
             ),
           ),
-        )
+        ),
       );
     }
     return headings;
@@ -568,7 +575,8 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
                     maxHeight: appBarMaxHeight,
                     child: NotificationListener<ScrollNotification>(
                       onNotification: (ScrollNotification notification) {
-                        return _handlePageNotification(notification, _headingPageController, _detailsPageController);
+                        return _handlePageNotification(
+                          notification, _headingPageController, _detailsPageController);
                       },
                       child: PageView(
                         physics: _headingScrollPhysics,
@@ -584,7 +592,8 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
                     height: 610.0,
                     child: NotificationListener<ScrollNotification>(
                       onNotification: (ScrollNotification notification) {
-                        return _handlePageNotification(notification, _detailsPageController, _headingPageController);
+                        return _handlePageNotification(
+                          notification, _detailsPageController, _headingPageController);
                       },
                       child: PageView(
                         controller: _detailsPageController,
@@ -614,7 +623,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
                   tooltip: 'Back',
                   onPressed: () {
                     _handleBackButton(appBarMidScrollOffset);
-                  }
+                  },
                 ),
               ),
             ),

--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -420,7 +420,7 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
 }
 
 class AnimationDemoHome extends StatefulWidget {
-  const AnimationDemoHome({Key key}) : super(key: key);
+  const AnimationDemoHome({ Key key }) : super(key: key);
 
   static const String routeName = '/animation';
 

--- a/examples/flutter_gallery/lib/demo/animation/home.dart
+++ b/examples/flutter_gallery/lib/demo/animation/home.dart
@@ -34,10 +34,10 @@ class _RenderStatusBarPaddingSliver extends RenderSliver {
   _RenderStatusBarPaddingSliver({
     @required double maxHeight,
     @required double scrollFactor,
-  })  : assert(maxHeight != null && maxHeight >= 0.0),
-        assert(scrollFactor != null && scrollFactor >= 1.0),
-        _maxHeight = maxHeight,
-        _scrollFactor = scrollFactor;
+  }) : assert(maxHeight != null && maxHeight >= 0.0),
+       assert(scrollFactor != null && scrollFactor >= 1.0),
+       _maxHeight = maxHeight,
+       _scrollFactor = scrollFactor;
 
   // The height of the status bar
   double get maxHeight => _maxHeight;
@@ -80,9 +80,9 @@ class _StatusBarPaddingSliver extends SingleChildRenderObjectWidget {
     Key key,
     @required this.maxHeight,
     this.scrollFactor = 5.0,
-  })  : assert(maxHeight != null && maxHeight >= 0.0),
-        assert(scrollFactor != null && scrollFactor >= 1.0),
-        super(key: key);
+  }) : assert(maxHeight != null && maxHeight >= 0.0),
+       assert(scrollFactor != null && scrollFactor >= 1.0),
+       super(key: key);
 
   final double maxHeight;
   final double scrollFactor;
@@ -269,13 +269,13 @@ class _AllSectionsView extends AnimatedWidget {
     this.midHeight,
     this.maxHeight,
     this.sectionCards = const <Widget>[],
-  })  : assert(sections != null),
-        assert(sectionCards != null),
-        assert(sectionCards.length == sections.length),
-        assert(sectionIndex >= 0 && sectionIndex < sections.length),
-        assert(selectedIndex != null),
-        assert(selectedIndex.value >= 0.0 && selectedIndex.value < sections.length.toDouble()),
-        super(key: key, listenable: selectedIndex);
+  }) : assert(sections != null),
+       assert(sectionCards != null),
+       assert(sectionCards.length == sections.length),
+       assert(sectionIndex >= 0 && sectionIndex < sections.length),
+       assert(selectedIndex != null),
+       assert(selectedIndex.value >= 0.0 && selectedIndex.value < sections.length.toDouble()),
+       super(key: key, listenable: selectedIndex);
 
   final int sectionIndex;
   final List<Section> sections;
@@ -362,8 +362,8 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
   const _SnappingScrollPhysics({
     ScrollPhysics parent,
     @required this.midScrollOffset,
-  })  : assert(midScrollOffset != null),
-        super(parent: parent);
+  }) : assert(midScrollOffset != null),
+       super(parent: parent);
 
   final double midScrollOffset;
 

--- a/examples/flutter_gallery/lib/demo/animation/sections.dart
+++ b/examples/flutter_gallery/lib/demo/animation/sections.dart
@@ -43,9 +43,10 @@ class Section {
   final List<SectionDetail> details;
 
   @override
-  bool operator==(Object other) {
-    if (other is! Section)
+  bool operator ==(Object other) {
+    if (other is! Section) {
       return false;
+    }
     final Section otherSection = other;
     return title == otherSection.title;
   }

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -10,9 +10,9 @@ const double kSectionIndicatorWidth = 32.0;
 
 // The card for a single section. Displays the section's gradient and background image.
 class SectionCard extends StatelessWidget {
-  const SectionCard({ Key key, @required this.section })
-    : assert(section != null),
-      super(key: key);
+  const SectionCard({Key key, @required this.section})
+      : assert(section != null),
+       super(key: key);
 
   final Section section;
 
@@ -52,10 +52,10 @@ class SectionTitle extends StatelessWidget {
     @required this.section,
     @required this.scale,
     @required this.opacity,
-  }) : assert(section != null),
-       assert(scale != null),
-       assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-       super(key: key);
+  })  : assert(section != null),
+        assert(scale != null),
+        assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+        super(key: key);
 
   final Section section;
   final double scale;
@@ -99,7 +99,7 @@ class SectionTitle extends StatelessWidget {
 
 // Small horizontal bar that indicates the selected section.
 class SectionIndicator extends StatelessWidget {
-  const SectionIndicator({ Key key, this.opacity = 1.0 }) : super(key: key);
+  const SectionIndicator({Key key, this.opacity = 1.0}) : super(key: key);
 
   final double opacity;
 
@@ -117,10 +117,10 @@ class SectionIndicator extends StatelessWidget {
 
 // Display a single SectionDetail.
 class SectionDetailView extends StatelessWidget {
-  SectionDetailView({ Key key, @required this.detail })
-    : assert(detail != null && detail.imageAsset != null),
-      assert((detail.imageAsset ?? detail.title) != null),
-      super(key: key);
+  SectionDetailView({Key key, @required this.detail})
+      : assert(detail != null && detail.imageAsset != null),
+       assert((detail.imageAsset ?? detail.title) != null),
+       super(key: key);
 
   final SectionDetail detail;
 

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -52,10 +52,10 @@ class SectionTitle extends StatelessWidget {
     @required this.section,
     @required this.scale,
     @required this.opacity,
-  })  : assert(section != null),
-        assert(scale != null),
-        assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-        super(key: key);
+  }) : assert(section != null),
+       assert(scale != null),
+       assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+       super(key: key);
 
   final Section section;
   final double scale;

--- a/examples/flutter_gallery/lib/demo/animation/widgets.dart
+++ b/examples/flutter_gallery/lib/demo/animation/widgets.dart
@@ -10,7 +10,7 @@ const double kSectionIndicatorWidth = 32.0;
 
 // The card for a single section. Displays the section's gradient and background image.
 class SectionCard extends StatelessWidget {
-  const SectionCard({Key key, @required this.section})
+  const SectionCard({ Key key, @required this.section })
       : assert(section != null),
        super(key: key);
 
@@ -99,7 +99,7 @@ class SectionTitle extends StatelessWidget {
 
 // Small horizontal bar that indicates the selected section.
 class SectionIndicator extends StatelessWidget {
-  const SectionIndicator({Key key, this.opacity = 1.0}) : super(key: key);
+  const SectionIndicator({ Key key, this.opacity = 1.0 }) : super(key: key);
 
   final double opacity;
 
@@ -117,7 +117,7 @@ class SectionIndicator extends StatelessWidget {
 
 // Display a single SectionDetail.
 class SectionDetailView extends StatelessWidget {
-  SectionDetailView({Key key, @required this.detail})
+  SectionDetailView({ Key key, @required this.detail })
       : assert(detail != null && detail.imageAsset != null),
        assert((detail.imageAsset ?? detail.title) != null),
        super(key: key);

--- a/examples/flutter_gallery/lib/demo/animation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/animation_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'animation/home.dart';
 
 class AnimationDemo extends StatelessWidget {
-  const AnimationDemo({Key key}) : super(key: key);
+  const AnimationDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/animation';
 

--- a/examples/flutter_gallery/lib/demo/calculator/home.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/home.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'logic.dart';
 
 class Calculator extends StatefulWidget {
-  const Calculator({Key key}) : super(key: key);
+  const Calculator({ Key key }) : super(key: key);
 
   @override
   _CalculatorState createState() => _CalculatorState();
@@ -138,7 +138,7 @@ class _CalculatorState extends State<Calculator> {
 }
 
 class CalcDisplay extends StatelessWidget {
-  const CalcDisplay({this.content});
+  const CalcDisplay({ this.content });
 
   final String content;
 
@@ -154,7 +154,7 @@ class CalcDisplay extends StatelessWidget {
 }
 
 class KeyPad extends StatelessWidget {
-  const KeyPad({this.calcState});
+  const KeyPad({ this.calcState });
 
   final _CalculatorState calcState;
 

--- a/examples/flutter_gallery/lib/demo/calculator/home.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/home.dart
@@ -116,7 +116,7 @@ class _CalculatorState extends State<Calculator> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).canvasColor,
-        elevation: 0.0
+        elevation: 0.0,
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -124,21 +124,21 @@ class _CalculatorState extends State<Calculator> {
           // Give the key-pad 3/5 of the vertical space and the display 2/5.
           Expanded(
             flex: 2,
-            child: CalcDisplay(content: _expression.toString())
+            child: CalcDisplay(content: _expression.toString()),
           ),
           const Divider(height: 1.0),
           Expanded(
             flex: 3,
-            child: KeyPad(calcState: this)
+            child: KeyPad(calcState: this),
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }
 
 class CalcDisplay extends StatelessWidget {
-  const CalcDisplay({ this.content });
+  const CalcDisplay({this.content});
 
   final String content;
 
@@ -147,14 +147,14 @@ class CalcDisplay extends StatelessWidget {
     return Center(
       child: Text(
         content,
-        style: const TextStyle(fontSize: 24.0)
-      )
+        style: const TextStyle(fontSize: 24.0),
+      ),
     );
   }
 }
 
 class KeyPad extends StatelessWidget {
-  const KeyPad({ this.calcState });
+  const KeyPad({this.calcState});
 
   final _CalculatorState calcState;
 
@@ -177,28 +177,16 @@ class KeyPad extends StatelessWidget {
               flex: 3,
               child: Column(
                 children: <Widget>[
-                  KeyRow(<Widget>[
-                    NumberKey(7, calcState),
-                    NumberKey(8, calcState),
-                    NumberKey(9, calcState)
-                  ]),
-                  KeyRow(<Widget>[
-                    NumberKey(4, calcState),
-                    NumberKey(5, calcState),
-                    NumberKey(6, calcState)
-                  ]),
-                  KeyRow(<Widget>[
-                    NumberKey(1, calcState),
-                    NumberKey(2, calcState),
-                    NumberKey(3, calcState)
-                  ]),
+                  KeyRow(<Widget>[NumberKey(7, calcState), NumberKey(8, calcState), NumberKey(9, calcState)]),
+                  KeyRow(<Widget>[NumberKey(4, calcState), NumberKey(5, calcState), NumberKey(6, calcState)]),
+                  KeyRow(<Widget>[NumberKey(1, calcState), NumberKey(2, calcState), NumberKey(3, calcState)]),
                   KeyRow(<Widget>[
                     CalcKey('.', calcState.handlePointTap),
                     NumberKey(0, calcState),
                     CalcKey('=', calcState.handleEqualsTap),
                   ])
-                ]
-              )
+                ],
+              ),
             ),
             Expanded(
               child: Material(
@@ -210,13 +198,13 @@ class KeyPad extends StatelessWidget {
                     CalcKey('\u00D7', calcState.handleMultTap),
                     CalcKey('-', calcState.handleMinusTap),
                     CalcKey('+', calcState.handlePlusTap)
-                  ]
-                )
-              )
+                  ],
+                ),
+              ),
             ),
-          ]
-        )
-      )
+          ],
+        ),
+      ),
     );
   }
 }
@@ -231,8 +219,8 @@ class KeyRow extends StatelessWidget {
     return Expanded(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: keys
-      )
+        children: keys,
+      ),
     );
   }
 }
@@ -253,18 +241,18 @@ class CalcKey extends StatelessWidget {
           child: Text(
             text,
             style: TextStyle(
-              fontSize: (orientation == Orientation.portrait) ? 32.0 : 24.0
-            )
-          )
-        )
-      )
+              fontSize: (orientation == Orientation.portrait) ? 32.0 : 24.0,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
 
 class NumberKey extends CalcKey {
   NumberKey(int value, _CalculatorState calcState)
-    : super('$value', () {
-        calcState.handleNumberTap(value);
-      });
+      : super('$value', () {
+         calcState.handleNumberTap(value);
+       });
 }

--- a/examples/flutter_gallery/lib/demo/calculator/logic.dart
+++ b/examples/flutter_gallery/lib/demo/calculator/logic.dart
@@ -35,10 +35,12 @@ class FloatToken extends NumberToken {
 
   static double _parse(String stringRep) {
     String toParse = stringRep;
-    if (toParse.startsWith('.'))
+    if (toParse.startsWith('.')) {
       toParse = '0' + toParse;
-    if (toParse.endsWith('.'))
+    }
+    if (toParse.endsWith('.')) {
       toParse = toParse + '0';
+    }
     return double.parse(toParse);
   }
 }
@@ -51,8 +53,9 @@ class ResultToken extends NumberToken {
   /// floating point number is guaranteed to have at least this many
   /// decimal digits of precision.
   static num round(num number) {
-    if (number is int)
+    if (number is int) {
       return number;
+    }
     return double.parse(number.toStringAsPrecision(14));
   }
 }
@@ -66,8 +69,7 @@ enum Operation { Addition, Subtraction, Multiplication, Division }
 
 /// A token that represents an arithmetic operation symbol.
 class OperationToken extends ExpressionToken {
-  OperationToken(this.operation)
-   : super(opString(operation));
+  OperationToken(this.operation) : super(opString(operation));
 
   Operation operation;
 
@@ -120,17 +122,17 @@ enum ExpressionState {
 class CalcExpression {
   CalcExpression(this._list, this.state);
 
-  CalcExpression.empty()
-    : this(<ExpressionToken>[], ExpressionState.Start);
+  CalcExpression.empty() : this(<ExpressionToken>[], ExpressionState.Start);
 
   CalcExpression.result(FloatToken result)
-    : _list = <ExpressionToken>[],
-      state = ExpressionState.Result {
+      : _list = <ExpressionToken>[],
+       state = ExpressionState.Result {
     _list.add(result);
   }
 
   /// The tokens comprising the expression.
   final List<ExpressionToken> _list;
+
   /// The state of the expression.
   final ExpressionState state;
 
@@ -332,10 +334,11 @@ class CalcExpression {
       // Remove the next number token.
       final NumberToken nextNumToken = list.removeAt(0);
       final num nextNumber = nextNumToken.number;
-      if (isDivision)
+      if (isDivision) {
         currentValue /= nextNumber;
-      else
+      } else {
         currentValue *= nextNumber;
+      }
     }
     return currentValue;
   }

--- a/examples/flutter_gallery/lib/demo/calculator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/calculator_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'calculator/home.dart';
 
 class CalculatorDemo extends StatelessWidget {
-  const CalculatorDemo({Key key}) : super(key: key);
+  const CalculatorDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/calculator';
 

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 const double kColorItemHeight = 48.0;
 
 class Palette {
-  Palette({ this.name, this.primary, this.accent, this.threshold = 900});
+  Palette({this.name, this.primary, this.accent, this.threshold = 900});
 
   final String name;
   final MaterialColor primary;
@@ -39,17 +39,16 @@ final List<Palette> allPalettes = <Palette>[
   Palette(name: 'BLUE GREY', primary: Colors.blueGrey, threshold: 500),
 ];
 
-
 class ColorItem extends StatelessWidget {
   const ColorItem({
     Key key,
     @required this.index,
     @required this.color,
     this.prefix = '',
-  }) : assert(index != null),
-       assert(color != null),
-       assert(prefix != null),
-       super(key: key);
+  })  : assert(index != null),
+        assert(color != null),
+        assert(prefix != null),
+        super(key: key);
 
   final int index;
   final Color color;
@@ -86,8 +85,8 @@ class PaletteTabView extends StatelessWidget {
   PaletteTabView({
     Key key,
     @required this.colors,
-  }) : assert(colors != null && colors.isValid),
-       super(key: key);
+  })  : assert(colors != null && colors.isValid),
+        super(key: key);
 
   final Palette colors;
 

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 const double kColorItemHeight = 48.0;
 
 class Palette {
-  Palette({this.name, this.primary, this.accent, this.threshold = 900});
+  Palette({ this.name, this.primary, this.accent, this.threshold = 900 });
 
   final String name;
   final MaterialColor primary;

--- a/examples/flutter_gallery/lib/demo/colors_demo.dart
+++ b/examples/flutter_gallery/lib/demo/colors_demo.dart
@@ -45,10 +45,10 @@ class ColorItem extends StatelessWidget {
     @required this.index,
     @required this.color,
     this.prefix = '',
-  })  : assert(index != null),
-        assert(color != null),
-        assert(prefix != null),
-        super(key: key);
+  }) : assert(index != null),
+       assert(color != null),
+       assert(prefix != null),
+       super(key: key);
 
   final int index;
   final Color color;
@@ -85,8 +85,8 @@ class PaletteTabView extends StatelessWidget {
   PaletteTabView({
     Key key,
     @required this.colors,
-  })  : assert(colors != null && colors.isValid),
-        super(key: key);
+  }) : assert(colors != null && colors.isValid),
+       super(key: key);
 
   final Palette colors;
 

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class _ContactCategory extends StatelessWidget {
-  const _ContactCategory({ Key key, this.icon, this.children }) : super(key: key);
+  const _ContactCategory({Key key, this.icon, this.children}) : super(key: key);
 
   final IconData icon;
   final List<Widget> children;
@@ -17,7 +17,7 @@ class _ContactCategory extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
       decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: themeData.dividerColor))
+        border: Border(bottom: BorderSide(color: themeData.dividerColor)),
       ),
       child: DefaultTextStyle(
         style: Theme.of(context).textTheme.subhead,
@@ -30,7 +30,7 @@ class _ContactCategory extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.symmetric(vertical: 24.0),
                 width: 72.0,
-                child: Icon(icon, color: themeData.primaryColor)
+                child: Icon(icon, color: themeData.primaryColor),
               ),
               Expanded(child: Column(children: children))
             ],
@@ -42,9 +42,9 @@ class _ContactCategory extends StatelessWidget {
 }
 
 class _ContactItem extends StatelessWidget {
-  _ContactItem({ Key key, this.icon, this.lines, this.tooltip, this.onPressed })
-    : assert(lines.length > 1),
-      super(key: key);
+  _ContactItem({Key key, this.icon, this.lines, this.tooltip, this.onPressed})
+      : assert(lines.length > 1),
+       super(key: key);
 
   final IconData icon;
   final List<String> lines;
@@ -54,15 +54,16 @@ class _ContactItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final List<Widget> columnChildren = lines.sublist(0, lines.length - 1).map<Widget>((String line) => Text(line)).toList();
+    final List<Widget> columnChildren =
+        lines.sublist(0, lines.length - 1).map<Widget>((String line) => Text(line)).toList();
     columnChildren.add(Text(lines.last, style: themeData.textTheme.caption));
 
     final List<Widget> rowChildren = <Widget>[
       Expanded(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: columnChildren
-        )
+          children: columnChildren,
+        ),
       )
     ];
     if (icon != null) {
@@ -71,8 +72,8 @@ class _ContactItem extends StatelessWidget {
         child: IconButton(
           icon: Icon(icon),
           color: themeData.primaryColor,
-          onPressed: onPressed
-        )
+          onPressed: onPressed,
+        ),
       ));
     }
     return MergeSemantics(
@@ -80,8 +81,8 @@ class _ContactItem extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 16.0),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: rowChildren
-        )
+          children: rowChildren,
+        ),
       ),
     );
   }
@@ -117,7 +118,8 @@ class ContactsDemoState extends State<ContactsDemo> {
             SliverAppBar(
               expandedHeight: _appBarHeight,
               pinned: _appBarBehavior == AppBarBehavior.pinned,
-              floating: _appBarBehavior == AppBarBehavior.floating || _appBarBehavior == AppBarBehavior.snapping,
+              floating:
+                  _appBarBehavior == AppBarBehavior.floating || _appBarBehavior == AppBarBehavior.snapping,
               snap: _appBarBehavior == AppBarBehavior.snapping,
               actions: <Widget>[
                 IconButton(
@@ -125,7 +127,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                   tooltip: 'Edit',
                   onPressed: () {
                     _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                      content: Text("Editing isn't supported in this screen.")
+                      content: Text("Editing isn't supported in this screen."),
                     ));
                   },
                 ),
@@ -136,23 +138,23 @@ class ContactsDemoState extends State<ContactsDemo> {
                     });
                   },
                   itemBuilder: (BuildContext context) => <PopupMenuItem<AppBarBehavior>>[
-                    const PopupMenuItem<AppBarBehavior>(
-                      value: AppBarBehavior.normal,
-                      child: Text('App bar scrolls away')
-                    ),
-                    const PopupMenuItem<AppBarBehavior>(
-                      value: AppBarBehavior.pinned,
-                      child: Text('App bar stays put')
-                    ),
-                    const PopupMenuItem<AppBarBehavior>(
-                      value: AppBarBehavior.floating,
-                      child: Text('App bar floats')
-                    ),
-                    const PopupMenuItem<AppBarBehavior>(
-                      value: AppBarBehavior.snapping,
-                      child: Text('App bar snaps')
-                    ),
-                  ],
+                        const PopupMenuItem<AppBarBehavior>(
+                          value: AppBarBehavior.normal,
+                          child: Text('App bar scrolls away'),
+                        ),
+                        const PopupMenuItem<AppBarBehavior>(
+                          value: AppBarBehavior.pinned,
+                          child: Text('App bar stays put'),
+                        ),
+                        const PopupMenuItem<AppBarBehavior>(
+                          value: AppBarBehavior.floating,
+                          child: Text('App bar floats'),
+                        ),
+                        const PopupMenuItem<AppBarBehavior>(
+                          value: AppBarBehavior.snapping,
+                          child: Text('App bar snaps'),
+                        ),
+                      ],
                 ),
               ],
               flexibleSpace: FlexibleSpaceBar(
@@ -193,7 +195,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                         tooltip: 'Send message',
                         onPressed: () {
                           _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                            content: Text('Pretend that this opened your SMS application.')
+                            content: Text('Pretend that this opened your SMS application.'),
                           ));
                         },
                         lines: const <String>[
@@ -206,7 +208,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                         tooltip: 'Send message',
                         onPressed: () {
                           _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                            content: Text('A messaging app appears.')
+                            content: Text('A messaging app appears.'),
                           ));
                         },
                         lines: const <String>[
@@ -219,7 +221,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                         tooltip: 'Send message',
                         onPressed: () {
                           _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                            content: Text('Imagine if you will, a messaging application.')
+                            content: Text('Imagine if you will, a messaging application.'),
                           ));
                         },
                         lines: const <String>[
@@ -238,7 +240,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                       tooltip: 'Send personal e-mail',
                       onPressed: () {
                         _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                          content: Text('Here, your e-mail application would open.')
+                          content: Text('Here, your e-mail application would open.'),
                         ));
                       },
                       lines: const <String>[
@@ -251,7 +253,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                       tooltip: 'Send work e-mail',
                       onPressed: () {
                         _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                          content: Text('Summon your favorite e-mail application here.')
+                          content: Text('Summon your favorite e-mail application here.'),
                         ));
                       },
                       lines: const <String>[
@@ -269,7 +271,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                       tooltip: 'Open map',
                       onPressed: () {
                         _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                          content: Text('This would show a map of San Francisco.')
+                          content: Text('This would show a map of San Francisco.'),
                         ));
                       },
                       lines: const <String>[
@@ -283,7 +285,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                       tooltip: 'Open map',
                       onPressed: () {
                         _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                          content: Text('This would show a map of Mountain View.')
+                          content: Text('This would show a map of Mountain View.'),
                         ));
                       },
                       lines: const <String>[
@@ -297,7 +299,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                       tooltip: 'Open map',
                       onPressed: () {
                         _scaffoldKey.currentState.showSnackBar(const SnackBar(
-                          content: Text('This would also show a map, if this was not a demo.')
+                          content: Text('This would also show a map, if this was not a demo.'),
                         ));
                       },
                       lines: const <String>[

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class _ContactCategory extends StatelessWidget {
-  const _ContactCategory({Key key, this.icon, this.children}) : super(key: key);
+  const _ContactCategory({ Key key, this.icon, this.children }) : super(key: key);
 
   final IconData icon;
   final List<Widget> children;
@@ -42,7 +42,7 @@ class _ContactCategory extends StatelessWidget {
 }
 
 class _ContactItem extends StatelessWidget {
-  _ContactItem({Key key, this.icon, this.lines, this.tooltip, this.onPressed})
+  _ContactItem({ Key key, this.icon, this.lines, this.tooltip, this.onPressed })
       : assert(lines.length > 1),
        super(key: key);
 

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -54,8 +54,10 @@ class _ContactItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final List<Widget> columnChildren =
-        lines.sublist(0, lines.length - 1).map<Widget>((String line) => Text(line)).toList();
+    final List<Widget> columnChildren = lines
+      .sublist(0, lines.length - 1)
+      .map<Widget>((String line) => Text(line))
+      .toList();
     columnChildren.add(Text(lines.last, style: themeData.textTheme.caption));
 
     final List<Widget> rowChildren = <Widget>[

--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -138,23 +138,23 @@ class ContactsDemoState extends State<ContactsDemo> {
                     });
                   },
                   itemBuilder: (BuildContext context) => <PopupMenuItem<AppBarBehavior>>[
-                        const PopupMenuItem<AppBarBehavior>(
-                          value: AppBarBehavior.normal,
-                          child: Text('App bar scrolls away'),
-                        ),
-                        const PopupMenuItem<AppBarBehavior>(
-                          value: AppBarBehavior.pinned,
-                          child: Text('App bar stays put'),
-                        ),
-                        const PopupMenuItem<AppBarBehavior>(
-                          value: AppBarBehavior.floating,
-                          child: Text('App bar floats'),
-                        ),
-                        const PopupMenuItem<AppBarBehavior>(
-                          value: AppBarBehavior.snapping,
-                          child: Text('App bar snaps'),
-                        ),
-                      ],
+                    const PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.normal,
+                      child: Text('App bar scrolls away'),
+                    ),
+                    const PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.pinned,
+                      child: Text('App bar stays put'),
+                    ),
+                    const PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.floating,
+                      child: Text('App bar floats'),
+                    ),
+                    const PopupMenuItem<AppBarBehavior>(
+                      value: AppBarBehavior.snapping,
+                      child: Text('App bar snaps'),
+                    ),
+                  ],
                 ),
               ],
               flexibleSpace: FlexibleSpaceBar(

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -17,7 +17,7 @@ class CupertinoAlertDemo extends StatefulWidget {
 class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  void showDemoDialog<T>({BuildContext context, Widget child}) {
+  void showDemoDialog<T>({ BuildContext context, Widget child }) {
     showDialog<T>(
       context: context,
       barrierDismissible: false,
@@ -34,7 +34,7 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
     });
   }
 
-  void showDemoActionSheet<T>({BuildContext context, Widget child}) {
+  void showDemoActionSheet<T>({ BuildContext context, Widget child }) {
     showCupertinoModalPopup<T>(
       context: context,
       builder: (BuildContext context) => child,
@@ -196,7 +196,7 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
 }
 
 class CupertinoDessertDialog extends StatelessWidget {
-  const CupertinoDessertDialog({Key key, this.title, this.content}) : super(key: key);
+  const CupertinoDessertDialog({ Key key, this.title, this.content }) : super(key: key);
 
   final Widget title;
   final Widget content;

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -129,8 +129,8 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
                 child: const CupertinoDessertDialog(
                   title: Text('Select Favorite Dessert'),
                   content: Text('Please select your favorite type of dessert from the '
-                      'list below. Your selection will be used to customize the suggested '
-                      'list of eateries in your area.'),
+                    'list below. Your selection will be used to customize the suggested '
+                    'list of eateries in your area.'),
                 ),
               );
             },
@@ -184,7 +184,7 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
                     onPressed: () {
                       Navigator.pop(context, 'Cancel');
                     },
-                  )
+                  ),
                 ),
               );
             },

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_buttons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_buttons_demo.dart
@@ -25,18 +25,18 @@ class _CupertinoButtonDemoState extends State<CupertinoButtonsDemo> {
         actions: <Widget>[MaterialDemoDocumentationButton(CupertinoButtonsDemo.routeName)],
       ),
       body: Column(
-        children: <Widget> [
+        children: <Widget>[
           const Padding(
             padding: EdgeInsets.all(16.0),
             child: Text(
               'iOS themed buttons are flat. They can have borders or backgrounds but '
-              'only when necessary.'
+                  'only when necessary.',
             ),
           ),
           Expanded(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget> [
+              children: <Widget>[
                 Text(_pressedCount > 0
                     ? 'Button pressed $_pressedCount time${_pressedCount == 1 ? "" : "s"}'
                     : ' '),
@@ -49,8 +49,10 @@ class _CupertinoButtonDemoState extends State<CupertinoButtonsDemo> {
                       CupertinoButton(
                         child: const Text('Cupertino Button'),
                         onPressed: () {
-                          setState(() { _pressedCount += 1; });
-                        }
+                          setState(() {
+                            _pressedCount += 1;
+                          });
+                        },
                       ),
                       const CupertinoButton(
                         child: Text('Disabled'),
@@ -64,8 +66,10 @@ class _CupertinoButtonDemoState extends State<CupertinoButtonsDemo> {
                   child: const Text('With Background'),
                   color: CupertinoColors.activeBlue,
                   onPressed: () {
-                    setState(() { _pressedCount += 1; });
-                  }
+                    setState(() {
+                      _pressedCount += 1;
+                    });
+                  },
                 ),
                 const Padding(padding: EdgeInsets.all(12.0)),
                 const CupertinoButton(
@@ -74,10 +78,10 @@ class _CupertinoButtonDemoState extends State<CupertinoButtonsDemo> {
                   onPressed: null,
                 ),
               ],
-            )
+            ),
           ),
         ],
-      )
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -24,10 +24,29 @@ const List<Color> coolColors = <Color>[
 ];
 
 const List<String> coolColorNames = <String>[
-  'Sarcoline', 'Coquelicot', 'Smaragdine', 'Mikado', 'Glaucous', 'Wenge',
-  'Fulvous', 'Xanadu', 'Falu', 'Eburnean', 'Amaranth', 'Australien',
-  'Banan', 'Falu', 'Gingerline', 'Incarnadine', 'Labrador', 'Nattier',
-  'Pervenche', 'Sinoper', 'Verditer', 'Watchet', 'Zaffre',
+  'Sarcoline',
+  'Coquelicot',
+  'Smaragdine',
+  'Mikado',
+  'Glaucous',
+  'Wenge',
+  'Fulvous',
+  'Xanadu',
+  'Falu',
+  'Eburnean',
+  'Amaranth',
+  'Australien',
+  'Banan',
+  'Falu',
+  'Gingerline',
+  'Incarnadine',
+  'Labrador',
+  'Nattier',
+  'Pervenche',
+  'Sinoper',
+  'Verditer',
+  'Watchet',
+  'Zaffre',
 ];
 
 const int _kChildCount = 50;
@@ -35,11 +54,11 @@ const int _kChildCount = 50;
 class CupertinoNavigationDemo extends StatelessWidget {
   CupertinoNavigationDemo()
       : colorItems = List<Color>.generate(_kChildCount, (int index) {
-          return coolColors[math.Random().nextInt(coolColors.length)];
-        }) ,
-        colorNameItems = List<String>.generate(_kChildCount, (int index) {
-          return coolColorNames[math.Random().nextInt(coolColorNames.length)];
-        });
+         return coolColors[math.Random().nextInt(coolColors.length)];
+       }),
+       colorNameItems = List<String>.generate(_kChildCount, (int index) {
+         return coolColorNames[math.Random().nextInt(coolColorNames.length)];
+       });
 
   static const String routeName = '/cupertino/navigation';
 
@@ -82,7 +101,7 @@ class CupertinoNavigationDemo extends StatelessWidget {
                   builder: (BuildContext context) {
                     return CupertinoDemoTab1(
                       colorItems: colorItems,
-                      colorNameItems: colorNameItems
+                      colorNameItems: colorNameItems,
                     );
                   },
                   defaultTitle: 'Colors',
@@ -156,11 +175,13 @@ class CupertinoDemoTab1 extends StatelessWidget {
           SliverPadding(
             // Top media padding consumed by CupertinoSliverNavigationBar.
             // Left/Right media padding consumed by Tab1RowItem.
-            padding: MediaQuery.of(context).removePadding(
-              removeTop: true,
-              removeLeft: true,
-              removeRight: true,
-            ).padding,
+            padding: MediaQuery.of(context)
+              .removePadding(
+                removeTop: true,
+                removeLeft: true,
+                removeRight: true,
+              )
+              .padding,
             sliver: SliverList(
               delegate: SliverChildBuilderDelegate(
                 (BuildContext context, int index) {
@@ -197,10 +218,10 @@ class Tab1RowItem extends StatelessWidget {
         Navigator.of(context).push(CupertinoPageRoute<void>(
           title: colorName,
           builder: (BuildContext context) => Tab1ItemPage(
-            color: color,
-            colorName: colorName,
-            index: index,
-          ),
+                color: color,
+                colorName: colorName,
+                index: index,
+              ),
         ));
       },
       child: SafeArea(
@@ -240,19 +261,21 @@ class Tab1RowItem extends StatelessWidget {
               ),
               CupertinoButton(
                 padding: EdgeInsets.zero,
-                child: const Icon(CupertinoIcons.plus_circled,
+                child: const Icon(
+                  CupertinoIcons.plus_circled,
                   color: CupertinoColors.activeBlue,
                   semanticLabel: 'Add',
                 ),
-                onPressed: () { },
+                onPressed: () {},
               ),
               CupertinoButton(
                 padding: EdgeInsets.zero,
-                child: const Icon(CupertinoIcons.share,
+                child: const Icon(
+                  CupertinoIcons.share,
                   color: CupertinoColors.activeBlue,
                   semanticLabel: 'Share',
                 ),
-                onPressed: () { },
+                onPressed: () {},
               ),
             ],
           ),
@@ -295,7 +318,7 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
       final math.Random random = math.Random();
       return Color.fromARGB(
         255,
-      (widget.color.red + random.nextInt(100) - 50).clamp(0, 255),
+        (widget.color.red + random.nextInt(100) - 50).clamp(0, 255),
         (widget.color.green + random.nextInt(100) - 50).clamp(0, 255),
         (widget.color.blue + random.nextInt(100) - 50).clamp(0, 255),
       );
@@ -365,7 +388,7 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
                                   letterSpacing: -0.28,
                                 ),
                               ),
-                              onPressed: () { },
+                              onPressed: () {},
                             ),
                             CupertinoButton(
                               color: CupertinoColors.activeBlue,
@@ -373,7 +396,7 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
                               padding: EdgeInsets.zero,
                               borderRadius: BorderRadius.circular(32.0),
                               child: const Icon(CupertinoIcons.ellipsis, color: CupertinoColors.white),
-                              onPressed: () { },
+                              onPressed: () {},
                             ),
                           ],
                         ),
@@ -416,7 +439,7 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
                             color: CupertinoColors.white,
                             size: 36.0,
                           ),
-                          onPressed: () { },
+                          onPressed: () {},
                         ),
                       ),
                     ),
@@ -593,9 +616,7 @@ class Tab2ConversationBubble extends StatelessWidget {
       child: Text(
         text,
         style: TextStyle(
-          color: color == Tab2ConversationBubbleColor.blue
-              ? CupertinoColors.white
-              : CupertinoColors.black,
+          color: color == Tab2ConversationBubbleColor.blue ? CupertinoColors.white : CupertinoColors.black,
           letterSpacing: -0.4,
           fontSize: 15.0,
           fontWeight: FontWeight.w400,
@@ -653,16 +674,15 @@ class Tab2ConversationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final List<Widget> children = <Widget>[];
-    if (avatar != null)
+    if (avatar != null) {
       children.add(avatar);
+    }
 
     final bool isSelf = avatar == null;
     children.add(
       Tab2ConversationBubble(
         text: text,
-        color: isSelf
-          ? Tab2ConversationBubbleColor.blue
-          : Tab2ConversationBubbleColor.gray,
+        color: isSelf ? Tab2ConversationBubbleColor.blue : Tab2ConversationBubbleColor.gray,
       ),
     );
     return SafeArea(
@@ -677,7 +697,7 @@ class Tab2ConversationRow extends StatelessWidget {
 }
 
 List<Widget> buildTab2Conversation() {
- return <Widget>[
+  return <Widget>[
     const Tab2ConversationRow(
       text: "My Xanadu doesn't look right",
     ),

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -158,7 +158,7 @@ final Widget trailingButtons = Row(
 );
 
 class CupertinoDemoTab1 extends StatelessWidget {
-  const CupertinoDemoTab1({this.colorItems, this.colorNameItems});
+  const CupertinoDemoTab1({ this.colorItems, this.colorNameItems });
 
   final List<Color> colorItems;
   final List<String> colorNameItems;
@@ -203,7 +203,7 @@ class CupertinoDemoTab1 extends StatelessWidget {
 }
 
 class Tab1RowItem extends StatelessWidget {
-  const Tab1RowItem({this.index, this.lastItem, this.color, this.colorName});
+  const Tab1RowItem({ this.index, this.lastItem, this.color, this.colorName });
 
   final int index;
   final bool lastItem;
@@ -300,7 +300,7 @@ class Tab1RowItem extends StatelessWidget {
 }
 
 class Tab1ItemPage extends StatefulWidget {
-  const Tab1ItemPage({this.color, this.colorName, this.index});
+  const Tab1ItemPage({ this.color, this.colorName, this.index });
 
   final Color color;
   final String colorName;
@@ -597,7 +597,7 @@ enum Tab2ConversationBubbleColor {
 }
 
 class Tab2ConversationBubble extends StatelessWidget {
-  const Tab2ConversationBubble({this.text, this.color});
+  const Tab2ConversationBubble({ this.text, this.color });
 
   final String text;
   final Tab2ConversationBubbleColor color;
@@ -627,7 +627,7 @@ class Tab2ConversationBubble extends StatelessWidget {
 }
 
 class Tab2ConversationAvatar extends StatelessWidget {
-  const Tab2ConversationAvatar({this.text, this.color});
+  const Tab2ConversationAvatar({ this.text, this.color });
 
   final String text;
   final Color color;
@@ -666,7 +666,7 @@ class Tab2ConversationAvatar extends StatelessWidget {
 }
 
 class Tab2ConversationRow extends StatelessWidget {
-  const Tab2ConversationRow({this.avatar, this.text});
+  const Tab2ConversationRow({ this.avatar, this.text });
 
   final Tab2ConversationAvatar avatar;
   final String text;

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -218,10 +218,10 @@ class Tab1RowItem extends StatelessWidget {
         Navigator.of(context).push(CupertinoPageRoute<void>(
           title: colorName,
           builder: (BuildContext context) => Tab1ItemPage(
-                color: color,
-                colorName: colorName,
-                index: index,
-              ),
+            color: color,
+            colorName: colorName,
+            index: index,
+          ),
         ));
       },
       child: SafeArea(

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
@@ -103,8 +103,8 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
                   setState(() => _selectedColorIndex = index);
                 },
                 children: List<Widget>.generate(coolColorNames.length, (int index) {
-                  return Center(child:
-                  Text(coolColorNames[index]),
+                  return Center(
+                    child: Text(coolColorNames[index]),
                   );
                 }),
               ),
@@ -118,7 +118,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
           Text(
             coolColorNames[_selectedColorIndex],
             style: const TextStyle(
-                color: CupertinoColors.inactiveGray
+              color: CupertinoColors.inactiveGray,
             ),
           ),
         ],
@@ -148,8 +148,8 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
           const Text('Countdown Timer'),
           Text(
             '${timer.inHours}:'
-                '${(timer.inMinutes % 60).toString().padLeft(2,'0')}:'
-                '${(timer.inSeconds % 60).toString().padLeft(2,'0')}',
+                '${(timer.inMinutes % 60).toString().padLeft(2, '0')}:'
+                '${(timer.inSeconds % 60).toString().padLeft(2, '0')}',
             style: const TextStyle(color: CupertinoColors.inactiveGray),
           ),
         ],
@@ -182,7 +182,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
             DateFormat.yMMMMd().format(date),
             style: const TextStyle(color: CupertinoColors.inactiveGray),
           ),
-        ]
+        ],
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
@@ -30,9 +30,9 @@ class _CupertinoRefreshControlDemoState extends State<CupertinoRefreshControlDem
       100,
       (int index) {
         return contacts[random.nextInt(contacts.length)]
-            // Randomly adds a telephone icon next to the contact or not.
-            ..add(random.nextBool().toString());
-      }
+          // Randomly adds a telephone icon next to the contact or not.
+          ..add(random.nextBool().toString());
+      },
     );
   }
 
@@ -58,11 +58,11 @@ class _CupertinoRefreshControlDemoState extends State<CupertinoRefreshControlDem
               CupertinoSliverRefreshControl(
                 onRefresh: () {
                   return Future<void>.delayed(const Duration(seconds: 2))
-                      ..then<void>((_) {
-                        if (mounted) {
-                          setState(() => repopulateList());
-                        }
-                      });
+                    ..then<void>((_) {
+                      if (mounted) {
+                        setState(() => repopulateList());
+                      }
+                    });
                 },
               ),
               SliverSafeArea(
@@ -170,8 +170,8 @@ class _ListItem extends StatelessWidget {
                   )
                 : null,
           ),
-        Expanded(
-          child: Container(
+          Expanded(
+            child: Container(
               decoration: const BoxDecoration(
                 border: Border(
                   bottom: BorderSide(color: Color(0xFFBCBBC1), width: 0.0),
@@ -219,7 +219,7 @@ class _ListItem extends StatelessWidget {
                     padding: EdgeInsets.only(left: 9.0),
                     child: Icon(
                       CupertinoIcons.info,
-                      color: CupertinoColors.activeBlue
+                      color: CupertinoColors.activeBlue,
                     ),
                   ),
                 ],

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_slider_demo.dart
@@ -31,7 +31,7 @@ class _CupertinoSliderDemoState extends State<CupertinoSliderDemo> {
           children: <Widget>[
             Column(
               mainAxisSize: MainAxisSize.min,
-              children: <Widget> [
+              children: <Widget>[
                 CupertinoSlider(
                   value: _value,
                   min: 0.0,
@@ -40,14 +40,14 @@ class _CupertinoSliderDemoState extends State<CupertinoSliderDemo> {
                     setState(() {
                       _value = value;
                     });
-                  }
+                  },
                 ),
                 Text('Cupertino Continuous: ${_value.toStringAsFixed(1)}'),
-              ]
+              ],
             ),
             Column(
               mainAxisSize: MainAxisSize.min,
-              children: <Widget> [
+              children: <Widget>[
                 CupertinoSlider(
                   value: _discreteValue,
                   min: 0.0,
@@ -57,10 +57,10 @@ class _CupertinoSliderDemoState extends State<CupertinoSliderDemo> {
                     setState(() {
                       _discreteValue = value;
                     });
-                  }
+                  },
                 ),
                 Text('Cupertino Discrete: $_discreteValue'),
-              ]
+              ],
             ),
           ],
         ),

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
@@ -15,7 +15,6 @@ class CupertinoSwitchDemo extends StatefulWidget {
 }
 
 class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
-
   bool _switchValue = false;
 
   @override
@@ -42,7 +41,7 @@ class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
                     },
                   ),
                   const Text(
-                    'Active'
+                    'Active',
                   ),
                 ],
               ),
@@ -56,7 +55,7 @@ class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
                     onChanged: null,
                   ),
                   Text(
-                    'Disabled'
+                    'Disabled',
                   ),
                 ],
               ),
@@ -70,7 +69,7 @@ class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
                     onChanged: null,
                   ),
                   Text(
-                    'Disabled'
+                    'Disabled',
                   ),
                 ],
               ),

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
@@ -51,12 +51,12 @@ class _CupertinoTextFieldDemoState extends State<CupertinoTextFieldDemo> {
           ),
           padding: const EdgeInsets.all(2.0),
           borderRadius: BorderRadius.circular(15.0),
-          onPressed: ()=> setState(()=> _chatTextController.clear()),
+          onPressed: () => setState(() => _chatTextController.clear()),
         ),
       ),
       autofocus: true,
       suffixMode: OverlayVisibilityMode.editing,
-      onSubmitted: (String text)=> setState(()=> _chatTextController.clear()),
+      onSubmitted: (String text) => setState(() => _chatTextController.clear()),
     );
   }
 

--- a/examples/flutter_gallery/lib/demo/images_demo.dart
+++ b/examples/flutter_gallery/lib/demo/images_demo.dart
@@ -28,13 +28,13 @@ class ImagesDemo extends StatelessWidget {
           exampleCodeTag: 'animated_image',
           demoWidget: Semantics(
             label: 'Example of animated GIF',
-            child:Image.asset(
+            child: Image.asset(
               'animated_images/animated_flutter_lgtm.gif',
               package: 'flutter_gallery_assets',
             ),
           ),
         ),
-      ]
+      ],
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 // (CategoryView) on top of the backdrop.
 
 class Category {
-  const Category({this.title, this.assets});
+  const Category({ this.title, this.assets });
   final String title;
   final List<String> assets;
   @override
@@ -95,7 +95,7 @@ const List<Category> allCategories = <Category>[
 ];
 
 class CategoryView extends StatelessWidget {
-  const CategoryView({Key key, this.category}) : super(key: key);
+  const CategoryView({ Key key, this.category }) : super(key: key);
 
   final Category category;
 

--- a/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 // (CategoryView) on top of the backdrop.
 
 class Category {
-  const Category({ this.title, this.assets });
+  const Category({this.title, this.assets});
   final String title;
   final List<String> assets;
   @override
@@ -95,7 +95,7 @@ const List<Category> allCategories = <Category>[
 ];
 
 class CategoryView extends StatelessWidget {
-  const CategoryView({ Key key, this.category }) : super(key: key);
+  const CategoryView({Key key, this.category}) : super(key: key);
 
   final Category category;
 
@@ -289,23 +289,26 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
   // the user must either tap its heading or the backdrop's menu icon.
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    if (_controller.isAnimating || _controller.status == AnimationStatus.completed)
+    if (_controller.isAnimating || _controller.status == AnimationStatus.completed) {
       return;
+    }
 
     _controller.value -= details.primaryDelta / (_backdropHeight ?? details.primaryDelta);
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    if (_controller.isAnimating || _controller.status == AnimationStatus.completed)
+    if (_controller.isAnimating || _controller.status == AnimationStatus.completed) {
       return;
+    }
 
     final double flingVelocity = details.velocity.pixelsPerSecond.dy / _backdropHeight;
-    if (flingVelocity < 0.0)
+    if (flingVelocity < 0.0) {
       _controller.fling(velocity: math.max(2.0, -flingVelocity));
-    else if (flingVelocity > 0.0)
+    } else if (flingVelocity > 0.0) {
       _controller.fling(velocity: math.min(-2.0, -flingVelocity));
-    else
+    } else {
       _controller.fling(velocity: _controller.value < 0.5 ? -2.0 : 2.0);
+    }
   }
 
   // Stacks a BackdropPanel, which displays the selected category, on top
@@ -337,9 +340,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(4.0)),
         ),
-        color: selected
-          ? Colors.white.withOpacity(0.25)
-          : Colors.transparent,
+        color: selected ? Colors.white.withOpacity(0.25) : Colors.transparent,
         child: ListTile(
           title: Text(category.title),
           selected: selected,

--- a/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -63,35 +63,38 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
 
   // FAB Position
 
-  static const _ChoiceValue<FloatingActionButtonLocation> kFabEndDocked = _ChoiceValue<FloatingActionButtonLocation>(
+  static const _ChoiceValue<FloatingActionButtonLocation> kFabEndDocked =
+      _ChoiceValue<FloatingActionButtonLocation>(
     title: 'Attached - End',
     label: 'floating action button is docked at the end of the bottom app bar',
     value: FloatingActionButtonLocation.endDocked,
   );
 
-  static const _ChoiceValue<FloatingActionButtonLocation> kFabCenterDocked = _ChoiceValue<FloatingActionButtonLocation>(
+  static const _ChoiceValue<FloatingActionButtonLocation> kFabCenterDocked =
+      _ChoiceValue<FloatingActionButtonLocation>(
     title: 'Attached - Center',
     label: 'floating action button is docked at the center of the bottom app bar',
     value: FloatingActionButtonLocation.centerDocked,
   );
 
-  static const _ChoiceValue<FloatingActionButtonLocation> kFabEndFloat= _ChoiceValue<FloatingActionButtonLocation>(
+  static const _ChoiceValue<FloatingActionButtonLocation> kFabEndFloat =
+      _ChoiceValue<FloatingActionButtonLocation>(
     title: 'Free - End',
     label: 'floating action button floats above the end of the bottom app bar',
     value: FloatingActionButtonLocation.endFloat,
   );
 
-  static const _ChoiceValue<FloatingActionButtonLocation> kFabCenterFloat = _ChoiceValue<FloatingActionButtonLocation>(
+  static const _ChoiceValue<FloatingActionButtonLocation> kFabCenterFloat =
+      _ChoiceValue<FloatingActionButtonLocation>(
     title: 'Free - Center',
     label: 'floating action button is floats above the center of the bottom app bar',
     value: FloatingActionButtonLocation.centerFloat,
   );
 
   static void _showSnackbar() {
-    const String text =
-      "When the Scaffold's floating action button location changes, "
-      'the floating action button animates to its new position.'
-      'The BottomAppBar adapts its shape appropriately.';
+    const String text = "When the Scaffold's floating action button location changes, "
+        'the floating action button animates to its new position.'
+        'The BottomAppBar adapts its shape appropriately.';
     _scaffoldKey.currentState.showSnackBar(
       const SnackBar(content: Text(text)),
     );
@@ -160,28 +163,21 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
         padding: const EdgeInsets.only(bottom: 88.0),
         children: <Widget>[
           const _Heading('FAB Shape'),
-
           _RadioItem<Widget>(kCircularFab, _fabShape, _onFabShapeChanged),
           _RadioItem<Widget>(kDiamondFab, _fabShape, _onFabShapeChanged),
           _RadioItem<Widget>(kNoFab, _fabShape, _onFabShapeChanged),
-
           const Divider(),
           const _Heading('Notch'),
-
           _RadioItem<bool>(kShowNotchTrue, _showNotch, _onShowNotchChanged),
           _RadioItem<bool>(kShowNotchFalse, _showNotch, _onShowNotchChanged),
-
           const Divider(),
           const _Heading('FAB Position'),
-
           _RadioItem<FloatingActionButtonLocation>(kFabEndDocked, _fabLocation, _onFabLocationChanged),
           _RadioItem<FloatingActionButtonLocation>(kFabCenterDocked, _fabLocation, _onFabLocationChanged),
           _RadioItem<FloatingActionButtonLocation>(kFabEndFloat, _fabLocation, _onFabLocationChanged),
           _RadioItem<FloatingActionButtonLocation>(kFabCenterFloat, _fabLocation, _onFabLocationChanged),
-
           const Divider(),
           const _Heading('App bar color'),
-
           _ColorsItem(kBabColors, _babColor, _onBabColorChanged),
         ],
       ),
@@ -196,18 +192,21 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
   }
 
   NotchedShape _selectNotch() {
-    if (!_showNotch.value)
+    if (!_showNotch.value) {
       return null;
-    if (_fabShape == kCircularFab)
+    }
+    if (_fabShape == kCircularFab) {
       return const CircularNotchedRectangle();
-    if (_fabShape == kDiamondFab)
+    }
+    if (_fabShape == kDiamondFab) {
       return const _DiamondNotchedRectangle();
+    }
     return null;
   }
 }
 
 class _ChoiceValue<T> {
-  const _ChoiceValue({ this.value, this.title, this.label });
+  const _ChoiceValue({this.value, this.title, this.label});
 
   final T value;
   final String title;
@@ -256,7 +255,7 @@ class _RadioItem<T> extends StatelessWidget {
                 ),
               ),
             ),
-          ]
+          ],
         ),
       ),
     );
@@ -333,7 +332,7 @@ class _DemoBottomAppBar extends StatelessWidget {
   const _DemoBottomAppBar({
     this.color,
     this.fabLocation,
-    this.shape
+    this.shape,
   });
 
   final Color color;
@@ -347,7 +346,7 @@ class _DemoBottomAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> rowContents = <Widget> [
+    final List<Widget> rowContents = <Widget>[
       IconButton(
         icon: const Icon(Icons.menu, semanticLabel: 'Show bottom sheet'),
         onPressed: () {
@@ -365,9 +364,12 @@ class _DemoBottomAppBar extends StatelessWidget {
       );
     }
 
-    rowContents.addAll(<Widget> [
+    rowContents.addAll(<Widget>[
       IconButton(
-        icon: const Icon(Icons.search, semanticLabel: 'show search action',),
+        icon: const Icon(
+          Icons.search,
+          semanticLabel: 'show search action',
+        ),
         onPressed: () {
           Scaffold.of(context).showSnackBar(
             const SnackBar(content: Text('This is a dummy search action.')),
@@ -376,9 +378,7 @@ class _DemoBottomAppBar extends StatelessWidget {
       ),
       IconButton(
         icon: Icon(
-          Theme.of(context).platform == TargetPlatform.iOS
-              ? Icons.more_horiz
-              : Icons.more_vert,
+          Theme.of(context).platform == TargetPlatform.iOS ? Icons.more_horiz : Icons.more_vert,
           semanticLabel: 'Show menu actions',
         ),
         onPressed: () {
@@ -456,8 +456,9 @@ class _DiamondNotchedRectangle implements NotchedShape {
 
   @override
   Path getOuterPath(Rect host, Rect guest) {
-    if (!host.overlaps(guest))
+    if (!host.overlaps(guest)) {
       return Path()..addRect(host);
+    }
     assert(guest.width > 0.0);
 
     final Rect intersection = guest.intersect(host);
@@ -473,9 +474,7 @@ class _DiamondNotchedRectangle implements NotchedShape {
     //  notchToCenter is the horizontal distance between the guest's center and
     //  the host's top edge where the notch starts (marked with "*").
     //  We compute notchToCenter by similar triangles:
-    final double notchToCenter =
-      intersection.height * (guest.height / 2.0)
-      / (guest.width / 2.0);
+    final double notchToCenter = intersection.height * (guest.height / 2.0) / (guest.width / 2.0);
 
     return Path()
       ..moveTo(host.left, host.top)
@@ -498,22 +497,22 @@ class _DiamondBorder extends ShapeBorder {
   }
 
   @override
-  Path getInnerPath(Rect rect, { TextDirection textDirection }) {
+  Path getInnerPath(Rect rect, {TextDirection textDirection}) {
     return getOuterPath(rect, textDirection: textDirection);
   }
 
   @override
-  Path getOuterPath(Rect rect, { TextDirection textDirection }) {
+  Path getOuterPath(Rect rect, {TextDirection textDirection}) {
     return Path()
       ..moveTo(rect.left + rect.width / 2.0, rect.top)
       ..lineTo(rect.right, rect.top + rect.height / 2.0)
-      ..lineTo(rect.left + rect.width  / 2.0, rect.bottom)
+      ..lineTo(rect.left + rect.width / 2.0, rect.bottom)
       ..lineTo(rect.left, rect.top + rect.height / 2.0)
       ..close();
   }
 
   @override
-  void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {}
+  void paint(Canvas canvas, Rect rect, {TextDirection textDirection}) {}
 
   // This border doesn't support scaling.
   @override

--- a/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -206,7 +206,7 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
 }
 
 class _ChoiceValue<T> {
-  const _ChoiceValue({this.value, this.title, this.label});
+  const _ChoiceValue({ this.value, this.title, this.label });
 
   final T value;
   final String title;
@@ -497,12 +497,12 @@ class _DiamondBorder extends ShapeBorder {
   }
 
   @override
-  Path getInnerPath(Rect rect, {TextDirection textDirection}) {
+  Path getInnerPath(Rect rect, { TextDirection textDirection }) {
     return getOuterPath(rect, textDirection: textDirection);
   }
 
   @override
-  Path getOuterPath(Rect rect, {TextDirection textDirection}) {
+  Path getOuterPath(Rect rect, { TextDirection textDirection }) {
     return Path()
       ..moveTo(rect.left + rect.width / 2.0, rect.top)
       ..lineTo(rect.right, rect.top + rect.height / 2.0)
@@ -512,7 +512,7 @@ class _DiamondBorder extends ShapeBorder {
   }
 
   @override
-  void paint(Canvas canvas, Rect rect, {TextDirection textDirection}) {}
+  void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {}
 
   // This border doesn't support scaling.
   @override

--- a/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -13,19 +13,19 @@ class NavigationIconView {
     String title,
     Color color,
     TickerProvider vsync,
-  }) : _icon = icon,
-       _color = color,
-       _title = title,
-       item = BottomNavigationBarItem(
-         icon: icon,
-         activeIcon: activeIcon,
-         title: Text(title),
-         backgroundColor: color,
-       ),
-       controller = AnimationController(
-         duration: kThemeAnimationDuration,
-         vsync: vsync,
-       ) {
+  })  : _icon = icon,
+        _color = color,
+        _title = title,
+        item = BottomNavigationBarItem(
+          icon: icon,
+          activeIcon: activeIcon,
+          title: Text(title),
+          backgroundColor: color,
+        ),
+        controller = AnimationController(
+          duration: kThemeAnimationDuration,
+          vsync: vsync,
+        ) {
     _animation = controller.drive(CurveTween(
       curve: const Interval(0.5, 1.0, curve: Curves.fastOutSlowIn),
     ));
@@ -44,9 +44,7 @@ class NavigationIconView {
       iconColor = _color;
     } else {
       final ThemeData themeData = Theme.of(context);
-      iconColor = themeData.brightness == Brightness.light
-          ? themeData.primaryColor
-          : themeData.accentColor;
+      iconColor = themeData.brightness == Brightness.light ? themeData.primaryColor : themeData.accentColor;
     }
 
     return FadeTransition(
@@ -96,7 +94,7 @@ class CustomInactiveIcon extends StatelessWidget {
       height: iconTheme.size - 8.0,
       decoration: BoxDecoration(
         border: Border.all(color: iconTheme.color, width: 2.0),
-      )
+      ),
     );
   }
 }
@@ -108,8 +106,7 @@ class BottomNavigationDemo extends StatefulWidget {
   _BottomNavigationDemoState createState() => _BottomNavigationDemoState();
 }
 
-class _BottomNavigationDemoState extends State<BottomNavigationDemo>
-    with TickerProviderStateMixin {
+class _BottomNavigationDemoState extends State<BottomNavigationDemo> with TickerProviderStateMixin {
   int _currentIndex = 0;
   BottomNavigationBarType _type = BottomNavigationBarType.shifting;
   List<NavigationIconView> _navigationViews;
@@ -158,16 +155,14 @@ class _BottomNavigationDemoState extends State<BottomNavigationDemo>
 
   @override
   void dispose() {
-    for (NavigationIconView view in _navigationViews)
-      view.controller.dispose();
+    for (NavigationIconView view in _navigationViews) view.controller.dispose();
     super.dispose();
   }
 
   Widget _buildTransitionsStack() {
     final List<FadeTransition> transitions = <FadeTransition>[];
 
-    for (NavigationIconView view in _navigationViews)
-      transitions.add(view.transition(_type, context));
+    for (NavigationIconView view in _navigationViews) transitions.add(view.transition(_type, context));
 
     // We want to have the newly animating (fading in) views on top.
     transitions.sort((FadeTransition a, FadeTransition b) {
@@ -185,8 +180,8 @@ class _BottomNavigationDemoState extends State<BottomNavigationDemo>
   Widget build(BuildContext context) {
     final BottomNavigationBar botNavBar = BottomNavigationBar(
       items: _navigationViews
-          .map<BottomNavigationBarItem>((NavigationIconView navigationView) => navigationView.item)
-          .toList(),
+        .map<BottomNavigationBarItem>((NavigationIconView navigationView) => navigationView.item)
+        .toList(),
       currentIndex: _currentIndex,
       type: _type,
       onTap: (int index) {
@@ -210,20 +205,20 @@ class _BottomNavigationDemoState extends State<BottomNavigationDemo>
               });
             },
             itemBuilder: (BuildContext context) => <PopupMenuItem<BottomNavigationBarType>>[
-              const PopupMenuItem<BottomNavigationBarType>(
-                value: BottomNavigationBarType.fixed,
-                child: Text('Fixed'),
-              ),
-              const PopupMenuItem<BottomNavigationBarType>(
-                value: BottomNavigationBarType.shifting,
-                child: Text('Shifting'),
-              )
-            ],
+                  const PopupMenuItem<BottomNavigationBarType>(
+                    value: BottomNavigationBarType.fixed,
+                    child: Text('Fixed'),
+                  ),
+                  const PopupMenuItem<BottomNavigationBarType>(
+                    value: BottomNavigationBarType.shifting,
+                    child: Text('Shifting'),
+                  )
+                ],
           )
         ],
       ),
       body: Center(
-        child: _buildTransitionsStack()
+        child: _buildTransitionsStack(),
       ),
       bottomNavigationBar: botNavBar,
     );

--- a/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -205,15 +205,15 @@ class _BottomNavigationDemoState extends State<BottomNavigationDemo> with Ticker
               });
             },
             itemBuilder: (BuildContext context) => <PopupMenuItem<BottomNavigationBarType>>[
-                  const PopupMenuItem<BottomNavigationBarType>(
-                    value: BottomNavigationBarType.fixed,
-                    child: Text('Fixed'),
-                  ),
-                  const PopupMenuItem<BottomNavigationBarType>(
-                    value: BottomNavigationBarType.shifting,
-                    child: Text('Shifting'),
-                  )
-                ],
+              const PopupMenuItem<BottomNavigationBarType>(
+                value: BottomNavigationBarType.fixed,
+                child: Text('Fixed'),
+              ),
+              const PopupMenuItem<BottomNavigationBarType>(
+                value: BottomNavigationBarType.shifting,
+                child: Text('Shifting'),
+              )
+            ],
           )
         ],
       ),

--- a/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -13,19 +13,19 @@ class NavigationIconView {
     String title,
     Color color,
     TickerProvider vsync,
-  })  : _icon = icon,
-        _color = color,
-        _title = title,
-        item = BottomNavigationBarItem(
-          icon: icon,
-          activeIcon: activeIcon,
-          title: Text(title),
-          backgroundColor: color,
-        ),
-        controller = AnimationController(
-          duration: kThemeAnimationDuration,
-          vsync: vsync,
-        ) {
+  }) : _icon = icon,
+       _color = color,
+       _title = title,
+       item = BottomNavigationBarItem(
+         icon: icon,
+         activeIcon: activeIcon,
+         title: Text(title),
+         backgroundColor: color,
+       ),
+       controller = AnimationController(
+         duration: kThemeAnimationDuration,
+         vsync: vsync,
+       ) {
     _animation = controller.drive(CurveTween(
       curve: const Interval(0.5, 1.0, curve: Curves.fastOutSlowIn),
     ));

--- a/examples/flutter_gallery/lib/demo/material/buttons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/buttons_demo.dart
@@ -6,8 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-const String _raisedText =
-    'Raised buttons add dimension to mostly flat layouts. They emphasize '
+const String _raisedText = 'Raised buttons add dimension to mostly flat layouts. They emphasize '
     'functions on busy or wide spaces.';
 
 const String _raisedCode = 'buttons_raised';
@@ -18,27 +17,23 @@ const String _flatText = 'A flat button displays an ink splash on press '
 
 const String _flatCode = 'buttons_flat';
 
-const String _outlineText =
-    'Outline buttons become opaque and elevate when pressed. They are often '
+const String _outlineText = 'Outline buttons become opaque and elevate when pressed. They are often '
     'paired with raised buttons to indicate an alternative, secondary action.';
 
 const String _outlineCode = 'buttons_outline';
 
-const String _dropdownText =
-    'A dropdown button displays a menu that\'s used to select a value from a '
+const String _dropdownText = 'A dropdown button displays a menu that\'s used to select a value from a '
     'small set of values. The button displays the current value and a down '
     'arrow.';
 
 const String _dropdownCode = 'buttons_dropdown';
 
-const String _iconText =
-    'IconButtons are appropriate for toggle buttons that allow a single choice '
+const String _iconText = 'IconButtons are appropriate for toggle buttons that allow a single choice '
     'to be selected or deselected, such as adding or removing an item\'s star.';
 
 const String _iconCode = 'buttons_icon';
 
-const String _actionText =
-    'Floating action buttons are used for a promoted action. They are '
+const String _actionText = 'Floating action buttons are used for a promoted action. They are '
     'distinguished by a circled icon floating above the UI and can have motion '
     'behaviors that include morphing, launching, and a transferring anchor '
     'point.';
@@ -58,7 +53,7 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
   @override
   Widget build(BuildContext context) {
     final ButtonThemeData buttonTheme = ButtonTheme.of(context).copyWith(
-      shape: _buttonShape
+      shape: _buttonShape,
     );
 
     final List<ComponentDemoTabData> demos = <ComponentDemoTabData>[
@@ -190,7 +185,10 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
                 },
               ),
               const FlatButton(
-                child: Text('DISABLED', semanticsLabel: 'DISABLED BUTTON 3',),
+                child: Text(
+                  'DISABLED',
+                  semanticsLabel: 'DISABLED BUTTON 3',
+                ),
                 onPressed: null,
               ),
             ],
@@ -322,17 +320,30 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
                 });
               },
               items: <String>[
-                  'One', 'Two', 'Free', 'Four', 'Can', 'I', 'Have', 'A', 'Little',
-                  'Bit', 'More', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten'
-                 ]
-                .map<DropdownMenuItem<String>>((String value) {
-                  return DropdownMenuItem<String>(
-                    value: value,
-                    child: Text(value),
-                  );
-                })
-                .toList(),
-             ),
+                'One',
+                'Two',
+                'Free',
+                'Four',
+                'Can',
+                'I',
+                'Have',
+                'A',
+                'Little',
+                'Bit',
+                'More',
+                'Five',
+                'Six',
+                'Seven',
+                'Eight',
+                'Nine',
+                'Ten'
+              ].map<DropdownMenuItem<String>>((String value) {
+                return DropdownMenuItem<String>(
+                  value: value,
+                  child: Text(value),
+                );
+              }).toList(),
+            ),
           ),
         ],
       ),
@@ -364,9 +375,7 @@ class _ButtonsDemoState extends State<ButtonsDemo> {
             ),
             onPressed: null,
           )
-        ]
-        .map<Widget>((Widget button) => SizedBox(width: 64.0, height: 64.0, child: button))
-        .toList(),
+        ].map<Widget>((Widget button) => SizedBox(width: 64.0, height: 64.0, child: button)).toList(),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -49,7 +49,7 @@ final List<TravelDestination> destinations = <TravelDestination>[
 ];
 
 class TravelDestinationItem extends StatelessWidget {
-  TravelDestinationItem({Key key, @required this.destination, this.shape})
+  TravelDestinationItem({ Key key, @required this.destination, this.shape })
       : assert(destination != null && destination.isValid),
        super(key: key);
 

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -49,9 +49,9 @@ final List<TravelDestination> destinations = <TravelDestination>[
 ];
 
 class TravelDestinationItem extends StatelessWidget {
-  TravelDestinationItem({ Key key, @required this.destination, this.shape })
-    : assert(destination != null && destination.isValid),
-      super(key: key);
+  TravelDestinationItem({Key key, @required this.destination, this.shape})
+      : assert(destination != null && destination.isValid),
+       super(key: key);
 
   static const double height = 366.0;
   final TravelDestination destination;
@@ -93,7 +93,8 @@ class TravelDestinationItem extends StatelessWidget {
                       child: FittedBox(
                         fit: BoxFit.scaleDown,
                         alignment: Alignment.centerLeft,
-                        child: Text(destination.title,
+                        child: Text(
+                          destination.title,
                           style: titleStyle,
                         ),
                       ),
@@ -135,12 +136,12 @@ class TravelDestinationItem extends StatelessWidget {
                     FlatButton(
                       child: Text('SHARE', semanticsLabel: 'Share ${destination.title}'),
                       textColor: Colors.amber.shade500,
-                      onPressed: () { /* do nothing */ },
+                      onPressed: () {/* do nothing */},
                     ),
                     FlatButton(
                       child: Text('EXPLORE', semanticsLabel: 'Explore ${destination.title}'),
                       textColor: Colors.amber.shade500,
-                      onPressed: () { /* do nothing */ },
+                      onPressed: () {/* do nothing */},
                     ),
                   ],
                 ),
@@ -152,7 +153,6 @@ class TravelDestinationItem extends StatelessWidget {
     );
   }
 }
-
 
 class CardsDemo extends StatefulWidget {
   static const String routeName = '/material/cards';
@@ -178,14 +178,16 @@ class _CardsDemoState extends State<CardsDemo> {
             ),
             onPressed: () {
               setState(() {
-                _shape = _shape != null ? null : const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(16.0),
-                    topRight: Radius.circular(16.0),
-                    bottomLeft: Radius.circular(2.0),
-                    bottomRight: Radius.circular(2.0),
-                  ),
-                );
+                _shape = _shape != null
+                    ? null
+                    : const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16.0),
+                          topRight: Radius.circular(16.0),
+                          bottomLeft: Radius.circular(2.0),
+                          bottomRight: Radius.circular(2.0),
+                        ),
+                      );
               });
             },
           ),
@@ -202,8 +204,8 @@ class _CardsDemoState extends State<CardsDemo> {
               shape: _shape,
             ),
           );
-        }).toList()
-      )
+        }).toList(),
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/chip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/chip_demo.dart
@@ -100,16 +100,15 @@ class _ChipsTile extends StatelessWidget {
       }).toList()));
     } else {
       final TextStyle textStyle = Theme.of(context).textTheme.caption.copyWith(fontStyle: FontStyle.italic);
-      cardChildren.add(
-        Semantics(
-          container: true,
-          child: Container(
-            alignment: Alignment.center,
-            constraints: const BoxConstraints(minWidth: 48.0, minHeight: 48.0),
-            padding: const EdgeInsets.all(8.0),
-            child: Text('None', style: textStyle),
-          ),
-        ));
+      cardChildren.add(Semantics(
+        container: true,
+        child: Container(
+          alignment: Alignment.center,
+          constraints: const BoxConstraints(minWidth: 48.0, minHeight: 48.0),
+          padding: const EdgeInsets.all(8.0),
+          child: Text('None', style: textStyle),
+        ),
+      ));
     }
 
     return Card(
@@ -117,7 +116,7 @@ class _ChipsTile extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: cardChildren,
-      )
+      ),
     );
   }
 }
@@ -217,16 +216,16 @@ class _ChipDemoState extends State<ChipDemo> {
 
     final List<Widget> inputChips = _tools.map<Widget>((String name) {
       return InputChip(
-          key: ValueKey<String>(name),
-          avatar: CircleAvatar(
-            backgroundImage: _nameToAvatar(name),
-          ),
-          label: Text(_capitalize(name)),
-          onDeleted: () {
-            setState(() {
-              _removeTool(name);
-            });
+        key: ValueKey<String>(name),
+        avatar: CircleAvatar(
+          backgroundImage: _nameToAvatar(name),
+        ),
+        label: Text(_capitalize(name)),
+        onDeleted: () {
+          setState(() {
+            _removeTool(name);
           });
+        });
     }).toList();
 
     final List<Widget> choiceChips = _materials.map<Widget>((String name) {
@@ -319,7 +318,7 @@ class _ChipDemoState extends State<ChipDemo> {
       body: ChipTheme(
         data: _showShapeBorder
             ? theme.chipTheme.copyWith(
-                shape: BeveledRectangleBorder(
+              shape: BeveledRectangleBorder(
                 side: const BorderSide(width: 0.66, style: BorderStyle.solid, color: Colors.grey),
                 borderRadius: BorderRadius.circular(10.0),
               ))

--- a/examples/flutter_gallery/lib/demo/material/data_table_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/data_table_demo.dart
@@ -23,60 +23,56 @@ class Dessert {
 
 class DessertDataSource extends DataTableSource {
   final List<Dessert> _desserts = <Dessert>[
-    Dessert('Frozen yogurt',                        159,  6.0,  24,  4.0,  87, 14,  1),
-    Dessert('Ice cream sandwich',                   237,  9.0,  37,  4.3, 129,  8,  1),
-    Dessert('Eclair',                               262, 16.0,  24,  6.0, 337,  6,  7),
-    Dessert('Cupcake',                              305,  3.7,  67,  4.3, 413,  3,  8),
-    Dessert('Gingerbread',                          356, 16.0,  49,  3.9, 327,  7, 16),
-    Dessert('Jelly bean',                           375,  0.0,  94,  0.0,  50,  0,  0),
-    Dessert('Lollipop',                             392,  0.2,  98,  0.0,  38,  0,  2),
-    Dessert('Honeycomb',                            408,  3.2,  87,  6.5, 562,  0, 45),
-    Dessert('Donut',                                452, 25.0,  51,  4.9, 326,  2, 22),
-    Dessert('KitKat',                               518, 26.0,  65,  7.0,  54, 12,  6),
-
-    Dessert('Frozen yogurt with sugar',             168,  6.0,  26,  4.0,  87, 14,  1),
-    Dessert('Ice cream sandwich with sugar',        246,  9.0,  39,  4.3, 129,  8,  1),
-    Dessert('Eclair with sugar',                    271, 16.0,  26,  6.0, 337,  6,  7),
-    Dessert('Cupcake with sugar',                   314,  3.7,  69,  4.3, 413,  3,  8),
-    Dessert('Gingerbread with sugar',               345, 16.0,  51,  3.9, 327,  7, 16),
-    Dessert('Jelly bean with sugar',                364,  0.0,  96,  0.0,  50,  0,  0),
-    Dessert('Lollipop with sugar',                  401,  0.2, 100,  0.0,  38,  0,  2),
-    Dessert('Honeycomb with sugar',                 417,  3.2,  89,  6.5, 562,  0, 45),
-    Dessert('Donut with sugar',                     461, 25.0,  53,  4.9, 326,  2, 22),
-    Dessert('KitKat with sugar',                    527, 26.0,  67,  7.0,  54, 12,  6),
-
-    Dessert('Frozen yogurt with honey',             223,  6.0,  36,  4.0,  87, 14,  1),
-    Dessert('Ice cream sandwich with honey',        301,  9.0,  49,  4.3, 129,  8,  1),
-    Dessert('Eclair with honey',                    326, 16.0,  36,  6.0, 337,  6,  7),
-    Dessert('Cupcake with honey',                   369,  3.7,  79,  4.3, 413,  3,  8),
-    Dessert('Gingerbread with honey',               420, 16.0,  61,  3.9, 327,  7, 16),
-    Dessert('Jelly bean with honey',                439,  0.0, 106,  0.0,  50,  0,  0),
-    Dessert('Lollipop with honey',                  456,  0.2, 110,  0.0,  38,  0,  2),
-    Dessert('Honeycomb with honey',                 472,  3.2,  99,  6.5, 562,  0, 45),
-    Dessert('Donut with honey',                     516, 25.0,  63,  4.9, 326,  2, 22),
-    Dessert('KitKat with honey',                    582, 26.0,  77,  7.0,  54, 12,  6),
-
-    Dessert('Frozen yogurt with milk',              262,  8.4,  36, 12.0, 194, 44,  1),
-    Dessert('Ice cream sandwich with milk',         339, 11.4,  49, 12.3, 236, 38,  1),
-    Dessert('Eclair with milk',                     365, 18.4,  36, 14.0, 444, 36,  7),
-    Dessert('Cupcake with milk',                    408,  6.1,  79, 12.3, 520, 33,  8),
-    Dessert('Gingerbread with milk',                459, 18.4,  61, 11.9, 434, 37, 16),
-    Dessert('Jelly bean with milk',                 478,  2.4, 106,  8.0, 157, 30,  0),
-    Dessert('Lollipop with milk',                   495,  2.6, 110,  8.0, 145, 30,  2),
-    Dessert('Honeycomb with milk',                  511,  5.6,  99, 14.5, 669, 30, 45),
-    Dessert('Donut with milk',                      555, 27.4,  63, 12.9, 433, 32, 22),
-    Dessert('KitKat with milk',                     621, 28.4,  77, 15.0, 161, 42,  6),
-
-    Dessert('Coconut slice and frozen yogurt',      318, 21.0,  31,  5.5,  96, 14,  7),
-    Dessert('Coconut slice and ice cream sandwich', 396, 24.0,  44,  5.8, 138,  8,  7),
-    Dessert('Coconut slice and eclair',             421, 31.0,  31,  7.5, 346,  6, 13),
-    Dessert('Coconut slice and cupcake',            464, 18.7,  74,  5.8, 422,  3, 14),
-    Dessert('Coconut slice and gingerbread',        515, 31.0,  56,  5.4, 316,  7, 22),
-    Dessert('Coconut slice and jelly bean',         534, 15.0, 101,  1.5,  59,  0,  6),
-    Dessert('Coconut slice and lollipop',           551, 15.2, 105,  1.5,  47,  0,  8),
-    Dessert('Coconut slice and honeycomb',          567, 18.2,  94,  8.0, 571,  0, 51),
-    Dessert('Coconut slice and donut',              611, 40.0,  58,  6.4, 335,  2, 28),
-    Dessert('Coconut slice and KitKat',             677, 41.0,  72,  8.5,  63, 12, 12),
+    Dessert('Frozen yogurt', 159, 6.0, 24, 4.0, 87, 14, 1),
+    Dessert('Ice cream sandwich', 237, 9.0, 37, 4.3, 129, 8, 1),
+    Dessert('Eclair', 262, 16.0, 24, 6.0, 337, 6, 7),
+    Dessert('Cupcake', 305, 3.7, 67, 4.3, 413, 3, 8),
+    Dessert('Gingerbread', 356, 16.0, 49, 3.9, 327, 7, 16),
+    Dessert('Jelly bean', 375, 0.0, 94, 0.0, 50, 0, 0),
+    Dessert('Lollipop', 392, 0.2, 98, 0.0, 38, 0, 2),
+    Dessert('Honeycomb', 408, 3.2, 87, 6.5, 562, 0, 45),
+    Dessert('Donut', 452, 25.0, 51, 4.9, 326, 2, 22),
+    Dessert('KitKat', 518, 26.0, 65, 7.0, 54, 12, 6),
+    Dessert('Frozen yogurt with sugar', 168, 6.0, 26, 4.0, 87, 14, 1),
+    Dessert('Ice cream sandwich with sugar', 246, 9.0, 39, 4.3, 129, 8, 1),
+    Dessert('Eclair with sugar', 271, 16.0, 26, 6.0, 337, 6, 7),
+    Dessert('Cupcake with sugar', 314, 3.7, 69, 4.3, 413, 3, 8),
+    Dessert('Gingerbread with sugar', 345, 16.0, 51, 3.9, 327, 7, 16),
+    Dessert('Jelly bean with sugar', 364, 0.0, 96, 0.0, 50, 0, 0),
+    Dessert('Lollipop with sugar', 401, 0.2, 100, 0.0, 38, 0, 2),
+    Dessert('Honeycomb with sugar', 417, 3.2, 89, 6.5, 562, 0, 45),
+    Dessert('Donut with sugar', 461, 25.0, 53, 4.9, 326, 2, 22),
+    Dessert('KitKat with sugar', 527, 26.0, 67, 7.0, 54, 12, 6),
+    Dessert('Frozen yogurt with honey', 223, 6.0, 36, 4.0, 87, 14, 1),
+    Dessert('Ice cream sandwich with honey', 301, 9.0, 49, 4.3, 129, 8, 1),
+    Dessert('Eclair with honey', 326, 16.0, 36, 6.0, 337, 6, 7),
+    Dessert('Cupcake with honey', 369, 3.7, 79, 4.3, 413, 3, 8),
+    Dessert('Gingerbread with honey', 420, 16.0, 61, 3.9, 327, 7, 16),
+    Dessert('Jelly bean with honey', 439, 0.0, 106, 0.0, 50, 0, 0),
+    Dessert('Lollipop with honey', 456, 0.2, 110, 0.0, 38, 0, 2),
+    Dessert('Honeycomb with honey', 472, 3.2, 99, 6.5, 562, 0, 45),
+    Dessert('Donut with honey', 516, 25.0, 63, 4.9, 326, 2, 22),
+    Dessert('KitKat with honey', 582, 26.0, 77, 7.0, 54, 12, 6),
+    Dessert('Frozen yogurt with milk', 262, 8.4, 36, 12.0, 194, 44, 1),
+    Dessert('Ice cream sandwich with milk', 339, 11.4, 49, 12.3, 236, 38, 1),
+    Dessert('Eclair with milk', 365, 18.4, 36, 14.0, 444, 36, 7),
+    Dessert('Cupcake with milk', 408, 6.1, 79, 12.3, 520, 33, 8),
+    Dessert('Gingerbread with milk', 459, 18.4, 61, 11.9, 434, 37, 16),
+    Dessert('Jelly bean with milk', 478, 2.4, 106, 8.0, 157, 30, 0),
+    Dessert('Lollipop with milk', 495, 2.6, 110, 8.0, 145, 30, 2),
+    Dessert('Honeycomb with milk', 511, 5.6, 99, 14.5, 669, 30, 45),
+    Dessert('Donut with milk', 555, 27.4, 63, 12.9, 433, 32, 22),
+    Dessert('KitKat with milk', 621, 28.4, 77, 15.0, 161, 42, 6),
+    Dessert('Coconut slice and frozen yogurt', 318, 21.0, 31, 5.5, 96, 14, 7),
+    Dessert('Coconut slice and ice cream sandwich', 396, 24.0, 44, 5.8, 138, 8, 7),
+    Dessert('Coconut slice and eclair', 421, 31.0, 31, 7.5, 346, 6, 13),
+    Dessert('Coconut slice and cupcake', 464, 18.7, 74, 5.8, 422, 3, 14),
+    Dessert('Coconut slice and gingerbread', 515, 31.0, 56, 5.4, 316, 7, 22),
+    Dessert('Coconut slice and jelly bean', 534, 15.0, 101, 1.5, 59, 0, 6),
+    Dessert('Coconut slice and lollipop', 551, 15.2, 105, 1.5, 47, 0, 8),
+    Dessert('Coconut slice and honeycomb', 567, 18.2, 94, 8.0, 571, 0, 51),
+    Dessert('Coconut slice and donut', 611, 40.0, 58, 6.4, 335, 2, 28),
+    Dessert('Coconut slice and KitKat', 677, 41.0, 72, 8.5, 63, 12, 12),
   ];
 
   void _sort<T>(Comparable<T> getField(Dessert d), bool ascending) {
@@ -98,8 +94,9 @@ class DessertDataSource extends DataTableSource {
   @override
   DataRow getRow(int index) {
     assert(index >= 0);
-    if (index >= _desserts.length)
+    if (index >= _desserts.length) {
       return null;
+    }
     final Dessert dessert = _desserts[index];
     return DataRow.byIndex(
       index: index,
@@ -121,7 +118,7 @@ class DessertDataSource extends DataTableSource {
         DataCell(Text('${dessert.sodium}')),
         DataCell(Text('${dessert.calcium}%')),
         DataCell(Text('${dessert.iron}%')),
-      ]
+      ],
     );
   }
 
@@ -135,8 +132,7 @@ class DessertDataSource extends DataTableSource {
   int get selectedRowCount => _selectedCount;
 
   void _selectAll(bool checked) {
-    for (Dessert dessert in _desserts)
-      dessert.selected = checked;
+    for (Dessert dessert in _desserts) dessert.selected = checked;
     _selectedCount = checked ? _desserts.length : 0;
     notifyListeners();
   }
@@ -178,57 +174,69 @@ class _DataTableDemoState extends State<DataTableDemo> {
           PaginatedDataTable(
             header: const Text('Nutrition'),
             rowsPerPage: _rowsPerPage,
-            onRowsPerPageChanged: (int value) { setState(() { _rowsPerPage = value; }); },
+            onRowsPerPageChanged: (int value) {
+              setState(() {
+                _rowsPerPage = value;
+              });
+            },
             sortColumnIndex: _sortColumnIndex,
             sortAscending: _sortAscending,
             onSelectAll: _dessertsDataSource._selectAll,
             columns: <DataColumn>[
               DataColumn(
                 label: const Text('Dessert (100g serving)'),
-                onSort: (int columnIndex, bool ascending) => _sort<String>((Dessert d) => d.name, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<String>((Dessert d) => d.name, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Calories'),
                 tooltip: 'The total amount of food energy in the given serving size.',
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.calories, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.calories, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Fat (g)'),
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.fat, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.fat, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Carbs (g)'),
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.carbs, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.carbs, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Protein (g)'),
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.protein, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.protein, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Sodium (mg)'),
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.sodium, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.sodium, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Calcium (%)'),
                 tooltip: 'The amount of calcium as a percentage of the recommended daily amount.',
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.calcium, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.calcium, columnIndex, ascending),
               ),
               DataColumn(
                 label: const Text('Iron (%)'),
                 numeric: true,
-                onSort: (int columnIndex, bool ascending) => _sort<num>((Dessert d) => d.iron, columnIndex, ascending)
+                onSort: (int columnIndex, bool ascending) =>
+                    _sort<num>((Dessert d) => d.iron, columnIndex, ascending),
               ),
             ],
-            source: _dessertsDataSource
+            source: _dessertsDataSource,
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
@@ -10,7 +10,8 @@ import 'package:intl/intl.dart';
 import '../../gallery/demo.dart';
 
 class _InputDropdown extends StatelessWidget {
-  const _InputDropdown({Key key, this.child, this.labelText, this.valueText, this.valueStyle, this.onPressed})
+  const _InputDropdown(
+      { Key key, this.child, this.labelText, this.valueText, this.valueStyle, this.onPressed })
       : super(key: key);
 
   final String labelText;

--- a/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
@@ -10,13 +10,8 @@ import 'package:intl/intl.dart';
 import '../../gallery/demo.dart';
 
 class _InputDropdown extends StatelessWidget {
-  const _InputDropdown({
-    Key key,
-    this.child,
-    this.labelText,
-    this.valueText,
-    this.valueStyle,
-    this.onPressed }) : super(key: key);
+  const _InputDropdown({Key key, this.child, this.labelText, this.valueText, this.valueStyle, this.onPressed})
+      : super(key: key);
 
   final String labelText;
   final String valueText;
@@ -38,8 +33,9 @@ class _InputDropdown extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Text(valueText, style: valueStyle),
-            Icon(Icons.arrow_drop_down,
-              color: Theme.of(context).brightness == Brightness.light ? Colors.grey.shade700 : Colors.white70
+            Icon(
+              Icons.arrow_drop_down,
+              color: Theme.of(context).brightness == Brightness.light ? Colors.grey.shade700 : Colors.white70,
             ),
           ],
         ),
@@ -55,7 +51,7 @@ class _DateTimePicker extends StatelessWidget {
     this.selectedDate,
     this.selectedTime,
     this.selectDate,
-    this.selectTime
+    this.selectTime,
   }) : super(key: key);
 
   final String labelText;
@@ -69,19 +65,21 @@ class _DateTimePicker extends StatelessWidget {
       context: context,
       initialDate: selectedDate,
       firstDate: DateTime(2015, 8),
-      lastDate: DateTime(2101)
+      lastDate: DateTime(2101),
     );
-    if (picked != null && picked != selectedDate)
+    if (picked != null && picked != selectedDate) {
       selectDate(picked);
+    }
   }
 
   Future<void> _selectTime(BuildContext context) async {
     final TimeOfDay picked = await showTimePicker(
       context: context,
-      initialTime: selectedTime
+      initialTime: selectedTime,
     );
-    if (picked != null && picked != selectedTime)
+    if (picked != null && picked != selectedTime) {
       selectTime(picked);
+    }
   }
 
   @override
@@ -96,7 +94,9 @@ class _DateTimePicker extends StatelessWidget {
             labelText: labelText,
             valueText: DateFormat.yMMMd().format(selectedDate),
             valueStyle: valueStyle,
-            onPressed: () { _selectDate(context); },
+            onPressed: () {
+              _selectDate(context);
+            },
           ),
         ),
         const SizedBox(width: 12.0),
@@ -105,7 +105,9 @@ class _DateTimePicker extends StatelessWidget {
           child: _InputDropdown(
             valueText: selectedTime.format(context),
             valueStyle: valueStyle,
-            onPressed: () { _selectTime(context); },
+            onPressed: () {
+              _selectTime(context);
+            },
           ),
         ),
       ],

--- a/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
@@ -72,7 +72,7 @@ class DialogDemoState extends State<DialogDemo> {
     _selectedTime = TimeOfDay(hour: now.hour, minute: now.minute);
   }
 
-  void showDemoDialog<T>({BuildContext context, Widget child}) {
+  void showDemoDialog<T>({ BuildContext context, Widget child }) {
     showDialog<T>(
       context: context,
       builder: (BuildContext context) => child,

--- a/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/dialog_demo.dart
@@ -17,11 +17,17 @@ enum DialogDemoAction {
 const String _alertWithoutTitleText = 'Discard draft?';
 
 const String _alertWithTitleText =
-  'Let Google help apps determine location. This means sending anonymous location '
-  'data to Google, even when no apps are running.';
+    'Let Google help apps determine location. This means sending anonymous location '
+    'data to Google, even when no apps are running.';
 
 class DialogDemoItem extends StatelessWidget {
-  const DialogDemoItem({ Key key, this.icon, this.color, this.text, this.onPressed }) : super(key: key);
+  const DialogDemoItem({
+    Key key,
+    this.icon,
+    this.color,
+    this.text,
+    this.onPressed,
+  }) : super(key: key);
 
   final IconData icon;
   final Color color;
@@ -66,15 +72,15 @@ class DialogDemoState extends State<DialogDemo> {
     _selectedTime = TimeOfDay(hour: now.hour, minute: now.minute);
   }
 
-  void showDemoDialog<T>({ BuildContext context, Widget child }) {
+  void showDemoDialog<T>({BuildContext context, Widget child}) {
     showDialog<T>(
       context: context,
       builder: (BuildContext context) => child,
-    )
-    .then<void>((T value) { // The value passed to Navigator.pop() or null.
+    ).then<void>((T value) {
+      // The value passed to Navigator.pop() or null.
       if (value != null) {
         _scaffoldKey.currentState.showSnackBar(SnackBar(
-          content: Text('You selected: $value')
+          content: Text('You selected: $value'),
         ));
       }
     });
@@ -102,21 +108,25 @@ class DialogDemoState extends State<DialogDemo> {
                 child: AlertDialog(
                   content: Text(
                     _alertWithoutTitleText,
-                    style: dialogTextStyle
+                    style: dialogTextStyle,
                   ),
                   actions: <Widget>[
                     FlatButton(
                       child: const Text('CANCEL'),
-                      onPressed: () { Navigator.pop(context, DialogDemoAction.cancel); }
+                      onPressed: () {
+                        Navigator.pop(context, DialogDemoAction.cancel);
+                      },
                     ),
                     FlatButton(
                       child: const Text('DISCARD'),
-                      onPressed: () { Navigator.pop(context, DialogDemoAction.discard); }
+                      onPressed: () {
+                        Navigator.pop(context, DialogDemoAction.discard);
+                      },
                     )
-                  ]
-                )
+                  ],
+                ),
               );
-            }
+            },
           ),
           RaisedButton(
             child: const Text('ALERT WITH TITLE'),
@@ -127,21 +137,25 @@ class DialogDemoState extends State<DialogDemo> {
                   title: const Text('Use Google\'s location service?'),
                   content: Text(
                     _alertWithTitleText,
-                    style: dialogTextStyle
+                    style: dialogTextStyle,
                   ),
                   actions: <Widget>[
                     FlatButton(
                       child: const Text('DISAGREE'),
-                      onPressed: () { Navigator.pop(context, DialogDemoAction.disagree); }
+                      onPressed: () {
+                        Navigator.pop(context, DialogDemoAction.disagree);
+                      },
                     ),
                     FlatButton(
                       child: const Text('AGREE'),
-                      onPressed: () { Navigator.pop(context, DialogDemoAction.agree); }
+                      onPressed: () {
+                        Navigator.pop(context, DialogDemoAction.agree);
+                      },
                     )
-                  ]
-                )
+                  ],
+                ),
               );
-            }
+            },
           ),
           RaisedButton(
             child: const Text('SIMPLE'),
@@ -155,60 +169,64 @@ class DialogDemoState extends State<DialogDemo> {
                       icon: Icons.account_circle,
                       color: theme.primaryColor,
                       text: 'username@gmail.com',
-                      onPressed: () { Navigator.pop(context, 'username@gmail.com'); }
+                      onPressed: () {
+                        Navigator.pop(context, 'username@gmail.com');
+                      },
                     ),
                     DialogDemoItem(
                       icon: Icons.account_circle,
                       color: theme.primaryColor,
                       text: 'user02@gmail.com',
-                      onPressed: () { Navigator.pop(context, 'user02@gmail.com'); }
+                      onPressed: () {
+                        Navigator.pop(context, 'user02@gmail.com');
+                      },
                     ),
                     DialogDemoItem(
                       icon: Icons.add_circle,
                       text: 'add account',
-                      color: theme.disabledColor
+                      color: theme.disabledColor,
                     )
-                  ]
-                )
+                  ],
+                ),
               );
-            }
+            },
           ),
           RaisedButton(
             child: const Text('CONFIRMATION'),
             onPressed: () {
               showTimePicker(
                 context: context,
-                initialTime: _selectedTime
-              )
-              .then<void>((TimeOfDay value) {
+                initialTime: _selectedTime,
+              ).then<void>((TimeOfDay value) {
                 if (value != null && value != _selectedTime) {
                   _selectedTime = value;
                   _scaffoldKey.currentState.showSnackBar(SnackBar(
-                    content: Text('You selected: ${value.format(context)}')
+                    content: Text('You selected: ${value.format(context)}'),
                   ));
                 }
               });
-            }
+            },
           ),
           RaisedButton(
             child: const Text('FULLSCREEN'),
             onPressed: () {
-              Navigator.push(context, MaterialPageRoute<DismissDialogAction>(
-                builder: (BuildContext context) => FullScreenDialogDemo(),
-                fullscreenDialog: true,
-              ));
-            }
+              Navigator.push(
+                context,
+                MaterialPageRoute<DismissDialogAction>(
+                  builder: (BuildContext context) => FullScreenDialogDemo(),
+                  fullscreenDialog: true,
+                ));
+            },
           ),
         ]
-        // Add a little space between the buttons
-        .map<Widget>((Widget button) {
+          // Add a little space between the buttons
+          .map<Widget>((Widget button) {
           return Container(
             padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: button
+            child: button,
           );
-        })
-        .toList()
-      )
+        }).toList(),
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -22,7 +22,11 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   static const List<String> _drawerContents = <String>[
-    'A', 'B', 'C', 'D', 'E',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
   ];
 
   static final Animatable<Offset> _drawerDetailsTween = Tween<Offset>(
@@ -72,7 +76,7 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
   void _showNotImplementedMessage() {
     Navigator.pop(context); // Dismiss the drawer.
     _scaffoldKey.currentState.showSnackBar(const SnackBar(
-      content: Text("The drawer's items don't do anything")
+      content: Text("The drawer's items don't do anything"),
     ));
   }
 
@@ -137,10 +141,11 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
               margin: EdgeInsets.zero,
               onDetailsPressed: () {
                 _showDrawerContents = !_showDrawerContents;
-                if (_showDrawerContents)
+                if (_showDrawerContents) {
                   _controller.reverse();
-                else
+                } else {
                   _controller.forward();
+                }
               },
             ),
             MediaQuery.removePadding(
@@ -227,7 +232,8 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
                 ),
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0),
-                  child: Text('Tap here to open the drawer',
+                  child: Text(
+                    'Tap here to open the drawer',
                     style: Theme.of(context).textTheme.subhead,
                   ),
                 ),

--- a/examples/flutter_gallery/lib/demo/material/expansion_panels_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/expansion_panels_demo.dart
@@ -7,11 +7,7 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 @visibleForTesting
-enum Location {
-  Barbados,
-  Bahamas,
-  Bermuda
-}
+enum Location { Barbados, Bahamas, Bermuda }
 
 typedef DemoItemBodyBuilder<T> = Widget Function(DemoItem<T> item);
 typedef ValueToString<T> = String Function(T value);
@@ -21,7 +17,7 @@ class DualHeaderWithHint extends StatelessWidget {
     this.name,
     this.value,
     this.hint,
-    this.showHint
+    this.showHint,
   });
 
   final String name;
@@ -69,11 +65,11 @@ class DualHeaderWithHint extends StatelessWidget {
             child: _crossFade(
               Text(value, style: textTheme.caption.copyWith(fontSize: 15.0)),
               Text(hint, style: textTheme.caption.copyWith(fontSize: 15.0)),
-              showHint
-            )
-          )
+              showHint,
+            ),
+          ),
         )
-      ]
+      ],
     );
   }
 }
@@ -83,7 +79,7 @@ class CollapsibleBody extends StatelessWidget {
     this.margin = EdgeInsets.zero,
     this.child,
     this.onSave,
-    this.onCancel
+    this.onCancel,
   });
 
   final EdgeInsets margin;
@@ -100,16 +96,17 @@ class CollapsibleBody extends StatelessWidget {
       children: <Widget>[
         Container(
           margin: const EdgeInsets.only(
-            left: 24.0,
-            right: 24.0,
-            bottom: 24.0
-          ) - margin,
+                left: 24.0,
+                right: 24.0,
+                bottom: 24.0,
+              ) -
+              margin,
           child: Center(
             child: DefaultTextStyle(
               style: textTheme.caption.copyWith(fontSize: 15.0),
-              child: child
-            )
-          )
+              child: child,
+            ),
+          ),
         ),
         const Divider(height: 1.0),
         Container(
@@ -121,25 +118,26 @@ class CollapsibleBody extends StatelessWidget {
                 margin: const EdgeInsets.only(right: 8.0),
                 child: FlatButton(
                   onPressed: onCancel,
-                  child: const Text('CANCEL', style: TextStyle(
-                    color: Colors.black54,
-                    fontSize: 15.0,
-                    fontWeight: FontWeight.w500
-                  ))
-                )
+                  child: const Text('CANCEL',
+                      style: TextStyle(
+                        color: Colors.black54,
+                        fontSize: 15.0,
+                        fontWeight: FontWeight.w500,
+                      )),
+                ),
               ),
               Container(
                 margin: const EdgeInsets.only(right: 8.0),
                 child: FlatButton(
                   onPressed: onSave,
                   textTheme: ButtonTextTheme.accent,
-                  child: const Text('SAVE')
-                )
+                  child: const Text('SAVE'),
+                ),
               )
-            ]
-          )
+            ],
+          ),
         )
-      ]
+      ],
     );
   }
 }
@@ -150,7 +148,7 @@ class DemoItem<T> {
     this.value,
     this.hint,
     this.builder,
-    this.valueToString
+    this.valueToString,
   }) : textController = TextEditingController(text: valueToString(value));
 
   final String name;
@@ -167,7 +165,7 @@ class DemoItem<T> {
         name: name,
         value: valueToString(value),
         hint: hint,
-        showHint: isExpanded
+        showHint: isExpanded,
       );
     };
   }
@@ -207,8 +205,14 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
               builder: (BuildContext context) {
                 return CollapsibleBody(
                   margin: const EdgeInsets.symmetric(horizontal: 16.0),
-                  onSave: () { Form.of(context).save(); close(); },
-                  onCancel: () { Form.of(context).reset(); close(); },
+                  onSave: () {
+                    Form.of(context).save();
+                    close();
+                  },
+                  onCancel: () {
+                    Form.of(context).reset();
+                    close();
+                  },
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16.0),
                     child: TextFormField(
@@ -217,7 +221,9 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
                         hintText: item.hint,
                         labelText: item.name,
                       ),
-                      onSaved: (String value) { item.value = value; },
+                      onSaved: (String value) {
+                        item.value = value;
+                      },
                     ),
                   ),
                 );
@@ -237,15 +243,24 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
               item.isExpanded = false;
             });
           }
+
           return Form(
             child: Builder(
               builder: (BuildContext context) {
                 return CollapsibleBody(
-                  onSave: () { Form.of(context).save(); close(); },
-                  onCancel: () { Form.of(context).reset(); close(); },
+                  onSave: () {
+                    Form.of(context).save();
+                    close();
+                  },
+                  onCancel: () {
+                    Form.of(context).reset();
+                    close();
+                  },
                   child: FormField<Location>(
                     initialValue: item.value,
-                    onSaved: (Location result) { item.value = result; },
+                    onSaved: (Location result) {
+                      item.value = result;
+                    },
                     builder: (FormFieldState<Location> field) {
                       return Column(
                         mainAxisSize: MainAxisSize.min,
@@ -269,15 +284,15 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
                             groupValue: field.value,
                             onChanged: field.didChange,
                           ),
-                        ]
+                        ],
                       );
-                    }
+                    },
                   ),
                 );
-              }
-            )
+              },
+            ),
           );
-        }
+        },
       ),
       DemoItem<double>(
         name: 'Sun',
@@ -295,11 +310,19 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
             child: Builder(
               builder: (BuildContext context) {
                 return CollapsibleBody(
-                  onSave: () { Form.of(context).save(); close(); },
-                  onCancel: () { Form.of(context).reset(); close(); },
+                  onSave: () {
+                    Form.of(context).save();
+                    close();
+                  },
+                  onCancel: () {
+                    Form.of(context).reset();
+                    close();
+                  },
                   child: FormField<double>(
                     initialValue: item.value,
-                    onSaved: (double value) { item.value = value; },
+                    onSaved: (double value) {
+                      item.value = value;
+                    },
                     builder: (FormFieldState<double> field) {
                       return Slider(
                         min: 0.0,
@@ -313,10 +336,10 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
                     },
                   ),
                 );
-              }
-            )
+              },
+            ),
           );
-        }
+        },
       )
     ];
   }
@@ -346,9 +369,9 @@ class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {
                 return ExpansionPanel(
                   isExpanded: item.isExpanded,
                   headerBuilder: item.headerBuilder,
-                  body: item.build()
+                  body: item.build(),
                 );
-              }).toList()
+              }).toList(),
             ),
           ),
         ),

--- a/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -17,7 +17,7 @@ enum DismissDialogAction {
 }
 
 class DateTimeItem extends StatelessWidget {
-  DateTimeItem({Key key, DateTime dateTime, @required this.onChanged})
+  DateTimeItem({ Key key, DateTime dateTime, @required this.onChanged })
       : assert(onChanged != null),
        date = DateTime(dateTime.year, dateTime.month, dateTime.day),
        time = TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),

--- a/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -17,11 +17,11 @@ enum DismissDialogAction {
 }
 
 class DateTimeItem extends StatelessWidget {
-  DateTimeItem({ Key key, DateTime dateTime, @required this.onChanged })
-    : assert(onChanged != null),
-      date = DateTime(dateTime.year, dateTime.month, dateTime.day),
-      time = TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),
-      super(key: key);
+  DateTimeItem({Key key, DateTime dateTime, @required this.onChanged})
+      : assert(onChanged != null),
+       date = DateTime(dateTime.year, dateTime.month, dateTime.day),
+       time = TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),
+       super(key: key);
 
   final DateTime date;
   final TimeOfDay time;
@@ -39,7 +39,7 @@ class DateTimeItem extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               decoration: BoxDecoration(
-                border: Border(bottom: BorderSide(color: theme.dividerColor))
+                border: Border(bottom: BorderSide(color: theme.dividerColor)),
               ),
               child: InkWell(
                 onTap: () {
@@ -47,11 +47,11 @@ class DateTimeItem extends StatelessWidget {
                     context: context,
                     initialDate: date,
                     firstDate: date.subtract(const Duration(days: 30)),
-                    lastDate: date.add(const Duration(days: 30))
-                  )
-                  .then<void>((DateTime value) {
-                    if (value != null)
+                    lastDate: date.add(const Duration(days: 30)),
+                  ).then<void>((DateTime value) {
+                    if (value != null) {
                       onChanged(DateTime(value.year, value.month, value.day, time.hour, time.minute));
+                    }
                   });
                 },
                 child: Row(
@@ -59,38 +59,38 @@ class DateTimeItem extends StatelessWidget {
                   children: <Widget>[
                     Text(DateFormat('EEE, MMM d yyyy').format(date)),
                     const Icon(Icons.arrow_drop_down, color: Colors.black54),
-                  ]
-                )
-              )
-            )
+                  ],
+                ),
+              ),
+            ),
           ),
           Container(
             margin: const EdgeInsets.only(left: 8.0),
             padding: const EdgeInsets.symmetric(vertical: 8.0),
             decoration: BoxDecoration(
-              border: Border(bottom: BorderSide(color: theme.dividerColor))
+              border: Border(bottom: BorderSide(color: theme.dividerColor)),
             ),
             child: InkWell(
               onTap: () {
                 showTimePicker(
                   context: context,
-                  initialTime: time
-                )
-                .then<void>((TimeOfDay value) {
-                  if (value != null)
+                  initialTime: time,
+                ).then<void>((TimeOfDay value) {
+                  if (value != null) {
                     onChanged(DateTime(date.year, date.month, date.day, value.hour, value.minute));
+                  }
                 });
               },
               child: Row(
                 children: <Widget>[
                   Text('${time.format(context)}'),
                   const Icon(Icons.arrow_drop_down, color: Colors.black54),
-                ]
-              )
-            )
+                ],
+              ),
+            ),
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }
@@ -111,37 +111,39 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
 
   Future<bool> _onWillPop() async {
     _saveNeeded = _hasLocation || _hasName || _saveNeeded;
-    if (!_saveNeeded)
+    if (!_saveNeeded) {
       return true;
+    }
 
     final ThemeData theme = Theme.of(context);
     final TextStyle dialogTextStyle = theme.textTheme.subhead.copyWith(color: theme.textTheme.caption.color);
 
     return await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          content: Text(
-            'Discard new event?',
-            style: dialogTextStyle
-          ),
-          actions: <Widget>[
-            FlatButton(
-              child: const Text('CANCEL'),
-              onPressed: () {
-                Navigator.of(context).pop(false); // Pops the confirmation dialog but not the page.
-              }
-            ),
-            FlatButton(
-              child: const Text('DISCARD'),
-              onPressed: () {
-                Navigator.of(context).pop(true); // Returning true to _onWillPop will pop again.
-              }
-            )
-          ],
-        );
-      },
-    ) ?? false;
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              content: Text(
+                'Discard new event?',
+                style: dialogTextStyle,
+              ),
+              actions: <Widget>[
+                FlatButton(
+                  child: const Text('CANCEL'),
+                  onPressed: () {
+                    Navigator.of(context).pop(false); // Pops the confirmation dialog but not the page.
+                  },
+                ),
+                FlatButton(
+                  child: const Text('DISCARD'),
+                  onPressed: () {
+                    Navigator.of(context).pop(true); // Returning true to _onWillPop will pop again.
+                  },
+                )
+              ],
+            );
+          },
+        ) ??
+        false;
   }
 
   @override
@@ -151,14 +153,14 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
     return Scaffold(
       appBar: AppBar(
         title: Text(_hasName ? _eventName : 'Event Name TBD'),
-        actions: <Widget> [
+        actions: <Widget>[
           FlatButton(
             child: Text('SAVE', style: theme.textTheme.body1.copyWith(color: Colors.white)),
             onPressed: () {
               Navigator.pop(context, DismissDialogAction.save);
-            }
+            },
           )
-        ]
+        ],
       ),
       body: Form(
         onWillPop: _onWillPop,
@@ -171,7 +173,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
               child: TextField(
                 decoration: const InputDecoration(
                   labelText: 'Event name',
-                  filled: true
+                  filled: true,
                 ),
                 style: theme.textTheme.headline,
                 onChanged: (String value) {
@@ -181,8 +183,8 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
                       _eventName = value;
                     }
                   });
-                }
-              )
+                },
+              ),
             ),
             Container(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -191,14 +193,14 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
                 decoration: const InputDecoration(
                   labelText: 'Location',
                   hintText: 'Where is the event?',
-                  filled: true
+                  filled: true,
                 ),
                 onChanged: (String value) {
                   setState(() {
                     _hasLocation = value.isNotEmpty;
                   });
-                }
-              )
+                },
+              ),
             ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -211,9 +213,9 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
                       _fromDateTime = value;
                       _saveNeeded = true;
                     });
-                  }
+                  },
                 )
-              ]
+              ],
             ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -226,17 +228,17 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
                       _toDateTime = value;
                       _saveNeeded = true;
                     });
-                  }
+                  },
                 ),
                 const Text('All-day'),
-              ]
+              ],
             ),
             Container(
               decoration: BoxDecoration(
-                border: Border(bottom: BorderSide(color: theme.dividerColor))
+                border: Border(bottom: BorderSide(color: theme.dividerColor)),
               ),
               child: Row(
-                children: <Widget> [
+                children: <Widget>[
                   Checkbox(
                     value: _allDayValue,
                     onChanged: (bool value) {
@@ -244,22 +246,20 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
                         _allDayValue = value;
                         _saveNeeded = true;
                       });
-                    }
+                    },
                   ),
                   const Text('All-day'),
-                ]
-              )
+                ],
+              ),
             )
-          ]
-          .map<Widget>((Widget child) {
+          ].map<Widget>((Widget child) {
             return Container(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               height: 96.0,
-              child: child
+              child: child,
             );
-          })
-          .toList()
-        )
+          }).toList(),
+        ),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -152,10 +152,10 @@ class GridDemoPhotoItem extends StatelessWidget {
     @required this.photo,
     @required this.tileStyle,
     @required this.onBannerTap,
-  })  : assert(photo != null && photo.isValid),
-        assert(tileStyle != null),
-        assert(onBannerTap != null),
-        super(key: key);
+  }) : assert(photo != null && photo.isValid),
+       assert(tileStyle != null),
+       assert(onBannerTap != null),
+       super(key: key);
 
   final Photo photo;
   final GridDemoTileStyle tileStyle;

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -34,7 +34,7 @@ class Photo {
 }
 
 class GridPhotoViewer extends StatefulWidget {
-  const GridPhotoViewer({Key key, this.photo}) : super(key: key);
+  const GridPhotoViewer({ Key key, this.photo }) : super(key: key);
 
   final Photo photo;
 
@@ -245,7 +245,7 @@ class GridDemoPhotoItem extends StatelessWidget {
 }
 
 class GridListDemo extends StatefulWidget {
-  const GridListDemo({Key key}) : super(key: key);
+  const GridListDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/grid-list';
 

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -348,19 +348,19 @@ class GridListDemoState extends State<GridListDemo> {
           PopupMenuButton<GridDemoTileStyle>(
             onSelected: changeTileStyle,
             itemBuilder: (BuildContext context) => <PopupMenuItem<GridDemoTileStyle>>[
-                  const PopupMenuItem<GridDemoTileStyle>(
-                    value: GridDemoTileStyle.imageOnly,
-                    child: Text('Image only'),
-                  ),
-                  const PopupMenuItem<GridDemoTileStyle>(
-                    value: GridDemoTileStyle.oneLine,
-                    child: Text('One line'),
-                  ),
-                  const PopupMenuItem<GridDemoTileStyle>(
-                    value: GridDemoTileStyle.twoLine,
-                    child: Text('Two line'),
-                  ),
-                ],
+              const PopupMenuItem<GridDemoTileStyle>(
+                value: GridDemoTileStyle.imageOnly,
+                child: Text('Image only'),
+              ),
+              const PopupMenuItem<GridDemoTileStyle>(
+                value: GridDemoTileStyle.oneLine,
+                child: Text('One line'),
+              ),
+              const PopupMenuItem<GridDemoTileStyle>(
+                value: GridDemoTileStyle.twoLine,
+                child: Text('Two line'),
+              ),
+            ],
           ),
         ],
       ),

--- a/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -6,11 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-enum GridDemoTileStyle {
-  imageOnly,
-  oneLine,
-  twoLine
-}
+enum GridDemoTileStyle { imageOnly, oneLine, twoLine }
 
 typedef BannerTapCallback = void Function(Photo photo);
 
@@ -38,7 +34,7 @@ class Photo {
 }
 
 class GridPhotoViewer extends StatefulWidget {
-  const GridPhotoViewer({ Key key, this.photo }) : super(key: key);
+  const GridPhotoViewer({Key key, this.photo}) : super(key: key);
 
   final Photo photo;
 
@@ -72,8 +68,7 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this)
-      ..addListener(_handleFlingAnimation);
+    _controller = AnimationController(vsync: this)..addListener(_handleFlingAnimation);
   }
 
   @override
@@ -115,13 +110,14 @@ class _GridPhotoViewerState extends State<GridPhotoViewer> with SingleTickerProv
 
   void _handleOnScaleEnd(ScaleEndDetails details) {
     final double magnitude = details.velocity.pixelsPerSecond.distance;
-    if (magnitude < _kMinFlingVelocity)
+    if (magnitude < _kMinFlingVelocity) {
       return;
+    }
     final Offset direction = details.velocity.pixelsPerSecond / magnitude;
     final double distance = (Offset.zero & context.size).shortestSide;
     _flingAnimation = _controller.drive(Tween<Offset>(
       begin: _offset,
-      end: _clampOffset(_offset + direction * distance)
+      end: _clampOffset(_offset + direction * distance),
     ));
     _controller
       ..value = 0.0
@@ -155,11 +151,11 @@ class GridDemoPhotoItem extends StatelessWidget {
     Key key,
     @required this.photo,
     @required this.tileStyle,
-    @required this.onBannerTap
-  }) : assert(photo != null && photo.isValid),
-       assert(tileStyle != null),
-       assert(onBannerTap != null),
-       super(key: key);
+    @required this.onBannerTap,
+  })  : assert(photo != null && photo.isValid),
+        assert(tileStyle != null),
+        assert(onBannerTap != null),
+        super(key: key);
 
   final Photo photo;
   final GridDemoTileStyle tileStyle;
@@ -170,7 +166,7 @@ class GridDemoPhotoItem extends StatelessWidget {
       builder: (BuildContext context) {
         return Scaffold(
           appBar: AppBar(
-            title: Text(photo.title)
+            title: Text(photo.title),
           ),
           body: SizedBox.expand(
             child: Hero(
@@ -179,14 +175,16 @@ class GridDemoPhotoItem extends StatelessWidget {
             ),
           ),
         );
-      }
+      },
     ));
   }
 
   @override
   Widget build(BuildContext context) {
     final Widget image = GestureDetector(
-      onTap: () { showPhoto(context); },
+      onTap: () {
+        showPhoto(context);
+      },
       child: Hero(
         key: Key(photo.assetName),
         tag: photo.tag,
@@ -194,8 +192,8 @@ class GridDemoPhotoItem extends StatelessWidget {
           photo.assetName,
           package: photo.assetPackage,
           fit: BoxFit.cover,
-        )
-      )
+        ),
+      ),
     );
 
     final IconData icon = photo.isFavorite ? Icons.star : Icons.star_border;
@@ -207,7 +205,9 @@ class GridDemoPhotoItem extends StatelessWidget {
       case GridDemoTileStyle.oneLine:
         return GridTile(
           header: GestureDetector(
-            onTap: () { onBannerTap(photo); },
+            onTap: () {
+              onBannerTap(photo);
+            },
             child: GridTileBar(
               title: _GridTitleText(photo.title),
               backgroundColor: Colors.black45,
@@ -223,7 +223,9 @@ class GridDemoPhotoItem extends StatelessWidget {
       case GridDemoTileStyle.twoLine:
         return GridTile(
           footer: GestureDetector(
-            onTap: () { onBannerTap(photo); },
+            onTap: () {
+              onBannerTap(photo);
+            },
             child: GridTileBar(
               backgroundColor: Colors.black45,
               title: _GridTitleText(photo.title),
@@ -243,7 +245,7 @@ class GridDemoPhotoItem extends StatelessWidget {
 }
 
 class GridListDemo extends StatefulWidget {
-  const GridListDemo({ Key key }) : super(key: key);
+  const GridListDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/grid-list';
 
@@ -346,19 +348,19 @@ class GridListDemoState extends State<GridListDemo> {
           PopupMenuButton<GridDemoTileStyle>(
             onSelected: changeTileStyle,
             itemBuilder: (BuildContext context) => <PopupMenuItem<GridDemoTileStyle>>[
-              const PopupMenuItem<GridDemoTileStyle>(
-                value: GridDemoTileStyle.imageOnly,
-                child: Text('Image only'),
-              ),
-              const PopupMenuItem<GridDemoTileStyle>(
-                value: GridDemoTileStyle.oneLine,
-                child: Text('One line'),
-              ),
-              const PopupMenuItem<GridDemoTileStyle>(
-                value: GridDemoTileStyle.twoLine,
-                child: Text('Two line'),
-              ),
-            ],
+                  const PopupMenuItem<GridDemoTileStyle>(
+                    value: GridDemoTileStyle.imageOnly,
+                    child: Text('Image only'),
+                  ),
+                  const PopupMenuItem<GridDemoTileStyle>(
+                    value: GridDemoTileStyle.oneLine,
+                    child: Text('One line'),
+                  ),
+                  const PopupMenuItem<GridDemoTileStyle>(
+                    value: GridDemoTileStyle.twoLine,
+                    child: Text('Two line'),
+                  ),
+                ],
           ),
         ],
       ),
@@ -382,7 +384,7 @@ class GridListDemoState extends State<GridListDemo> {
                       setState(() {
                         photo.isFavorite = !photo.isFavorite;
                       });
-                    }
+                    },
                   );
                 }).toList(),
               ),

--- a/examples/flutter_gallery/lib/demo/material/icons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/icons_demo.dart
@@ -88,10 +88,10 @@ class _IconsDemoCard extends StatelessWidget {
   }
 
   Widget _centeredText(String label) => Padding(
-        // Match the default padding of IconButton.
-        padding: const EdgeInsets.all(8.0),
-        child: Text(label, textAlign: TextAlign.center),
-      );
+    // Match the default padding of IconButton.
+    padding: const EdgeInsets.all(8.0),
+    child: Text(label, textAlign: TextAlign.center),
+  );
 
   TableRow _buildIconRow(double size) {
     return TableRow(

--- a/examples/flutter_gallery/lib/demo/material/icons_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/icons_demo.dart
@@ -83,20 +83,19 @@ class _IconsDemoCard extends StatelessWidget {
       icon: Icon(icon),
       iconSize: iconSize,
       tooltip: "${enabled ? 'Enabled' : 'Disabled'} icon button",
-      onPressed: enabled ? handleIconButtonPress : null
+      onPressed: enabled ? handleIconButtonPress : null,
     );
   }
 
-  Widget _centeredText(String label) =>
-    Padding(
-      // Match the default padding of IconButton.
-      padding: const EdgeInsets.all(8.0),
-      child: Text(label, textAlign: TextAlign.center),
-    );
+  Widget _centeredText(String label) => Padding(
+        // Match the default padding of IconButton.
+        padding: const EdgeInsets.all(8.0),
+        child: Text(label, textAlign: TextAlign.center),
+      );
 
   TableRow _buildIconRow(double size) {
     return TableRow(
-      children: <Widget> [
+      children: <Widget>[
         _centeredText(size.floor().toString()),
         _buildIconButton(size, icon, true),
         _buildIconButton(size, icon, false),
@@ -115,13 +114,13 @@ class _IconsDemoCard extends StatelessWidget {
           explicitChildNodes: true,
           child: Table(
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-            children: <TableRow> [
+            children: <TableRow>[
               TableRow(
-                children: <Widget> [
+                children: <Widget>[
                   _centeredText('Size'),
                   _centeredText('Enabled'),
                   _centeredText('Disabled'),
-                ]
+                ],
               ),
               _buildIconRow(18.0),
               _buildIconRow(24.0),

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -9,18 +9,16 @@ import 'package:flutter/semantics.dart';
 
 import '../../gallery/demo.dart';
 
-enum LeaveBehindDemoAction {
-  reset,
-  horizontalSwipe,
-  leftSwipe,
-  rightSwipe
-}
+enum LeaveBehindDemoAction { reset, horizontalSwipe, leftSwipe, rightSwipe }
 
 class LeaveBehindItem implements Comparable<LeaveBehindItem> {
-  LeaveBehindItem({ this.index, this.name, this.subject, this.body });
+  LeaveBehindItem({this.index, this.name, this.subject, this.body});
 
   LeaveBehindItem.from(LeaveBehindItem item)
-    : index = item.index, name = item.name, subject = item.subject, body = item.body;
+      : index = item.index,
+       name = item.name,
+       subject = item.subject,
+       body = item.body;
 
   final int index;
   final String name;
@@ -32,7 +30,7 @@ class LeaveBehindItem implements Comparable<LeaveBehindItem> {
 }
 
 class LeaveBehindDemo extends StatefulWidget {
-  const LeaveBehindDemo({ Key key }) : super(key: key);
+  const LeaveBehindDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/leave-behind';
 
@@ -51,7 +49,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
         index: index,
         name: 'Item $index Sender',
         subject: 'Subject: $index',
-        body: "[$index] first line of the message's body..."
+        body: "[$index] first line of the message's body...",
       );
     });
   }
@@ -96,8 +94,10 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
       content: Text('You archived item ${item.index}'),
       action: SnackBarAction(
         label: 'UNDO',
-        onPressed: () { handleUndo(item); }
-      )
+        onPressed: () {
+          handleUndo(item);
+        },
+      ),
     ));
   }
 
@@ -109,8 +109,10 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
       content: Text('You deleted item ${item.index}'),
       action: SnackBarAction(
         label: 'UNDO',
-        onPressed: () { handleUndo(item); }
-      )
+        onPressed: () {
+          handleUndo(item);
+        },
+      ),
     ));
   }
 
@@ -133,7 +135,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
             onDelete: _handleDelete,
             dismissDirection: _dismissDirection,
           );
-        }).toList()
+        }).toList(),
       );
     }
 
@@ -146,29 +148,29 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
           PopupMenuButton<LeaveBehindDemoAction>(
             onSelected: handleDemoAction,
             itemBuilder: (BuildContext context) => <PopupMenuEntry<LeaveBehindDemoAction>>[
-              const PopupMenuItem<LeaveBehindDemoAction>(
-                value: LeaveBehindDemoAction.reset,
-                child: Text('Reset the list')
-              ),
-              const PopupMenuDivider(),
-              CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                value: LeaveBehindDemoAction.horizontalSwipe,
-                checked: _dismissDirection == DismissDirection.horizontal,
-                child: const Text('Horizontal swipe')
-              ),
-              CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                value: LeaveBehindDemoAction.leftSwipe,
-                checked: _dismissDirection == DismissDirection.endToStart,
-                child: const Text('Only swipe left')
-              ),
-              CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                value: LeaveBehindDemoAction.rightSwipe,
-                checked: _dismissDirection == DismissDirection.startToEnd,
-                child: const Text('Only swipe right')
-              )
-            ]
+                  const PopupMenuItem<LeaveBehindDemoAction>(
+                    value: LeaveBehindDemoAction.reset,
+                    child: Text('Reset the list'),
+                  ),
+                  const PopupMenuDivider(),
+                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                    value: LeaveBehindDemoAction.horizontalSwipe,
+                    checked: _dismissDirection == DismissDirection.horizontal,
+                    child: const Text('Horizontal swipe'),
+                  ),
+                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                    value: LeaveBehindDemoAction.leftSwipe,
+                    checked: _dismissDirection == DismissDirection.endToStart,
+                    child: const Text('Only swipe left'),
+                  ),
+                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                    value: LeaveBehindDemoAction.rightSwipe,
+                    checked: _dismissDirection == DismissDirection.startToEnd,
+                    child: const Text('Only swipe right'),
+                  )
+                ],
           )
-        ]
+        ],
       ),
       body: body,
     );
@@ -209,32 +211,33 @@ class _LeaveBehindListItem extends StatelessWidget {
         key: ObjectKey(item),
         direction: dismissDirection,
         onDismissed: (DismissDirection direction) {
-          if (direction == DismissDirection.endToStart)
+          if (direction == DismissDirection.endToStart) {
             _handleArchive();
-          else
+          } else {
             _handleDelete();
+          }
         },
         background: Container(
           color: theme.primaryColor,
           child: const ListTile(
-            leading: Icon(Icons.delete, color: Colors.white, size: 36.0)
-          )
+            leading: Icon(Icons.delete, color: Colors.white, size: 36.0),
+          ),
         ),
         secondaryBackground: Container(
           color: theme.primaryColor,
           child: const ListTile(
-            trailing: Icon(Icons.archive, color: Colors.white, size: 36.0)
-          )
+            trailing: Icon(Icons.archive, color: Colors.white, size: 36.0),
+          ),
         ),
         child: Container(
           decoration: BoxDecoration(
             color: theme.canvasColor,
-            border: Border(bottom: BorderSide(color: theme.dividerColor))
+            border: Border(bottom: BorderSide(color: theme.dividerColor)),
           ),
           child: ListTile(
             title: Text(item.name),
             subtitle: Text('${item.subject}\n${item.body}'),
-            isThreeLine: true
+            isThreeLine: true,
           ),
         ),
       ),

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -12,7 +12,7 @@ import '../../gallery/demo.dart';
 enum LeaveBehindDemoAction { reset, horizontalSwipe, leftSwipe, rightSwipe }
 
 class LeaveBehindItem implements Comparable<LeaveBehindItem> {
-  LeaveBehindItem({this.index, this.name, this.subject, this.body});
+  LeaveBehindItem({ this.index, this.name, this.subject, this.body });
 
   LeaveBehindItem.from(LeaveBehindItem item)
       : index = item.index,
@@ -30,7 +30,7 @@ class LeaveBehindItem implements Comparable<LeaveBehindItem> {
 }
 
 class LeaveBehindDemo extends StatefulWidget {
-  const LeaveBehindDemo({Key key}) : super(key: key);
+  const LeaveBehindDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/leave-behind';
 

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -148,27 +148,27 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
           PopupMenuButton<LeaveBehindDemoAction>(
             onSelected: handleDemoAction,
             itemBuilder: (BuildContext context) => <PopupMenuEntry<LeaveBehindDemoAction>>[
-                  const PopupMenuItem<LeaveBehindDemoAction>(
-                    value: LeaveBehindDemoAction.reset,
-                    child: Text('Reset the list'),
-                  ),
-                  const PopupMenuDivider(),
-                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                    value: LeaveBehindDemoAction.horizontalSwipe,
-                    checked: _dismissDirection == DismissDirection.horizontal,
-                    child: const Text('Horizontal swipe'),
-                  ),
-                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                    value: LeaveBehindDemoAction.leftSwipe,
-                    checked: _dismissDirection == DismissDirection.endToStart,
-                    child: const Text('Only swipe left'),
-                  ),
-                  CheckedPopupMenuItem<LeaveBehindDemoAction>(
-                    value: LeaveBehindDemoAction.rightSwipe,
-                    checked: _dismissDirection == DismissDirection.startToEnd,
-                    child: const Text('Only swipe right'),
-                  )
-                ],
+              const PopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.reset,
+                child: Text('Reset the list'),
+              ),
+              const PopupMenuDivider(),
+              CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.horizontalSwipe,
+                checked: _dismissDirection == DismissDirection.horizontal,
+                child: const Text('Horizontal swipe'),
+              ),
+              CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.leftSwipe,
+                checked: _dismissDirection == DismissDirection.endToStart,
+                child: const Text('Only swipe left'),
+              ),
+              CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.rightSwipe,
+                checked: _dismissDirection == DismissDirection.startToEnd,
+                child: const Text('Only swipe right'),
+              )
+            ],
           )
         ],
       ),

--- a/examples/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/list_demo.dart
@@ -21,7 +21,7 @@ enum _MaterialListType {
 }
 
 class ListDemo extends StatefulWidget {
-  const ListDemo({Key key}) : super(key: key);
+  const ListDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/list';
 

--- a/examples/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/list_demo.dart
@@ -64,8 +64,8 @@ class _ListDemoState extends State<ListDemo> {
   }
 
   void _showConfigurationSheet() {
-    final PersistentBottomSheetController<void> bottomSheet =
-        scaffoldKey.currentState.showBottomSheet<void>((BuildContext bottomSheetContext) {
+    final PersistentBottomSheetController<void> bottomSheet = scaffoldKey.currentState
+      .showBottomSheet<void>((BuildContext bottomSheetContext) {
       return Container(
         decoration: const BoxDecoration(
           border: Border(top: BorderSide(color: Colors.black26)),

--- a/examples/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/list_demo.dart
@@ -21,7 +21,7 @@ enum _MaterialListType {
 }
 
 class ListDemo extends StatefulWidget {
-  const ListDemo({ Key key }) : super(key: key);
+  const ListDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/list';
 
@@ -40,18 +40,32 @@ class _ListDemoState extends State<ListDemo> {
   bool _showDividers = false;
   bool _reverseSort = false;
   List<String> items = <String>[
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
   ];
 
   void changeItemType(_MaterialListType type) {
     setState(() {
       _itemType = type;
     });
-    _bottomSheet?.setState(() { });
+    _bottomSheet?.setState(() {});
   }
 
   void _showConfigurationSheet() {
-    final PersistentBottomSheetController<void> bottomSheet = scaffoldKey.currentState.showBottomSheet<void>((BuildContext bottomSheetContext) {
+    final PersistentBottomSheetController<void> bottomSheet =
+        scaffoldKey.currentState.showBottomSheet<void>((BuildContext bottomSheetContext) {
       return Container(
         decoration: const BoxDecoration(
           border: Border(top: BorderSide(color: Colors.black26)),
@@ -68,7 +82,7 @@ class _ListDemoState extends State<ListDemo> {
                   value: _showAvatars ? _MaterialListType.oneLineWithAvatar : _MaterialListType.oneLine,
                   groupValue: _itemType,
                   onChanged: changeItemType,
-                )
+                ),
               ),
             ),
             MergeSemantics(
@@ -79,7 +93,7 @@ class _ListDemoState extends State<ListDemo> {
                   value: _MaterialListType.twoLine,
                   groupValue: _itemType,
                   onChanged: changeItemType,
-                )
+                ),
               ),
             ),
             MergeSemantics(
@@ -103,7 +117,7 @@ class _ListDemoState extends State<ListDemo> {
                     setState(() {
                       _showAvatars = value;
                     });
-                    _bottomSheet?.setState(() { });
+                    _bottomSheet?.setState(() {});
                   },
                 ),
               ),
@@ -118,7 +132,7 @@ class _ListDemoState extends State<ListDemo> {
                     setState(() {
                       _showIcons = value;
                     });
-                    _bottomSheet?.setState(() { });
+                    _bottomSheet?.setState(() {});
                   },
                 ),
               ),
@@ -133,7 +147,7 @@ class _ListDemoState extends State<ListDemo> {
                     setState(() {
                       _showDividers = value;
                     });
-                    _bottomSheet?.setState(() { });
+                    _bottomSheet?.setState(() {});
                   },
                 ),
               ),
@@ -148,7 +162,7 @@ class _ListDemoState extends State<ListDemo> {
                     setState(() {
                       _dense = value;
                     });
-                    _bottomSheet?.setState(() { });
+                    _bottomSheet?.setState(() {});
                   },
                 ),
               ),
@@ -210,8 +224,9 @@ class _ListDemoState extends State<ListDemo> {
     }
 
     Iterable<Widget> listTiles = items.map<Widget>((String item) => buildListTile(context, item));
-    if (_showDividers)
+    if (_showDividers) {
       listTiles = ListTile.divideTiles(context: context, tiles: listTiles);
+    }
 
     return Scaffold(
       key: scaffoldKey,
@@ -231,9 +246,7 @@ class _ListDemoState extends State<ListDemo> {
           ),
           IconButton(
             icon: Icon(
-              Theme.of(context).platform == TargetPlatform.iOS
-                  ? Icons.more_horiz
-                  : Icons.more_vert,
+              Theme.of(context).platform == TargetPlatform.iOS ? Icons.more_horiz : Icons.more_vert,
             ),
             tooltip: 'Show menu',
             onPressed: _bottomSheet == null ? _showConfigurationSheet : null,

--- a/examples/flutter_gallery/lib/demo/material/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/menu_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 class MenuDemo extends StatefulWidget {
-  const MenuDemo({ Key key }) : super(key: key);
+  const MenuDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/menu';
 
@@ -38,21 +38,23 @@ class MenuDemoState extends State<MenuDemo> {
 
   void showInSnackBar(String value) {
     _scaffoldKey.currentState.showSnackBar(SnackBar(
-     content: Text(value)
+      content: Text(value),
     ));
   }
 
   void showMenuSelection(String value) {
-    if (<String>[_simpleValue1, _simpleValue2, _simpleValue3].contains(value))
+    if (<String>[_simpleValue1, _simpleValue2, _simpleValue3].contains(value)) {
       _simpleValue = value;
+    }
     showInSnackBar('You selected: $value');
   }
 
   void showCheckedMenuSelections(String value) {
-    if (_checkedValues.contains(value))
+    if (_checkedValues.contains(value)) {
       _checkedValues.remove(value);
-    else
+    } else {
       _checkedValues.add(value);
+    }
 
     showInSnackBar('Checked $_checkedValues');
   }
@@ -70,19 +72,19 @@ class MenuDemoState extends State<MenuDemo> {
           PopupMenuButton<String>(
             onSelected: showMenuSelection,
             itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-              const PopupMenuItem<String>(
-                value: 'Toolbar menu',
-                child: Text('Toolbar menu')
-              ),
-              const PopupMenuItem<String>(
-                value: 'Right here',
-                child: Text('Right here')
-              ),
-              const PopupMenuItem<String>(
-                value: 'Hooray!',
-                child: Text('Hooray!')
-              ),
-            ],
+                  const PopupMenuItem<String>(
+                    value: 'Toolbar menu',
+                    child: Text('Toolbar menu'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'Right here',
+                    child: Text('Right here'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'Hooray!',
+                    child: Text('Hooray!'),
+                  ),
+                ],
           ),
         ],
       ),
@@ -98,20 +100,20 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                PopupMenuItem<String>(
-                  value: _simpleValue1,
-                  child: const Text('Context menu item one')
-                ),
-                const PopupMenuItem<String>(
-                  enabled: false,
-                  child: Text('A disabled menu item')
-                ),
-                PopupMenuItem<String>(
-                  value: _simpleValue3,
-                  child: const Text('Context menu item three')
-                ),
-              ]
-            )
+                    PopupMenuItem<String>(
+                      value: _simpleValue1,
+                      child: const Text('Context menu item one'),
+                    ),
+                    const PopupMenuItem<String>(
+                      enabled: false,
+                      child: Text('A disabled menu item'),
+                    ),
+                    PopupMenuItem<String>(
+                      value: _simpleValue3,
+                      child: const Text('Context menu item three'),
+                    ),
+                  ],
+            ),
           ),
           // Pressing the PopupMenuButton on the right of this item shows
           // a menu whose items have text labels and icons and a divider
@@ -122,37 +124,37 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                const PopupMenuItem<String>(
-                  value: 'Preview',
-                  child: ListTile(
-                    leading: Icon(Icons.visibility),
-                    title: Text('Preview')
-                  )
-                ),
-                const PopupMenuItem<String>(
-                  value: 'Share',
-                  child: ListTile(
-                    leading: Icon(Icons.person_add),
-                    title: Text('Share')
-                  )
-                ),
-                const PopupMenuItem<String>(
-                  value: 'Get Link',
-                  child: ListTile(
-                    leading: Icon(Icons.link),
-                    title: Text('Get link')
-                  )
-                ),
-                const PopupMenuDivider(),
-                const PopupMenuItem<String>(
-                  value: 'Remove',
-                  child: ListTile(
-                    leading: Icon(Icons.delete),
-                    title: Text('Remove')
-                  )
-                )
-              ]
-            )
+                    const PopupMenuItem<String>(
+                      value: 'Preview',
+                      child: ListTile(
+                        leading: Icon(Icons.visibility),
+                        title: Text('Preview'),
+                      ),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Share',
+                      child: ListTile(
+                        leading: Icon(Icons.person_add),
+                        title: Text('Share'),
+                      ),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Get Link',
+                      child: ListTile(
+                        leading: Icon(Icons.link),
+                        title: Text('Get link'),
+                      ),
+                    ),
+                    const PopupMenuDivider(),
+                    const PopupMenuItem<String>(
+                      value: 'Remove',
+                      child: ListTile(
+                        leading: Icon(Icons.delete),
+                        title: Text('Remove'),
+                      ),
+                    )
+                  ],
+            ),
           ),
           // This entire list item is a PopupMenuButton. Tapping anywhere shows
           // a menu whose current value is highlighted and aligned over the
@@ -163,22 +165,22 @@ class MenuDemoState extends State<MenuDemo> {
             onSelected: showMenuSelection,
             child: ListTile(
               title: const Text('An item with a simple menu'),
-              subtitle: Text(_simpleValue)
+              subtitle: Text(_simpleValue),
             ),
             itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-              PopupMenuItem<String>(
-                value: _simpleValue1,
-                child: Text(_simpleValue1)
-              ),
-              PopupMenuItem<String>(
-                value: _simpleValue2,
-                child: Text(_simpleValue2)
-              ),
-              PopupMenuItem<String>(
-                value: _simpleValue3,
-                child: Text(_simpleValue3)
-              )
-            ]
+                  PopupMenuItem<String>(
+                    value: _simpleValue1,
+                    child: Text(_simpleValue1),
+                  ),
+                  PopupMenuItem<String>(
+                    value: _simpleValue2,
+                    child: Text(_simpleValue2),
+                  ),
+                  PopupMenuItem<String>(
+                    value: _simpleValue3,
+                    child: Text(_simpleValue3),
+                  )
+                ],
           ),
           // Pressing the PopupMenuButton on the right of this item shows a menu
           // whose items have checked icons that reflect this app's state.
@@ -188,32 +190,32 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showCheckedMenuSelections,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                CheckedPopupMenuItem<String>(
-                  value: _checkedValue1,
-                  checked: isChecked(_checkedValue1),
-                  child: Text(_checkedValue1)
-                ),
-                CheckedPopupMenuItem<String>(
-                  value: _checkedValue2,
-                  enabled: false,
-                  checked: isChecked(_checkedValue2),
-                  child: Text(_checkedValue2)
-                ),
-                CheckedPopupMenuItem<String>(
-                  value: _checkedValue3,
-                  checked: isChecked(_checkedValue3),
-                  child: Text(_checkedValue3)
-                ),
-                CheckedPopupMenuItem<String>(
-                  value: _checkedValue4,
-                  checked: isChecked(_checkedValue4),
-                  child: Text(_checkedValue4)
-                )
-              ]
-            )
+                    CheckedPopupMenuItem<String>(
+                      value: _checkedValue1,
+                      checked: isChecked(_checkedValue1),
+                      child: Text(_checkedValue1),
+                    ),
+                    CheckedPopupMenuItem<String>(
+                      value: _checkedValue2,
+                      enabled: false,
+                      checked: isChecked(_checkedValue2),
+                      child: Text(_checkedValue2),
+                    ),
+                    CheckedPopupMenuItem<String>(
+                      value: _checkedValue3,
+                      checked: isChecked(_checkedValue3),
+                      child: Text(_checkedValue3),
+                    ),
+                    CheckedPopupMenuItem<String>(
+                      value: _checkedValue4,
+                      checked: isChecked(_checkedValue4),
+                      child: Text(_checkedValue4),
+                    )
+                  ],
+            ),
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/menu_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 class MenuDemo extends StatefulWidget {
-  const MenuDemo({Key key}) : super(key: key);
+  const MenuDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/menu';
 

--- a/examples/flutter_gallery/lib/demo/material/menu_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/menu_demo.dart
@@ -72,19 +72,19 @@ class MenuDemoState extends State<MenuDemo> {
           PopupMenuButton<String>(
             onSelected: showMenuSelection,
             itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                  const PopupMenuItem<String>(
-                    value: 'Toolbar menu',
-                    child: Text('Toolbar menu'),
-                  ),
-                  const PopupMenuItem<String>(
-                    value: 'Right here',
-                    child: Text('Right here'),
-                  ),
-                  const PopupMenuItem<String>(
-                    value: 'Hooray!',
-                    child: Text('Hooray!'),
-                  ),
-                ],
+              const PopupMenuItem<String>(
+                value: 'Toolbar menu',
+                child: Text('Toolbar menu'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'Right here',
+                child: Text('Right here'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'Hooray!',
+                child: Text('Hooray!'),
+              ),
+            ],
           ),
         ],
       ),
@@ -100,19 +100,19 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                    PopupMenuItem<String>(
-                      value: _simpleValue1,
-                      child: const Text('Context menu item one'),
-                    ),
-                    const PopupMenuItem<String>(
-                      enabled: false,
-                      child: Text('A disabled menu item'),
-                    ),
-                    PopupMenuItem<String>(
-                      value: _simpleValue3,
-                      child: const Text('Context menu item three'),
-                    ),
-                  ],
+                PopupMenuItem<String>(
+                  value: _simpleValue1,
+                  child: const Text('Context menu item one'),
+                ),
+                const PopupMenuItem<String>(
+                  enabled: false,
+                  child: Text('A disabled menu item'),
+                ),
+                PopupMenuItem<String>(
+                  value: _simpleValue3,
+                  child: const Text('Context menu item three'),
+                ),
+              ],
             ),
           ),
           // Pressing the PopupMenuButton on the right of this item shows
@@ -124,36 +124,36 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showMenuSelection,
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                    const PopupMenuItem<String>(
-                      value: 'Preview',
-                      child: ListTile(
-                        leading: Icon(Icons.visibility),
-                        title: Text('Preview'),
-                      ),
-                    ),
-                    const PopupMenuItem<String>(
-                      value: 'Share',
-                      child: ListTile(
-                        leading: Icon(Icons.person_add),
-                        title: Text('Share'),
-                      ),
-                    ),
-                    const PopupMenuItem<String>(
-                      value: 'Get Link',
-                      child: ListTile(
-                        leading: Icon(Icons.link),
-                        title: Text('Get link'),
-                      ),
-                    ),
-                    const PopupMenuDivider(),
-                    const PopupMenuItem<String>(
-                      value: 'Remove',
-                      child: ListTile(
-                        leading: Icon(Icons.delete),
-                        title: Text('Remove'),
-                      ),
-                    )
-                  ],
+                const PopupMenuItem<String>(
+                  value: 'Preview',
+                  child: ListTile(
+                    leading: Icon(Icons.visibility),
+                    title: Text('Preview'),
+                  ),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'Share',
+                  child: ListTile(
+                    leading: Icon(Icons.person_add),
+                    title: Text('Share'),
+                  ),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'Get Link',
+                  child: ListTile(
+                    leading: Icon(Icons.link),
+                    title: Text('Get link'),
+                  ),
+                ),
+                const PopupMenuDivider(),
+                const PopupMenuItem<String>(
+                  value: 'Remove',
+                  child: ListTile(
+                    leading: Icon(Icons.delete),
+                    title: Text('Remove'),
+                  ),
+                )
+              ],
             ),
           ),
           // This entire list item is a PopupMenuButton. Tapping anywhere shows
@@ -168,19 +168,19 @@ class MenuDemoState extends State<MenuDemo> {
               subtitle: Text(_simpleValue),
             ),
             itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                  PopupMenuItem<String>(
-                    value: _simpleValue1,
-                    child: Text(_simpleValue1),
-                  ),
-                  PopupMenuItem<String>(
-                    value: _simpleValue2,
-                    child: Text(_simpleValue2),
-                  ),
-                  PopupMenuItem<String>(
-                    value: _simpleValue3,
-                    child: Text(_simpleValue3),
-                  )
-                ],
+              PopupMenuItem<String>(
+                value: _simpleValue1,
+                child: Text(_simpleValue1),
+              ),
+              PopupMenuItem<String>(
+                value: _simpleValue2,
+                child: Text(_simpleValue2),
+              ),
+              PopupMenuItem<String>(
+                value: _simpleValue3,
+                child: Text(_simpleValue3),
+              )
+            ],
           ),
           // Pressing the PopupMenuButton on the right of this item shows a menu
           // whose items have checked icons that reflect this app's state.
@@ -190,28 +190,28 @@ class MenuDemoState extends State<MenuDemo> {
               padding: EdgeInsets.zero,
               onSelected: showCheckedMenuSelections,
               itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                    CheckedPopupMenuItem<String>(
-                      value: _checkedValue1,
-                      checked: isChecked(_checkedValue1),
-                      child: Text(_checkedValue1),
-                    ),
-                    CheckedPopupMenuItem<String>(
-                      value: _checkedValue2,
-                      enabled: false,
-                      checked: isChecked(_checkedValue2),
-                      child: Text(_checkedValue2),
-                    ),
-                    CheckedPopupMenuItem<String>(
-                      value: _checkedValue3,
-                      checked: isChecked(_checkedValue3),
-                      child: Text(_checkedValue3),
-                    ),
-                    CheckedPopupMenuItem<String>(
-                      value: _checkedValue4,
-                      checked: isChecked(_checkedValue4),
-                      child: Text(_checkedValue4),
-                    )
-                  ],
+                CheckedPopupMenuItem<String>(
+                  value: _checkedValue1,
+                  checked: isChecked(_checkedValue1),
+                  child: Text(_checkedValue1),
+                ),
+                CheckedPopupMenuItem<String>(
+                  value: _checkedValue2,
+                  enabled: false,
+                  checked: isChecked(_checkedValue2),
+                  child: Text(_checkedValue2),
+                ),
+                CheckedPopupMenuItem<String>(
+                  value: _checkedValue3,
+                  checked: isChecked(_checkedValue3),
+                  child: Text(_checkedValue3),
+                ),
+                CheckedPopupMenuItem<String>(
+                  value: _checkedValue4,
+                  checked: isChecked(_checkedValue4),
+                  child: Text(_checkedValue4),
+                )
+              ],
             ),
           )
         ],

--- a/examples/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
@@ -20,23 +20,26 @@ class ModalBottomSheetDemo extends StatelessWidget {
         child: RaisedButton(
           child: const Text('SHOW BOTTOM SHEET'),
           onPressed: () {
-            showModalBottomSheet<void>(context: context, builder: (BuildContext context) {
-              return Container(
-                child: Padding(
-                  padding: const EdgeInsets.all(32.0),
-                  child: Text('This is the modal bottom sheet. Tap anywhere to dismiss.',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Theme.of(context).accentColor,
-                      fontSize: 24.0
-                    )
-                  )
-                )
-              );
-            });
-          }
-        )
-      )
+            showModalBottomSheet<void>(
+              context: context,
+              builder: (BuildContext context) {
+                return Container(
+                  child: Padding(
+                    padding: const EdgeInsets.all(32.0),
+                    child: Text(
+                      'This is the modal bottom sheet. Tap anywhere to dismiss.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Theme.of(context).accentColor,
+                        fontSize: 24.0,
+                      ),
+                    ),
+                  ),
+                );
+              });
+          },
+        ),
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -11,7 +11,7 @@ import '../../gallery/demo.dart';
 enum IndicatorType { overscroll, refresh }
 
 class OverscrollDemo extends StatefulWidget {
-  const OverscrollDemo({Key key}) : super(key: key);
+  const OverscrollDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/overscroll';
 

--- a/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -11,7 +11,7 @@ import '../../gallery/demo.dart';
 enum IndicatorType { overscroll, refresh }
 
 class OverscrollDemo extends StatefulWidget {
-  const OverscrollDemo({ Key key }) : super(key: key);
+  const OverscrollDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/overscroll';
 
@@ -23,22 +23,37 @@ class OverscrollDemoState extends State<OverscrollDemo> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
   static final List<String> _items = <String>[
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N'
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N'
   ];
 
   Future<void> _handleRefresh() {
     final Completer<void> completer = Completer<void>();
-    Timer(const Duration(seconds: 3), () { completer.complete(); });
+    Timer(const Duration(seconds: 3), () {
+      completer.complete();
+    });
     return completer.future.then<void>((_) {
-       _scaffoldKey.currentState?.showSnackBar(SnackBar(
-         content: const Text('Refresh complete'),
-         action: SnackBarAction(
-           label: 'RETRY',
-           onPressed: () {
-             _refreshIndicatorKey.currentState.show();
-           }
-         )
-       ));
+      _scaffoldKey.currentState?.showSnackBar(SnackBar(
+        content: const Text('Refresh complete'),
+        action: SnackBarAction(
+          label: 'RETRY',
+          onPressed: () {
+            _refreshIndicatorKey.currentState.show();
+          },
+        ),
+      ));
     });
   }
 
@@ -55,9 +70,9 @@ class OverscrollDemoState extends State<OverscrollDemo> {
             tooltip: 'Refresh',
             onPressed: () {
               _refreshIndicatorKey.currentState.show();
-            }
+            },
           ),
-        ]
+        ],
       ),
       body: RefreshIndicator(
         key: _refreshIndicatorKey,

--- a/examples/flutter_gallery/lib/demo/material/page_selector_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/page_selector_demo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 class _PageSelector extends StatelessWidget {
-  const _PageSelector({this.icons});
+  const _PageSelector({ this.icons });
 
   final List<Icon> icons;
 

--- a/examples/flutter_gallery/lib/demo/material/page_selector_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/page_selector_demo.dart
@@ -7,14 +7,15 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 class _PageSelector extends StatelessWidget {
-  const _PageSelector({ this.icons });
+  const _PageSelector({this.icons});
 
   final List<Icon> icons;
 
   void _handleArrowButtonPress(BuildContext context, int delta) {
     final TabController controller = DefaultTabController.of(context);
-    if (!controller.indexIsChanging)
+    if (!controller.indexIsChanging) {
       controller.animateTo((controller.index + delta).clamp(0, icons.length - 1));
+    }
   }
 
   @override
@@ -33,19 +34,23 @@ class _PageSelector extends StatelessWidget {
                 IconButton(
                   icon: const Icon(Icons.chevron_left),
                   color: color,
-                  onPressed: () { _handleArrowButtonPress(context, -1); },
-                  tooltip: 'Page back'
+                  onPressed: () {
+                    _handleArrowButtonPress(context, -1);
+                  },
+                  tooltip: 'Page back',
                 ),
                 TabPageSelector(controller: controller),
                 IconButton(
                   icon: const Icon(Icons.chevron_right),
                   color: color,
-                  onPressed: () { _handleArrowButtonPress(context, 1); },
-                  tooltip: 'Page forward'
+                  onPressed: () {
+                    _handleArrowButtonPress(context, 1);
+                  },
+                  tooltip: 'Page forward',
                 )
               ],
-              mainAxisAlignment: MainAxisAlignment.spaceBetween
-            )
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            ),
           ),
           Expanded(
             child: IconTheme(
@@ -63,7 +68,7 @@ class _PageSelector extends StatelessWidget {
                       ),
                     ),
                   );
-                }).toList()
+                }).toList(),
               ),
             ),
           ),

--- a/examples/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
@@ -25,34 +25,39 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
   }
 
   void _showBottomSheet() {
-    setState(() { // disable the button
+    setState(() {
+      // disable the button
       _showBottomSheetCallback = null;
     });
-    _scaffoldKey.currentState.showBottomSheet<void>((BuildContext context) {
-      final ThemeData themeData = Theme.of(context);
-      return Container(
-        decoration: BoxDecoration(
-          border: Border(top: BorderSide(color: themeData.disabledColor))
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(32.0),
-          child: Text('This is a Material persistent bottom sheet. Drag downwards to dismiss it.',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: themeData.accentColor,
-              fontSize: 24.0
-            )
-          )
-        )
-      );
-    })
-    .closed.whenComplete(() {
-      if (mounted) {
-        setState(() { // re-enable the button
-          _showBottomSheetCallback = _showBottomSheet;
-        });
-      }
-    });
+    _scaffoldKey.currentState
+      .showBottomSheet<void>((BuildContext context) {
+        final ThemeData themeData = Theme.of(context);
+        return Container(
+          decoration: BoxDecoration(
+            border: Border(top: BorderSide(color: themeData.disabledColor)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(32.0),
+            child: Text(
+              'This is a Material persistent bottom sheet. Drag downwards to dismiss it.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: themeData.accentColor,
+                fontSize: 24.0,
+              ),
+            ),
+          ),
+        );
+      })
+      .closed
+      .whenComplete(() {
+        if (mounted) {
+          setState(() {
+            // re-enable the button
+            _showBottomSheetCallback = _showBottomSheet;
+          });
+        }
+      });
   }
 
   void _showMessage() {
@@ -66,7 +71,7 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
               onPressed: () {
                 Navigator.pop(context);
               },
-              child: const Text('OK')
+              child: const Text('OK'),
             )
           ],
         );
@@ -95,9 +100,9 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
       body: Center(
         child: RaisedButton(
           onPressed: _showBottomSheetCallback,
-          child: const Text('SHOW BOTTOM SHEET')
-        )
-      )
+          child: const Text('SHOW BOTTOM SHEET'),
+        ),
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -29,13 +29,14 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
     _animation = CurvedAnimation(
       parent: _controller,
       curve: const Interval(0.0, 0.9, curve: Curves.fastOutSlowIn),
-      reverseCurve: Curves.fastOutSlowIn
+      reverseCurve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed)
-        _controller.forward();
-      else if (status == AnimationStatus.completed)
-        _controller.reverse();
-    });
+        if (status == AnimationStatus.dismissed) {
+          _controller.forward();
+        } else if (status == AnimationStatus.completed) {
+          _controller.reverse();
+        }
+      });
   }
 
   @override
@@ -68,7 +69,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
     final List<Widget> indicators = <Widget>[
       const SizedBox(
         width: 200.0,
-        child: LinearProgressIndicator()
+        child: LinearProgressIndicator(),
       ),
       const LinearProgressIndicator(),
       const LinearProgressIndicator(),
@@ -78,15 +79,16 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
         children: <Widget>[
           const CircularProgressIndicator(),
           SizedBox(
-              width: 20.0,
-              height: 20.0,
-              child: CircularProgressIndicator(value: _animation.value)
+            width: 20.0,
+            height: 20.0,
+            child: CircularProgressIndicator(value: _animation.value),
           ),
           SizedBox(
             width: 100.0,
             height: 20.0,
-            child: Text('${(_animation.value * 100.0).toStringAsFixed(1)}%',
-              textAlign: TextAlign.right
+            child: Text(
+              '${(_animation.value * 100.0).toStringAsFixed(1)}%',
+              textAlign: TextAlign.right,
             ),
           ),
         ],
@@ -94,7 +96,8 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
     ];
     return Column(
       children: indicators
-        .map<Widget>((Widget c) => Container(child: c, margin: const EdgeInsets.symmetric(vertical: 15.0, horizontal: 20.0)))
+        .map<Widget>((Widget c) =>
+            Container(child: c, margin: const EdgeInsets.symmetric(vertical: 15.0, horizontal: 20.0)))
         .toList(),
     );
   }
@@ -120,7 +123,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
                   padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
                   child: AnimatedBuilder(
                     animation: _animation,
-                    builder: _buildIndicators
+                    builder: _buildIndicators,
                   ),
                 ),
               ),

--- a/examples/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
@@ -20,7 +20,7 @@ enum _ReorderableListType {
 }
 
 class ReorderableListDemo extends StatefulWidget {
-  const ReorderableListDemo({ Key key }) : super(key: key);
+  const ReorderableListDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/reorderable-list';
 
@@ -43,7 +43,20 @@ class _ListDemoState extends State<ReorderableListDemo> {
   _ReorderableListType _itemType = _ReorderableListType.threeLine;
   bool _reverseSort = false;
   final List<_ListItem> _items = <String>[
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
   ].map<_ListItem>((String item) => _ListItem(item, false)).toList();
 
   void changeItemType(_ReorderableListType type) {
@@ -51,7 +64,7 @@ class _ListDemoState extends State<ReorderableListDemo> {
       _itemType = type;
     });
     // Rebuild the bottom sheet to reflect the selected list view.
-    _bottomSheet?.setState(() { });
+    _bottomSheet?.setState(() {});
     // Close the bottom sheet to give the user a clear view of the list.
     _bottomSheet?.close();
   }
@@ -131,7 +144,8 @@ class _ListDemoState extends State<ReorderableListDemo> {
           key: Key(item.value),
           height: 100.0,
           width: 100.0,
-          child: CircleAvatar(child: Text(item.value),
+          child: CircleAvatar(
+            child: Text(item.value),
             backgroundColor: Colors.green,
           ),
         );
@@ -151,7 +165,6 @@ class _ListDemoState extends State<ReorderableListDemo> {
     });
   }
 
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -166,15 +179,14 @@ class _ListDemoState extends State<ReorderableListDemo> {
             onPressed: () {
               setState(() {
                 _reverseSort = !_reverseSort;
-                _items.sort((_ListItem a, _ListItem b) => _reverseSort ? b.value.compareTo(a.value) : a.value.compareTo(b.value));
+                _items.sort((_ListItem a, _ListItem b) =>
+                    _reverseSort ? b.value.compareTo(a.value) : a.value.compareTo(b.value));
               });
             },
           ),
           IconButton(
             icon: Icon(
-              Theme.of(context).platform == TargetPlatform.iOS
-                  ? Icons.more_horiz
-                  : Icons.more_vert,
+              Theme.of(context).platform == TargetPlatform.iOS ? Icons.more_horiz : Icons.more_vert,
             ),
             tooltip: 'Show menu',
             onPressed: _bottomSheet == null ? _showConfigurationSheet : null,
@@ -185,11 +197,12 @@ class _ListDemoState extends State<ReorderableListDemo> {
         child: ReorderableListView(
           header: _itemType != _ReorderableListType.threeLine
               ? Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text('Header of the list', style: Theme.of(context).textTheme.headline))
+                padding: const EdgeInsets.all(8.0),
+                child: Text('Header of the list', style: Theme.of(context).textTheme.headline))
               : null,
           onReorder: _onReorder,
-          scrollDirection: _itemType == _ReorderableListType.horizontalAvatar ? Axis.horizontal : Axis.vertical,
+          scrollDirection:
+              _itemType == _ReorderableListType.horizontalAvatar ? Axis.horizontal : Axis.vertical,
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           children: _items.map<Widget>(buildListTile).toList(),
         ),

--- a/examples/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
@@ -20,7 +20,7 @@ enum _ReorderableListType {
 }
 
 class ReorderableListDemo extends StatefulWidget {
-  const ReorderableListDemo({Key key}) : super(key: key);
+  const ReorderableListDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/reorderable-list';
 

--- a/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -139,19 +139,19 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
           PopupMenuButton<TabsDemoStyle>(
             onSelected: changeDemoStyle,
             itemBuilder: (BuildContext context) => <PopupMenuItem<TabsDemoStyle>>[
-                  const PopupMenuItem<TabsDemoStyle>(
-                    value: TabsDemoStyle.iconsAndText,
-                    child: Text('Icons and text'),
-                  ),
-                  const PopupMenuItem<TabsDemoStyle>(
-                    value: TabsDemoStyle.iconsOnly,
-                    child: Text('Icons only'),
-                  ),
-                  const PopupMenuItem<TabsDemoStyle>(
-                    value: TabsDemoStyle.textOnly,
-                    child: Text('Text only'),
-                  ),
-                ],
+              const PopupMenuItem<TabsDemoStyle>(
+                value: TabsDemoStyle.iconsAndText,
+                child: Text('Icons and text'),
+              ),
+              const PopupMenuItem<TabsDemoStyle>(
+                value: TabsDemoStyle.iconsOnly,
+                child: Text('Icons only'),
+              ),
+              const PopupMenuItem<TabsDemoStyle>(
+                value: TabsDemoStyle.textOnly,
+                child: Text('Text only'),
+              ),
+            ],
           ),
         ],
         bottom: TabBar(

--- a/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -6,14 +6,10 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-enum TabsDemoStyle {
-  iconsAndText,
-  iconsOnly,
-  textOnly
-}
+enum TabsDemoStyle { iconsAndText, iconsOnly, textOnly }
 
 class _Page {
-  const _Page({ this.icon, this.text });
+  const _Page({this.icon, this.text});
   final IconData icon;
   final String text;
 }
@@ -66,55 +62,59 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
   }
 
   Decoration getIndicator() {
-    if (!_customIndicator)
+    if (!_customIndicator) {
       return const UnderlineTabIndicator();
+    }
 
-    switch(_demoStyle) {
+    switch (_demoStyle) {
       case TabsDemoStyle.iconsAndText:
         return ShapeDecoration(
           shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(4.0)),
-            side: BorderSide(
-              color: Colors.white24,
-              width: 2.0,
-            ),
-          ) + const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(4.0)),
-            side: BorderSide(
-              color: Colors.transparent,
-              width: 4.0,
-            ),
-          ),
+                borderRadius: BorderRadius.all(Radius.circular(4.0)),
+                side: BorderSide(
+                  color: Colors.white24,
+                  width: 2.0,
+                ),
+              ) +
+              const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(4.0)),
+                side: BorderSide(
+                  color: Colors.transparent,
+                  width: 4.0,
+                ),
+              ),
         );
 
       case TabsDemoStyle.iconsOnly:
         return ShapeDecoration(
           shape: const CircleBorder(
-            side: BorderSide(
-              color: Colors.white24,
-              width: 4.0,
-            ),
-          ) + const CircleBorder(
-            side: BorderSide(
-              color: Colors.transparent,
-              width: 4.0,
-            ),
-          ),
+                side: BorderSide(
+                  color: Colors.white24,
+                  width: 4.0,
+                ),
+              ) +
+              const CircleBorder(
+                side: BorderSide(
+                  color: Colors.transparent,
+                  width: 4.0,
+                ),
+              ),
         );
 
       case TabsDemoStyle.textOnly:
         return ShapeDecoration(
           shape: const StadiumBorder(
-            side: BorderSide(
-              color: Colors.white24,
-              width: 2.0,
-            ),
-          ) + const StadiumBorder(
-            side: BorderSide(
-              color: Colors.transparent,
-              width: 4.0,
-            ),
-          ),
+                side: BorderSide(
+                  color: Colors.white24,
+                  width: 2.0,
+                ),
+              ) +
+              const StadiumBorder(
+                side: BorderSide(
+                  color: Colors.transparent,
+                  width: 4.0,
+                ),
+              ),
         );
     }
     return null;
@@ -139,19 +139,19 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
           PopupMenuButton<TabsDemoStyle>(
             onSelected: changeDemoStyle,
             itemBuilder: (BuildContext context) => <PopupMenuItem<TabsDemoStyle>>[
-              const PopupMenuItem<TabsDemoStyle>(
-                value: TabsDemoStyle.iconsAndText,
-                child: Text('Icons and text')
-              ),
-              const PopupMenuItem<TabsDemoStyle>(
-                value: TabsDemoStyle.iconsOnly,
-                child: Text('Icons only')
-              ),
-              const PopupMenuItem<TabsDemoStyle>(
-                value: TabsDemoStyle.textOnly,
-                child: Text('Text only')
-              ),
-            ],
+                  const PopupMenuItem<TabsDemoStyle>(
+                    value: TabsDemoStyle.iconsAndText,
+                    child: Text('Icons and text'),
+                  ),
+                  const PopupMenuItem<TabsDemoStyle>(
+                    value: TabsDemoStyle.iconsOnly,
+                    child: Text('Icons only'),
+                  ),
+                  const PopupMenuItem<TabsDemoStyle>(
+                    value: TabsDemoStyle.textOnly,
+                    child: Text('Text only'),
+                  ),
+                ],
           ),
         ],
         bottom: TabBar(
@@ -193,7 +193,7 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
               ),
             ),
           );
-        }).toList()
+        }).toList(),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -9,7 +9,7 @@ import '../../gallery/demo.dart';
 enum TabsDemoStyle { iconsAndText, iconsOnly, textOnly }
 
 class _Page {
-  const _Page({this.icon, this.text});
+  const _Page({ this.icon, this.text });
   final IconData icon;
   final String text;
 }

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -56,9 +56,7 @@ class _SearchDemoState extends State<SearchDemo> {
           IconButton(
             tooltip: 'More (not implemented)',
             icon: Icon(
-              Theme.of(context).platform == TargetPlatform.iOS
-                  ? Icons.more_horiz
-                  : Icons.more_vert,
+              Theme.of(context).platform == TargetPlatform.iOS ? Icons.more_horiz : Icons.more_vert,
             ),
             onPressed: () {},
           ),
@@ -91,7 +89,7 @@ class _SearchDemoState extends State<SearchDemo> {
               ),
             ),
             const SizedBox(height: 64.0),
-            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE' }.')
+            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE'}.')
           ],
         ),
       ),
@@ -153,10 +151,8 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
-
-    final Iterable<int> suggestions = query.isEmpty
-        ? _history
-        : _data.where((int i) => '$i'.startsWith(query));
+    final Iterable<int> suggestions =
+        query.isEmpty ? _history : _data.where((int i) => '$i'.startsWith(query));
 
     return _SuggestionList(
       query: query,

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -221,7 +221,7 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 }
 
 class _ResultCard extends StatelessWidget {
-  const _ResultCard({this.integer, this.title, this.searchDelegate});
+  const _ResultCard({ this.integer, this.title, this.searchDelegate });
 
   final int integer;
   final String title;
@@ -253,7 +253,7 @@ class _ResultCard extends StatelessWidget {
 }
 
 class _SuggestionList extends StatelessWidget {
-  const _SuggestionList({this.suggestions, this.query, this.onSelected});
+  const _SuggestionList({ this.suggestions, this.query, this.onSelected });
 
   final List<String> suggestions;
   final String query;

--- a/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/selection_controls_demo.dart
@@ -6,24 +6,21 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-const String _checkboxText =
-  'Checkboxes allow the user to select multiple options from a set. '
-  'A normal checkbox\'s value is true or false and a tristate checkbox\'s '
-  'value can also be null.';
+const String _checkboxText = 'Checkboxes allow the user to select multiple options from a set. '
+    'A normal checkbox\'s value is true or false and a tristate checkbox\'s '
+    'value can also be null.';
 
 const String _checkboxCode = 'selectioncontrols_checkbox';
 
-const String _radioText =
-  'Radio buttons allow the user to select one option from a set. Use radio '
-  'buttons for exclusive selection if you think that the user needs to see '
-  'all available options side-by-side.';
+const String _radioText = 'Radio buttons allow the user to select one option from a set. Use radio '
+    'buttons for exclusive selection if you think that the user needs to see '
+    'all available options side-by-side.';
 
 const String _radioCode = 'selectioncontrols_radio';
 
-const String _switchText =
-  'On/off switches toggle the state of a single settings option. The option '
-  'that the switch controls, as well as the state it’s in, should be made '
-  'clear from the corresponding inline label.';
+const String _switchText = 'On/off switches toggle the state of a single settings option. The option '
+    'that the switch controls, as well as the state it’s in, should be made '
+    'clear from the corresponding inline label.';
 
 const String _switchCode = 'selectioncontrols_switch';
 
@@ -63,7 +60,7 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
 
     return TabbedComponentDemoScaffold(
       title: 'Selection controls',
-      demos: demos
+      demos: demos,
     );
   }
 
@@ -122,10 +119,10 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
               Checkbox(value: true, onChanged: null),
               Checkbox(value: false, onChanged: null),
               Checkbox(value: null, tristate: true, onChanged: null),
-            ]
+            ],
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 
@@ -141,19 +138,19 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
               Radio<int>(
                 value: 0,
                 groupValue: radioValue,
-                onChanged: handleRadioValueChanged
+                onChanged: handleRadioValueChanged,
               ),
               Radio<int>(
                 value: 1,
                 groupValue: radioValue,
-                onChanged: handleRadioValueChanged
+                onChanged: handleRadioValueChanged,
               ),
               Radio<int>(
                 value: 2,
                 groupValue: radioValue,
-                onChanged: handleRadioValueChanged
+                onChanged: handleRadioValueChanged,
               )
-            ]
+            ],
           ),
           // Disabled radio buttons
           Row(
@@ -162,22 +159,22 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
               Radio<int>(
                 value: 0,
                 groupValue: 0,
-                onChanged: null
+                onChanged: null,
               ),
               Radio<int>(
                 value: 1,
                 groupValue: 0,
-                onChanged: null
+                onChanged: null,
               ),
               Radio<int>(
                 value: 2,
                 groupValue: 0,
-                onChanged: null
+                onChanged: null,
               )
-            ]
+            ],
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 
@@ -193,7 +190,7 @@ class _SelectionControlsDemoState extends State<SelectionControlsDemo> {
               setState(() {
                 switchValue = value;
               });
-            }
+            },
           ),
           // Disabled switches
           const Switch.adaptive(value: true, onChanged: null),

--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -110,19 +110,21 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
       thumbCenter + slideUpOffset,
       invert: true,
     );
-    final Color paintColor = enableColor.evaluate(enableAnimation).withAlpha((255.0 * activationAnimation.value).round());
+    final Color paintColor =
+        enableColor.evaluate(enableAnimation).withAlpha((255.0 * activationAnimation.value).round());
     canvas.drawPath(
       thumbPath,
       Paint()..color = paintColor,
     );
     canvas.drawLine(
-        thumbCenter,
-        thumbCenter + slideUpOffset,
-        Paint()
-          ..color = paintColor
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 2.0);
-    labelPainter.paint(canvas, thumbCenter + slideUpOffset + Offset(-labelPainter.width / 2.0, -labelPainter.height - 4.0));
+      thumbCenter,
+      thumbCenter + slideUpOffset,
+      Paint()
+        ..color = paintColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.0);
+    labelPainter.paint(
+      canvas, thumbCenter + slideUpOffset + Offset(-labelPainter.width / 2.0, -labelPainter.height - 4.0));
   }
 }
 

--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -15,7 +15,7 @@ class SliderDemo extends StatefulWidget {
   _SliderDemoState createState() => _SliderDemoState();
 }
 
-Path _triangle(double size, Offset thumbCenter, {bool invert = false}) {
+Path _triangle(double size, Offset thumbCenter, { bool invert = false }) {
   final Path thumbPath = Path();
   final double height = math.sqrt(3.0) / 2.0;
   final double halfSide = size / 2.0;

--- a/examples/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -110,8 +110,9 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
       thumbCenter + slideUpOffset,
       invert: true,
     );
-    final Color paintColor =
-        enableColor.evaluate(enableAnimation).withAlpha((255.0 * activationAnimation.value).round());
+    final Color paintColor = enableColor
+      .evaluate(enableAnimation)
+      .withAlpha((255.0 * activationAnimation.value).round());
     canvas.drawPath(
       thumbPath,
       Paint()..color = paintColor,

--- a/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -16,7 +16,7 @@ const String _text2 = 'Snackbars should contain a single line of text directly r
 const String _text3 = 'By default snackbars automatically disappear after a few seconds ';
 
 class SnackBarDemo extends StatefulWidget {
-  const SnackBarDemo({Key key}) : super(key: key);
+  const SnackBarDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/snack-bar';
 

--- a/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -6,20 +6,17 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-const String _text1 =
-  'Snackbars provide lightweight feedback about an operation by '
-  'showing a brief message at the bottom of the screen. Snackbars '
-  'can contain an action.';
+const String _text1 = 'Snackbars provide lightweight feedback about an operation by '
+    'showing a brief message at the bottom of the screen. Snackbars '
+    'can contain an action.';
 
-const String _text2 =
-  'Snackbars should contain a single line of text directly related '
-  'to the operation performed. They cannot contain icons.';
+const String _text2 = 'Snackbars should contain a single line of text directly related '
+    'to the operation performed. They cannot contain icons.';
 
-const String _text3 =
-  'By default snackbars automatically disappear after a few seconds ';
+const String _text3 = 'By default snackbars automatically disappear after a few seconds ';
 
 class SnackBarDemo extends StatefulWidget {
-  const SnackBarDemo({ Key key }) : super(key: key);
+  const SnackBarDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/snack-bar';
 
@@ -50,23 +47,21 @@ class _SnackBarDemoState extends State<SnackBarDemo> {
                     label: 'ACTION',
                     onPressed: () {
                       Scaffold.of(context).showSnackBar(SnackBar(
-                        content: Text('You pressed snackbar $thisSnackBarIndex\'s action.')
+                        content: Text('You pressed snackbar $thisSnackBarIndex\'s action.'),
                       ));
-                    }
+                    },
                   ),
                 ));
-              }
+              },
             ),
           ),
           const Text(_text3),
-        ]
-        .map<Widget>((Widget child) {
+        ].map<Widget>((Widget child) {
           return Container(
             margin: const EdgeInsets.symmetric(vertical: 12.0),
-            child: child
+            child: child,
           );
-        })
-        .toList()
+        }).toList(),
       ),
     );
   }
@@ -81,8 +76,8 @@ class _SnackBarDemoState extends State<SnackBarDemo> {
       body: Builder(
         // Create an inner BuildContext so that the snackBar onPressed methods
         // can refer to the Scaffold with Scaffold.of().
-        builder: buildBody
-      )
+        builder: buildBody,
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
@@ -12,7 +12,7 @@ import '../../gallery/demo.dart';
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
 
 class _Page {
-  _Page({this.label});
+  _Page({ this.label });
   final String label;
   String get id => label[0];
   @override
@@ -20,7 +20,7 @@ class _Page {
 }
 
 class _CardData {
-  const _CardData({this.title, this.imageAsset, this.imageAssetPackage});
+  const _CardData({ this.title, this.imageAsset, this.imageAssetPackage });
   final String title;
   final String imageAsset;
   final String imageAssetPackage;
@@ -94,7 +94,7 @@ final Map<_Page, List<_CardData>> _allPages = <_Page, List<_CardData>>{
 };
 
 class _CardDataItem extends StatelessWidget {
-  const _CardDataItem({this.page, this.data});
+  const _CardDataItem({ this.page, this.data });
 
   static const double height = 272.0;
   final _Page page;

--- a/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_demo.dart
@@ -12,7 +12,7 @@ import '../../gallery/demo.dart';
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
 
 class _Page {
-  _Page({ this.label });
+  _Page({this.label});
   final String label;
   String get id => label[0];
   @override
@@ -20,7 +20,7 @@ class _Page {
 }
 
 class _CardData {
-  const _CardData({ this.title, this.imageAsset, this.imageAssetPackage });
+  const _CardData({this.title, this.imageAsset, this.imageAssetPackage});
   final String title;
   final String imageAsset;
   final String imageAssetPackage;
@@ -94,7 +94,7 @@ final Map<_Page, List<_CardData>> _allPages = <_Page, List<_CardData>>{
 };
 
 class _CardDataItem extends StatelessWidget {
-  const _CardDataItem({ this.page, this.data });
+  const _CardDataItem({this.page, this.data});
 
   static const double height = 272.0;
   final _Page page;
@@ -110,9 +110,7 @@ class _CardDataItem extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
             Align(
-              alignment: page.id == 'H'
-                ? Alignment.centerLeft
-                : Alignment.centerRight,
+              alignment: page.id == 'H' ? Alignment.centerLeft : Alignment.centerRight,
               child: CircleAvatar(child: Text('${page.id}')),
             ),
             SizedBox(
@@ -157,9 +155,11 @@ class TabsDemo extends StatelessWidget {
                   expandedHeight: 150.0,
                   forceElevated: innerBoxIsScrolled,
                   bottom: TabBar(
-                    tabs: _allPages.keys.map<Widget>(
-                      (_Page page) => Tab(text: page.label),
-                    ).toList(),
+                    tabs: _allPages.keys
+                      .map<Widget>(
+                        (_Page page) => Tab(text: page.label),
+                      )
+                      .toList(),
                   ),
                 ),
               ),

--- a/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
@@ -13,7 +13,7 @@ const String _explanatoryText =
     'by its key.';
 
 class _Page {
-  _Page({this.label, this.colors, this.icon});
+  _Page({ this.label, this.colors, this.icon });
 
   final String label;
   final MaterialColor colors;

--- a/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
@@ -7,13 +7,13 @@ import 'package:flutter/material.dart';
 import '../../gallery/demo.dart';
 
 const String _explanatoryText =
-  "When the Scaffold's floating action button changes, the new button fades and "
-  'turns into view. In this demo, changing tabs can cause the app to be rebuilt '
-  'with a FloatingActionButton that the Scaffold distinguishes from the others '
-  'by its key.';
+    "When the Scaffold's floating action button changes, the new button fades and "
+    'turns into view. In this demo, changing tabs can cause the app to be rebuilt '
+    'with a FloatingActionButton that the Scaffold distinguishes from the others '
+    'by its key.';
 
 class _Page {
-  _Page({ this.label, this.colors, this.icon });
+  _Page({this.label, this.colors, this.icon});
 
   final String label;
   final MaterialColor colors;
@@ -72,12 +72,12 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
     _scaffoldKey.currentState.showBottomSheet<void>((BuildContext context) {
       return Container(
         decoration: BoxDecoration(
-          border: Border(top: BorderSide(color: Theme.of(context).dividerColor))
+          border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
         ),
         child: Padding(
           padding: const EdgeInsets.all(32.0),
-          child: Text(_explanatoryText, style: Theme.of(context).textTheme.subhead)
-        )
+          child: Text(_explanatoryText, style: Theme.of(context).textTheme.subhead),
+        ),
       );
     });
   }
@@ -90,23 +90,25 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
           padding: const EdgeInsets.fromLTRB(48.0, 48.0, 48.0, 96.0),
           child: Card(
             child: Center(
-              child: Text(page.label,
+              child: Text(
+                page.label,
                 style: TextStyle(
                   color: page.labelColor,
-                  fontSize: 32.0
+                  fontSize: 32.0,
                 ),
-                textAlign: TextAlign.center
-              )
-            )
-          )
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
         );
-      }
+      },
     );
   }
 
   Widget buildFloatingActionButton(_Page page) {
-    if (!page.fabDefined)
+    if (!page.fabDefined) {
       return null;
+    }
 
     if (_extendedButtons) {
       return FloatingActionButton.extended(
@@ -115,7 +117,7 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
         backgroundColor: page.fabColor,
         icon: page.fabIcon,
         label: Text(page.label.toUpperCase()),
-        onPressed: _showExplanatoryText
+        onPressed: _showExplanatoryText,
       );
     }
 
@@ -124,7 +126,7 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
       tooltip: 'Show explanation',
       backgroundColor: page.fabColor,
       child: page.fabIcon,
-      onPressed: _showExplanatoryText
+      onPressed: _showExplanatoryText,
     );
   }
 
@@ -153,7 +155,7 @@ class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStat
       floatingActionButton: buildFloatingActionButton(_selectedPage),
       body: TabBarView(
         controller: _controller,
-        children: _allPages.map<Widget>(buildTabView).toList()
+        children: _allPages.map<Widget>(buildTabView).toList(),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import '../../gallery/demo.dart';
 
 class TextFormFieldDemo extends StatefulWidget {
-  const TextFormFieldDemo({ Key key }) : super(key: key);
+  const TextFormFieldDemo({Key key}) : super(key: key);
 
   static const String routeName = '/material/text-form-field';
 
@@ -89,7 +89,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
 
   void showInSnackBar(String value) {
     _scaffoldKey.currentState.showSnackBar(SnackBar(
-      content: Text(value)
+      content: Text(value),
     ));
   }
 
@@ -112,56 +112,67 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
 
   String _validateName(String value) {
     _formWasEdited = true;
-    if (value.isEmpty)
+    if (value.isEmpty) {
       return 'Name is required.';
+    }
     final RegExp nameExp = RegExp(r'^[A-Za-z ]+$');
-    if (!nameExp.hasMatch(value))
+    if (!nameExp.hasMatch(value)) {
       return 'Please enter only alphabetical characters.';
+    }
     return null;
   }
 
   String _validatePhoneNumber(String value) {
     _formWasEdited = true;
     final RegExp phoneExp = RegExp(r'^\(\d\d\d\) \d\d\d\-\d\d\d\d$');
-    if (!phoneExp.hasMatch(value))
+    if (!phoneExp.hasMatch(value)) {
       return '(###) ###-#### - Enter a US phone number.';
+    }
     return null;
   }
 
   String _validatePassword(String value) {
     _formWasEdited = true;
     final FormFieldState<String> passwordField = _passwordFieldKey.currentState;
-    if (passwordField.value == null || passwordField.value.isEmpty)
+    if (passwordField.value == null || passwordField.value.isEmpty) {
       return 'Please enter a password.';
-    if (passwordField.value != value)
+    }
+    if (passwordField.value != value) {
       return 'The passwords don\'t match';
+    }
     return null;
   }
 
   Future<bool> _warnUserAboutInvalidData() async {
     final FormState form = _formKey.currentState;
-    if (form == null || !_formWasEdited || form.validate())
+    if (form == null || !_formWasEdited || form.validate()) {
       return true;
+    }
 
     return await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('This form has errors'),
-          content: const Text('Really leave this form?'),
-          actions: <Widget> [
-            FlatButton(
-              child: const Text('YES'),
-              onPressed: () { Navigator.of(context).pop(true); },
-            ),
-            FlatButton(
-              child: const Text('NO'),
-              onPressed: () { Navigator.of(context).pop(false); },
-            ),
-          ],
-        );
-      },
-    ) ?? false;
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('This form has errors'),
+              content: const Text('Really leave this form?'),
+              actions: <Widget>[
+                FlatButton(
+                  child: const Text('YES'),
+                  onPressed: () {
+                    Navigator.of(context).pop(true);
+                  },
+                ),
+                FlatButton(
+                  child: const Text('NO'),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  },
+                ),
+              ],
+            );
+          },
+        ) ??
+        false;
   }
 
   @override
@@ -194,7 +205,9 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                     hintText: 'What do people call you?',
                     labelText: 'Name *',
                   ),
-                  onSaved: (String value) { person.name = value; },
+                  onSaved: (String value) {
+                    person.name = value;
+                  },
                   validator: _validateName,
                 ),
                 const SizedBox(height: 24.0),
@@ -208,10 +221,12 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                     prefixText: '+1',
                   ),
                   keyboardType: TextInputType.phone,
-                  onSaved: (String value) { person.phoneNumber = value; },
+                  onSaved: (String value) {
+                    person.phoneNumber = value;
+                  },
                   validator: _validatePhoneNumber,
                   // TextInputFormatters are applied in sequence.
-                  inputFormatters: <TextInputFormatter> [
+                  inputFormatters: <TextInputFormatter>[
                     WhitelistingTextInputFormatter.digitsOnly,
                     // Fit the validating format.
                     _phoneNumberFormatter,
@@ -227,7 +242,9 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                     labelText: 'E-mail',
                   ),
                   keyboardType: TextInputType.emailAddress,
-                  onSaved: (String value) { person.email = value; },
+                  onSaved: (String value) {
+                    person.email = value;
+                  },
                 ),
                 const SizedBox(height: 24.0),
                 TextFormField(
@@ -247,7 +264,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                     labelText: 'Salary',
                     prefixText: '\$',
                     suffixText: 'USD',
-                    suffixStyle: TextStyle(color: Colors.green)
+                    suffixStyle: TextStyle(color: Colors.green),
                   ),
                   maxLines: 1,
                 ),
@@ -284,7 +301,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                 const SizedBox(height: 24.0),
                 Text(
                   '* indicates required field',
-                  style: Theme.of(context).textTheme.caption
+                  style: Theme.of(context).textTheme.caption,
                 ),
                 const SizedBox(height: 24.0),
               ],
@@ -301,7 +318,7 @@ class _UsNumberTextInputFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(
     TextEditingValue oldValue,
-    TextEditingValue newValue
+    TextEditingValue newValue,
   ) {
     final int newTextLength = newValue.text.length;
     int selectionIndex = newValue.selection.end;
@@ -309,27 +326,32 @@ class _UsNumberTextInputFormatter extends TextInputFormatter {
     final StringBuffer newText = StringBuffer();
     if (newTextLength >= 1) {
       newText.write('(');
-      if (newValue.selection.end >= 1)
+      if (newValue.selection.end >= 1) {
         selectionIndex++;
+      }
     }
     if (newTextLength >= 4) {
       newText.write(newValue.text.substring(0, usedSubstringIndex = 3) + ') ');
-      if (newValue.selection.end >= 3)
+      if (newValue.selection.end >= 3) {
         selectionIndex += 2;
+      }
     }
     if (newTextLength >= 7) {
       newText.write(newValue.text.substring(3, usedSubstringIndex = 6) + '-');
-      if (newValue.selection.end >= 6)
+      if (newValue.selection.end >= 6) {
         selectionIndex++;
+      }
     }
     if (newTextLength >= 11) {
       newText.write(newValue.text.substring(6, usedSubstringIndex = 10) + ' ');
-      if (newValue.selection.end >= 10)
+      if (newValue.selection.end >= 10) {
         selectionIndex++;
+      }
     }
     // Dump the rest.
-    if (newTextLength >= usedSubstringIndex)
+    if (newTextLength >= usedSubstringIndex) {
       newText.write(newValue.text.substring(usedSubstringIndex));
+    }
     return TextEditingValue(
       text: newText.toString(),
       selection: TextSelection.collapsed(offset: selectionIndex),

--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import '../../gallery/demo.dart';
 
 class TextFormFieldDemo extends StatefulWidget {
-  const TextFormFieldDemo({Key key}) : super(key: key);
+  const TextFormFieldDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/material/text-form-field';
 

--- a/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart
@@ -6,13 +6,11 @@ import 'package:flutter/material.dart';
 
 import '../../gallery/demo.dart';
 
-const String _introText =
-  'Tooltips are short identifying messages that briefly appear in response to '
-  'a long press. Tooltip messages are also used by services that make Flutter '
-  'apps accessible, like screen readers.';
+const String _introText = 'Tooltips are short identifying messages that briefly appear in response to '
+    'a long press. Tooltip messages are also used by services that make Flutter '
+    'apps accessible, like screen readers.';
 
 class TooltipDemo extends StatelessWidget {
-
   static const String routeName = '/material/tooltips';
 
   @override
@@ -39,11 +37,11 @@ class TooltipDemo extends StatelessWidget {
                       child: Icon(
                         Icons.call,
                         size: 18.0,
-                        color: theme.iconTheme.color
-                      )
+                        color: theme.iconTheme.color,
+                      ),
                     ),
                     Text(' icon.', style: theme.textTheme.subhead)
-                  ]
+                  ],
                 ),
                 Center(
                   child: IconButton(
@@ -53,23 +51,21 @@ class TooltipDemo extends StatelessWidget {
                     tooltip: 'Place a phone call',
                     onPressed: () {
                       Scaffold.of(context).showSnackBar(const SnackBar(
-                         content: Text('That was an ordinary tap.')
+                        content: Text('That was an ordinary tap.'),
                       ));
-                    }
-                  )
+                    },
+                  ),
                 )
-              ]
-              .map<Widget>((Widget widget) {
+              ].map<Widget>((Widget widget) {
                 return Padding(
                   padding: const EdgeInsets.only(top: 16.0, left: 16.0, right: 16.0),
-                  child: widget
+                  child: widget,
                 );
-              })
-              .toList()
+              }).toList(),
             ),
           );
-        }
-      )
+        },
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/material/two_level_list_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/two_level_list_demo.dart
@@ -20,19 +20,19 @@ class TwoLevelListDemo extends StatelessWidget {
         children: <Widget>[
           const ListTile(title: Text('Top')),
           ExpansionTile(
-             title: const Text('Sublist'),
-             backgroundColor: Theme.of(context).accentColor.withOpacity(0.025),
-             children: const <Widget>[
-               ListTile(title: Text('One')),
-               ListTile(title: Text('Two')),
-               // https://en.wikipedia.org/wiki/Free_Four
-               ListTile(title: Text('Free')),
-               ListTile(title: Text('Four'))
-             ]
+            title: const Text('Sublist'),
+            backgroundColor: Theme.of(context).accentColor.withOpacity(0.025),
+            children: const <Widget>[
+              ListTile(title: Text('One')),
+              ListTile(title: Text('Two')),
+              // https://en.wikipedia.org/wiki/Free_Four
+              ListTile(title: Text('Free')),
+              ListTile(title: Text('Four'))
+            ],
           ),
-           const ListTile(title: Text('Bottom'))
-        ]
-      )
+          const ListTile(title: Text('Bottom'))
+        ],
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -371,11 +371,11 @@ class _RecipePageState extends State<RecipePage> {
                   PopupMenuButton<String>(
                     onSelected: (String item) {},
                     itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                          _buildMenuItem(Icons.share, 'Tweet recipe'),
-                          _buildMenuItem(Icons.email, 'Email recipe'),
-                          _buildMenuItem(Icons.message, 'Message recipe'),
-                          _buildMenuItem(Icons.people, 'Share on Facebook'),
-                        ],
+                      _buildMenuItem(Icons.share, 'Tweet recipe'),
+                      _buildMenuItem(Icons.email, 'Email recipe'),
+                      _buildMenuItem(Icons.message, 'Message recipe'),
+                      _buildMenuItem(Icons.people, 'Share on Facebook'),
+                    ],
                   ),
                 ],
                 flexibleSpace: const FlexibleSpaceBar(

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 class PestoDemo extends StatelessWidget {
-  const PestoDemo({Key key}) : super(key: key);
+  const PestoDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/pesto';
 
@@ -63,7 +63,7 @@ class PestoStyle extends TextStyle {
 
 // Displays a grid of recipe cards.
 class RecipeGridPage extends StatefulWidget {
-  const RecipeGridPage({Key key, this.recipes}) : super(key: key);
+  const RecipeGridPage({ Key key, this.recipes }) : super(key: key);
 
   final List<Recipe> recipes;
 
@@ -193,7 +193,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
 }
 
 class PestoLogo extends StatefulWidget {
-  const PestoLogo({this.height, this.t});
+  const PestoLogo({ this.height, this.t });
 
   final double height;
   final double t;
@@ -257,7 +257,7 @@ class _PestoLogoState extends State<PestoLogo> {
 
 // A card with the recipe's image, author, and title.
 class RecipeCard extends StatelessWidget {
-  const RecipeCard({Key key, this.recipe, this.onTap}) : super(key: key);
+  const RecipeCard({ Key key, this.recipe, this.onTap }) : super(key: key);
 
   final Recipe recipe;
   final VoidCallback onTap;
@@ -320,7 +320,7 @@ class RecipeCard extends StatelessWidget {
 
 // Displays one recipe. Includes the recipe sheet with a background image.
 class RecipePage extends StatefulWidget {
-  const RecipePage({Key key, this.recipe}) : super(key: key);
+  const RecipePage({ Key key, this.recipe }) : super(key: key);
 
   final Recipe recipe;
 
@@ -442,7 +442,7 @@ class _RecipePageState extends State<RecipePage> {
 
 /// Displays the recipe's name and instructions.
 class RecipeSheet extends StatelessWidget {
-  RecipeSheet({Key key, this.recipe}) : super(key: key);
+  RecipeSheet({ Key key, this.recipe }) : super(key: key);
 
   final TextStyle titleStyle = const PestoStyle(fontSize: 34.0);
   final TextStyle descriptionStyle =
@@ -572,14 +572,14 @@ class Recipe {
 }
 
 class RecipeIngredient {
-  const RecipeIngredient({this.amount, this.description});
+  const RecipeIngredient({ this.amount, this.description });
 
   final String amount;
   final String description;
 }
 
 class RecipeStep {
-  const RecipeStep({this.duration, this.description});
+  const RecipeStep({ this.duration, this.description });
 
   final String duration;
   final String description;

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -50,15 +50,15 @@ class PestoStyle extends TextStyle {
     double letterSpacing,
     double height,
   }) : super(
-          inherit: false,
-          color: color,
-          fontFamily: 'Raleway',
-          fontSize: fontSize,
-          fontWeight: fontWeight,
-          textBaseline: TextBaseline.alphabetic,
-          letterSpacing: letterSpacing,
-          height: height,
-        );
+         inherit: false,
+         color: color,
+         fontFamily: 'Raleway',
+         fontSize: fontSize,
+         fontWeight: fontWeight,
+         textBaseline: TextBaseline.alphabetic,
+         letterSpacing: letterSpacing,
+         height: height,
+       );
 }
 
 // Displays a grid of recipe cards.

--- a/examples/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/examples/flutter_gallery/lib/demo/pesto_demo.dart
@@ -6,14 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 class PestoDemo extends StatelessWidget {
-  const PestoDemo({ Key key }) : super(key: key);
+  const PestoDemo({Key key}) : super(key: key);
 
   static const String routeName = '/pesto';
 
   @override
   Widget build(BuildContext context) => PestoHome();
 }
-
 
 const String _kSmallLogoImage = 'logos/pesto/logo_small.png';
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
@@ -51,20 +50,20 @@ class PestoStyle extends TextStyle {
     double letterSpacing,
     double height,
   }) : super(
-    inherit: false,
-    color: color,
-    fontFamily: 'Raleway',
-    fontSize: fontSize,
-    fontWeight: fontWeight,
-    textBaseline: TextBaseline.alphabetic,
-    letterSpacing: letterSpacing,
-    height: height,
-  );
+          inherit: false,
+          color: color,
+          fontFamily: 'Raleway',
+          fontSize: fontSize,
+          fontWeight: fontWeight,
+          textBaseline: TextBaseline.alphabetic,
+          letterSpacing: letterSpacing,
+          height: height,
+        );
 }
 
 // Displays a grid of recipe cards.
 class RecipeGridPage extends StatefulWidget {
-  const RecipeGridPage({ Key key, this.recipes }) : super(key: key);
+  const RecipeGridPage({Key key, this.recipes}) : super(key: key);
 
   final List<Recipe> recipes;
 
@@ -129,7 +128,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
               bottom: extraPadding,
             ),
             child: Center(
-              child: PestoLogo(height: logoHeight, t: t.clamp(0.0, 1.0))
+              child: PestoLogo(height: logoHeight, t: t.clamp(0.0, 1.0)),
             ),
           );
         },
@@ -143,7 +142,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
       top: 8.0,
       left: 8.0 + mediaPadding.left,
       right: 8.0 + mediaPadding.right,
-      bottom: 8.0
+      bottom: 8.0,
     );
     return SliverPadding(
       padding: padding,
@@ -158,7 +157,9 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
             final Recipe recipe = widget.recipes[index];
             return RecipeCard(
               recipe: recipe,
-              onTap: () { showRecipePage(context, recipe); },
+              onTap: () {
+                showRecipePage(context, recipe);
+              },
             );
           },
           childCount: widget.recipes.length,
@@ -168,22 +169,26 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
   }
 
   void showFavoritesPage(BuildContext context) {
-    Navigator.push(context, MaterialPageRoute<void>(
-      settings: const RouteSettings(name: '/pesto/favorites'),
-      builder: (BuildContext context) => PestoFavorites(),
-    ));
+    Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/pesto/favorites'),
+        builder: (BuildContext context) => PestoFavorites(),
+      ));
   }
 
   void showRecipePage(BuildContext context, Recipe recipe) {
-    Navigator.push(context, MaterialPageRoute<void>(
-      settings: const RouteSettings(name: '/pesto/recipe'),
-      builder: (BuildContext context) {
-        return Theme(
-          data: _kTheme.copyWith(platform: Theme.of(context).platform),
-          child: RecipePage(recipe: recipe),
-        );
-      },
-    ));
+    Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: '/pesto/recipe'),
+        builder: (BuildContext context) {
+          return Theme(
+            data: _kTheme.copyWith(platform: Theme.of(context).platform),
+            child: RecipePage(recipe: recipe),
+          );
+        },
+      ));
   }
 }
 
@@ -203,10 +208,11 @@ class _PestoLogoState extends State<PestoLogo> {
   static const double kLogoWidth = 220.0;
   static const double kImageHeight = 108.0;
   static const double kTextHeight = 48.0;
-  final TextStyle titleStyle = const PestoStyle(fontSize: kTextHeight, fontWeight: FontWeight.w900, color: Colors.white, letterSpacing: 3.0);
+  final TextStyle titleStyle = const PestoStyle(
+      fontSize: kTextHeight, fontWeight: FontWeight.w900, color: Colors.white, letterSpacing: 3.0);
   final RectTween _textRectTween = RectTween(
     begin: Rect.fromLTWH(0.0, kLogoHeight, kLogoWidth, kTextHeight),
-    end: Rect.fromLTWH(0.0, kImageHeight, kLogoWidth, kTextHeight)
+    end: Rect.fromLTWH(0.0, kImageHeight, kLogoWidth, kTextHeight),
   );
   final Curve _textOpacity = const Interval(0.4, 1.0, curve: Curves.easeInOut);
   final RectTween _imageRectTween = RectTween(
@@ -251,7 +257,7 @@ class _PestoLogoState extends State<PestoLogo> {
 
 // A card with the recipe's image, author, and title.
 class RecipeCard extends StatelessWidget {
-  const RecipeCard({ Key key, this.recipe, this.onTap }) : super(key: key);
+  const RecipeCard({Key key, this.recipe, this.onTap}) : super(key: key);
 
   final Recipe recipe;
   final VoidCallback onTap;
@@ -296,7 +302,8 @@ class RecipeCard extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                        Text(recipe.name, style: titleStyle, softWrap: false, overflow: TextOverflow.ellipsis),
+                        Text(recipe.name,
+                          style: titleStyle, softWrap: false, overflow: TextOverflow.ellipsis),
                         Text(recipe.author, style: authorStyle),
                       ],
                     ),
@@ -313,7 +320,7 @@ class RecipeCard extends StatelessWidget {
 
 // Displays one recipe. Includes the recipe sheet with a background image.
 class RecipePage extends StatefulWidget {
-  const RecipePage({ Key key, this.recipe }) : super(key: key);
+  const RecipePage({Key key, this.recipe}) : super(key: key);
 
   final Recipe recipe;
 
@@ -323,7 +330,8 @@ class RecipePage extends StatefulWidget {
 
 class _RecipePageState extends State<RecipePage> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final TextStyle menuItemStyle = const PestoStyle(fontSize: 15.0, color: Colors.black54, height: 24.0/15.0);
+  final TextStyle menuItemStyle =
+      const PestoStyle(fontSize: 15.0, color: Colors.black54, height: 24.0 / 15.0);
 
   double _getAppBarHeight(BuildContext context) => MediaQuery.of(context).size.height * 0.3;
 
@@ -363,11 +371,11 @@ class _RecipePageState extends State<RecipePage> {
                   PopupMenuButton<String>(
                     onSelected: (String item) {},
                     itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                      _buildMenuItem(Icons.share, 'Tweet recipe'),
-                      _buildMenuItem(Icons.email, 'Email recipe'),
-                      _buildMenuItem(Icons.message, 'Message recipe'),
-                      _buildMenuItem(Icons.people, 'Share on Facebook'),
-                    ],
+                          _buildMenuItem(Icons.share, 'Tweet recipe'),
+                          _buildMenuItem(Icons.email, 'Email recipe'),
+                          _buildMenuItem(Icons.message, 'Message recipe'),
+                          _buildMenuItem(Icons.people, 'Share on Facebook'),
+                        ],
                   ),
                 ],
                 flexibleSpace: const FlexibleSpaceBar(
@@ -398,7 +406,7 @@ class _RecipePageState extends State<RecipePage> {
                       ),
                     ),
                   ],
-                )
+                ),
               ),
             ],
           ),
@@ -413,7 +421,7 @@ class _RecipePageState extends State<RecipePage> {
         children: <Widget>[
           Padding(
             padding: const EdgeInsets.only(right: 24.0),
-            child: Icon(icon, color: Colors.black54)
+            child: Icon(icon, color: Colors.black54),
           ),
           Text(label, style: menuItemStyle),
         ],
@@ -423,23 +431,27 @@ class _RecipePageState extends State<RecipePage> {
 
   void _toggleFavorite() {
     setState(() {
-      if (_favoriteRecipes.contains(widget.recipe))
+      if (_favoriteRecipes.contains(widget.recipe)) {
         _favoriteRecipes.remove(widget.recipe);
-      else
+      } else {
         _favoriteRecipes.add(widget.recipe);
+      }
     });
   }
 }
 
 /// Displays the recipe's name and instructions.
 class RecipeSheet extends StatelessWidget {
-  RecipeSheet({ Key key, this.recipe }) : super(key: key);
+  RecipeSheet({Key key, this.recipe}) : super(key: key);
 
   final TextStyle titleStyle = const PestoStyle(fontSize: 34.0);
-  final TextStyle descriptionStyle = const PestoStyle(fontSize: 15.0, color: Colors.black54, height: 24.0/15.0);
-  final TextStyle itemStyle = const PestoStyle(fontSize: 15.0, height: 24.0/15.0);
-  final TextStyle itemAmountStyle = PestoStyle(fontSize: 15.0, color: _kTheme.primaryColor, height: 24.0/15.0);
-  final TextStyle headingStyle = const PestoStyle(fontSize: 16.0, fontWeight: FontWeight.bold, height: 24.0/15.0);
+  final TextStyle descriptionStyle =
+      const PestoStyle(fontSize: 15.0, color: Colors.black54, height: 24.0 / 15.0);
+  final TextStyle itemStyle = const PestoStyle(fontSize: 15.0, height: 24.0 / 15.0);
+  final TextStyle itemAmountStyle =
+      PestoStyle(fontSize: 15.0, color: _kTheme.primaryColor, height: 24.0 / 15.0);
+  final TextStyle headingStyle =
+      const PestoStyle(fontSize: 16.0, fontWeight: FontWeight.bold, height: 24.0 / 15.0);
 
   final Recipe recipe;
 
@@ -452,9 +464,7 @@ class RecipeSheet extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 40.0),
           child: Table(
-            columnWidths: const <int, TableColumnWidth>{
-              0: FixedColumnWidth(64.0)
-            },
+            columnWidths: const <int, TableColumnWidth>{0: FixedColumnWidth(64.0)},
             children: <TableRow>[
               TableRow(
                 children: <Widget>[
@@ -466,52 +476,55 @@ class RecipeSheet extends StatelessWidget {
                       width: 32.0,
                       height: 32.0,
                       alignment: Alignment.centerLeft,
-                      fit: BoxFit.scaleDown
-                    )
+                      fit: BoxFit.scaleDown,
+                    ),
                   ),
                   TableCell(
                     verticalAlignment: TableCellVerticalAlignment.middle,
-                    child: Text(recipe.name, style: titleStyle)
+                    child: Text(recipe.name, style: titleStyle),
                   ),
-                ]
+                ],
               ),
               TableRow(
                 children: <Widget>[
                   const SizedBox(),
                   Padding(
                     padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                    child: Text(recipe.description, style: descriptionStyle)
+                    child: Text(recipe.description, style: descriptionStyle),
                   ),
-                ]
+                ],
               ),
               TableRow(
                 children: <Widget>[
                   const SizedBox(),
                   Padding(
                     padding: const EdgeInsets.only(top: 24.0, bottom: 4.0),
-                    child: Text('Ingredients', style: headingStyle)
+                    child: Text('Ingredients', style: headingStyle),
                   ),
-                ]
+                ],
               ),
-            ]..addAll(recipe.ingredients.map<TableRow>(
-              (RecipeIngredient ingredient) {
-                return _buildItemRow(ingredient.amount, ingredient.description);
-              }
-            ))..add(
-              TableRow(
-                children: <Widget>[
-                  const SizedBox(),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 24.0, bottom: 4.0),
-                    child: Text('Steps', style: headingStyle)
-                  ),
-                ]
+            ]
+              ..addAll(recipe.ingredients.map<TableRow>(
+                (RecipeIngredient ingredient) {
+                  return _buildItemRow(ingredient.amount, ingredient.description);
+                },
+              ))
+              ..add(
+                TableRow(
+                  children: <Widget>[
+                    const SizedBox(),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 24.0, bottom: 4.0),
+                      child: Text('Steps', style: headingStyle),
+                    ),
+                  ],
+                ),
               )
-            )..addAll(recipe.steps.map<TableRow>(
-              (RecipeStep step) {
-                return _buildItemRow(step.duration ?? '', step.description);
-              }
-            )),
+              ..addAll(recipe.steps.map<TableRow>(
+                (RecipeStep step) {
+                  return _buildItemRow(step.duration ?? '', step.description);
+                },
+              )),
           ),
         ),
       ),
@@ -544,7 +557,7 @@ class Recipe {
     this.ingredientsImagePath,
     this.ingredientsImagePackage,
     this.ingredients,
-    this.steps
+    this.steps,
   });
 
   final String name;
@@ -578,7 +591,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Peter Carlsson',
     ingredientsImagePath: 'food/icons/main.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'The perfect dish to welcome your family and friends with on a crisp autumn night. Pair with roasted veggies to truly impress them.',
+    description:
+        'The perfect dish to welcome your family and friends with on a crisp autumn night. Pair with roasted veggies to truly impress them.',
     imagePath: 'food/roasted_chicken.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
@@ -598,11 +612,12 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Trevor Hansen',
     ingredientsImagePath: 'food/icons/veggie.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'This vegetable has more to offer than just its root. Beet greens can be tossed into a salad to add some variety or sauteed on its own with some oil and garlic.',
+    description:
+        'This vegetable has more to offer than just its root. Beet greens can be tossed into a salad to add some variety or sauteed on its own with some oil and garlic.',
     imagePath: 'food/chopped_beet_leaves.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
-       RecipeIngredient(amount: '3 cups', description: 'Beet greens'),
+      RecipeIngredient(amount: '3 cups', description: 'Beet greens'),
     ],
     steps: <RecipeStep>[
       RecipeStep(duration: '5 min', description: 'Chop'),
@@ -613,7 +628,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Ali Connors',
     ingredientsImagePath: 'food/icons/main.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'With this pesto recipe, you can quickly whip up a meal to satisfy your savory needs. And if you\'re feeling festive, you can add bacon to taste.',
+    description:
+        'With this pesto recipe, you can quickly whip up a meal to satisfy your savory needs. And if you\'re feeling festive, you can add bacon to taste.',
     imagePath: 'food/pesto_pasta.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
@@ -637,7 +653,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Sandra Adams',
     ingredientsImagePath: 'food/icons/main.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'Sometimes when you\'re craving some cheer in your life you can jumpstart your day with some cherry pie. Dessert for breakfast is perfectly acceptable.',
+    description:
+        'Sometimes when you\'re craving some cheer in your life you can jumpstart your day with some cherry pie. Dessert for breakfast is perfectly acceptable.',
     imagePath: 'food/cherry_pie.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
@@ -657,7 +674,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Peter Carlsson',
     ingredientsImagePath: 'food/icons/spicy.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'Everyone\'s favorite leafy green is back. Paired with fresh sliced onion, it\'s ready to tackle any dish, whether it be a salad or an egg scramble.',
+    description:
+        'Everyone\'s favorite leafy green is back. Paired with fresh sliced onion, it\'s ready to tackle any dish, whether it be a salad or an egg scramble.',
     imagePath: 'food/spinach_onion_salad.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
@@ -673,7 +691,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Ali Connors',
     ingredientsImagePath: 'food/icons/healthy.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'This creamy butternut squash soup will warm you on the chilliest of winter nights and bring a delightful pop of orange to the dinner table.',
+    description:
+        'This creamy butternut squash soup will warm you on the chilliest of winter nights and bring a delightful pop of orange to the dinner table.',
     imagePath: 'food/butternut_squash_soup.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[
@@ -697,7 +716,8 @@ const List<Recipe> kPestoRecipes = <Recipe>[
     author: 'Trevor Hansen',
     ingredientsImagePath: 'food/icons/quick.png',
     ingredientsImagePackage: _kGalleryAssetsPackage,
-    description: 'You \'feta\' believe this is a crowd-pleaser! Flaky phyllo pastry surrounds a delicious mixture of spinach and cheeses to create the perfect appetizer.',
+    description:
+        'You \'feta\' believe this is a crowd-pleaser! Flaky phyllo pastry surrounds a delicious mixture of spinach and cheeses to create the perfect appetizer.',
     imagePath: 'food/spanakopita.png',
     imagePackage: _kGalleryAssetsPackage,
     ingredients: <RecipeIngredient>[

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_data.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_data.dart
@@ -10,52 +10,47 @@ const Vendor _ali = Vendor(
   name: 'Ali’s shop',
   avatarAsset: 'people/square/ali.png',
   avatarAssetPackage: _kGalleryAssetsPackage,
-  description:
-    'Ali Connor’s makes custom goods for folks of all shapes and sizes '
-    'made by hand and sometimes by machine, but always with love and care. '
-    'Custom orders are available upon request if you need something extra special.'
+  description: 'Ali Connor’s makes custom goods for folks of all shapes and sizes '
+      'made by hand and sometimes by machine, but always with love and care. '
+      'Custom orders are available upon request if you need something extra special.',
 );
 
 const Vendor _peter = Vendor(
   name: 'Peter’s shop',
   avatarAsset: 'people/square/peter.png',
   avatarAssetPackage: _kGalleryAssetsPackage,
-  description:
-    'Peter makes great stuff for awesome people like you. Super cool and extra '
-    'awesome all of his shop’s goods are handmade with love. Custom orders are '
-    'available upon request if you need something extra special.'
+  description: 'Peter makes great stuff for awesome people like you. Super cool and extra '
+      'awesome all of his shop’s goods are handmade with love. Custom orders are '
+      'available upon request if you need something extra special.',
 );
 
 const Vendor _sandra = Vendor(
-    name: 'Sandra’s shop',
-    avatarAsset: 'people/square/sandra.png',
-    avatarAssetPackage: _kGalleryAssetsPackage,
-    description:
-    'Sandra specializes in furniture, beauty and travel products with a classic vibe. '
-        'Custom orders are available if you’re looking for a certain color or material.'
+  name: 'Sandra’s shop',
+  avatarAsset: 'people/square/sandra.png',
+  avatarAssetPackage: _kGalleryAssetsPackage,
+  description: 'Sandra specializes in furniture, beauty and travel products with a classic vibe. '
+      'Custom orders are available if you’re looking for a certain color or material.',
 );
 
 const Vendor _stella = Vendor(
   name: 'Stella’s shop',
   avatarAsset: 'people/square/stella.png',
   avatarAssetPackage: _kGalleryAssetsPackage,
-  description:
-    'Stella sells awesome stuff at lovely prices. made by hand and sometimes by '
-    'machine, but always with love and care. Custom orders are available upon request '
-    'if you need something extra special.'
+  description: 'Stella sells awesome stuff at lovely prices. made by hand and sometimes by '
+      'machine, but always with love and care. Custom orders are available upon request '
+      'if you need something extra special.',
 );
 
 const Vendor _trevor = Vendor(
-    name: 'Trevor’s shop',
-    avatarAsset: 'people/square/trevor.png',
-    avatarAssetPackage: _kGalleryAssetsPackage,
-    description:
-    'Trevor makes great stuff for awesome people like you. Super cool and extra '
-        'awesome all of his shop’s goods are handmade with love. Custom orders are '
-        'available upon request if you need something extra special.'
+  name: 'Trevor’s shop',
+  avatarAsset: 'people/square/trevor.png',
+  avatarAssetPackage: _kGalleryAssetsPackage,
+  description: 'Trevor makes great stuff for awesome people like you. Super cool and extra '
+      'awesome all of his shop’s goods are handmade with love. Custom orders are '
+      'available upon request if you need something extra special.',
 );
 
-const List<Product> _allProducts = <Product> [
+const List<Product> _allProducts = <Product>[
   Product(
     name: 'Vintage Brown Belt',
     imageAsset: 'products/belt.png',
@@ -63,9 +58,8 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion', 'latest'],
     price: 300.00,
     vendor: _sandra,
-    description:
-      'Isn’t it cool when things look old, but they\'re not. Looks Old But Not makes '
-      'awesome vintage goods that are super smart. This ol’ belt just got an upgrade. '
+    description: 'Isn’t it cool when things look old, but they\'re not. Looks Old But Not makes '
+        'awesome vintage goods that are super smart. This ol’ belt just got an upgrade. ',
   ),
   Product(
     name: 'Sunglasses',
@@ -74,11 +68,10 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'fashion', 'beauty'],
     price: 20.00,
     vendor: _trevor,
-    description:
-      'Be an optimist. Carry Sunglasses with you at all times. All Tints and '
-      'Shades products come with polarized lenses and super duper UV protection '
-      'so you can look at the sun for however long you want. Sunglasses make you '
-      'look cool, wear them.'
+    description: 'Be an optimist. Carry Sunglasses with you at all times. All Tints and '
+        'Shades products come with polarized lenses and super duper UV protection '
+        'so you can look at the sun for however long you want. Sunglasses make you '
+        'look cool, wear them.',
   ),
   Product(
     name: 'Flatwear',
@@ -87,8 +80,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['furniture'],
     price: 30.00,
     vendor: _trevor,
-    description:
-    'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Salmon Sweater',
@@ -97,10 +89,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion'],
     price: 300.00,
     vendor: _stella,
-    description:
-      'Looks can be deceiving. This sweater comes in a wide variety of '
-      'flavors, including salmon, that pop as soon as they hit your eyes. '
-      'Sweaters heat quickly, so savor the warmth.'
+    description: 'Looks can be deceiving. This sweater comes in a wide variety of '
+        'flavors, including salmon, that pop as soon as they hit your eyes. '
+        'Sweaters heat quickly, so savor the warmth.',
   ),
   Product(
     name: 'Pine Table',
@@ -109,8 +100,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['furniture'],
     price: 63.00,
     vendor: _stella,
-    description:
-      'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Green Comfort Jacket',
@@ -119,8 +109,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion'],
     price: 36.00,
     vendor: _ali,
-    description:
-      'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Chambray Top',
@@ -129,8 +118,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion'],
     price: 125.00,
     vendor: _peter,
-    description:
-      'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Blue Cup',
@@ -139,10 +127,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'furniture'],
     price: 75.00,
     vendor: _sandra,
-    description:
-      'Drinksy has been making extraordinary mugs for decades. With each '
-      'cup purchased Drinksy donates a cup to those in need. Buy yourself a mug, '
-      'buy someone else a mug.'
+    description: 'Drinksy has been making extraordinary mugs for decades. With each '
+        'cup purchased Drinksy donates a cup to those in need. Buy yourself a mug, '
+        'buy someone else a mug.',
   ),
   Product(
     name: 'Tea Set',
@@ -152,12 +139,10 @@ const List<Product> _allProducts = <Product> [
     price: 70.00,
     vendor: _trevor,
     featureTitle: 'Beautiful glass teapot',
-    featureDescription:
-      'Teapot holds extremely hot liquids and pours them from the spout.',
-    description:
-      'Impress your guests with Tea Set by Kitchen Stuff. Teapot holds extremely '
-      'hot liquids and pours them from the spout. Use the handle, shown on the right, '
-      'so your fingers don’t get burnt while pouring.'
+    featureDescription: 'Teapot holds extremely hot liquids and pours them from the spout.',
+    description: 'Impress your guests with Tea Set by Kitchen Stuff. Teapot holds extremely '
+        'hot liquids and pours them from the spout. Use the handle, shown on the right, '
+        'so your fingers don’t get burnt while pouring.',
   ),
   Product(
     name: 'Blue linen napkins',
@@ -166,9 +151,8 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['furniture', 'fashion'],
     price: 89.00,
     vendor: _trevor,
-    description:
-      'Blue linen napkins were meant to go with friends, so you may want to pick '
-      'up a bunch of these. These things are absorbant.'
+    description: 'Blue linen napkins were meant to go with friends, so you may want to pick '
+        'up a bunch of these. These things are absorbant.',
   ),
   Product(
     name: 'Dipped Earrings',
@@ -177,10 +161,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion', 'beauty'],
     price: 25.00,
     vendor: _stella,
-    description:
-      'WeDipIt does it again. These hand-dipped 4 inch earrings are perfect for '
-      'the office or the beach. Just be sure you don’t drop it in a bucket of '
-      'red paint, then they won’t look dipped anymore.'
+    description: 'WeDipIt does it again. These hand-dipped 4 inch earrings are perfect for '
+        'the office or the beach. Just be sure you don’t drop it in a bucket of '
+        'red paint, then they won’t look dipped anymore.',
   ),
   Product(
     name: 'Perfect Planters',
@@ -189,10 +172,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['latest', 'furniture'],
     price: 30.00,
     vendor: _ali,
-    description:
-      'The Perfect Planter Co makes the best vessels for just about anything you '
-      'can pot. This set of Perfect Planters holds succulents and cuttings perfectly. '
-      'Looks great in any room. Keep out of reach from cats.'
+    description: 'The Perfect Planter Co makes the best vessels for just about anything you '
+        'can pot. This set of Perfect Planters holds succulents and cuttings perfectly. '
+        'Looks great in any room. Keep out of reach from cats.',
   ),
   Product(
     name: 'Cloud-White Dress',
@@ -201,10 +183,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['fashion'],
     price: 54.00,
     vendor: _sandra,
-    description:
-      'Trying to find the perfect outift to match your mood? Try no longer. '
-      'This Cloud-White Dress has you covered for those nights when you need '
-      'to get out, or even if you’re just headed to work.'
+    description: 'Trying to find the perfect outift to match your mood? Try no longer. '
+        'This Cloud-White Dress has you covered for those nights when you need '
+        'to get out, or even if you’re just headed to work.',
   ),
   Product(
     name: 'Backpack',
@@ -213,10 +194,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'fashion'],
     price: 25.00,
     vendor: _peter,
-    description:
-      'This backpack by Bags ‘n’ stuff can hold just about anything: a laptop, '
-      'a pen, a protractor, notebooks, small animals, plugs for your devices, '
-      'sunglasses, gym clothes, shoes, gloves, two kittens, and even lunch!'
+    description: 'This backpack by Bags ‘n’ stuff can hold just about anything: a laptop, '
+        'a pen, a protractor, notebooks, small animals, plugs for your devices, '
+        'sunglasses, gym clothes, shoes, gloves, two kittens, and even lunch!',
   ),
   Product(
     name: 'Charcoal Straw Hat',
@@ -225,10 +205,9 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'fashion', 'latest'],
     price: 25.00,
     vendor: _ali,
-    description:
-      'This is the  helmet for those warm summer days on the road. '
-      'Jetset approved, these hats have been rigorously tested. Keep that face '
-      'protected from the sun.'
+    description: 'This is the  helmet for those warm summer days on the road. '
+        'Jetset approved, these hats have been rigorously tested. Keep that face '
+        'protected from the sun.',
   ),
   Product(
     name: 'Ginger Scarf',
@@ -237,8 +216,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['latest', 'fashion'],
     price: 17.00,
     vendor: _peter,
-    description:
-    'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Blush Sweats',
@@ -247,8 +225,7 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'fashion', 'latest'],
     price: 25.00,
     vendor: _stella,
-    description:
-    'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Mint Jumper',
@@ -257,18 +234,16 @@ const List<Product> _allProducts = <Product> [
     categories: <String>['travel', 'fashion', 'beauty'],
     price: 25.00,
     vendor: _peter,
-    description:
-    'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   ),
   Product(
     name: 'Ochre Shirt',
     imageAsset: 'products/shirt.png',
     imageAssetPackage: _kGalleryAssetsPackage,
-    categories: <String>[ 'fashion', 'latest'],
+    categories: <String>['fashion', 'latest'],
     price: 120.00,
     vendor: _stella,
-    description:
-    'Leave the tunnel and the rain is fallin amazing things happen when you wait'
+    description: 'Leave the tunnel and the rain is fallin amazing things happen when you wait',
   )
 ];
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -34,7 +34,8 @@ int _maxIndexInRow(int rowIndex) {
 
 int _rowAtIndex(int index) {
   final int blockCount = index ~/ _childrenPerBlock;
-  return const <int>[0, 0, 1, 1, 2, 2, 3, 4][index - blockCount * _childrenPerBlock] + blockCount * _rowsPerBlock;
+  return const <int>[0, 0, 1, 1, 2, 2, 3, 4][index - blockCount * _childrenPerBlock] +
+      blockCount * _rowsPerBlock;
 }
 
 int _columnAtIndex(int index) {
@@ -85,8 +86,9 @@ class _ShrineGridLayout extends SliverGridLayout {
 
   @override
   double computeMaxScrollOffset(int childCount) {
-    if (childCount == 0)
+    if (childCount == 0) {
       return 0.0;
+    }
     final int rowCount = _rowAtIndex(childCount - 1) + 1;
     final double rowSpacing = rowStride - tileHeight;
     return rowStride * rowCount - rowSpacing;
@@ -114,9 +116,9 @@ class _ShrineGridDelegate extends SliverGridDelegate {
 
 // Displays the Vendor's name and avatar.
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({ Key key, @required this.vendor })
-    : assert(vendor != null),
-      super(key: key);
+  const _VendorItem({Key key, @required this.vendor})
+      : assert(vendor != null),
+       super(key: key);
 
   final Vendor vendor;
 
@@ -150,16 +152,17 @@ class _VendorItem extends StatelessWidget {
 // Displays the product's price. If the product is in the shopping cart then the
 // background is highlighted.
 abstract class _PriceItem extends StatelessWidget {
-  const _PriceItem({ Key key, @required this.product })
+  const _PriceItem({Key key, @required this.product})
       : assert(product != null),
-        super(key: key);
+       super(key: key);
 
   final Product product;
 
   Widget buildItem(BuildContext context, TextStyle style, EdgeInsets padding) {
     BoxDecoration decoration;
-    if (_shoppingCart[product] != null)
+    if (_shoppingCart[product] != null) {
       decoration = BoxDecoration(color: ShrineTheme.of(context).priceHighlightColor);
+    }
 
     return Container(
       padding: padding,
@@ -170,7 +173,7 @@ abstract class _PriceItem extends StatelessWidget {
 }
 
 class _ProductPriceItem extends _PriceItem {
-  const _ProductPriceItem({ Key key, Product product }) : super(key: key, product: product);
+  const _ProductPriceItem({Key key, Product product}) : super(key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -183,7 +186,7 @@ class _ProductPriceItem extends _PriceItem {
 }
 
 class _FeaturePriceItem extends _PriceItem {
-  const _FeaturePriceItem({ Key key, Product product }) : super(key: key, product: product);
+  const _FeaturePriceItem({Key key, Product product}) : super(key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -216,8 +219,8 @@ class _HeadingLayout extends MultiChildLayoutDelegate {
 
     final Size imageSize = layoutChild(image, BoxConstraints.loose(size));
     final double imageX = imageSize.width < halfWidth - halfUnit
-      ? halfWidth / 2.0 - imageSize.width / 2.0 - halfUnit
-      : halfWidth - imageSize.width;
+        ? halfWidth / 2.0 - imageSize.width / 2.0 - halfUnit
+        : halfWidth - imageSize.width;
     positionChild(image, Offset(imageX, halfHeight - imageSize.height / 2.0));
 
     final double maxTitleWidth = halfWidth + unitSize - margin;
@@ -242,11 +245,11 @@ class _HeadingLayout extends MultiChildLayoutDelegate {
 
 // A card that highlights the "featured" catalog item.
 class _Heading extends StatelessWidget {
-  _Heading({ Key key, @required this.product })
-    : assert(product != null),
-      assert(product.featureTitle != null),
-      assert(product.featureDescription != null),
-      super(key: key);
+  _Heading({Key key, @required this.product})
+      : assert(product != null),
+       assert(product.featureTitle != null),
+       assert(product.featureDescription != null),
+       super(key: key);
 
   final Product product;
 
@@ -257,8 +260,8 @@ class _Heading extends StatelessWidget {
     return MergeSemantics(
       child: SizedBox(
         height: screenSize.width > screenSize.height
-          ? (screenSize.height - kToolbarHeight) * 0.85
-          : (screenSize.height - kToolbarHeight) * 0.70,
+            ? (screenSize.height - kToolbarHeight) * 0.85
+            : (screenSize.height - kToolbarHeight) * 0.70,
         child: Container(
           decoration: BoxDecoration(
             color: theme.cardBackgroundColor,
@@ -302,9 +305,9 @@ class _Heading extends StatelessWidget {
 // A card that displays a product's image, price, and vendor. The _ProductItem
 // cards appear in a grid below the heading.
 class _ProductItem extends StatelessWidget {
-  const _ProductItem({ Key key, @required this.product, this.onPressed })
-    : assert(product != null),
-      super(key: key);
+  const _ProductItem({Key key, @required this.product, this.onPressed})
+      : assert(product != null),
+       super(key: key);
 
   final Product product;
   final VoidCallback onPressed;
@@ -326,14 +329,14 @@ class _ProductItem extends StatelessWidget {
                   height: 144.0,
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: Hero(
-                      tag: product.tag,
-                      child: Image.asset(
-                        product.imageAsset,
-                        package: product.imageAssetPackage,
-                        fit: BoxFit.contain,
-                      ),
+                    tag: product.tag,
+                    child: Image.asset(
+                      product.imageAsset,
+                      package: product.imageAssetPackage,
+                      fit: BoxFit.contain,
                     ),
                   ),
+                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: _VendorItem(vendor: product.vendor),
@@ -364,19 +367,22 @@ class _ShrineHomeState extends State<ShrineHome> {
 
   Future<void> _showOrderPage(Product product) async {
     final Order order = _shoppingCart[product] ?? Order(product: product);
-    final Order completedOrder = await Navigator.push(context, ShrineOrderRoute(
-      order: order,
-      builder: (BuildContext context) {
-        return OrderPage(
-          order: order,
-          products: _products,
-          shoppingCart: _shoppingCart,
-        );
-      }
-    ));
+    final Order completedOrder = await Navigator.push(
+      context,
+      ShrineOrderRoute(
+        order: order,
+        builder: (BuildContext context) {
+          return OrderPage(
+            order: order,
+            products: _products,
+            shoppingCart: _shoppingCart,
+          );
+        },
+      ));
     assert(completedOrder.product != null);
-    if (completedOrder.quantity == 0)
+    if (completedOrder.quantity == 0) {
       _shoppingCart.remove(completedOrder.product);
+    }
   }
 
   @override
@@ -398,7 +404,9 @@ class _ShrineHomeState extends State<ShrineHome> {
                 _products.map<Widget>((Product product) {
                   return _ProductItem(
                     product: product,
-                    onPressed: () { _showOrderPage(product); },
+                    onPressed: () {
+                      _showOrderPage(product);
+                    },
                   );
                 }).toList(),
               ),

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_home.dart
@@ -116,7 +116,7 @@ class _ShrineGridDelegate extends SliverGridDelegate {
 
 // Displays the Vendor's name and avatar.
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({Key key, @required this.vendor})
+  const _VendorItem({ Key key, @required this.vendor })
       : assert(vendor != null),
        super(key: key);
 
@@ -152,7 +152,7 @@ class _VendorItem extends StatelessWidget {
 // Displays the product's price. If the product is in the shopping cart then the
 // background is highlighted.
 abstract class _PriceItem extends StatelessWidget {
-  const _PriceItem({Key key, @required this.product})
+  const _PriceItem({ Key key, @required this.product })
       : assert(product != null),
        super(key: key);
 
@@ -173,7 +173,7 @@ abstract class _PriceItem extends StatelessWidget {
 }
 
 class _ProductPriceItem extends _PriceItem {
-  const _ProductPriceItem({Key key, Product product}) : super(key: key, product: product);
+  const _ProductPriceItem({ Key key, Product product }) : super(key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -186,7 +186,7 @@ class _ProductPriceItem extends _PriceItem {
 }
 
 class _FeaturePriceItem extends _PriceItem {
-  const _FeaturePriceItem({Key key, Product product}) : super(key: key, product: product);
+  const _FeaturePriceItem({ Key key, Product product }) : super(key: key, product: product);
 
   @override
   Widget build(BuildContext context) {
@@ -245,7 +245,7 @@ class _HeadingLayout extends MultiChildLayoutDelegate {
 
 // A card that highlights the "featured" catalog item.
 class _Heading extends StatelessWidget {
-  _Heading({Key key, @required this.product})
+  _Heading({ Key key, @required this.product })
       : assert(product != null),
        assert(product.featureTitle != null),
        assert(product.featureDescription != null),
@@ -305,7 +305,7 @@ class _Heading extends StatelessWidget {
 // A card that displays a product's image, price, and vendor. The _ProductItem
 // cards appear in a grid below the heading.
 class _ProductItem extends StatelessWidget {
-  const _ProductItem({Key key, @required this.product, this.onPressed})
+  const _ProductItem({ Key key, @required this.product, this.onPressed })
       : assert(product != null),
        super(key: key);
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -16,10 +16,10 @@ class _ProductItem extends StatelessWidget {
     @required this.product,
     @required this.quantity,
     @required this.onChanged,
-  }) : assert(product != null),
-       assert(quantity != null),
-       assert(onChanged != null),
-       super(key: key);
+  })  : assert(product != null),
+        assert(quantity != null),
+        assert(onChanged != null),
+        super(key: key);
 
   final Product product;
   final int quantity;
@@ -68,9 +68,9 @@ class _ProductItem extends StatelessWidget {
 
 // Vendor name and description
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({ Key key, @required this.vendor })
-    : assert(vendor != null),
-      super(key: key);
+  const _VendorItem({Key key, @required this.vendor})
+      : assert(vendor != null),
+       super(key: key);
 
   final Vendor vendor;
 
@@ -144,9 +144,9 @@ class _Heading extends StatelessWidget {
     @required this.product,
     @required this.quantity,
     this.quantityChanged,
-  }) : assert(product != null),
-       assert(quantity != null && quantity >= 0 && quantity <= 5),
-       super(key: key);
+  })  : assert(product != null),
+        assert(quantity != null && quantity >= 0 && quantity <= 5),
+        super(key: key);
 
   final Product product;
   final int quantity;
@@ -211,10 +211,10 @@ class OrderPage extends StatefulWidget {
     @required this.order,
     @required this.products,
     @required this.shoppingCart,
-  }) : assert(order != null),
-       assert(products != null && products.isNotEmpty),
-       assert(shoppingCart != null),
-       super(key: key);
+  })  : assert(order != null),
+        assert(products != null && products.isNotEmpty),
+        assert(shoppingCart != null),
+        super(key: key);
 
   final Order order;
   final List<Product> products;
@@ -242,7 +242,7 @@ class _OrderPageState extends State<OrderPage> {
     ShrineOrderRoute.of(context).order = value;
   }
 
-  void updateOrder({ int quantity, bool inCart }) {
+  void updateOrder({int quantity, bool inCart}) {
     final Order newOrder = currentOrder.copyWith(quantity: quantity, inCart: inCart);
     if (currentOrder != newOrder) {
       setState(() {
@@ -268,7 +268,7 @@ class _OrderPageState extends State<OrderPage> {
           final int n = currentOrder.quantity;
           final String item = currentOrder.product.name;
           showSnackBarMessage(
-            'There ${ n == 1 ? "is one $item item" : "are $n $item items" } in the shopping cart.'
+            'There ${n == 1 ? "is one $item item" : "are $n $item items"} in the shopping cart.',
           );
         },
         backgroundColor: const Color(0xFF16F0F0),
@@ -284,7 +284,9 @@ class _OrderPageState extends State<OrderPage> {
             child: _Heading(
               product: widget.order.product,
               quantity: currentOrder.quantity,
-              quantityChanged: (int value) { updateOrder(quantity: value); },
+              quantityChanged: (int value) {
+                updateOrder(quantity: value);
+              },
             ),
           ),
           SliverSafeArea(
@@ -300,15 +302,15 @@ class _OrderPageState extends State<OrderPage> {
                 widget.products
                   .where((Product product) => product != widget.order.product)
                   .map((Product product) {
-                    return Card(
-                      elevation: 1.0,
-                      child: Image.asset(
-                        product.imageAsset,
-                        package: product.imageAssetPackage,
-                        fit: BoxFit.contain,
-                      ),
-                    );
-                  }).toList(),
+                  return Card(
+                    elevation: 1.0,
+                    child: Image.asset(
+                      product.imageAsset,
+                      package: product.imageAssetPackage,
+                      fit: BoxFit.contain,
+                    ),
+                  );
+                }).toList(),
               ),
             ),
           ),
@@ -328,8 +330,8 @@ class ShrineOrderRoute extends ShrinePageRoute<Order> {
     @required this.order,
     WidgetBuilder builder,
     RouteSettings settings,
-  }) : assert(order != null),
-       super(builder: builder, settings: settings);
+  })  : assert(order != null),
+        super(builder: builder, settings: settings);
 
   Order order;
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -68,7 +68,7 @@ class _ProductItem extends StatelessWidget {
 
 // Vendor name and description
 class _VendorItem extends StatelessWidget {
-  const _VendorItem({Key key, @required this.vendor})
+  const _VendorItem({ Key key, @required this.vendor })
       : assert(vendor != null),
        super(key: key);
 
@@ -242,7 +242,7 @@ class _OrderPageState extends State<OrderPage> {
     ShrineOrderRoute.of(context).order = value;
   }
 
-  void updateOrder({int quantity, bool inCart}) {
+  void updateOrder({ int quantity, bool inCart }) {
     final Order newOrder = currentOrder.copyWith(quantity: quantity, inCart: inCart);
     if (currentOrder != newOrder) {
       setState(() {

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_order.dart
@@ -16,10 +16,10 @@ class _ProductItem extends StatelessWidget {
     @required this.product,
     @required this.quantity,
     @required this.onChanged,
-  })  : assert(product != null),
-        assert(quantity != null),
-        assert(onChanged != null),
-        super(key: key);
+  }) : assert(product != null),
+       assert(quantity != null),
+       assert(onChanged != null),
+       super(key: key);
 
   final Product product;
   final int quantity;
@@ -144,9 +144,9 @@ class _Heading extends StatelessWidget {
     @required this.product,
     @required this.quantity,
     this.quantityChanged,
-  })  : assert(product != null),
-        assert(quantity != null && quantity >= 0 && quantity <= 5),
-        super(key: key);
+  }) : assert(product != null),
+       assert(quantity != null && quantity >= 0 && quantity <= 5),
+       super(key: key);
 
   final Product product;
   final int quantity;
@@ -211,10 +211,10 @@ class OrderPage extends StatefulWidget {
     @required this.order,
     @required this.products,
     @required this.shoppingCart,
-  })  : assert(order != null),
-        assert(products != null && products.isNotEmpty),
-        assert(shoppingCart != null),
-        super(key: key);
+  }) : assert(order != null),
+       assert(products != null && products.isNotEmpty),
+       assert(shoppingCart != null),
+       super(key: key);
 
   final Order order;
   final List<Product> products;
@@ -330,8 +330,8 @@ class ShrineOrderRoute extends ShrinePageRoute<Order> {
     @required this.order,
     WidgetBuilder builder,
     RouteSettings settings,
-  })  : assert(order != null),
-        super(builder: builder, settings: settings);
+  }) : assert(order != null),
+       super(builder: builder, settings: settings);
 
   Order order;
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -108,19 +108,19 @@ class ShrinePageState extends State<ShrinePage> {
           ),
           PopupMenuButton<ShrineAction>(
             itemBuilder: (BuildContext context) => <PopupMenuItem<ShrineAction>>[
-                  const PopupMenuItem<ShrineAction>(
-                    value: ShrineAction.sortByPrice,
-                    child: Text('Sort by price'),
-                  ),
-                  const PopupMenuItem<ShrineAction>(
-                    value: ShrineAction.sortByProduct,
-                    child: Text('Sort by product'),
-                  ),
-                  const PopupMenuItem<ShrineAction>(
-                    value: ShrineAction.emptyCart,
-                    child: Text('Empty shopping cart'),
-                  )
-                ],
+              const PopupMenuItem<ShrineAction>(
+                value: ShrineAction.sortByPrice,
+                child: Text('Sort by price'),
+              ),
+              const PopupMenuItem<ShrineAction>(
+                value: ShrineAction.sortByProduct,
+                child: Text('Sort by product'),
+              ),
+              const PopupMenuItem<ShrineAction>(
+                value: ShrineAction.emptyCart,
+                child: Text('Empty shopping cart'),
+              )
+            ],
             onSelected: (ShrineAction action) {
               switch (action) {
                 case ShrineAction.sortByPrice:

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -7,11 +7,7 @@ import 'package:flutter/material.dart';
 import 'shrine_theme.dart';
 import 'shrine_types.dart';
 
-enum ShrineAction {
-  sortByPrice,
-  sortByProduct,
-  emptyCart
-}
+enum ShrineAction { sortByPrice, sortByProduct, emptyCart }
 
 class ShrinePage extends StatefulWidget {
   const ShrinePage({
@@ -20,10 +16,10 @@ class ShrinePage extends StatefulWidget {
     @required this.body,
     this.floatingActionButton,
     this.products,
-    this.shoppingCart
-  }) : assert(body != null),
-       assert(scaffoldKey != null),
-       super(key: key);
+    this.shoppingCart,
+  })  : assert(body != null),
+        assert(scaffoldKey != null),
+        super(key: key);
 
   final GlobalKey<ScaffoldState> scaffoldKey;
   final Widget body;
@@ -50,24 +46,26 @@ class ShrinePageState extends State<ShrinePage> {
   }
 
   void _showShoppingCart() {
-    showModalBottomSheet<void>(context: context, builder: (BuildContext context) {
-      if (widget.shoppingCart.isEmpty) {
-        return const Padding(
-          padding: EdgeInsets.all(24.0),
-          child: Text('The shopping cart is empty')
-        );
-      }
-      return ListView(
-        padding: kMaterialListPadding,
-        children: widget.shoppingCart.values.map((Order order) {
-          return ListTile(
-            title: Text(order.product.name),
-            leading: Text('${order.quantity}'),
-            subtitle: Text(order.product.vendor.name)
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (BuildContext context) {
+        if (widget.shoppingCart.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.all(24.0),
+            child: Text('The shopping cart is empty'),
           );
-        }).toList(),
-      );
-    });
+        }
+        return ListView(
+          padding: kMaterialListPadding,
+          children: widget.shoppingCart.values.map((Order order) {
+            return ListTile(
+              title: Text(order.product.name),
+              leading: Text('${order.quantity}'),
+              subtitle: Text(order.product.vendor.name),
+            );
+          }).toList(),
+        );
+      });
   }
 
   void _sortByPrice() {
@@ -96,9 +94,9 @@ class ShrinePageState extends State<ShrinePage> {
         flexibleSpace: Container(
           decoration: BoxDecoration(
             border: Border(
-              bottom: BorderSide(color: theme.dividerColor)
-            )
-          )
+              bottom: BorderSide(color: theme.dividerColor),
+            ),
+          ),
         ),
         title: Text('SHRINE', style: ShrineTheme.of(context).appBarTitleStyle),
         centerTitle: true,
@@ -106,23 +104,23 @@ class ShrinePageState extends State<ShrinePage> {
           IconButton(
             icon: const Icon(Icons.shopping_cart),
             tooltip: 'Shopping cart',
-            onPressed: _showShoppingCart
+            onPressed: _showShoppingCart,
           ),
           PopupMenuButton<ShrineAction>(
             itemBuilder: (BuildContext context) => <PopupMenuItem<ShrineAction>>[
-              const PopupMenuItem<ShrineAction>(
-                value: ShrineAction.sortByPrice,
-                child: Text('Sort by price')
-              ),
-              const PopupMenuItem<ShrineAction>(
-                value: ShrineAction.sortByProduct,
-                child: Text('Sort by product')
-              ),
-              const PopupMenuItem<ShrineAction>(
-                value: ShrineAction.emptyCart,
-                child: Text('Empty shopping cart')
-              )
-            ],
+                  const PopupMenuItem<ShrineAction>(
+                    value: ShrineAction.sortByPrice,
+                    child: Text('Sort by price'),
+                  ),
+                  const PopupMenuItem<ShrineAction>(
+                    value: ShrineAction.sortByProduct,
+                    child: Text('Sort by product'),
+                  ),
+                  const PopupMenuItem<ShrineAction>(
+                    value: ShrineAction.emptyCart,
+                    child: Text('Empty shopping cart'),
+                  )
+                ],
             onSelected: (ShrineAction action) {
               switch (action) {
                 case ShrineAction.sortByPrice:
@@ -135,15 +133,15 @@ class ShrinePageState extends State<ShrinePage> {
                   setState(_emptyCart);
                   break;
               }
-            }
+            },
           )
-        ]
+        ],
       ),
       floatingActionButton: widget.floatingActionButton,
       body: NotificationListener<ScrollNotification>(
         onNotification: _handleScrollNotification,
-        child: widget.body
-      )
+        child: widget.body,
+      ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_page.dart
@@ -17,9 +17,9 @@ class ShrinePage extends StatefulWidget {
     this.floatingActionButton,
     this.products,
     this.shoppingCart,
-  })  : assert(body != null),
-        assert(scaffoldKey != null),
-        super(key: key);
+  }) : assert(body != null),
+       assert(scaffoldKey != null),
+       super(key: key);
 
   final GlobalKey<ScaffoldState> scaffoldKey;
   final Widget body;

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
@@ -37,7 +37,7 @@ TextStyle abrilFatfaceRegular34(Color color) => ShrineStyle.abrilFatface(34.0, F
 /// InheritedWidget is shared by all of the routes and widgets created for
 /// the Shrine app.
 class ShrineTheme extends InheritedWidget {
-  ShrineTheme({Key key, @required Widget child})
+  ShrineTheme({ Key key, @required Widget child })
       : assert(child != null),
        super(key: key, child: child);
 

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_theme.dart
@@ -6,10 +6,21 @@ import 'package:flutter/material.dart';
 
 class ShrineStyle extends TextStyle {
   const ShrineStyle.roboto(double size, FontWeight weight, Color color)
-    : super(inherit: false, color: color, fontSize: size, fontWeight: weight, textBaseline: TextBaseline.alphabetic);
+      : super(
+           inherit: false,
+           color: color,
+           fontSize: size,
+           fontWeight: weight,
+           textBaseline: TextBaseline.alphabetic);
 
   const ShrineStyle.abrilFatface(double size, FontWeight weight, Color color)
-    : super(inherit: false, color: color, fontFamily: 'AbrilFatface', fontSize: size, fontWeight: weight, textBaseline: TextBaseline.alphabetic);
+      : super(
+           inherit: false,
+           color: color,
+           fontFamily: 'AbrilFatface',
+           fontSize: size,
+           fontWeight: weight,
+           textBaseline: TextBaseline.alphabetic);
 }
 
 TextStyle robotoRegular12(Color color) => ShrineStyle.roboto(12.0, FontWeight.w500, color);
@@ -26,9 +37,9 @@ TextStyle abrilFatfaceRegular34(Color color) => ShrineStyle.abrilFatface(34.0, F
 /// InheritedWidget is shared by all of the routes and widgets created for
 /// the Shrine app.
 class ShrineTheme extends InheritedWidget {
-  ShrineTheme({ Key key, @required Widget child })
-    : assert(child != null),
-      super(key: key, child: child);
+  ShrineTheme({Key key, @required Widget child})
+      : assert(child != null),
+       super(key: key, child: child);
 
   final Color cardBackgroundColor = Colors.white;
   final Color appBarBackgroundColor = Colors.white;

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_types.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_types.dart
@@ -68,7 +68,7 @@ class Product {
 }
 
 class Order {
-  Order({@required this.product, this.quantity = 1, this.inCart = false})
+  Order({ @required this.product, this.quantity = 1, this.inCart = false })
       : assert(product != null),
        assert(quantity != null && quantity >= 0),
        assert(inCart != null);
@@ -77,7 +77,7 @@ class Order {
   final int quantity;
   final bool inCart;
 
-  Order copyWith({Product product, int quantity, bool inCart}) {
+  Order copyWith({ Product product, int quantity, bool inCart }) {
     return Order(
       product: product ?? this.product,
       quantity: quantity ?? this.quantity,

--- a/examples/flutter_gallery/lib/demo/shrine/shrine_types.dart
+++ b/examples/flutter_gallery/lib/demo/shrine/shrine_types.dart
@@ -20,9 +20,7 @@ class Vendor {
   final String avatarAssetPackage;
 
   bool isValid() {
-    return name != null &&
-      description != null &&
-      avatarAsset != null;
+    return name != null && description != null && avatarAsset != null;
   }
 
   @override
@@ -39,7 +37,7 @@ class Product {
     this.imageAssetPackage,
     this.categories,
     this.price,
-    this.vendor
+    this.vendor,
   });
 
   final String name;
@@ -57,12 +55,12 @@ class Product {
 
   bool isValid() {
     return name != null &&
-      description != null &&
-      imageAsset != null &&
-      categories != null &&
-      categories.isNotEmpty &&
-      price != null &&
-      vendor.isValid();
+        description != null &&
+        imageAsset != null &&
+        categories != null &&
+        categories.isNotEmpty &&
+        price != null &&
+        vendor.isValid();
   }
 
   @override
@@ -70,33 +68,33 @@ class Product {
 }
 
 class Order {
-  Order({ @required this.product, this.quantity = 1, this.inCart = false })
-    : assert(product != null),
-      assert(quantity != null && quantity >= 0),
-      assert(inCart != null);
+  Order({@required this.product, this.quantity = 1, this.inCart = false})
+      : assert(product != null),
+       assert(quantity != null && quantity >= 0),
+       assert(inCart != null);
 
   final Product product;
   final int quantity;
   final bool inCart;
 
-  Order copyWith({ Product product, int quantity, bool inCart }) {
+  Order copyWith({Product product, int quantity, bool inCart}) {
     return Order(
       product: product ?? this.product,
       quantity: quantity ?? this.quantity,
-      inCart: inCart ?? this.inCart
+      inCart: inCart ?? this.inCart,
     );
   }
 
   @override
   bool operator ==(dynamic other) {
-    if (identical(this, other))
+    if (identical(this, other)) {
       return true;
-    if (other.runtimeType != runtimeType)
+    }
+    if (other.runtimeType != runtimeType) {
       return false;
+    }
     final Order typedOther = other;
-    return product == typedOther.product &&
-           quantity == typedOther.quantity &&
-           inCart == typedOther.inCart;
+    return product == typedOther.product && quantity == typedOther.quantity && inCart == typedOther.inCart;
   }
 
   @override

--- a/examples/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/examples/flutter_gallery/lib/demo/shrine_demo.dart
@@ -17,7 +17,7 @@ Widget buildShrine(BuildContext context, Widget child) {
       iconTheme: const IconThemeData(color: Color(0xFF707070)),
       platform: Theme.of(context).platform,
     ),
-    child: ShrineTheme(child: child)
+    child: ShrineTheme(child: child),
   );
 }
 

--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -10,10 +10,10 @@ class TextStyleItem extends StatelessWidget {
     @required this.name,
     @required this.style,
     @required this.text,
-  }) : assert(name != null),
-       assert(style != null),
-       assert(text != null),
-       super(key: key);
+  })  : assert(name != null),
+        assert(style != null),
+        assert(text != null),
+        super(key: key);
 
   final String name;
   final TextStyle style;
@@ -30,13 +30,13 @@ class TextStyleItem extends StatelessWidget {
         children: <Widget>[
           SizedBox(
             width: 72.0,
-            child: Text(name, style: nameStyle)
+            child: Text(name, style: nameStyle),
           ),
           Expanded(
-            child: Text(text, style: style.copyWith(height: 1.0))
+            child: Text(text, style: style.copyWith(height: 1.0)),
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }
@@ -61,11 +61,13 @@ class TypographyDemo extends StatelessWidget {
     ];
 
     if (MediaQuery.of(context).size.width > 500.0) {
-      styleItems.insert(0, TextStyleItem(
-        name: 'Display 4',
-        style: textTheme.display4,
-        text: 'Light 112sp'
-      ));
+      styleItems.insert(
+        0,
+        TextStyleItem(
+          name: 'Display 4',
+          style: textTheme.display4,
+          text: 'Light 112sp',
+        ));
     }
 
     return Scaffold(

--- a/examples/flutter_gallery/lib/demo/typography_demo.dart
+++ b/examples/flutter_gallery/lib/demo/typography_demo.dart
@@ -10,10 +10,10 @@ class TextStyleItem extends StatelessWidget {
     @required this.name,
     @required this.style,
     @required this.text,
-  })  : assert(name != null),
-        assert(style != null),
-        assert(text != null),
-        super(key: key);
+  }) : assert(name != null),
+       assert(style != null),
+       assert(text != null),
+       super(key: key);
 
   final String name;
   final TextStyle style;

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -10,12 +10,10 @@ import 'package:video_player/video_player.dart';
 import 'package:device_info/device_info.dart';
 
 // TODO(sigurdm): This should not be stored here.
-const String beeUri =
-    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
+const String beeUri = 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
 
 class VideoCard extends StatelessWidget {
-  const VideoCard({Key key, this.controller, this.title, this.subtitle})
-      : super(key: key);
+  const VideoCard({Key key, this.controller, this.title, this.subtitle}) : super(key: key);
 
   final VideoPlayerController controller;
   final String title;
@@ -55,8 +53,8 @@ class VideoCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget fullScreenRoutePageBuilder(BuildContext context,
-        Animation<double> animation, Animation<double> secondaryAnimation) {
+    Widget fullScreenRoutePageBuilder(
+        BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
       return _buildFullScreenVideo();
     }
 
@@ -148,8 +146,9 @@ class VideoPlayPause extends StatefulWidget {
 class _VideoPlayPauseState extends State<VideoPlayPause> {
   _VideoPlayPauseState() {
     listener = () {
-      if (mounted)
+      if (mounted) {
         setState(() {});
+      }
     };
   }
 
@@ -214,8 +213,7 @@ class FadeAnimation extends StatefulWidget {
   _FadeAnimationState createState() => _FadeAnimationState();
 }
 
-class _FadeAnimationState extends State<FadeAnimation>
-    with SingleTickerProviderStateMixin {
+class _FadeAnimationState extends State<FadeAnimation> with SingleTickerProviderStateMixin {
   AnimationController animationController;
 
   @override
@@ -297,8 +295,7 @@ class _ConnectivityOverlayState extends State<ConnectivityOverlay> {
     final Connectivity connectivity = Connectivity();
     ConnectivityResult previousResult = await connectivity.checkConnectivity();
     yield previousResult;
-    await for (ConnectivityResult result
-        in connectivity.onConnectivityChanged) {
+    await for (ConnectivityResult result in connectivity.onConnectivityChanged) {
       if (result != previousResult) {
         yield result;
         previousResult = result;
@@ -350,13 +347,11 @@ Future<bool> isIOSSimulator() async {
   return Platform.isIOS && !(await deviceInfoPlugin.iosInfo).isPhysicalDevice;
 }
 
-class _VideoDemoState extends State<VideoDemo>
-    with SingleTickerProviderStateMixin {
-  final VideoPlayerController butterflyController =
-      VideoPlayerController.asset(
-        'videos/butterfly.mp4',
-        package: 'flutter_gallery_assets',
-      );
+class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMixin {
+  final VideoPlayerController butterflyController = VideoPlayerController.asset(
+    'videos/butterfly.mp4',
+    package: 'flutter_gallery_assets',
+  );
   final VideoPlayerController beeController = VideoPlayerController.network(
     beeUri,
   );
@@ -375,8 +370,9 @@ class _VideoDemoState extends State<VideoDemo>
       controller.play();
       await connectedCompleter.future;
       await controller.initialize();
-      if (mounted)
+      if (mounted) {
         setState(() {});
+      }
     }
 
     initController(butterflyController);

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -13,7 +13,7 @@ import 'package:device_info/device_info.dart';
 const String beeUri = 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
 
 class VideoCard extends StatelessWidget {
-  const VideoCard({Key key, this.controller, this.title, this.subtitle}) : super(key: key);
+  const VideoCard({ Key key, this.controller, this.title, this.subtitle }) : super(key: key);
 
   final VideoPlayerController controller;
   final String title;
@@ -333,7 +333,7 @@ class _ConnectivityOverlayState extends State<ConnectivityOverlay> {
 }
 
 class VideoDemo extends StatefulWidget {
-  const VideoDemo({Key key}) : super(key: key);
+  const VideoDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/video';
 

--- a/examples/flutter_gallery/lib/gallery/about.dart
+++ b/examples/flutter_gallery/lib/gallery/about.dart
@@ -22,7 +22,7 @@ class _LinkTextSpan extends TextSpan {
   // manage the recognizer from outside the TextSpan, e.g. in the State of a
   // stateful widget that then hands the recognizer to the TextSpan.
 
-  _LinkTextSpan({TextStyle style, String url, String text})
+  _LinkTextSpan({ TextStyle style, String url, String text })
       : super(
          style: style,
          text: text ?? url,

--- a/examples/flutter_gallery/lib/gallery/about.dart
+++ b/examples/flutter_gallery/lib/gallery/about.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class _LinkTextSpan extends TextSpan {
-
   // Beware!
   //
   // This class is only safe because the TapGestureRecognizer is not
@@ -23,13 +22,15 @@ class _LinkTextSpan extends TextSpan {
   // manage the recognizer from outside the TextSpan, e.g. in the State of a
   // stateful widget that then hands the recognizer to the TextSpan.
 
-  _LinkTextSpan({ TextStyle style, String url, String text }) : super(
-    style: style,
-    text: text ?? url,
-    recognizer: TapGestureRecognizer()..onTap = () {
-      launch(url, forceSafariVC: false);
-    }
-  );
+  _LinkTextSpan({TextStyle style, String url, String text})
+      : super(
+         style: style,
+         text: text ?? url,
+         recognizer: TapGestureRecognizer()
+           ..onTap = () {
+             launch(url, forceSafariVC: false);
+           },
+       );
 }
 
 void showGalleryAboutDialog(BuildContext context) {
@@ -51,11 +52,11 @@ void showGalleryAboutDialog(BuildContext context) {
               TextSpan(
                 style: aboutTextStyle,
                 text: 'Flutter is an early-stage, open-source project to help developers '
-                      'build high-performance, high-fidelity, mobile apps for '
-                      '${defaultTargetPlatform == TargetPlatform.iOS ? 'multiple platforms' : 'iOS and Android'} '
-                      'from a single codebase. This gallery is a preview of '
-                      "Flutter's many widgets, behaviors, animations, layouts, "
-                      'and more. Learn more about Flutter at '
+                    'build high-performance, high-fidelity, mobile apps for '
+                    '${defaultTargetPlatform == TargetPlatform.iOS ? 'multiple platforms' : 'iOS and Android'} '
+                    'from a single codebase. This gallery is a preview of '
+                    "Flutter's many widgets, behaviors, animations, layouts, "
+                    'and more. Learn more about Flutter at ',
               ),
               _LinkTextSpan(
                 style: linkStyle,

--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -113,9 +113,10 @@ class _GalleryAppState extends State<GalleryApp> {
       optionsPage: GalleryOptionsPage(
         options: _options,
         onOptionsChanged: _handleOptionsChanged,
-        onSendFeedback: widget.onSendFeedback ?? () {
-          launch('https://github.com/flutter/flutter/issues/new/choose', forceSafariVC: false);
-        },
+        onSendFeedback: widget.onSendFeedback ??
+            () {
+              launch('https://github.com/flutter/flutter/issues/new/choose', forceSafariVC: false);
+            },
       ),
     );
 

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -130,9 +130,9 @@ class _BackAppBar extends StatelessWidget {
     this.leading = const SizedBox(width: 56.0),
     @required this.title,
     this.trailing,
-  })  : assert(leading != null),
-        assert(title != null),
-        super(key: key);
+  }) : assert(leading != null),
+       assert(title != null),
+       super(key: key);
 
   final Widget leading;
   final Widget title;

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -24,7 +24,8 @@ final Animatable<BorderRadius> _kFrontHeadingBevelRadius = BorderRadiusTween(
 );
 
 class _TappableWhileStatusIs extends StatefulWidget {
-  const _TappableWhileStatusIs(this.status, {
+  const _TappableWhileStatusIs(
+    this.status, {
     Key key,
     this.controller,
     this.child,
@@ -129,7 +130,9 @@ class _BackAppBar extends StatelessWidget {
     this.leading = const SizedBox(width: 56.0),
     @required this.title,
     this.trailing,
-  }) : assert(leading != null), assert(title != null), super(key: key);
+  })  : assert(leading != null),
+        assert(title != null),
+        super(key: key);
 
   final Widget leading;
   final Widget title;
@@ -231,16 +234,18 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    if (_controller.isAnimating || _controller.status == AnimationStatus.completed)
+    if (_controller.isAnimating || _controller.status == AnimationStatus.completed) {
       return;
+    }
 
     final double flingVelocity = details.velocity.pixelsPerSecond.dy / _backdropHeight;
-    if (flingVelocity < 0.0)
+    if (flingVelocity < 0.0) {
       _controller.fling(velocity: math.max(2.0, -flingVelocity));
-    else if (flingVelocity > 0.0)
+    } else if (flingVelocity > 0.0) {
       _controller.fling(velocity: math.min(-2.0, -flingVelocity));
-    else
+    } else {
       _controller.fling(velocity: _controller.value < 0.5 ? -2.0 : 2.0);
+    }
   }
 
   void _toggleFrontLayer() {
@@ -282,7 +287,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
               child: widget.backLayer,
               visible: _controller.status != AnimationStatus.completed,
               maintainState: true,
-            )
+            ),
           ),
         ],
       ),

--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -129,7 +129,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
 }
 
 class FullScreenCodeDialog extends StatefulWidget {
-  const FullScreenCodeDialog({this.exampleCodeTag});
+  const FullScreenCodeDialog({ this.exampleCodeTag });
 
   final String exampleCodeTag;
 
@@ -196,7 +196,7 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
 }
 
 class MaterialDemoDocumentationButton extends StatelessWidget {
-  MaterialDemoDocumentationButton(String routeName, {Key key})
+  MaterialDemoDocumentationButton(String routeName, { Key key })
       : documentationUrl = kDemoDocumentationUrl[routeName],
        assert(kDemoDocumentationUrl[routeName] != null,
            'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',),
@@ -215,7 +215,7 @@ class MaterialDemoDocumentationButton extends StatelessWidget {
 }
 
 class CupertinoDemoDocumentationButton extends StatelessWidget {
-  CupertinoDemoDocumentationButton(String routeName, {Key key})
+  CupertinoDemoDocumentationButton(String routeName, { Key key })
       : documentationUrl = kDemoDocumentationUrl[routeName],
        assert(kDemoDocumentationUrl[routeName] != null,
            'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',),

--- a/examples/flutter_gallery/lib/gallery/demo.dart
+++ b/examples/flutter_gallery/lib/gallery/demo.dart
@@ -26,13 +26,14 @@ class ComponentDemoTabData {
   final String documentationUrl;
 
   @override
-  bool operator==(Object other) {
-    if (other.runtimeType != runtimeType)
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
       return false;
+    }
     final ComponentDemoTabData typedOther = other;
-    return typedOther.tabName == tabName
-        && typedOther.description == description
-        && typedOther.documentationUrl == documentationUrl;
+    return typedOther.tabName == tabName &&
+        typedOther.description == description &&
+        typedOther.documentationUrl == documentationUrl;
   }
 
   @override
@@ -53,9 +54,11 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
   void _showExampleCode(BuildContext context) {
     final String tag = demos[DefaultTabController.of(context).index].exampleCodeTag;
     if (tag != null) {
-      Navigator.push(context, MaterialPageRoute<FullScreenCodeDialog>(
-        builder: (BuildContext context) => FullScreenCodeDialog(exampleCodeTag: tag)
-      ));
+      Navigator.push(
+        context,
+        MaterialPageRoute<FullScreenCodeDialog>(
+          builder: (BuildContext context) => FullScreenCodeDialog(exampleCodeTag: tag),
+        ));
     }
   }
 
@@ -73,27 +76,28 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           title: Text(title),
-          actions: (actions ?? <Widget>[])..addAll(
-            <Widget>[
-              Builder(
-                builder: (BuildContext context) {
-                  return IconButton(
-                    icon: const Icon(Icons.library_books, semanticLabel: 'Show documentation'),
-                    onPressed: () => _showApiDocumentation(context),
-                  );
-                },
-              ),
-              Builder(
-                builder: (BuildContext context) {
-                  return IconButton(
-                    icon: const Icon(Icons.code),
-                    tooltip: 'Show example code',
-                    onPressed: () => _showExampleCode(context),
-                  );
-                },
-              )
-            ],
-          ),
+          actions: (actions ?? <Widget>[])
+            ..addAll(
+              <Widget>[
+                Builder(
+                  builder: (BuildContext context) {
+                    return IconButton(
+                      icon: const Icon(Icons.library_books, semanticLabel: 'Show documentation'),
+                      onPressed: () => _showApiDocumentation(context),
+                    );
+                  },
+                ),
+                Builder(
+                  builder: (BuildContext context) {
+                    return IconButton(
+                      icon: const Icon(Icons.code),
+                      tooltip: 'Show example code',
+                      onPressed: () => _showExampleCode(context),
+                    );
+                  },
+                )
+              ],
+            ),
           bottom: TabBar(
             isScrollable: true,
             tabs: demos.map<Widget>((ComponentDemoTabData data) => Tab(text: data.tabName)).toList(),
@@ -108,9 +112,10 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
                 children: <Widget>[
                   Padding(
                     padding: const EdgeInsets.all(16.0),
-                    child: Text(demo.description,
-                      style: Theme.of(context).textTheme.subhead
-                    )
+                    child: Text(
+                      demo.description,
+                      style: Theme.of(context).textTheme.subhead,
+                    ),
                   ),
                   Expanded(child: demo.demoWidget)
                 ],
@@ -124,7 +129,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
 }
 
 class FullScreenCodeDialog extends StatefulWidget {
-  const FullScreenCodeDialog({ this.exampleCodeTag });
+  const FullScreenCodeDialog({this.exampleCodeTag});
 
   final String exampleCodeTag;
 
@@ -133,7 +138,6 @@ class FullScreenCodeDialog extends StatefulWidget {
 }
 
 class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
-
   String _exampleCode;
 
   @override
@@ -151,13 +155,13 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
   @override
   Widget build(BuildContext context) {
     final SyntaxHighlighterStyle style = Theme.of(context).brightness == Brightness.dark
-      ? SyntaxHighlighterStyle.darkThemeStyle()
-      : SyntaxHighlighterStyle.lightThemeStyle();
+        ? SyntaxHighlighterStyle.darkThemeStyle()
+        : SyntaxHighlighterStyle.lightThemeStyle();
 
     Widget body;
     if (_exampleCode == null) {
       body = const Center(
-        child: CircularProgressIndicator()
+        child: CircularProgressIndicator(),
       );
     } else {
       body = SingleChildScrollView(
@@ -166,12 +170,10 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
           child: RichText(
             text: TextSpan(
               style: const TextStyle(fontFamily: 'monospace', fontSize: 10.0),
-              children: <TextSpan>[
-                DartSyntaxHighlighter(style).format(_exampleCode)
-              ]
-            )
-          )
-        )
+              children: <TextSpan>[DartSyntaxHighlighter(style).format(_exampleCode)],
+            ),
+          ),
+        ),
       );
     }
 
@@ -182,23 +184,23 @@ class FullScreenCodeDialogState extends State<FullScreenCodeDialog> {
             Icons.clear,
             semanticLabel: 'Close',
           ),
-          onPressed: () { Navigator.pop(context); }
+          onPressed: () {
+            Navigator.pop(context);
+          },
         ),
-        title: const Text('Example code')
+        title: const Text('Example code'),
       ),
-      body: body
+      body: body,
     );
   }
 }
 
 class MaterialDemoDocumentationButton extends StatelessWidget {
-  MaterialDemoDocumentationButton(String routeName, { Key key })
-    : documentationUrl = kDemoDocumentationUrl[routeName],
-      assert(
-        kDemoDocumentationUrl[routeName] != null,
-        'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',
-      ),
-      super(key: key);
+  MaterialDemoDocumentationButton(String routeName, {Key key})
+      : documentationUrl = kDemoDocumentationUrl[routeName],
+       assert(kDemoDocumentationUrl[routeName] != null,
+           'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',),
+       super(key: key);
 
   final String documentationUrl;
 
@@ -207,19 +209,17 @@ class MaterialDemoDocumentationButton extends StatelessWidget {
     return IconButton(
       icon: const Icon(Icons.library_books),
       tooltip: 'API documentation',
-      onPressed: () => launch(documentationUrl, forceWebView: true)
+      onPressed: () => launch(documentationUrl, forceWebView: true),
     );
   }
 }
 
 class CupertinoDemoDocumentationButton extends StatelessWidget {
-  CupertinoDemoDocumentationButton(String routeName, { Key key })
-    : documentationUrl = kDemoDocumentationUrl[routeName],
-      assert(
-        kDemoDocumentationUrl[routeName] != null,
-        'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',
-      ),
-      super(key: key);
+  CupertinoDemoDocumentationButton(String routeName, {Key key})
+      : documentationUrl = kDemoDocumentationUrl[routeName],
+       assert(kDemoDocumentationUrl[routeName] != null,
+           'A documentation URL was not specified for demo route $routeName in kAllGalleryDemos',),
+       super(key: key);
 
   final String documentationUrl;
 
@@ -231,7 +231,7 @@ class CupertinoDemoDocumentationButton extends StatelessWidget {
         label: 'API documentation',
         child: const Icon(CupertinoIcons.book),
       ),
-      onPressed: () => launch(documentationUrl, forceWebView: true)
+      onPressed: () => launch(documentationUrl, forceWebView: true),
     );
   }
 }

--- a/examples/flutter_gallery/lib/gallery/demos.dart
+++ b/examples/flutter_gallery/lib/gallery/demos.dart
@@ -8,16 +8,20 @@ import '../demo/all.dart';
 import 'icons.dart';
 
 class GalleryDemoCategory {
-  const GalleryDemoCategory._({ this.name, this.icon });
-  @required final String name;
-  @required final IconData icon;
+  const GalleryDemoCategory._({this.name, this.icon});
+  @required
+  final String name;
+  @required
+  final IconData icon;
 
   @override
   bool operator ==(dynamic other) {
-    if (identical(this, other))
+    if (identical(this, other)) {
       return true;
-    if (runtimeType != other.runtimeType)
+    }
+    if (runtimeType != other.runtimeType) {
       return false;
+    }
     final GalleryDemoCategory typedOther = other;
     return typedOther.name == name && typedOther.icon == icon;
   }
@@ -65,10 +69,10 @@ class GalleryDemo {
     @required this.routeName,
     this.documentationUrl,
     @required this.buildRoute,
-  }) : assert(title != null),
-       assert(category != null),
-       assert(routeName != null),
-       assert(buildRoute != null);
+  })  : assert(title != null),
+        assert(category != null),
+        assert(routeName != null),
+        assert(buildRoute != null);
 
   final String title;
   final IconData icon;
@@ -530,7 +534,8 @@ List<GalleryDemo> _buildGalleryDemos() {
   // Keep Pesto around for its regression test value. It is not included
   // in (release builds) the performance tests.
   assert(() {
-    galleryDemos.insert(0,
+    galleryDemos.insert(
+      0,
       GalleryDemo(
         title: 'Pesto',
         subtitle: 'Simple recipe browser',
@@ -549,19 +554,18 @@ List<GalleryDemo> _buildGalleryDemos() {
 final List<GalleryDemo> kAllGalleryDemos = _buildGalleryDemos();
 
 final Set<GalleryDemoCategory> kAllGalleryDemoCategories =
-  kAllGalleryDemos.map<GalleryDemoCategory>((GalleryDemo demo) => demo.category).toSet();
+    kAllGalleryDemos.map<GalleryDemoCategory>((GalleryDemo demo) => demo.category).toSet();
 
 final Map<GalleryDemoCategory, List<GalleryDemo>> kGalleryCategoryToDemos =
-  Map<GalleryDemoCategory, List<GalleryDemo>>.fromIterable(
-    kAllGalleryDemoCategories,
-    value: (dynamic category) {
-      return kAllGalleryDemos.where((GalleryDemo demo) => demo.category == category).toList();
-    },
-  );
+    Map<GalleryDemoCategory, List<GalleryDemo>>.fromIterable(
+  kAllGalleryDemoCategories,
+  value: (dynamic category) {
+    return kAllGalleryDemos.where((GalleryDemo demo) => demo.category == category).toList();
+  },
+);
 
-final Map<String, String> kDemoDocumentationUrl =
-    Map<String, String>.fromIterable(
-      kAllGalleryDemos.where((GalleryDemo demo) => demo.documentationUrl != null),
-      key: (dynamic demo) => demo.routeName,
-      value: (dynamic demo) => demo.documentationUrl,
-    );
+final Map<String, String> kDemoDocumentationUrl = Map<String, String>.fromIterable(
+  kAllGalleryDemos.where((GalleryDemo demo) => demo.documentationUrl != null),
+  key: (dynamic demo) => demo.routeName,
+  value: (dynamic demo) => demo.documentationUrl,
+);

--- a/examples/flutter_gallery/lib/gallery/demos.dart
+++ b/examples/flutter_gallery/lib/gallery/demos.dart
@@ -553,8 +553,9 @@ List<GalleryDemo> _buildGalleryDemos() {
 
 final List<GalleryDemo> kAllGalleryDemos = _buildGalleryDemos();
 
-final Set<GalleryDemoCategory> kAllGalleryDemoCategories =
-    kAllGalleryDemos.map<GalleryDemoCategory>((GalleryDemo demo) => demo.category).toSet();
+final Set<GalleryDemoCategory> kAllGalleryDemoCategories = kAllGalleryDemos
+  .map<GalleryDemoCategory>((GalleryDemo demo) => demo.category)
+  .toSet();
 
 final Map<GalleryDemoCategory, List<GalleryDemo>> kGalleryCategoryToDemos =
     Map<GalleryDemoCategory, List<GalleryDemo>>.fromIterable(

--- a/examples/flutter_gallery/lib/gallery/demos.dart
+++ b/examples/flutter_gallery/lib/gallery/demos.dart
@@ -69,10 +69,10 @@ class GalleryDemo {
     @required this.routeName,
     this.documentationUrl,
     @required this.buildRoute,
-  })  : assert(title != null),
-        assert(category != null),
-        assert(routeName != null),
-        assert(buildRoute != null);
+  }) : assert(title != null),
+       assert(category != null),
+       assert(routeName != null),
+       assert(buildRoute != null);
 
   final String title;
   final IconData icon;

--- a/examples/flutter_gallery/lib/gallery/demos.dart
+++ b/examples/flutter_gallery/lib/gallery/demos.dart
@@ -8,7 +8,7 @@ import '../demo/all.dart';
 import 'icons.dart';
 
 class GalleryDemoCategory {
-  const GalleryDemoCategory._({this.name, this.icon});
+  const GalleryDemoCategory._({ this.name, this.icon });
   @required
   final String name;
   @required

--- a/examples/flutter_gallery/lib/gallery/example_code.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code.dart
@@ -8,279 +8,267 @@
 import 'package:flutter/material.dart';
 
 class ButtonsDemo {
-  void setState(VoidCallback callback) { }
+  void setState(VoidCallback callback) {}
   BuildContext context;
 
   void buttons() {
-
 // START buttons_raised
 // Create a raised button.
-RaisedButton(
-  child: const Text('BUTTON TITLE'),
-  onPressed: () {
-    // Perform some action
-  }
-);
+    RaisedButton(
+      child: const Text('BUTTON TITLE'),
+      onPressed: () {
+        // Perform some action
+      },
+    );
 
 // Create a disabled button.
 // Buttons are disabled when onPressed isn't
 // specified or is null.
-const RaisedButton(
-  child: Text('BUTTON TITLE'),
-  onPressed: null
-);
+    const RaisedButton(
+      child: Text('BUTTON TITLE'),
+      onPressed: null,
+    );
 
 // Create a button with an icon and a
 // title.
-RaisedButton.icon(
-  icon: const Icon(Icons.add, size: 18.0),
-  label: const Text('BUTTON TITLE'),
-  onPressed: () {
-    // Perform some action
-  },
-);
+    RaisedButton.icon(
+      icon: const Icon(Icons.add, size: 18.0),
+      label: const Text('BUTTON TITLE'),
+      onPressed: () {
+        // Perform some action
+      },
+    );
 // END
 
 // START buttons_outline
 // Create an outline button.
-OutlineButton(
-  child: const Text('BUTTON TITLE'),
-  onPressed: () {
-    // Perform some action
-  }
-);
+    OutlineButton(
+      child: const Text('BUTTON TITLE'),
+      onPressed: () {
+        // Perform some action
+      },
+    );
 
 // Create a disabled button.
 // Buttons are disabled when onPressed isn't
 // specified or is null.
-const OutlineButton(
-  child: Text('BUTTON TITLE'),
-  onPressed: null
-);
+    const OutlineButton(
+      child: Text('BUTTON TITLE'),
+      onPressed: null,
+    );
 
 // Create a button with an icon and a
 // title.
-OutlineButton.icon(
-  icon: const Icon(Icons.add, size: 18.0),
-  label: const Text('BUTTON TITLE'),
-  onPressed: () {
-    // Perform some action
-  },
-);
+    OutlineButton.icon(
+      icon: const Icon(Icons.add, size: 18.0),
+      label: const Text('BUTTON TITLE'),
+      onPressed: () {
+        // Perform some action
+      },
+    );
 // END
 
 // START buttons_flat
 // Create a flat button.
-FlatButton(
-  child: const Text('BUTTON TITLE'),
-  onPressed: () {
-    // Perform some action
-  }
-);
+    FlatButton(
+      child: const Text('BUTTON TITLE'),
+      onPressed: () {
+        // Perform some action
+      },
+    );
 
 // Create a disabled button.
 // Buttons are disabled when onPressed isn't
 // specified or is null.
-const FlatButton(
-  child: Text('BUTTON TITLE'),
-  onPressed: null
-);
+    const FlatButton(
+      child: Text('BUTTON TITLE'),
+      onPressed: null,
+    );
 // END
-
 
 // START buttons_dropdown
 // Member variable holding value.
-String dropdownValue;
+    String dropdownValue;
 
 // Dropdown button with string values.
-DropdownButton<String>(
-  value: dropdownValue,
-  onChanged: (String newValue) {
-    // null indicates the user didn't select a
-    // new value.
-    setState(() {
-      if (newValue != null)
-        dropdownValue = newValue;
-    });
-  },
-  items: <String>['One', 'Two', 'Free', 'Four']
-    .map<DropdownMenuItem<String>>((String value) {
-      return DropdownMenuItem<String>(
-        value: value,
-        child: Text(value));
-    })
-    .toList()
-);
+    DropdownButton<String>(
+      value: dropdownValue,
+      onChanged: (String newValue) {
+        // null indicates the user didn't select a
+        // new value.
+        setState(() {
+          if (newValue != null) {
+            dropdownValue = newValue;
+          }
+        });
+      },
+      items: <String>['One', 'Two', 'Free', 'Four'].map<DropdownMenuItem<String>>((String value) {
+        return DropdownMenuItem<String>(value: value, child: Text(value));
+      }).toList(),
+    );
 // END
-
 
 // START buttons_icon
 // Member variable holding toggle value.
-bool value;
+    bool value;
 
 // Toggleable icon button.
-IconButton(
-  icon: const Icon(Icons.thumb_up),
-  onPressed: () {
-    setState(() => value = !value);
-  },
-  color: value ? Theme.of(context).primaryColor : null
-);
+    IconButton(
+      icon: const Icon(Icons.thumb_up),
+      onPressed: () {
+        setState(() => value = !value);
+      },
+      color: value ? Theme.of(context).primaryColor : null,
+    );
 // END
-
 
 // START buttons_action
 // Floating action button in Scaffold.
-Scaffold(
-  appBar: AppBar(
-    title: const Text('Demo')
-  ),
-  floatingActionButton: const FloatingActionButton(
-    child: Icon(Icons.add),
-    onPressed: null
-  )
-);
+    Scaffold(
+      appBar: AppBar(
+        title: const Text('Demo'),
+      ),
+      floatingActionButton: const FloatingActionButton(
+        child: Icon(Icons.add),
+        onPressed: null,
+      ),
+    );
 // END
   }
 }
 
-
 class SelectionControls {
-  void setState(VoidCallback callback) { }
+  void setState(VoidCallback callback) {}
 
   void selectionControls() {
-
 // START selectioncontrols_checkbox
 // Member variable holding the checkbox's value.
-bool checkboxValue = false;
+    bool checkboxValue = false;
 
 // Create a checkbox.
-Checkbox(
-  value: checkboxValue,
-  onChanged: (bool value) {
-    setState(() {
-      checkboxValue = value;
-    });
-  },
-);
+    Checkbox(
+      value: checkboxValue,
+      onChanged: (bool value) {
+        setState(() {
+          checkboxValue = value;
+        });
+      },
+    );
 
 // Create a tristate checkbox.
-Checkbox(
-  tristate: true,
-  value: checkboxValue,
-  onChanged: (bool value) {
-    setState(() {
-      checkboxValue = value;
-    });
-  },
-);
+    Checkbox(
+      tristate: true,
+      value: checkboxValue,
+      onChanged: (bool value) {
+        setState(() {
+          checkboxValue = value;
+        });
+      },
+    );
 
 // Create a disabled checkbox.
 // Checkboxes are disabled when onChanged isn't
 // specified or null.
-const Checkbox(value: false, onChanged: null);
+    const Checkbox(value: false, onChanged: null);
 // END
-
 
 // START selectioncontrols_radio
 // Member variable holding value.
-int radioValue = 0;
+    int radioValue = 0;
 
 // Method setting value.
-void handleRadioValueChanged(int value) {
-  setState(() {
-    radioValue = value;
-  });
-}
+    void handleRadioValueChanged(int value) {
+      setState(() {
+        radioValue = value;
+      });
+    }
 
 // Creates a set of radio buttons.
-Row(
-  children: <Widget>[
-    Radio<int>(
-      value: 0,
-      groupValue: radioValue,
-      onChanged: handleRadioValueChanged
-    ),
-    Radio<int>(
-      value: 1,
-      groupValue: radioValue,
-      onChanged: handleRadioValueChanged
-    ),
-    Radio<int>(
-      value: 2,
-      groupValue: radioValue,
-      onChanged: handleRadioValueChanged
-    )
-  ]
-);
+    Row(
+      children: <Widget>[
+        Radio<int>(
+          value: 0,
+          groupValue: radioValue,
+          onChanged: handleRadioValueChanged,
+        ),
+        Radio<int>(
+          value: 1,
+          groupValue: radioValue,
+          onChanged: handleRadioValueChanged,
+        ),
+        Radio<int>(
+          value: 2,
+          groupValue: radioValue,
+          onChanged: handleRadioValueChanged,
+        )
+      ],
+    );
 
 // Creates a disabled radio button.
-const Radio<int>(
-  value: 0,
-  groupValue: 0,
-  onChanged: null
-);
+    const Radio<int>(
+      value: 0,
+      groupValue: 0,
+      onChanged: null,
+    );
 // END
-
 
 // START selectioncontrols_switch
 // Member variable holding value.
-bool switchValue = false;
+    bool switchValue = false;
 
 // Create a switch.
-Switch(
-  value: switchValue,
-  onChanged: (bool value) {
-    setState(() {
-      switchValue = value;
-    }
-  );
-});
+    Switch(
+      value: switchValue,
+      onChanged: (bool value) {
+        setState(
+          () {
+            switchValue = value;
+          },
+        );
+      });
 
 // Create a disabled switch.
 // Switches are disabled when onChanged isn't
 // specified or null.
-const Switch(value: false, onChanged: null);
+    const Switch(value: false, onChanged: null);
 // END
   }
 }
-
 
 class GridLists {
   void gridlists() {
 // START gridlists
 // Creates a scrollable grid list with images
 // loaded from the web.
-GridView.count(
-  crossAxisCount: 3,
-  childAspectRatio: 1.0,
-  padding: const EdgeInsets.all(4.0),
-  mainAxisSpacing: 4.0,
-  crossAxisSpacing: 4.0,
-  children: <String>[
-    'https://example.com/image-0.jpg',
-    'https://example.com/image-1.jpg',
-    'https://example.com/image-2.jpg',
-    '...',
-    'https://example.com/image-n.jpg'
-  ].map<Widget>((String url) {
-    return GridTile(
-      footer: GridTileBar(
-        title: Text(url)
-      ),
-      child: Image.network(url, fit: BoxFit.cover)
+    GridView.count(
+      crossAxisCount: 3,
+      childAspectRatio: 1.0,
+      padding: const EdgeInsets.all(4.0),
+      mainAxisSpacing: 4.0,
+      crossAxisSpacing: 4.0,
+      children: <String>[
+        'https://example.com/image-0.jpg',
+        'https://example.com/image-1.jpg',
+        'https://example.com/image-2.jpg',
+        '...',
+        'https://example.com/image-n.jpg'
+      ].map<Widget>((String url) {
+        return GridTile(
+          footer: GridTileBar(
+            title: Text(url),
+          ),
+          child: Image.network(url, fit: BoxFit.cover),
+        );
+      }).toList(),
     );
-  }).toList(),
-);
 // END
   }
 }
 
-
 class AnimatedImage {
   void animatedImage() {
 // START animated_image
-Image.network('https://example.com/animated-image.gif');
+    Image.network('https://example.com/animated-image.gif');
 // END
   }
 }

--- a/examples/flutter_gallery/lib/gallery/example_code_parser.dart
+++ b/examples/flutter_gallery/lib/gallery/example_code_parser.dart
@@ -12,14 +12,15 @@ const String _kEndTag = '// END';
 Map<String, String> _exampleCode;
 
 Future<String> getExampleCode(String tag, AssetBundle bundle) async {
-  if (_exampleCode == null)
+  if (_exampleCode == null) {
     await _parseExampleCode(bundle);
+  }
   return _exampleCode[tag];
 }
 
 Future<void> _parseExampleCode(AssetBundle bundle) async {
   final String code = await bundle.loadString('lib/gallery/example_code.dart') ??
-    '// lib/gallery/example_code.dart not found\n';
+      '// lib/gallery/example_code.dart not found\n';
   _exampleCode = <String, String>{};
 
   final List<String> lines = code.split('\n');

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -18,7 +18,7 @@ const double _kDemoItemHeight = 64.0;
 const Duration _kFrontLayerSwitchDuration = Duration(milliseconds: 300);
 
 class _FlutterLogo extends StatelessWidget {
-  const _FlutterLogo({Key key}) : super(key: key);
+  const _FlutterLogo({ Key key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -163,7 +163,7 @@ class _CategoriesPage extends StatelessWidget {
 }
 
 class _DemoItem extends StatelessWidget {
-  const _DemoItem({Key key, this.demo}) : super(key: key);
+  const _DemoItem({ Key key, this.demo }) : super(key: key);
 
   final GalleryDemo demo;
 

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -18,7 +18,7 @@ const double _kDemoItemHeight = 64.0;
 const Duration _kFrontLayerSwitchDuration = Duration(milliseconds: 300);
 
 class _FlutterLogo extends StatelessWidget {
-  const _FlutterLogo({ Key key }) : super(key: key);
+  const _FlutterLogo({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +44,7 @@ class _CategoryItem extends StatelessWidget {
     Key key,
     this.category,
     this.onTap,
-  }) : super (key: key);
+  }) : super(key: key);
 
   final GalleryDemoCategory category;
   final VoidCallback onTap;
@@ -132,8 +132,8 @@ class _CategoriesPage extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: List<Widget>.generate(rowCount, (int rowIndex) {
                   final int columnCountForRow = rowIndex == rowCount - 1
-                    ? categories.length - columnCount * math.max(0, rowCount - 1)
-                    : columnCount;
+                      ? categories.length - columnCount * math.max(0, rowCount - 1)
+                      : columnCount;
 
                   return Row(
                     children: List<Widget>.generate(columnCountForRow, (int columnIndex) {
@@ -163,7 +163,7 @@ class _CategoriesPage extends StatelessWidget {
 }
 
 class _DemoItem extends StatelessWidget {
-  const _DemoItem({ Key key, this.demo }) : super(key: key);
+  const _DemoItem({Key key, this.demo}) : super(key: key);
 
   final GalleryDemo demo;
 
@@ -196,7 +196,7 @@ class _DemoItem extends StatelessWidget {
         Text(
           demo.subtitle,
           style: theme.textTheme.body1.copyWith(
-            color: isDark ? Colors.white : const Color(0xFF60646B)
+            color: isDark ? Colors.white : const Color(0xFF60646B),
           ),
         ),
       );
@@ -292,8 +292,9 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
 
   static Widget _topHomeLayout(Widget currentChild, List<Widget> previousChildren) {
     List<Widget> children = previousChildren;
-    if (currentChild != null)
+    if (currentChild != null) {
       children = children.toList()..add(currentChild);
+    }
     return Stack(
       children: children,
       alignment: Alignment.topCenter,
@@ -350,18 +351,16 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
               switchOutCurve: switchOutCurve,
               switchInCurve: switchInCurve,
               child: _category == null
-                ? const _FlutterLogo()
-                : IconButton(
-                  icon: const BackButtonIcon(),
-                  tooltip: 'Back',
-                  onPressed: () => setState(() => _category = null),
-                ),
+                  ? const _FlutterLogo()
+                  : IconButton(
+                      icon: const BackButtonIcon(),
+                      tooltip: 'Back',
+                      onPressed: () => setState(() => _category = null),
+                    ),
             ),
             frontTitle: AnimatedSwitcher(
               duration: _kFrontLayerSwitchDuration,
-              child: _category == null
-                ? const Text('Flutter gallery')
-                : Text(_category.name),
+              child: _category == null ? const Text('Flutter gallery') : Text(_category.name),
             ),
             frontHeading: widget.testMode ? null : Container(height: 24.0),
             frontLayer: AnimatedSwitcher(
@@ -370,13 +369,13 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
               switchInCurve: switchInCurve,
               layoutBuilder: centerHome ? _centerHomeLayout : _topHomeLayout,
               child: _category != null
-                ? _DemosPage(_category)
-                : _CategoriesPage(
-                  categories: kAllGalleryDemoCategories,
-                  onCategoryTap: (GalleryDemoCategory category) {
-                    setState(() => _category = category);
-                  },
-                ),
+                  ? _DemosPage(_category)
+                  : _CategoriesPage(
+                      categories: kAllGalleryDemoCategories,
+                      onCategoryTap: (GalleryDemoCategory category) {
+                        setState(() => _category = category);
+                      },
+                    ),
             ),
           ),
         ),
@@ -398,14 +397,14 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
             child: const Banner(
               message: 'PREVIEW',
               location: BannerLocation.topEnd,
-            )
+            ),
           ),
-        ]
+        ],
       );
     }
     home = AnnotatedRegion<SystemUiOverlayStyle>(
       child: home,
-      value: SystemUiOverlayStyle.light
+      value: SystemUiOverlayStyle.light,
     );
 
     return home;

--- a/examples/flutter_gallery/lib/gallery/options.dart
+++ b/examples/flutter_gallery/lib/gallery/options.dart
@@ -70,15 +70,15 @@ class GalleryOptions {
 
   @override
   int get hashCode => hashValues(
-        theme,
-        textScaleFactor,
-        textDirection,
-        timeDilation,
-        platform,
-        showPerformanceOverlay,
-        showRasterCacheImagesCheckerboard,
-        showOffscreenLayersCheckerboard,
-      );
+    theme,
+    textScaleFactor,
+    textDirection,
+    timeDilation,
+    platform,
+    showPerformanceOverlay,
+    showRasterCacheImagesCheckerboard,
+    showOffscreenLayersCheckerboard,
+  );
 
   @override
   String toString() {

--- a/examples/flutter_gallery/lib/gallery/options.dart
+++ b/examples/flutter_gallery/lib/gallery/options.dart
@@ -90,7 +90,7 @@ const double _kItemHeight = 48.0;
 const EdgeInsetsDirectional _kItemPadding = EdgeInsetsDirectional.only(start: 56.0);
 
 class _OptionsItem extends StatelessWidget {
-  const _OptionsItem({Key key, this.child}) : super(key: key);
+  const _OptionsItem({ Key key, this.child }) : super(key: key);
 
   final Widget child;
 
@@ -118,7 +118,7 @@ class _OptionsItem extends StatelessWidget {
 }
 
 class _BooleanItem extends StatelessWidget {
-  const _BooleanItem(this.title, this.value, this.onChanged, {this.switchKey});
+  const _BooleanItem(this.title, this.value, this.onChanged, { this.switchKey });
 
   final String title;
   final bool value;
@@ -164,7 +164,7 @@ class _ActionItem extends StatelessWidget {
 }
 
 class _FlatButton extends StatelessWidget {
-  const _FlatButton({Key key, this.onPressed, this.child}) : super(key: key);
+  const _FlatButton({ Key key, this.onPressed, this.child }) : super(key: key);
 
   final VoidCallback onPressed;
   final Widget child;

--- a/examples/flutter_gallery/lib/gallery/options.dart
+++ b/examples/flutter_gallery/lib/gallery/options.dart
@@ -46,36 +46,39 @@ class GalleryOptions {
       timeDilation: timeDilation ?? this.timeDilation,
       platform: platform ?? this.platform,
       showPerformanceOverlay: showPerformanceOverlay ?? this.showPerformanceOverlay,
-      showOffscreenLayersCheckerboard: showOffscreenLayersCheckerboard ?? this.showOffscreenLayersCheckerboard,
-      showRasterCacheImagesCheckerboard: showRasterCacheImagesCheckerboard ?? this.showRasterCacheImagesCheckerboard,
+      showOffscreenLayersCheckerboard:
+          showOffscreenLayersCheckerboard ?? this.showOffscreenLayersCheckerboard,
+      showRasterCacheImagesCheckerboard:
+          showRasterCacheImagesCheckerboard ?? this.showRasterCacheImagesCheckerboard,
     );
   }
 
   @override
   bool operator ==(dynamic other) {
-    if (runtimeType != other.runtimeType)
+    if (runtimeType != other.runtimeType) {
       return false;
+    }
     final GalleryOptions typedOther = other;
-    return theme == typedOther.theme
-        && textScaleFactor == typedOther.textScaleFactor
-        && textDirection == typedOther.textDirection
-        && platform == typedOther.platform
-        && showPerformanceOverlay == typedOther.showPerformanceOverlay
-        && showRasterCacheImagesCheckerboard == typedOther.showRasterCacheImagesCheckerboard
-        && showOffscreenLayersCheckerboard == typedOther.showRasterCacheImagesCheckerboard;
+    return theme == typedOther.theme &&
+        textScaleFactor == typedOther.textScaleFactor &&
+        textDirection == typedOther.textDirection &&
+        platform == typedOther.platform &&
+        showPerformanceOverlay == typedOther.showPerformanceOverlay &&
+        showRasterCacheImagesCheckerboard == typedOther.showRasterCacheImagesCheckerboard &&
+        showOffscreenLayersCheckerboard == typedOther.showRasterCacheImagesCheckerboard;
   }
 
   @override
   int get hashCode => hashValues(
-    theme,
-    textScaleFactor,
-    textDirection,
-    timeDilation,
-    platform,
-    showPerformanceOverlay,
-    showRasterCacheImagesCheckerboard,
-    showOffscreenLayersCheckerboard,
-  );
+        theme,
+        textScaleFactor,
+        textDirection,
+        timeDilation,
+        platform,
+        showPerformanceOverlay,
+        showRasterCacheImagesCheckerboard,
+        showOffscreenLayersCheckerboard,
+      );
 
   @override
   String toString() {
@@ -87,7 +90,7 @@ const double _kItemHeight = 48.0;
 const EdgeInsetsDirectional _kItemPadding = EdgeInsetsDirectional.only(start: 56.0);
 
 class _OptionsItem extends StatelessWidget {
-  const _OptionsItem({ Key key, this.child }) : super(key: key);
+  const _OptionsItem({Key key, this.child}) : super(key: key);
 
   final Widget child;
 
@@ -115,7 +118,7 @@ class _OptionsItem extends StatelessWidget {
 }
 
 class _BooleanItem extends StatelessWidget {
-  const _BooleanItem(this.title, this.value, this.onChanged, { this.switchKey });
+  const _BooleanItem(this.title, this.value, this.onChanged, {this.switchKey});
 
   final String title;
   final bool value;
@@ -161,7 +164,7 @@ class _ActionItem extends StatelessWidget {
 }
 
 class _FlatButton extends StatelessWidget {
-  const _FlatButton({ Key key, this.onPressed, this.child }) : super(key: key);
+  const _FlatButton({Key key, this.onPressed, this.child}) : super(key: key);
 
   final VoidCallback onPressed;
   final Widget child;
@@ -252,7 +255,8 @@ class _TextScaleFactorItem extends StatelessWidget {
             padding: const EdgeInsetsDirectional.only(end: 16.0),
             icon: const Icon(Icons.arrow_drop_down),
             itemBuilder: (BuildContext context) {
-              return kAllGalleryTextScaleValues.map<PopupMenuItem<GalleryTextScaleValue>>((GalleryTextScaleValue scaleValue) {
+              return kAllGalleryTextScaleValues
+                .map<PopupMenuItem<GalleryTextScaleValue>>((GalleryTextScaleValue scaleValue) {
                 return PopupMenuItem<GalleryTextScaleValue>(
                   value: scaleValue,
                   child: Text(scaleValue.label),
@@ -324,7 +328,7 @@ class _PlatformItem extends StatelessWidget {
   final ValueChanged<GalleryOptions> onOptionsChanged;
 
   String _platformLabel(TargetPlatform platform) {
-    switch(platform) {
+    switch (platform) {
       case TargetPlatform.android:
         return 'Mountain View';
       case TargetPlatform.fuchsia:
@@ -346,10 +350,10 @@ class _PlatformItem extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 const Text('Platform mechanics'),
-                 Text(
-                   '${_platformLabel(options.platform)}',
-                   style: Theme.of(context).primaryTextTheme.body1,
-                 ),
+                Text(
+                  '${_platformLabel(options.platform)}',
+                  style: Theme.of(context).primaryTextTheme.body1,
+                ),
               ],
             ),
           ),
@@ -391,10 +395,11 @@ class GalleryOptionsPage extends StatelessWidget {
   List<Widget> _enabledDiagnosticItems() {
     // Boolean showFoo options with a value of null: don't display
     // the showFoo option at all.
-    if (null == options.showOffscreenLayersCheckerboard
-             ?? options.showRasterCacheImagesCheckerboard
-             ?? options.showPerformanceOverlay)
+    if (null == options.showOffscreenLayersCheckerboard ??
+        options.showRasterCacheImagesCheckerboard ??
+        options.showPerformanceOverlay) {
       return const <Widget>[];
+    }
 
     final List<Widget> items = <Widget>[
       const Divider(),
@@ -408,7 +413,7 @@ class GalleryOptionsPage extends StatelessWidget {
           options.showOffscreenLayersCheckerboard,
           (bool value) {
             onOptionsChanged(options.copyWith(showOffscreenLayersCheckerboard: value));
-          }
+          },
         ),
       );
     }
@@ -455,18 +460,20 @@ class GalleryOptionsPage extends StatelessWidget {
           const Divider(),
           const _Heading('Platform mechanics'),
           _PlatformItem(options, onOptionsChanged),
-        ]..addAll(
-          _enabledDiagnosticItems(),
-        )..addAll(
-          <Widget>[
-            const Divider(),
-            const _Heading('Flutter gallery'),
-            _ActionItem('About Flutter Gallery', () {
-              showGalleryAboutDialog(context);
-            }),
-            _ActionItem('Send feedback', onSendFeedback),
-          ],
-        ),
+        ]
+          ..addAll(
+            _enabledDiagnosticItems(),
+          )
+          ..addAll(
+            <Widget>[
+              const Divider(),
+              const _Heading('Flutter gallery'),
+              _ActionItem('About Flutter Gallery', () {
+                showGalleryAboutDialog(context);
+              }),
+              _ActionItem('Send feedback', onSendFeedback),
+            ],
+          ),
       ),
     );
   }

--- a/examples/flutter_gallery/lib/gallery/scales.dart
+++ b/examples/flutter_gallery/lib/gallery/scales.dart
@@ -12,8 +12,9 @@ class GalleryTextScaleValue {
 
   @override
   bool operator ==(dynamic other) {
-    if (runtimeType != other.runtimeType)
+    if (runtimeType != other.runtimeType) {
       return false;
+    }
     final GalleryTextScaleValue typedOther = other;
     return scale == typedOther.scale && label == typedOther.label;
   }
@@ -25,7 +26,6 @@ class GalleryTextScaleValue {
   String toString() {
     return '$runtimeType($label)';
   }
-
 }
 
 const List<GalleryTextScaleValue> kAllGalleryTextScaleValues = <GalleryTextScaleValue>[

--- a/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
+++ b/examples/flutter_gallery/lib/gallery/syntax_highlighter.dart
@@ -14,7 +14,7 @@ class SyntaxHighlighterStyle {
     this.stringStyle,
     this.punctuationStyle,
     this.classStyle,
-    this.constantStyle
+    this.constantStyle,
   });
 
   static SyntaxHighlighterStyle lightThemeStyle() {
@@ -26,7 +26,7 @@ class SyntaxHighlighterStyle {
       stringStyle: const TextStyle(color: Color(0xFF43A047)),
       punctuationStyle: const TextStyle(color: Color(0xFF000000)),
       classStyle: const TextStyle(color: Color(0xFF512DA8)),
-      constantStyle: const TextStyle(color: Color(0xFF795548))
+      constantStyle: const TextStyle(color: Color(0xFF795548)),
     );
   }
 
@@ -39,7 +39,7 @@ class SyntaxHighlighterStyle {
       stringStyle: const TextStyle(color: Color(0xFF009688)),
       punctuationStyle: const TextStyle(color: Color(0xFFFFFFFF)),
       classStyle: const TextStyle(color: Color(0xFF009688)),
-      constantStyle: const TextStyle(color: Color(0xFF795548))
+      constantStyle: const TextStyle(color: Color(0xFF795548)),
     );
   }
 
@@ -53,7 +53,8 @@ class SyntaxHighlighterStyle {
   final TextStyle constantStyle;
 }
 
-abstract class SyntaxHighlighter { // ignore: one_member_abstracts
+abstract class SyntaxHighlighter {
+  // ignore: one_member_abstracts
   TextSpan format(String src);
 }
 
@@ -66,18 +67,62 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
   SyntaxHighlighterStyle _style;
 
   static const List<String> _keywords = <String>[
-    'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
-    'class', 'const', 'continue', 'default', 'deferred', 'do', 'dynamic', 'else',
-    'enum', 'export', 'external', 'extends', 'factory', 'false', 'final',
-    'finally', 'for', 'get', 'if', 'implements', 'import', 'in', 'is', 'library',
-    'new', 'null', 'operator', 'part', 'rethrow', 'return', 'set', 'static',
-    'super', 'switch', 'sync', 'this', 'throw', 'true', 'try', 'typedef', 'var',
-    'void', 'while', 'with', 'yield'
+    'abstract',
+    'as',
+    'assert',
+    'async',
+    'await',
+    'break',
+    'case',
+    'catch',
+    'class',
+    'const',
+    'continue',
+    'default',
+    'deferred',
+    'do',
+    'dynamic',
+    'else',
+    'enum',
+    'export',
+    'external',
+    'extends',
+    'factory',
+    'false',
+    'final',
+    'finally',
+    'for',
+    'get',
+    'if',
+    'implements',
+    'import',
+    'in',
+    'is',
+    'library',
+    'new',
+    'null',
+    'operator',
+    'part',
+    'rethrow',
+    'return',
+    'set',
+    'static',
+    'super',
+    'switch',
+    'sync',
+    'this',
+    'throw',
+    'true',
+    'try',
+    'typedef',
+    'var',
+    'void',
+    'while',
+    'with',
+    'yield'
   ];
 
-  static const List<String> _builtInTypes = <String>[
-    'int', 'double', 'num', 'bool'
-  ];
+  static const List<String> _builtInTypes = <String>['int', 'double', 'num', 'bool'];
 
   String _src;
   StringScanner _scanner;
@@ -95,16 +140,18 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
       int currentPosition = 0;
 
       for (_HighlightSpan span in _spans) {
-        if (currentPosition != span.start)
+        if (currentPosition != span.start) {
           formattedText.add(TextSpan(text: _src.substring(currentPosition, span.start)));
+        }
 
         formattedText.add(TextSpan(style: span.textStyle(_style), text: span.textForSpan(_src)));
 
         currentPosition = span.end;
       }
 
-      if (currentPosition != _src.length)
+      if (currentPosition != _src.length) {
         formattedText.add(TextSpan(text: _src.substring(currentPosition, _src.length)));
+      }
 
       return TextSpan(style: _style.baseStyle, children: formattedText);
     } else {
@@ -125,7 +172,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.comment,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -146,11 +193,12 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.comment,
           startComment,
-          endComment
+          endComment,
         ));
 
-        if (eof)
+        if (eof) {
           break;
+        }
 
         continue;
       }
@@ -160,7 +208,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -170,7 +218,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -180,7 +228,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -190,7 +238,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -200,7 +248,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -210,7 +258,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.string,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -220,17 +268,15 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.number,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
 
       // Integer
       if (_scanner.scan(RegExp(r'\d+'))) {
-        _spans.add(_HighlightSpan(
-          _HighlightType.number,
-          _scanner.lastMatch.start,
-          _scanner.lastMatch.end)
+        _spans.add(
+          _HighlightSpan(_HighlightType.number, _scanner.lastMatch.start, _scanner.lastMatch.end),
         );
         continue;
       }
@@ -240,7 +286,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.punctuation,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -250,7 +296,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans.add(_HighlightSpan(
           _HighlightType.keyword,
           _scanner.lastMatch.start,
-          _scanner.lastMatch.end
+          _scanner.lastMatch.end,
         ));
         continue;
       }
@@ -260,23 +306,25 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _HighlightType type;
 
         String word = _scanner.lastMatch[0];
-        if (word.startsWith('_'))
+        if (word.startsWith('_')) {
           word = word.substring(1);
+        }
 
-        if (_keywords.contains(word))
+        if (_keywords.contains(word)) {
           type = _HighlightType.keyword;
-        else if (_builtInTypes.contains(word))
+        } else if (_builtInTypes.contains(word)) {
           type = _HighlightType.keyword;
-        else if (_firstLetterIsUpperCase(word))
+        } else if (_firstLetterIsUpperCase(word)) {
           type = _HighlightType.klass;
-        else if (word.length >= 2 && word.startsWith('k') && _firstLetterIsUpperCase(word.substring(1)))
+        } else if (word.length >= 2 && word.startsWith('k') && _firstLetterIsUpperCase(word.substring(1))) {
           type = _HighlightType.constant;
+        }
 
         if (type != null) {
           _spans.add(_HighlightSpan(
             type,
             _scanner.lastMatch.start,
-            _scanner.lastMatch.end
+            _scanner.lastMatch.end,
           ));
         }
       }
@@ -299,7 +347,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
         _spans[i] = _HighlightSpan(
           _spans[i].type,
           _spans[i].start,
-          _spans[i + 1].end
+          _spans[i + 1].end,
         );
         _spans.removeAt(i + 1);
       }
@@ -315,15 +363,7 @@ class DartSyntaxHighlighter extends SyntaxHighlighter {
   }
 }
 
-enum _HighlightType {
-  number,
-  comment,
-  keyword,
-  string,
-  punctuation,
-  klass,
-  constant
-}
+enum _HighlightType { number, comment, keyword, string, punctuation, klass, constant }
 
 class _HighlightSpan {
   _HighlightSpan(this.type, this.start, this.end);
@@ -336,21 +376,22 @@ class _HighlightSpan {
   }
 
   TextStyle textStyle(SyntaxHighlighterStyle style) {
-    if (type == _HighlightType.number)
+    if (type == _HighlightType.number) {
       return style.numberStyle;
-    else if (type == _HighlightType.comment)
+    } else if (type == _HighlightType.comment) {
       return style.commentStyle;
-    else if (type == _HighlightType.keyword)
+    } else if (type == _HighlightType.keyword) {
       return style.keywordStyle;
-    else if (type == _HighlightType.string)
+    } else if (type == _HighlightType.string) {
       return style.stringStyle;
-    else if (type == _HighlightType.punctuation)
+    } else if (type == _HighlightType.punctuation) {
       return style.punctuationStyle;
-    else if (type == _HighlightType.klass)
+    } else if (type == _HighlightType.klass) {
       return style.classStyle;
-    else if (type == _HighlightType.constant)
+    } else if (type == _HighlightType.constant) {
       return style.constantStyle;
-    else
+    } else {
       return style.baseStyle;
+    }
   }
 }

--- a/examples/flutter_gallery/lib/gallery/updater.dart
+++ b/examples/flutter_gallery/lib/gallery/updater.dart
@@ -11,7 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 typedef UpdateUrlFetcher = Future<String> Function();
 
 class Updater extends StatefulWidget {
-  const Updater({@required this.updateUrlFetcher, this.child, Key key})
+  const Updater({ @required this.updateUrlFetcher, this.child, Key key })
       : assert(updateUrlFetcher != null),
        super(key: key);
 

--- a/examples/flutter_gallery/lib/gallery/updater.dart
+++ b/examples/flutter_gallery/lib/gallery/updater.dart
@@ -11,9 +11,9 @@ import 'package:url_launcher/url_launcher.dart';
 typedef UpdateUrlFetcher = Future<String> Function();
 
 class Updater extends StatefulWidget {
-  const Updater({ @required this.updateUrlFetcher, this.child, Key key })
-    : assert(updateUrlFetcher != null),
-      super(key: key);
+  const Updater({@required this.updateUrlFetcher, this.child, Key key})
+      : assert(updateUrlFetcher != null),
+       super(key: key);
 
   final UpdateUrlFetcher updateUrlFetcher;
   final Widget child;
@@ -32,8 +32,7 @@ class UpdaterState extends State<Updater> {
   static DateTime _lastUpdateCheck;
   Future<void> _checkForUpdates() async {
     // Only prompt once a day
-    if (_lastUpdateCheck != null &&
-        DateTime.now().difference(_lastUpdateCheck) < const Duration(days: 1)) {
+    if (_lastUpdateCheck != null && DateTime.now().difference(_lastUpdateCheck) < const Duration(days: 1)) {
       return; // We already checked for updates recently
     }
     _lastUpdateCheck = DateTime.now();
@@ -41,15 +40,15 @@ class UpdaterState extends State<Updater> {
     final String updateUrl = await widget.updateUrlFetcher();
     if (updateUrl != null) {
       final bool wantsUpdate = await showDialog<bool>(context: context, builder: _buildDialog);
-      if (wantsUpdate != null && wantsUpdate)
+      if (wantsUpdate != null && wantsUpdate) {
         launch(updateUrl);
+      }
     }
   }
 
   Widget _buildDialog(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final TextStyle dialogTextStyle =
-        theme.textTheme.subhead.copyWith(color: theme.textTheme.caption.color);
+    final TextStyle dialogTextStyle = theme.textTheme.subhead.copyWith(color: theme.textTheme.caption.color);
     return AlertDialog(
       title: const Text('Update Flutter Gallery?'),
       content: Text('A newer version is available.', style: dialogTextStyle),

--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -104,70 +104,70 @@ void main() {
     });
 
     testWidgets('leave_behind_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: LeaveBehindDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('list_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: ListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('menu_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: MenuDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ModalBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('overscroll_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('page_selector_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: PageSelectorDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: PersistentBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('progress_indicator_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ProgressIndicatorDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('reorderable_list_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: ReorderableListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ScrollableTabsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
@@ -337,70 +337,70 @@ void main() {
     });
 
     testWidgets('leave_behind_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: LeaveBehindDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('list_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: ListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('menu_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: MenuDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ModalBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('overscroll_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('page_selector_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: PageSelectorDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: PersistentBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('progress_indicator_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ProgressIndicatorDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('reorderable_list_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(const MaterialApp(home: ReorderableListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
-     final SemanticsHandle handle = tester.ensureSemantics();
+      final SemanticsHandle handle = tester.ensureSemantics();
       await tester.pumpWidget(MaterialApp(home: ScrollableTabsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
@@ -649,14 +649,14 @@ void main() {
         handle.dispose();
       });
 
-    testWidgets('overscroll_demo', (WidgetTester tester) async {
-      final AutomatedTestWidgetsFlutterBinding binding = tester.binding;
-      binding.addTime(const Duration(seconds: 3));
-      final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
-      await expectLater(tester, meetsGuideline(textContrastGuideline));
-      handle.dispose();
-    });
+      testWidgets('overscroll_demo', (WidgetTester tester) async {
+        final AutomatedTestWidgetsFlutterBinding binding = tester.binding;
+        binding.addTime(const Duration(seconds: 3));
+        final SemanticsHandle handle = tester.ensureSemantics();
+        await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
+        await expectLater(tester, meetsGuideline(textContrastGuideline));
+        handle.dispose();
+      });
 
       testWidgets('page_selector_demo $themeName', (WidgetTester tester) async {
         final AutomatedTestWidgetsFlutterBinding binding = tester.binding;

--- a/examples/flutter_gallery/test/calculator/smoke_test.dart
+++ b/examples/flutter_gallery/test/calculator/smoke_test.dart
@@ -8,8 +8,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   // We press the "1" and the "2" buttons and check that the display
   // reads "12".

--- a/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/chip_demo_test.dart
@@ -14,21 +14,25 @@ void main() {
       home: ChipDemo(),
     ));
 
-    expect(tester.getSemantics(find.byIcon(Icons.vignette)), matchesSemantics(
-      isButton: true,
-      hasEnabledState: true,
-      isEnabled: true,
-      hasTapAction: true,
-      label: 'Update border shape',
-    ));
+    expect(
+      tester.getSemantics(find.byIcon(Icons.vignette)),
+      matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasTapAction: true,
+        label: 'Update border shape',
+      ));
 
-    expect(tester.getSemantics(find.byIcon(Icons.refresh)), matchesSemantics(
-      isButton: true,
-      hasEnabledState: true,
-      isEnabled: true,
-      hasTapAction: true,
-      label: 'Reset chips',
-    ));
+    expect(
+      tester.getSemantics(find.byIcon(Icons.refresh)),
+      matchesSemantics(
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasTapAction: true,
+        label: 'Reset chips',
+      ));
 
     handle.dispose();
   });

--- a/examples/flutter_gallery/test/demo/material/expansion_panels_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/expansion_panels_demo_test.dart
@@ -7,8 +7,7 @@ import 'package:flutter_gallery/demo/material/expansion_panels_demo.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
-  testWidgets('Expansion panel demo: radio tile selection changes on tap',
-      (WidgetTester tester) async {
+  testWidgets('Expansion panel demo: radio tile selection changes on tap', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(home: ExpansionPanelsDemo()));
 
     expect(_expandIcons, findsNWidgets(3));
@@ -35,20 +34,16 @@ Finder get _expandIcons => find.byType(ExpandIcon);
 
 Widget get _radioPanelExpandIcon => _expandIcons.evaluate().toList()[1].widget;
 
-bool _isRadioSelected(int index) =>
-    _radios[index].value == _radios[index].groupValue;
+bool _isRadioSelected(int index) => _radios[index].value == _radios[index].groupValue;
 
-List<Radio<Location>> get _radios => List<Radio<Location>>.from(
-    _radioFinder.evaluate().map<Widget>((Element e) => e.widget));
+List<Radio<Location>> get _radios =>
+    List<Radio<Location>>.from(_radioFinder.evaluate().map<Widget>((Element e) => e.widget));
 
 // [find.byType] and [find.widgetWithText] do not match subclasses; `Radio` is not sufficient to find a `Radio<_Location>`.
 // Another approach is to grab the `runtimeType` of a dummy instance; see packages/flutter/test/material/control_list_tile_test.dart.
-Finder get _radioFinder =>
-    find.byWidgetPredicate((Widget w) => w is Radio<Location>);
+Finder get _radioFinder => find.byWidgetPredicate((Widget w) => w is Radio<Location>);
 
 List<RadioListTile<Location>> get _radioListTiles =>
-    List<RadioListTile<Location>>.from(
-        _radioListTilesFinder.evaluate().map<Widget>((Element e) => e.widget));
+    List<RadioListTile<Location>>.from(_radioListTilesFinder.evaluate().map<Widget>((Element e) => e.widget));
 
-Finder get _radioListTilesFinder =>
-    find.byWidgetPredicate((Widget w) => w is RadioListTile<Location>);
+Finder get _radioListTilesFinder => find.byWidgetPredicate((Widget w) => w is RadioListTile<Location>);

--- a/examples/flutter_gallery/test/drawer_test.dart
+++ b/examples/flutter_gallery/test/drawer_test.dart
@@ -9,8 +9,9 @@ import 'package:flutter_gallery/gallery/app.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   testWidgets('Flutter Gallery drawer item test', (WidgetTester tester) async {
     bool hasFeedback = false;

--- a/examples/flutter_gallery/test/example_code_display_test.dart
+++ b/examples/flutter_gallery/test/example_code_display_test.dart
@@ -8,8 +8,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   testWidgets('Flutter gallery button example code displays', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/6147

--- a/examples/flutter_gallery/test/example_code_parser_test.dart
+++ b/examples/flutter_gallery/test/example_code_parser_test.dart
@@ -44,9 +44,10 @@ class TestAssetBundle extends AssetBundle {
   Future<ByteData> load(String key) async => null;
 
   @override
-  Future<String> loadString(String key, { bool cache = true }) async {
-    if (key == 'lib/gallery/example_code.dart')
+  Future<String> loadString(String key, {bool cache = true}) async {
+    if (key == 'lib/gallery/example_code.dart') {
       return testCodeFile;
+    }
     return null;
   }
 

--- a/examples/flutter_gallery/test/example_code_parser_test.dart
+++ b/examples/flutter_gallery/test/example_code_parser_test.dart
@@ -44,7 +44,7 @@ class TestAssetBundle extends AssetBundle {
   Future<ByteData> load(String key) async => null;
 
   @override
-  Future<String> loadString(String key, {bool cache = true}) async {
+  Future<String> loadString(String key, { bool cache = true }) async {
     if (key == 'lib/gallery/example_code.dart') {
       return testCodeFile;
     }

--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -139,11 +139,11 @@ class _LiveWidgetController extends LiveWidgetController {
   }
 
   @override
-  Future<void> tap(Finder finder, {int pointer}) async {
+  Future<void> tap(Finder finder, { int pointer }) async {
     await super.tap(await _waitForElement(finder), pointer: pointer);
   }
 
-  Future<void> scrollIntoView(Finder finder, {double alignment}) async {
+  Future<void> scrollIntoView(Finder finder, { double alignment }) async {
     final Finder target = await _waitForElement(finder);
     await Scrollable.ensureVisible(target.evaluate().single,
       duration: const Duration(milliseconds: 100), alignment: alignment);

--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -52,10 +52,12 @@ Future<void> main() async {
     // Verify that _kUnsynchronizedDemos and _kSkippedDemos identify
     // demos that actually exist.
     final List<String> allDemoTitles = kAllGalleryDemos.map((GalleryDemo demo) => demo.title).toList();
-    if (!Set<String>.from(allDemoTitles).containsAll(_kUnsynchronizedDemoTitles))
+    if (!Set<String>.from(allDemoTitles).containsAll(_kUnsynchronizedDemoTitles)) {
       fail('Unrecognized demo titles in _kUnsynchronizedDemosTitles: $_kUnsynchronizedDemoTitles');
-    if (!Set<String>.from(allDemoTitles).containsAll(_kSkippedDemoTitles))
+    }
+    if (!Set<String>.from(allDemoTitles).containsAll(_kSkippedDemoTitles)) {
       fail('Unrecognized demo names in _kSkippedDemoTitles: $_kSkippedDemoTitles');
+    }
 
     print('Starting app...');
     runApp(const GalleryApp(testMode: true));
@@ -67,8 +69,9 @@ Future<void> main() async {
         final Finder demoItem = find.text(demo.title);
         print('Scrolling to "${demo.title}"...');
         await controller.scrollIntoView(demoItem, alignment: 0.5);
-        if (_kSkippedDemoTitles.contains(demo.title))
+        if (_kSkippedDemoTitles.contains(demo.title)) {
           continue;
+        }
         for (int i = 0; i < 2; i += 1) {
           print('Tapping "${demo.title}"...');
           await controller.tap(demoItem); // Launch the demo
@@ -92,10 +95,12 @@ Future<void> main() async {
 final Finder backFinder = find.byElementPredicate(
   (Element element) {
     final Widget widget = element.widget;
-    if (widget is Tooltip)
+    if (widget is Tooltip) {
       return widget.message == 'Back';
-    if (widget is CupertinoNavigationBarBackButton)
+    }
+    if (widget is CupertinoNavigationBarBackButton) {
       return true;
+    }
     return false;
   },
   description: 'Material or Cupertino back button',
@@ -123,21 +128,24 @@ class _LiveWidgetController extends LiveWidgetController {
 
   /// Runs `finder` repeatedly until it finds one or more [Element]s.
   Future<Finder> _waitForElement(Finder finder) async {
-    if (frameSync)
+    if (frameSync) {
       await _waitUntilFrame(() => binding.transientCallbackCount == 0);
+    }
     await _waitUntilFrame(() => finder.precache());
-    if (frameSync)
+    if (frameSync) {
       await _waitUntilFrame(() => binding.transientCallbackCount == 0);
+    }
     return finder;
   }
 
   @override
-  Future<void> tap(Finder finder, { int pointer }) async {
+  Future<void> tap(Finder finder, {int pointer}) async {
     await super.tap(await _waitForElement(finder), pointer: pointer);
   }
 
   Future<void> scrollIntoView(Finder finder, {double alignment}) async {
     final Finder target = await _waitForElement(finder);
-    await Scrollable.ensureVisible(target.evaluate().single, duration: const Duration(milliseconds: 100), alignment: alignment);
+    await Scrollable.ensureVisible(target.evaluate().single,
+      duration: const Duration(milliseconds: 100), alignment: alignment);
   }
 }

--- a/examples/flutter_gallery/test/pesto_test.dart
+++ b/examples/flutter_gallery/test/pesto_test.dart
@@ -8,8 +8,9 @@ import 'package:flutter_gallery/gallery/app.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   // Regression test for https://github.com/flutter/flutter/pull/5168
   testWidgets('Pesto appbar heroics', (WidgetTester tester) async {
@@ -19,9 +20,9 @@ void main() {
         child: SizedBox(
           width: 450.0,
           height: 800.0,
-          child: GalleryApp(testMode: true)
-        )
-      )
+          child: GalleryApp(testMode: true),
+        ),
+      ),
     );
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame

--- a/examples/flutter_gallery/test/simple_smoke_test.dart
+++ b/examples/flutter_gallery/test/simple_smoke_test.dart
@@ -8,13 +8,14 @@ import 'package:flutter_gallery/gallery/app.dart' show GalleryApp;
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   testWidgets('Flutter Gallery app simple smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const GalleryApp(testMode: true) // builds the app and schedules a frame but doesn't trigger one
-    );
+      );
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame
 

--- a/examples/flutter_gallery/test/smoke_test.dart
+++ b/examples/flutter_gallery/test/smoke_test.dart
@@ -33,21 +33,24 @@ void reportToStringError(String name, String route, int lineNumber, List<String>
   const int margin = 5;
   final int firstLine = math.max(0, lineNumber - margin);
   final int lastLine = math.min(lines.length, lineNumber + margin);
-  print('$name : $route : line $lineNumber of ${lines.length} : $message; nearby lines were:\n  ${lines.sublist(firstLine, lastLine).join("\n  ")}');
+  print(
+    '$name : $route : line $lineNumber of ${lines.length} : $message; nearby lines were:\n  ${lines.sublist(firstLine, lastLine).join("\n  ")}');
   toStringErrors += 1;
 }
 
 void verifyToStringOutput(String name, String route, String testString) {
   int lineNumber = 0;
   final List<String> lines = testString.split('\n');
-  if (!testString.endsWith('\n'))
+  if (!testString.endsWith('\n')) {
     reportToStringError(name, route, lines.length, lines, 'does not end with a line feed');
+  }
   for (String line in lines) {
     lineNumber += 1;
     if (line == '' && lineNumber != lines.length) {
       reportToStringError(name, route, lineNumber, lines, 'found empty line');
     } else if (line.contains('Instance of ')) {
-      reportToStringError(name, route, lineNumber, lines, 'found a class that does not have its own toString');
+      reportToStringError(
+        name, route, lineNumber, lines, 'found a class that does not have its own toString');
     } else if (line.endsWith(' ')) {
       reportToStringError(name, route, lineNumber, lines, 'found a line with trailing whitespace');
     }
@@ -78,8 +81,10 @@ Future<void> smokeDemo(WidgetTester tester, GalleryDemo demo) async {
   // Verify that the dumps are pretty.
   final String routeName = demo.routeName;
   verifyToStringOutput('debugDumpApp', routeName, WidgetsBinding.instance.renderViewElement.toStringDeep());
-  verifyToStringOutput('debugDumpRenderTree', routeName, RendererBinding.instance?.renderView?.toStringDeep());
-  verifyToStringOutput('debugDumpLayerTree', routeName, RendererBinding.instance?.renderView?.debugLayer?.toStringDeep());
+  verifyToStringOutput(
+    'debugDumpRenderTree', routeName, RendererBinding.instance?.renderView?.toStringDeep());
+  verifyToStringOutput(
+    'debugDumpLayerTree', routeName, RendererBinding.instance?.renderView?.debugLayer?.toStringDeep());
 
   // Scroll the demo around a bit more.
   await tester.flingFrom(const Offset(400.0, 300.0), const Offset(-200.0, 0.0), 500.0);
@@ -164,7 +169,8 @@ Future<void> smokeGallery(WidgetTester tester) async {
     for (GalleryDemo demo in kGalleryCategoryToDemos[category]) {
       await Scrollable.ensureVisible(tester.element(find.text(demo.title)), alignment: 0.0);
       await smokeDemo(tester, demo);
-      tester.binding.debugAssertNoTransientCallbacks('A transient callback was still active after running $demo');
+      tester.binding
+        .debugAssertNoTransientCallbacks('A transient callback was still active after running $demo');
     }
     await tester.pageBack();
     await tester.pumpAndSettle();

--- a/examples/flutter_gallery/test/update_test.dart
+++ b/examples/flutter_gallery/test/update_test.dart
@@ -12,16 +12,17 @@ Future<String> mockUpdateUrlFetcher() {
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  if (binding is LiveTestWidgetsFlutterBinding)
+  if (binding is LiveTestWidgetsFlutterBinding) {
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  }
 
   // Regression test for https://github.com/flutter/flutter/pull/5168
   testWidgets('update dialog', (WidgetTester tester) async {
     await tester.pumpWidget(
       const GalleryApp(
         testMode: true,
-        updateUrlFetcher: mockUpdateUrlFetcher
-      )
+        updateUrlFetcher: mockUpdateUrlFetcher,
+      ),
     );
     await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
     await tester.pump(); // triggers a frame

--- a/examples/flutter_gallery/test_driver/scroll_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/scroll_perf_test.dart
@@ -16,8 +16,9 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
+      if (driver != null) {
         driver.close();
+      }
     });
 
     test('measure', () async {

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -82,8 +82,9 @@ Future<void> saveDurationsHistogram(List<Map<String, dynamic>> events, String ou
   }
 
   // Verify that the durations data is valid.
-  if (durations.keys.isEmpty)
+  if (durations.keys.isEmpty) {
     throw 'no "Start Transition" timeline events found';
+  }
   final Map<String, int> unexpectedValueCounts = <String, int>{};
   durations.forEach((String routeName, List<int> values) {
     if (values.length != 2) {
@@ -92,7 +93,8 @@ Future<void> saveDurationsHistogram(List<Map<String, dynamic>> events, String ou
   });
 
   if (unexpectedValueCounts.isNotEmpty) {
-    final StringBuffer error = StringBuffer('Some routes recorded wrong number of values (expected 2 values/route):\n\n');
+    final StringBuffer error =
+        StringBuffer('Some routes recorded wrong number of values (expected 2 values/route):\n\n');
     unexpectedValueCounts.forEach((String routeName, int count) {
       error.writeln(' - $routeName recorded $count values.');
     });
@@ -103,12 +105,11 @@ Future<void> saveDurationsHistogram(List<Map<String, dynamic>> events, String ou
     while (eventIter.moveNext()) {
       final String eventName = eventIter.current['name'];
 
-      if (!<String>['Start Transition', 'Frame'].contains(eventName))
+      if (!<String>['Start Transition', 'Frame'].contains(eventName)) {
         continue;
+      }
 
-      final String routeName = eventName == 'Start Transition'
-        ? eventIter.current['args']['to']
-        : '';
+      final String routeName = eventName == 'Start Transition' ? eventIter.current['args']['to'] : '';
 
       if (eventName == lastEventName && routeName == lastRouteName) {
         error.write('.');
@@ -134,8 +135,9 @@ Future<void> runDemos(List<String> demos, FlutterDriver driver) async {
   String currentDemoCategory;
 
   for (String demo in demos) {
-    if (kSkippedDemos.contains(demo))
+    if (kSkippedDemos.contains(demo)) {
       continue;
+    }
 
     final String demoName = demo.substring(0, demo.indexOf('@'));
     final String demoCategory = demo.substring(demo.indexOf('@') + 1);
@@ -152,7 +154,9 @@ Future<void> runDemos(List<String> demos, FlutterDriver driver) async {
     currentDemoCategory = demoCategory;
 
     final SerializableFinder demoItem = find.text(demoName);
-    await driver.scrollUntilVisible(demoList, demoItem,
+    await driver.scrollUntilVisible(
+      demoList,
+      demoItem,
       dyScroll: -48.0,
       alignment: 0.5,
       timeout: const Duration(seconds: 30),
@@ -190,17 +194,18 @@ void main([List<String> args = const <String>[]]) {
 
       // See _handleMessages() in transitions_perf.dart.
       _allDemos = List<String>.from(const JsonDecoder().convert(await driver.requestData('demoNames')));
-      if (_allDemos.isEmpty)
+      if (_allDemos.isEmpty) {
         throw 'no demo names found';
+      }
     });
 
     tearDownAll(() async {
-      if (driver != null)
+      if (driver != null) {
         await driver.close();
+      }
     });
 
     test('all demos', () async {
-
       // Collect timeline data for just a limited set of demos to avoid OOMs.
       final Timeline timeline = await driver.traceAction(
         () async {
@@ -219,13 +224,11 @@ void main([List<String> args = const <String>[]]) {
       await summary.writeSummaryToFile('transitions', pretty: true);
       final String histogramPath = path.join(testOutputsDirectory, 'transition_durations.timeline.json');
       await saveDurationsHistogram(
-          List<Map<String, dynamic>>.from(timeline.json['traceEvents']),
-          histogramPath);
+        List<Map<String, dynamic>>.from(timeline.json['traceEvents']), histogramPath);
 
       // Execute the remaining tests.
       final Set<String> unprofiledDemos = Set<String>.from(_allDemos)..removeAll(kProfiledDemos);
       await runDemos(unprofiledDemos.toList(), driver);
-
     }, timeout: const Timeout(Duration(minutes: 5)));
   });
 }

--- a/examples/flutter_gallery/test_memory/back_button.dart
+++ b/examples/flutter_gallery/test_memory/back_button.dart
@@ -20,11 +20,11 @@ Future<void> endOfAnimation() async {
 int iteration = 0;
 
 class LifecycleObserver extends WidgetsBindingObserver {
-   @override
-   void didChangeAppLifecycleState(AppLifecycleState state) {
-     debugPrint('==== MEMORY BENCHMARK ==== $state ====');
-     debugPrint('This was lifecycle event number $iteration in this instance');
-   }
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    debugPrint('==== MEMORY BENCHMARK ==== $state ====');
+    debugPrint('This was lifecycle event number $iteration in this instance');
+  }
 }
 
 Future<void> main() async {

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -11,7 +11,6 @@ void main() {
 }
 
 class FlutterView extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -33,8 +32,7 @@ class _MyHomePageState extends State<MyHomePage> {
   static const String _channel = 'increment';
   static const String _pong = 'pong';
   static const String _emptyMessage = '';
-  static const BasicMessageChannel<String> platform =
-      BasicMessageChannel<String>(_channel, StringCodec());
+  static const BasicMessageChannel<String> platform = BasicMessageChannel<String>(_channel, StringCodec());
 
   int _counter = 0;
 
@@ -63,9 +61,8 @@ class _MyHomePageState extends State<MyHomePage> {
         children: <Widget>[
           Expanded(
             child: Center(
-              child: Text(
-                'Platform button tapped $_counter time${ _counter == 1 ? '' : 's' }.',
-                style: const TextStyle(fontSize: 17.0))
+              child: Text('Platform button tapped $_counter time${_counter == 1 ? '' : 's'}.',
+                style: const TextStyle(fontSize: 17.0)),
             ),
           ),
           Container(

--- a/examples/layers/raw/canvas.dart
+++ b/examples/layers/raw/canvas.dart
@@ -38,22 +38,33 @@ ui.Picture paint(ui.Rect paintBounds) {
 
   canvas.translate(mid.dx, mid.dy);
   paint.color = const ui.Color.fromARGB(128, 255, 0, 255);
-  canvas.rotate(math.pi/4.0);
+  canvas.rotate(math.pi / 4.0);
 
   final ui.Gradient yellowBlue = ui.Gradient.linear(
     ui.Offset(-radius, -radius),
     const ui.Offset(0.0, 0.0),
     <ui.Color>[const ui.Color(0xFFFFFF00), const ui.Color(0xFF0000FF)],
   );
-  canvas.drawRect(ui.Rect.fromLTRB(-radius, -radius, radius, radius),
-                  ui.Paint()..shader = yellowBlue);
+  canvas.drawRect(ui.Rect.fromLTRB(-radius, -radius, radius, radius), ui.Paint()..shader = yellowBlue);
 
   // Scale x and y by 0.5.
   final Float64List scaleMatrix = Float64List.fromList(<double>[
-      0.5, 0.0, 0.0, 0.0,
-      0.0, 0.5, 0.0, 0.0,
-      0.0, 0.0, 1.0, 0.0,
-      0.0, 0.0, 0.0, 1.0,
+    0.5,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.5,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
   ]);
   canvas.transform(scaleMatrix);
   paint.color = const ui.Color.fromARGB(128, 0, 255, 0);

--- a/examples/layers/raw/hello_world.dart
+++ b/examples/layers/raw/hello_world.dart
@@ -13,8 +13,7 @@ void beginFrame(Duration timeStamp) {
 
   final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(
     ui.ParagraphStyle(textDirection: ui.TextDirection.ltr),
-  )
-    ..addText('Hello, world.');
+  )..addText('Hello, world.');
   final ui.Paragraph paragraph = paragraphBuilder.build()
     ..layout(ui.ParagraphConstraints(width: logicalSize.width));
 
@@ -22,10 +21,12 @@ void beginFrame(Duration timeStamp) {
   final ui.PictureRecorder recorder = ui.PictureRecorder();
   final ui.Canvas canvas = ui.Canvas(recorder, physicalBounds);
   canvas.scale(devicePixelRatio, devicePixelRatio);
-  canvas.drawParagraph(paragraph, ui.Offset(
-    (logicalSize.width - paragraph.maxIntrinsicWidth) / 2.0,
-    (logicalSize.height - paragraph.height) / 2.0
-  ));
+  canvas.drawParagraph(
+    paragraph,
+    ui.Offset(
+      (logicalSize.width - paragraph.maxIntrinsicWidth) / 2.0,
+      (logicalSize.height - paragraph.height) / 2.0,
+    ));
   final ui.Picture picture = recorder.endRecording();
 
   final ui.SceneBuilder sceneBuilder = ui.SceneBuilder()

--- a/examples/layers/raw/spinning_square.dart
+++ b/examples/layers/raw/spinning_square.dart
@@ -30,7 +30,7 @@ void beginFrame(Duration timeStamp) {
   canvas.rotate(math.pi * (t % 1.0));
 
   canvas.drawRect(ui.Rect.fromLTRB(-100.0, -100.0, 100.0, 100.0),
-                  ui.Paint()..color = const ui.Color.fromARGB(255, 0, 255, 0));
+    ui.Paint()..color = const ui.Color.fromARGB(255, 0, 255, 0));
   final ui.Picture picture = recorder.endRecording();
 
   // COMPOSITE

--- a/examples/layers/raw/text.dart
+++ b/examples/layers/raw/text.dart
@@ -20,7 +20,7 @@ ui.Picture paint(ui.Rect paintBounds) {
 
   canvas.translate(logicalSize.width / 2.0, logicalSize.height / 2.0);
   canvas.drawRect(ui.Rect.fromLTRB(-100.0, -100.0, 100.0, 100.0),
-                  ui.Paint()..color = const ui.Color.fromARGB(255, 0, 255, 0));
+    ui.Paint()..color = const ui.Color.fromARGB(255, 0, 255, 0));
 
   // The paint method of Paragraph draws the contents of the paragraph onto the
   // given canvas.

--- a/examples/layers/raw/touch_input.dart
+++ b/examples/layers/raw/touch_input.dart
@@ -28,7 +28,7 @@ ui.Picture paint(ui.Rect paintBounds) {
   canvas.drawCircle(
     size.center(ui.Offset.zero),
     size.shortestSide * 0.45,
-    ui.Paint()..color = color
+    ui.Paint()..color = color,
   );
 
   // When we're done issuing painting commands, we end the recording an receive

--- a/examples/layers/rendering/flex_layout.dart
+++ b/examples/layers/rendering/flex_layout.dart
@@ -19,7 +19,10 @@ void main() {
       textDirection: TextDirection.ltr,
     );
     table.add(RenderPadding(child: paragraph, padding: const EdgeInsets.only(top: 20.0)));
-    final RenderFlex row = RenderFlex(crossAxisAlignment: crossAxisAlignment, textBaseline: TextBaseline.alphabetic, textDirection: TextDirection.ltr);
+    final RenderFlex row = RenderFlex(
+      crossAxisAlignment: crossAxisAlignment,
+      textBaseline: TextBaseline.alphabetic,
+      textDirection: TextDirection.ltr);
     style = const TextStyle(fontSize: 15.0, color: Color(0xFF000000));
     row.add(RenderDecoratedBox(
       decoration: const BoxDecoration(color: Color(0x7FFFCCCC)),
@@ -36,7 +39,10 @@ void main() {
         textDirection: TextDirection.ltr,
       ),
     ));
-    final RenderFlex subrow = RenderFlex(crossAxisAlignment: crossAxisAlignment, textBaseline: TextBaseline.alphabetic, textDirection: TextDirection.ltr);
+    final RenderFlex subrow = RenderFlex(
+      crossAxisAlignment: crossAxisAlignment,
+      textBaseline: TextBaseline.alphabetic,
+      textDirection: TextDirection.ltr);
     style = const TextStyle(fontSize: 25.0, color: Color(0xFF000000));
     subrow.add(RenderDecoratedBox(
       decoration: const BoxDecoration(color: Color(0x7FCCCCFF)),

--- a/examples/layers/rendering/hello_world.dart
+++ b/examples/layers/rendering/hello_world.dart
@@ -24,6 +24,6 @@ void main() {
         // particular text direction.
         textDirection: TextDirection.ltr,
       ),
-    )
+    ),
   );
 }

--- a/examples/layers/rendering/spinning_square.dart
+++ b/examples/layers/rendering/spinning_square.dart
@@ -20,13 +20,13 @@ class NonStopVSync implements TickerProvider {
 void main() {
   // We first create a render object that represents a green box.
   final RenderBox green = RenderDecoratedBox(
-    decoration: const BoxDecoration(color: Color(0xFF00FF00))
+    decoration: const BoxDecoration(color: Color(0xFF00FF00)),
   );
   // Second, we wrap that green box in a render object that forces the green box
   // to have a specific size.
   final RenderBox square = RenderConstrainedBox(
     additionalConstraints: const BoxConstraints.tightFor(width: 200.0, height: 200.0),
-    child: green
+    child: green,
   );
   // Third, we wrap the sized green square in a render object that applies rotation
   // transform before painting its child. Each frame of the animation, we'll
@@ -35,12 +35,12 @@ void main() {
   final RenderTransform spin = RenderTransform(
     transform: Matrix4.identity(),
     alignment: Alignment.center,
-    child: square
+    child: square,
   );
   // Finally, we center the spinning green square...
   final RenderBox root = RenderPositionedBox(
     alignment: Alignment.center,
-    child: spin
+    child: spin,
   );
   // and attach it to the window.
   RenderingFlutterBinding(root: root);

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -15,16 +15,16 @@ class SectorConstraints extends Constraints {
     this.maxDeltaRadius = double.infinity,
     this.minDeltaTheta = 0.0,
     this.maxDeltaTheta = kTwoPi,
-  })  : assert(maxDeltaRadius >= minDeltaRadius),
-        assert(maxDeltaTheta >= minDeltaTheta);
+  }) : assert(maxDeltaRadius >= minDeltaRadius),
+       assert(maxDeltaTheta >= minDeltaTheta);
 
   const SectorConstraints.tight({
     double deltaRadius = 0.0,
     double deltaTheta = 0.0,
-  })  : minDeltaRadius = deltaRadius,
-        maxDeltaRadius = deltaRadius,
-        minDeltaTheta = deltaTheta,
-        maxDeltaTheta = deltaTheta;
+  }) : minDeltaRadius = deltaRadius,
+       maxDeltaRadius = deltaRadius,
+       minDeltaTheta = deltaTheta,
+       maxDeltaTheta = deltaTheta;
 
   final double minDeltaRadius;
   final double maxDeltaRadius;
@@ -225,10 +225,10 @@ class RenderSectorRing extends RenderSectorWithChildren {
     BoxDecoration decoration,
     double deltaRadius = double.infinity,
     double padding = 0.0,
-  })  : _padding = padding,
-        assert(deltaRadius >= 0.0),
-        _desiredDeltaRadius = deltaRadius,
-        super(decoration);
+  }) : _padding = padding,
+       assert(deltaRadius >= 0.0),
+       _desiredDeltaRadius = deltaRadius,
+       super(decoration);
 
   double _desiredDeltaRadius;
   double get desiredDeltaRadius => _desiredDeltaRadius;
@@ -342,9 +342,9 @@ class RenderSectorSlice extends RenderSectorWithChildren {
     BoxDecoration decoration,
     double deltaTheta = kTwoPi,
     double padding = 0.0,
-  })  : _padding = padding,
-        _desiredDeltaTheta = deltaTheta,
-        super(decoration);
+  }) : _padding = padding,
+       _desiredDeltaTheta = deltaTheta,
+       super(decoration);
 
   double _desiredDeltaTheta;
   double get desiredDeltaTheta => _desiredDeltaTheta;

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -512,8 +512,8 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
       return Size.zero;
     }
     final double maxChildDeltaRadius = math.max(0.0, math.min(width, height) / 2.0 - innerRadius);
-    final SectorDimensions childDimensions =
-        child.getIntrinsicDimensions(SectorConstraints(maxDeltaRadius: maxChildDeltaRadius), innerRadius);
+    final SectorDimensions childDimensions = child
+      .getIntrinsicDimensions(SectorConstraints(maxDeltaRadius: maxChildDeltaRadius), innerRadius);
     final double dimension = (innerRadius + childDimensions.deltaRadius) * 2.0;
     return Size.square(dimension);
   }

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -56,10 +56,10 @@ class SectorConstraints extends Constraints {
 }
 
 class SectorDimensions {
-  const SectorDimensions({this.deltaRadius = 0.0, this.deltaTheta = 0.0});
+  const SectorDimensions({ this.deltaRadius = 0.0, this.deltaTheta = 0.0 });
 
   factory SectorDimensions.withConstraints(SectorConstraints constraints,
-      {double deltaRadius = 0.0, double deltaTheta = 0.0}) {
+      { double deltaRadius = 0.0, double deltaTheta = 0.0 }) {
     return SectorDimensions(
       deltaRadius: constraints.constrainDeltaRadius(deltaRadius),
       deltaTheta: constraints.constrainDeltaTheta(deltaTheta),
@@ -129,7 +129,7 @@ abstract class RenderSector extends RenderObject {
   @override
   Rect get semanticBounds => Rect.fromLTWH(-deltaRadius, -deltaRadius, 2.0 * deltaRadius, 2.0 * deltaRadius);
 
-  bool hitTest(HitTestResult result, {double radius, double theta}) {
+  bool hitTest(HitTestResult result, { double radius, double theta }) {
     if (radius < parentData.radius ||
         radius >= parentData.radius + deltaRadius ||
         theta < parentData.theta ||
@@ -141,7 +141,7 @@ abstract class RenderSector extends RenderObject {
     return true;
   }
 
-  void hitTestChildren(HitTestResult result, {double radius, double theta}) {}
+  void hitTestChildren(HitTestResult result, { double radius, double theta }) {}
 
   double deltaRadius;
   double deltaTheta;
@@ -196,7 +196,7 @@ class RenderSectorWithChildren extends RenderDecoratedSector
   RenderSectorWithChildren(BoxDecoration decoration) : super(decoration);
 
   @override
-  void hitTestChildren(HitTestResult result, {double radius, double theta}) {
+  void hitTestChildren(HitTestResult result, { double radius, double theta }) {
     RenderSector child = lastChild;
     while (child != null) {
       if (child.hitTest(result, radius: radius, theta: theta)) {
@@ -546,7 +546,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
   }
 
   @override
-  bool hitTest(HitTestResult result, {Offset position}) {
+  bool hitTest(HitTestResult result, { Offset position }) {
     if (child == null) {
       return false;
     }

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -14,15 +14,17 @@ class SectorConstraints extends Constraints {
     this.minDeltaRadius = 0.0,
     this.maxDeltaRadius = double.infinity,
     this.minDeltaTheta = 0.0,
-    this.maxDeltaTheta = kTwoPi
-  }) : assert(maxDeltaRadius >= minDeltaRadius),
-       assert(maxDeltaTheta >= minDeltaTheta);
+    this.maxDeltaTheta = kTwoPi,
+  })  : assert(maxDeltaRadius >= minDeltaRadius),
+        assert(maxDeltaTheta >= minDeltaTheta);
 
-  const SectorConstraints.tight({ double deltaRadius = 0.0, double deltaTheta = 0.0 })
-    : minDeltaRadius = deltaRadius,
-      maxDeltaRadius = deltaRadius,
-      minDeltaTheta = deltaTheta,
-      maxDeltaTheta = deltaTheta;
+  const SectorConstraints.tight({
+    double deltaRadius = 0.0,
+    double deltaTheta = 0.0,
+  })  : minDeltaRadius = deltaRadius,
+        maxDeltaRadius = deltaRadius,
+        minDeltaTheta = deltaTheta,
+        maxDeltaTheta = deltaTheta;
 
   final double minDeltaRadius;
   final double maxDeltaRadius;
@@ -46,7 +48,7 @@ class SectorConstraints extends Constraints {
   @override
   bool debugAssertIsValid({
     bool isAppliedConstraint = false,
-    InformationCollector informationCollector
+    InformationCollector informationCollector,
   }) {
     assert(isNormalized);
     return isNormalized;
@@ -54,15 +56,13 @@ class SectorConstraints extends Constraints {
 }
 
 class SectorDimensions {
-  const SectorDimensions({ this.deltaRadius = 0.0, this.deltaTheta = 0.0 });
+  const SectorDimensions({this.deltaRadius = 0.0, this.deltaTheta = 0.0});
 
-  factory SectorDimensions.withConstraints(
-    SectorConstraints constraints,
-    { double deltaRadius = 0.0, double deltaTheta = 0.0 }
-  ) {
+  factory SectorDimensions.withConstraints(SectorConstraints constraints,
+      {double deltaRadius = 0.0, double deltaTheta = 0.0}) {
     return SectorDimensions(
       deltaRadius: constraints.constrainDeltaRadius(deltaRadius),
-      deltaTheta: constraints.constrainDeltaTheta(deltaTheta)
+      deltaTheta: constraints.constrainDeltaTheta(deltaTheta),
     );
   }
 
@@ -76,11 +76,11 @@ class SectorParentData extends ParentData {
 }
 
 abstract class RenderSector extends RenderObject {
-
   @override
   void setupParentData(RenderObject child) {
-    if (child.parentData is! SectorParentData)
+    if (child.parentData is! SectorParentData) {
       child.parentData = SectorParentData();
+    }
   }
 
   // RenderSectors always use SectorParentData subclasses, as they need to be
@@ -129,29 +129,33 @@ abstract class RenderSector extends RenderObject {
   @override
   Rect get semanticBounds => Rect.fromLTWH(-deltaRadius, -deltaRadius, 2.0 * deltaRadius, 2.0 * deltaRadius);
 
-  bool hitTest(HitTestResult result, { double radius, double theta }) {
-    if (radius < parentData.radius || radius >= parentData.radius + deltaRadius ||
-        theta < parentData.theta || theta >= parentData.theta + deltaTheta)
+  bool hitTest(HitTestResult result, {double radius, double theta}) {
+    if (radius < parentData.radius ||
+        radius >= parentData.radius + deltaRadius ||
+        theta < parentData.theta ||
+        theta >= parentData.theta + deltaTheta) {
       return false;
+    }
     hitTestChildren(result, radius: radius, theta: theta);
     result.add(HitTestEntry(this));
     return true;
   }
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) { }
+
+  void hitTestChildren(HitTestResult result, {double radius, double theta}) {}
 
   double deltaRadius;
   double deltaTheta;
 }
 
 abstract class RenderDecoratedSector extends RenderSector {
-
   RenderDecoratedSector(BoxDecoration decoration) : _decoration = decoration;
 
   BoxDecoration _decoration;
   BoxDecoration get decoration => _decoration;
   set decoration(BoxDecoration value) {
-    if (value == _decoration)
+    if (value == _decoration) {
       return;
+    }
     _decoration = value;
     markNeedsPaint();
   }
@@ -163,37 +167,41 @@ abstract class RenderDecoratedSector extends RenderSector {
     assert(deltaTheta != null);
     assert(parentData is SectorParentData);
 
-    if (_decoration == null)
+    if (_decoration == null) {
       return;
+    }
 
     if (_decoration.color != null) {
       final Canvas canvas = context.canvas;
       final Paint paint = Paint()..color = _decoration.color;
       final Path path = Path();
       final double outerRadius = parentData.radius + deltaRadius;
-      final Rect outerBounds = Rect.fromLTRB(offset.dx-outerRadius, offset.dy-outerRadius, offset.dx+outerRadius, offset.dy+outerRadius);
+      final Rect outerBounds = Rect.fromLTRB(
+        offset.dx - outerRadius, offset.dy - outerRadius, offset.dx + outerRadius, offset.dy + outerRadius);
       path.arcTo(outerBounds, parentData.theta, deltaTheta, true);
       final double innerRadius = parentData.radius;
-      final Rect innerBounds = Rect.fromLTRB(offset.dx-innerRadius, offset.dy-innerRadius, offset.dx+innerRadius, offset.dy+innerRadius);
+      final Rect innerBounds = Rect.fromLTRB(
+        offset.dx - innerRadius, offset.dy - innerRadius, offset.dx + innerRadius, offset.dy + innerRadius);
       path.arcTo(innerBounds, parentData.theta + deltaTheta, -deltaTheta, false);
       path.close();
       canvas.drawPath(path, paint);
     }
   }
-
 }
 
-class SectorChildListParentData extends SectorParentData with ContainerParentDataMixin<RenderSector> { }
+class SectorChildListParentData extends SectorParentData with ContainerParentDataMixin<RenderSector> {}
 
-class RenderSectorWithChildren extends RenderDecoratedSector with ContainerRenderObjectMixin<RenderSector, SectorChildListParentData> {
+class RenderSectorWithChildren extends RenderDecoratedSector
+    with ContainerRenderObjectMixin<RenderSector, SectorChildListParentData> {
   RenderSectorWithChildren(BoxDecoration decoration) : super(decoration);
 
   @override
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) {
+  void hitTestChildren(HitTestResult result, {double radius, double theta}) {
     RenderSector child = lastChild;
     while (child != null) {
-      if (child.hitTest(result, radius: radius, theta: theta))
+      if (child.hitTest(result, radius: radius, theta: theta)) {
         return;
+      }
       final SectorChildListParentData childParentData = child.parentData;
       child = childParentData.previousSibling;
     }
@@ -216,11 +224,11 @@ class RenderSectorRing extends RenderSectorWithChildren {
   RenderSectorRing({
     BoxDecoration decoration,
     double deltaRadius = double.infinity,
-    double padding = 0.0
-  }) : _padding = padding,
-       assert(deltaRadius >= 0.0),
-       _desiredDeltaRadius = deltaRadius,
-       super(decoration);
+    double padding = 0.0,
+  })  : _padding = padding,
+        assert(deltaRadius >= 0.0),
+        _desiredDeltaRadius = deltaRadius,
+        super(decoration);
 
   double _desiredDeltaRadius;
   double get desiredDeltaRadius => _desiredDeltaRadius;
@@ -247,8 +255,9 @@ class RenderSectorRing extends RenderSectorWithChildren {
   @override
   void setupParentData(RenderObject child) {
     // TODO(ianh): avoid code duplication
-    if (child.parentData is! SectorChildListParentData)
+    if (child.parentData is! SectorChildListParentData) {
       child.parentData = SectorChildListParentData();
+    }
   }
 
   @override
@@ -263,7 +272,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
     while (child != null) {
       final SectorConstraints innerConstraints = SectorConstraints(
         maxDeltaRadius: innerDeltaRadius,
-        maxDeltaTheta: remainingDeltaTheta
+        maxDeltaTheta: remainingDeltaTheta,
       );
       final SectorDimensions childDimensions = child.getIntrinsicDimensions(innerConstraints, childRadius);
       innerTheta += childDimensions.deltaTheta;
@@ -276,8 +285,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
       }
     }
     return SectorDimensions.withConstraints(constraints,
-                                                deltaRadius: outerDeltaRadius,
-                                                deltaTheta: innerTheta);
+      deltaRadius: outerDeltaRadius, deltaTheta: innerTheta);
   }
 
   @override
@@ -294,7 +302,7 @@ class RenderSectorRing extends RenderSectorWithChildren {
     while (child != null) {
       final SectorConstraints innerConstraints = SectorConstraints(
         maxDeltaRadius: innerDeltaRadius,
-        maxDeltaTheta: remainingDeltaTheta
+        maxDeltaTheta: remainingDeltaTheta,
       );
       assert(child.parentData is SectorParentData);
       child.parentData.theta = innerTheta;
@@ -325,7 +333,6 @@ class RenderSectorRing extends RenderSectorWithChildren {
       child = childParentData.nextSibling;
     }
   }
-
 }
 
 class RenderSectorSlice extends RenderSectorWithChildren {
@@ -334,8 +341,10 @@ class RenderSectorSlice extends RenderSectorWithChildren {
   RenderSectorSlice({
     BoxDecoration decoration,
     double deltaTheta = kTwoPi,
-    double padding = 0.0
-  }) : _padding = padding, _desiredDeltaTheta = deltaTheta, super(decoration);
+    double padding = 0.0,
+  })  : _padding = padding,
+        _desiredDeltaTheta = deltaTheta,
+        super(decoration);
 
   double _desiredDeltaTheta;
   double get desiredDeltaTheta => _desiredDeltaTheta;
@@ -361,8 +370,9 @@ class RenderSectorSlice extends RenderSectorWithChildren {
   @override
   void setupParentData(RenderObject child) {
     // TODO(ianh): avoid code duplication
-    if (child.parentData is! SectorChildListParentData)
+    if (child.parentData is! SectorChildListParentData) {
       child.parentData = SectorChildListParentData();
+    }
   }
 
   @override
@@ -377,7 +387,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
     while (child != null) {
       final SectorConstraints innerConstraints = SectorConstraints(
         maxDeltaRadius: remainingDeltaRadius,
-        maxDeltaTheta: innerDeltaTheta
+        maxDeltaTheta: innerDeltaTheta,
       );
       final SectorDimensions childDimensions = child.getIntrinsicDimensions(innerConstraints, childRadius);
       childRadius += childDimensions.deltaRadius;
@@ -388,8 +398,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
       remainingDeltaRadius -= padding;
     }
     return SectorDimensions.withConstraints(constraints,
-                                                deltaRadius: childRadius - parentData.radius,
-                                                deltaTheta: outerDeltaTheta);
+      deltaRadius: childRadius - parentData.radius, deltaTheta: outerDeltaTheta);
   }
 
   @override
@@ -406,7 +415,7 @@ class RenderSectorSlice extends RenderSectorWithChildren {
     while (child != null) {
       final SectorConstraints innerConstraints = SectorConstraints(
         maxDeltaRadius: remainingDeltaRadius,
-        maxDeltaTheta: innerDeltaTheta
+        maxDeltaTheta: innerDeltaTheta,
       );
       child.parentData.theta = innerTheta;
       child.parentData.radius = childRadius;
@@ -435,13 +444,13 @@ class RenderSectorSlice extends RenderSectorWithChildren {
       child = childParentData.nextSibling;
     }
   }
-
 }
 
 class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChildMixin<RenderSector> {
-
-  RenderBoxToRenderSectorAdapter({ double innerRadius = 0.0, RenderSector child }) :
-    _innerRadius = innerRadius {
+  RenderBoxToRenderSectorAdapter({
+    double innerRadius = 0.0,
+    RenderSector child,
+  }) : _innerRadius = innerRadius {
     this.child = child;
   }
 
@@ -454,50 +463,57 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
 
   @override
   void setupParentData(RenderObject child) {
-    if (child.parentData is! SectorParentData)
+    if (child.parentData is! SectorParentData) {
       child.parentData = SectorParentData();
+    }
   }
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    if (child == null)
+    if (child == null) {
       return 0.0;
+    }
     return getIntrinsicDimensions(height: height).width;
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    if (child == null)
+    if (child == null) {
       return 0.0;
+    }
     return getIntrinsicDimensions(height: height).width;
   }
 
   @override
   double computeMinIntrinsicHeight(double width) {
-    if (child == null)
+    if (child == null) {
       return 0.0;
+    }
     return getIntrinsicDimensions(width: width).height;
   }
 
   @override
   double computeMaxIntrinsicHeight(double width) {
-    if (child == null)
+    if (child == null) {
       return 0.0;
+    }
     return getIntrinsicDimensions(width: width).height;
   }
 
   Size getIntrinsicDimensions({
     double width = double.infinity,
-    double height = double.infinity
+    double height = double.infinity,
   }) {
     assert(child is RenderSector);
     assert(child.parentData is SectorParentData);
     assert(width != null);
     assert(height != null);
-    if (!width.isFinite && !height.isFinite)
+    if (!width.isFinite && !height.isFinite) {
       return Size.zero;
+    }
     final double maxChildDeltaRadius = math.max(0.0, math.min(width, height) / 2.0 - innerRadius);
-    final SectorDimensions childDimensions = child.getIntrinsicDimensions(SectorConstraints(maxDeltaRadius: maxChildDeltaRadius), innerRadius);
+    final SectorDimensions childDimensions =
+        child.getIntrinsicDimensions(SectorConstraints(maxDeltaRadius: maxChildDeltaRadius), innerRadius);
     final double dimension = (innerRadius + childDimensions.deltaRadius) * 2.0;
     return Size.square(dimension);
   }
@@ -510,7 +526,8 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
     }
     assert(child is RenderSector);
     assert(child.parentData is SectorParentData);
-    final double maxChildDeltaRadius = math.min(constraints.maxWidth, constraints.maxHeight) / 2.0 - innerRadius;
+    final double maxChildDeltaRadius =
+        math.min(constraints.maxWidth, constraints.maxHeight) / 2.0 - innerRadius;
     child.parentData.radius = innerRadius;
     child.parentData.theta = 0.0;
     child.layout(SectorConstraints(maxDeltaRadius: maxChildDeltaRadius), parentUsesSize: true);
@@ -529,9 +546,10 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
-    if (child == null)
+  bool hitTest(HitTestResult result, {Offset position}) {
+    if (child == null) {
       return false;
+    }
     double x = position.dx;
     double y = position.dy;
     // translate to our origin
@@ -540,23 +558,26 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
     // convert to radius/theta
     final double radius = math.sqrt(x * x + y * y);
     final double theta = (math.atan2(x, -y) - math.pi / 2.0) % kTwoPi;
-    if (radius < innerRadius)
+    if (radius < innerRadius) {
       return false;
-    if (radius >= innerRadius + child.deltaRadius)
+    }
+    if (radius >= innerRadius + child.deltaRadius) {
       return false;
-    if (theta > child.deltaTheta)
+    }
+    if (theta > child.deltaTheta) {
       return false;
+    }
     child.hitTest(result, radius: radius, theta: theta);
     result.add(BoxHitTestEntry(this, position));
     return true;
   }
-
 }
 
 class RenderSolidColor extends RenderDecoratedSector {
-  RenderSolidColor(this.backgroundColor, {
+  RenderSolidColor(
+    this.backgroundColor, {
     this.desiredDeltaRadius = double.infinity,
-    this.desiredDeltaTheta = kTwoPi
+    this.desiredDeltaTheta = kTwoPi,
   }) : super(BoxDecoration(color: backgroundColor));
 
   double desiredDeltaRadius;

--- a/examples/layers/rendering/src/solid_color_box.dart
+++ b/examples/layers/rendering/src/solid_color_box.dart
@@ -6,8 +6,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/gestures.dart';
 
 class RenderSolidColorBox extends RenderDecoratedBox {
-  RenderSolidColorBox(this.backgroundColor, { this.desiredSize = Size.infinite })
-      : super(decoration: BoxDecoration(color: backgroundColor));
+  RenderSolidColorBox(
+    this.backgroundColor, {
+    this.desiredSize = Size.infinite,
+  }) : super(decoration: BoxDecoration(color: backgroundColor));
 
   final Size desiredSize;
   final Color backgroundColor;

--- a/examples/layers/rendering/touch_input.dart
+++ b/examples/layers/rendering/touch_input.dart
@@ -20,7 +20,7 @@ List<Color> _kColors = <Color>[
 
 /// A simple model object for a dot that reacts to pointer pressure.
 class Dot {
-  Dot({Color color}) : _paint = Paint()..color = color;
+  Dot({ Color color }) : _paint = Paint()..color = color;
 
   final Paint _paint;
   Offset position = Offset.zero;

--- a/examples/layers/rendering/touch_input.dart
+++ b/examples/layers/rendering/touch_input.dart
@@ -20,7 +20,7 @@ List<Color> _kColors = <Color>[
 
 /// A simple model object for a dot that reacts to pointer pressure.
 class Dot {
-  Dot({ Color color }) : _paint = Paint()..color = color;
+  Dot({Color color}) : _paint = Paint()..color = color;
 
   final Paint _paint;
   Offset position = Offset.zero;
@@ -94,8 +94,7 @@ class RenderDots extends RenderBox {
     canvas.drawRect(offset & size, Paint()..color = const Color(0xFFFFFFFF));
 
     // We iterate through our model and paint each dot.
-    for (Dot dot in _dots.values)
-      dot.paint(canvas, offset);
+    for (Dot dot in _dots.values) dot.paint(canvas, offset);
   }
 }
 

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -21,11 +21,11 @@ class Calculator {
     @required this.onProgressListener,
     @required this.onResultListener,
     String data,
-  })  : assert(onProgressListener != null),
-        assert(onResultListener != null),
-        // In order to keep the example files smaller, we "cheat" a little and
-        // replicate our small json string into a 10,000-element array.
-        _data = _replicateJson(data, 10000);
+  }) : assert(onProgressListener != null),
+       assert(onResultListener != null),
+       // In order to keep the example files smaller, we "cheat" a little and
+       // replicate our small json string into a 10,000-element array.
+       _data = _replicateJson(data, 10000);
 
   final OnProgressListener onProgressListener;
   final OnResultListener onResultListener;
@@ -89,9 +89,9 @@ class CalculationManager {
   CalculationManager({
     @required this.onProgressListener,
     @required this.onResultListener,
-  })  : assert(onProgressListener != null),
-        assert(onResultListener != null),
-        _receivePort = ReceivePort() {
+  }) : assert(onProgressListener != null),
+       assert(onResultListener != null),
+       _receivePort = ReceivePort() {
     _receivePort.listen(_handleMessage);
   }
 

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -17,12 +17,15 @@ typedef OnResultListener = void Function(String result);
 // The choice of JSON parsing here is meant as an example that might surface
 // in real-world applications.
 class Calculator {
-  Calculator({ @required this.onProgressListener, @required this.onResultListener, String data })
-    : assert(onProgressListener != null),
-      assert(onResultListener != null),
-      // In order to keep the example files smaller, we "cheat" a little and
-      // replicate our small json string into a 10,000-element array.
-      _data = _replicateJson(data, 10000);
+  Calculator({
+    @required this.onProgressListener,
+    @required this.onResultListener,
+    String data,
+  })  : assert(onProgressListener != null),
+        assert(onResultListener != null),
+        // In order to keep the example files smaller, we "cheat" a little and
+        // replicate our small json string into a 10,000-element array.
+        _data = _replicateJson(data, 10000);
 
   final OnProgressListener onProgressListener;
   final OnResultListener onResultListener;
@@ -38,10 +41,11 @@ class Calculator {
     int i = 0;
     final JsonDecoder decoder = JsonDecoder(
       (dynamic key, dynamic value) {
-        if (key is int && i++ % _NOTIFY_INTERVAL == 0)
+        if (key is int && i++ % _NOTIFY_INTERVAL == 0) {
           onProgressListener(i.toDouble(), _NUM_ITEMS.toDouble());
+        }
         return value;
-      }
+      },
     );
     try {
       final List<dynamic> result = decoder.convert(_data);
@@ -57,8 +61,9 @@ class Calculator {
     final StringBuffer buffer = StringBuffer()..write('[');
     for (int i = 0; i < count; i++) {
       buffer.write(data);
-      if (i < count - 1)
+      if (i < count - 1) {
         buffer.write(',');
+      }
     }
     buffer.write(']');
     return buffer.toString();
@@ -66,11 +71,7 @@ class Calculator {
 }
 
 // The current state of the calculation.
-enum CalculationState {
-  idle,
-  loading,
-  calculating
-}
+enum CalculationState { idle, loading, calculating }
 
 // Structured message to initialize the spawned isolate.
 class CalculationMessage {
@@ -85,10 +86,12 @@ class CalculationMessage {
 // This class manages these ports and maintains state related to the
 // progress of the background computation.
 class CalculationManager {
-  CalculationManager({ @required this.onProgressListener, @required this.onResultListener })
-    : assert(onProgressListener != null),
-      assert(onResultListener != null),
-      _receivePort = ReceivePort() {
+  CalculationManager({
+    @required this.onProgressListener,
+    @required this.onResultListener,
+  })  : assert(onProgressListener != null),
+        assert(onResultListener != null),
+        _receivePort = ReceivePort() {
     _receivePort.listen(_handleMessage);
   }
 
@@ -180,10 +183,10 @@ class CalculationManager {
     final SendPort sender = message.sendPort;
     final Calculator calculator = Calculator(
       onProgressListener: (double completed, double total) {
-        sender.send(<double>[ completed, total ]);
+        sender.send(<double>[completed, total]);
       },
       onResultListener: sender.send,
-      data: message.data
+      data: message.data,
     );
     calculator.run();
   }
@@ -204,7 +207,6 @@ class IsolateExampleWidget extends StatefulWidget {
 
 // Main application state.
 class IsolateExampleState extends State<StatefulWidget> with SingleTickerProviderStateMixin {
-
   String _status = 'Idle';
   String _label = 'Start';
   String _result = ' ';
@@ -221,7 +223,7 @@ class IsolateExampleState extends State<StatefulWidget> with SingleTickerProvide
     )..repeat();
     _calculationManager = CalculationManager(
       onProgressListener: _handleProgressUpdate,
-      onResultListener: _handleResult
+      onResultListener: _handleResult,
     );
   }
 
@@ -243,24 +245,24 @@ class IsolateExampleState extends State<StatefulWidget> with SingleTickerProvide
               width: 120.0,
               height: 120.0,
               color: const Color(0xFF882222),
-            )
+            ),
           ),
           Opacity(
             opacity: _calculationManager.isRunning ? 1.0 : 0.0,
             child: CircularProgressIndicator(
-              value: _progress
-            )
+              value: _progress,
+            ),
           ),
           Text(_status),
           Center(
             child: RaisedButton(
               child: Text(_label),
-              onPressed: _handleButtonPressed
-            )
+              onPressed: _handleButtonPressed,
+            ),
           ),
           Text(_result)
-        ]
-      )
+        ],
+      ),
     );
   }
 
@@ -273,23 +275,24 @@ class IsolateExampleState extends State<StatefulWidget> with SingleTickerProvide
   }
 
   void _handleButtonPressed() {
-    if (_calculationManager.isRunning)
+    if (_calculationManager.isRunning) {
       _calculationManager.stop();
-    else
+    } else {
       _calculationManager.start();
+    }
     _updateState(' ', 0.0);
   }
 
   String _getStatus(CalculationState state) {
-      switch (state) {
-        case CalculationState.loading:
-          return 'Loading...';
-        case CalculationState.calculating:
-          return 'In Progress';
-        case CalculationState.idle:
-        default:
-          return 'Idle';
-      }
+    switch (state) {
+      case CalculationState.loading:
+        return 'Loading...';
+      case CalculationState.calculating:
+        return 'In Progress';
+      case CalculationState.idle:
+      default:
+        return 'Idle';
+    }
   }
 
   void _updateState(String result, double progress) {

--- a/examples/layers/services/lifecycle.dart
+++ b/examples/layers/services/lifecycle.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/widgets.dart';
 
 class LifecycleWatcher extends StatefulWidget {
-  const LifecycleWatcher({Key key}) : super(key: key);
+  const LifecycleWatcher({ Key key }) : super(key: key);
 
   @override
   _LifecycleWatcherState createState() => _LifecycleWatcherState();

--- a/examples/layers/services/lifecycle.dart
+++ b/examples/layers/services/lifecycle.dart
@@ -5,14 +5,13 @@
 import 'package:flutter/widgets.dart';
 
 class LifecycleWatcher extends StatefulWidget {
-  const LifecycleWatcher({ Key key }) : super(key: key);
+  const LifecycleWatcher({Key key}) : super(key: key);
 
   @override
   _LifecycleWatcherState createState() => _LifecycleWatcherState();
 }
 
-class _LifecycleWatcherState extends State<LifecycleWatcher>
-                             with WidgetsBindingObserver {
+class _LifecycleWatcherState extends State<LifecycleWatcher> with WidgetsBindingObserver {
   AppLifecycleState _lastLifecycleState;
 
   @override
@@ -36,12 +35,12 @@ class _LifecycleWatcherState extends State<LifecycleWatcher>
 
   @override
   Widget build(BuildContext context) {
-    if (_lastLifecycleState == null)
+    if (_lastLifecycleState == null) {
       return const Text('This widget has not observed any lifecycle changes.');
+    }
     return Text('The most recent lifecycle state this widget observed was: $_lastLifecycleState.');
   }
 }
-
 
 void main() {
   runApp(

--- a/examples/layers/test/smoketests/rendering/custom_coordinate_systems_test.dart
+++ b/examples/layers/test/smoketests/rendering/custom_coordinate_systems_test.dart
@@ -9,7 +9,9 @@ import '../../../rendering/custom_coordinate_systems.dart' as demo;
 
 void main() {
   test('layers smoketest for rendering/custom_coordinate_systems.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/test/smoketests/rendering/flex_layout_test.dart
+++ b/examples/layers/test/smoketests/rendering/flex_layout_test.dart
@@ -9,7 +9,9 @@ import '../../../rendering/flex_layout.dart' as demo;
 
 void main() {
   test('layers smoketest for rendering/flex_layout.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/test/smoketests/rendering/hello_world_test.dart
+++ b/examples/layers/test/smoketests/rendering/hello_world_test.dart
@@ -9,7 +9,9 @@ import '../../../rendering/hello_world.dart' as demo;
 
 void main() {
   test('layers smoketest for rendering/hello_world.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/test/smoketests/rendering/spinning_square_test.dart
+++ b/examples/layers/test/smoketests/rendering/spinning_square_test.dart
@@ -9,7 +9,9 @@ import '../../../rendering/spinning_square.dart' as demo;
 
 void main() {
   test('layers smoketest for rendering/spinning_square.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/test/smoketests/rendering/touch_input_test.dart
+++ b/examples/layers/test/smoketests/rendering/touch_input_test.dart
@@ -9,7 +9,9 @@ import '../../../rendering/touch_input.dart' as demo;
 
 void main() {
   test('layers smoketest for rendering/touch_input.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
+++ b/examples/layers/test/smoketests/widgets/spinning_mixed_test.dart
@@ -9,7 +9,9 @@ import '../../../widgets/spinning_mixed.dart' as demo;
 
 void main() {
   test('layers smoketest for widgets/spinning_mixed.dart', () {
-    FlutterError.onError = (FlutterErrorDetails details) { throw details.exception; };
+    FlutterError.onError = (FlutterErrorDetails details) {
+      throw details.exception;
+    };
     demo.main();
   });
 }

--- a/examples/layers/widgets/custom_render_box.dart
+++ b/examples/layers/widgets/custom_render_box.dart
@@ -31,15 +31,14 @@ class RenderDots extends RenderConstrainedBox {
     canvas.drawRect(offset & size, Paint()..color = const Color(0xFF0000FF));
 
     final Paint paint = Paint()..color = const Color(0xFF00FF00);
-    for (Offset point in _dots.values)
-      canvas.drawCircle(point, 50.0, paint);
+    for (Offset point in _dots.values) canvas.drawCircle(point, 50.0, paint);
 
     super.paint(context, offset);
   }
 }
 
 class Dots extends SingleChildRenderObjectWidget {
-  const Dots({ Key key, Widget child }) : super(key: key, child: child);
+  const Dots({Key key, Widget child}) : super(key: key, child: child);
 
   @override
   RenderDots createRenderObject(BuildContext context) => RenderDots();

--- a/examples/layers/widgets/custom_render_box.dart
+++ b/examples/layers/widgets/custom_render_box.dart
@@ -38,7 +38,7 @@ class RenderDots extends RenderConstrainedBox {
 }
 
 class Dots extends SingleChildRenderObjectWidget {
-  const Dots({Key key, Widget child}) : super(key: key, child: child);
+  const Dots({ Key key, Widget child }) : super(key: key, child: child);
 
   @override
   RenderDots createRenderObject(BuildContext context) => RenderDots();

--- a/examples/layers/widgets/gestures.dart
+++ b/examples/layers/widgets/gestures.dart
@@ -13,7 +13,7 @@ class _GesturePainter extends CustomPainter {
     this.scaleEnabled,
     this.tapEnabled,
     this.doubleTapEnabled,
-    this.longPressEnabled
+    this.longPressEnabled,
   });
 
   final double zoom;
@@ -30,8 +30,7 @@ class _GesturePainter extends CustomPainter {
     final Offset center = size.center(Offset.zero) * zoom + offset;
     final double radius = size.width / 2.0 * zoom;
     final Gradient gradient = RadialGradient(
-      colors: forward ? <Color>[swatch.shade50, swatch.shade900]
-                      : <Color>[swatch.shade900, swatch.shade50]
+      colors: forward ? <Color>[swatch.shade50, swatch.shade900] : <Color>[swatch.shade900, swatch.shade50],
     );
     final Paint paint = Paint()
       ..shader = gradient.createShader(Rect.fromCircle(
@@ -43,14 +42,14 @@ class _GesturePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_GesturePainter oldPainter) {
-    return oldPainter.zoom != zoom
-        || oldPainter.offset != offset
-        || oldPainter.swatch != swatch
-        || oldPainter.forward != forward
-        || oldPainter.scaleEnabled != scaleEnabled
-        || oldPainter.tapEnabled != tapEnabled
-        || oldPainter.doubleTapEnabled != doubleTapEnabled
-        || oldPainter.longPressEnabled != longPressEnabled;
+    return oldPainter.zoom != zoom ||
+        oldPainter.offset != offset ||
+        oldPainter.swatch != swatch ||
+        oldPainter.forward != forward ||
+        oldPainter.scaleEnabled != scaleEnabled ||
+        oldPainter.tapEnabled != tapEnabled ||
+        oldPainter.doubleTapEnabled != doubleTapEnabled ||
+        oldPainter.longPressEnabled != longPressEnabled;
   }
 }
 
@@ -60,7 +59,6 @@ class GestureDemo extends StatefulWidget {
 }
 
 class GestureDemoState extends State<GestureDemo> {
-
   Offset _startingFocalPoint;
 
   Offset _previousOffset;
@@ -127,8 +125,9 @@ class GestureDemoState extends State<GestureDemo> {
   void _handleColorChange() {
     setState(() {
       _swatchIndex += 1;
-      if (_swatchIndex == kSwatches.length)
+      if (_swatchIndex == kSwatches.length) {
         _swatchIndex = 0;
+      }
       _swatch = kSwatches[_swatchIndex];
     });
   }
@@ -159,9 +158,9 @@ class GestureDemoState extends State<GestureDemo> {
               scaleEnabled: _scaleEnabled,
               tapEnabled: _tapEnabled,
               doubleTapEnabled: _doubleTapEnabled,
-              longPressEnabled: _longPressEnabled
-            )
-          )
+              longPressEnabled: _longPressEnabled,
+            ),
+          ),
         ),
         Positioned(
           bottom: 0.0,
@@ -175,45 +174,61 @@ class GestureDemoState extends State<GestureDemo> {
                     children: <Widget>[
                       Checkbox(
                         value: _scaleEnabled,
-                        onChanged: (bool value) { setState(() { _scaleEnabled = value; }); }
+                        onChanged: (bool value) {
+                          setState(() {
+                            _scaleEnabled = value;
+                          });
+                        },
                       ),
                       const Text('Scale'),
-                    ]
+                    ],
                   ),
                   Row(
                     children: <Widget>[
                       Checkbox(
                         value: _tapEnabled,
-                        onChanged: (bool value) { setState(() { _tapEnabled = value; }); }
+                        onChanged: (bool value) {
+                          setState(() {
+                            _tapEnabled = value;
+                          });
+                        },
                       ),
                       const Text('Tap'),
-                    ]
+                    ],
                   ),
                   Row(
                     children: <Widget>[
                       Checkbox(
                         value: _doubleTapEnabled,
-                        onChanged: (bool value) { setState(() { _doubleTapEnabled = value; }); }
+                        onChanged: (bool value) {
+                          setState(() {
+                            _doubleTapEnabled = value;
+                          });
+                        },
                       ),
                       const Text('Double Tap'),
-                    ]
+                    ],
                   ),
                   Row(
                     children: <Widget>[
                       Checkbox(
                         value: _longPressEnabled,
-                        onChanged: (bool value) { setState(() { _longPressEnabled = value; }); }
+                        onChanged: (bool value) {
+                          setState(() {
+                            _longPressEnabled = value;
+                          });
+                        },
                       ),
                       const Text('Long Press'),
-                    ]
+                    ],
                   ),
                 ],
-                crossAxisAlignment: CrossAxisAlignment.start
-              )
-            )
-          )
+                crossAxisAlignment: CrossAxisAlignment.start,
+              ),
+            ),
+          ),
         ),
-      ]
+      ],
     );
   }
 }
@@ -223,7 +238,7 @@ void main() {
     theme: ThemeData.dark(),
     home: Scaffold(
       appBar: AppBar(title: const Text('Gestures Demo')),
-      body: GestureDemo()
-    )
+      body: GestureDemo(),
+    ),
   ));
 }

--- a/examples/layers/widgets/media_query.dart
+++ b/examples/layers/widgets/media_query.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 class AdaptedListItem extends StatelessWidget {
-  const AdaptedListItem({ Key key, this.name }) : super(key: key);
+  const AdaptedListItem({Key key, this.name}) : super(key: key);
 
   final String name;
 
@@ -20,13 +20,13 @@ class AdaptedListItem extends StatelessWidget {
           color: Colors.lightBlueAccent.shade100,
         ),
         Text(name)
-      ]
+      ],
     );
   }
 }
 
 class AdaptedGridItem extends StatelessWidget {
-  const AdaptedGridItem({ Key key, this.name }) : super(key: key);
+  const AdaptedGridItem({Key key, this.name}) : super(key: key);
 
   final String name;
 
@@ -38,24 +38,24 @@ class AdaptedGridItem extends StatelessWidget {
           Expanded(
             child: Container(
               color: Colors.lightBlueAccent.shade100,
-            )
+            ),
           ),
           Container(
             margin: const EdgeInsets.only(left: 8.0),
             child: Row(
               children: <Widget>[
                 Expanded(
-                  child: Text(name)
+                  child: Text(name),
                 ),
                 const IconButton(
                   icon: Icon(Icons.more_vert),
-                  onPressed: null
+                  onPressed: null,
                 )
-              ]
-            )
+              ],
+            ),
           )
-        ]
-      )
+        ],
+      ),
     );
   }
 }
@@ -65,7 +65,7 @@ const double _kMaxTileWidth = 150.0;
 const double _kGridViewBreakpoint = 450.0;
 
 class AdaptiveContainer extends StatelessWidget {
-  const AdaptiveContainer({ Key key, this.names }) : super(key: key);
+  const AdaptiveContainer({Key key, this.names}) : super(key: key);
 
   final List<String> names;
 
@@ -87,8 +87,7 @@ class AdaptiveContainer extends StatelessWidget {
 
 List<String> _initNames() {
   final List<String> names = <String>[];
-  for (int i = 0; i < 30; i++)
-    names.add('Item $i');
+  for (int i = 0; i < 30; i++) names.add('Item $i');
   return names;
 }
 
@@ -99,9 +98,9 @@ void main() {
     title: 'Media Query Example',
     home: Scaffold(
       appBar: AppBar(
-        title: const Text('Media Query Example')
+        title: const Text('Media Query Example'),
       ),
-      body: Material(child: AdaptiveContainer(names: _kNames))
-    )
+      body: Material(child: AdaptiveContainer(names: _kNames)),
+    ),
   ));
 }

--- a/examples/layers/widgets/media_query.dart
+++ b/examples/layers/widgets/media_query.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 class AdaptedListItem extends StatelessWidget {
-  const AdaptedListItem({Key key, this.name}) : super(key: key);
+  const AdaptedListItem({ Key key, this.name }) : super(key: key);
 
   final String name;
 
@@ -26,7 +26,7 @@ class AdaptedListItem extends StatelessWidget {
 }
 
 class AdaptedGridItem extends StatelessWidget {
-  const AdaptedGridItem({Key key, this.name}) : super(key: key);
+  const AdaptedGridItem({ Key key, this.name }) : super(key: key);
 
   final String name;
 
@@ -65,7 +65,7 @@ const double _kMaxTileWidth = 150.0;
 const double _kGridViewBreakpoint = 450.0;
 
 class AdaptiveContainer extends StatelessWidget {
-  const AdaptiveContainer({Key key, this.names}) : super(key: key);
+  const AdaptiveContainer({ Key key, this.names }) : super(key: key);
 
   final List<String> names;
 

--- a/examples/layers/widgets/sectors.dart
+++ b/examples/layers/widgets/sectors.dart
@@ -12,7 +12,7 @@ import '../rendering/src/sector_layout.dart';
 RenderBox initCircle() {
   return RenderBoxToRenderSectorAdapter(
     innerRadius: 25.0,
-    child: RenderSectorRing(padding: 0.0)
+    child: RenderSectorRing(padding: 0.0),
   );
 }
 
@@ -22,22 +22,23 @@ class SectorApp extends StatefulWidget {
 }
 
 class SectorAppState extends State<SectorApp> {
-
   final RenderBoxToRenderSectorAdapter sectors = initCircle();
   final math.Random rand = math.Random(1);
 
   List<double> wantedSectorSizes = <double>[];
   List<double> actualSectorSizes = <double>[];
-  double get currentTheta => wantedSectorSizes.fold<double>(0.0, (double total, double value) => total + value);
+  double get currentTheta =>
+      wantedSectorSizes.fold<double>(0.0, (double total, double value) => total + value);
 
   void addSector() {
     final double currentTheta = this.currentTheta;
     if (currentTheta < kTwoPi) {
       double deltaTheta;
-      if (currentTheta >= kTwoPi - (math.pi * 0.2 + 0.05))
+      if (currentTheta >= kTwoPi - (math.pi * 0.2 + 0.05)) {
         deltaTheta = kTwoPi - currentTheta;
-      else
+      } else {
         deltaTheta = math.pi * rand.nextDouble() / 5.0 + 0.05;
+      }
       wantedSectorSizes.add(deltaTheta);
       updateEnabledState();
     }
@@ -52,8 +53,9 @@ class SectorAppState extends State<SectorApp> {
 
   void doUpdates() {
     int index = 0;
-    while (index < actualSectorSizes.length && index < wantedSectorSizes.length && actualSectorSizes[index] == wantedSectorSizes[index])
-      index += 1;
+    while (index < actualSectorSizes.length &&
+        index < wantedSectorSizes.length &&
+        actualSectorSizes[index] == wantedSectorSizes[index]) index += 1;
     final RenderSectorRing ring = sectors.child;
     while (index < actualSectorSizes.length) {
       ring.remove(ring.lastChild);
@@ -74,9 +76,10 @@ class SectorAppState extends State<SectorApp> {
     ring.add(RenderSolidColor(color, desiredDeltaTheta: kTwoPi * 0.2));
     return RenderBoxToRenderSectorAdapter(
       innerRadius: 5.0,
-      child: ring
+      child: ring,
     );
   }
+
   RenderBoxToRenderSectorAdapter sectorAddIcon = initSector(const Color(0xFF00DD00));
   RenderBoxToRenderSectorAdapter sectorRemoveIcon = initSector(const Color(0xFFDD0000));
 
@@ -104,12 +107,12 @@ class SectorAppState extends State<SectorApp> {
                       Container(
                         padding: const EdgeInsets.all(4.0),
                         margin: const EdgeInsets.only(right: 10.0),
-                        child: WidgetToRenderBoxAdapter(renderBox: sectorAddIcon)
+                        child: WidgetToRenderBoxAdapter(renderBox: sectorAddIcon),
                       ),
                       const Text('ADD SECTOR'),
-                    ]
-                  )
-                )
+                    ],
+                  ),
+                ),
               ),
               RaisedButton(
                 onPressed: _enabledRemove ? removeSector : null,
@@ -119,32 +122,32 @@ class SectorAppState extends State<SectorApp> {
                       Container(
                         padding: const EdgeInsets.all(4.0),
                         margin: const EdgeInsets.only(right: 10.0),
-                        child: WidgetToRenderBoxAdapter(renderBox: sectorRemoveIcon)
+                        child: WidgetToRenderBoxAdapter(renderBox: sectorRemoveIcon),
                       ),
                       const Text('REMOVE SECTOR'),
-                    ]
-                  )
-                )
+                    ],
+                  ),
+                ),
               ),
             ],
-            mainAxisAlignment: MainAxisAlignment.spaceAround
-          )
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+          ),
         ),
         Expanded(
           child: Container(
             margin: const EdgeInsets.all(8.0),
             decoration: BoxDecoration(
-              border: Border.all()
+              border: Border.all(),
             ),
             padding: const EdgeInsets.all(8.0),
             child: WidgetToRenderBoxAdapter(
               renderBox: sectors,
-              onBuild: doUpdates
-            )
-          )
+              onBuild: doUpdates,
+            ),
+          ),
         ),
       ],
-      mainAxisAlignment: MainAxisAlignment.spaceBetween
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
     );
   }
 
@@ -155,10 +158,10 @@ class SectorAppState extends State<SectorApp> {
       title: 'Sector Layout',
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('Sector Layout in a Widget Tree')
+          title: const Text('Sector Layout in a Widget Tree'),
         ),
-        body: buildBody()
-      )
+        body: buildBody(),
+      ),
     );
   }
 }

--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -21,7 +21,7 @@ void addFlexChildSolidColor(
 
 // Solid colour, Widget version
 class Rectangle extends StatelessWidget {
-  const Rectangle(this.color, {Key key}) : super(key: key);
+  const Rectangle(this.color, { Key key }) : super(key: key);
 
   final Color color;
 

--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -8,7 +8,11 @@ import 'package:flutter/rendering.dart';
 import '../rendering/src/solid_color_box.dart';
 
 // Solid colour, RenderObject version
-void addFlexChildSolidColor(RenderFlex parent, Color backgroundColor, { int flex = 0 }) {
+void addFlexChildSolidColor(
+  RenderFlex parent,
+  Color backgroundColor, {
+  int flex = 0,
+}) {
   final RenderSolidColorBox child = RenderSolidColorBox(backgroundColor);
   parent.add(child);
   final FlexParentData childParentData = child.parentData;
@@ -17,7 +21,7 @@ void addFlexChildSolidColor(RenderFlex parent, Color backgroundColor, { int flex
 
 // Solid colour, Widget version
 class Rectangle extends StatelessWidget {
-  const Rectangle(this.color, { Key key }) : super(key: key);
+  const Rectangle(this.color, {Key key}) : super(key: key);
 
   final Color color;
 
@@ -26,7 +30,7 @@ class Rectangle extends StatelessWidget {
     return Expanded(
       child: Container(
         color: color,
-      )
+      ),
     );
   }
 }
@@ -82,7 +86,8 @@ RenderTransform transformBox;
 
 void rotate(Duration timeStamp) {
   timeBase ??= timeStamp;
-  final double delta = (timeStamp - timeBase).inMicroseconds.toDouble() / Duration.microsecondsPerSecond; // radians
+  final double delta =
+      (timeStamp - timeBase).inMicroseconds.toDouble() / Duration.microsecondsPerSecond; // radians
 
   transformBox.setIdentity();
   transformBox.rotateZ(delta);

--- a/examples/layers/widgets/spinning_square.dart
+++ b/examples/layers/widgets/spinning_square.dart
@@ -38,7 +38,7 @@ class _SpinningSquareState extends State<SpinningSquare> with SingleTickerProvid
         width: 200.0,
         height: 200.0,
         color: const Color(0xFF00FF00),
-      )
+      ),
     );
   }
 }

--- a/examples/layers/widgets/styled_text.dart
+++ b/examples/layers/widgets/styled_text.dart
@@ -18,10 +18,8 @@ Dave: What are you talking about, HAL?
 HAL: This mission is too important for me to allow you to jeopardize it.''';
 
 // [["Dave", "Open the pod bay..."] ...]
-final List<List<String>> _kNameLines = _kDialogText
-  .split('\n')
-  .map<List<String>>((String line) => line.split(':'))
-  .toList();
+final List<List<String>> _kNameLines =
+    _kDialogText.split('\n').map<List<String>>((String line) => line.split(':')).toList();
 
 final TextStyle _kDaveStyle = TextStyle(color: Colors.indigo.shade400, height: 1.8);
 final TextStyle _kHalStyle = TextStyle(color: Colors.red.shade400, fontFamily: 'monospace');
@@ -29,7 +27,7 @@ const TextStyle _kBold = TextStyle(fontWeight: FontWeight.bold);
 const TextStyle _kUnderline = TextStyle(
   decoration: TextDecoration.underline,
   decorationColor: Color(0xFF000000),
-  decorationStyle: TextDecorationStyle.wavy
+  decorationStyle: TextDecorationStyle.wavy,
 );
 
 Widget toStyledText(String name, String text) {
@@ -44,14 +42,14 @@ Widget toStyledText(String name, String text) {
           children: <TextSpan>[
             TextSpan(
               style: _kUnderline,
-              text: name
+              text: name,
             ),
             const TextSpan(text: ':')
-          ]
+          ],
         ),
         TextSpan(text: text)
-      ]
-    )
+      ],
+    ),
   );
 }
 
@@ -65,9 +63,9 @@ class SpeakerSeparator extends StatelessWidget {
       margin: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 64.0),
       decoration: const BoxDecoration(
         border: Border(
-          bottom: BorderSide(color: Color.fromARGB(24, 0, 0, 0))
-        )
-      )
+          bottom: BorderSide(color: Color.fromARGB(24, 0, 0, 0)),
+        ),
+      ),
     );
   }
 }
@@ -101,8 +99,9 @@ class _StyledTextDemoState extends State<StyledTextDemo> {
     final List<Widget> children = <Widget>[];
     for (Widget line in lines) {
       children.add(line);
-      if (line != lines.last)
+      if (line != lines.last) {
         children.add(SpeakerSeparator());
+      }
     }
 
     return GestureDetector(
@@ -112,9 +111,9 @@ class _StyledTextDemoState extends State<StyledTextDemo> {
         child: Column(
           children: children,
           mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start
-        )
-      )
+          crossAxisAlignment: CrossAxisAlignment.start,
+        ),
+      ),
     );
   }
 }
@@ -124,12 +123,12 @@ void main() {
     theme: ThemeData.light(),
     home: Scaffold(
       appBar: AppBar(
-        title: const Text('Hal and Dave')
+        title: const Text('Hal and Dave'),
       ),
       body: Material(
         color: Colors.grey.shade50,
-        child: StyledTextDemo()
-      )
-    )
+        child: StyledTextDemo(),
+      ),
+    ),
   ));
 }

--- a/examples/layers/widgets/styled_text.dart
+++ b/examples/layers/widgets/styled_text.dart
@@ -18,8 +18,10 @@ Dave: What are you talking about, HAL?
 HAL: This mission is too important for me to allow you to jeopardize it.''';
 
 // [["Dave", "Open the pod bay..."] ...]
-final List<List<String>> _kNameLines =
-    _kDialogText.split('\n').map<List<String>>((String line) => line.split(':')).toList();
+final List<List<String>> _kNameLines = _kDialogText
+  .split('\n')
+  .map<List<String>>((String line) => line.split(':'))
+  .toList();
 
 final TextStyle _kDaveStyle = TextStyle(color: Colors.indigo.shade400, height: 1.8);
 final TextStyle _kHalStyle = TextStyle(color: Colors.red.shade400, fontFamily: 'monospace');

--- a/examples/platform_channel/lib/main.dart
+++ b/examples/platform_channel/lib/main.dart
@@ -13,10 +13,8 @@ class PlatformChannel extends StatefulWidget {
 }
 
 class _PlatformChannelState extends State<PlatformChannel> {
-  static const MethodChannel methodChannel =
-      MethodChannel('samples.flutter.io/battery');
-  static const EventChannel eventChannel =
-      EventChannel('samples.flutter.io/charging');
+  static const MethodChannel methodChannel = MethodChannel('samples.flutter.io/battery');
+  static const EventChannel eventChannel = EventChannel('samples.flutter.io/charging');
 
   String _batteryLevel = 'Battery level: unknown.';
   String _chargingStatus = 'Battery status: unknown.';
@@ -42,8 +40,7 @@ class _PlatformChannelState extends State<PlatformChannel> {
 
   void _onEvent(Object event) {
     setState(() {
-      _chargingStatus =
-          "Battery status: ${event == 'charging' ? '' : 'dis'}charging.";
+      _chargingStatus = "Battery status: ${event == 'charging' ? '' : 'dis'}charging.";
     });
   }
 

--- a/examples/platform_channel/test_driver/button_tap_test.dart
+++ b/examples/platform_channel/test_driver/button_tap_test.dart
@@ -14,13 +14,13 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
+      if (driver != null) {
         driver.close();
+      }
     });
 
     test('tap on the button, verify result', () async {
-      final SerializableFinder batteryLevelLabel =
-          find.byValueKey('Battery level label');
+      final SerializableFinder batteryLevelLabel = find.byValueKey('Battery level label');
       expect(batteryLevelLabel, isNotNull);
 
       final SerializableFinder button = find.text('Refresh');

--- a/examples/platform_channel_swift/lib/main.dart
+++ b/examples/platform_channel_swift/lib/main.dart
@@ -13,10 +13,8 @@ class PlatformChannel extends StatefulWidget {
 }
 
 class _PlatformChannelState extends State<PlatformChannel> {
-  static const MethodChannel methodChannel =
-      MethodChannel('samples.flutter.io/battery');
-  static const EventChannel eventChannel =
-      EventChannel('samples.flutter.io/charging');
+  static const MethodChannel methodChannel = MethodChannel('samples.flutter.io/battery');
+  static const EventChannel eventChannel = EventChannel('samples.flutter.io/charging');
 
   String _batteryLevel = 'Battery level: unknown.';
   String _chargingStatus = 'Battery status: unknown.';
@@ -42,8 +40,7 @@ class _PlatformChannelState extends State<PlatformChannel> {
 
   void _onEvent(Object event) {
     setState(() {
-      _chargingStatus =
-          "Battery status: ${event == 'charging' ? '' : 'dis'}charging.";
+      _chargingStatus = "Battery status: ${event == 'charging' ? '' : 'dis'}charging.";
     });
   }
 

--- a/examples/platform_channel_swift/test_driver/button_tap_test.dart
+++ b/examples/platform_channel_swift/test_driver/button_tap_test.dart
@@ -14,23 +14,24 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
+      if (driver != null) {
         driver.close();
+      }
     });
 
     test('tap on the button, verify result', () async {
-        final SerializableFinder batteryLevelLabel = find.byValueKey('Battery level label');
-        expect(batteryLevelLabel, isNotNull);
+      final SerializableFinder batteryLevelLabel = find.byValueKey('Battery level label');
+      expect(batteryLevelLabel, isNotNull);
 
-        final SerializableFinder button = find.text('Get Battery Level');
-        await driver.waitFor(button);
-        await driver.tap(button);
+      final SerializableFinder button = find.text('Get Battery Level');
+      await driver.waitFor(button);
+      await driver.tap(button);
 
-        String batteryLevel;
-        while (batteryLevel == null || batteryLevel.isEmpty) {
-          batteryLevel = await driver.getText(batteryLevelLabel);
-        }
-        expect(batteryLevel, isNotEmpty);
+      String batteryLevel;
+      while (batteryLevel == null || batteryLevel.isEmpty) {
+        batteryLevel = await driver.getText(batteryLevelLabel);
+      }
+      expect(batteryLevel, isNotEmpty);
     });
   });
 }

--- a/examples/platform_view/lib/main.dart
+++ b/examples/platform_view/lib/main.dart
@@ -25,7 +25,7 @@ class PlatformView extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key key, this.title}) : super(key: key);
+  const MyHomePage({ Key key, this.title }) : super(key: key);
 
   final String title;
 

--- a/examples/platform_view/lib/main.dart
+++ b/examples/platform_view/lib/main.dart
@@ -53,51 +53,51 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(
-          title: Text(widget.title),
-        ),
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Expanded(
-              child: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Text(
-                      'Button tapped $_counter time${_counter == 1 ? '' : 's'}.',
-                      style: const TextStyle(fontSize: 17.0),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(18.0),
-                      child: RaisedButton(
-                        child: Platform.isIOS
-                            ? const Text('Continue in iOS view')
-                            : const Text('Continue in Android view'),
-                        onPressed: _launchPlatformCount),
-                    ),
-                  ],
+    appBar: AppBar(
+      title: Text(widget.title),
+    ),
+    body: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  'Button tapped $_counter time${_counter == 1 ? '' : 's'}.',
+                  style: const TextStyle(fontSize: 17.0),
                 ),
-              ),
+                Padding(
+                  padding: const EdgeInsets.all(18.0),
+                  child: RaisedButton(
+                    child: Platform.isIOS
+                        ? const Text('Continue in iOS view')
+                        : const Text('Continue in Android view'),
+                    onPressed: _launchPlatformCount),
+                ),
+              ],
             ),
-            Container(
-              padding: const EdgeInsets.only(bottom: 15.0, left: 5.0),
-              child: Row(
-                children: <Widget>[
-                  Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
-                  const Text(
-                    'Flutter',
-                    style: TextStyle(fontSize: 30.0),
-                  ),
-                ],
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.only(bottom: 15.0, left: 5.0),
+          child: Row(
+            children: <Widget>[
+              Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
+              const Text(
+                'Flutter',
+                style: TextStyle(fontSize: 30.0),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: _incrementCounter,
-          tooltip: 'Increment',
-          child: const Icon(Icons.add),
-        ),
-      );
+      ],
+    ),
+    floatingActionButton: FloatingActionButton(
+      onPressed: _incrementCounter,
+      tooltip: 'Increment',
+      child: const Icon(Icons.add),
+    ),
+  );
 }

--- a/examples/platform_view/lib/main.dart
+++ b/examples/platform_view/lib/main.dart
@@ -34,8 +34,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  static const MethodChannel _methodChannel =
-      MethodChannel('samples.flutter.io/platform_view');
+  static const MethodChannel _methodChannel = MethodChannel('samples.flutter.io/platform_view');
 
   int _counter = 0;
 
@@ -46,8 +45,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _launchPlatformCount() async {
-    final int platformCounter =
-        await _methodChannel.invokeMethod('switchView', _counter);
+    final int platformCounter = await _methodChannel.invokeMethod('switchView', _counter);
     setState(() {
       _counter = platformCounter;
     });
@@ -67,16 +65,16 @@ class _MyHomePageState extends State<MyHomePage> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
                     Text(
-                      'Button tapped $_counter time${ _counter == 1 ? '' : 's' }.',
+                      'Button tapped $_counter time${_counter == 1 ? '' : 's'}.',
                       style: const TextStyle(fontSize: 17.0),
                     ),
                     Padding(
                       padding: const EdgeInsets.all(18.0),
                       child: RaisedButton(
-                          child: Platform.isIOS
-                              ? const Text('Continue in iOS view')
-                              : const Text('Continue in Android view'),
-                          onPressed: _launchPlatformCount),
+                        child: Platform.isIOS
+                            ? const Text('Continue in iOS view')
+                            : const Text('Continue in Android view'),
+                        onPressed: _launchPlatformCount),
                     ),
                   ],
                 ),
@@ -86,8 +84,7 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: const EdgeInsets.only(bottom: 15.0, left: 5.0),
               child: Row(
                 children: <Widget>[
-                  Image.asset('assets/flutter-mark-square-64.png',
-                      scale: 1.5),
+                  Image.asset('assets/flutter-mark-square-64.png', scale: 1.5),
                   const Text(
                     'Flutter',
                     style: TextStyle(fontSize: 30.0),

--- a/examples/stocks/lib/i18n/stock_messages_all.dart
+++ b/examples/stocks/lib/i18n/stock_messages_all.dart
@@ -12,10 +12,10 @@ import 'package:intl/src/intl_helpers.dart';
 import 'stock_messages_en.dart' as messages_en;
 import 'stock_messages_es.dart' as messages_es;
 
-typedef Future<dynamic> LibraryLoader();
+typedef LibraryLoader = Future<dynamic> Function();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'en': () => new Future.value(null),
-  'es': () => new Future.value(null),
+  'en': () => Future.value(null),
+  'es': () => Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(localeName) {
@@ -31,18 +31,16 @@ MessageLookupByLibrary _findExact(localeName) {
 
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
-  var availableLocale = Intl.verifiedLocale(
-    localeName,
-    (locale) => _deferredLibraries[locale] != null,
-    onFailure: (_) => null);
+  var availableLocale =
+      Intl.verifiedLocale(localeName, (locale) => _deferredLibraries[locale] != null, onFailure: (_) => null);
   if (availableLocale == null) {
-    return new Future.value(false);
+    return Future.value(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? new Future.value(false) : lib());
-  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  await (lib == null ? Future.value(false) : lib());
+  initializeInternalMessageLookup(() => CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return new Future.value(true);
+  return Future.value(true);
 }
 
 bool _messagesExistFor(String locale) {
@@ -54,8 +52,9 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
-  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
-      onFailure: (_) => null);
-  if (actualLocale == null) return null;
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
+  if (actualLocale == null) {
+    return null;
+  }
   return _findExact(actualLocale);
 }

--- a/examples/stocks/lib/i18n/stock_messages_en.dart
+++ b/examples/stocks/lib/i18n/stock_messages_en.dart
@@ -6,21 +6,21 @@
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 
-final messages = new MessageLookup();
+final messages = MessageLookup();
 
 // ignore: unused_element
 final _keepAnalysisHappy = Intl.defaultLocale;
 
 // ignore: non_constant_identifier_names
-typedef MessageIfAbsent(String message_str, List args);
+typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
   get localeName => 'en';
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "market" : MessageLookupByLibrary.simpleMessage("MARKET"),
-    "portfolio" : MessageLookupByLibrary.simpleMessage("PORTFOLIO"),
-    "title" : MessageLookupByLibrary.simpleMessage("Stocks")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "market": MessageLookupByLibrary.simpleMessage("MARKET"),
+        "portfolio": MessageLookupByLibrary.simpleMessage("PORTFOLIO"),
+        "title": MessageLookupByLibrary.simpleMessage("Stocks")
+      };
 }

--- a/examples/stocks/lib/i18n/stock_messages_en.dart
+++ b/examples/stocks/lib/i18n/stock_messages_en.dart
@@ -19,8 +19,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function>{
-        "market": MessageLookupByLibrary.simpleMessage("MARKET"),
-        "portfolio": MessageLookupByLibrary.simpleMessage("PORTFOLIO"),
-        "title": MessageLookupByLibrary.simpleMessage("Stocks")
-      };
+    "market": MessageLookupByLibrary.simpleMessage("MARKET"),
+    "portfolio": MessageLookupByLibrary.simpleMessage("PORTFOLIO"),
+    "title": MessageLookupByLibrary.simpleMessage("Stocks")
+  };
 }

--- a/examples/stocks/lib/i18n/stock_messages_es.dart
+++ b/examples/stocks/lib/i18n/stock_messages_es.dart
@@ -6,21 +6,21 @@
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 
-final messages = new MessageLookup();
+final messages = MessageLookup();
 
 // ignore: unused_element
 final _keepAnalysisHappy = Intl.defaultLocale;
 
 // ignore: non_constant_identifier_names
-typedef MessageIfAbsent(String message_str, List args);
+typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
   get localeName => 'es';
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "market" : MessageLookupByLibrary.simpleMessage("MERCADO"),
-    "portfolio" : MessageLookupByLibrary.simpleMessage("CARTERA"),
-    "title" : MessageLookupByLibrary.simpleMessage("Acciones")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "market": MessageLookupByLibrary.simpleMessage("MERCADO"),
+        "portfolio": MessageLookupByLibrary.simpleMessage("CARTERA"),
+        "title": MessageLookupByLibrary.simpleMessage("Acciones")
+      };
 }

--- a/examples/stocks/lib/i18n/stock_messages_es.dart
+++ b/examples/stocks/lib/i18n/stock_messages_es.dart
@@ -19,8 +19,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function>{
-        "market": MessageLookupByLibrary.simpleMessage("MERCADO"),
-        "portfolio": MessageLookupByLibrary.simpleMessage("CARTERA"),
-        "title": MessageLookupByLibrary.simpleMessage("Acciones")
-      };
+    "market": MessageLookupByLibrary.simpleMessage("MERCADO"),
+    "portfolio": MessageLookupByLibrary.simpleMessage("CARTERA"),
+    "title": MessageLookupByLibrary.simpleMessage("Acciones")
+  };
 }

--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -7,12 +7,13 @@ library stocks;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show
-  debugPaintSizeEnabled,
-  debugPaintBaselinesEnabled,
-  debugPaintLayerBordersEnabled,
-  debugPaintPointersEnabled,
-  debugRepaintRainbowEnabled;
+import 'package:flutter/rendering.dart'
+    show
+        debugPaintSizeEnabled,
+        debugPaintBaselinesEnabled,
+        debugPaintLayerBordersEnabled,
+        debugPaintPointersEnabled,
+        debugRepaintRainbowEnabled;
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'stock_data.dart';
@@ -51,7 +52,7 @@ class StocksAppState extends State<StocksApp> {
     debugShowPointers: false,
     debugShowRainbow: false,
     showPerformanceOverlay: false,
-    showSemanticsDebugger: false
+    showSemanticsDebugger: false,
   );
 
   @override
@@ -71,12 +72,12 @@ class StocksAppState extends State<StocksApp> {
       case StockMode.optimistic:
         return ThemeData(
           brightness: Brightness.light,
-          primarySwatch: Colors.purple
+          primarySwatch: Colors.purple,
         );
       case StockMode.pessimistic:
         return ThemeData(
           brightness: Brightness.dark,
-          accentColor: Colors.redAccent
+          accentColor: Colors.redAccent,
         );
     }
     assert(_configuration.stockMode != null);
@@ -88,15 +89,17 @@ class StocksAppState extends State<StocksApp> {
     final List<String> path = settings.name.split('/');
     // We only support paths that start with a slash, so bail if
     // the first component is not empty:
-    if (path[0] != '')
+    if (path[0] != '') {
       return null;
+    }
     // If the path is "/stock:..." then show a stock page for the
     // specified stock symbol.
     if (path[1].startsWith('stock:')) {
       // We don't yet support subpages of a stock, so bail if there's
       // any more path components.
-      if (path.length != 2)
+      if (path.length != 2) {
         return null;
+      }
       // Extract the symbol part of "stock:..." and return a route
       // for that symbol.
       final String symbol = path[1].substring(6);
@@ -135,8 +138,8 @@ class StocksAppState extends State<StocksApp> {
       showPerformanceOverlay: _configuration.showPerformanceOverlay,
       showSemanticsDebugger: _configuration.showSemanticsDebugger,
       routes: <String, WidgetBuilder>{
-         '/':         (BuildContext context) => StockHome(stocks, _configuration, configurationUpdater),
-         '/settings': (BuildContext context) => StockSettings(_configuration, configurationUpdater)
+        '/': (BuildContext context) => StockHome(stocks, _configuration, configurationUpdater),
+        '/settings': (BuildContext context) => StockSettings(_configuration, configurationUpdater)
       },
       onGenerateRoute: _getRoute,
     );

--- a/examples/stocks/lib/stock_arrow.dart
+++ b/examples/stocks/lib/stock_arrow.dart
@@ -7,7 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 class StockArrowPainter extends CustomPainter {
-  StockArrowPainter({this.color, this.percentChange});
+  StockArrowPainter({ this.color, this.percentChange });
 
   final Color color;
   final double percentChange;
@@ -52,7 +52,7 @@ class StockArrowPainter extends CustomPainter {
 }
 
 class StockArrow extends StatelessWidget {
-  const StockArrow({Key key, this.percentChange}) : super(key: key);
+  const StockArrow({ Key key, this.percentChange }) : super(key: key);
 
   final double percentChange;
 

--- a/examples/stocks/lib/stock_arrow.dart
+++ b/examples/stocks/lib/stock_arrow.dart
@@ -7,7 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 class StockArrowPainter extends CustomPainter {
-  StockArrowPainter({ this.color, this.percentChange });
+  StockArrowPainter({this.color, this.percentChange});
 
   final Color color;
   final double percentChange;
@@ -47,13 +47,12 @@ class StockArrowPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(StockArrowPainter oldDelegate) {
-    return oldDelegate.color != color
-        || oldDelegate.percentChange != percentChange;
+    return oldDelegate.color != color || oldDelegate.percentChange != percentChange;
   }
 }
 
 class StockArrow extends StatelessWidget {
-  const StockArrow({ Key key, this.percentChange }) : super(key: key);
+  const StockArrow({Key key, this.percentChange}) : super(key: key);
 
   final double percentChange;
 
@@ -64,8 +63,9 @@ class StockArrow extends StatelessWidget {
   }
 
   Color _colorForPercentChange(double percentChange) {
-    if (percentChange > 0)
+    if (percentChange > 0) {
       return Colors.green[_colorIndexForPercentChange(percentChange)];
+    }
     return Colors.red[_colorIndexForPercentChange(percentChange)];
   }
 
@@ -79,9 +79,9 @@ class StockArrow extends StatelessWidget {
         painter: StockArrowPainter(
           // TODO(jackson): This should change colors with the theme
           color: _colorForPercentChange(percentChange),
-          percentChange: percentChange
-        )
-      )
+          percentChange: percentChange,
+        ),
+      ),
     );
   }
 }

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -202,24 +202,24 @@ class StockHomeState extends State<StockHome> {
             _handleStockMenu(context, value);
           },
           itemBuilder: (BuildContext context) => <PopupMenuItem<_StockMenuItem>>[
-                CheckedPopupMenuItem<_StockMenuItem>(
-                  value: _StockMenuItem.autorefresh,
-                  checked: _autorefresh,
-                  child: const Text('Autorefresh'),
-                ),
-                const PopupMenuItem<_StockMenuItem>(
-                  value: _StockMenuItem.refresh,
-                  child: Text('Refresh'),
-                ),
-                const PopupMenuItem<_StockMenuItem>(
-                  value: _StockMenuItem.speedUp,
-                  child: Text('Increase animation speed'),
-                ),
-                const PopupMenuItem<_StockMenuItem>(
-                  value: _StockMenuItem.speedDown,
-                  child: Text('Decrease animation speed'),
-                ),
-              ],
+            CheckedPopupMenuItem<_StockMenuItem>(
+              value: _StockMenuItem.autorefresh,
+              checked: _autorefresh,
+              child: const Text('Autorefresh'),
+            ),
+            const PopupMenuItem<_StockMenuItem>(
+              value: _StockMenuItem.refresh,
+              child: Text('Refresh'),
+            ),
+            const PopupMenuItem<_StockMenuItem>(
+              value: _StockMenuItem.speedUp,
+              child: Text('Increase animation speed'),
+            ),
+            const PopupMenuItem<_StockMenuItem>(
+              value: _StockMenuItem.speedDown,
+              child: Text('Decrease animation speed'),
+            ),
+          ],
         ),
       ],
       bottom: TabBar(

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show debugDumpRenderTree, debugDumpLayerTree, debugDumpSemanticsTree, DebugSemanticsDumpOrder;
+import 'package:flutter/rendering.dart'
+    show debugDumpRenderTree, debugDumpLayerTree, debugDumpSemanticsTree, DebugSemanticsDumpOrder;
 import 'package:flutter/scheduler.dart' show timeDilation;
 import 'stock_data.dart';
 import 'stock_list.dart';
@@ -81,8 +82,9 @@ class StockHomeState extends State<StockHome> {
   }
 
   void _handleStockModeChange(StockMode value) {
-    if (widget.updater != null)
+    if (widget.updater != null) {
       widget.updater(widget.configuration.copyWith(stockMode: value));
+    }
   }
 
   void _handleStockMenu(BuildContext context, _StockMenuItem value) {
@@ -196,26 +198,28 @@ class StockHomeState extends State<StockHome> {
           tooltip: 'Search',
         ),
         PopupMenuButton<_StockMenuItem>(
-          onSelected: (_StockMenuItem value) { _handleStockMenu(context, value); },
+          onSelected: (_StockMenuItem value) {
+            _handleStockMenu(context, value);
+          },
           itemBuilder: (BuildContext context) => <PopupMenuItem<_StockMenuItem>>[
-            CheckedPopupMenuItem<_StockMenuItem>(
-              value: _StockMenuItem.autorefresh,
-              checked: _autorefresh,
-              child: const Text('Autorefresh'),
-            ),
-            const PopupMenuItem<_StockMenuItem>(
-              value: _StockMenuItem.refresh,
-              child: Text('Refresh'),
-            ),
-            const PopupMenuItem<_StockMenuItem>(
-              value: _StockMenuItem.speedUp,
-              child: Text('Increase animation speed'),
-            ),
-            const PopupMenuItem<_StockMenuItem>(
-              value: _StockMenuItem.speedDown,
-              child: Text('Decrease animation speed'),
-            ),
-          ],
+                CheckedPopupMenuItem<_StockMenuItem>(
+                  value: _StockMenuItem.autorefresh,
+                  checked: _autorefresh,
+                  child: const Text('Autorefresh'),
+                ),
+                const PopupMenuItem<_StockMenuItem>(
+                  value: _StockMenuItem.refresh,
+                  child: Text('Refresh'),
+                ),
+                const PopupMenuItem<_StockMenuItem>(
+                  value: _StockMenuItem.speedUp,
+                  child: Text('Increase animation speed'),
+                ),
+                const PopupMenuItem<_StockMenuItem>(
+                  value: _StockMenuItem.speedDown,
+                  child: Text('Decrease animation speed'),
+                ),
+              ],
         ),
       ],
       bottom: TabBar(
@@ -228,13 +232,13 @@ class StockHomeState extends State<StockHome> {
   }
 
   static Iterable<Stock> _getStockList(StockData stocks, Iterable<String> symbols) {
-    return symbols.map<Stock>((String symbol) => stocks[symbol])
-        .where((Stock stock) => stock != null);
+    return symbols.map<Stock>((String symbol) => stocks[symbol]).where((Stock stock) => stock != null);
   }
 
   Iterable<Stock> _filterBySearchQuery(Iterable<Stock> stocks) {
-    if (_searchQuery.text.isEmpty)
+    if (_searchQuery.text.isEmpty) {
       return stocks;
+    }
     final RegExp regexp = RegExp(_searchQuery.text, caseSensitive: false);
     return stocks.where((Stock stock) => stock.symbol.contains(regexp));
   }
@@ -263,7 +267,8 @@ class StockHomeState extends State<StockHome> {
         Navigator.pushNamed(context, '/stock:${stock.symbol}');
       },
       onShow: (Stock stock) {
-        _scaffoldKey.currentState.showBottomSheet<void>((BuildContext context) => StockSymbolBottomSheet(stock: stock));
+        _scaffoldKey.currentState
+          .showBottomSheet<void>((BuildContext context) => StockSymbolBottomSheet(stock: stock));
       },
     );
   }
@@ -273,12 +278,13 @@ class StockHomeState extends State<StockHome> {
       key: ValueKey<StockHomeTab>(tab),
       animation: Listenable.merge(<Listenable>[_searchQuery, widget.stocks]),
       builder: (BuildContext context, Widget child) {
-        return _buildStockList(context, _filterBySearchQuery(_getStockList(widget.stocks, stockSymbols)).toList(), tab);
+        return _buildStockList(
+          context, _filterBySearchQuery(_getStockList(widget.stocks, stockSymbols)).toList(), tab);
       },
     );
   }
 
-  static const List<String> portfolioSymbols = <String>['AAPL','FIZZ', 'FIVE', 'FLAT', 'ZINC', 'ZNGA'];
+  static const List<String> portfolioSymbols = <String>['AAPL', 'FIZZ', 'FIVE', 'FLAT', 'ZINC', 'ZNGA'];
 
   Widget buildSearchBar() {
     return AppBar(

--- a/examples/stocks/lib/stock_list.dart
+++ b/examples/stocks/lib/stock_list.dart
@@ -8,7 +8,13 @@ import 'stock_data.dart';
 import 'stock_row.dart';
 
 class StockList extends StatelessWidget {
-  const StockList({ Key key, this.stocks, this.onOpen, this.onShow, this.onAction }) : super(key: key);
+  const StockList({
+    Key key,
+    this.stocks,
+    this.onOpen,
+    this.onShow,
+    this.onAction,
+  }) : super(key: key);
 
   final List<Stock> stocks;
   final StockRowActionCallback onOpen;
@@ -26,7 +32,7 @@ class StockList extends StatelessWidget {
           stock: stocks[index],
           onPressed: onOpen,
           onDoubleTap: onShow,
-          onLongPressed: onAction
+          onLongPressed: onAction,
         );
       },
     );

--- a/examples/stocks/lib/stock_row.dart
+++ b/examples/stocks/lib/stock_row.dart
@@ -14,7 +14,7 @@ class StockRow extends StatelessWidget {
     this.stock,
     this.onPressed,
     this.onDoubleTap,
-    this.onLongPressed
+    this.onLongPressed,
   }) : super(key: ObjectKey(stock));
 
   final Stock stock;
@@ -32,8 +32,9 @@ class StockRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final String lastSale = '\$${stock.lastSale.toStringAsFixed(2)}';
     String changeInPrice = '${stock.percentChange.toStringAsFixed(2)}%';
-    if (stock.percentChange > 0)
+    if (stock.percentChange > 0) {
       changeInPrice = '+' + changeInPrice;
+    }
     return InkWell(
       onTap: _getHandler(onPressed),
       onDoubleTap: _getHandler(onDoubleTap),
@@ -42,8 +43,8 @@ class StockRow extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 20.0),
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(color: Theme.of(context).dividerColor)
-          )
+            bottom: BorderSide(color: Theme.of(context).dividerColor),
+          ),
         ),
         child: Row(
           children: <Widget>[
@@ -51,8 +52,8 @@ class StockRow extends StatelessWidget {
               margin: const EdgeInsets.only(right: 5.0),
               child: Hero(
                 tag: stock,
-                child: StockArrow(percentChange: stock.percentChange)
-              )
+                child: StockArrow(percentChange: stock.percentChange),
+              ),
             ),
             Expanded(
               child: Row(
@@ -60,29 +61,29 @@ class StockRow extends StatelessWidget {
                   Expanded(
                     flex: 2,
                     child: Text(
-                      stock.symbol
-                    )
+                      stock.symbol,
+                    ),
                   ),
                   Expanded(
                     child: Text(
                       lastSale,
-                      textAlign: TextAlign.right
-                    )
+                      textAlign: TextAlign.right,
+                    ),
                   ),
                   Expanded(
                     child: Text(
                       changeInPrice,
-                      textAlign: TextAlign.right
-                    )
+                      textAlign: TextAlign.right,
+                    ),
                   ),
                 ],
                 crossAxisAlignment: CrossAxisAlignment.baseline,
-                textBaseline: DefaultTextStyle.of(context).style.textBaseline
-              )
+                textBaseline: DefaultTextStyle.of(context).style.textBaseline,
+              ),
             ),
-          ]
-        )
-      )
+          ],
+        ),
+      ),
     );
   }
 }

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -19,7 +19,8 @@ class StockSettings extends StatefulWidget {
 class StockSettingsState extends State<StockSettings> {
   void _handleOptimismChanged(bool value) {
     value ??= false;
-    sendUpdates(widget.configuration.copyWith(stockMode: value ? StockMode.optimistic : StockMode.pessimistic));
+    sendUpdates(
+      widget.configuration.copyWith(stockMode: value ? StockMode.optimistic : StockMode.pessimistic));
   }
 
   void _handleBackupChanged(bool value) {
@@ -50,7 +51,6 @@ class StockSettingsState extends State<StockSettings> {
     sendUpdates(widget.configuration.copyWith(debugShowRainbow: value));
   }
 
-
   void _handleShowPerformanceOverlayChanged(bool value) {
     sendUpdates(widget.configuration.copyWith(showPerformanceOverlay: value));
   }
@@ -67,22 +67,23 @@ class StockSettingsState extends State<StockSettings> {
       case StockMode.pessimistic:
         showDialog<bool>(
           context: context,
-           builder: (BuildContext context) {
+          builder: (BuildContext context) {
             return AlertDialog(
               title: const Text('Change mode?'),
-              content: const Text('Optimistic mode means everything is awesome. Are you sure you can handle that?'),
+              content: const Text(
+                  'Optimistic mode means everything is awesome. Are you sure you can handle that?'),
               actions: <Widget>[
                 FlatButton(
                   child: const Text('NO THANKS'),
                   onPressed: () {
                     Navigator.pop(context, false);
-                  }
+                  },
                 ),
                 FlatButton(
                   child: const Text('AGREE'),
                   onPressed: () {
                     Navigator.pop(context, true);
-                  }
+                  },
                 ),
               ],
             );
@@ -93,13 +94,14 @@ class StockSettingsState extends State<StockSettings> {
   }
 
   void sendUpdates(StockConfiguration value) {
-    if (widget.updater != null)
+    if (widget.updater != null) {
       widget.updater(value);
+    }
   }
 
   Widget buildAppBar(BuildContext context) {
     return AppBar(
-      title: const Text('Settings')
+      title: const Text('Settings'),
     );
   }
 
@@ -117,7 +119,9 @@ class StockSettingsState extends State<StockSettings> {
       ListTile(
         leading: const Icon(Icons.backup),
         title: const Text('Back up stock list to the cloud'),
-        onTap: () { _handleBackupChanged(!(widget.configuration.backupMode == BackupMode.enabled)); },
+        onTap: () {
+          _handleBackupChanged(!(widget.configuration.backupMode == BackupMode.enabled));
+        },
         trailing: Switch(
           value: widget.configuration.backupMode == BackupMode.enabled,
           onChanged: _handleBackupChanged,
@@ -126,7 +130,9 @@ class StockSettingsState extends State<StockSettings> {
       ListTile(
         leading: const Icon(Icons.picture_in_picture),
         title: const Text('Show rendering performance overlay'),
-        onTap: () { _handleShowPerformanceOverlayChanged(!widget.configuration.showPerformanceOverlay); },
+        onTap: () {
+          _handleShowPerformanceOverlayChanged(!widget.configuration.showPerformanceOverlay);
+        },
         trailing: Switch(
           value: widget.configuration.showPerformanceOverlay,
           onChanged: _handleShowPerformanceOverlayChanged,
@@ -135,7 +141,9 @@ class StockSettingsState extends State<StockSettings> {
       ListTile(
         leading: const Icon(Icons.accessibility),
         title: const Text('Show semantics overlay'),
-        onTap: () { _handleShowSemanticsDebuggerChanged(!widget.configuration.showSemanticsDebugger); },
+        onTap: () {
+          _handleShowSemanticsDebuggerChanged(!widget.configuration.showSemanticsDebugger);
+        },
         trailing: Switch(
           value: widget.configuration.showSemanticsDebugger,
           onChanged: _handleShowSemanticsDebuggerChanged,
@@ -148,7 +156,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.border_clear),
           title: const Text('Show material grid (for debugging)'),
-          onTap: () { _handleShowGridChanged(!widget.configuration.debugShowGrid); },
+          onTap: () {
+            _handleShowGridChanged(!widget.configuration.debugShowGrid);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowGrid,
             onChanged: _handleShowGridChanged,
@@ -157,7 +167,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.border_all),
           title: const Text('Show construction lines (for debugging)'),
-          onTap: () { _handleShowSizesChanged(!widget.configuration.debugShowSizes); },
+          onTap: () {
+            _handleShowSizesChanged(!widget.configuration.debugShowSizes);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowSizes,
             onChanged: _handleShowSizesChanged,
@@ -166,7 +178,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.format_color_text),
           title: const Text('Show baselines (for debugging)'),
-          onTap: () { _handleShowBaselinesChanged(!widget.configuration.debugShowBaselines); },
+          onTap: () {
+            _handleShowBaselinesChanged(!widget.configuration.debugShowBaselines);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowBaselines,
             onChanged: _handleShowBaselinesChanged,
@@ -175,7 +189,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.filter_none),
           title: const Text('Show layer boundaries (for debugging)'),
-          onTap: () { _handleShowLayersChanged(!widget.configuration.debugShowLayers); },
+          onTap: () {
+            _handleShowLayersChanged(!widget.configuration.debugShowLayers);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowLayers,
             onChanged: _handleShowLayersChanged,
@@ -184,7 +200,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.mouse),
           title: const Text('Show pointer hit-testing (for debugging)'),
-          onTap: () { _handleShowPointersChanged(!widget.configuration.debugShowPointers); },
+          onTap: () {
+            _handleShowPointersChanged(!widget.configuration.debugShowPointers);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowPointers,
             onChanged: _handleShowPointersChanged,
@@ -193,7 +211,9 @@ class StockSettingsState extends State<StockSettings> {
         ListTile(
           leading: const Icon(Icons.gradient),
           title: const Text('Show repaint rainbow (for debugging)'),
-          onTap: () { _handleShowRainbowChanged(!widget.configuration.debugShowRainbow); },
+          onTap: () {
+            _handleShowRainbowChanged(!widget.configuration.debugShowRainbow);
+          },
           trailing: Switch(
             value: widget.configuration.debugShowRainbow,
             onChanged: _handleShowRainbowChanged,
@@ -212,7 +232,7 @@ class StockSettingsState extends State<StockSettings> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: buildAppBar(context),
-      body: buildSettingsPane(context)
+      body: buildSettingsPane(context),
     );
   }
 }

--- a/examples/stocks/lib/stock_strings.dart
+++ b/examples/stocks/lib/stock_strings.dart
@@ -37,16 +37,16 @@ class StockStrings {
   }
 
   String market() => Intl.message(
-        'MARKET',
-        name: 'market',
-        desc: 'Label for the Market tab',
-        locale: _localeName,
-      );
+    'MARKET',
+    name: 'market',
+    desc: 'Label for the Market tab',
+    locale: _localeName,
+  );
 
   String portfolio() => Intl.message(
-        'PORTFOLIO',
-        name: 'portfolio',
-        desc: 'Label for the Portfolio tab',
-        locale: _localeName,
-      );
+    'PORTFOLIO',
+    name: 'portfolio',
+    desc: 'Label for the Portfolio tab',
+    locale: _localeName,
+  );
 }

--- a/examples/stocks/lib/stock_strings.dart
+++ b/examples/stocks/lib/stock_strings.dart
@@ -18,10 +18,9 @@ class StockStrings {
   final String _localeName;
 
   static Future<StockStrings> load(Locale locale) {
-    return initializeMessages(locale.toString())
-      .then<StockStrings>((Object _) {
-        return StockStrings(locale);
-      });
+    return initializeMessages(locale.toString()).then<StockStrings>((Object _) {
+      return StockStrings(locale);
+    });
   }
 
   static StockStrings of(BuildContext context) {
@@ -38,16 +37,16 @@ class StockStrings {
   }
 
   String market() => Intl.message(
-    'MARKET',
-    name: 'market',
-    desc: 'Label for the Market tab',
-    locale: _localeName,
-  );
+        'MARKET',
+        name: 'market',
+        desc: 'Label for the Market tab',
+        locale: _localeName,
+      );
 
   String portfolio() => Intl.message(
-    'PORTFOLIO',
-    name: 'portfolio',
-    desc: 'Label for the Portfolio tab',
-    locale: _localeName,
-  );
+        'PORTFOLIO',
+        name: 'portfolio',
+        desc: 'Label for the Portfolio tab',
+        locale: _localeName,
+      );
 }

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -8,7 +8,7 @@ import 'stock_arrow.dart';
 import 'stock_data.dart';
 
 class _StockSymbolView extends StatelessWidget {
-  const _StockSymbolView({this.stock, this.arrow});
+  const _StockSymbolView({ this.stock, this.arrow });
 
   final Stock stock;
   final Widget arrow;
@@ -65,7 +65,7 @@ class _StockSymbolView extends StatelessWidget {
 }
 
 class StockSymbolPage extends StatelessWidget {
-  const StockSymbolPage({this.symbol, this.stocks});
+  const StockSymbolPage({ this.symbol, this.stocks });
 
   final String symbol;
   final StockData stocks;
@@ -115,7 +115,7 @@ class StockSymbolPage extends StatelessWidget {
 }
 
 class StockSymbolBottomSheet extends StatelessWidget {
-  const StockSymbolBottomSheet({this.stock});
+  const StockSymbolBottomSheet({ this.stock });
 
   final Stock stock;
 

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -8,7 +8,7 @@ import 'stock_arrow.dart';
 import 'stock_data.dart';
 
 class _StockSymbolView extends StatelessWidget {
-  const _StockSymbolView({ this.stock, this.arrow });
+  const _StockSymbolView({this.stock, this.arrow});
 
   final Stock stock;
   final Widget arrow;
@@ -18,8 +18,9 @@ class _StockSymbolView extends StatelessWidget {
     assert(stock != null);
     final String lastSale = '\$${stock.lastSale.toStringAsFixed(2)}';
     String changeInPrice = '${stock.percentChange.toStringAsFixed(2)}%';
-    if (stock.percentChange > 0)
+    if (stock.percentChange > 0) {
       changeInPrice = '+' + changeInPrice;
+    }
 
     final TextStyle headings = Theme.of(context).textTheme.body2;
     return Container(
@@ -30,21 +31,21 @@ class _StockSymbolView extends StatelessWidget {
             children: <Widget>[
               Text(
                 '${stock.symbol}',
-                style: Theme.of(context).textTheme.display2
+                style: Theme.of(context).textTheme.display2,
               ),
               arrow,
             ],
-            mainAxisAlignment: MainAxisAlignment.spaceBetween
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
           ),
           Text('Last Sale', style: headings),
           Text('$lastSale ($changeInPrice)'),
           Container(
-            height: 8.0
+            height: 8.0,
           ),
           Text('Market Cap', style: headings),
           Text('${stock.marketCap}'),
           Container(
-            height: 8.0
+            height: 8.0,
           ),
           RichText(
             text: TextSpan(
@@ -53,18 +54,18 @@ class _StockSymbolView extends StatelessWidget {
               children: const <TextSpan>[
                 TextSpan(text: 'several', style: TextStyle(fontStyle: FontStyle.italic)),
                 TextSpan(text: ' years.'),
-              ]
-            )
+              ],
+            ),
           ),
         ],
-        mainAxisSize: MainAxisSize.min
-      )
+        mainAxisSize: MainAxisSize.min,
+      ),
     );
   }
 }
 
 class StockSymbolPage extends StatelessWidget {
-  const StockSymbolPage({ this.symbol, this.stocks });
+  const StockSymbolPage({this.symbol, this.stocks});
 
   final String symbol;
   final StockData stocks;
@@ -77,7 +78,7 @@ class StockSymbolPage extends StatelessWidget {
         final Stock stock = stocks[symbol];
         return Scaffold(
           appBar: AppBar(
-            title: Text(stock?.name ?? symbol)
+            title: Text(stock?.name ?? symbol),
           ),
           body: SingleChildScrollView(
             child: Container(
@@ -90,21 +91,23 @@ class StockSymbolPage extends StatelessWidget {
                     child: Center(child: CircularProgressIndicator()),
                   ),
                   secondChild: stock != null
-                    ? _StockSymbolView(
-                      stock: stock,
-                      arrow: Hero(
-                        tag: stock,
-                        child: StockArrow(percentChange: stock.percentChange),
-                      ),
-                    ) : Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Center(child: Text('$symbol not found')),
-                    ),
-                  crossFadeState: stock == null && stocks.loading ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                      ? _StockSymbolView(
+                          stock: stock,
+                          arrow: Hero(
+                            tag: stock,
+                            child: StockArrow(percentChange: stock.percentChange),
+                          ),
+                        )
+                      : Padding(
+                          padding: const EdgeInsets.all(20.0),
+                          child: Center(child: Text('$symbol not found')),
+                        ),
+                  crossFadeState:
+                      stock == null && stocks.loading ? CrossFadeState.showFirst : CrossFadeState.showSecond,
                 ),
-              )
-            )
-          )
+              ),
+            ),
+          ),
         );
       },
     );
@@ -112,7 +115,7 @@ class StockSymbolPage extends StatelessWidget {
 }
 
 class StockSymbolBottomSheet extends StatelessWidget {
-  const StockSymbolBottomSheet({ this.stock });
+  const StockSymbolBottomSheet({this.stock});
 
   final Stock stock;
 
@@ -121,12 +124,12 @@ class StockSymbolBottomSheet extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(10.0),
       decoration: const BoxDecoration(
-        border: Border(top: BorderSide(color: Colors.black26))
+        border: Border(top: BorderSide(color: Colors.black26)),
       ),
       child: _StockSymbolView(
         stock: stock,
-        arrow: StockArrow(percentChange: stock.percentChange)
-      )
-   );
+        arrow: StockArrow(percentChange: stock.percentChange),
+      ),
+    );
   }
 }

--- a/examples/stocks/lib/stock_types.dart
+++ b/examples/stocks/lib/stock_types.dart
@@ -19,16 +19,16 @@ class StockConfiguration {
     @required this.debugShowRainbow,
     @required this.showPerformanceOverlay,
     @required this.showSemanticsDebugger,
-  })  : assert(stockMode != null),
-        assert(backupMode != null),
-        assert(debugShowGrid != null),
-        assert(debugShowSizes != null),
-        assert(debugShowBaselines != null),
-        assert(debugShowLayers != null),
-        assert(debugShowPointers != null),
-        assert(debugShowRainbow != null),
-        assert(showPerformanceOverlay != null),
-        assert(showSemanticsDebugger != null);
+  }) : assert(stockMode != null),
+       assert(backupMode != null),
+       assert(debugShowGrid != null),
+       assert(debugShowSizes != null),
+       assert(debugShowBaselines != null),
+       assert(debugShowLayers != null),
+       assert(debugShowPointers != null),
+       assert(debugShowRainbow != null),
+       assert(showPerformanceOverlay != null),
+       assert(showSemanticsDebugger != null);
 
   final StockMode stockMode;
   final BackupMode backupMode;

--- a/examples/stocks/lib/stock_types.dart
+++ b/examples/stocks/lib/stock_types.dart
@@ -18,17 +18,17 @@ class StockConfiguration {
     @required this.debugShowPointers,
     @required this.debugShowRainbow,
     @required this.showPerformanceOverlay,
-    @required this.showSemanticsDebugger
-  }) : assert(stockMode != null),
-       assert(backupMode != null),
-       assert(debugShowGrid != null),
-       assert(debugShowSizes != null),
-       assert(debugShowBaselines != null),
-       assert(debugShowLayers != null),
-       assert(debugShowPointers != null),
-       assert(debugShowRainbow != null),
-       assert(showPerformanceOverlay != null),
-       assert(showSemanticsDebugger != null);
+    @required this.showSemanticsDebugger,
+  })  : assert(stockMode != null),
+        assert(backupMode != null),
+        assert(debugShowGrid != null),
+        assert(debugShowSizes != null),
+        assert(debugShowBaselines != null),
+        assert(debugShowLayers != null),
+        assert(debugShowPointers != null),
+        assert(debugShowRainbow != null),
+        assert(showPerformanceOverlay != null),
+        assert(showSemanticsDebugger != null);
 
   final StockMode stockMode;
   final BackupMode backupMode;
@@ -51,7 +51,7 @@ class StockConfiguration {
     bool debugShowPointers,
     bool debugShowRainbow,
     bool showPerformanceOverlay,
-    bool showSemanticsDebugger
+    bool showSemanticsDebugger,
   }) {
     return StockConfiguration(
       stockMode: stockMode ?? this.stockMode,
@@ -63,7 +63,7 @@ class StockConfiguration {
       debugShowPointers: debugShowPointers ?? this.debugShowPointers,
       debugShowRainbow: debugShowRainbow ?? this.debugShowRainbow,
       showPerformanceOverlay: showPerformanceOverlay ?? this.showPerformanceOverlay,
-      showSemanticsDebugger: showSemanticsDebugger ?? this.showSemanticsDebugger
+      showSemanticsDebugger: showSemanticsDebugger ?? this.showSemanticsDebugger,
     );
   }
 }

--- a/examples/stocks/test/icon_color_test.dart
+++ b/examples/stocks/test/icon_color_test.dart
@@ -12,10 +12,12 @@ import 'package:stocks/stock_data.dart' as stock_data;
 
 Element findElementOfExactWidgetTypeGoingDown(Element node, Type targetType) {
   void walker(Element child) {
-    if (child.widget.runtimeType == targetType)
+    if (child.widget.runtimeType == targetType) {
       throw child;
+    }
     child.visitChildElements(walker);
   }
+
   try {
     walker(node);
   } on Element catch (result) {
@@ -27,10 +29,12 @@ Element findElementOfExactWidgetTypeGoingDown(Element node, Type targetType) {
 Element findElementOfExactWidgetTypeGoingUp(Element node, Type targetType) {
   Element result;
   bool walker(Element ancestor) {
-    if (ancestor.widget.runtimeType == targetType)
+    if (ancestor.widget.runtimeType == targetType) {
       result = ancestor;
+    }
     return result == null;
   }
+
   node.visitAncestorElements(walker);
   return result;
 }

--- a/examples/stocks/test_driver/scroll_perf_test.dart
+++ b/examples/stocks/test_driver/scroll_perf_test.dart
@@ -16,8 +16,9 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
+      if (driver != null) {
         driver.close();
+      }
     });
 
     test('measure', () async {


### PR DESCRIPTION
For discussion.

I've run an experimental version of dartfmt that adds trailing commas where they are needed to maintain the existing indentation.

The goal is to reduce friction when users copy and paste code from the examples and then run dartfmt. Shipping a version of dartfmt with this optional `--fix-trailing-commas` could also help educate new flutter users on when to use trailing commas to get the desired formatting.

For comparison here is what the dartfmt does to this directory without the auto fix. 
https://github.com/flutter/flutter/compare/master...jacob314:format_baseline?expand=1

