### PR TITLE
remove ignore_for_file lints

### DIFF
--- a/dev/tools/gen_date_localizations.dart
+++ b/dev/tools/gen_date_localizations.dart
@@ -81,9 +81,11 @@ Future<void> main(List<String> rawArgs) async {
 // To regenerate run (omit --overwrite to print to console instead of the file):
 // dart --enable-asserts dev/tools/gen_date_localizations.dart --overwrite
 
-// ignore_for_file: public_member_api_docs
 '''
 );
+  buffer.writeln('''
+/// The subset of date symbols supported by the intl package supported by
+/// flutter_localizations.''');
   buffer.writeln('const Map<String, dynamic> dateSymbols = <String, dynamic> {');
   symbolFiles.forEach((String locale, File data) {
     if (materialLocales.contains(locale))
@@ -93,6 +95,9 @@ Future<void> main(List<String> rawArgs) async {
 
   // Code that uses datePatterns expects it to contain values of type
   // Map<String, String> not Map<String, dynamic>.
+  buffer.writeln('''
+/// The subset of date patterns supported by the intl package supported by
+/// flutter_localizations.''');
   buffer.writeln('const Map<String, Map<String, String>> datePatterns = <String, Map<String, String>> {');
   patternFiles.forEach((String locale, File data) {
     if (materialLocales.contains(locale)) {

--- a/dev/tools/gen_date_localizations.dart
+++ b/dev/tools/gen_date_localizations.dart
@@ -84,8 +84,8 @@ Future<void> main(List<String> rawArgs) async {
 '''
 );
   buffer.writeln('''
-/// The subset of date symbols supported by the intl package supported by
-/// flutter_localizations.''');
+/// The subset of date symbols supported by the intl package which are also
+/// supported by flutter_localizations.''');
   buffer.writeln('const Map<String, dynamic> dateSymbols = <String, dynamic> {');
   symbolFiles.forEach((String locale, File data) {
     if (materialLocales.contains(locale))
@@ -96,8 +96,8 @@ Future<void> main(List<String> rawArgs) async {
   // Code that uses datePatterns expects it to contain values of type
   // Map<String, String> not Map<String, dynamic>.
   buffer.writeln('''
-/// The subset of date patterns supported by the intl package supported by
-/// flutter_localizations.''');
+/// The subset of date patterns supported by the intl package which are also
+/// supported by flutter_localizations.''');
   buffer.writeln('const Map<String, Map<String, String>> datePatterns = <String, Map<String, String>> {');
   patternFiles.forEach((String locale, File data) {
     if (materialLocales.contains(locale)) {

--- a/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
@@ -6,8 +6,8 @@
 // To regenerate run (omit --overwrite to print to console instead of the file):
 // dart --enable-asserts dev/tools/gen_date_localizations.dart --overwrite
 
-// ignore_for_file: public_member_api_docs
-
+/// The subset of date symbols supported by the intl package supported by
+/// flutter_localizations.
 const Map<String, dynamic> dateSymbols = <String, dynamic>{
   'ar': <String, dynamic>{
     'NAME': r'''ar''',
@@ -11356,6 +11356,9 @@ const Map<String, dynamic> dateSymbols = <String, dynamic>{
     ],
   },
 };
+
+/// The subset of date patterns supported by the intl package supported by
+/// flutter_localizations.
 const Map<String, Map<String, String>> datePatterns =
     <String, Map<String, String>>{
   'ar': <String, String>{

--- a/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/date_localizations.dart
@@ -6,8 +6,8 @@
 // To regenerate run (omit --overwrite to print to console instead of the file):
 // dart --enable-asserts dev/tools/gen_date_localizations.dart --overwrite
 
-/// The subset of date symbols supported by the intl package supported by
-/// flutter_localizations.
+/// The subset of date symbols supported by the intl package which are also
+/// supported by flutter_localizations.
 const Map<String, dynamic> dateSymbols = <String, dynamic>{
   'ar': <String, dynamic>{
     'NAME': r'''ar''',
@@ -11357,8 +11357,8 @@ const Map<String, dynamic> dateSymbols = <String, dynamic>{
   },
 };
 
-/// The subset of date patterns supported by the intl package supported by
-/// flutter_localizations.
+/// The subset of date patterns supported by the intl package which are also
+/// supported by flutter_localizations.
 const Map<String, Map<String, String>> datePatterns =
     <String, Map<String, String>>{
   'ar': <String, String>{

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: flutter_style_todos
-
 import 'dart:async';
 import 'dart:collection';
 
@@ -26,7 +24,7 @@ import '../runner/flutter_command.dart';
 /// Example:
 ///
 /// ```
-///   'linter': '0.1.35', // TODO(yjbanov): https://github.com/dart-lang/linter/issues/824
+///   'linter': '0.1.35',
 /// ```
 const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here.

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -24,7 +24,7 @@ import '../runner/flutter_command.dart';
 /// Example:
 ///
 /// ```
-///   'linter': '0.1.35',
+///   'linter': '0.1.35', // See https://github.com/dart-lang/linter/issues/824
 /// ```
 const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here.

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -20,12 +20,6 @@ import '../runner/flutter_command.dart';
 
 /// Map from package name to package version, used to artificially pin a pub
 /// package version in cases when upgrading to the latest breaks Flutter.
-///
-/// Example:
-///
-/// ```
-///   'linter': '0.1.35', // See https://github.com/dart-lang/linter/issues/824
-/// ```
 const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here.
   'flutter_gallery_assets': '0.1.6', // See //examples/flutter_gallery/pubspec.yaml


### PR DESCRIPTION
Adds documentation to some undocumented members.

Removes ignore_for_file lints (as well as a TODO that links to a bug that's been resolved).