### PR TITLE
Fix missing const analyzer warning

### DIFF
--- a/packages/flutter/test/widgets/scrollable_of_test.dart
+++ b/packages/flutter/test/widgets/scrollable_of_test.dart
@@ -91,8 +91,8 @@ void main() {
         notification = value;
         return false;
       },
-      child: SingleChildScrollView(
-        child: const SizedBox(height: 1200.0)
+      child: const SingleChildScrollView(
+        child: SizedBox(height: 1200.0)
       )
     ));
 


### PR DESCRIPTION
Introduced by merging an old PR (https://github.com/flutter/flutter/pull/21157).