### PR TITLE
floating action button y-offset respect inset bottom

### DIFF
--- a/dev/manual_tests/lib/floating_action_button_location_configurations.dart
+++ b/dev/manual_tests/lib/floating_action_button_location_configurations.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/material.dart';
 
-const _kTestSnackBar = SnackBar(content: Text('Yay! A SnackBar!'));
+const SnackBar _kTestSnackBar = SnackBar(content: Text('Yay! A SnackBar!'));
 
-const _kFABLocationConfigurations = [
+const List<FloatingActionButtonLocation> _kFABLocationConfigurations =
+    <FloatingActionButtonLocation>[
   FloatingActionButtonLocation.centerDocked,
   FloatingActionButtonLocation.endDocked,
   FloatingActionButtonLocation.centerFloat,
@@ -90,8 +91,8 @@ class _FloatingActionButtonConfigurationsTestRoute extends StatelessWidget {
       return BottomAppBar(
         child: Container(
           height: 100,
-          child: Center(
-            child: const Text('Bottom App Bar'),
+          child: const Center(
+            child: Text('Bottom App Bar'),
           ),
           color: Colors.amber,
         ),
@@ -158,7 +159,8 @@ class _ConfigurationOptionsState extends State<_ConfigurationOptions> {
                     fabLocation, hasBab, resizeToAvoidBottomInset);
             final MaterialPageRoute<
                     _FloatingActionButtonConfigurationsTestRoute> nextRoute =
-                MaterialPageRoute(builder: (context) => preview);
+                MaterialPageRoute<_FloatingActionButtonConfigurationsTestRoute>(
+                    builder: (BuildContext context) => preview);
             Navigator.push(context, nextRoute);
           },
         )

--- a/dev/manual_tests/lib/floating_action_button_location_configurations.dart
+++ b/dev/manual_tests/lib/floating_action_button_location_configurations.dart
@@ -1,0 +1,212 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+const _kTestSnackBar = SnackBar(content: Text('Yay! A SnackBar!'));
+
+const _kFABLocationConfigurations = [
+  FloatingActionButtonLocation.centerDocked,
+  FloatingActionButtonLocation.endDocked,
+  FloatingActionButtonLocation.centerFloat,
+  FloatingActionButtonLocation.endFloat,
+  FloatingActionButtonLocation.endTop,
+  FloatingActionButtonLocation.miniStartTop,
+  FloatingActionButtonLocation.startTop
+];
+
+/// This demos the following configurations:
+/// [FloatingActionButtonLocation]:
+///  1. Docked:
+///     a. Center
+///     b. End
+///  2. Float:
+///     a. Center
+///     b. Start
+///  3. Top
+///     a. Start
+///     b. MiniStart
+///     c. End
+///
+/// Toggle on and off for:
+///   * [BottomAppBar]
+///   * [SnackBar]
+///   * [Scaffold]'s resizeToAvoidBottomInset
+///   * KeyBoard
+///
+class FloatingActionButtonConfigurationsTestApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Floating Action Button Configurations Test',
+      home: _ConfigurationRoute(),
+    );
+  }
+}
+
+class _ConfigurationRoute extends StatelessWidget {
+  const _ConfigurationRoute();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select Configuration'),
+      ),
+      body: Center(
+        child: _ConfigurationOptions(),
+      ),
+    );
+  }
+}
+
+class _FloatingActionButtonConfigurationsTestRoute extends StatelessWidget {
+  const _FloatingActionButtonConfigurationsTestRoute(
+      this.fabLocation, this.hasBab, this.resizeToAvoidBottomInset);
+
+  final FloatingActionButtonLocation fabLocation;
+  final bool hasBab;
+  final bool resizeToAvoidBottomInset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Preview'),
+      ),
+      body: _SnackBarPage(),
+      bottomNavigationBar: buildBab(),
+      floatingActionButton: buildFAB(),
+      floatingActionButtonLocation: fabLocation,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+    );
+  }
+
+  BottomAppBar buildBab() {
+    if (!hasBab)
+      return null;
+    else
+      return BottomAppBar(
+        child: Container(
+          height: 100,
+          child: Center(
+            child: const Text('Bottom App Bar'),
+          ),
+          color: Colors.amber,
+        ),
+      );
+  }
+
+  FloatingActionButton buildFAB() {
+    return FloatingActionButton(
+        child: const Icon(Icons.add),
+        backgroundColor: Colors.red,
+        onPressed: () {});
+  }
+}
+
+class _SnackBarPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ListView(
+        padding: const EdgeInsets.all(40),
+        children: <Widget>[
+          RaisedButton(
+              onPressed: () {
+                Scaffold.of(context).showSnackBar(_kTestSnackBar);
+              },
+              color: Colors.lime,
+              child: const Text('Show SnackBar')),
+          TextFormField(
+            autofocus: true,
+            initialValue: 'Keyboard Trigger',
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class _ConfigurationOptions extends StatefulWidget {
+  @override
+  _ConfigurationOptionsState createState() {
+    return _ConfigurationOptionsState();
+  }
+}
+
+class _ConfigurationOptionsState extends State<_ConfigurationOptions> {
+  FloatingActionButtonLocation fabLocation = _kFABLocationConfigurations[0];
+  bool hasBab = false;
+  bool resizeToAvoidBottomInset = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(20.0),
+      children: <Widget>[
+        buildFabDropDown(),
+        buildBabToggle(),
+        buildResetToAvoidBottomInsetToggle(),
+        RaisedButton(
+          child: const Text('Try Configuration'),
+          color: Colors.green,
+          onPressed: () {
+            final _FloatingActionButtonConfigurationsTestRoute preview =
+                _FloatingActionButtonConfigurationsTestRoute(
+                    fabLocation, hasBab, resizeToAvoidBottomInset);
+            final MaterialPageRoute<
+                    _FloatingActionButtonConfigurationsTestRoute> nextRoute =
+                MaterialPageRoute(builder: (context) => preview);
+            Navigator.push(context, nextRoute);
+          },
+        )
+      ],
+    );
+  }
+
+  Widget buildBabToggle() {
+    return SwitchListTile.adaptive(
+        title: const Text('BottomAppBar'),
+        value: hasBab,
+        onChanged: (bool value) {
+          setState(() {
+            hasBab = value;
+          });
+        });
+  }
+
+  Widget buildResetToAvoidBottomInsetToggle() {
+    return SwitchListTile.adaptive(
+        title: const Text('resizeToAvoidBottomInset'),
+        value: resizeToAvoidBottomInset,
+        onChanged: (bool value) {
+          setState(() {
+            resizeToAvoidBottomInset = value;
+          });
+        });
+  }
+
+  Widget buildFabDropDown() {
+    return DropdownButton<FloatingActionButtonLocation>(
+      items:
+          _kFABLocationConfigurations.map((FloatingActionButtonLocation item) {
+        return DropdownMenuItem<FloatingActionButtonLocation>(
+          value: item,
+          child: Text(item.toString()),
+        );
+      }).toList(),
+      value: fabLocation,
+      onChanged: (FloatingActionButtonLocation selectedItem) {
+        setState(() {
+          fabLocation = selectedItem;
+        });
+      },
+    );
+  }
+}
+
+void main() {
+  runApp(FloatingActionButtonConfigurationsTestApp());
+}

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -165,11 +165,15 @@ double _yAxisOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, bool isDocked) {
   final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
   final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
   final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight - scaffoldGeometry.minInsets.bottom;
 
   double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
-  if (isDocked)
+  if (isDocked) {
     fabY = contentBottom - fabHeight / 2.0;
+    final double maxVisibleFabY =
+        scaffoldGeometry.scaffoldSize.height -
+            scaffoldGeometry.minInsets.bottom - fabHeight;
+    fabY = math.min(fabY, maxVisibleFabY);
+  }
 
   // The FAB should sit with a margin between it and the snack bar.
   if (snackBarHeight > 0.0)
@@ -178,7 +182,7 @@ double _yAxisOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, bool isDocked) {
   if (bottomSheetHeight > 0.0)
     fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
 
-  return math.min(fabY, maxFabY);
+  return fabY;
 }
 
 class _CenterFloatFloatingActionButtonLocation extends FloatingActionButtonLocation {

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -165,7 +165,8 @@ double _yAxisOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, bool isDocked) {
   final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
   final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
   final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight - scaffoldGeometry.minInsets.bottom;
+  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight
+      - scaffoldGeometry.minInsets.bottom - kFloatingActionButtonMargin;
 
   double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
   if (isDocked)
@@ -254,7 +255,7 @@ class _CenterDockedFloatingActionButtonLocation extends _DockedFloatingActionBut
 
 double _straddleAppBar(ScaffoldPrelayoutGeometry scaffoldGeometry) {
   final double fabHalfHeight = scaffoldGeometry.floatingActionButtonSize.height / 2.0;
-  return scaffoldGeometry.contentTop - fabHalfHeight;
+  return scaffoldGeometry.contentTop + scaffoldGeometry.minInsets.top + kFloatingActionButtonMargin - fabHalfHeight;
 }
 
 class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation {

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -160,6 +160,27 @@ double _startOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, { double offset 
   return null;
 }
 
+double _yAxisOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, bool isDocked) {
+  final double contentBottom = scaffoldGeometry.contentBottom;
+  final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
+  final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
+  final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
+  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight - scaffoldGeometry.minInsets.bottom;
+
+  double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
+  if (isDocked)
+    fabY = contentBottom - fabHeight / 2.0;
+
+  // The FAB should sit with a margin between it and the snack bar.
+  if (snackBarHeight > 0.0)
+    fabY = math.min(fabY, contentBottom - snackBarHeight - fabHeight - kFloatingActionButtonMargin);
+  // The FAB should sit with its center in front of the top of the bottom sheet.
+  if (bottomSheetHeight > 0.0)
+    fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
+
+  return math.min(fabY, maxFabY);
+}
+
 class _CenterFloatFloatingActionButtonLocation extends FloatingActionButtonLocation {
   const _CenterFloatFloatingActionButtonLocation();
 
@@ -167,17 +188,7 @@ class _CenterFloatFloatingActionButtonLocation extends FloatingActionButtonLocat
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
     // Compute the x-axis offset.
     final double fabX = (scaffoldGeometry.scaffoldSize.width - scaffoldGeometry.floatingActionButtonSize.width) / 2.0;
-
-    // Compute the y-axis offset.
-    final double contentBottom = scaffoldGeometry.contentBottom;
-    final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
-    final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
-    final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-    double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
-    if (snackBarHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - snackBarHeight - fabHeight - kFloatingActionButtonMargin);
-    if (bottomSheetHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
+    final double fabY = _yAxisOffset(scaffoldGeometry, false);
 
     return Offset(fabX, fabY);
   }
@@ -193,18 +204,7 @@ class _EndFloatFloatingActionButtonLocation extends FloatingActionButtonLocation
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
     // Compute the x-axis offset.
     final double fabX = _endOffset(scaffoldGeometry);
-
-    // Compute the y-axis offset.
-    final double contentBottom = scaffoldGeometry.contentBottom;
-    final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
-    final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
-    final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-
-    double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
-    if (snackBarHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - snackBarHeight - fabHeight - kFloatingActionButtonMargin);
-    if (bottomSheetHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
+    final double fabY = _yAxisOffset(scaffoldGeometry, false);
 
     return Offset(fabX, fabY);
   }
@@ -222,21 +222,7 @@ abstract class _DockedFloatingActionButtonLocation extends FloatingActionButtonL
   // where it docks to the [BottomAppBar].
   @protected
   double getDockedY(ScaffoldPrelayoutGeometry scaffoldGeometry) {
-    final double contentBottom = scaffoldGeometry.contentBottom;
-    final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
-    final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
-    final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-
-    double fabY = contentBottom - fabHeight / 2.0;
-    // The FAB should sit with a margin between it and the snack bar.
-    if (snackBarHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - snackBarHeight - fabHeight - kFloatingActionButtonMargin);
-    // The FAB should sit with its center in front of the top of the bottom sheet.
-    if (bottomSheetHeight > 0.0)
-      fabY = math.min(fabY, contentBottom - bottomSheetHeight - fabHeight / 2.0);
-
-    final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight;
-    return math.min(maxFabY, fabY);
+    return _yAxisOffset(scaffoldGeometry, true);
   }
 }
 

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -254,7 +254,7 @@ class _CenterDockedFloatingActionButtonLocation extends _DockedFloatingActionBut
 
 double _straddleAppBar(ScaffoldPrelayoutGeometry scaffoldGeometry) {
   final double fabHalfHeight = scaffoldGeometry.floatingActionButtonSize.height / 2.0;
-  return scaffoldGeometry.contentTop + scaffoldGeometry.minInsets.top - fabHalfHeight;
+  return scaffoldGeometry.contentTop - fabHalfHeight;
 }
 
 class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation {

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -165,8 +165,7 @@ double _yAxisOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, bool isDocked) {
   final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
   final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
   final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight
-      - scaffoldGeometry.minInsets.bottom - kFloatingActionButtonMargin;
+  final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight - scaffoldGeometry.minInsets.bottom;
 
   double fabY = contentBottom - fabHeight - kFloatingActionButtonMargin;
   if (isDocked)
@@ -255,7 +254,7 @@ class _CenterDockedFloatingActionButtonLocation extends _DockedFloatingActionBut
 
 double _straddleAppBar(ScaffoldPrelayoutGeometry scaffoldGeometry) {
   final double fabHalfHeight = scaffoldGeometry.floatingActionButtonSize.height / 2.0;
-  return scaffoldGeometry.contentTop + scaffoldGeometry.minInsets.top + kFloatingActionButtonMargin - fabHalfHeight;
+  return scaffoldGeometry.contentTop + scaffoldGeometry.minInsets.top - fabHalfHeight;
 }
 
 class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation {

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -250,6 +250,17 @@ void main() {
     );
     expect(tester.getRect(find.byType(FloatingActionButton)), Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0));
   });
