### PR TITLE
Add modifier functions to RawKeyEventAndroid.

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -52,6 +52,15 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
        assert(scanCode != null),
        assert(metaState != null);
 
+  /// Provides the state of either control key.
+  bool isCtrlPressed() => (metaState & 0x1000) != 0;
+
+  /// Provides the state of either alt key.
+  bool isAltPressed() => (metaState & 0x02) != 0;
+
+  /// Provides the state of either shift key.
+  bool isShiftPressed() => (metaState & 0x1) != 0;
+
   /// See <https://developer.android.com/reference/android/view/KeyEvent.html#getFlags()>
   final int flags;
 

--- a/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
+++ b/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
@@ -59,6 +59,41 @@ void main() {
     focusNode.dispose();
   });
 
+  testWidgets('Combined modifier keys pass check',
+    (WidgetTester tester) async{
+      final List<RawKeyEvent> events = <RawKeyEvent>[];
+
+      final FocusNode focusNode = FocusNode();
+
+      await tester.pumpWidget(RawKeyboardListener(
+        focusNode: focusNode,
+        onKey: events.add,
+        child: Container(),
+      ));
+
+      tester.binding.focusManager.rootScope.requestFocus(focusNode);
+      await tester.idle();
+
+      sendFakeKeyEvent(<String, dynamic>{
+        'type': 'keydown',
+        'keymap': 'android',
+        'hidUsage': 0x04,
+        'codePoint': 0x64,
+        'metaState': 1<<12|1|2, // Ctrl, Shift, Alt
+      });
+      await tester.idle();
+
+      final RawKeyEventDataAndroid data = events[0].data;
+
+      expect(data.isCtrlPressed(), equals(true));
+      expect(data.isShiftPressed(), equals(true));
+      expect(data.isAltPressed(), equals(true));
+
+      await tester.pumpWidget(Container());
+      focusNode.dispose();
+    }
+  );
+
   testWidgets('Defunct listeners do not receive events',
       (WidgetTester tester) async {
     final List<RawKeyEvent> events = <RawKeyEvent>[];


### PR DESCRIPTION
This adds `isCtrlPressed`, `isAltPressed`, and `isShiftPressed` to `RawKeyEventAndroid`. This closes issue #26155.

cc: @gspencergoog 