### PR TITLE
rev the min dart sdk dep in the templates to 2.1.0

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -15,7 +15,7 @@ version: 1.0.0+1
 {{/withPluginHook}}
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -14,7 +14,7 @@ description: {{description}}
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ author:
 homepage:
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ author:
 homepage:
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
- rev the min dart sdk dep in the templates to `2.1.0` (Flutter is currently on `2.1.1-dev.0.1`)

This will avoid an issue in user projects, where use of `Future` without an import will warn: 
`The class 'Future' was not exported from 'dart:core' until version 2.1, but this code is required to be able to run on earlier versions`, even though this is legal on the VM that Flutter's running on.
