### PR TITLE
[flutter_driver] Move Fuchsia logging code.

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -199,6 +199,9 @@ class FlutterDriver {
     // If the user has already supplied an isolate number/URL to the Dart VM
     // service, then this won't be run as it is unnecessary.
     if (Platform.isFuchsia && isolateNumber == null) {
+      // TODO(awdavies): Use something other than print. On fuchsia
+      // `stderr`/`stdout` appear to have issues working correctly.
+      flutterDriverLog.listen(print);
       fuchsiaModuleTarget ??= Platform.environment['FUCHSIA_MODULE_TARGET'];
       if (fuchsiaModuleTarget == null) {
         throw DriverError('No Fuchsia module target has been specified.\n'
@@ -215,10 +218,6 @@ class FlutterDriver {
       dartVmServiceUrl = ref.dartVm.uri.toString();
       await fuchsiaConnection.stop();
       FuchsiaCompat.cleanup();
-
-      // TODO(awdavies): Use something other than print. On fuchsia
-      // `stderr`/`stdout` appear to have issues working correctly.
-      flutterDriverLog.listen(print);
     }
 
     dartVmServiceUrl ??= Platform.environment['VM_SERVICE_URL'];


### PR DESCRIPTION
When setting the Fuchsia logging function, it should happen before any
initialization code, as init can still cause warning/error/info messages
to get printed to logs. Since the default stderr/stdout fd's aren't
correct, this can cause a program to crash for unclear reasons.