### PR TITLE
Fix deprecated_memer_use[_from_same_package] ignores

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -420,12 +420,12 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
 
     if (!widget.transitionBetweenRoutes || !_isTransitionable(context)) {
       // Lint ignore to maintain backward compatibility.
-      return _wrapActiveColor(widget.actionsForegroundColor, context, navBar); // ignore: deprecated_member_use
+      return _wrapActiveColor(widget.actionsForegroundColor, context, navBar); // ignore: deprecated_member_use_from_same_package
     }
 
     return _wrapActiveColor(
       // Lint ignore to maintain backward compatibility.
-      widget.actionsForegroundColor, // ignore: deprecated_member_use
+      widget.actionsForegroundColor, // ignore: deprecated_member_use_from_same_package
       context,
       Builder(
         // Get the context that might have a possibly changed CupertinoTheme.
@@ -631,7 +631,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
   @override
   Widget build(BuildContext context) {
     // Lint ignore to maintain backward compatibility.
-    final Color actionsForegroundColor = widget.actionsForegroundColor ?? CupertinoTheme.of(context).primaryColor; // ignore: deprecated_member_use
+    final Color actionsForegroundColor = widget.actionsForegroundColor ?? CupertinoTheme.of(context).primaryColor; // ignore: deprecated_member_use_from_same_package
 
     final _NavigationBarStaticComponents components = _NavigationBarStaticComponents(
       keys: keys,
@@ -649,7 +649,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
 
     return _wrapActiveColor(
       // Lint ignore to maintain backward compatibility.
-      widget.actionsForegroundColor, // ignore: deprecated_member_use
+      widget.actionsForegroundColor, // ignore: deprecated_member_use_from_same_package
       context,
       SliverPersistentHeader(
         pinned: true, // iOS navigation bars are always pinned.

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -84,10 +84,10 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
     _kDecodedCacheRatioCap = value;
   }
 
-  // ignore: deprecated_member_use
+  // ignore: deprecated_member_use_from_same_package
   /// Calls through to [dart:ui] with [decodedCacheRatioCap] from [ImageCache].
   Future<ui.Codec> instantiateImageCodec(Uint8List list) {
-    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use
+    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use_from_same_package
   }
 
   @override

--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -16,7 +16,7 @@ class PaintingBindingSpy extends BindingBase with ServicesBinding, PaintingBindi
   @override
   Future<ui.Codec> instantiateImageCodec(Uint8List list) {
     counter++;
-    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use
+    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use_from_same_package
   }
 
   @override
@@ -32,11 +32,11 @@ void main() {
   test('decodedCacheRatio', () async {
     // final PaintingBinding binding = PaintingBinding.instance;
     // Has default value.
-    expect(binding.decodedCacheRatioCap, isNot(null)); // ignore: deprecated_member_use
+    expect(binding.decodedCacheRatioCap, isNot(null)); // ignore: deprecated_member_use_from_same_package
 
     // Can be set.
-    binding.decodedCacheRatioCap = 1.0; // ignore: deprecated_member_use
-    expect(binding.decodedCacheRatioCap, 1.0); // ignore: deprecated_member_use
+    binding.decodedCacheRatioCap = 1.0; // ignore: deprecated_member_use_from_same_package
+    expect(binding.decodedCacheRatioCap, 1.0); // ignore: deprecated_member_use_from_same_package
   });
 
   test('instantiateImageCodec used for loading images', () async {


### PR DESCRIPTION
In a recent Dart SDK commit, deprecated_member_use was split into cross-package deprecated_member_use and same-package deprecated_member_use_from_same_package.

This fixes the same-package ignore directives by giving them the new name.