### PR TITLE
Restore ignore for *.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Miscellaneous
 *.class
+*.lock
 *.log
 *.pyc
 *.swp


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/24209, we were a little overzealous in removing .lock from .gitignore files.  The top level .gitignore should still ignore them, since we don't check them in for the Flutter repo.