### PR TITLE
Revert #26303

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/main.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/main.dart
@@ -26,7 +26,7 @@ Future<String> dataHandler(String message) async {
     final Completer<String> completer = Completer<String>();
     final int id = int.tryParse(message.split('#')[1]) ?? 0;
     Future<void> completeSemantics([Object _]) async {
-      final dynamic result = await kSemanticsChannel.invokeMethod<dynamic>('getSemanticsNode', <String, dynamic>{
+      final dynamic result = await kSemanticsChannel.invokeMethod('getSemanticsNode', <String, dynamic>{
         'id': id,
       });
       completer.complete(json.encode(result));

--- a/dev/integration_tests/android_views/lib/main.dart
+++ b/dev/integration_tests/android_views/lib/main.dart
@@ -125,15 +125,15 @@ class PlatformViewState extends State<PlatformViewPage> {
           .cast<Map<dynamic, dynamic>>()
           .map<Map<String, dynamic>>((Map<dynamic, dynamic> e) =>e.cast<String, dynamic>())
           .toList();
-      await channel.invokeMethod<void>('pipeFlutterViewEvents');
-      await viewChannel.invokeMethod<void>('pipeTouchEvents');
+      await channel.invokeMethod('pipeFlutterViewEvents');
+      await viewChannel.invokeMethod('pipeTouchEvents');
       print('replaying ${recordedEvents.length} motion events');
       for (Map<String, dynamic> event in recordedEvents.reversed) {
-        await channel.invokeMethod<void>('synthesizeEvent', event);
+        await channel.invokeMethod('synthesizeEvent', event);
       }
 
-      await channel.invokeMethod<void>('stopFlutterViewEvents');
-      await viewChannel.invokeMethod<void>('stopTouchEvents');
+      await channel.invokeMethod('stopFlutterViewEvents');
+      await viewChannel.invokeMethod('stopTouchEvents');
 
       if (flutterViewEvents.length != embeddedViewEvents.length)
         return 'Synthesized ${flutterViewEvents.length} events but the embedded view received ${embeddedViewEvents.length} events';
@@ -160,7 +160,7 @@ class PlatformViewState extends State<PlatformViewPage> {
   }
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
-    if (!await channel.invokeMethod<bool>('getStoragePermission')) {
+    if (!await channel.invokeMethod('getStoragePermission')) {
       showMessage(
           context, 'External storage permissions are required to save events');
       return;
@@ -190,11 +190,11 @@ class PlatformViewState extends State<PlatformViewPage> {
   }
 
   void listenToFlutterViewEvents() {
-    channel.invokeMethod<void>('pipeFlutterViewEvents');
-    viewChannel.invokeMethod<void>('pipeTouchEvents');
+    channel.invokeMethod('pipeFlutterViewEvents');
+    viewChannel.invokeMethod('pipeTouchEvents');
     Timer(const Duration(seconds: 3), () {
-      channel.invokeMethod<void>('stopFlutterViewEvents');
-      viewChannel.invokeMethod<void>('stopTouchEvents');
+      channel.invokeMethod('stopFlutterViewEvents');
+      viewChannel.invokeMethod('stopTouchEvents');
     });
   }
 

--- a/dev/integration_tests/channels/lib/src/method_calls.dart
+++ b/dev/integration_tests/channels/lib/src/method_calls.dart
@@ -67,7 +67,7 @@ Future<TestStepResult> _methodCallSuccessHandshake(
   dynamic result = nothing;
   dynamic error = nothing;
   try {
-    result = await channel.invokeMethod<dynamic>('success', arguments);
+    result = await channel.invokeMethod('success', arguments);
   } catch (e) {
     error = e;
   }
@@ -95,7 +95,7 @@ Future<TestStepResult> _methodCallErrorHandshake(
   dynamic errorDetails = nothing;
   dynamic error = nothing;
   try {
-    error = await channel.invokeMethod<dynamic>('error', arguments);
+    error = await channel.invokeMethod('error', arguments);
   } on PlatformException catch (e) {
     errorDetails = e.details;
   } catch (e) {
@@ -123,7 +123,7 @@ Future<TestStepResult> _methodCallNotImplementedHandshake(
   dynamic result = nothing;
   dynamic error = nothing;
   try {
-    error = await channel.invokeMethod<dynamic>('notImplemented');
+    error = await channel.invokeMethod('notImplemented');
   } on MissingPluginException {
     result = null;
   } catch (e) {

--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -47,11 +47,11 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at .5x speed...';
         _state = FrameState.slow;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', _flutterFrameRate ~/ 2);
+        channel.invokeMethod('start', _flutterFrameRate ~/ 2);
         break;
       case FrameState.slow:
         debugPrint('Stopping .5x speed test...');
-        await channel.invokeMethod<void>('stop');
+        await channel.invokeMethod('stop');
         await _summarizeStats();
         _icon = Icons.fast_forward;
         _state = FrameState.afterSlow;
@@ -62,11 +62,11 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at 2x speed...';
         _state = FrameState.fast;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', (_flutterFrameRate * 2).toInt());
+        channel.invokeMethod('start', (_flutterFrameRate * 2).toInt());
         break;
       case FrameState.fast:
         debugPrint('Stopping 2x speed test...');
-        await channel.invokeMethod<void>('stop');
+        await channel.invokeMethod('stop');
         await _summarizeStats();
         _state = FrameState.afterFast;
         _icon = Icons.replay;

--- a/dev/integration_tests/flavors/lib/main.dart
+++ b/dev/integration_tests/flavors/lib/main.dart
@@ -18,7 +18,7 @@ class _FlavorState extends State<Flavor> {
   @override
   void initState() {
     super.initState();
-    const MethodChannel('flavor').invokeMethod<String>('getFlavor').then((String flavor) {
+    const MethodChannel('flavor').invokeMethod('getFlavor').then((Object flavor) {
       setState(() {
         _flavor = flavor;
       });

--- a/examples/flutter_gallery/test/live_smoketest.dart
+++ b/examples/flutter_gallery/test/live_smoketest.dart
@@ -82,10 +82,10 @@ Future<void> main() async {
       await controller.tap(find.byTooltip('Back'));
     }
     print('Finished successfully!');
-    _kTestChannel.invokeMethod<void>('success');
+    _kTestChannel.invokeMethod('success');
   } catch (error, stack) {
     print('Caught error: $error\n$stack');
-    _kTestChannel.invokeMethod<void>('failure');
+    _kTestChannel.invokeMethod('failure');
   }
 }
 

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -34,7 +34,7 @@ class Clipboard {
 
   /// Stores the given clipboard data on the clipboard.
   static Future<void> setData(ClipboardData data) async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'Clipboard.setData',
       <String, dynamic>{
         'text': data.text,

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -21,7 +21,7 @@ class HapticFeedback {
   /// On Android, this uses the platform haptic feedback API to simulate a
   /// response to a long press (`HapticFeedbackConstants.LONG_PRESS`).
   static Future<void> vibrate() async {
-    await SystemChannels.platform.invokeMethod<void>('HapticFeedback.vibrate');
+    await SystemChannels.platform.invokeMethod('HapticFeedback.vibrate');
   }
 
   /// Provides a haptic feedback corresponding a collision impact with a light mass.
@@ -32,7 +32,7 @@ class HapticFeedback {
   ///
   /// On Android, this uses `HapticFeedbackConstants.VIRTUAL_KEY`.
   static Future<void> lightImpact() async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'HapticFeedback.vibrate',
       'HapticFeedbackType.lightImpact',
     );
@@ -46,7 +46,7 @@ class HapticFeedback {
   ///
   /// On Android, this uses `HapticFeedbackConstants.KEYBOARD_TAP`.
   static Future<void> mediumImpact() async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'HapticFeedback.vibrate',
       'HapticFeedbackType.mediumImpact',
     );
@@ -61,7 +61,7 @@ class HapticFeedback {
   /// On Android, this uses `HapticFeedbackConstants.CONTEXT_CLICK` on API levels
   /// 23 and above. This call has no effects on Android API levels below 23.
   static Future<void> heavyImpact() async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'HapticFeedback.vibrate',
       'HapticFeedbackType.heavyImpact',
     );
@@ -74,7 +74,7 @@ class HapticFeedback {
   ///
   /// On Android, this uses `HapticFeedbackConstants.CLOCK_TICK`.
   static Future<void> selectionClick() async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'HapticFeedback.vibrate',
       'HapticFeedbackType.selectionClick',
     );

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -129,7 +129,7 @@ class PlatformViewsService {
         paramsByteData.lengthInBytes,
       );
     }
-    await SystemChannels.platform_views.invokeMethod<void>('create', args);
+    await SystemChannels.platform_views.invokeMethod('create', args);
     return UiKitViewController._(id, layoutDirection);
   }
 }
@@ -485,7 +485,7 @@ class AndroidViewController {
   /// disposed.
   Future<void> dispose() async {
     if (_state == _AndroidViewState.creating || _state == _AndroidViewState.created)
-      await SystemChannels.platform_views.invokeMethod<void>('dispose', id);
+      await SystemChannels.platform_views.invokeMethod('dispose', id);
     _state = _AndroidViewState.disposed;
   }
 
@@ -504,7 +504,7 @@ class AndroidViewController {
     if (_state == _AndroidViewState.waitingForSize)
       return _create(size);
 
-    await SystemChannels.platform_views.invokeMethod<void>('resize', <String, dynamic> {
+    await SystemChannels.platform_views.invokeMethod('resize', <String, dynamic> {
       'id': id,
       'width': size.width,
       'height': size.height,
@@ -526,7 +526,7 @@ class AndroidViewController {
     if (_state == _AndroidViewState.waitingForSize)
       return;
 
-    await SystemChannels.platform_views.invokeMethod<void>('setDirection', <String, dynamic> {
+    await SystemChannels.platform_views.invokeMethod('setDirection', <String, dynamic> {
       'id': id,
       'direction': _getAndroidDirection(layoutDirection),
     });
@@ -550,7 +550,7 @@ class AndroidViewController {
   /// See documentation of [MotionEvent.obtain](https://developer.android.com/reference/android/view/MotionEvent.html#obtain(long,%20long,%20int,%20float,%20float,%20float,%20float,%20int,%20float,%20float,%20int,%20int))
   /// for description of the parameters.
   Future<void> sendMotionEvent(AndroidMotionEvent event) async {
-    await SystemChannels.platform_views.invokeMethod<dynamic>(
+    await SystemChannels.platform_views.invokeMethod(
         'touch',
         event._asList(id),
     );
@@ -649,6 +649,6 @@ class UiKitViewController {
   /// disposed.
   Future<void> dispose() async {
     _debugDisposed = true;
-    await SystemChannels.platform_views.invokeMethod<void>('dispose', id);
+    await SystemChannels.platform_views.invokeMethod('dispose', id);
   }
 }

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -238,7 +238,7 @@ class SystemChrome {
   /// The empty list causes the application to defer to the operating system
   /// default.
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'SystemChrome.setPreferredOrientations',
       _stringify(orientations),
     );
@@ -250,7 +250,7 @@ class SystemChrome {
   /// Any part of the description that is unsupported on the current platform
   /// will be ignored.
   static Future<void> setApplicationSwitcherDescription(ApplicationSwitcherDescription description) async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'SystemChrome.setApplicationSwitcherDescription',
       <String, dynamic>{
         'label': description.label,
@@ -282,7 +282,7 @@ class SystemChrome {
   /// or calling this again. Otherwise, the original UI overlay settings will be
   /// automatically restored only when the application loses and regains focus.
   static Future<void> setEnabledSystemUIOverlays(List<SystemUiOverlay> overlays) async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'SystemChrome.setEnabledSystemUIOverlays',
       _stringify(overlays),
     );
@@ -298,7 +298,7 @@ class SystemChrome {
   /// On Android, the system UI cannot be changed until 1 second after the previous
   /// change. This is to prevent malware from permanently hiding navigation buttons.
   static Future<void> restoreSystemUIOverlays() async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'SystemChrome.restoreSystemUIOverlays',
       null,
     );
@@ -349,7 +349,7 @@ class SystemChrome {
     scheduleMicrotask(() {
       assert(_pendingStyle != null);
       if (_pendingStyle != _latestStyle) {
-        SystemChannels.platform.invokeMethod<void>(
+        SystemChannels.platform.invokeMethod(
           'SystemChrome.setSystemUIOverlayStyle',
           _pendingStyle._toMap(),
         );

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -20,6 +20,6 @@ class SystemNavigator {
   /// the latter may cause the underlying platform to act as if the application
   /// had crashed.
   static Future<void> pop() async {
-    await SystemChannels.platform.invokeMethod<void>('SystemNavigator.pop');
+    await SystemChannels.platform.invokeMethod('SystemNavigator.pop');
   }
 }

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -20,7 +20,7 @@ class SystemSound {
   /// Play the specified system sound. If that sound is not present on the
   /// system, the call is ignored.
   static Future<void> play(SystemSoundType type) async {
-    await SystemChannels.platform.invokeMethod<void>(
+    await SystemChannels.platform.invokeMethod(
       'SystemSound.play',
       type.toString(),
     );

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -626,13 +626,13 @@ class TextInputConnection {
   /// Requests that the text input control become visible.
   void show() {
     assert(attached);
-    SystemChannels.textInput.invokeMethod<void>('TextInput.show');
+    SystemChannels.textInput.invokeMethod('TextInput.show');
   }
 
   /// Requests that the text input control change its internal state to match the given state.
   void setEditingState(TextEditingValue value) {
     assert(attached);
-    SystemChannels.textInput.invokeMethod<void>(
+    SystemChannels.textInput.invokeMethod(
       'TextInput.setEditingState',
       value.toJSON(),
     );
@@ -644,7 +644,7 @@ class TextInputConnection {
   /// other client attaches to it within this animation frame.
   void close() {
     if (attached) {
-      SystemChannels.textInput.invokeMethod<void>('TextInput.clearClient');
+      SystemChannels.textInput.invokeMethod('TextInput.clearClient');
       _clientHandler
         .._currentConnection = null
         .._scheduleHide();
@@ -749,7 +749,7 @@ class _TextInputClientHandler {
     scheduleMicrotask(() {
       _hidePending = false;
       if (_currentConnection == null)
-        SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
+        SystemChannels.textInput.invokeMethod('TextInput.hide');
     });
   }
 }
@@ -802,7 +802,7 @@ class TextInput {
     assert(_debugEnsureInputActionWorksOnPlatform(configuration.inputAction));
     final TextInputConnection connection = TextInputConnection._(client);
     _clientHandler._currentConnection = connection;
-    SystemChannels.textInput.invokeMethod<void>(
+    SystemChannels.textInput.invokeMethod(
       'TextInput.setClient',
       <dynamic>[ connection._id, configuration.toJson() ],
     );

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -53,38 +53,6 @@ void main() {
       final String result = await channel.invokeMethod('sayHello', 'hello');
       expect(result, equals('hello world'));
     });
-    test('can invoke list method and get result', () async {
-      BinaryMessages.setMockMessageHandler(
-        'ch7',
-        (ByteData message) async {
-          final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
-          if (methodCall['method'] == 'sayHello') {
-            return jsonMessage.encodeMessage(<dynamic>[<String>['${methodCall['args']}', 'world']]);
-          } else {
-            return jsonMessage.encodeMessage(<dynamic>['unknown', null, null]);
-          }
-        },
-      );
-      expect(channel.invokeMethod<List<String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
-      expect(await channel.invokeListMethod<String>('sayHello', 'hello'), <String>['hello', 'world']);
-    });
-
-
-    test('can invoke map method and get result', () async {
-      BinaryMessages.setMockMessageHandler(
-        'ch7',
-        (ByteData message) async {
-          final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
-          if (methodCall['method'] == 'sayHello') {
-            return jsonMessage.encodeMessage(<dynamic>[<String, String>{'${methodCall['args']}': 'world'}]);
-          } else {
-            return jsonMessage.encodeMessage(<dynamic>['unknown', null, null]);
-          }
-        },
-      );
-      expect(channel.invokeMethod<Map<String, String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
-      expect(await channel.invokeMapMethod<String, String>('sayHello', 'hello'), <String, String>{'hello': 'world'});
-    });
 
     test('can invoke method and get error', () async {
       BinaryMessages.setMockMessageHandler(
@@ -98,7 +66,7 @@ void main() {
         },
       );
       try {
-        await channel.invokeMethod<dynamic>('sayHello', 'hello');
+        await channel.invokeMethod('sayHello', 'hello');
         fail('Exception expected');
       } on PlatformException catch (e) {
         expect(e.code, equals('bad'));
@@ -114,7 +82,7 @@ void main() {
         (ByteData message) async => null,
       );
       try {
-        await channel.invokeMethod<void>('sayHello', 'hello');
+        await channel.invokeMethod('sayHello', 'hello');
         fail('Exception expected');
       } on MissingPluginException catch (e) {
         expect(e.message, contains('sayHello'));


### PR DESCRIPTION
The change in https://github.com/flutter/flutter/pull/26303 ended up being breaking after all.

As is the change triggers `strong_mode_implicit_dynamic_method` in the plugins repo. The repo cannot update their code to conform unless they change the sdk bound to the very latest master flutter.

Updating the code on the flutter side is not possible either: `@optionalTypeArgs` is ignored unless `T extends Object` is given as a bound. However, this would be breaking to users without the strong_mode_implicit_dynamic_method lint enabled, since the following code would fail to compile:

```
var result = wait channel.invokeMethod(..); // returns double
result.toInt(); // passed when result is dynamic
```

To land this change, we would have to be okay with adding a second typed method called `invokeMethodTyped` or getting a fix for https://github.com/dart-lang/sdk/issues/32538.