### PR TITLE
Update test temp folder name to be more consistent with others

### DIFF
--- a/packages/flutter_tools/test/integration/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration/expression_evaluation_test.dart
@@ -22,7 +22,7 @@ void main() {
     FlutterRunTestDriver _flutter;
 
     setUp(() async {
-      tempDir = createResolvedTempDirectorySync('expression_test.');
+      tempDir = createResolvedTempDirectorySync('run_expression_eval_test.');
       await _project.setUpIn(tempDir);
       _flutter = FlutterRunTestDriver(tempDir);
     });


### PR DESCRIPTION
This change was dropped out of #26227 because it seems to inexplicably result in timeouts talking to the VM service on Windows Cirrus. Opening as its own change for easier debugging/head scratching.