### PR TITLE
use RRect to draw avatar check on chip

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -305,8 +305,10 @@ abstract class SelectableChipAttributes {
   /// are) of the chip.
   String get tooltip;
 
-  /// The shape of the avatar, used to draw a darkended layer when a checkmark
-  /// is drawn over it.
+  /// The shape of the translucent highlight painted over the avatar when the
+  /// [selected] property is true.
+  ///
+  /// Only the outer path of the shape is used.
   ///
   /// Defaults to [CircleBorder].
   ShapeBorder get avatarBorder;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1492,7 +1492,6 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
       elevation: isTapping ? widget.pressElevation : 0.0,
       animationDuration: pressedAnimationDuration,
       shape: shape,
-      clipBehavior: widget.clipBehavior,
       child: InkResponse(
         onTap: canTap ? _handleTap : null,
         onTapDown: canTap ? _handleTapDown : null,
@@ -2357,7 +2356,8 @@ class _RenderChip extends RenderBox {
         final Paint darkenPaint = Paint()
           ..color = selectionScrimTween.evaluate(checkmarkAnimation)
           ..blendMode = BlendMode.srcATop;
-        context.canvas.drawRect(avatarRect, darkenPaint);
+        final double shortestSide = math.min(avatarRect.width, avatarRect.height);
+        context.canvas.drawRRect(RRect.fromRectAndRadius(avatarRect, Radius.circular(shortestSide / 2)), darkenPaint);
       }
       // Need to make the check mark be a little smaller than the avatar.
       final double checkSize = avatar.size.height * 0.75;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1492,6 +1492,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
       elevation: isTapping ? widget.pressElevation : 0.0,
       animationDuration: pressedAnimationDuration,
       shape: shape,
+      clipBehavior: widget.clipBehavior,
       child: InkResponse(
         onTap: canTap ? _handleTap : null,
         onTapDown: canTap ? _handleTapDown : null,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -38,6 +38,19 @@ const Duration _kDisableDuration = Duration(milliseconds: 75);
 const Color _kSelectScrimColor = Color(0x60191919);
 const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 
+/// A function which describes the shape of the avatar widget as a path.
+///
+/// The path is used to draw an additional darkened layer over the avatar
+/// when combined with a selected choice chip. Differently shaped avatars
+/// may require different paths. The default implementation creates a circle
+/// to cover the [CircleAvatar] widget.
+typedef AvatarShapeDescriber = Path Function(Rect avatarRect);
+
+Path _kDefaultAvatarPath(Rect avatarRect) {
+  final Radius radius = Radius.circular(avatarRect.shortestSide / 2);
+  return Path()..addRRect(RRect.fromRectAndRadius(avatarRect, radius));
+}
+
 /// An interface defining the base attributes for a material design chip.
 ///
 /// Chips are compact elements that represent an attribute, text, entity, or
@@ -304,6 +317,9 @@ abstract class SelectableChipAttributes {
   /// Tooltip string to be used for the body area (where the label and avatar
   /// are) of the chip.
   String get tooltip;
+
+  /// A function which describes the shape of the avatar widget as a path.
+  AvatarShapeDescriber get avatarShapeDescriber;
 }
 
 /// An interface for material design chips that can be enabled and disabled.
@@ -604,6 +620,7 @@ class InputChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
+    this.avatarShapeDescriber = _kDefaultAvatarPath,
   })  : assert(selected != null),
         assert(isEnabled != null),
         assert(label != null),
@@ -652,6 +669,8 @@ class InputChip extends StatelessWidget
   final EdgeInsetsGeometry padding;
   @override
   final MaterialTapTargetSize materialTapTargetSize;
+  @override
+  final AvatarShapeDescriber avatarShapeDescriber;
 
   @override
   Widget build(BuildContext context) {
@@ -679,6 +698,7 @@ class InputChip extends StatelessWidget
       padding: padding,
       materialTapTargetSize: materialTapTargetSize,
       isEnabled: isEnabled && (onSelected != null || onDeleted != null || onPressed != null),
+      avatarShapeDescriber: avatarShapeDescriber,
     );
   }
 }
