### PR TITLE
Update dartdoc to 0.28.0 and add flags to constrain warnings

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -103,7 +103,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.27.0
+"$PUB" global activate dartdoc 0.28.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -137,6 +137,14 @@ Future<void> main(List<String> arguments) async {
     '--header', 'snippets.html',
     '--header', 'opensearch.html',
     '--footer-text', 'lib/footer.html',
+    '--allow-warnings-in-packages', <String>[
+      'Flutter',
+      'flutter',
+      'platform_integration',
+      'flutter_test',
+      'flutter_driver',
+      'flutter_localizations',
+    ].join(','),
     '--exclude-packages',
     <String>[
       'analyzer',


### PR DESCRIPTION
Updates the version of dartdoc and adds a flag to limit displayed warnings to those for Flutter, only.

Changelog: https://github.com/dart-lang/dartdoc/releases/tag/v0.28.0

TL;DR:  All warnings displayed for flutter docs are now actionable and can be configured to result in errors.   Performance improvement of about ~15%.

