### PR TITLE
Use stderr instead of stdout to contain errors in flutter attach test

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test.dart
@@ -47,7 +47,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
       .transform<String>(const LineSplitter())
       .listen((String line) {
     print('run:stderr: $line');
-    stdout.add(line);
+    stderr.add(line);
   });
 
   process.exitCode.then<void>((int processExitCode) { exitCode = processExitCode; });


### PR DESCRIPTION
Fixes #25304 