### PR TITLE
Fix --build-shared-library on newer NDKs

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -211,6 +211,7 @@ class AndroidNdk {
         throw AndroidNdkSearchError('Can not establish ndk-bundle version: ${propertiesFile} not found');
       }
 
+      // Parse source.properties: each line has Key = Value format.
       final Map<String, String> properties = Map<String, String>.fromIterable(
           fs.file(propertiesFile).readAsStringSync().split('\n').map((String line) => line.trim()).where((line) => line.isNotEmpty).map((String line) => line.split(' = ')),
           key: (dynamic split) => split[0],

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -139,7 +139,8 @@ class AndroidNdk {
       return ndkDirectory;
     }
 
-    String findCompiler(String ndkDirectory) {
+    // Returns list that contains toolchain bin folder and compiler binary name.
+    List<String> findToolchainAndCompiler(String ndkDirectory) {
       String directory;
       if (platform.isLinux) {
         directory = 'linux-x86_64';
@@ -149,14 +150,16 @@ class AndroidNdk {
         throw AndroidNdkSearchError('Only Linux and macOS are supported');
       }
 
-      final String ndkCompiler = fs.path.join(ndkDirectory,
+      final String toolchainBin = fs.path.join(ndkDirectory,
           'toolchains', 'arm-linux-androideabi-4.9', 'prebuilt', directory,
-          'bin', 'arm-linux-androideabi-gcc');
+          'bin');
+      final String ndkCompiler = fs.path.join(toolchainBin,
+          'arm-linux-androideabi-gcc');
       if (!fs.isFileSync(ndkCompiler)) {
         throw AndroidNdkSearchError('Can not locate GCC binary, tried $ndkCompiler');
       }
 
-      return ndkCompiler;
+      return [toolchainBin, ndkCompiler];
     }
 
     List<String> findSysroot(String ndkDirectory) {
@@ -202,9 +205,41 @@ class AndroidNdk {
       return <String>['--sysroot', armPlatform];
     }
 
+    int findNdkMajorVersion(String ndkDirectory) {
+      final String propertiesFile = fs.path.join(ndkDirectory, 'source.properties');
+      if (!fs.isFileSync(propertiesFile)) {
+        throw AndroidNdkSearchError('Can not establish ndk-bundle version: ${propertiesFile} not found');
+      }
+
+      final Map<String, String> properties = Map<String, String>.fromIterable(
+          fs.file(propertiesFile).readAsStringSync().split('\n').map((String line) => line.trim()).where((line) => line.isNotEmpty).map((String line) => line.split(' = ')),
+          key: (dynamic split) => split[0],
+          value: (dynamic split) => split[1]);
+
+      if (!properties.containsKey('Pkg.Revision')) {
+        throw AndroidNdkSearchError('Can not establish ndk-bundle version: ${propertiesFile} does not contain Pkg.Revision');
+      }
+
+      return int.parse(properties['Pkg.Revision'].split('.').first);
+    }
+
     final String ndkDir = findBundle(androidHomeDir);
-    final String ndkCompiler = findCompiler(ndkDir);
+    final int ndkVersion = findNdkMajorVersion(ndkDir);
+    final List<String> ndkToolchainAndCompiler = findToolchainAndCompiler(ndkDir);
+    final String ndkToolchain = ndkToolchainAndCompiler[0];
+    final String ndkCompiler = ndkToolchainAndCompiler[1];
     final List<String> ndkCompilerArgs = findSysroot(ndkDir);
+    if (ndkVersion >= 18) {
+      // Newer versions of NDK use clang instead of gcc, which falls back to
+      // system linker instead of using toolchain linker. Force clang to
+      // use appropriate linker by passing -fuse-ld=<path-to-ld> command line
+      // flag.
+      final ndkLinker = fs.path.join(ndkToolchain, 'arm-linux-androideabi-ld');
+      if (!fs.isFileSync(ndkLinker)) {
+        throw AndroidNdkSearchError('Can not locate linker binary, tried $ndkLinker');
+      }
+      ndkCompilerArgs.add('-fuse-ld=${ndkLinker}');
+    }
     return AndroidNdk._(ndkDir, ndkCompiler, ndkCompilerArgs);
   }
 

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -161,7 +161,7 @@ void main() {
           Platform: () => FakePlatform(operatingSystem: os),
         });
 
-        testUsingContext('newer NDK require explicit -fuse-ld on ${os}', () {
+        testUsingContext('newer NDK require explicit -fuse-ld on $os', () {
           sdkDir = MockAndroidSdk.createSdkDirectory(
               withAndroidN: true, withNdkDir: osDir, withNdkSysroot: true, ndkVersion: 18);
           Config.instance.setValue('android-sdk', sdkDir.path);
@@ -189,7 +189,7 @@ void main() {
           expect(sdk.ndk, isNotNull);
           expect(sdk.ndk.directory, realNdkDir);
           expect(sdk.ndk.compiler, realNdkCompiler);
-          expect(sdk.ndk.compilerArgs, <String>['--sysroot', realNdkSysroot, '-fuse-ld=${realNdkLinker}']);
+          expect(sdk.ndk.compilerArgs, <String>['--sysroot', realNdkSysroot, '-fuse-ld=$realNdkLinker']);
         }, overrides: <Type, Generator>{
           FileSystem: () => fs,
           Platform: () => FakePlatform(operatingSystem: os),

--- a/packages/flutter_tools/test/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/android/android_sdk_test.dart
@@ -160,6 +160,40 @@ void main() {
           FileSystem: () => fs,
           Platform: () => FakePlatform(operatingSystem: os),
         });
+
+        testUsingContext('newer NDK require explicit -fuse-ld on ${os}', () {
+          sdkDir = MockAndroidSdk.createSdkDirectory(
+              withAndroidN: true, withNdkDir: osDir, withNdkSysroot: true, ndkVersion: 18);
+          Config.instance.setValue('android-sdk', sdkDir.path);
+
+          final String realSdkDir = sdkDir.path;
+          final String realNdkDir = fs.path.join(realSdkDir, 'ndk-bundle');
+          final String realNdkToolchainBin = fs.path.join(
+              realNdkDir,
+              'toolchains',
+              'arm-linux-androideabi-4.9',
+              'prebuilt',
+              osDir,
+              'bin');
+          final String realNdkCompiler = fs.path.join(
+              realNdkToolchainBin,
+              'arm-linux-androideabi-gcc');
+          final String realNdkLinker = fs.path.join(
+              realNdkToolchainBin,
+              'arm-linux-androideabi-ld');
+          final String realNdkSysroot =
+              fs.path.join(realNdkDir, 'platforms', 'android-9', 'arch-arm');
+
+          final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+          expect(sdk.directory, realSdkDir);
+          expect(sdk.ndk, isNotNull);
+          expect(sdk.ndk.directory, realNdkDir);
+          expect(sdk.ndk.compiler, realNdkCompiler);
+          expect(sdk.ndk.compilerArgs, <String>['--sysroot', realNdkSysroot, '-fuse-ld=${realNdkLinker}']);
+        }, overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          Platform: () => FakePlatform(operatingSystem: os),
+        });
       });
 
       for (String os in <String>['linux', 'macos']) {

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -41,6 +41,7 @@ class MockAndroidSdk extends Mock implements AndroidSdk {
   static Directory createSdkDirectory({
     bool withAndroidN = false,
     String withNdkDir,
+    int ndkVersion = 16,
     bool withNdkSysroot = false,
     bool withSdkManager = true,
   }) {
@@ -65,16 +66,29 @@ class MockAndroidSdk extends Mock implements AndroidSdk {
       _createSdkFile(dir, 'tools/bin/sdkmanager');
 
     if (withNdkDir != null) {
-      final String ndkCompiler = fs.path.join(
+      final String ndkToolchainBin = fs.path.join(
         'ndk-bundle',
         'toolchains',
         'arm-linux-androideabi-4.9',
         'prebuilt',
         withNdkDir,
         'bin',
+      );
+      final String ndkCompiler = fs.path.join(
+        ndkToolchainBin,
         'arm-linux-androideabi-gcc',
       );
+      final String ndkLinker = fs.path.join(
+        ndkToolchainBin,
+        'arm-linux-androideabi-ld',
+      );
       _createSdkFile(dir, ndkCompiler);
+      _createSdkFile(dir, ndkLinker);
+      _createSdkFile(dir, fs.path.join('ndk-bundle', 'source.properties'), contents: """
+Pkg.Desc = Android NDK
+Pkg.Revision = ${ndkVersion}.1.5063045
+
+""");
     }
     if (withNdkSysroot) {
       final String armPlatform = fs.path.join(

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -84,11 +84,11 @@ class MockAndroidSdk extends Mock implements AndroidSdk {
       );
       _createSdkFile(dir, ndkCompiler);
       _createSdkFile(dir, ndkLinker);
-      _createSdkFile(dir, fs.path.join('ndk-bundle', 'source.properties'), contents: """
-Pkg.Desc = Android NDK
-Pkg.Revision = ${ndkVersion}.1.5063045
+      _createSdkFile(dir, fs.path.join('ndk-bundle', 'source.properties'), contents: '''
+Pkg.Desc = Android NDK[]
+Pkg.Revision = $ndkVersion.1.5063045
 
-""");
+''');
     }
     if (withNdkSysroot) {
       final String armPlatform = fs.path.join(


### PR DESCRIPTION
Newer NDKs switched to clang which by default uses system linker, instead
we need to force it to use appropriate toolchain linker by passing
-fuse-ld=<path-to-linker> command line flag.

Fixes #23458