### PR TITLE
Change flutter create to use master-docs.flutter.io instead of firebase URL.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -187,7 +187,7 @@ class CreateCommand extends FlutterCommand {
 
     final String host = FlutterVersion.instance.channel == 'stable'
         ? 'docs.flutter.io'
-        : 'master-docs-flutter-io.firebaseapp.com';
+        : 'master-docs.flutter.io';
     return utf8.decode(await fetchUrl(Uri.https(host, 'snippets/$sampleId.dart')));
   }
 


### PR DESCRIPTION
Now that we have our DNS mapping we should refer to the master docs site that way everywhere.