### PR TITLE
[fuchsia] Get Dart VM service ports from The Hub

### DIFF
--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -13,9 +13,6 @@ import 'package:fuchsia_remote_debug_protocol/fuchsia_remote_debug_protocol.dart
 
 import 'error.dart';
 
-// TODO(awdavies): Update this to use the hub.
-final Directory _kDartPortDir = Directory('/tmp/dart.services');
-
 class _DummyPortForwarder implements PortForwarder {
   _DummyPortForwarder(this._port, this._remotePort);
 
@@ -49,13 +46,13 @@ class _DummySshCommandRunner implements SshCommandRunner {
   @override
   Future<List<String>> run(String command) async {
     try {
-      return List<String>.of(_kDartPortDir
-          .listSync(recursive: false, followLinks: false)
-          .map((FileSystemEntity entity) => entity.path
-              .replaceAll(entity.parent.path, '')
-              .replaceFirst(Platform.pathSeparator, '')));
-    } on FileSystemException catch (e) {
-      _log.warning('Error listing directory: $e');
+      final List<String> splitCommand = command.split(' ');
+      final String exe = splitCommand[0];
+      final List<String> args = splitCommand.skip(1).toList();
+      final ProcessResult r = Process.runSync(exe, args);
+      return r.stdout.split('\n');
+    } on ProcessException catch (e) {
+      _log.warning("Error running '$command': $e");
     }
     return <String>[];
   }

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -36,16 +36,6 @@ void main() {
       expect(names.length, 1);
       expect(names.first, 'lilia-shore-only-last');
     });
-
-    test('parse ls tmp/dart.servies output', () {
-      const String example = '''
-d  2          0 .
-'-  1          0 36780
-''';
-      final List<int> ports = parseFuchsiaDartPortOutput(example);
-      expect(ports.length, 1);
-      expect(ports.single, 36780);
-    });
   });
 
   group('displays friendly error when', () {
@@ -60,7 +50,7 @@ d  2          0 .
     )).thenAnswer((Invocation invocation) => Future<ProcessResult>.value(mockProcessResult));
     when(mockProcessResult.exitCode).thenReturn(1);
     when<String>(mockProcessResult.stdout).thenReturn('');
-    when<String>(mockProcessResult.stderr).thenReturn('ls: lstat /tmp/dart.services: No such file or directory');
+    when<String>(mockProcessResult.stderr).thenReturn('');
     when(mockFuchsiaArtifacts.sshConfig).thenReturn(mockFile);
     when(mockFile.absolute).thenReturn(mockFile);
     when(mockFile.path).thenReturn('');
@@ -78,7 +68,18 @@ d  2          0 .
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('with BUILD_DIR set', () async {
+    final MockProcessManager emptyStdoutProcessManager = MockProcessManager();
+    final MockProcessResult emptyStdoutProcessResult = MockProcessResult();
+    when(emptyStdoutProcessManager.run(
+      any,
+      environment: anyNamed('environment'),
+      workingDirectory: anyNamed('workingDirectory'),
+    )).thenAnswer((Invocation invocation) => Future<ProcessResult>.value(emptyStdoutProcessResult));
+    when(emptyStdoutProcessResult.exitCode).thenReturn(0);
+    when<String>(emptyStdoutProcessResult.stdout).thenReturn('');
+    when<String>(emptyStdoutProcessResult.stderr).thenReturn('');
+
+    testUsingContext('No vmservices found', () async {
       final FuchsiaDevice device = FuchsiaDevice('id');
       ToolExit toolExit;
       try {
@@ -86,9 +87,9 @@ d  2          0 .
       } on ToolExit catch (err) {
         toolExit = err;
       }
-      expect(toolExit.message, 'No Dart Observatories found. Are you running a debug build?');
+      expect(toolExit.message, contains('No Dart Observatories found. Are you running a debug build?'));
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => emptyStdoutProcessManager,
       FuchsiaArtifacts: () => mockFuchsiaArtifacts,
     });
 

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -523,24 +523,21 @@ class FuchsiaRemoteConnection {
   /// found. An exception is thrown in the event of an actual error when
   /// attempting to acquire the ports.
   Future<List<int>> getDeviceServicePorts() async {
-    // TODO(awdavies): This is using a temporary workaround rather than a
-    // well-defined service, and will be deprecated in the near future.
-    final List<String> lsOutput =
-        await _sshCommandRunner.run('ls /tmp/dart.services');
+    final List<String> portPaths =
+        await _sshCommandRunner.run('find /hub -name vmservice-port');
     final List<int> ports = <int>[];
-
-    // The output of lsOutput is a list of available ports as the Fuchsia dart
-    // service advertises. An example lsOutput would look like:
-    //
-    // [ '31782\n', '1234\n', '11967' ]
-    for (String s in lsOutput) {
-      final String trimmed = s.trim();
-      final int lastSpace = trimmed.lastIndexOf(' ');
-      final String lastWord = trimmed.substring(lastSpace + 1);
-      if ((lastWord != '.') && (lastWord != '..')) {
-        final int value = int.tryParse(lastWord);
-        if (value != null) {
-          ports.add(value);
+    for (String path in portPaths) {
+      if (path == '') {
+        continue;
+      }
+      final List<String> lsOutput = await _sshCommandRunner.run('ls $path');
+      for (String line in lsOutput) {
+        if (line == '') {
+          continue;
+        }
+        final int port = int.tryParse(line);
+        if (port != null) {
+          ports.add(port);
         }
       }
     }

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -21,7 +21,9 @@ void main() {
     setUp(() {
       mockRunner = MockSshCommandRunner();
       // Adds some extra junk to make sure the strings will be cleaned up.
-      when(mockRunner.run(any)).thenAnswer((_) =>
+      when(mockRunner.run(argThat(startsWith('find')))).thenAnswer((_) =>
+          Future<List<String>>.value(<String>['/hub/blah/blah/blah/vmservice-port\n']));
+      when(mockRunner.run(argThat(startsWith('ls')))).thenAnswer((_) =>
           Future<List<String>>.value(<String>['123\n\n\n', '456  ', '789']));
       const String address = 'fe80::8eae:4cff:fef4:9247';
       const String interface = 'eno1';


### PR DESCRIPTION
Jonah, Andrew

PTAL at this PR as well as the needed Fuchsia changes here: https://fuchsia-review.googlesource.com/c/topaz/+/230072. Instead of reading/writing vm service port numbers into global /tmp, these changes read/write them into The Hub.

I'm not sure what all I should be testing locally to make sure this is okay. Please comment on this PR with instruction, or patch the changes in and try them out =)

Also I couldn't get:
```
fx shell /pkgfs/packages/topaz_modular_integration_tests/0/test/run_topaz_modular_integration_tests.sh
```
to even start running on my vim2, so the instructions on DX-434 may need a refresh.