### PR TITLE
Add callback when long long press event is rejected

### DIFF
--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -14,6 +14,9 @@ typedef GestureLongPressCallback = void Function();
 /// Signature for when a pointer stops contacting the screen after a long press gesture was detected.
 typedef GestureLongPressUpCallback = void Function();
 
+/// Signature for when a pointer travels beyond[kTouchSlop] pixels from the original contact point.
+typedef GestureLongPressRejectedCallback = void Function();
+
 /// Recognizes when the user has pressed down at the same location for a long
 /// period of time.
 class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
@@ -30,6 +33,9 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
 
   /// Called when the pointer stops contacting the screen after the long-press gesture has been recognized.
   GestureLongPressUpCallback onLongPressUp;
+
+  /// Called when the pointer travels beyond[kTouchSlop] pixels from the original contact point after the long-press gesture has been recognized.
+  GestureLongPressRejectedCallback onLongPressRejected;
 
   @override
   void didExceedDeadline() {
@@ -57,4 +63,13 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
 
   @override
   String get debugDescription => 'long press';
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    super.didStopTrackingLastPointer(pointer);
+    if (_longPressAccepted) {
+      _longPressAccepted = false;
+      invokeCallback<void>('onLongPressRejected', onLongPressRejected);
+    }
+  }
 }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -161,6 +161,7 @@ class GestureDetector extends StatelessWidget {
     this.onDoubleTap,
     this.onLongPress,
     this.onLongPressUp,
+    this.onLongPressRejected,
     this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
@@ -259,6 +260,9 @@ class GestureDetector extends StatelessWidget {
 
   /// A pointer that has triggered a long-press has stopped contacting the screen.
   final GestureLongPressUpCallback onLongPressUp;
+
+  /// A pointer that has triggered a long-press travelled beyond[kTouchSlop] pixels from the original contact point.
+  final GestureLongPressUpCallback onLongPressRejected;
 
   /// A pointer has contacted the screen and might begin to move vertically.
   final GestureDragDownCallback onVerticalDragDown;
@@ -396,14 +400,14 @@ class GestureDetector extends StatelessWidget {
         },
       );
     }
-
-    if (onLongPress != null || onLongPressUp !=null) {
+    if (onLongPress != null || onLongPressUp != null || onLongPressRejected != null) {
       gestures[LongPressGestureRecognizer] = GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
         () => LongPressGestureRecognizer(debugOwner: this),
         (LongPressGestureRecognizer instance) {
           instance
             ..onLongPress = onLongPress
-            ..onLongPressUp = onLongPressUp;
+            ..onLongPressUp = onLongPressUp
+            ..onLongPressRejected = onLongPressRejected;
         },
       );
     }


### PR DESCRIPTION
Make sure widgets receive a callback when a long press event was rejected.
(Issue related: https://github.com/flutter/flutter/issues/25610)