### PR TITLE
Add source line to snippet metadata file

### DIFF
--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -146,6 +146,7 @@ void main(List<String> argList) {
     output: args[_kOutputOption] != null ? File(args[_kOutputOption]) : null,
     metadata: <String, Object>{
       'sourcePath': environment['SOURCE_PATH'],
+      'sourceLine': environment['SOURCE_LINE'],
       'package': packageName,
       'library': libraryName,
       'element': elementName,

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -146,7 +146,9 @@ void main(List<String> argList) {
     output: args[_kOutputOption] != null ? File(args[_kOutputOption]) : null,
     metadata: <String, Object>{
       'sourcePath': environment['SOURCE_PATH'],
-      'sourceLine': environment['SOURCE_LINE'],
+      'sourceLine': environment['SOURCE_LINE'] != null
+          ? int.tryParse(environment['SOURCE_LINE'])
+          : null,
       'package': packageName,
       'library': libraryName,
       'element': elementName,


### PR DESCRIPTION
This adds the line number alongside the path. Note: this data is based on the version used to build the docs (eg. latest stable for docs.flutter.io) which *might not* match the version the user is looking at in the IDE, so care should be taken how this is used!

@gspencergoog @pq 