### PR TITLE
checking for nulls when calling stop

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -647,7 +647,7 @@ class AnimationController extends Animation<double>
   void stop({ bool canceled = true }) {
     _simulation = null;
     _lastElapsedDuration = null;
-    _ticker.stop(canceled: canceled);
+    _ticker?.stop(canceled: canceled);
   }
 
   /// Release the resources used by this object. The object is no longer usable


### PR DESCRIPTION
If the animation controller is disposed before the stop method is called internally, the following error is produced:

```
NoSuchMethodError: NoSuchMethodError: The method 'stop' was called on null.
Receiver: null

Tried calling: stop()
  File "animation_controller.dart", line 650, in AnimationController.stop
  File "animation_controller.dart", line 525, in AnimationController._animateToInternal
  File "animation_controller.dart", line 442, in AnimationController.forward
```

It's not the case of calling the disponse twice.