### PR TITLE
Allow dynamic patches without a patch number.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -469,8 +469,14 @@ Future<void> _buildGradleProjectV2(
         update.addFile(ArchiveFile(name, newFile.content.length, newFile.content));
       }
 
-      final File updateFile = fs.directory(buildInfo.patchDir)
-          .childFile('${package.versionCode}-${buildInfo.patchNumber}.zip');
+      File updateFile;
+      if (buildInfo.patchNumber != null) {
+        updateFile = fs.directory(buildInfo.patchDir)
+            .childFile('${package.versionCode}-${buildInfo.patchNumber}.zip');
+      } else {
+        updateFile = fs.directory(buildInfo.patchDir)
+            .childFile('${package.versionCode}.zip');
+      }
 
       if (update.files.isEmpty) {
         printStatus('No changes detected relative to baseline build.');
@@ -490,8 +496,13 @@ Future<void> _buildGradleProjectV2(
       final Map<String, dynamic> manifest = <String, dynamic>{
         'baselineChecksum': baselineChecksum,
         'buildNumber': package.versionCode,
-        'patchNumber': buildInfo.patchNumber,
       };
+
+      if (buildInfo.patchNumber != null) {
+        manifest.addAll(<String, dynamic>{
+          'patchNumber': buildInfo.patchNumber,
+        });
+      }
 
       const JsonEncoder encoder = JsonEncoder.withIndent('  ');
       final String manifestJson = encoder.convert(manifest);

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -54,7 +54,7 @@ class BuildInfo {
   final bool createPatch;
 
   /// Internal version number of dynamic patch (not displayed to users).
-  /// Each patch should have a unique number to differentiate from previous
+  /// Each patch may have a unique number to differentiate from previous
   /// patches for the same versionCode on Android or CFBundleVersion on iOS.
   final int patchNumber;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -261,11 +261,13 @@ abstract class FlutterCommand extends Command<void> {
 
   void addDynamicPatchingFlags({bool verboseHelp = false}) {
     argParser.addOption('patch-number',
-        defaultsTo: '1',
         hide: !verboseHelp,
         help: 'An integer used as an internal version number for dynamic patch.\n'
-              'Each update should have a unique number to differentiate from previous '
+              'Each update may have a unique number to differentiate from previous\n'
               'patches for same \'versionCode\' on Android or \'CFBundleVersion\' on iOS.\n'
+              'This optional setting allows several dynamic patches to coexist\n'
+              'for same baseline build, and is useful for canary and A-B testing\n'
+              'of dynamic patches.\n'
               'This flag is only used when --dynamic --patch is specified.\n'
     );
     argParser.addOption('patch-dir',


### PR DESCRIPTION
Unique patch numbers are mainly useful for canary and A-B testing, but otherwise complicate things and can now be omitted.

Also see https://github.com/flutter/engine/pull/7309.