### PR TITLE
Fix lerp in textTheme to allow for null parameters

### DIFF
--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -459,23 +459,21 @@ class TextTheme extends Diagnosticable {
   ///
   /// {@macro flutter.material.themeData.lerp}
   static TextTheme lerp(TextTheme a, TextTheme b, double t) {
-    assert(a != null);
-    assert(b != null);
     assert(t != null);
     return TextTheme(
-      display4: TextStyle.lerp(a.display4, b.display4, t),
-      display3: TextStyle.lerp(a.display3, b.display3, t),
-      display2: TextStyle.lerp(a.display2, b.display2, t),
-      display1: TextStyle.lerp(a.display1, b.display1, t),
-      headline: TextStyle.lerp(a.headline, b.headline, t),
-      title: TextStyle.lerp(a.title, b.title, t),
-      subhead: TextStyle.lerp(a.subhead, b.subhead, t),
-      body2: TextStyle.lerp(a.body2, b.body2, t),
-      body1: TextStyle.lerp(a.body1, b.body1, t),
-      caption: TextStyle.lerp(a.caption, b.caption, t),
-      button: TextStyle.lerp(a.button, b.button, t),
-      subtitle: TextStyle.lerp(a.subtitle, b.subtitle, t),
-      overline: TextStyle.lerp(a.overline, b.overline, t),
+      display4: TextStyle.lerp(a?.display4, b?.display4, t),
+      display3: TextStyle.lerp(a?.display3, b?.display3, t),
+      display2: TextStyle.lerp(a?.display2, b?.display2, t),
+      display1: TextStyle.lerp(a?.display1, b?.display1, t),
+      headline: TextStyle.lerp(a?.headline, b?.headline, t),
+      title: TextStyle.lerp(a?.title, b?.title, t),
+      subhead: TextStyle.lerp(a?.subhead, b?.subhead, t),
+      body2: TextStyle.lerp(a?.body2, b?.body2, t),
+      body1: TextStyle.lerp(a?.body1, b?.body1, t),
+      caption: TextStyle.lerp(a?.caption, b?.caption, t),
+      button: TextStyle.lerp(a?.button, b?.button, t),
+      subtitle: TextStyle.lerp(a?.subtitle, b?.subtitle, t),
+      overline: TextStyle.lerp(a?.overline, b?.overline, t),
     );
   }
 

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -455,8 +455,6 @@ class TextTheme extends Diagnosticable {
 
   /// Linearly interpolate between two text themes.
   ///
-  /// The arguments must not be null.
-  ///
   /// {@macro flutter.material.themeData.lerp}
   static TextTheme lerp(TextTheme a, TextTheme b, double t) {
     assert(t != null);

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -152,4 +152,58 @@ void main() {
     expect(sizeTheme.overline.fontSize, baseTheme.overline.fontSize * 2.0 + 5.0);
   });
 
+  test('TextTheme lerp with second parameter null', () {
+    final TextTheme theme = Typography(platform: TargetPlatform.android).black;
+    final TextTheme lerped = TextTheme.lerp(theme, null, 0.25);
+
+    expect(lerped.display4, TextStyle.lerp(theme.display4, null, 0.25));
+    expect(lerped.display3, TextStyle.lerp(theme.display3, null, 0.25));
+    expect(lerped.display2, TextStyle.lerp(theme.display2, null, 0.25));
+    expect(lerped.display1, TextStyle.lerp(theme.display1, null, 0.25));
+    expect(lerped.caption, TextStyle.lerp(theme.caption, null, 0.25));
+    expect(lerped.headline, TextStyle.lerp(theme.headline, null, 0.25));
+    expect(lerped.title, TextStyle.lerp(theme.title, null, 0.25));
+    expect(lerped.subhead, TextStyle.lerp(theme.subhead, null, 0.25));
+    expect(lerped.body2, TextStyle.lerp(theme.body2, null, 0.25));
+    expect(lerped.body1, TextStyle.lerp(theme.body1, null, 0.25));
+    expect(lerped.button, TextStyle.lerp(theme.button, null, 0.25));
+    expect(lerped.subtitle, TextStyle.lerp(theme.subtitle, null, 0.25));
+    expect(lerped.overline, TextStyle.lerp(theme.overline, null, 0.25));
+  });
+
+  test('TextTheme lerp with first parameter null', () {
+    final TextTheme theme = Typography(platform: TargetPlatform.android).black;
+    final TextTheme lerped = TextTheme.lerp(null, theme, 0.25);
+
+    expect(lerped.display4, TextStyle.lerp(null, theme.display4, 0.25));
+    expect(lerped.display3, TextStyle.lerp(null, theme.display3, 0.25));
+    expect(lerped.display2, TextStyle.lerp(null, theme.display2, 0.25));
+    expect(lerped.display1, TextStyle.lerp(null, theme.display1, 0.25));
+    expect(lerped.caption, TextStyle.lerp(null, theme.caption, 0.25));
+    expect(lerped.headline, TextStyle.lerp(null, theme.headline, 0.25));
+    expect(lerped.title, TextStyle.lerp(null, theme.title, 0.25));
+    expect(lerped.subhead, TextStyle.lerp(null, theme.subhead, 0.25));
+    expect(lerped.body2, TextStyle.lerp(null, theme.body2, 0.25));
+    expect(lerped.body1, TextStyle.lerp(null, theme.body1, 0.25));
+    expect(lerped.button, TextStyle.lerp(null, theme.button, 0.25));
+    expect(lerped.subtitle, TextStyle.lerp(null, theme.subtitle, 0.25));
+    expect(lerped.overline, TextStyle.lerp(null, theme.overline, 0.25));
+  });
+
+  test('TextTheme lerp with null parameters', () {
+    final TextTheme lerped = TextTheme.lerp(null, null, 0.25);
+    expect(lerped.display4, null);
+    expect(lerped.display3, null);
+    expect(lerped.display2, null);
+    expect(lerped.display1, null);
+    expect(lerped.caption, null);
+    expect(lerped.headline, null);
+    expect(lerped.title, null);
+    expect(lerped.subhead, null);
+    expect(lerped.body2, null);
+    expect(lerped.body1, null);
+    expect(lerped.button, null);
+    expect(lerped.subtitle, null);
+    expect(lerped.overline, null);
+  });
 }

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -153,7 +153,7 @@ void main() {
   });
 
   test('TextTheme lerp with second parameter null', () {
-    final TextTheme theme = Typography(platform: TargetPlatform.android).black;
+    final TextTheme theme = Typography().black;
     final TextTheme lerped = TextTheme.lerp(theme, null, 0.25);
 
     expect(lerped.display4, TextStyle.lerp(theme.display4, null, 0.25));
@@ -172,7 +172,7 @@ void main() {
   });
 
   test('TextTheme lerp with first parameter null', () {
-    final TextTheme theme = Typography(platform: TargetPlatform.android).black;
+    final TextTheme theme = Typography().black;
     final TextTheme lerped = TextTheme.lerp(null, theme, 0.25);
 
     expect(lerped.display4, TextStyle.lerp(null, theme.display4, 0.25));


### PR DESCRIPTION
There's no reason to disallow this as TextStyle can handle lerping between null parameters just fine. This change also adds tests to ensure the correct behavior