### PR TITLE
Improve the intergrity checking for "gradle wrapper".

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -568,6 +568,10 @@ class FlutterEngine extends CachedArtifact {
 class GradleWrapper extends CachedArtifact {
   GradleWrapper(Cache cache): super('gradle_wrapper', cache);
 
+  List<String> get _gradleScripts => <String>['gradlew', 'gradlew.bat'];
+
+  String get _gradleWrapper => fs.path.join('gradle', 'wrapper', 'gradle-wrapper.jar');
+
   @override
   Future<void> updateInner() {
     final Uri archiveUri = _toStorageUri(version);
@@ -577,6 +581,22 @@ class GradleWrapper extends CachedArtifact {
       // Remove NOTICE file. Should not be part of the template.
       fs.file(fs.path.join(location.path, 'NOTICE')).deleteSync();
     });
+  }
+
+  @override
+  bool isUpToDateInner() {
+    final Directory wrapperDir = cache.getCacheDir(fs.path.join('artifacts', 'gradle_wrapper'));
+    if (!fs.directory(wrapperDir).existsSync())
+      return false;
+    for (String scriptName in _gradleScripts) {
+      final File scriptFile = fs.file(fs.path.join(wrapperDir.path, scriptName));
+      if (!scriptFile.existsSync())
+        return false;
+    }
+    final File gradleWrapperJar = fs.file(fs.path.join(wrapperDir.path, _gradleWrapper));
+    if (!gradleWrapperJar.existsSync())
+      return false;
+    return true;
   }
 }
 

--- a/packages/flutter_tools/test/cache_test.dart
+++ b/packages/flutter_tools/test/cache_test.dart
@@ -51,6 +51,36 @@ void main() {
   });
 
   group('Cache', () {
+    final MockCache mockCache = MockCache();
+    final MemoryFileSystem fs = MemoryFileSystem();
+
+    testUsingContext('Gradle wrapper should not be up to date, if some cached artifact is not available', () {
+      final GradleWrapper gradleWrapper = GradleWrapper(mockCache);
+      final Directory directory = fs.directory('/Applications/flutter/bin/cache');
+      directory.createSync(recursive: true);
+      fs.file(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper', 'gradle', 'wrapper', 'gradle-wrapper.jar')).createSync(recursive: true);
+      when(mockCache.getCacheDir(fs.path.join('artifacts', 'gradle_wrapper'))).thenReturn(fs.directory(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper')));
+      expect(gradleWrapper.isUpToDateInner(), false);
+    }, overrides: <Type, Generator>{
+      Cache: ()=> mockCache,
+      FileSystem: () => fs
+    });
+
+    testUsingContext('Gradle wrapper should be up to date, only if all cached artifact are available', () {
+      final GradleWrapper gradleWrapper = GradleWrapper(mockCache);
+      final Directory directory = fs.directory('/Applications/flutter/bin/cache');
+      directory.createSync(recursive: true);
+      fs.file(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper', 'gradle', 'wrapper', 'gradle-wrapper.jar')).createSync(recursive: true);
+      fs.file(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper', 'gradlew')).createSync(recursive: true);
+      fs.file(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper', 'gradlew.bat')).createSync(recursive: true);
+
+      when(mockCache.getCacheDir(fs.path.join('artifacts', 'gradle_wrapper'))).thenReturn(fs.directory(fs.path.join(directory.path, 'artifacts', 'gradle_wrapper')));
+      expect(gradleWrapper.isUpToDateInner(), true);
+    }, overrides: <Type, Generator>{
+      Cache: ()=> mockCache,
+      FileSystem: () => fs
+    });
+
     test('should not be up to date, if some cached artifact is not', () {
       final CachedArtifact artifact1 = MockCachedArtifact();
       final CachedArtifact artifact2 = MockCachedArtifact();
@@ -132,3 +162,4 @@ class MockFile extends Mock implements File {
 class MockRandomAccessFile extends Mock implements RandomAccessFile {}
 class MockCachedArtifact extends Mock implements CachedArtifact {}
 class MockInternetAddress extends Mock implements InternetAddress {}
+class MockCache extends Mock implements Cache {}


### PR DESCRIPTION
Once when I create a new flutter project with `flutter create hello_flutter` and run it using `flutter run`
I meet error message below;
···
Launching lib/main.dart on MHA AL00 in debug mode...
Initializing gradle...                                           
Unable to locate gradlew script
···
I found that that's because `flutterroot/bin/cache/artifacts/gradle_wrapper` is empty
And when I run flutter command, it didn't check whether the gradle_wrapper is empty. 
Other part like `flutterroot/bin/cache/artifacts/engine` will be checked normally.