### PR TITLE
Add fuchsia devices to daemon command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -615,7 +615,6 @@ class DeviceDomain extends Domain {
   Future<List<Device>> getDevices([Map<String, dynamic> args]) async {
     final List<Device> devices = <Device>[];
     for (PollingDeviceDiscovery discoverer in _discoverers) {
-      print(await discoverer.devices);
       devices.addAll(await discoverer.devices);
     }
     return devices;

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -19,6 +19,7 @@ import '../build_info.dart';
 import '../cache.dart';
 import '../device.dart';
 import '../emulator.dart';
+import '../fuchsia/fuchsia_device.dart';
 import '../globals.dart';
 import '../ios/devices.dart';
 import '../ios/simulators.dart';
@@ -567,6 +568,7 @@ class DeviceDomain extends Domain {
     registerHandler('forward', forward);
     registerHandler('unforward', unforward);
 
+    addDeviceDiscoverer(FuchsiaDevices());
     addDeviceDiscoverer(AndroidDevices());
     addDeviceDiscoverer(IOSDevices());
     addDeviceDiscoverer(IOSSimulators());
@@ -613,6 +615,7 @@ class DeviceDomain extends Domain {
   Future<List<Device>> getDevices([Map<String, dynamic> args]) async {
     final List<Device> devices = <Device>[];
     for (PollingDeviceDiscovery discoverer in _discoverers) {
+      print(await discoverer.devices);
       devices.addAll(await discoverer.devices);
     }
     return devices;

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -307,7 +307,7 @@ bool _notEvent(Map<String, dynamic> map) => map['event'] == null;
 bool _isConnectedEvent(Map<String, dynamic> map) => map['event'] == 'daemon.connected';
 
 class MockFuchsiaWorkflow extends FuchsiaWorkflow {
-  MockFuchsiaWorkflow({ this.canListDevices = true });  
+  MockFuchsiaWorkflow({ this.canListDevices = true });
 
   @override
   final bool canListDevices;

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
@@ -197,6 +198,7 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidWorkflow: () => MockAndroidWorkflow(canListDevices: false),
       IOSWorkflow: () => MockIOSWorkflow(),
+      FuchsiaWorkflow: () => MockFuchsiaWorkflow(),
     });
 
     testUsingContext('device.getDevices should respond with list', () async {
@@ -241,6 +243,7 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidWorkflow: () => MockAndroidWorkflow(),
       IOSWorkflow: () => MockIOSWorkflow(),
+      FuchsiaWorkflow: () => MockFuchsiaWorkflow(),
     });
 
     testUsingContext('emulator.launch without an emulatorId should report an error', () async {
@@ -302,6 +305,13 @@ void main() {
 bool _notEvent(Map<String, dynamic> map) => map['event'] == null;
 
 bool _isConnectedEvent(Map<String, dynamic> map) => map['event'] == 'daemon.connected';
+
+class MockFuchsiaWorkflow extends FuchsiaWorkflow {
+  MockFuchsiaWorkflow({ this.canListDevices = true });  
+
+  @override
+  final bool canListDevices;
+}
 
 class MockAndroidWorkflow extends AndroidWorkflow {
   MockAndroidWorkflow({ this.canListDevices = true });


### PR DESCRIPTION
With the following change I was able to show fuchsia devices in the daemon command:

```
> flutter daemon
Starting device daemon...
[{"event":"daemon.connected","params":{"version":"0.4.2","pid":14253}}]
[{"method":"device.enable","id":10}]
[{"id":10}]
[{"event":"device.added","params":{"id":"fe80::250:b6ff:fe1e:f80d%eth1","name":"paper-pulp-bush-angel","platform":"fuchsia","emulator":false}}]
```