### PR TITLE
Remove todo from Podhelpr.rb

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -61,7 +61,6 @@ plugin_pods.map { |r|
 
 # Ensure that ENABLE_BITCODE is set to NO, add a #include to Generated.xcconfig, and
 # add a run script to the Build Phases.
-# TODO(dnfield): Figure out a way to deliver the Build Phase scripts without manual user intervention.
 post_install do |installer|
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|


### PR DESCRIPTION
This TODO is meaningless at this point.  There's no good way to achieve this as part of Cocoapods - since writing the comment I did some more investigation and there's no reliable way to achieve adding a build script to the main project without wrok that would go far beyond whatever we can achieve in this helper script.