### PR TITLE
Add the ability to list physical iOS devices without having XCode installed and return no devices if 'idevice_id -l' throws specific error

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -27,7 +27,7 @@ class IOSWorkflow implements Workflow {
 
   // We need xcode (+simctl) to list simulator devices, and libimobiledevice to list real devices.
   @override
-  bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck && xcode.isSimctlInstalled;
+  bool get canListDevices => iMobileDevice.isInstalled || (xcode.isInstalledAndMeetsVersionCheck && xcode.isSimctlInstalled);
 
   // We need xcode to launch simulator devices, and ideviceinstaller and ios-deploy
   // for real devices.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -124,8 +124,14 @@ class IMobileDevice {
   Future<String> getAvailableDeviceIDs() async {
     try {
       final ProcessResult result = await processManager.run(<String>['idevice_id', '-l']);
-      if (result.exitCode != 0)
-        throw ToolExit('idevice_id returned an error:\n${result.stderr}');
+      if (result.exitCode != 0) {
+        if (result.stderr.toString().contains('ERROR: Unable to retrieve device list!')) {
+          // idevice_id might throw this error if there are no connected devices
+          return '';
+        } else {
+          throw ToolExit('idevice_id returned an error:\n${result.stderr}');
+        }
+      }
       return result.stdout;
     } on ProcessException {
       throw ToolExit('Failed to invoke idevice_id. Run flutter doctor.');


### PR DESCRIPTION
If simctl is not installed but libimobiledevice is installed, it's possible to list and attach to physical iOS devices.

`idevice_id -l` might output `ERROR: Unable to retrieve device list!` to stderr if there are no connected iOS devices, so return no iOS devices instead of throwing an exception if that's the case.