### PR TITLE
Give integration tests unique temp folder names

### DIFF
--- a/packages/flutter_tools/test/integration/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration/daemon_mode_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_deamon_mode_test.');
+      tempDir = createResolvedTempDirectorySync('flutter_daemon_mode_test.');
       await _project.setUpIn(tempDir);
     });
 

--- a/packages/flutter_tools/test/integration/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration/daemon_mode_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_deamon_mode_test.');
       await _project.setUpIn(tempDir);
     });
 

--- a/packages/flutter_tools/test/integration/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration/daemon_mode_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('daemon_mode_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
     });
 

--- a/packages/flutter_tools/test/integration/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration/daemon_mode_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_daemon_mode_test.');
+      tempDir = createResolvedTempDirectorySync('daemon_mode_test.');
       await _project.setUpIn(tempDir);
     });
 

--- a/packages/flutter_tools/test/integration/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration/daemon_mode_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('daemon_mode_test.');
       await _project.setUpIn(tempDir);
     });
 

--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -17,7 +17,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_debugger_stepping_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -17,7 +17,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('debugger_stepping_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -17,7 +17,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('debugger_stepping_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration/debugger_stepping_test.dart
@@ -17,7 +17,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_debugger_stepping_test.');
+      tempDir = createResolvedTempDirectorySync('debugger_stepping_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('run_expression_eval_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('run_expression_eval_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });
@@ -87,7 +87,7 @@ void main() {
     FlutterTestTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('test_expression_eval_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterTestTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_expression_evaluation_test.');
+      tempDir = createResolvedTempDirectorySync('flutter_run_expression_evaluation_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });
@@ -87,7 +87,7 @@ void main() {
     FlutterTestTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_test_expression_evaluation_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterTestTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_run_expression_evaluation_test.');
+      tempDir = createResolvedTempDirectorySync('run_expression_evaluation_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });
@@ -87,7 +87,7 @@ void main() {
     FlutterTestTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_test_expression_evaluation_test.');
+      tempDir = createResolvedTempDirectorySync('test_expression_evaluation_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterTestTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_expression_evaluation_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('run_expression_evaluation_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });
@@ -87,7 +87,7 @@ void main() {
     FlutterTestTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('test_expression_evaluation_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterTestTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('run_expression_eval_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });
@@ -87,7 +87,7 @@ void main() {
     FlutterTestTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('test_expression_eval_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterTestTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -16,7 +16,7 @@ void main() {
   Directory tempDir;
 
   setUp(() async {
-    tempDir = createResolvedTempDirectorySync('flutter_attach_test.');
+    tempDir = createResolvedTempDirectorySync('attach_test.');
     await _project.setUpIn(tempDir);
     _flutterRun = FlutterRunTestDriver(tempDir, logPrefix: 'RUN');
     _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH');

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -16,7 +16,7 @@ void main() {
   Directory tempDir;
 
   setUp(() async {
-    tempDir = createResolvedTempDirectorySync();
+    tempDir = createResolvedTempDirectorySync('flutter_attach_test.');
     await _project.setUpIn(tempDir);
     _flutterRun = FlutterRunTestDriver(tempDir, logPrefix: 'RUN');
     _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH');

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -16,7 +16,7 @@ void main() {
   Directory tempDir;
 
   setUp(() async {
-    tempDir = createResolvedTempDirectorySync('expression_test.');
+    tempDir = createResolvedTempDirectorySync('attach_test.');
     await _project.setUpIn(tempDir);
     _flutterRun = FlutterRunTestDriver(tempDir, logPrefix: 'RUN');
     _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH');

--- a/packages/flutter_tools/test/integration/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_attach_test.dart
@@ -16,7 +16,7 @@ void main() {
   Directory tempDir;
 
   setUp(() async {
-    tempDir = createResolvedTempDirectorySync('attach_test.');
+    tempDir = createResolvedTempDirectorySync('expression_test.');
     await _project.setUpIn(tempDir);
     _flutterRun = FlutterRunTestDriver(tempDir, logPrefix: 'RUN');
     _flutterAttach = FlutterRunTestDriver(tempDir, logPrefix: 'ATTACH');

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -19,7 +19,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_run_test.');
+      tempDir = createResolvedTempDirectorySync('run_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -19,7 +19,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_run_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -19,7 +19,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('run_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration/flutter_run_test.dart
@@ -19,7 +19,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('run_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -20,7 +20,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_hot_reload_test.');
+      tempDir = createResolvedTempDirectorySync('hot_reload_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -20,7 +20,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_hot_reload_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -20,7 +20,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('hot_reload_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration/hot_reload_test.dart
@@ -20,7 +20,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('hot_reload_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -24,7 +24,7 @@ void main() {
     Directory tempDir;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('flutter_lifetime_test.');
+      tempDir = createResolvedTempDirectorySync('lifetime_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -24,7 +24,7 @@ void main() {
     Directory tempDir;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('lifetime_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -24,7 +24,7 @@ void main() {
     Directory tempDir;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync();
+      tempDir = createResolvedTempDirectorySync('flutter_lifetime_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration/lifetime_test.dart
@@ -24,7 +24,7 @@ void main() {
     Directory tempDir;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('lifetime_test.');
+      tempDir = createResolvedTempDirectorySync('expression_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -15,7 +15,7 @@ import 'package:vm_service_lib/vm_service_lib_io.dart';
 import '../src/common.dart';
 
 // Set this to true for debugging to get JSON written to stdout.
-const bool _printDebugOutputToStdOut = false;
+const bool _printDebugOutputToStdOut = true;
 const Duration defaultTimeout = Duration(seconds: 40);
 const Duration appStartTimeout = Duration(seconds: 120);
 const Duration quitTimeout = Duration(seconds: 10);

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -15,7 +15,7 @@ import 'package:vm_service_lib/vm_service_lib_io.dart';
 import '../src/common.dart';
 
 // Set this to true for debugging to get JSON written to stdout.
-const bool _printDebugOutputToStdOut = true;
+const bool _printDebugOutputToStdOut = false;
 const Duration defaultTimeout = Duration(seconds: 40);
 const Duration appStartTimeout = Duration(seconds: 120);
 const Duration quitTimeout = Duration(seconds: 10);

--- a/packages/flutter_tools/test/integration/test_utils.dart
+++ b/packages/flutter_tools/test/integration/test_utils.dart
@@ -15,7 +15,7 @@ import '../src/common.dart';
 /// underlying path to avoid issues with breakpoints/hot reload.
 /// https://github.com/flutter/flutter/pull/21741
 Directory createResolvedTempDirectorySync(String prefix) {
-  final Directory tempDir = fs.systemTempDirectory.createTempSync(prefix);
+  final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_$prefix');
   return fs.directory(tempDir.resolveSymbolicLinksSync());
 }
 

--- a/packages/flutter_tools/test/integration/test_utils.dart
+++ b/packages/flutter_tools/test/integration/test_utils.dart
@@ -14,8 +14,8 @@ import '../src/common.dart';
 /// Creates a temporary directory but resolves any symlinks to return the real
 /// underlying path to avoid issues with breakpoints/hot reload.
 /// https://github.com/flutter/flutter/pull/21741
-Directory createResolvedTempDirectorySync() {
-  final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_expression_test.');
+Directory createResolvedTempDirectorySync(String prefix) {
+  final Directory tempDir = fs.systemTempDirectory.createTempSync(prefix);
   return fs.directory(tempDir.resolveSymbolicLinksSync());
 }
 


### PR DESCRIPTION
This will help track down any that aren't cleaning up and also may help track down leaked flutter_tester processes (https://github.com/dart-lang/sdk/issues/35549).