### PR TITLE
Add a validator to ensure NO_PROXY is set correctly if HTTP_PROXY is set

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -25,6 +25,7 @@ import 'globals.dart';
 import 'intellij/intellij.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_utils.dart';
+import 'proxy_validator.dart';
 import 'tester/flutter_tester.dart';
 import 'version.dart';
 import 'vscode/vscode_validator.dart';
@@ -65,6 +66,9 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         _validators.addAll(ideValidators);
       else
         _validators.add(NoIdeValidator());
+
+      if (ProxyValidator.shouldShow)
+      _validators.add(ProxyValidator());
 
       if (deviceManager.canListAnything)
         _validators.add(DeviceValidator());

--- a/packages/flutter_tools/lib/src/proxy_validator.dart
+++ b/packages/flutter_tools/lib/src/proxy_validator.dart
@@ -1,0 +1,55 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'base/platform.dart';
+import 'doctor.dart';
+
+class ProxyValidator extends DoctorValidator {
+  ProxyValidator() : super('Proxy Configguration');
+
+  static bool get shouldShow => _getEnv('HTTP_PROXY').isNotEmpty;
+
+  final String _httpProxy = _getEnv('HTTP_PROXY');
+  final String _noProxy = _getEnv('NO_PROXY');
+
+  /// Gets a trimmed, non-null environment variable. If the variable is not set
+  /// an empty string will be returned. Checks for the lowercase version of the
+  /// environment variable first, then uppercase to match Dart's HTTP implementation.
+  static String _getEnv(String key) =>
+      platform.environment[key.toLowerCase()]?.trim() ??
+      platform.environment[key.toUpperCase()]?.trim() ??
+      '';
+
+  @override
+  Future<ValidationResult> validate() async {
+    final List<ValidationMessage> messages = <ValidationMessage>[];
+
+    if (_httpProxy.isNotEmpty) {
+      messages.add(ValidationMessage('HTTP_PROXY is set'));
+
+      if (_noProxy.isEmpty) {
+        messages.add(ValidationMessage.hint('NO_PROXY is not set'));
+      } else {
+        messages.add(ValidationMessage('NO_PROXY is $_noProxy'));
+        for (String host in const <String>['127.0.0.1', 'localhost']) {
+          final ValidationMessage msg = _noProxy.contains(host)
+              ? ValidationMessage('NO_PROXY contains $host')
+              : ValidationMessage.hint('NO_PROXY does not contain $host');
+
+          messages.add(msg);
+        }
+      }
+    }
+
+    final bool hasIssues =
+        messages.any((ValidationMessage msg) => msg.isHint || msg.isHint);
+
+    return ValidationResult(
+      hasIssues ? ValidationType.partial : ValidationType.installed,
+      messages,
+    );
+  }
+}

--- a/packages/flutter_tools/lib/src/proxy_validator.dart
+++ b/packages/flutter_tools/lib/src/proxy_validator.dart
@@ -8,7 +8,7 @@ import 'base/platform.dart';
 import 'doctor.dart';
 
 class ProxyValidator extends DoctorValidator {
-  ProxyValidator() : super('Proxy Configguration');
+  ProxyValidator() : super('Proxy Configuration');
 
   static bool get shouldShow => _getEnv('HTTP_PROXY').isNotEmpty;
 

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/proxy_validator.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
 import 'package:flutter_tools/src/vscode/vscode_validator.dart';
 
@@ -89,6 +90,95 @@ void main() {
       expect(message.message, startsWith('Flutter extension not installed'));
       expect(message.isError, isTrue);
     }, overrides: noColorTerminalOverride);