+
+  // Scaffold 800x600, FAB is 56x56, No BAB
+  testWidgets('Center docked floating action button location respects insets', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildFrame(
+        location: FloatingActionButtonLocation.centerDocked,
+        viewInsets: const EdgeInsets.only(bottom: 100),
+      ),
+    );
+    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(800.0 / 2.0, 600.0 - 28.0 - 100.0));
+  });
 }
 
 

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -259,7 +259,8 @@ void main() {
         viewInsets: const EdgeInsets.only(bottom: 100),
       ),
     );
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(800.0 / 2.0, 600.0 - 28.0 - 100.0));
+    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(
+        800.0 / 2.0, 600.0 - 28.0 - 100.0));
   });
 }
 


### PR DESCRIPTION
Floating action button should be visible when `Scaffolding.resizeToAvoidBottomInset` is set.

### Current behavior / Repro steps:

1. Center or End docked FAB.
2. Open Keyboard.
3. FAB is only partially visible.

<img src="https://i.imgur.com/VF73E71.png" height="256" >

### The configuration this PR specifically addresses:

1. Docked FAB implementations.
2. When`Scaffolding.resizeToAvoidBottomInset` is `true`.
3. When insets exist AND `contentBottom` does not have enough space for the FAB to fully reside below it. E.g. Keyboard is open.

New behavior: 

FAB is completely visible.

<img src="https://i.imgur.com/veztaNf.png" height="256" >