@@ -762,6 +782,7 @@ class ChoiceChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
+    this.avatarShapeDescriber = _kDefaultAvatarPath,
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -797,6 +818,8 @@ class ChoiceChip extends StatelessWidget
   final EdgeInsetsGeometry padding;
   @override
   final MaterialTapTargetSize materialTapTargetSize;
+  @override
+  final AvatarShapeDescriber avatarShapeDescriber;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -824,6 +847,7 @@ class ChoiceChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
+      avatarShapeDescriber: avatarShapeDescriber,
     );
   }
 }
@@ -939,6 +963,7 @@ class FilterChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
+    this.avatarShapeDescriber = _kDefaultAvatarPath,
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -974,6 +999,8 @@ class FilterChip extends StatelessWidget
   final EdgeInsetsGeometry padding;
   @override
   final MaterialTapTargetSize materialTapTargetSize;
+  @override
+  final AvatarShapeDescriber avatarShapeDescriber;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -998,6 +1025,7 @@ class FilterChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
+      avatarShapeDescriber: avatarShapeDescriber,
     );
   }
 }
@@ -1190,6 +1218,7 @@ class RawChip extends StatefulWidget
     this.clipBehavior = Clip.none,
     this.backgroundColor,
     this.materialTapTargetSize,
+    this.avatarShapeDescriber = _kDefaultAvatarPath,
   })  : assert(label != null),
         assert(isEnabled != null),
         assert(clipBehavior != null),
@@ -1239,6 +1268,8 @@ class RawChip extends StatefulWidget
   final EdgeInsetsGeometry padding;
   @override
   final MaterialTapTargetSize materialTapTargetSize;
+  @override
+  final AvatarShapeDescriber avatarShapeDescriber;
 
   /// Whether or not to show a check mark when [selected] is true.
   ///
@@ -1543,6 +1574,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
               avatarDrawerAnimation: avatarDrawerAnimation,
               deleteDrawerAnimation: deleteDrawerAnimation,
               isEnabled: widget.isEnabled,
+              avatarShapeDescriber: widget.avatarShapeDescriber,
             ),
           ),
         ),
@@ -1623,6 +1655,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
+    this.avatarShapeDescriber,
   })  : assert(theme != null),
         super(key: key);
 
@@ -1633,6 +1666,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
   final Animation<double> avatarDrawerAnimation;
   final Animation<double> deleteDrawerAnimation;
   final Animation<double> enableAnimation;
+  final AvatarShapeDescriber avatarShapeDescriber;
 
   @override
   _RenderChipElement createElement() => _RenderChipElement(this);
@@ -1647,7 +1681,8 @@ class _ChipRenderWidget extends RenderObjectWidget {
       ..checkmarkAnimation = checkmarkAnimation
       ..avatarDrawerAnimation = avatarDrawerAnimation
       ..deleteDrawerAnimation = deleteDrawerAnimation
-      ..enableAnimation = enableAnimation;
+      ..enableAnimation = enableAnimation
+      ..avatarShapeDescriber = avatarShapeDescriber;
   }
 
   @override
@@ -1661,6 +1696,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
       avatarDrawerAnimation: avatarDrawerAnimation,
       deleteDrawerAnimation: deleteDrawerAnimation,
       enableAnimation: enableAnimation,
+      avatarShapeDescriber: avatarShapeDescriber,
     );
   }
 }
@@ -1848,6 +1884,7 @@ class _RenderChip extends RenderBox {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
+    this.avatarShapeDescriber,
   })  : assert(theme != null),
         assert(textDirection != null),
         _theme = theme,
