### PR TITLE
Added key.properties and *.jks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ unlinked_spec.ds
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
 
 # iOS/XCode related
 **/ios/**/*.mode1v3


### PR DESCRIPTION
`android/key.properties` and `key.jks` are mentioned [here](https://flutter.io/docs/deployment/android), which store sensitive information that one could inadvertently commit to a repository (which the documentation itself says to avoid).