### PR TITLE
Make doctor output consistent between VS Code/IntelliJ/Android Studio when plugins are missing

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -44,7 +44,7 @@ class AndroidStudioValidator extends DoctorValidator {
     plugins.validatePackage(messages, <String>['Dart'], 'Dart');
 
     if (_studio.isValid) {
-      type = ValidationType.installed;
+      type = _hasIssues(messages) ? ValidationType.partial : ValidationType.installed;
       messages.addAll(_studio.validationMessages
           .map<ValidationMessage>((String m) => ValidationMessage(m)));
     } else {
@@ -60,6 +60,10 @@ class AndroidStudioValidator extends DoctorValidator {
     }
 
     return ValidationResult(type, messages, statusInfo: studioVersionText);
+  }
+
+  bool _hasIssues(List<ValidationMessage> messages) {
+    return messages.any((ValidationMessage message) => message.isError);
   }
 }
 

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:flutter_tools/src/doctor.dart';
+
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/platform.dart';
@@ -12,18 +14,28 @@ import '../base/version.dart';
 // Include VS Code insiders (useful for debugging).
 const bool _includeInsiders = false;
 
+
+const String extensionIdentifier = 'Dart-Code.flutter';
+const String extensionMarketplaceUrl =
+  'https://marketplace.visualstudio.com/items?itemName=$extensionIdentifier';
+
 class VsCode {
   VsCode._(this.directory, this.extensionDirectory, { Version version, this.edition })
       : version = version ?? Version.unknown {
 
     if (!fs.isDirectorySync(directory)) {
-      _validationMessages.add('VS Code not found at $directory');
+      _validationMessages.add(ValidationMessage.error('VS Code not found at $directory'));
       return;
+    } else {
+      _validationMessages.add(ValidationMessage('VS Code at $directory'));
     }
 
     // If the extensions directory doesn't exist at all, the listSync()
     // below will fail, so just bail out early.
+    final ValidationMessage notInstalledMessage = ValidationMessage.error(
+          'Flutter extension not installed; install from\n$extensionMarketplaceUrl');
     if (!fs.isDirectorySync(extensionDirectory)) {
+      _validationMessages.add(notInstalledMessage);
       return;
     }
 
@@ -38,10 +50,11 @@ class VsCode {
     if (extensionDirs.isNotEmpty) {
       final FileSystemEntity extensionDir = extensionDirs.first;
 
-      _isValid = true;
       _extensionVersion = Version.parse(
           extensionDir.basename.substring('$extensionIdentifier-'.length));
-      _validationMessages.add('Flutter extension version $_extensionVersion');
+      _validationMessages.add(ValidationMessage('Flutter extension version $_extensionVersion'));
+    } else {
+      _validationMessages.add(notInstalledMessage);
     }
   }
 
@@ -61,16 +74,12 @@ class VsCode {
   final Version version;
   final String edition;
 
-  static const String extensionIdentifier = 'Dart-Code.flutter';
-
-  bool _isValid = false;
   Version _extensionVersion;
-  final List<String> _validationMessages = <String>[];
+  final List<ValidationMessage> _validationMessages = <ValidationMessage>[];
 
-  bool get isValid => _isValid;
   String get productName => 'VS Code' + (edition != null ? ', $edition' : '');
 
-  Iterable<String> get validationMessages => _validationMessages;
+  Iterable<ValidationMessage> get validationMessages => _validationMessages;
 
   static List<VsCode> allInstalled() {
     if (platform.isMacOS)

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -4,12 +4,11 @@
 
 import 'dart:convert';
 
-import 'package:flutter_tools/src/doctor.dart';
-
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/version.dart';
+import '../doctor.dart';
 
 // Include VS Code insiders (useful for debugging).
 const bool _includeInsiders = false;

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -49,6 +49,7 @@ class VsCode {
     if (extensionDirs.isNotEmpty) {
       final FileSystemEntity extensionDir = extensionDirs.first;
 
+      _isValid = true;
       _extensionVersion = Version.parse(
           extensionDir.basename.substring('$extensionIdentifier-'.length));
       _validationMessages.add(ValidationMessage('Flutter extension version $_extensionVersion'));
@@ -73,9 +74,11 @@ class VsCode {
   final Version version;
   final String edition;
 
+  bool _isValid = false;
   Version _extensionVersion;
   final List<ValidationMessage> _validationMessages = <ValidationMessage>[];
 
+  bool get isValid => _isValid;
   String get productName => 'VS Code' + (edition != null ? ', $edition' : '');
 
   Iterable<ValidationMessage> get validationMessages => _validationMessages;

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -13,8 +13,6 @@ class VsCodeValidator extends DoctorValidator {
 
   final VsCode _vsCode;
 
-  static const String extensionMarketplaceUrl =
-    'https://marketplace.visualstudio.com/items?itemName=${VsCode.extensionIdentifier}';
 
   static Iterable<DoctorValidator> get installedValidators {
     return VsCode
@@ -24,24 +22,14 @@ class VsCodeValidator extends DoctorValidator {
 
   @override
   Future<ValidationResult> validate() async {
-    final List<ValidationMessage> messages = <ValidationMessage>[];
-    ValidationType type = ValidationType.missing;
     final String vsCodeVersionText = _vsCode.version == Version.unknown
         ? null
         : 'version ${_vsCode.version}';
-    messages.add(ValidationMessage('VS Code at ${_vsCode.directory}'));
-    if (_vsCode.isValid) {
-      type = ValidationType.installed;
-      messages.addAll(_vsCode.validationMessages
-          .map<ValidationMessage>((String m) => ValidationMessage(m)));
-    } else {
-      type = ValidationType.partial;
-      messages.addAll(_vsCode.validationMessages
-          .map<ValidationMessage>((String m) => ValidationMessage.error(m)));
-      messages.add(ValidationMessage(
-          'Flutter extension not installed; install from\n$extensionMarketplaceUrl'));
-    }
 
-    return ValidationResult(type, messages, statusInfo: vsCodeVersionText);
+    return ValidationResult(
+      ValidationType.installed,
+      _vsCode.validationMessages,
+      statusInfo: vsCodeVersionText,
+    );
   }
 }

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -26,8 +26,12 @@ class VsCodeValidator extends DoctorValidator {
         ? null
         : 'version ${_vsCode.version}';
 
+    final ValidationType validationType = _vsCode.isValid
+        ? ValidationType.installed
+        : ValidationType.partial;
+
     return ValidationResult(
-      ValidationType.installed,
+      validationType,
       _vsCode.validationMessages,
       statusInfo: vsCodeVersionText,
     );

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -55,6 +55,7 @@ void main() {
       message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Flutter '));
       expect(message.message, 'Flutter extension version 4.5.6');
+      expect(message.isError, isFalse);
     }, overrides: noColorTerminalOverride);
 
     testUsingContext('vs code validator when 64bit installed', () async {
@@ -75,7 +76,7 @@ void main() {
 
     testUsingContext('vs code validator when extension missing', () async {
       final ValidationResult result = await VsCodeValidatorTestTargets.installedWithoutExtension.validate();
-      expect(result.type, ValidationType.partial);
+      expect(result.type, ValidationType.installed);
       expect(result.statusInfo, 'version 1.2.3');
       expect(result.messages, hasLength(2));
 
@@ -86,6 +87,7 @@ void main() {
       message = result.messages
           .firstWhere((ValidationMessage m) => m.message.startsWith('Flutter '));
       expect(message.message, startsWith('Flutter extension not installed'));
+      expect(message.isError, isTrue);
     }, overrides: noColorTerminalOverride);
   });
 

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -76,7 +76,7 @@ void main() {
 
     testUsingContext('vs code validator when extension missing', () async {
       final ValidationResult result = await VsCodeValidatorTestTargets.installedWithoutExtension.validate();
-      expect(result.type, ValidationType.installed);
+      expect(result.type, ValidationType.partial);
       expect(result.statusInfo, 'version 1.2.3');
       expect(result.messages, hasLength(2));
 


### PR DESCRIPTION
Fixes #22931 by:

1. Making the "Flutter extension not installed" bullet against VS code have a cross
2. Making Android Studio show partial `!` instead of tick if its extensions are not installed (this matches the IntelliJ + VS Code behaviour)

@devoncarew @goderbauer @gspencergoog FYI - with this change, people who previously ran `doctor` in non-verbose mode and got all ticks may start seeing a `!` against Android Studio if they don't have the plugins. I personally think this is ok (`!` is just a warning that it's not set up for Flutter dev) but it may cause some confusion (it says "Doctor found issues in 1 category" for "partials" and not just errors).