### PR TITLE
Fix rounding error in build tests

### DIFF
--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1757,7 +1757,7 @@ void main() {
     // line text field).
     final double lineHeight = findRenderEditable(tester).preferredLineHeight;
     scrollableState = tester.firstState(find.byType(Scrollable));
-    expect(scrollableState.position.pixels, equals(lineHeight));
+    expect(scrollableState.position.pixels, closeTo(lineHeight, 0.1));
   });
 
   testWidgets('haptic feedback', (WidgetTester tester) async {


### PR DESCRIPTION
Fix a [build error](https://build.chromium.org/p/client.flutter/builders/Mac/builds/7623/steps/steps/logs/stdio) that happened due to a rounding error in a test I just added in https://github.com/flutter/flutter/pull/26309.