### PR TITLE
Fix instantaneous jump at start of scroll for Android

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -445,6 +445,11 @@ class ClampingScrollPhysics extends ScrollPhysics {
       tolerance: tolerance,
     );
   }
+
+  // Eyeballed from observation to counter the effect of an unintended scroll
+  // from the natural motion of lifting the finger after a scroll.
+  @override
+  double get dragStartDistanceMotionThreshold => 3.5;
 }
 
 /// Scroll physics that always lets the user scroll.


### PR DESCRIPTION
Fixes #20495, adapted from @knopp's workaround (which matches the fix on iOS): https://github.com/flutter/flutter/issues/20495#issuecomment-441712268