### PR TITLE
Add asserts for @required parameters

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -203,7 +203,8 @@ class ScaleTransition extends AnimatedWidget {
     @required Animation<double> scale,
     this.alignment = Alignment.center,
     this.child,
-  }) : super(key: key, listenable: scale);
+  }) : assert(scale != null),
+       super(key: key, listenable: scale);
 
   /// The animation that controls the scale of the child.
   ///
@@ -256,7 +257,8 @@ class RotationTransition extends AnimatedWidget {
     @required Animation<double> turns,
     this.alignment = Alignment.center,
     this.child,
-  }) : super(key: key, listenable: turns);
+  }) : assert(turns != null),
+       super(key: key, listenable: turns);
 
   /// The animation that controls the rotation of the child.
   ///
@@ -399,7 +401,8 @@ class FadeTransition extends SingleChildRenderObjectWidget {
     @required this.opacity,
     this.alwaysIncludeSemantics = false,
     Widget child,
-  }) : super(key: key, child: child);
+  }) : assert(opacity != null),
+       super(key: key, child: child);
 
   /// The animation that controls the opacity of the child.
   ///
@@ -491,7 +494,8 @@ class PositionedTransition extends AnimatedWidget {
     Key key,
     @required Animation<RelativeRect> rect,
     @required this.child,
-  }) : super(key: key, listenable: rect);
+  }) : assert(rect != null),
+       super(key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
   Animation<RelativeRect> get rect => listenable;
@@ -543,7 +547,10 @@ class RelativePositionedTransition extends AnimatedWidget {
     @required Animation<Rect> rect,
     @required this.size,
     @required this.child,
-  }) : super(key: key, listenable: rect);
+  }) : assert(rect != null),
+       assert(size != null),
+       assert(child != null),
+       super(key: key, listenable: rect);
 
   /// The animation that controls the child's size and position.
   ///
@@ -598,7 +605,9 @@ class DecoratedBoxTransition extends AnimatedWidget {
     @required this.decoration,
     this.position = DecorationPosition.background,
     @required this.child,
-  }) : super(key: key, listenable: decoration);
+  }) : assert(decoration != null),
+       assert(child != null),
+       super(key: key, listenable: decoration);
 
   /// Animation of the decoration to paint.
   ///
@@ -653,7 +662,9 @@ class AlignTransition extends AnimatedWidget {
     @required this.child,
     this.widthFactor,
     this.heightFactor,
-  }) : super(key: key, listenable: alignment);
+  }) : assert(alignment != null),
+       assert(child != null),
+       super(key: key, listenable: alignment);
 
   /// The animation that controls the child's alignment.
   Animation<AlignmentGeometry> get alignment => listenable;
@@ -698,7 +709,9 @@ class DefaultTextStyleTransition extends AnimatedWidget {
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
     this.maxLines,
-  }) : super(key: key, listenable: style);
+  }) : assert(style != null),
+       assert(child != null),
+       super(key: key, listenable: style);
 
   /// The animation that controls the descendants' text style.
   Animation<TextStyle> get style => listenable;
@@ -815,7 +828,8 @@ class AnimatedBuilder extends AnimatedWidget {
     @required Listenable animation,
     @required this.builder,
     this.child,
-  }) : assert(builder != null),
+  }) : assert(animation != null),
+       assert(builder != null),
        super(key: key, listenable: animation);
 
   /// Called every time the animation changes value.


### PR DESCRIPTION
Adds asserts on required constructor parameters to a transition widgets.
This improves debuggability for those who aren't developing with live
analysis. e.g. when `turns` is not specified in a RotationTransition
constructor:

    package:flutter/src/widgets/transitions.dart: Failed assertion: line 43 pos 15: 'listenable != null': is not true.

becomes:

    package:flutter/src/widgets/transitions.dart': Failed assertion: line 259 pos 15: 'turns != null': is not true.