### PR TITLE
Video demo instrumentation

### DIFF
--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -364,7 +364,7 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
     super.initState();
 
     Future<void> initController(VideoPlayerController controller, String name) async {
-      print('> VideoDemo initController "$name" ${isDisposed ? "DISPOSED" : ""');
+      print('> VideoDemo initController "$name" ${isDisposed ? "DISPOSED" : ""}');
       controller.setLooping(true);
       controller.setVolume(0.0);
       controller.play();

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -357,20 +357,21 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
   final Completer<void> connectedCompleter = Completer<void>();
   bool isSupported = true;
+  bool isDisposed = false;
 
   @override
   void initState() {
     super.initState();
 
     Future<void> initController(VideoPlayerController controller, String name) async {
-      print('> VideoDemo initController "$name"');
+      print('> VideoDemo initController "$name" ${isDisposed ? "DISPOSED" : ""');
       controller.setLooping(true);
       controller.setVolume(0.0);
       controller.play();
       await connectedCompleter.future;
       await controller.initialize();
       if (mounted)
-        print('< VideoDemo initController "$name" done');
+        print('< VideoDemo initController "$name" done ${isDisposed ? "DISPOSED" : ""}');
         setState(() {});
     }
 
@@ -384,6 +385,7 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
   @override
   void dispose() {
     print('> VideoDemo dispose');
+    isDisposed  = true;
     butterflyController.dispose();
     beeController.dispose();
     print('< VideoDemo dispose');

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -9,13 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 import 'package:device_info/device_info.dart';
 
-// TODO(sigurdm): This should not be stored here.
-const String beeUri =
-    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
-
 class VideoCard extends StatelessWidget {
-  const VideoCard({Key key, this.controller, this.title, this.subtitle})
-      : super(key: key);
+  const VideoCard({ Key key, this.controller, this.title, this.subtitle }) : super(key: key);
 
   final VideoPlayerController controller;
   final String title;
@@ -214,8 +209,7 @@ class FadeAnimation extends StatefulWidget {
   _FadeAnimationState createState() => _FadeAnimationState();
 }
 
-class _FadeAnimationState extends State<FadeAnimation>
-    with SingleTickerProviderStateMixin {
+class _FadeAnimationState extends State<FadeAnimation> with SingleTickerProviderStateMixin {
   AnimationController animationController;
 
   @override
@@ -336,7 +330,7 @@ class _ConnectivityOverlayState extends State<ConnectivityOverlay> {
 }
 
 class VideoDemo extends StatefulWidget {
-  const VideoDemo({Key key}) : super(key: key);
+  const VideoDemo({ Key key }) : super(key: key);
 
   static const String routeName = '/video';
 
@@ -350,16 +344,15 @@ Future<bool> isIOSSimulator() async {
   return Platform.isIOS && !(await deviceInfoPlugin.iosInfo).isPhysicalDevice;
 }
 
-class _VideoDemoState extends State<VideoDemo>
-    with SingleTickerProviderStateMixin {
-  final VideoPlayerController butterflyController =
-      VideoPlayerController.asset(
-        'videos/butterfly.mp4',
-        package: 'flutter_gallery_assets',
-      );
-  final VideoPlayerController beeController = VideoPlayerController.network(
-    beeUri,
+class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMixin {
+  final VideoPlayerController butterflyController = VideoPlayerController.asset(
+    'videos/butterfly.mp4',
+    package: 'flutter_gallery_assets',
   );
+
+  // TODO(sigurdm): This should not be stored here.
+  static const String beeUri = 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
+  final VideoPlayerController beeController = VideoPlayerController.network(beeUri);
 
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
   final Completer<void> connectedCompleter = Completer<void>();
@@ -369,18 +362,20 @@ class _VideoDemoState extends State<VideoDemo>
   void initState() {
     super.initState();
 
-    Future<void> initController(VideoPlayerController controller) async {
+    Future<void> initController(VideoPlayerController controller, String name) async {
+      print('> VideoDemo initController "$name"');
       controller.setLooping(true);
       controller.setVolume(0.0);
       controller.play();
       await connectedCompleter.future;
       await controller.initialize();
       if (mounted)
+        print('< VideoDemo initController "$name" done');
         setState(() {});
     }
 
-    initController(butterflyController);
-    initController(beeController);
+    initController(butterflyController, 'butterfly');
+    initController(beeController, 'bee');
     isIOSSimulator().then<void>((bool result) {
       isSupported = !result;
     });
@@ -388,8 +383,10 @@ class _VideoDemoState extends State<VideoDemo>
 
   @override
   void dispose() {
+    print('> VideoDemo dispose');
     butterflyController.dispose();
     beeController.dispose();
+    print('< VideoDemo dispose');
     super.dispose();
   }
 
@@ -401,29 +398,29 @@ class _VideoDemoState extends State<VideoDemo>
         title: const Text('Videos'),
       ),
       body: isSupported
-          ? ConnectivityOverlay(
-              child: ListView(
-                children: <Widget>[
-                  VideoCard(
-                    title: 'Butterfly',
-                    subtitle: '… flutters by',
-                    controller: butterflyController,
-                  ),
-                  VideoCard(
-                    title: 'Bee',
-                    subtitle: '… gently buzzing',
-                    controller: beeController,
-                  ),
-                ],
-              ),
-              connectedCompleter: connectedCompleter,
-              scaffoldKey: scaffoldKey,
-            )
-          : const Center(
-              child: Text(
-                'Video playback not supported on the iOS Simulator.',
-              ),
+        ? ConnectivityOverlay(
+            child: ListView(
+              children: <Widget>[
+                VideoCard(
+                  title: 'Butterfly',
+                  subtitle: '… flutters by',
+                  controller: butterflyController,
+                ),
+                VideoCard(
+                  title: 'Bee',
+                  subtitle: '… gently buzzing',
+                  controller: beeController,
+                ),
+              ],
             ),
+            connectedCompleter: connectedCompleter,
+            scaffoldKey: scaffoldKey,
+          )
+        : const Center(
+            child: Text(
+              'Video playback not supported on the iOS Simulator.',
+            ),
+          ),
     );
   }
 }

--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -370,9 +370,10 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
       controller.play();
       await connectedCompleter.future;
       await controller.initialize();
-      if (mounted)
+      if (mounted) {
         print('< VideoDemo initController "$name" done ${isDisposed ? "DISPOSED" : ""}');
         setState(() {});
+      }
     }
 
     initController(butterflyController, 'butterfly');


### PR DESCRIPTION
Added some print statements to the video demo to help determine where/why the transitions_perf test is flaking.

The demo's initState/dispose methods seems like they could be racy. At initState() time the video controllers do their initialization asynchronously. In a benchmark situation, the demo may be quit before the initialization continuations finish. The video controllers are disposed by the demo's dispose method - they should probably also (effectively) cancel the initialization futures.
