### PR TITLE
Close the Scaffold drawer in scroll_perf_test.dart

### DIFF
--- a/dev/benchmarks/complex_layout/lib/main.dart
+++ b/dev/benchmarks/complex_layout/lib/main.dart
@@ -620,7 +620,11 @@ class GalleryDrawer extends StatelessWidget {
           FancyDrawerHeader(),
           ListTile(
             key: const Key('scroll-switcher'),
-            onTap: () { _changeScrollMode(context, currentMode == ScrollMode.complex ? ScrollMode.tile : ScrollMode.complex); },
+            title: const Text('Scroll Mode'),
+            onTap: () {
+              _changeScrollMode(context, currentMode == ScrollMode.complex ? ScrollMode.tile : ScrollMode.complex);
+             Navigator.pop(context);
+            },
             trailing: Text(currentMode == ScrollMode.complex ? 'Tile' : 'Complex')
           ),
           ListTile(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26724

Without this change the benchmark fails consistently when run interactively.

See here for an explanation of the problem: https://github.com/flutter/flutter/issues/25047#issuecomment-448431099