### PR TITLE
Fix+unskip `flutter test` expression eval tests

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -102,6 +102,7 @@ void main() {
         withDebugger: true,
         beforeStart: () => _flutter.addBreakpoint(_project.breakpointUri, _project.breakpointLine),
       );
+      await _flutter.waitForPause();
       await evaluateTrivialExpressions(_flutter);
     });
 
@@ -110,6 +111,7 @@ void main() {
         withDebugger: true,
         beforeStart: () => _flutter.addBreakpoint(_project.breakpointUri, _project.breakpointLine),
       );
+      await _flutter.waitForPause();
       await evaluateComplexExpressions(_flutter);
     });
 
@@ -118,6 +120,7 @@ void main() {
         withDebugger: true,
         beforeStart: () => _flutter.addBreakpoint(_project.breakpointUri, _project.breakpointLine),
       );
+      await _flutter.waitForPause();
       await evaluateComplexReturningExpressions(_flutter);
     });
     // Skipped due to https://github.com/flutter/flutter/issues/26518

--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -121,7 +121,7 @@ void main() {
       await evaluateComplexReturningExpressions(_flutter);
     });
     // Skipped due to https://github.com/flutter/flutter/issues/26518
-  }, timeout: const Timeout.factor(6), skip: true);
+  }, timeout: const Timeout.factor(6));
 }
 
 Future<void> evaluateTrivialExpressions(FlutterTestDriver flutter) async {

--- a/packages/flutter_tools/test/integration/test_data/tests_project.dart
+++ b/packages/flutter_tools/test/integration/test_data/tests_project.dart
@@ -51,5 +51,5 @@ class TestsProject extends Project {
   Uri get breakpointUri => Uri.file(testFilePath);
 
   @override
-  int get breakpointLine => lineContaining(main, '// BREAKPOINT');
+  int get breakpointLine => lineContaining(testContent, '// BREAKPOINT');
 }

--- a/packages/flutter_tools/test/integration/test_driver.dart
+++ b/packages/flutter_tools/test/integration/test_driver.dart
@@ -521,7 +521,7 @@ class FlutterTestTestDriver extends FlutterTestDriver {
         '--machine',
         '-d',
         'flutter-tester'
-    ], script: testFile, withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions, pidFile: pidFile);
+    ], script: testFile, withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions, pidFile: pidFile, beforeStart: beforeStart);
   }
 
   @override


### PR DESCRIPTION
We weren't passing `beforeStart` through so the breakpoints were never being set, which means the evaluations were happening while the code was running.

(I'll run a bunch of times on Cirrus to ensure no flakes).