### PR TITLE
Add link to Flutter brand guidelines

### DIFF
--- a/packages/flutter/lib/src/material/flutter_logo.dart
+++ b/packages/flutter/lib/src/material/flutter_logo.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 
 /// The Flutter logo, in widget form. This widget respects the [IconTheme].
+/// For guidelines on using the Flutter logo, visit https://flutter.io/brand.
 ///
 /// See also:
 ///


### PR DESCRIPTION
We now have [brand guidelines](https://flutter.io/brand) for the appropriate usage of the trademarked Flutter logo. This PR adds a comment that links to the guidelines from `FlutterLogo`.