@@ -1869,6 +1906,7 @@ class _RenderChip extends RenderBox {
   Animation<double> avatarDrawerAnimation;
   Animation<double> deleteDrawerAnimation;
   Animation<double> enableAnimation;
+  AvatarShapeDescriber avatarShapeDescriber;
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _ChipSlot slot) {
     if (oldChild != null) {
@@ -2356,8 +2394,8 @@ class _RenderChip extends RenderBox {
         final Paint darkenPaint = Paint()
           ..color = selectionScrimTween.evaluate(checkmarkAnimation)
           ..blendMode = BlendMode.srcATop;
-        final double shortestSide = math.min(avatarRect.width, avatarRect.height);
-        context.canvas.drawRRect(RRect.fromRectAndRadius(avatarRect, Radius.circular(shortestSide / 2)), darkenPaint);
+        final Path path = avatarShapeDescriber(avatarRect);
+        context.canvas.drawPath(path, darkenPaint);
       }
       // Need to make the check mark be a little smaller than the avatar.
       final double checkSize = avatar.size.height * 0.75;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -38,19 +38,6 @@ const Duration _kDisableDuration = Duration(milliseconds: 75);
 const Color _kSelectScrimColor = Color(0x60191919);
 const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 
-/// A function which describes the shape of the avatar widget as a path.
-///
-/// The path is used to draw an additional darkened layer over the avatar
-/// when combined with a selected choice chip. Differently shaped avatars
-/// may require different paths. The default implementation creates a circle
-/// to cover the [CircleAvatar] widget.
-typedef AvatarShapeDescriber = Path Function(Rect avatarRect);
-
-Path _kDefaultAvatarPath(Rect avatarRect) {
-  final Radius radius = Radius.circular(avatarRect.shortestSide / 2);
-  return Path()..addRRect(RRect.fromRectAndRadius(avatarRect, radius));
-}
-
 /// An interface defining the base attributes for a material design chip.
 ///
 /// Chips are compact elements that represent an attribute, text, entity, or
@@ -318,8 +305,11 @@ abstract class SelectableChipAttributes {
   /// are) of the chip.
   String get tooltip;
 
-  /// A function which describes the shape of the avatar widget as a path.
-  AvatarShapeDescriber get avatarShapeDescriber;
+  /// The shape of the avatar border to be used to draw a darkended layer when
+  /// a checkmark is drawn over it.
+  ///
+  /// Defaults to [CircleBorder].
+  ShapeBorder get avatarBorderShape;
 }
 
 /// An interface for material design chips that can be enabled and disabled.
@@ -620,7 +610,7 @@ class InputChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarShapeDescriber = _kDefaultAvatarPath,
+    this.avatarBorderShape = const CircleBorder(),
   })  : assert(selected != null),
         assert(isEnabled != null),
         assert(label != null),
@@ -670,7 +660,7 @@ class InputChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final AvatarShapeDescriber avatarShapeDescriber;
+  final ShapeBorder avatarBorderShape;
 
   @override
   Widget build(BuildContext context) {
@@ -698,7 +688,7 @@ class InputChip extends StatelessWidget
       padding: padding,
       materialTapTargetSize: materialTapTargetSize,
       isEnabled: isEnabled && (onSelected != null || onDeleted != null || onPressed != null),
-      avatarShapeDescriber: avatarShapeDescriber,
+      avatarBorderShape: avatarBorderShape,
     );
   }
 }
@@ -782,7 +772,7 @@ class ChoiceChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarShapeDescriber = _kDefaultAvatarPath,
+    this.avatarBorderShape = const CircleBorder(),
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -819,7 +809,7 @@ class ChoiceChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final AvatarShapeDescriber avatarShapeDescriber;
+  final ShapeBorder avatarBorderShape;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -847,7 +837,7 @@ class ChoiceChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
-      avatarShapeDescriber: avatarShapeDescriber,
+      avatarBorderShape: avatarBorderShape,
     );
   }
 }
@@ -963,7 +953,7 @@ class FilterChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarShapeDescriber = _kDefaultAvatarPath,
+    this.avatarBorderShape = const CircleBorder(),
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -1000,7 +990,7 @@ class FilterChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final AvatarShapeDescriber avatarShapeDescriber;
+  final ShapeBorder avatarBorderShape;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -1025,7 +1015,7 @@ class FilterChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
-      avatarShapeDescriber: avatarShapeDescriber,
+      avatarBorderShape: avatarBorderShape,
     );
   }
 }
