### PR TITLE
Force DatePicker value to stay within firstDate and lastDate upon year change

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -902,6 +902,13 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
   }
 
   void _handleYearChanged(DateTime value) {
+    if (value.isBefore(widget.firstDate))
+      value = widget.firstDate;
+    else if (value.isAfter(widget.lastDate))
+      value = widget.lastDate;
+    if (value == _selectedDate)
+      return;
+
     _vibrate();
     setState(() {
       _mode = DatePickerMode.day;
@@ -1090,6 +1097,9 @@ Future<DateTime> showDatePicker({
   Locale locale,
   TextDirection textDirection,
 }) async {
+  assert(initialDate != null);
+  assert(firstDate != null);
+  assert(lastDate != null);
   assert(!initialDate.isBefore(firstDate), 'initialDate must be on or after firstDate');
   assert(!initialDate.isAfter(lastDate), 'initialDate must be on or before lastDate');
   assert(!firstDate.isAfter(lastDate), 'lastDate must be on or after firstDate');

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1074,8 +1074,11 @@ typedef SelectableDayPredicate = bool Function(DateTime day);
 /// provided by [Directionality]. If both [locale] and [textDirection] are not
 /// null, [textDirection] overrides the direction chosen for the [locale].
 ///
-/// The `context` argument is passed to [showDialog], the documentation for
+/// The [context] argument is passed to [showDialog], the documentation for
 /// which discusses how it is used.
+///
+/// The [context], [initialDate], [firstDate], and [lastDate] parameters must
+/// not be null.
 ///
 /// See also:
 ///

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -279,6 +279,39 @@ void _tests() {
     });
   });
 
+  testWidgets('Selecting firstDate year respects firstDate', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/17309
+    initialDate = DateTime(2018, DateTime.may, 4);
+    firstDate = DateTime(2016, DateTime.june, 9);
+    lastDate = DateTime(2019, DateTime.january, 15);
+    await preparePicker(tester, (Future<DateTime> date) async {
+      await tester.tap(find.text('2018'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('2016'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(await date, DateTime(2016, DateTime.june, 9));
+    });
+  });
+
+  testWidgets('Selecting lastDate year respects lastDate', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/17309
+    initialDate = DateTime(2018, DateTime.may, 4);
+    firstDate = DateTime(2016, DateTime.june, 9);
+    lastDate = DateTime(2019, DateTime.january, 15);
+    await preparePicker(tester, (Future<DateTime> date) async {
+      await tester.tap(find.text('2018'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('2019'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(await date, DateTime(2019, DateTime.january, 15));
+    });
+  });
+
+
   testWidgets('Only predicate days are selectable', (WidgetTester tester) async {
     initialDate = DateTime(2017, DateTime.january, 16);
     firstDate = DateTime(2017, DateTime.january, 10);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/17309
Fixes https://github.com/flutter/flutter/issues/22168

This fix was contributed by @Koerty in https://github.com/flutter/flutter/pull/24931, and independently by @iqbalmineraltown here: https://github.com/flutter/flutter/pull/24817.
