### PR TITLE
IconButton backgroundColor doc sample

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -71,9 +71,10 @@ const double _kMinButtonSize = 48.0;
 ///
 /// {@tool snippet --template=stateless_widget}
 ///
-/// In this sample the descendant widget is an [IconButton]. The icon
-/// button's filled background is a light shade of blue, it's a filled
-/// circle, and it's as big as the button is.
+/// In this sample the icon button's background color is defined with an [Ink]
+/// widget whose child is an [IconButton]. The icon button's filled background
+/// is a light shade of blue, it's a filled circle, and it's as big as the
+/// button is.
 ///
 /// ```dart
 /// Ink(

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -76,19 +76,17 @@ const double _kMinButtonSize = 48.0;
 /// circle, and it's as big as the button is.
 ///
 /// ```dart
-/// Widget build(BuildContext) {
-///   return Ink(
-///     decoration: ShapeDecoration(
-///       color: Colors.purple,
-///       shape: CircleBorder(),
-///     ),
-///     child: IconButton(
-///       icon: Icon(Icons.android),
-///       color: Colors.white,
-///       onPressed: () { print("filled background"); },
-///     ),
-///   );
-/// }
+/// Ink(
+///   decoration: ShapeDecoration(
+///     color: Colors.purple,
+///     shape: CircleBorder(),
+///   ),
+///   child: IconButton(
+///     icon: Icon(Icons.android),
+///     color: Colors.white,
+///     onPressed: () { print("filled background"); },
+///   ),
+/// )
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -57,6 +57,41 @@ const double _kMinButtonSize = 48.0;
 /// ```
 /// {@end-tool}
 ///
+/// ### Adding a filled background
+///
+/// Icon buttons don't support specifying a background color or other
+/// background decoration because typically the icon is just displayed
+/// on top of the parent widget's background. Icon buttons that appear
+/// in [AppBar.actions] are an example of this.
+///
+/// It's easy enough to create an icon button with a filled background
+/// using the [Ink] widget. The [Ink] widget renders a decoration on
+/// the underlying [Material] along with the splash and highlight
+/// [InkResponse] contributed by descendant widgets.
+///
+/// {@tool snippet --template=stateless_widget}
+///
+/// In this sample the descendant widget is an [IconButton]. The icon
+/// button's filled background is a light shade of blue, it's a filled
+/// circle, and it's as big as the button is.
+///
+/// ```dart
+/// Widget build(BuildContext) {
+///   return Ink(
+///     decoration: ShapeDecoration(
+///       color: Colors.purple,
+///       shape: CircleBorder(),
+///     ),
+///     child: IconButton(
+///       icon: Icon(Icons.android),
+///       color: Colors.white,
+///       onPressed: () { print("filled background"); },
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [Icons], a library of predefined icons.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/18220

Updated the IconButton doc: add a sample that demos how to create an icon button with a filled background.