### PR TITLE
Document that SearchDelegate.buildResults can be called multiple time…

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -133,12 +133,6 @@ class _SearchDemoState extends State<SearchDemo> {
   }
 }
 
-/// [SearchDelegate.buildResults] might be called multiple times. Please cache
-/// the search result if you don't want to call search backend multiple times
-/// on the same query.
-/// See:
-/// https://github.com/flutter/flutter/issues/11655#issuecomment-412413030
-/// https://github.com/flutter/flutter/issues/26759
 class _SearchDemoSearchDelegate extends SearchDelegate<int> {
   final List<int> _data = List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -133,6 +133,12 @@ class _SearchDemoState extends State<SearchDemo> {
   }
 }
 
+/// [SearchDelegate.buildResults] might be called multiple times. Please cache
+/// the search result if you don't want to call search backend multiple times
+/// on the same query.
+/// See:
+/// https://github.com/flutter/flutter/issues/11655#issuecomment-412413030
+/// https://github.com/flutter/flutter/issues/26759
 class _SearchDemoSearchDelegate extends SearchDelegate<int> {
   final List<int> _data = List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -108,12 +108,9 @@ abstract class SearchDelegate<T> {
   /// The current value of [query] can be used to determine what the user
   /// searched for.
   ///
-  /// Note that this method might be called multiple times just like any other
-  /// build function in Flutter. Please cache the search results if you don't
-  /// want to call search backend multiple times on the same query.
-  /// See:
-  /// https://github.com/flutter/flutter/issues/11655#issuecomment-412413030
-  /// https://github.com/flutter/flutter/issues/26759
+  /// This method might be applied more than once to the same query.
+  /// If your [buildResults] method is computationally expensive, you may want
+  /// to cache the search results for one or more queries.
   ///
   /// Typically, this method returns a [ListView] with the search results.
   /// When the user taps on a particular search result, [close] should be called

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -108,6 +108,13 @@ abstract class SearchDelegate<T> {
   /// The current value of [query] can be used to determine what the user
   /// searched for.
   ///
+  /// Note that this method might be called multiple times just like any other
+  /// build function in Flutter. Please cache the search results if you don't
+  /// want to call search backend multiple times on the same query.
+  /// See:
+  /// https://github.com/flutter/flutter/issues/11655#issuecomment-412413030
+  /// https://github.com/flutter/flutter/issues/26759
+  ///
   /// Typically, this method returns a [ListView] with the search results.
   /// When the user taps on a particular search result, [close] should be called
   /// with the selected result as argument. This will close the search page and


### PR DESCRIPTION
Document that SearchDelegate.buildResults can be called multiple times, to avoid confusion.

Fixed https://github.com/flutter/flutter/issues/26759.