### PR TITLE
Removed assertion for a zero duration transition.

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -155,7 +155,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
           overlayEntries.first.opaque = false;
         break;
       case AnimationStatus.dismissed:
-        assert(!overlayEntries.first.opaque);
         // We might still be the current route if a subclass is controlling the
         // the transition and hits the dismissed status. For example, the iOS
         // back gesture drives this animation to the dismissed status before


### PR DESCRIPTION
Removing an assertion. Animation can be dismissed in a case when `PageRouteBuilder` used with `transitionDuration: Duration.zero`. Unless there is particular reason why the assertion needs to be there, I propose to remove it.