### PR TITLE
Fix red tree (Android module)

### DIFF
--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -4,6 +4,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         applicationId "{{androidIdentifier}}.host"
         minSdkVersion 16


### PR DESCRIPTION
This will fix the `module_test` in the device lab - the module project does not import (apply) `flutter.gradle`, so it doesn't pick this up the way our regular projects do.

This is related to the Android 28/Java 1.8 support.  It's happening as of the last engine roll because that is the first roll to actually utilize any Java 1.8 features.