### PR TITLE
Add logic for creating rollback dynamic patches.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -479,13 +479,7 @@ Future<void> _buildGradleProjectV2(
       }
 
       if (update.files.isEmpty) {
-        printStatus('No changes detected relative to baseline build.');
-
-        if (updateFile.existsSync()) {
-          updateFile.deleteSync();
-          printStatus('Deleted dynamic patch ${updateFile.path}.');
-        }
-        return;
+        printStatus('No changes detected, creating rollback patch.');
       }
 
       final ArchiveFile oldFile = oldApk.findFile('assets/flutter_assets/isolate_snapshot_data');


### PR DESCRIPTION
Before this change, rolling back a patch relied on deleting the patch
file from the server completely. This PR implements a more reliable
approach where developer needs to create a physical rollback patch file.
This is more robust to mistakenly taking down a patch from user devices.