### PR TITLE
Doc fix: SliverChildBuilderDelegate is the lazy one

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -54,7 +54,7 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 /// While laying out the list, visible children's elements, states and render
 /// objects will be created lazily based on existing widgets (such as in the
 /// case of [SliverChildListDelegate]) or lazily provided ones (such as in the
-/// case of [SliverChildListDelegate]).
+/// case of [SliverChildBuilderDelegate]).
 ///
 /// ### Destruction
 ///


### PR DESCRIPTION
It used to say that SliverChildListDelegate is both lazy and non-lazy at the same time. I think the lazy one should be SliverChildBuilderDelegate. 

This problem is also there in the API docs [here](https://docs.flutter.io/flutter/widgets/SliverChildDelegate-class.html#creation), [here](https://docs.flutter.io/flutter/widgets/SliverFixedExtentList-class.html#creation), [here](https://docs.flutter.io/flutter/widgets/SliverGrid-class.html#creation) and [here](https://docs.flutter.io/flutter/widgets/SliverList-class.html#creation). Should that be reported to https://github.com/flutter/website?