+  });
+
+  group('proxy validator', () {
+    testUsingContext('does not show if HTTP_PROXY is not set', () {
+      expect(ProxyValidator.shouldShow, isFalse);
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()..environment = <String, String>{},
+    });
+
+    testUsingContext('does not show if HTTP_PROXY is only whitespace', () {
+      expect(ProxyValidator.shouldShow, isFalse);
+    }, overrides: <Type, Generator>{
+      Platform: () =>
+          FakePlatform()..environment = <String, String>{'HTTP_PROXY': ' '},
+    });
+
+    testUsingContext('shows when HTTP_PROXY is set', () {
+      expect(ProxyValidator.shouldShow, isTrue);
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{'HTTP_PROXY': 'fakeproxy.local'},
+    });
+
+    testUsingContext('shows when http_proxy is set', () {
+      expect(ProxyValidator.shouldShow, isTrue);
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{'http_proxy': 'fakeproxy.local'},
+    });
+
+    testUsingContext('reports success when NO_PROXY is configured correctly',
+        () async {
+      final ValidationResult results = await ProxyValidator().validate();
+      final List<ValidationMessage> issues = results.messages
+          .where((ValidationMessage msg) => msg.isError || msg.isHint)
+          .toList();
+      expect(issues, hasLength(0));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{
+          'HTTP_PROXY': 'fakeproxy.local',
+          'NO_PROXY': 'localhost,127.0.0.1'
+        },
+    });
+
+    testUsingContext('reports success when no_proxy is configured correctly',
+        () async {
+      final ValidationResult results = await ProxyValidator().validate();
+      final List<ValidationMessage> issues = results.messages
+          .where((ValidationMessage msg) => msg.isError || msg.isHint)
+          .toList();
+      expect(issues, hasLength(0));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{
+          'http_proxy': 'fakeproxy.local',
+          'no_proxy': 'localhost,127.0.0.1'
+        },
+    });
+
+    testUsingContext('reports issues when NO_PROXY is missing localhost',
+        () async {
+      final ValidationResult results = await ProxyValidator().validate();
+      final List<ValidationMessage> issues = results.messages
+          .where((ValidationMessage msg) => msg.isError || msg.isHint)
+          .toList();
+      expect(issues, isNot(hasLength(0)));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{
+          'HTTP_PROXY': 'fakeproxy.local',
+          'NO_PROXY': '127.0.0.1'
+        },
+    });
+
+    testUsingContext('reports issues when NO_PROXY is missing 127.0.0.1',
+        () async {
+      final ValidationResult results = await ProxyValidator().validate();
+      final List<ValidationMessage> issues = results.messages
+          .where((ValidationMessage msg) => msg.isError || msg.isHint)
+          .toList();
+      expect(issues, isNot(hasLength(0)));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform()
+        ..environment = <String, String>{
+          'HTTP_PROXY': 'fakeproxy.local',
+          'NO_PROXY': 'localhost'
+        },
+    });
   });
 
   group('doctor with overriden validators', () {


### PR DESCRIPTION
I've seen quite a number of issues where users have errors connecting to the VM service that appear to be caused by proxy servers. Since most people don't often connect to localhost it seems a lot of people end up with `HTTP_PROXY` set but `localhost`/`127.0.0.1` are not excluded from the proxy with `NO_PROXY`. Usually setting `NO_PROXY` solves the issue for them, however because it's easy to set it somewhere that doesn't propagate to editors (eg. you set it in a bash startup script that doesn't apply to the editor launched outside of the terminal) sometimes we end up going down the wrong path looking for other issues (and sometimes, it's just typos https://github.com/flutter/flutter/issues/24854#issuecomment-444506334)

I think `flutter doctor` should detect and warn (in VS Code you can run `flutter doctor` in the same environment that we spawn all Flutter commands, which should make it easy to then troubleshoot this.

This change adds a new validator to check `HTTP_PROXY`/`NO_PROXY` but only adds it if `HTTP_PROXY` is set (so that most users don't get the additional noise in the doctor output).

Here's some example output (I've trimmed the unimportant stuff to make it easier to see and changed the ticks to `v` and bullets to `.` because it may be [breaking builds](https://github.com/flutter/flutter/issues/24935)):

```
dantup-macbookpro:flutter dantup$ flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[v] Flutter (Channel unknown, v1.1.5-pre.39, on Mac OS X 10.14.2 18C54, locale en-GB)
[v] Android toolchain - develop for Android devices (Android SDK version 27.0.3)
[v] iOS toolchain - develop for iOS devices (Xcode 10.0)
[v] Android Studio (version 3.2)
[v] VS Code (version 1.30.1)
[!] Connected device
    ! No devices available

! Doctor found issues in 1 category.



dantup-macbookpro:flutter dantup$ HTTP_PROXY=foo flutter doctor
[!] Proxy Configuration
    ! NO_PROXY is not set
[!] Connected device
    ! No devices available

! Doctor found issues in 2 categories.



dantup-macbookpro:flutter dantup$ HTTP_PROXY=foo NO_PROXY=127.0.0.1 flutter doctor
[!] Proxy Configuration
    ! NO_PROXY does not contain localhost
[!] Connected device
    ! No devices available

! Doctor found issues in 2 categories.



dantup-macbookpro:flutter dantup$ HTTP_PROXY=foo NO_PROXY=127.0.0.1,localhost flutter doctor
[v] Proxy Configuration
[!] Connected device
    ! No devices available

! Doctor found issues in 1 category.
```

And the verbose output is like this:

```
[!] Proxy Configuration
    . HTTP_PROXY is set
    . NO_PROXY is 127.0.0.1,foo
    . NO_PROXY contains 127.0.0.1
    ! NO_PROXY does not contain localhost
```

I've set the failures to `partial` instead of `missing` so they're just exclamation marks instead of crosses because I'm not sure how solid my understand of this is, but we can always upgrade it to real failures if we think it's worthwhile in future.

@gspencergoog @devoncarew WDYT?

cc @zoechi who may have a better view on how common proxy issues are from triaging.

(Fixes #24854).