### PR TITLE
Add a manifest for profile builds that enables INTERNET permission

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="{{androidIdentifier}}">
+    <!-- Flutter needs it to communicate with the running application
+         to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>


### PR DESCRIPTION
Profile builds need access to sockets in order to launch the Dart
observatory server.

This permission used to be enabled by default in all build types,
but was moved to a build type specific manifest in
https://github.com/flutter/flutter/commit/88b853f7eb85bf0b47e1ca4d1bf9d9a9f821730d