### PR TITLE
targetSdkVersion 28

### DIFF
--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "com.example.cullopacity"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/android_host_app/app/build.gradle
+++ b/dev/integration_tests/android_host_app/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.androidviews"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/external_ui/android/app/build.gradle
+++ b/dev/integration_tests/external_ui/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.externalui"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/named_isolates/android/app/build.gradle
+++ b/dev/integration_tests/named_isolates/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.named_isolates"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -25,7 +25,7 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         applicationId "io.flutter.examples.manual_tests"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/examples/catalog/android/app/build.gradle
+++ b/examples/catalog/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.catalog"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/flutter_gallery/android/app/build.gradle
+++ b/examples/flutter_gallery/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.demo.gallery"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.layers"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/stocks/android/app/build.gradle
+++ b/examples/stocks/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.stocks"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "{{androidIdentifier}}.host"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
I should have bumped this up with the last PR that bumped compileSdkVersion.

This is less essential because CI is passing now, but I think it's technically incorrect to have this be lower than compileSdkVersion.