### PR TITLE
Fix failed assert when running `flutter test` with `--start-paused`

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -84,7 +84,7 @@ void installHook({
   InternetAddressType serverType = InternetAddressType.IPv4,
   Uri projectRootDirectory,
 }) {
-  assert(!enableObservatory || (!startPaused && observatoryPort == null));
+  assert(enableObservatory || (!startPaused && observatoryPort == null));
   hack.registerPlatformPlugin(
     <Runtime>[Runtime.vm],
     () => _FlutterPlatform(


### PR DESCRIPTION
Running `flutter test` with `--start-paused` when asserts are enabled results in a failed assertion. I believe there was an error in this change:

https://github.com/flutter/flutter/pull/16237/files#diff-39538134dff328da5360691916bf0f06L69

## Original

```dart
if (startPaused || observatoryPort != null)
    assert(enableObservatory);
```

## Current

```dart
assert(!enableObservatory || (!startPaused && observatoryPort == null));
```

I believe the first `!` is a mistake, since this asserts that if observatory is enabled that `startedPaused = false && observatoryPort == null`. [Here's a DartPad sample](https://dartpad.dartlang.org/f21d2b44b5b138fcbe24341aba12c81e) showing a truth table for the original/current/proposed changes for convenience of the reviewer.

cc @Hixie 

Fixes #25201.