### PR TITLE
Add more hint information when UsageException. #25613

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -77,7 +77,14 @@ Future<int> _handleToolError(
     ) async {
   if (error is UsageException) {
     printError('${error.message}\n');
-    printError("Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.");
+    String commandHint = 'flutter <command> -h -v';
+    const String usagePrefix = 'Usage: ';
+    final String usageLine = error.usage.split('\n').firstWhere((String line) => line.startsWith(usagePrefix), orElse: () => null);
+    if (usageLine != null) {
+        final String expectedCommandUsage = usageLine.replaceAll(usagePrefix, '').trim();
+        commandHint = '$expectedCommandUsage -h -v';
+    }
+    printError("Run '$commandHint' (or 'flutter -h -v') for available flutter commands and options.");
     // Argument error exit code.
     return _exit(64);
   } else if (error is ToolExit) {


### PR DESCRIPTION
See: #25613
The error message reported now is given as below:
```
Could not find an option named "track-widget-creation".
Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
Failed to build /Users/yewenyu/Desktop/FlutterProject/ProAndFree/my_flutter.
Command PhaseScriptExecution failed with a nonzero exit code
```
In fact, -h is not enough, add '-v' will be better.
In this pr, the result hint would be:
```
Could not find an option named "track-widget-creation".

Run 'flutter build aot [arguments] -h -v' (or 'flutter -h -v') for available flutter commands and options.
Failed to build /Users/kylewong/Codes/Flutter/alibaba-flutter/Projects/track_widget_creation_demo.
Command /bin/sh failed with exit code 255
```