### PR TITLE
Unable to know if layout has built

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -974,6 +974,11 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   /// It is an error to call [setState] unless [mounted] is true.
   bool get mounted => _element != null;
 
+  /// It is false while your widget haven't called [build]
+  /// No matters how many times your widget call [build]
+  /// After the first [build] will be true
+  bool get hasBuilt => _element.hasBuilt;
+
   /// Called when this object is inserted into the tree.
   ///
   /// The framework will call this method exactly once for each [State] object
@@ -3816,6 +3821,10 @@ class StatefulElement extends ComponentElement {
   State<StatefulWidget> get state => _state;
   State<StatefulWidget> _state;
 
+  /// Indicate the state of build method
+  /// This just change to true after first build
+  bool hasBuilt = false;
+
   @override
   void _reassemble() {
     state.reassemble();
@@ -3846,6 +3855,7 @@ class StatefulElement extends ComponentElement {
     _state.didChangeDependencies();
     assert(() { _state._debugLifecycleState = _StateLifecycle.ready; return true; }());
     super._firstBuild();
+    hasBuilt = true;
   }
 
   @override

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -626,6 +626,26 @@ void main() {
     expect(state22.mounted, isTrue);
   });
 
+  testWidgets('Table widget - hasBuilt', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Table(
+          children: const <TableRow>[
+            TableRow(
+              children: <Widget>[
+                TestStatefulWidget(key: ValueKey<int>(21)),
+              ],
+            ),
+          ],
+        )
+      ),
+    );
+
+    final TestStatefulWidgetState state1 = tester.state(find.byKey(const ValueKey<int>(21)));
+    expect(state1.hasBuilt, true);
+  });
+
   testWidgets('Table widget - global key reparenting', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     final Key tableKey = UniqueKey();


### PR DESCRIPTION
I just added an easy way to allow users to verify if your widget already have built or not without using `addListener`

I think this is likely in case you have a getter that depends on this (#26185) 