### PR TITLE
Support Java 1.8

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -26,6 +26,13 @@ buildscript {
     }
 }
 
+android {
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+}
+
 apply plugin: FlutterPlugin
 
 class FlutterPlugin implements Plugin<Project> {


### PR DESCRIPTION
This will allow Java 1.8 transformations for plugins that need it.

Pre-requisite for landing https://github.com/flutter/buildroot/pull/194

Fixes issues reported in  https://github.com/flutter/plugins/pull/984 as well