### PR TITLE
Reland: Switch to dev_finder

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -41,6 +41,7 @@ Future<void> main(List<String> args) async {
   final String buildDirectory = argResults['build-dir'];
   final File frontendServer = fs.file('$buildDirectory/host_x64/gen/third_party/flutter/frontend_server/frontend_server_tool.snapshot');
   final File sshConfig = fs.file('$buildDirectory/ssh-keys/ssh_config');
+  final File devFinder = fs.file('$buildDirectory/host_x64/dev_finder');
   final File platformKernelDill = fs.file('$buildDirectory/flutter_runner_patched_sdk/platform_strong.dill');
   final File flutterPatchedSdk = fs.file('$buildDirectory/flutter_runner_patched_sdk');
   final String packages = '$buildDirectory/dartlang/gen/$path/${name}_dart_library.packages';
@@ -91,7 +92,7 @@ Future<void> main(List<String> args) async {
     muteCommandLogging: false,
     verboseHelp: false,
     overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig, devFinder: devFinder),
       Artifacts: () => OverrideArtifacts(
         parent: CachedArtifacts(),
         frontendServer: frontendServer,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -117,27 +117,6 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
   Future<List<String>> getDiagnostics() async => const <String>[];
 }
 
-/// Parses output from the netls tool into fuchsia devices names.
-///
-/// Example output:
-///     $ ./netls
-///     > device liliac-shore-only-last (fe80::82e4:da4d:fe81:227d/3)
-@visibleForTesting
-@Deprecated('Use parseListDevices with listDevices instead')
-List<String> parseFuchsiaDeviceOutput(String text) {
-  final List<String> names = <String>[];
-  for (String rawLine in text.trim().split('\n')) {
-    final String line = rawLine.trim();
-    if (!line.startsWith('device'))
-      continue;
-    // ['device', 'device name', '(id)']
-    final List<String> words = line.split(' ');
-    final String name = words[1];
-    names.add(name);
-  }
-  return names;
-}
-
 @visibleForTesting
 List<FuchsiaDevice> parseListDevices(String text) {
   final List<FuchsiaDevice> devices = <FuchsiaDevice>[];

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -123,7 +123,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
 ///     $ ./netls
 ///     > device liliac-shore-only-last (fe80::82e4:da4d:fe81:227d/3)
 @visibleForTesting
-@deprecated
+@Deprecated('Use parseListDevices with listDevices instead')
 List<String> parseFuchsiaDeviceOutput(String text) {
   final List<String> names = <String>[];
   for (String rawLine in text.trim().split('\n')) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -108,12 +108,8 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
     if (!fuchsiaWorkflow.canListDevices) {
       return <Device>[];
     }
-    final String text = await fuchsiaSdk.netls();
-    final List<FuchsiaDevice> devices = <FuchsiaDevice>[];
-    for (String name in parseFuchsiaDeviceOutput(text)) {
-      final String id = await fuchsiaSdk.netaddr();
-      devices.add(FuchsiaDevice(id, name: name));
-    }
+    final String text = await fuchsiaSdk.listDevices();
+    final List<FuchsiaDevice> devices = parseListDevices(text);
     return devices;
   }
 
@@ -127,6 +123,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
 ///     $ ./netls
 ///     > device liliac-shore-only-last (fe80::82e4:da4d:fe81:227d/3)
 @visibleForTesting
+@deprecated
 List<String> parseFuchsiaDeviceOutput(String text) {
   final List<String> names = <String>[];
   for (String rawLine in text.trim().split('\n')) {
@@ -139,6 +136,20 @@ List<String> parseFuchsiaDeviceOutput(String text) {
     names.add(name);
   }
   return names;
+}
+
+@visibleForTesting
+List<FuchsiaDevice> parseListDevices(String text) {
+  final List<FuchsiaDevice> devices = <FuchsiaDevice>[];
+  for (String rawLine in text.trim().split('\n')) {
+    final String line = rawLine.trim();
+    // ['ip', 'device name']
+    final List<String> words = line.split(' ');
+    final String name = words[1];
+    final String id = words[0];
+    devices.add(FuchsiaDevice(id, name: name));
+  }
+  return devices;
 }
 
 class FuchsiaDevice extends Device {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -9,7 +9,6 @@ import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
-import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 
@@ -68,45 +67,13 @@ class FuchsiaSdk {
 /// Fuchsia-specific artifacts used to interact with a device.
 class FuchsiaArtifacts {
   /// Creates a new [FuchsiaArtifacts].
-  ///
-  /// May optionally provide a file `sshConfig` file and `devFinder` file.
-  FuchsiaArtifacts({File sshConfig, File devFinder})
-    : _sshConfig = sshConfig,
-      _devFinder = devFinder;
+  FuchsiaArtifacts({this.sshConfig, this.devFinder});
 
   /// The location of the SSH configuration file used to interact with a
   /// Fuchsia device.
-  ///
-  /// Requires the env variable `BUILD_DIR` to be set if not provided by
-  /// the constructor.
-  File get sshConfig {
-    if (_sshConfig == null) {
-      final String buildDirectory = platform.environment['BUILD_DIR'];
-      if (buildDirectory == null) {
-        throwToolExit('BUILD_DIR must be supplied to locate SSH keys. For example:\n'
-          '  export BUILD_DIR=path/to/fuchsia/out/x64\n');
-      }
-      _sshConfig = fs.file('$buildDirectory/ssh-keys/ssh_config');
-    }
-    return _sshConfig;
-  }
-  File _sshConfig;
+  final File sshConfig;
 
   /// The location of the dev finder tool used to locate connected
   /// Fuchsia devices.
-  ///
-  /// Requires the env variable `BUILD_DIR` to be set if not provided by
-  /// the constructor.
-  File get devFinder {
-    if (_devFinder == null) {
-      final String buildDirectory = platform.environment['BUILD_DIR'];
-      if (buildDirectory == null) {
-        throwToolExit('BUILD_DIR must be supplied to dev_finder. For example:\n'
-          '  export BUILD_DIR=path/to/fuchsia/out/x64\n');
-      }
-      _devFinder = fs.file('$buildDirectory/host_x64/dev_finder');
-    }
-    return _devFinder;
-  }
-  File _devFinder;
+  final File devFinder;
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -24,8 +24,6 @@ FuchsiaArtifacts get fuchsiaArtifacts => context[FuchsiaArtifacts];
 /// This workflow assumes development within the fuchsia source tree,
 /// including a working fx command-line tool in the user's PATH.
 class FuchsiaSdk {
-  static const List<String> _netaddrCommand = <String>['fx', 'netaddr', '--fuchsia', '--nowait'];
-  static const List<String> _netlsCommand = <String>['fx', 'netls', '--nowait'];
   static const List<String> _syslogCommand = <String>['fx', 'syslog', '--clock', 'Local'];
 
   /// Example output:
@@ -36,29 +34,6 @@ class FuchsiaSdk {
       final String path = fuchsiaArtifacts.devFinder.absolute.path;
       final RunResult process = await runAsync(<String>[path, 'list', '-full']);
       return process.stdout.trim();
-    } on ArgumentError catch (exception) {
-      throwToolExit('$exception');
-    }
-    return null;
-  }
-
-  /// Invokes the `netaddr` command.
-  ///
-  /// This returns the network address of an attached fuchsia device. Does
-  /// not currently support multiple attached devices.
-  ///
-  /// Example output:
-  ///     $ fx netaddr --fuchsia --nowait
-  ///     > fe80::9aaa:fcff:fe60:d3af%eth1
-  @Deprecated('Use listDevices instead')
-  Future<String> netaddr() async {
-    try {
-      final RunResult process = await runAsync(_netaddrCommand);
-      final String result = process.stdout.trim();
-      if (result.contains('timeout')) {
-        return '';
-      }
-      return result;
     } on ArgumentError catch (exception) {
       throwToolExit('$exception');
     }
@@ -83,26 +58,6 @@ class FuchsiaSdk {
         controller.addStream(process.stdout.transform(utf8.decoder).transform(const LineSplitter()));
       });
       return controller.stream;
-    } on ArgumentError catch (exception) {
-      throwToolExit('$exception');
-    }
-    return null;
-  }
-
-  /// Invokes the `netls` command.
-  ///
-  /// This lists attached fuchsia devices with their name and address. Does
-  /// not currently support multiple attached devices.
-  ///
-  /// Example output:
-  ///     $ fx netls --nowait
-  ///     > device liliac-shore-only-last (fe80::82e4:da4d:fe81:227d/3)
-  @Deprecated('Use listDevices instead')
-
-  Future<String> netls() async {
-    try {
-      final RunResult process = await runAsync(_netlsCommand);
-      return process.stdout;
     } on ArgumentError catch (exception) {
       throwToolExit('$exception');
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import '../base/context.dart';
-import '../base/os.dart';
 import '../base/platform.dart';
 import '../doctor.dart';
+import 'fuchsia_sdk.dart';
 
 /// The [FuchsiaWorkflow] instance.
 FuchsiaWorkflow get fuchsiaWorkflow => context[FuchsiaWorkflow];
@@ -21,12 +21,12 @@ class FuchsiaWorkflow implements Workflow {
 
   @override
   bool get canListDevices {
-    return os.which('fx') != null;
+    return fuchsiaArtifacts.devFinder != null;
   }
 
   @override
   bool get canLaunchDevices {
-    return os.which('fx') != null;
+    return fuchsiaArtifacts.devFinder != null && fuchsiaArtifacts.sshConfig != null;
   }
 
   @override

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -42,7 +42,6 @@ void main() {
   group('displays friendly error when', () {
     final MockProcessManager mockProcessManager = MockProcessManager();
     final MockProcessResult mockProcessResult = MockProcessResult();
-    final MockFuchsiaArtifacts mockFuchsiaArtifacts = MockFuchsiaArtifacts();
     final MockFile mockFile = MockFile();
     when(mockProcessManager.run(
       any,
@@ -52,22 +51,8 @@ void main() {
     when(mockProcessResult.exitCode).thenReturn(1);
     when<String>(mockProcessResult.stdout).thenReturn('');
     when<String>(mockProcessResult.stderr).thenReturn('');
-    when(mockFuchsiaArtifacts.sshConfig).thenReturn(mockFile);
     when(mockFile.absolute).thenReturn(mockFile);
     when(mockFile.path).thenReturn('');
-
-    testUsingContext('No BUILD_DIR set', () async {
-      final FuchsiaDevice device = FuchsiaDevice('id');
-      ToolExit toolExit;
-      try {
-        await device.servicePorts();
-      } on ToolExit catch (err) {
-        toolExit = err;
-      }
-      expect(toolExit.message, contains('BUILD_DIR must be supplied to locate SSH keys'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-    });
 
     final MockProcessManager emptyStdoutProcessManager = MockProcessManager();
     final MockProcessResult emptyStdoutProcessResult = MockProcessResult();
@@ -91,7 +76,10 @@ void main() {
       expect(toolExit.message, contains('No Dart Observatories found. Are you running a debug build?'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => emptyStdoutProcessManager,
-      FuchsiaArtifacts: () => mockFuchsiaArtifacts,
+      FuchsiaArtifacts: () => FuchsiaArtifacts(
+        sshConfig: mockFile,
+        devFinder: mockFile,
+      ),
     });
 
     group('device logs', () {
@@ -202,8 +190,6 @@ void main() {
     });
   });
 }
-
-class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
 
 class MockProcessManager extends Mock implements ProcessManager {}
 

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -29,12 +29,13 @@ void main() {
       expect(device.name, name);
     });
 
-    test('parse netls log output', () {
-      const String example = 'device lilia-shore-only-last (fe80::0000:a00a:f00f:2002/3)';
-      final List<String> names = parseFuchsiaDeviceOutput(example);
+    test('parse dev_finder output', () {
+      const String example = '192.168.42.56 paper-pulp-bush-angel';
+      final List<FuchsiaDevice> names = parseListDevices(example);
 
       expect(names.length, 1);
-      expect(names.first, 'lilia-shore-only-last');
+      expect(names.first.name, 'paper-pulp-bush-angel');
+      expect(names.first.id, '192.168.42.56');
     });
   });
 

--- a/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
 import 'package:mockito/mockito.dart';
 
@@ -14,28 +15,29 @@ class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
 class MockFile extends Mock implements File {}
 
 void main() {
-  bool fxPresent = false;
-  final MockOperatingSystemUtils utils = MockOperatingSystemUtils();
-  final MockFile file = MockFile();
-  when(utils.which('fx')).thenAnswer((Invocation _) => fxPresent ? file : null);
-
   group('android workflow', () {
-    testUsingContext('can not list and launch devices if there is no `fx` command', () {
-      fxPresent = false;
+    testUsingContext('can not list and launch devices if there is not ssh config and dev finder', () {
       expect(fuchsiaWorkflow.canLaunchDevices, false);
       expect(fuchsiaWorkflow.canListDevices, false);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      OperatingSystemUtils: () => utils,
+      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: null, sshConfig: null),
+    });
+
+    testUsingContext('can not list and launch devices if there is not ssh config and dev finder', () {
+      expect(fuchsiaWorkflow.canLaunchDevices, false);
+      expect(fuchsiaWorkflow.canListDevices, true);
+      expect(fuchsiaWorkflow.canListEmulators, false);
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: MockFile(), sshConfig: null),
     });
 
     testUsingContext('can list and launch devices supported if there is a `fx` command', () {
-      fxPresent = true;
       expect(fuchsiaWorkflow.canLaunchDevices, true);
       expect(fuchsiaWorkflow.canListDevices, true);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      OperatingSystemUtils: () => utils,
+      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: MockFile(), sshConfig: MockFile()),
     });
   });
 }

--- a/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
@@ -16,6 +16,11 @@ class MockFile extends Mock implements File {}
 
 void main() {
   group('android workflow', () {
+    final MockFile devFinder = MockFile();
+    final MockFile sshConfig = MockFile();
+    when(devFinder.absolute).thenReturn(devFinder);
+    when(sshConfig.absolute).thenReturn(sshConfig);
+
     testUsingContext('can not list and launch devices if there is not ssh config and dev finder', () {
       expect(fuchsiaWorkflow.canLaunchDevices, false);
       expect(fuchsiaWorkflow.canListDevices, false);
@@ -29,7 +34,7 @@ void main() {
       expect(fuchsiaWorkflow.canListDevices, true);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: MockFile(), sshConfig: null),
+      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: devFinder, sshConfig: null),
     });
 
     testUsingContext('can list and launch devices supported if there is a `fx` command', () {
@@ -37,7 +42,7 @@ void main() {
       expect(fuchsiaWorkflow.canListDevices, true);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: MockFile(), sshConfig: MockFile()),
+      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
     });
   });
 }


### PR DESCRIPTION
The Fuchsia workflow checked for the presence of the fx tool but wasn't updated to check for the presence of dev finder. If a user had the fx command line tool installed this would throw exceptions in non-fuchsia workflows.

Fixes https://github.com/flutter/flutter/issues/25347