### PR TITLE
Emit more of HTTP error response bodies

### DIFF
--- a/dev/tools/java_and_objc_doc.dart
+++ b/dev/tools/java_and_objc_doc.dart
@@ -37,7 +37,7 @@ Future<Archive> fetchArchive(String url, int maxTries) async {
     stderr.writeln('Failed attempt ${i+1} to fetch $url.');
 
     // On failure print a short snipped from the body in case it's helpful.
-    final int bodyLength = min(80, response.body.length);
+    final int bodyLength = min(1024, response.body.length);
     stderr.writeln('Response status code ${response.statusCode}. Body: ' + response.body.substring(0, bodyLength));
     sleep(const Duration(seconds: 1));
   }


### PR DESCRIPTION
80 characters was short enough that after the XML boilerplate in the
response, all we got was 'The'.