### PR TITLE
Prevent calls to view.uiIsolate.flutterExit on devices which do not support it

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -183,7 +183,24 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
   String toString() => '$name device discovery';
 }
 
-abstract class Device {
+/// The Features that are not uniformly supported across flutter devices.
+abstract class DeviceCapabilities {
+  /// Whether this device implements support for hot reload.
+  bool get supportsHotReload;
+
+  /// Whether this device implements support for hot restart.
+  bool get supportsHotRestart;
+
+  /// Whether flutter applications running on this device can be terminated
+  /// from the vmservice.
+  bool get supportsStopApp;
+
+  /// Whether the device supports taking screenshots of a running flutter
+  /// application.
+  bool get supportsScreenshot;
+}
+
+abstract class Device implements DeviceCapabilities {
   Device(this.id);
 
   final String id;
@@ -270,20 +287,20 @@ abstract class Device {
     bool ipv6 = false,
   });
 
-  /// Whether this device implements support for hot reload.
+  @override
   bool get supportsHotReload => true;
 
-  /// Whether this device implements support for hot restart.
+  @override
   bool get supportsHotRestart => true;
 
-  /// Whether flutter applications running on this device can be terminated
-  /// from the vmservice.
+  @override
   bool get supportsStopApp => true;
+
+  @override
+  bool get supportsScreenshot => false;
 
   /// Stop an app package on the current device.
   Future<bool> stopApp(ApplicationPackage app);
-
-  bool get supportsScreenshot => false;
 
   Future<void> takeScreenshot(File outputFile) => Future<void>.error('unimplemented');
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -183,7 +183,7 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
   String toString() => '$name device discovery';
 }
 
-/// The Features that are not uniformly supported across flutter devices.
+/// Features that are not uniformly supported across flutter devices.
 abstract class DeviceCapabilities {
   /// Whether this device implements support for hot reload.
   bool get supportsHotReload;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -276,6 +276,10 @@ abstract class Device {
   /// Whether this device implements support for hot restart.
   bool get supportsHotRestart => true;
 
+  /// Whether flutter applications running on this device can be terminated
+  /// from the vmservice.
+  bool get supportsStopApp => true;
+
   /// Stop an app package on the current device.
   Future<bool> stopApp(ApplicationPackage app);
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -183,24 +183,7 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
   String toString() => '$name device discovery';
 }
 
-/// The Features that are not uniformly supported across flutter devices.
-abstract class DeviceCapabilities {
-  /// Whether this device implements support for hot reload.
-  bool get supportsHotReload;
-
-  /// Whether this device implements support for hot restart.
-  bool get supportsHotRestart;
-
-  /// Whether flutter applications running on this device can be terminated
-  /// from the vmservice.
-  bool get supportsStopApp;
-
-  /// Whether the device supports taking screenshots of a running flutter
-  /// application.
-  bool get supportsScreenshot;
-}
-
-abstract class Device implements DeviceCapabilities {
+abstract class Device {
   Device(this.id);
 
   final String id;
@@ -287,16 +270,18 @@ abstract class Device implements DeviceCapabilities {
     bool ipv6 = false,
   });
 
-  @override
+  /// Whether this device implements support for hot reload.
   bool get supportsHotReload => true;
 
-  @override
+  /// Whether this device implements support for hot restart.
   bool get supportsHotRestart => true;
 
-  @override
+  /// Whether flutter applications running on this device can be terminated
+  /// from the vmservice.
   bool get supportsStopApp => true;
 
-  @override
+  /// Whether the device supports taking screenshots of a running flutter
+  /// application.
   bool get supportsScreenshot => false;
 
   /// Stop an app package on the current device.

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -151,6 +151,9 @@ class FuchsiaDevice extends Device {
   bool get supportsHotRestart => false;
 
   @override
+  bool get supportsStopApp => false;
+
+  @override
   final String name;
 
   @override

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -109,6 +109,9 @@ class FlutterDevice {
   }
 
   Future<void> stopApps() async {
+    if (!device.supportsStopApp) {
+      return;
+    }
     final List<FlutterView> flutterViews = views;
     if (flutterViews == null || flutterViews.isEmpty)
       return;

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -36,6 +36,15 @@ void main() {
       expect(names.length, 1);
       expect(names.first, 'lilia-shore-only-last');
     });
+
+    test('default capabilities', () async {
+      final FuchsiaDevice device = FuchsiaDevice('123');
+
+      expect(device.supportsHotReload, true);
+      expect(device.supportsHotRestart, false);
+      expect(device.supportsStopApp, false);
+      expect(await device.stopApp(null), false);
+    });
   });
 
   group('displays friendly error when', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/25565