### PR TITLE
Let the packaging recipe use gsutil.py

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -534,7 +534,7 @@ class ArchivePublisher {
     bool failOk = false,
   }) async {
     return _processRunner.runProcess(
-      <String>['gsutil']..addAll(args),
+      <String>['gsutil.py', '--']..addAll(args),
       workingDirectory: workingDirectory,
       failOk: failOk,
     );

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -561,7 +561,7 @@ class ArchivePublisher {
       args.addAll(<String>['-h', 'Content-Type:$mimeType']);
     }
     args.addAll(<String>['cp', src, dest]);
-    return _runGsUtil(args);
+    return await _runGsUtil(args);
   }
 }
 

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -257,11 +257,11 @@ void main() {
 ''';
         File(jsonPath).writeAsStringSync(releasesJson);
         final Map<String, List<ProcessResult>> calls = <String, List<ProcessResult>>{
-          'gsutil rm $gsArchivePath': null,
-          'gsutil -h Content-Type:$archiveMime cp $archivePath $gsArchivePath': null,
-          'gsutil cp $gsJsonPath $jsonPath': null,
-          'gsutil rm $gsJsonPath': null,
-          'gsutil -h Content-Type:application/json cp $jsonPath $gsJsonPath': null,
+          'gsutil.py -- rm $gsArchivePath': null,
+          'gsutil.py -- -h Content-Type:$archiveMime cp $archivePath $gsArchivePath': null,
+          'gsutil.py -- cp $gsJsonPath $jsonPath': null,
+          'gsutil.py -- rm $gsJsonPath': null,
+          'gsutil.py -- -h Content-Type:application/json cp $jsonPath $gsJsonPath': null,
         };
         processManager.fakeResults = calls;
         final File outputFile = File(path.join(tempDir.absolute.path, archiveName));


### PR DESCRIPTION
Unfortunately I don't have a way to make it not a hack without editing our repo. The bash script is going away and only the depot_tools/gsutil.py is the real API which we can expect them to not break. 

Luckily it works locally too.