@@ -1218,7 +1208,7 @@ class RawChip extends StatefulWidget
     this.clipBehavior = Clip.none,
     this.backgroundColor,
     this.materialTapTargetSize,
-    this.avatarShapeDescriber = _kDefaultAvatarPath,
+    this.avatarBorderShape = const CircleBorder(),
   })  : assert(label != null),
         assert(isEnabled != null),
         assert(clipBehavior != null),
@@ -1269,7 +1259,7 @@ class RawChip extends StatefulWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final AvatarShapeDescriber avatarShapeDescriber;
+  final CircleBorder avatarBorderShape;
 
   /// Whether or not to show a check mark when [selected] is true.
   ///
@@ -1575,7 +1565,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
               avatarDrawerAnimation: avatarDrawerAnimation,
               deleteDrawerAnimation: deleteDrawerAnimation,
               isEnabled: widget.isEnabled,
-              avatarShapeDescriber: widget.avatarShapeDescriber,
+              avatarBorderShape: widget.avatarBorderShape,
             ),
           ),
         ),
@@ -1656,7 +1646,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
-    this.avatarShapeDescriber,
+    this.avatarBorderShape,
   })  : assert(theme != null),
         super(key: key);
 
@@ -1667,7 +1657,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
   final Animation<double> avatarDrawerAnimation;
   final Animation<double> deleteDrawerAnimation;
   final Animation<double> enableAnimation;
-  final AvatarShapeDescriber avatarShapeDescriber;
+  final ShapeBorder avatarBorderShape;
 
   @override
   _RenderChipElement createElement() => _RenderChipElement(this);
@@ -1683,7 +1673,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
       ..avatarDrawerAnimation = avatarDrawerAnimation
       ..deleteDrawerAnimation = deleteDrawerAnimation
       ..enableAnimation = enableAnimation
-      ..avatarShapeDescriber = avatarShapeDescriber;
+      ..avatarBorderShape = avatarBorderShape;
   }
 
   @override
@@ -1697,7 +1687,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
       avatarDrawerAnimation: avatarDrawerAnimation,
       deleteDrawerAnimation: deleteDrawerAnimation,
       enableAnimation: enableAnimation,
-      avatarShapeDescriber: avatarShapeDescriber,
+      avatarBorderShape: avatarBorderShape,
     );
   }
 }
@@ -1885,7 +1875,7 @@ class _RenderChip extends RenderBox {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
-    this.avatarShapeDescriber,
+    this.avatarBorderShape,
   })  : assert(theme != null),
         assert(textDirection != null),
         _theme = theme,
@@ -1907,7 +1897,7 @@ class _RenderChip extends RenderBox {
   Animation<double> avatarDrawerAnimation;
   Animation<double> deleteDrawerAnimation;
   Animation<double> enableAnimation;
-  AvatarShapeDescriber avatarShapeDescriber;
+  ShapeBorder avatarBorderShape;
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _ChipSlot slot) {
     if (oldChild != null) {
@@ -2395,7 +2385,7 @@ class _RenderChip extends RenderBox {
         final Paint darkenPaint = Paint()
           ..color = selectionScrimTween.evaluate(checkmarkAnimation)
           ..blendMode = BlendMode.srcATop;
-        final Path path = avatarShapeDescriber(avatarRect);
+        final Path path =  avatarBorderShape.getOuterPath(avatarRect);
         context.canvas.drawPath(path, darkenPaint);
       }
       // Need to make the check mark be a little smaller than the avatar.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -305,11 +305,11 @@ abstract class SelectableChipAttributes {
   /// are) of the chip.
   String get tooltip;
 
-  /// The shape of the avatar border to be used to draw a darkended layer when
-  /// a checkmark is drawn over it.
+  /// The shape of the avatar, used to draw a darkended layer when a checkmark
+  /// is drawn over it.
   ///
   /// Defaults to [CircleBorder].
-  ShapeBorder get avatarBorderShape;
+  ShapeBorder get avatarBorder;
 }
 
 /// An interface for material design chips that can be enabled and disabled.
@@ -610,7 +610,7 @@ class InputChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarBorderShape = const CircleBorder(),
+    this.avatarBorder = const CircleBorder(),
   })  : assert(selected != null),
         assert(isEnabled != null),
         assert(label != null),
