### PR TITLE
Add compileOptions to android_host_app

### DIFF
--- a/dev/integration_tests/android_host_app/app/build.gradle
+++ b/dev/integration_tests/android_host_app/app/build.gradle
@@ -2,6 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16


### PR DESCRIPTION
I missed this in #26270 - that PR fixed part of the integration test, this fixes a later stage.

Verified works locally (whereas previous PR only worked for part).

Will have to land on red to fix red tree.