### PR TITLE
Optimize cocoapods logic in flutter doctor.

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -170,6 +170,11 @@ class UserMessages {
       '$consequence\n'
       'To install:\n'
       '$installInstructions';
+  String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
+      'CocoaPods unknown version installed.\n'
+      '$consequence\n'
+      'To upgrade:\n'
+      '$upgradeInstructions';
   String cocoaPodsOutdated(String recVersion, String consequence, String upgradeInstructions) =>
       'CocoaPods out of date ($recVersion is recommended).\n'
       '$consequence\n'

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -171,7 +171,7 @@ class UserMessages {
       'To install:\n'
       '$installInstructions';
   String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
-      'CocoaPods unknown version installed.\n'
+      'Unknown CocoaPods version installed.\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -25,7 +25,8 @@ const String noCocoaPodsConsequence = '''
   For more info, see https://flutter.io/platform-plugins''';
 
 const String unknownCocoaPodsConsequence = '''
-  Make sure that `pod --version` always return pure version like :''';
+  Flutter is unable to determine the installed CocoaPods's version.
+  Ensure that the output of 'pod --version' contains only digits and . to be recognized by Flutter.''';
 
 const String cocoaPodsInstallInstructions = '''
   brew install cocoapods
@@ -121,8 +122,8 @@ class CocoaPods {
         return false;
       case CocoaPodsStatus.unknownVersion:
         printError(
-          'Warning: CocoaPods unknown version installed.\n'
-          '$unknownCocoaPodsConsequence $cocoaPodsRecommendedVersion\n'
+          'Warning: Unknown CocoaPods version installed.\n'
+          '$unknownCocoaPodsConsequence\n'
           'To upgrade:\n'
           '$cocoaPodsUpgradeInstructions\n',
           emphasis: true,

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -24,6 +24,9 @@ const String noCocoaPodsConsequence = '''
   Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
   For more info, see https://flutter.io/platform-plugins''';
 
+const String unknownCocoaPodsConsequence = '''
+  Make sure that `pod --version` always return pure version like :''';
+
 const String cocoaPodsInstallInstructions = '''
   brew install cocoapods
   pod setup''';
@@ -38,6 +41,8 @@ CocoaPods get cocoaPods => context[CocoaPods];
 enum CocoaPodsStatus {
   /// iOS plugins will not work, installation required.
   notInstalled,
+  /// iOS plugins might not work, upgrade recommended.
+  unknownVersion,
   /// iOS plugins will not work, upgrade required.
   belowMinimumVersion,
   /// iOS plugins may not work in certain situations (Swift, static libraries),
@@ -66,6 +71,8 @@ class CocoaPods {
       return CocoaPodsStatus.notInstalled;
     try {
       final Version installedVersion = Version.parse(versionText);
+      if (installedVersion == null)
+        return CocoaPodsStatus.unknownVersion;
       if (installedVersion < Version.parse(cocoaPodsMinimumVersion))
         return CocoaPodsStatus.belowMinimumVersion;
       else if (installedVersion < Version.parse(cocoaPodsRecommendedVersion))
@@ -112,6 +119,15 @@ class CocoaPods {
           emphasis: true,
         );
         return false;
+      case CocoaPodsStatus.unknownVersion:
+        printError(
+          'Warning: CocoaPods unknown version installed.\n'
+          '$unknownCocoaPodsConsequence $cocoaPodsRecommendedVersion\n'
+          'To upgrade:\n'
+          '$cocoaPodsUpgradeInstructions\n',
+          emphasis: true,
+        );
+        break;
       case CocoaPodsStatus.belowMinimumVersion:
         printError(
           'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -196,7 +196,7 @@ class CocoaPodsValidator extends DoctorValidator {
         else if (cocoaPodsStatus == CocoaPodsStatus.unknownVersion) {
           status = ValidationType.partial;
           messages.add(ValidationMessage.hint(
-              userMessages.cocoaPodsUnknownVersion('$unknownCocoaPodsConsequence ${cocoaPods.cocoaPodsRecommendedVersion}', cocoaPodsUpgradeInstructions)));
+              userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
         } else {
           status = ValidationType.partial;
           messages.add(ValidationMessage.hint(

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -192,6 +192,11 @@ class CocoaPodsValidator extends DoctorValidator {
           status = ValidationType.missing;
           messages.add(ValidationMessage.error(
               userMessages.cocoaPodsMissing(noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+        }
+        else if (cocoaPodsStatus == CocoaPodsStatus.unknownVersion) {
+          status = ValidationType.partial;
+          messages.add(ValidationMessage.hint(
+              userMessages.cocoaPodsUnknownVersion('$unknownCocoaPodsConsequence ${cocoaPods.cocoaPodsRecommendedVersion}', cocoaPodsUpgradeInstructions)));
         } else {
           status = ValidationType.partial;
           messages.add(ValidationMessage.hint(

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -94,6 +94,13 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('detects unknown version', () async {
+      pretendPodVersionIs('Plugin loaded.\n1.5.3');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.unknownVersion);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('detects below minimum version', () async {
       pretendPodVersionIs('0.39.8');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowMinimumVersion);

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -297,6 +297,16 @@ Show information about a connected device.
       CocoaPods: () => cocoaPods,
     });
 
+    testUsingContext('Emits partial status when CocoaPods is installed with unknown version', () async {
+      when(cocoaPods.evaluateCocoaPodsInstallation)
+          .thenAnswer((_) async => CocoaPodsStatus.unknownVersion);
+      final CocoaPodsTestTarget workflow = CocoaPodsTestTarget();
+      final ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{
+      CocoaPods: () => cocoaPods,
+    });
+
     testUsingContext('Emits partial status when CocoaPods is not initialized', () async {
       when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => false);
       final CocoaPodsTestTarget workflow = CocoaPodsTestTarget();


### PR DESCRIPTION
Optimize cocoapods logic in flutter doctor.
Fixes #23462 

In fact, I've also experience same problems. In my company, developers are using customized cocoapods, when running `pod --version`, it might output "xxx plugin loaded.\n1.5.0", which will cause failure in `flutter doctor`,etc. In fact, when you run `pod install` directly, it works fine. 