@@ -660,7 +660,7 @@ class InputChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final ShapeBorder avatarBorderShape;
+  final ShapeBorder avatarBorder;
 
   @override
   Widget build(BuildContext context) {
@@ -688,7 +688,7 @@ class InputChip extends StatelessWidget
       padding: padding,
       materialTapTargetSize: materialTapTargetSize,
       isEnabled: isEnabled && (onSelected != null || onDeleted != null || onPressed != null),
-      avatarBorderShape: avatarBorderShape,
+      avatarBorder: avatarBorder,
     );
   }
 }
@@ -772,7 +772,7 @@ class ChoiceChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarBorderShape = const CircleBorder(),
+    this.avatarBorder = const CircleBorder(),
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -809,7 +809,7 @@ class ChoiceChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final ShapeBorder avatarBorderShape;
+  final ShapeBorder avatarBorder;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -837,7 +837,7 @@ class ChoiceChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
-      avatarBorderShape: avatarBorderShape,
+      avatarBorder: avatarBorder,
     );
   }
 }
@@ -953,7 +953,7 @@ class FilterChip extends StatelessWidget
     this.backgroundColor,
     this.padding,
     this.materialTapTargetSize,
-    this.avatarBorderShape = const CircleBorder(),
+    this.avatarBorder = const CircleBorder(),
   })  : assert(selected != null),
         assert(label != null),
         assert(clipBehavior != null),
@@ -990,7 +990,7 @@ class FilterChip extends StatelessWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final ShapeBorder avatarBorderShape;
+  final ShapeBorder avatarBorder;
 
   @override
   bool get isEnabled => onSelected != null;
@@ -1015,7 +1015,7 @@ class FilterChip extends StatelessWidget
       padding: padding,
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
-      avatarBorderShape: avatarBorderShape,
+      avatarBorder: avatarBorder,
     );
   }
 }
@@ -1208,7 +1208,7 @@ class RawChip extends StatefulWidget
     this.clipBehavior = Clip.none,
     this.backgroundColor,
     this.materialTapTargetSize,
-    this.avatarBorderShape = const CircleBorder(),
+    this.avatarBorder = const CircleBorder(),
   })  : assert(label != null),
         assert(isEnabled != null),
         assert(clipBehavior != null),
@@ -1259,7 +1259,7 @@ class RawChip extends StatefulWidget
   @override
   final MaterialTapTargetSize materialTapTargetSize;
   @override
-  final CircleBorder avatarBorderShape;
+  final CircleBorder avatarBorder;
 
   /// Whether or not to show a check mark when [selected] is true.
   ///
@@ -1565,7 +1565,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
               avatarDrawerAnimation: avatarDrawerAnimation,
               deleteDrawerAnimation: deleteDrawerAnimation,
               isEnabled: widget.isEnabled,
-              avatarBorderShape: widget.avatarBorderShape,
+              avatarBorder: widget.avatarBorder,
             ),
           ),
         ),
@@ -1646,7 +1646,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
-    this.avatarBorderShape,
+    this.avatarBorder,
   })  : assert(theme != null),
         super(key: key);
 
@@ -1657,7 +1657,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
   final Animation<double> avatarDrawerAnimation;
   final Animation<double> deleteDrawerAnimation;
   final Animation<double> enableAnimation;
-  final ShapeBorder avatarBorderShape;
+  final ShapeBorder avatarBorder;
 
   @override
   _RenderChipElement createElement() => _RenderChipElement(this);
@@ -1673,7 +1673,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
       ..avatarDrawerAnimation = avatarDrawerAnimation
       ..deleteDrawerAnimation = deleteDrawerAnimation
       ..enableAnimation = enableAnimation
-      ..avatarBorderShape = avatarBorderShape;
+      ..avatarBorder = avatarBorder;
   }
 
   @override
