### PR TITLE
Clarify doc for AnimatedContainer

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -419,6 +419,8 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
 ///    position over a given duration whenever the given [alignment] changes.
+///  * [AnimatedSwitcher], which switches out a child for a new one with a customizable transition.
+///  * [AnimatedCrossFade], which fades between two children and interpolates their sizes.
 class AnimatedContainer extends ImplicitlyAnimatedWidget {
   /// Creates a container that animates its parameters implicitly.
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -396,7 +396,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// The [AnimatedContainer] will automatically animate between the old and
 /// new values of properties when they change using the provided curve and
-/// duration. Properties that are null are not animated. Its child and 
+/// duration. Properties that are null are not animated. Its child and
 /// descendants are not animated.
 ///
 /// This class is useful for generating simple implicit transitions between

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -396,7 +396,8 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// The [AnimatedContainer] will automatically animate between the old and
 /// new values of properties when they change using the provided curve and
-/// duration. Properties that are null are not animated.
+/// duration. Properties that are null are not animated. Its child and 
+/// descendants are not animated.
 ///
 /// This class is useful for generating simple implicit transitions between
 /// different parameters to [Container] with its internal [AnimationController].


### PR DESCRIPTION
The sentence `The AnimatedContainer will automatically animate between the old and new values of properties when they change using the provided curve and duration. Properties that are null are not animated.` is confusing as it implied (for me) that if I were to update the AnimatedContainer's `child` property, that the AnimatedContainer would animate between the old and new `child`. However, this isn't the case - the AnimatedContainer doesn't animate its descendent(s). Instead, one may use an AnimatedCrossFade or other widget. I've added a sentence clarifying that `child` does not get animated when it changes.