### PR TITLE
Utilize animation curves that closer match iOS where possible

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -348,18 +348,19 @@ class CupertinoPageTransition extends StatelessWidget {
        _primaryPositionAnimation = (linearTransition ? primaryRouteAnimation :
          CurvedAnimation(
            parent: primaryRouteAnimation,
-           curve: Curves.easeOut,
-           reverseCurve: Curves.easeIn,
+           curve: Curves.fastOutSlowIn,
+           reverseCurve: Curves.fastOutSlowIn.flipped,
          )
        ).drive(_kRightMiddleTween),
        _secondaryPositionAnimation = CurvedAnimation(
          parent: secondaryRouteAnimation,
-         curve: Curves.easeOut,
-         reverseCurve: Curves.easeIn,
+         curve: Curves.fastOutSlowIn,
+         reverseCurve: Curves.fastOutSlowIn.flipped,
        ).drive(_kMiddleLeftTween),
        _primaryShadowAnimation = CurvedAnimation(
          parent: primaryRouteAnimation,
-         curve: Curves.easeOut,
+         curve: Curves.fastOutSlowIn,
+         reverseCurve: Curves.fastOutSlowIn.flipped,
        ).drive(_kGradientShadowTween),
        super(key: key);
 
@@ -403,7 +404,7 @@ class CupertinoFullscreenDialogTransition extends StatelessWidget {
     @required Animation<double> animation,
     @required this.child,
   }) : _positionAnimation = animation
-         .drive(CurveTween(curve: Curves.easeInOut))
+         .drive(CurveTween(curve: Curves.fastOutSlowIn))
          .drive(_kBottomUpTween),
        super(key: key);
 
@@ -783,8 +784,8 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
     assert(_animation == null);
     _animation = CurvedAnimation(
       parent: super.createAnimation(),
-      curve: Curves.ease,
-      reverseCurve: Curves.ease.flipped,
+      curve: Curves.fastOutSlowIn,
+      reverseCurve: Curves.fastOutSlowIn.flipped,
     );
     _offsetTween = Tween<Offset>(
       begin: const Offset(0.0, 1.0),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1382,8 +1382,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     if (_primaryScrollController.hasClients) {
       _primaryScrollController.animateTo(
         0.0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.linear, // TODO(ianh): Use a more appropriate curve.
+        duration: const Duration(milliseconds: 600),
+        curve: Curves.fastOutSlowIn,
       );
     }
   }


### PR DESCRIPTION
This PR uses more specific values from the `Curves` that are more similar to native. Route transitions and scrolling to top with the status bar now feel much more natural when running on an iOS device.

There are some differences with the curves I used and those used natively:

- Ramps up the acceleration before reaching maximum speed
- Not as steep as native (native is usually closer to ease-out-quint or so)

Unfortunately `Curves.fastOutSlowIn` was the closest match despite the above. It's still a net gain in closeness to the platform though. If my other PR (#25788) is merged which includes more appropriate easing functions (including ease-out-quint), then this PR will be obsolete, but the commits at least serve as a stopgap until then, and as a sentinel for where to replace the curve instances next time.

Before

![ezgif-4-56fa98ad8155](https://user-images.githubusercontent.com/4211302/50740901-05e08680-11ee-11e9-8c0b-f6214c8d64b8.gif)

After

![ezgif-4-b6d4815c9596](https://user-images.githubusercontent.com/4211302/50740906-1264df00-11ee-11e9-8db0-46768533eb1e.gif)

The only thing I wasn't able to alter was the hero animation where the current route title becomes the back button. `Hero` doesn't let you specify a curve or a reverse curve, so it effectively uses an ease out for the back animation, which gives the animation a very abrupt ending (which goes without saying doesn't look native)

--

Update: Opened an issue for Hero at #26150 