### PR TITLE
Change the tooltip background color

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -281,6 +281,7 @@ class _TooltipOverlay extends StatelessWidget {
       brightness: Brightness.dark,
       textTheme: theme.brightness == Brightness.dark ? theme.textTheme : theme.primaryTextTheme,
       platform: theme.platform,
+      backgroundColor: theme.backgroundColor,
     );
     return Positioned.fill(
       child: IgnorePointer(


### PR DESCRIPTION

Make the tooltip background color same as the theme background color. Currently, it takes the default theme background color which is the dark grey.