### PR TITLE
Read correct cached VM snapshot in dynamic mode (PRODUCT vs RELEASE)

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -359,10 +359,14 @@ class JITSnapshotter {
     final Directory outputDir = fs.directory(outputPath);
     outputDir.createSync(recursive: true);
 
-    final String engineVmSnapshotData = artifacts.getArtifactPath(Artifact.vmSnapshotData);
-    final String engineIsolateSnapshotData = artifacts.getArtifactPath(Artifact.isolateSnapshotData);
-    final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
-    final String isolateSnapshotInstructions = fs.path.join(outputDir.path, 'isolate_snapshot_instr');
+    final String engineVmSnapshotData =
+        artifacts.getArtifactPath(Artifact.vmSnapshotData, null, buildMode);
+    final String engineIsolateSnapshotData =
+        artifacts.getArtifactPath(Artifact.isolateSnapshotData, null, buildMode);
+    final String isolateSnapshotData =
+        fs.path.join(outputDir.path, 'isolate_snapshot_data');
+    final String isolateSnapshotInstructions =
+        fs.path.join(outputDir.path, 'isolate_snapshot_instr');
 
     final List<String> inputPaths = <String>[
       mainPath, compilationTraceFilePath, engineVmSnapshotData, engineIsolateSnapshotData,

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -359,14 +359,10 @@ class JITSnapshotter {
     final Directory outputDir = fs.directory(outputPath);
     outputDir.createSync(recursive: true);
 
-    final String engineVmSnapshotData =
-        artifacts.getArtifactPath(Artifact.vmSnapshotData, null, buildMode);
-    final String engineIsolateSnapshotData =
-        artifacts.getArtifactPath(Artifact.isolateSnapshotData, null, buildMode);
-    final String isolateSnapshotData =
-        fs.path.join(outputDir.path, 'isolate_snapshot_data');
-    final String isolateSnapshotInstructions =
-        fs.path.join(outputDir.path, 'isolate_snapshot_instr');
+    final String engineVmSnapshotData = artifacts.getArtifactPath(Artifact.vmSnapshotData, null, buildMode);
+    final String engineIsolateSnapshotData = artifacts.getArtifactPath(Artifact.isolateSnapshotData, null, buildMode);
+    final String isolateSnapshotData = fs.path.join(outputDir.path, 'isolate_snapshot_data');
+    final String isolateSnapshotInstructions = fs.path.join(outputDir.path, 'isolate_snapshot_instr');
 
     final List<String> inputPaths = <String>[
       mainPath, compilationTraceFilePath, engineVmSnapshotData, engineIsolateSnapshotData,

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -526,8 +526,13 @@ void main() {
       snapshotter = JITSnapshotter();
       mockAndroidSdk = MockAndroidSdk();
       mockArtifacts = MockArtifacts();
-      when(mockArtifacts.getArtifactPath(Artifact.vmSnapshotData)).thenReturn(kEngineVmSnapshotData);
-      when(mockArtifacts.getArtifactPath(Artifact.isolateSnapshotData)).thenReturn(kEngineIsolateSnapshotData);
+
+      for (BuildMode mode in BuildMode.values) {
+        when(mockArtifacts.getArtifactPath(Artifact.vmSnapshotData, null, mode))
+            .thenReturn(kEngineVmSnapshotData);
+        when(mockArtifacts.getArtifactPath(Artifact.isolateSnapshotData, null, mode))
+            .thenReturn(kEngineIsolateSnapshotData);
+      }
     });
 
     final Map<Type, Generator> contextOverrides = <Type, Generator>{


### PR DESCRIPTION
This fixes the last case, when using cached engine with dynamic mode and JIT snapshot. The cases that use cached engine and dynamic mode *without* JIT snapshot, or that use *local* engine with dynamic mode, were already implemented before.