### PR TITLE
Fix gradle local.properties tests that were never excersized

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -203,6 +203,7 @@ class SettingsFile {
   final Map<String, String> values = <String, String>{};
 
   void writeContents(File file) {
+    file.parent.createSync(recursive: true);
     file.writeAsStringSync(values.keys.map<String>((String key) {
       return '$key=${values[key]}';
     }).join('\n'));

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -167,11 +167,10 @@ someOtherTask
     }
 
     String propertyFor(String key, File file) {
-      return file
-          .readAsLinesSync()
+      final Iterable<String> result = file.readAsLinesSync()
           .where((String line) => line.startsWith('$key='))
-          .map((String line) => line.split('=')[1])
-          .first;
+          .map((String line) => line.split('=')[1]);
+      return result.isEmpty ? null : result.first;
     }
 
     Future<void> checkBuildVersion({
@@ -190,18 +189,15 @@ someOtherTask
       // write schemaData otherwise pubspec.yaml file can't be loaded
       writeEmptySchemaFile(fs);
 
-      try {
-        updateLocalProperties(
-          project: await FlutterProject.fromPath('path/to/project'),
-          buildInfo: buildInfo,
-        );
+      updateLocalProperties(
+        project: await FlutterProject.fromPath('path/to/project'),
+        buildInfo: buildInfo,
+        requireAndroidSdk: false,
+      );
 
-        final File localPropertiesFile = fs.file('path/to/project/android/local.properties');
-        expect(propertyFor('flutter.versionName', localPropertiesFile), expectedBuildName);
-        expect(propertyFor('flutter.versionCode', localPropertiesFile), expectedBuildNumber);
-      } on Exception {
-        // Android SDK not found, skip test
-      }
+      final File localPropertiesFile = fs.file('path/to/project/android/local.properties');
+      expect(propertyFor('flutter.versionName', localPropertiesFile), expectedBuildName);
+      expect(propertyFor('flutter.versionCode', localPropertiesFile), expectedBuildNumber);
     }
 
     testUsingAndroidContext('extract build name and number from pubspec.yaml', () async {


### PR DESCRIPTION
These tests were actually failing, but were silently ignored due overly broad exception catching logic.