### PR TITLE
Fix descenders cutoff in TextField

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -17,9 +17,7 @@ import 'object.dart';
 import 'viewport_offset.dart';
 
 const double _kCaretGap = 1.0; // pixels
-
-/// TODO document this or find a better way to expose this info
-const double kCaretHeightOffset = 2.0; // pixels
+const double _kCaretHeightOffset = 2.0; // pixels
 
 // The additional size on the x and y axis with which to expand the prototype
 // cursor to render the floating cursor in pixels.
@@ -1244,7 +1242,7 @@ class RenderEditable extends RenderBox {
   @override
   void performLayout() {
     _layoutText(constraints.maxWidth);
-    _caretPrototype = Rect.fromLTWH(0.0, kCaretHeightOffset, cursorWidth, preferredLineHeight - 2.0 * kCaretHeightOffset);
+    _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth, preferredLineHeight - 2.0 * _kCaretHeightOffset);
     _selectionRects = null;
     // We grab _textPainter.size here because assigning to `size` on the next
     // line will trigger us to validate our intrinsic sizes, which will change

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -17,7 +17,9 @@ import 'object.dart';
 import 'viewport_offset.dart';
 
 const double _kCaretGap = 1.0; // pixels
-const double _kCaretHeightOffset = 2.0; // pixels
+
+/// TODO document this or find a better way to expose this info
+const double kCaretHeightOffset = 2.0; // pixels
 
 // The additional size on the x and y axis with which to expand the prototype
 // cursor to render the floating cursor in pixels.
@@ -1242,7 +1244,7 @@ class RenderEditable extends RenderBox {
   @override
   void performLayout() {
     _layoutText(constraints.maxWidth);
-    _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth, preferredLineHeight - 2.0 * _kCaretHeightOffset);
+    _caretPrototype = Rect.fromLTWH(0.0, kCaretHeightOffset, cursorWidth, preferredLineHeight - 2.0 * kCaretHeightOffset);
     _selectionRects = null;
     // We grab _textPainter.size here because assigning to `size` on the next
     // line will trigger us to validate our intrinsic sizes, which will change

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
@@ -756,7 +755,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // expanded caret is scrolled into view.
       final double lineHeight = renderEditable.preferredLineHeight;
       final double caretOffset = (lineHeight - caretRect.height) / 2;
-      caretStart = math.max(0.0, caretRect.top - caretOffset);
+      caretStart = caretRect.top - caretOffset;
       caretEnd = caretRect.bottom + caretOffset;
     } else {
       caretStart = caretRect.left;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -750,11 +750,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     double caretStart;
     double caretEnd;
     if (_isMultiline) {
-      caretStart = caretRect.top;
-      // The caret is vertically centered in the line with an offset. Include this
-      // offset so that text on the caret's line is fully visible.
+      // The caret is vertically centered within the line. Expand the caret's
+      // height so that it spans the line because we're going to ensure that the entire
+      // expanded caret is scrolled into view.
       final double lineHeight = renderEditable.preferredLineHeight;
       final double caretOffset = (lineHeight - caretRect.height) / 2;
+      caretStart = caretRect.top >= 0.0
+        ? caretRect.top - caretOffset : caretRect.top;
       caretEnd = caretRect.bottom + caretOffset;
     } else {
       caretStart = caretRect.left;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -747,20 +747,26 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   // Calculate the new scroll offset so the cursor remains visible.
   double _getScrollOffsetForCaret(Rect caretRect) {
-    final double caretStart = _isMultiline ? caretRect.top : caretRect.left;
-    final double caretEnd = _isMultiline ? caretRect.bottom : caretRect.right;
-    final double lineHeight = renderEditable.preferredLineHeight;
-    // The caret is vertically centered in the line with an offset. Include this
-    // offset so that text on the caret's line is fully visible.
-    final double caretOffset = (lineHeight - caretRect.height) / 2;
-    final double lineEnd = caretEnd + caretOffset;
+    double caretStart;
+    double caretEnd;
+    if (_isMultiline) {
+      caretStart = caretRect.top;
+      // The caret is vertically centered in the line with an offset. Include this
+      // offset so that text on the caret's line is fully visible.
+      final double lineHeight = renderEditable.preferredLineHeight;
+      final double caretOffset = (lineHeight - caretRect.height) / 2;
+      caretEnd = caretRect.bottom + caretOffset;
+    } else {
+      caretStart = caretRect.left;
+      caretEnd = caretRect.right;
+    }
 
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
     if (caretStart < 0.0) // cursor before start of bounds
       scrollOffset += caretStart;
-    else if (lineEnd >= viewportExtent) // cursor after end of bounds
-      scrollOffset += lineEnd - viewportExtent;
+    else if (caretEnd >= viewportExtent) // cursor after end of bounds
+      scrollOffset += caretEnd - viewportExtent;
     return scrollOffset;
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
@@ -755,8 +756,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // expanded caret is scrolled into view.
       final double lineHeight = renderEditable.preferredLineHeight;
       final double caretOffset = (lineHeight - caretRect.height) / 2;
-      caretStart = caretRect.top >= 0.0
-        ? caretRect.top - caretOffset : caretRect.top;
+      caretStart = math.max(0.0, caretRect.top - caretOffset);
       caretEnd = caretRect.bottom + caretOffset;
     } else {
       caretStart = caretRect.left;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -747,8 +747,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   // Calculate the new scroll offset so the cursor remains visible.
   double _getScrollOffsetForCaret(Rect caretRect) {
-    final double caretStart = _isMultiline ? caretRect.top : caretRect.left;
-    final double caretEnd = _isMultiline ? caretRect.bottom : caretRect.right;
+    final double caretStart = _isMultiline ? caretRect.top - kCaretHeightOffset : caretRect.left;
+    final double caretEnd = _isMultiline ? caretRect.bottom + kCaretHeightOffset : caretRect.right;
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
     if (caretStart < 0.0) // cursor before start of bounds

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -747,14 +747,21 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   // Calculate the new scroll offset so the cursor remains visible.
   double _getScrollOffsetForCaret(Rect caretRect) {
-    final double caretStart = _isMultiline ? caretRect.top - kCaretHeightOffset : caretRect.left;
-    final double caretEnd = _isMultiline ? caretRect.bottom + kCaretHeightOffset : caretRect.right;
+    final double caretStart = _isMultiline ? caretRect.top : caretRect.left;
+    final double caretEnd = _isMultiline ? caretRect.bottom : caretRect.right;
+    final double lineHeight = renderEditable.preferredLineHeight;
+    // The caret is vertically centered in the line with an offset. Include this
+    // offset so that text on the caret's line is fully visible.
+    final double caretOffset = (lineHeight - caretRect.height) / 2;
+    final double lineStart = caretStart - caretOffset;
+    final double lineEnd = caretEnd + caretOffset;
+
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
-    if (caretStart < 0.0) // cursor before start of bounds
-      scrollOffset += caretStart;
-    else if (caretEnd >= viewportExtent) // cursor after end of bounds
-      scrollOffset += caretEnd - viewportExtent;
+    if (lineStart < 0.0) // cursor before start of bounds
+      scrollOffset += lineStart;
+    else if (lineEnd >= viewportExtent) // cursor after end of bounds
+      scrollOffset += lineEnd - viewportExtent;
     return scrollOffset;
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -753,13 +753,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // The caret is vertically centered in the line with an offset. Include this
     // offset so that text on the caret's line is fully visible.
     final double caretOffset = (lineHeight - caretRect.height) / 2;
-    final double lineStart = caretStart - caretOffset;
     final double lineEnd = caretEnd + caretOffset;
 
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
-    if (lineStart < 0.0) // cursor before start of bounds
-      scrollOffset += lineStart;
+    if (caretStart < 0.0) // cursor before start of bounds
+      scrollOffset += caretStart;
     else if (lineEnd >= viewportExtent) // cursor after end of bounds
       scrollOffset += lineEnd - viewportExtent;
     return scrollOffset;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1721,7 +1721,7 @@ void main() {
     await skipPastScrollingAnimation(tester);
 
     scrollableState = tester.firstState(find.byType(Scrollable));
-    expect(scrollableState.position.pixels, isNot(equals(0.0)));
+    expect(scrollableState.position.pixels, equals(222.0));
   });
 
   testWidgets('Multiline text field scrolls the caret into view', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1721,6 +1721,7 @@ void main() {
     await skipPastScrollingAnimation(tester);
 
     scrollableState = tester.firstState(find.byType(Scrollable));
+    // For a horizontal input, scrolls to the exact position of the caret.
     expect(scrollableState.position.pixels, equals(222.0));
   });
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1724,6 +1724,40 @@ void main() {
     expect(scrollableState.position.pixels, isNot(equals(0.0)));
   });
 
+  testWidgets('Multiline text field scrolls the caret into view', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      overlay(
+        child: Container(
+          child: TextField(
+            controller: controller,
+            maxLines: 6,
+          ),
+        ),
+      ),
+    );
+
+    const String tallText = 'a\nb\nc\nd\ne\nf\ng'; // One line over max
+    await tester.enterText(find.byType(TextField), tallText);
+    await skipPastScrollingAnimation(tester);
+
+    ScrollableState scrollableState = tester.firstState(find.byType(Scrollable));
+    expect(scrollableState.position.pixels, equals(0.0));
+
+    // Move the caret to the end of the text and check that the text field
+    // scrolls to make the caret visible.
+    controller.selection = const TextSelection.collapsed(offset: tallText.length);
+    await tester.pump();
+    await skipPastScrollingAnimation(tester);
+
+    // Should have scrolled down exactly one line height (7 lines of text in 6
+    // line text field).
+    final double lineHeight = findRenderEditable(tester).preferredLineHeight;
+    scrollableState = tester.firstState(find.byType(Scrollable));
+    expect(scrollableState.position.pixels, equals(lineHeight));
+  });
+
   testWidgets('haptic feedback', (WidgetTester tester) async {
     final FeedbackTester feedback = FeedbackTester();
     final TextEditingController controller = TextEditingController();


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter/issues/26023

Currently, when a multiline TextField scrolls to the next bottom line, it doesn't include enough space for descenders:

<img src="https://user-images.githubusercontent.com/22005/50655791-6487d500-0f4e-11e9-81aa-a24e1637b607.png" height="600px"></img>

This fix works by noticing that the scrolling happens based on the position and size of the cursor, but the cursor is slightly smaller than the full line.