### PR TITLE
Avoid use of ParagraphConstrains const ctor

### DIFF
--- a/examples/layers/raw/text.dart
+++ b/examples/layers/raw/text.dart
@@ -84,7 +84,9 @@ void main() {
     // Next, we supply a width that the text is permitted to occupy and we ask
     // the paragraph to the visual position of each its glyphs as well as its
     // overall size, subject to its sizing constraints.
-    ..layout(const ui.ParagraphConstraints(width: 180.0));
+    // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
+    // ignore:prefer_const_constructors
+    ..layout(ui.ParagraphConstraints(width: 180.0));
 
   // Finally, we register our beginFrame callback and kick off the first frame.
   ui.window.onBeginFrame = beginFrame;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -242,7 +242,9 @@ class TextPainter {
         builder.pushStyle(text.style.getTextStyle(textScaleFactor: textScaleFactor));
       builder.addText(' ');
       _layoutTemplate = builder.build()
-        ..layout(const ui.ParagraphConstraints(width: double.infinity));
+        // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
+        // ignore:prefer_const_constructors
+        ..layout(ui.ParagraphConstraints(width: double.infinity));
     }
     return _layoutTemplate.height;
   }

--- a/packages/flutter/test/engine/paragraph_builder_test.dart
+++ b/packages/flutter/test/engine/paragraph_builder_test.dart
@@ -13,7 +13,9 @@ void main() {
     final Paragraph paragraph = builder.build();
     expect(paragraph, isNotNull);
 
-    paragraph.layout(const ParagraphConstraints(width: 800.0));
+    // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
+    // ignore:prefer_const_constructors
+    paragraph.layout(ParagraphConstraints(width: 800.0));
     expect(paragraph.width, isNonZero);
     expect(paragraph.height, isNonZero);
   });

--- a/packages/flutter/test/engine/paragraph_test.dart
+++ b/packages/flutter/test/engine/paragraph_test.dart
@@ -20,7 +20,9 @@ void main() {
       ));
       builder.addText('Test');
       final Paragraph paragraph = builder.build();
-      paragraph.layout(const ParagraphConstraints(width: 400.0));
+      // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
+      // ignore:prefer_const_constructors
+      paragraph.layout(ParagraphConstraints(width: 400.0));
 
       expect(paragraph.height, closeTo(fontSize, 0.001));
       expect(paragraph.width, closeTo(400.0, 0.001));


### PR DESCRIPTION
Usages of ParagraphConstraints (from dart:ui) whose constructor could be
const as of flutter/engine#7346 are currently marked //
ignore:prefer_const_constructors in the framework until all
Google-internal embedders have been updated to an engine version that
includes the above change. These were initially updated in engine roll
flutter/flutter#26252, but broke internal embedders.

We should re-enable use of the const constructor in those cases once
internal embedders are updated.

See: https://github.com/flutter/flutter/issues/26390