### PR TITLE
[cupertino_icons] add car, bus, train, paw, controller, and flask icons.

### DIFF
--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -766,72 +766,72 @@ class CupertinoIcons {
   static const IconData bus = IconData(0xf36d, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// A filled in car.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [car_detailed], similar, but a more detailed and realistic representation.
   static const IconData car = IconData(0xf36f, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// A filled in detailed, realistic car.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [car], similar, but a more simple representation.
   static const IconData car_detailed = IconData(0xf2c1, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// A filled in train with a window divided in half and two headlights.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [train_style_two], similar, but with a full, undivided window and a single, centered headlight.
   static const IconData train_style_one = IconData(0xf3af, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// A filled in train with a window and a single, centered headlight.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [train_style_one], similar, but with a with a window divided in half and two headlights.
   static const IconData train_style_two = IconData(0xf3b4, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// An outlined paw.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [paw_solid], similar, but filled in.
   static const IconData paw = IconData(0xf479, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// A filled in paw.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [paw], similar, but not filled in.
   static const IconData paw_solid = IconData(0xf47a, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// An outlined game controller.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [game_controller_solid], similar, but filled in.
   static const IconData game_controller = IconData(0xf43a, fontFamily: iconFont, fontPackage: iconFontPackage);
-  
+
   /// A filled in game controller.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [game_controller], similar, but not filled in.
   static const IconData game_controller_solid = IconData(0xf43b, fontFamily: iconFont, fontPackage: iconFontPackage);
 
   /// An outlined lab flask.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [lab_flask_solid], similar, but filled in.
   static const IconData lab_flask = IconData(0xf430, fontFamily: iconFont, fontPackage: iconFontPackage);
-  
+
   /// A filled in lab flask.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [lab_flask], similar, but not filled in.
   static const IconData lab_flask_solid = IconData(0xf431, fontFamily: iconFont, fontPackage: iconFontPackage);
 }

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -761,4 +761,77 @@ class CupertinoIcons {
   ///
   ///  * [tag_solid], similar but with only one tag.
   static const IconData tags_solid = IconData(0xf48f, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in bus.
+  static const IconData bus = IconData(0xf36d, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in car.
+  /// 
+  /// See also:
+  /// 
+  ///  * [car_detailed], similar, but a more detailed and realistic representation.
+  static const IconData car = IconData(0xf36f, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in detailed, realistic car.
+  /// 
+  /// See also:
+  /// 
+  ///  * [car], similar, but a more simple representation.
+  static const IconData car_detailed = IconData(0xf2c1, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in train with a window divided in half and two headlights.
+  /// 
+  /// See also:
+  /// 
+  ///  * [train_style_two], similar, but with a full, undivided window and a single, centered headlight.
+  static const IconData train_style_one = IconData(0xf3af, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in train with a window and a single, centered headlight.
+  /// 
+  /// See also:
+  /// 
+  ///  * [train_style_one], similar, but with a with a window divided in half and two headlights.
+  static const IconData train_style_two = IconData(0xf3b4, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// An outlined paw.
+  /// 
+  /// See also:
+  /// 
+  ///  * [paw_solid], similar, but filled in.
+  static const IconData paw = IconData(0xf479, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// A filled in paw.
+  /// 
+  /// See also:
+  /// 
+  ///  * [paw], similar, but not filled in.
+  static const IconData paw_solid = IconData(0xf47a, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// An outlined game controller.
+  /// 
+  /// See also:
+  /// 
+  ///  * [game_controller_solid], similar, but filled in.
+  static const IconData game_controller = IconData(0xf43a, fontFamily: iconFont, fontPackage: iconFontPackage);
+  
+  /// A filled in game controller.
+  /// 
+  /// See also:
+  /// 
+  ///  * [game_controller], similar, but not filled in.
+  static const IconData game_controller_solid = IconData(0xf43b, fontFamily: iconFont, fontPackage: iconFontPackage);
+
+  /// An outlined lab flask.
+  /// 
+  /// See also:
+  /// 
+  ///  * [lab_flask_solid], similar, but filled in.
+  static const IconData lab_flask = IconData(0xf430, fontFamily: iconFont, fontPackage: iconFontPackage);
+  
+  /// A filled in lab flask.
+  /// 
+  /// See also:
+  /// 
+  ///  * [lab_flask], similar, but not filled in.
+  static const IconData lab_flask_solid = IconData(0xf431, fontFamily: iconFont, fontPackage: iconFontPackage);
 }


### PR DESCRIPTION
**Issue:** Not all icons displayed in [Cupertino Icon's map.png](https://raw.githubusercontent.com/flutter/cupertino_icons/master/map.png) are available when calling `CupertinoIcons.{x}`.

**What was changed:** While not all missing icons were added in this PR, the following icons were: `bus`, `car`, `car_detailed`, `train_style_one`, `train_style_two`, `paw`, `paw_solid`, `game_controller`, `game_controller_solid`, `lab_flask`, and `lab_flask_solid`.

**Testing:** In order to test these new icons I threw them in a `Column` real quick: 
```
Column(
    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
    children: <Widget>[
        Icon(CupertinoIcons.bus),
        Icon(CupertinoIcons.car),
        Icon(CupertinoIcons.car_detailed),
        Icon(CupertinoIcons.train_style_one),
        Icon(CupertinoIcons.train_style_two),
        Icon(CupertinoIcons.paw),
        Icon(CupertinoIcons.paw_solid),
        Icon(CupertinoIcons.game_controller),
        Icon(CupertinoIcons.game_controller_solid),
        Icon(CupertinoIcons.lab_flask),
        Icon(CupertinoIcons.lab_flask_solid)
    ]),
```

**Testing results:** which resulted in the expected behavior of these icons displaying appropriately:

![new icons](https://user-images.githubusercontent.com/3655571/51413083-18d74d00-1b44-11e9-93a4-f2daa5a55b6b.png)