@@ -1687,7 +1687,7 @@ class _ChipRenderWidget extends RenderObjectWidget {
       avatarDrawerAnimation: avatarDrawerAnimation,
       deleteDrawerAnimation: deleteDrawerAnimation,
       enableAnimation: enableAnimation,
-      avatarBorderShape: avatarBorderShape,
+      avatarBorder: avatarBorder,
     );
   }
 }
@@ -1875,7 +1875,7 @@ class _RenderChip extends RenderBox {
     this.avatarDrawerAnimation,
     this.deleteDrawerAnimation,
     this.enableAnimation,
-    this.avatarBorderShape,
+    this.avatarBorder,
   })  : assert(theme != null),
         assert(textDirection != null),
         _theme = theme,
@@ -1897,7 +1897,7 @@ class _RenderChip extends RenderBox {
   Animation<double> avatarDrawerAnimation;
   Animation<double> deleteDrawerAnimation;
   Animation<double> enableAnimation;
-  ShapeBorder avatarBorderShape;
+  ShapeBorder avatarBorder;
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _ChipSlot slot) {
     if (oldChild != null) {
@@ -2385,7 +2385,7 @@ class _RenderChip extends RenderBox {
         final Paint darkenPaint = Paint()
           ..color = selectionScrimTween.evaluate(checkmarkAnimation)
           ..blendMode = BlendMode.srcATop;
-        final Path path =  avatarBorderShape.getOuterPath(avatarRect);
+        final Path path =  avatarBorder.getOuterPath(avatarRect);
         context.canvas.drawPath(path, darkenPaint);
       }
       // Need to make the check mark be a little smaller than the avatar.

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1596,4 +1596,27 @@ void main() {
     await tester.pumpWidget(_wrapForChip(child: const InputChip(label: label, clipBehavior: Clip.antiAlias)));
     checkChipMaterialClipBehavior(tester, Clip.antiAlias);
   });
+
+  testWidgets('selected chip and avatar draw darkened layer within avatar circle', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrapForChip(child: const FilterChip(
+      avatar: CircleAvatar(child: Text('t')),
+      label: Text('test'),
+      selected: true,
+      onSelected: null,
+    )));
+    final RenderBox rawChip = tester.firstRenderObject<RenderBox>(
+      find.descendant(
+        of: find.byType(RawChip),
+        matching: find.byWidgetPredicate((Widget widget) {
+          return widget.runtimeType.toString() == '_ChipRenderWidget';
+        })
+      )
+    );
+    const Color selectScrimColor = Color(0x60191919);
+    expect(rawChip, paints..path(color: selectScrimColor, includes: <Offset>[
+      const Offset(10, 10),
+    ], excludes: <Offset>[
+      const Offset(4, 4),
+    ]));
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/24773

Previously the darkened layer was drawn incorrectly when combined with the default avatar. I believe this was due to clipping changes. Nevertheless, a clip isn't necessary since we know the shape of the avatar.
<img src="https://user-images.githubusercontent.com/8975114/50729537-96d13800-10f0-11e9-9849-a1f360f3c28e.png" width="250">

We can support this by adding a (please help me name this better) "AvatarShapeDescriber", which given the rect of the avatar, returns a Path which we use to paint the darkened layer. I explored other options such as a widget or painter, but I felt that it exposed too many of the lower-level bits of the chip.

```
typedef AvatarShapeDescriber = Path Function(Rect avatarRect);

Path _kDefaultAvatarPath(Rect avatarRect) {
  final Radius radius = Radius.circular(avatarRect.shortestSide / 2);
  return Path()..addRRect(RRect.fromRectAndRadius(avatarRect, radius));
}
```

Now the default implementation and a circle avatar look correct:
<img src="https://user-images.githubusercontent.com/8975114/50611437-3d1c0400-0e8b-11e9-920b-cfdadc11aa96.png" width="250">

This can also be customized to suit any shape without using a clip, for example a square with rounded corners:

<img src="https://user-images.githubusercontent.com/8975114/50729550-c41de600-10f0-11e9-9446-1f08fab6c910.png" width="250">
