### PR TITLE
Add didSendFirstFrameEvent service extension.

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -292,7 +292,7 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
 
       registerServiceExtension(
         name: 'didSendFirstFrameEvent',
-        callback: (Map<String, String> parameters) async {
+        callback: (_) async {
           return <String, dynamic>{
             'enabled': _needToReportFirstFrame ? 'false' : 'true'
           };

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -289,6 +289,15 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
           return _forceRebuild();
         },
       );
+
+      registerServiceExtension(
+        name: 'didSendFirstFrameEvent',
+        callback: (Map<String, String> parameters) async {
+          return <String, dynamic>{
+            'enabled': _needToReportFirstFrame ? 'false' : 'true'
+          };
+        },
+      );
     }
 
     assert(() {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -104,7 +104,18 @@ void main() {
   test('Service extensions - pretest', () async {
     binding = TestServiceExtensionsBinding();
     expect(binding.frameScheduled, isTrue);
+
+    // We need to test this service extension here because the result should
+    // always be true after the first binding.doFrame() call.
+    Map<String, dynamic> firstFrameResult;
+    firstFrameResult = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
+    expect(firstFrameResult, <String, String>{ 'enabled': 'false' });
+
     await binding.doFrame(); // initial frame scheduled by creating the binding
+
+    firstFrameResult = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
+    expect(firstFrameResult, <String, String>{ 'enabled': 'true' });
+
     expect(binding.frameScheduled, isFalse);
 
     expect(debugPrint, equals(debugPrintThrottled));
@@ -296,6 +307,12 @@ void main() {
     expect(result, <String, String>{ 'enabled': 'false' });
     expect(debugPaintBaselinesEnabled, false);
     expect(binding.frameScheduled, isFalse);
+  });
+
+  test('Service extensions - didSendFirstFrameEvent', () async {
+    Map<String, dynamic> result;
+    result = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
+    expect(result, <String, String>{ 'enabled': 'true' });
   });
 
   test('Service extensions - profileWidgetBuilds', () async {
@@ -548,7 +565,7 @@ void main() {
 
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 24 + widgetInspectorExtensionCount);
+    expect(binding.extensions.length, 25 + widgetInspectorExtensionCount);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -105,14 +105,16 @@ void main() {
     binding = TestServiceExtensionsBinding();
     expect(binding.frameScheduled, isTrue);
 
-    // We need to test this service extension here because the result should
-    // always be true after the first binding.doFrame() call.
+    // We need to test this service extension here because the result is true
+    // after the first binding.doFrame() call.
     Map<String, dynamic> firstFrameResult;
+    expect(binding.debugDidSendFirstFrameEvent, isFalse);
     firstFrameResult = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
     expect(firstFrameResult, <String, String>{ 'enabled': 'false' });
 
     await binding.doFrame(); // initial frame scheduled by creating the binding
 
+    expect(binding.debugDidSendFirstFrameEvent, isTrue);
     firstFrameResult = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
     expect(firstFrameResult, <String, String>{ 'enabled': 'true' });
 
@@ -307,12 +309,6 @@ void main() {
     expect(result, <String, String>{ 'enabled': 'false' });
     expect(debugPaintBaselinesEnabled, false);
     expect(binding.frameScheduled, isFalse);
-  });
-
-  test('Service extensions - didSendFirstFrameEvent', () async {
-    Map<String, dynamic> result;
-    result = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});
-    expect(result, <String, String>{ 'enabled': 'true' });
   });
 
   test('Service extensions - profileWidgetBuilds', () async {
@@ -565,7 +561,7 @@ void main() {
 
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 25 + widgetInspectorExtensionCount);
+    expect(binding.extensions.length, 24 + widgetInspectorExtensionCount);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -561,7 +561,7 @@ void main() {
 
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 24 + widgetInspectorExtensionCount);
+    expect(binding.extensions.length, 25 + widgetInspectorExtensionCount);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;


### PR DESCRIPTION
This will be consumed by the tooling web app to gate adding other service extensions upon didSendFirstFrameEvent returning true. We need to be able to tell if the first frame has rendered even if we are attaching to an app that might have already rendered a frame.