### PR TITLE
#19060 Update material.google.com links to material.io

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ Available examples include:
 
 - **Flutter gallery** The [flutter gallery app](flutter_gallery) showcases
   Flutter's widgets, including its implementation of [material
-  design](https://material.google.com/).
+  design](https://material.io/design/).
 
 - **Layers** The [layers vignettes](layers) show how to use the various layers
   in the Flutter framework. For details, see the [layers

--- a/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 // This demo is based on
-// https://material.google.com/components/dialogs.html#dialogs-full-screen-dialogs
+// https://material.io/design/components/dialogs.html#full-screen-dialog
 
 enum DismissDialogAction {
   cancel,

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -10,7 +10,7 @@
 ///
 ///  * [flutter.io/widgets](https://flutter.io/widgets/)
 ///    for a catalog of commonly-used Flutter widgets.
-///  * [material.google.com](https://material.google.com/)
+///  * [material.io/design](https://material.io/design/)
 ///    for an introduction to Material Design.
 library material;
 

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -316,7 +316,7 @@ class MaterialApp extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * <https://material.google.com/layout/metrics-keylines.html>
+  ///  * <https://material.io/design/layout/spacing-methods.html>
   final bool debugShowMaterialGrid;
 
   @override

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -53,7 +53,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 }
 
 // TODO(eseidel): Toolbar needs to change size based on orientation:
-// http://material.google.com/layout/structure.html#structure-app-bar
+// https://material.io/design/components/app-bars-top.html#specs
 // Mobile Landscape: 48dp
 // Mobile Portrait: 56dp
 // Tablet/Desktop: 64dp
@@ -126,7 +126,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 ///  * [PopupMenuButton], to show a popup menu on the app bar, via [actions].
 ///  * [FlexibleSpaceBar], which is used with [flexibleSpace] when the app bar
 ///    can expand and collapse.
-///  * <https://material.google.com/layout/structure.html#structure-toolbars>
+///  * <https://material.io/design/components/app-bars-top.html>
 class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a material design app bar.
   ///
@@ -802,7 +802,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///  * [PopupMenuButton], to show a popup menu on the app bar, via [actions].
 ///  * [FlexibleSpaceBar], which is used with [flexibleSpace] when the app bar
 ///    can expand and collapse.
-///  * <https://material.google.com/layout/structure.html#structure-toolbars>
+///  * <https://material.io/design/components/app-bars-top.html>
 class SliverAppBar extends StatefulWidget {
   /// Creates a material design app bar that can be placed in a [CustomScrollView].
   ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -28,7 +28,7 @@ const double _kBottomMargin = 8.0;
 ///
 ///  * [BottomNavigationBar]
 ///  * [BottomNavigationBarItem]
-///  * <https://material.google.com/components/bottom-navigation.html#bottom-navigation-specs>
+///  * <https://material.io/design/components/bottom-navigation.html#specs>
 enum BottomNavigationBarType {
   /// The [BottomNavigationBar]'s [BottomNavigationBarItem]s have fixed width, always
   /// display their text labels, and do not shift when tapped.
@@ -127,7 +127,7 @@ enum BottomNavigationBarType {
 ///
 ///  * [BottomNavigationBarItem]
 ///  * [Scaffold]
-///  * <https://material.google.com/components/bottom-navigation.html>
+///  * <https://material.io/design/components/bottom-navigation.html>
 class BottomNavigationBar extends StatefulWidget {
   /// Creates a bottom navigation bar, typically used in a [Scaffold] where it
   /// is provided as the [Scaffold.bottomNavigationBar] argument.

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -61,7 +61,7 @@ import 'theme.dart';
 ///  * [ButtonBar], to display buttons at the bottom of a card. Typically these
 ///    would be styled using a [ButtonTheme] created with [new ButtonTheme.bar].
 ///  * [showDialog], to display a modal card.
-///  * <https://material.google.com/components/cards.html>
+///  * <https://material.io/design/components/cards.html>
 class Card extends StatelessWidget {
   /// Creates a material design card.
   ///

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -34,8 +34,8 @@ import 'toggleable.dart';
 ///  * [Switch], a widget with semantics similar to [Checkbox].
 ///  * [Radio], for selecting among a set of explicit values.
 ///  * [Slider], for selecting a value in a range.
-///  * <https://material.google.com/components/selection-controls.html#selection-controls-checkbox>
-///  * <https://material.google.com/components/lists-controls.html#lists-controls-types-of-list-controls>
+///  * <https://material.io/design/components/selection-controls.html#checkboxes>
+///  * <https://material.io/design/components/lists.html#types>
 class Checkbox extends StatefulWidget {
   /// Creates a material design checkbox.
   ///

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -57,7 +57,7 @@ const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * [ActionChip], represents an action related to primary content.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 abstract class ChipAttributes {
   // This class is intended to be used as an interface, and should not be
   // extended directly.
@@ -125,7 +125,7 @@ abstract class ChipAttributes {
 ///  * [InputChip], a chip that represents a complex piece of information, such
 ///    as an entity (person, place, or thing) or conversational text, in a
 ///    compact form.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 abstract class DeletableChipAttributes {
   // This class is intended to be used as an interface, and should not be
   // extended directly.
@@ -227,7 +227,7 @@ abstract class DeletableChipAttributes {
 ///  * [ChoiceChip], allows a single selection from a set of options. Choice
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 abstract class SelectableChipAttributes {
   // This class is intended to be used as an interface, and should not be
   // extended directly.
@@ -328,7 +328,7 @@ abstract class SelectableChipAttributes {
 ///  * [ChoiceChip], allows a single selection from a set of options. Choice
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 abstract class DisabledChipAttributes {
   // This class is intended to be used as an interface, and should not be
   // extended directly.
@@ -375,7 +375,7 @@ abstract class DisabledChipAttributes {
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * [ActionChip], represents an action related to primary content.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 abstract class TappableChipAttributes {
   // This class is intended to be used as an interface, and should not be
   // extended directly.
@@ -456,7 +456,7 @@ abstract class TappableChipAttributes {
 ///  * [CircleAvatar], which shows images or initials of entities.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttributes {
   /// Creates a material design chip.
   ///
@@ -574,7 +574,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
 ///  * [CircleAvatar], which shows images or initials of people.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class InputChip extends StatelessWidget
     implements
         ChipAttributes,
@@ -748,7 +748,7 @@ class InputChip extends StatelessWidget
 ///  * [CircleAvatar], which shows images or initials of people.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class ChoiceChip extends StatelessWidget
     implements
         ChipAttributes,
@@ -929,7 +929,7 @@ class ChoiceChip extends StatelessWidget
 ///  * [CircleAvatar], which shows images or initials of people.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class FilterChip extends StatelessWidget
     implements
         ChipAttributes,
@@ -1068,7 +1068,7 @@ class FilterChip extends StatelessWidget
 ///  * [CircleAvatar], which shows images or initials of people.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class ActionChip extends StatelessWidget implements ChipAttributes, TappableChipAttributes {
   /// Create a chip that acts like a button.
   ///
@@ -1170,7 +1170,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
 ///  * [CircleAvatar], which shows images or initials of people.
 ///  * [Wrap], A widget that displays its children in multiple horizontal or
 ///    vertical runs.
-///  * <https://material.google.com/components/chips.html>
+///  * <https://material.io/design/components/chips.html>
 class RawChip extends StatefulWidget
     implements
         ChipAttributes,

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -49,7 +49,7 @@ import 'theme_data.dart';
 ///  * [Chip], for representing users or concepts in long form.
 ///  * [ListTile], which can combine an icon (such as a [CircleAvatar]) with
 ///    some text for a fixed height list entry.
-///  * <https://material.google.com/components/chips.html#chips-contact-chips>
+///  * <https://material.io/design/components/chips.html#input-chips>
 class CircleAvatar extends StatelessWidget {
   /// Creates a circle that represents a user.
   const CircleAvatar({

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -89,7 +89,7 @@ class MaterialAccentColor extends ColorSwatch<int> {
 }
 
 /// [Color] and [ColorSwatch] constants which represent Material design's
-/// [color palette](http://material.google.com/style/color.html).
+/// [color palette](https://material.io/design/color/).
 ///
 /// Instead of using an absolute color from these palettes, consider using
 /// [Theme.of] to obtain the local [ThemeData] structure, which exposes the

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -229,7 +229,7 @@ class DataCell {
 ///  * [DataCell], which contains the data for a single cell in the data table.
 ///  * [PaginatedDataTable], which shows part of the data in a data table and
 ///    provides controls for paging through the remainder of the data.
-///  * <https://material.google.com/components/data-tables.html>
+///  * <https://material.io/design/components/data-tables.html>
 class DataTable extends StatelessWidget {
   /// Creates a widget describing a data table.
   ///

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -33,7 +33,7 @@ import 'theme.dart';
 ///  * [AlertDialog], for dialogs that have a message and some buttons.
 ///  * [SimpleDialog], for dialogs that offer a variety of options.
 ///  * [showDialog], which actually displays the dialog and returns its result.
-///  * <https://material.google.com/components/dialogs.html>
+///  * <https://material.io/design/components/dialogs.html>
 class Dialog extends StatelessWidget {
   /// Creates a dialog.
   ///
@@ -190,7 +190,7 @@ class Dialog extends StatelessWidget {
 ///  * [SimpleDialog], which handles the scrolling of the contents but has no [actions].
 ///  * [Dialog], on which [AlertDialog] and [SimpleDialog] are based.
 ///  * [showDialog], which actually displays the dialog and returns its result.
-///  * <https://material.google.com/components/dialogs.html#dialogs-alerts>
+///  * <https://material.io/design/components/dialogs.html#alert-dialog>
 class AlertDialog extends StatelessWidget {
   /// Creates an alert dialog.
   ///
@@ -402,7 +402,7 @@ class AlertDialog extends StatelessWidget {
 ///  * [showDialog], which actually displays the dialog and returns its result.
 ///  * [FlatButton], which are commonly used as actions in other kinds of
 ///    dialogs, such as [AlertDialog]s.
-///  * <https://material.google.com/components/dialogs.html#dialogs-simple-dialogs>
+///  * <https://material.io/design/components/dialogs.html#simple-dialog>
 class SimpleDialogOption extends StatelessWidget {
   /// Creates an option for a [SimpleDialog].
   const SimpleDialogOption({
@@ -502,7 +502,7 @@ class SimpleDialogOption extends StatelessWidget {
 ///  * [AlertDialog], for dialogs that have a row of buttons below the body.
 ///  * [Dialog], on which [SimpleDialog] and [AlertDialog] are based.
 ///  * [showDialog], which actually displays the dialog and returns its result.
-///  * <https://material.google.com/components/dialogs.html#dialogs-simple-dialogs>
+///  * <https://material.io/design/components/dialogs.html#simple-dialog>
 class SimpleDialog extends StatelessWidget {
   /// Creates a simple dialog.
   ///
@@ -686,7 +686,7 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 ///  * [Dialog], on which [SimpleDialog] and [AlertDialog] are based.
 ///  * [showCupertinoDialog], which displays an iOS-style dialog.
 ///  * [showGeneralDialog], which allows for customization of the dialog popup.
-///  * <https://material.google.com/components/dialogs.html>
+///  * <https://material.io/design/components/dialogs.html>
 Future<T> showDialog<T>({
   @required BuildContext context,
   bool barrierDismissible = true,

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///
 ///  * [PopupMenuDivider], which is the equivalent but for popup menus.
 ///  * [ListTile.divideTiles], another approach to dividing widgets in a list.
-///  * <https://material.google.com/components/dividers.html>
+///  * <https://material.io/design/components/dividers.html>
 class Divider extends StatelessWidget {
   /// Creates a material design divider.
   ///
@@ -136,7 +136,7 @@ class Divider extends StatelessWidget {
 ///
 ///  * [PopupMenuDivider], which is the equivalent but for popup menus.
 ///  * [ListTile.divideTiles], another approach to dividing widgets in a list.
-///  * <https://material.google.com/components/dividers.html>
+///  * <https://material.io/design/components/dividers.html>
 class VerticalDivider extends StatelessWidget {
   /// Creates a material design divider.
   ///

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -30,7 +30,7 @@ enum DrawerAlignment {
 }
 
 // TODO(eseidel): Draw width should vary based on device size:
-// http://material.google.com/layout/structure.html#structure-side-nav
+// https://material.io/design/components/navigation-drawer.html#specs
 
 // Mobile:
 // Width = Screen width − 56 dp
@@ -81,7 +81,7 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 ///  * [Scaffold.of], to obtain the current [ScaffoldState], which manages the
 ///    display and animation of the drawer.
 ///  * [ScaffoldState.openDrawer], which displays its [Drawer], if any.
-///  * <https://material.google.com/patterns/navigation-drawer.html>
+///  * <https://material.io/design/components/navigation-drawer.html>
 class Drawer extends StatelessWidget {
   /// Creates a material design drawer.
   ///

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -23,7 +23,7 @@ const double _kDrawerHeaderHeight = 160.0 + 1.0; // bottom edge
 ///
 ///  * [UserAccountsDrawerHeader], a variant of [DrawerHeader] that is
 ///    specialized for showing user accounts.
-///  * <https://material.google.com/patterns/navigation-drawer.html>
+///  * <https://material.io/design/components/navigation-drawer.html>
 class DrawerHeader extends StatelessWidget {
   /// Creates a material design drawer header.
   ///

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -223,7 +223,7 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     // The maximum height of a simple menu should be one or more rows less than
     // the view height. This ensures a tappable area outside of the simple menu
     // with which to dismiss the menu.
-    //   -- https://material.google.com/components/menus.html#menus-simple-menus
+    //   -- https://material.io/design/components/menus.html#usage
     final double maxHeight = math.max(0.0, constraints.maxHeight - 2 * _kMenuItemHeight);
     // The width of a menu should be at most the view width. This ensures that
     // the menu does not extend past the left and right edges of the screen.
@@ -489,7 +489,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 ///  * [DropdownButtonHideUnderline], which prevents its descendant dropdown buttons
 ///    from displaying their underlines.
 ///  * [RaisedButton], [FlatButton], ordinary buttons that trigger a single action.
-///  * <https://material.google.com/components/buttons.html#buttons-dropdown-buttons>
+///  * <https://material.io/design/components/menus.html#dropdown-menu>
 class DropdownButton<T> extends StatefulWidget {
   /// Creates a dropdown button.
   ///

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -59,7 +59,7 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 /// See also:
 ///
 ///  * [ExpansionPanelList]
-///  * <https://material.google.com/components/expansion-panels.html>
+///  * <https://material.io/design/components/lists.html#types>
 class ExpansionPanel {
   /// Creates an expansion panel to be used as a child for [ExpansionPanelList].
   ///
@@ -114,7 +114,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
 /// See also:
 ///
 ///  * [ExpansionPanel]
-///  * <https://material.google.com/components/expansion-panels.html>
+///  * <https://material.io/design/components/lists.html#types>
 class ExpansionPanelList extends StatefulWidget {
   /// Creates an expansion panel list widget. The [expansionCallback] is
   /// triggered when an expansion panel expand/collapse button is pushed.

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -48,7 +48,7 @@ import 'theme_data.dart';
 ///  * [IconButton], to create buttons that just contain icons.
 ///  * [InkWell], which implements the ink splash part of a flat button.
 ///  * [RawMaterialButton], the widget this widget is based on.
-///  * <https://material.google.com/components/buttons.html>
+///  * <https://material.io/design/components/buttons.html>
 class FlatButton extends MaterialButton {
   /// Create a simple text button.
   const FlatButton({

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -37,7 +37,7 @@ enum CollapseMode {
 ///
 ///  * [SliverAppBar], which implements the expanding and contracting.
 ///  * [AppBar], which is used by [SliverAppBar].
-///  * <https://material.google.com/patterns/scrolling-techniques.html>
+///  * <https://material.io/design/components/app-bars-top.html#behavior>
 class FlexibleSpaceBar extends StatefulWidget {
   /// Creates a flexible space bar.
   ///

--- a/packages/flutter/lib/src/material/grid_tile.dart
+++ b/packages/flutter/lib/src/material/grid_tile.dart
@@ -15,7 +15,7 @@ import 'package:flutter/widgets.dart';
 ///  * [GridView], which is a scrollable grid of tiles.
 ///  * [GridTileBar], which is typically used in either the [header] or
 ///    [footer].
-///  * <https://material.google.com/components/grid-lists.html>
+///  * <https://material.io/design/components/image-lists.html>
 class GridTile extends StatelessWidget {
   /// Creates a grid tile.
   ///

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -17,7 +17,7 @@ import 'theme.dart';
 /// See also:
 ///
 ///  * [GridTile]
-///  * <https://material.google.com/components/grid-lists.html#grid-lists-specs>
+///  * <https://material.io/design/components/image-lists.html#anatomy>
 class GridTileBar extends StatelessWidget {
   /// Creates a grid tile bar.
   ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -211,7 +211,7 @@ enum ListTileControlAffinity {
 ///  * [ListTile.divideTiles], a utility for inserting [Divider]s in between [ListTile]s.
 ///  * [CheckboxListTile], [RadioListTile], and [SwitchListTile], widgets
 ///    that combine [ListTile] with other controls.
-///  * <https://material.google.com/components/lists.html>
+///  * <https://material.io/design/components/lists.html>
 class ListTile extends StatelessWidget {
   /// Creates a list tile.
   ///

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -151,7 +151,7 @@ abstract class MaterialInkController {
 ///
 ///  * [MergeableMaterial], a piece of material that can split and remerge.
 ///  * [Card], a wrapper for a [Material] of [type] [MaterialType.card].
-///  * <https://material.google.com/>
+///  * <https://material.io/design/>
 class Material extends StatefulWidget {
   /// Creates a piece of material.
   ///

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -48,7 +48,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 ///  * [FloatingActionButton], the round button in material applications.
 ///  * [IconButton], to create buttons that just contain icons.
 ///  * [InkWell], which implements the ink splash part of a flat button.
-///  * <https://material.google.com/components/buttons.html>
+///  * <https://material.io/design/components/buttons.html>
 class OutlineButton extends MaterialButton {
   /// Create a filled button.
   ///

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -398,7 +398,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
             child: DefaultTextStyle(
               // These typographic styles aren't quite the regular ones. We pick the closest ones from the regular
               // list and then tweak them appropriately.
-              // See https://material.google.com/components/data-tables.html#data-tables-tables-within-cards
+              // See https://material.io/design/components/data-tables.html#tables-within-cards
               style: _selectedRowCount > 0 ? themeData.textTheme.subhead.copyWith(color: themeData.accentColor)
                                            : themeData.textTheme.title.copyWith(fontWeight: FontWeight.w400),
               child: IconTheme.merge(

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -24,7 +24,7 @@ const int _kIndeterminateLinearDuration = 1800;
 ///
 /// See also:
 ///
-///  * <https://material.google.com/components/progress-activity.html>
+///  * <https://material.io/design/components/progress-indicators.html>
 abstract class ProgressIndicator extends StatefulWidget {
   /// Creates a progress indicator.
   ///
@@ -219,7 +219,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 /// See also:
 ///
 ///  * [CircularProgressIndicator]
-///  * <https://material.google.com/components/progress-activity.html#progress-activity-types-of-indicators>
+///  * <https://material.io/design/components/progress-indicators.html#linear-progress-indicators>
 class LinearProgressIndicator extends ProgressIndicator {
   /// Creates a linear progress indicator.
   ///
@@ -389,7 +389,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 /// See also:
 ///
 ///  * [LinearProgressIndicator]
-///  * <https://material.google.com/components/progress-activity.html#progress-activity-types-of-indicators>
+///  * <https://material.io/design/components/progress-indicators.html#circular-progress-indicators>
 class CircularProgressIndicator extends ProgressIndicator {
   /// Creates a circular progress indicator.
   ///

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -35,7 +35,7 @@ const double _kInnerRadius = 4.5;
 ///    you can give the radio button a label.
 ///  * [Slider], for selecting a value in a range.
 ///  * [Checkbox] and [Switch], for toggling a particular value on or off.
-///  * <https://material.google.com/components/selection-controls.html#selection-controls-radio-button>
+///  * <https://material.io/design/components/selection-controls.html#radio-buttons>
 class Radio<T> extends StatefulWidget {
   /// Creates a material design radio button.
   ///

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -39,7 +39,7 @@ import 'theme_data.dart';
 ///  * [IconButton], to create buttons that just contain icons.
 ///  * [InkWell], which implements the ink splash part of a flat button.
 ///  * [RawMaterialButton], the widget this widget is based on.
-///  * <https://material.google.com/components/buttons.html>
+///  * <https://material.io/design/components/buttons.html>
 class RaisedButton extends MaterialButton {
   /// Create a filled button.
   ///

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -73,7 +73,7 @@ enum _RefreshIndicatorMode {
 ///
 /// See also:
 ///
-///  * <https://material.google.com/patterns/swipe-to-refresh.html>
+///  * <https://material.io/design/platform-guidance/android-swipe-to-refresh.html>
 ///  * [RefreshIndicatorState], can be used to programmatically show the refresh indicator.
 ///  * [RefreshProgressIndicator], widget used by [RefreshIndicator] to show
 ///    the inner circular progress spinner during refreshes.

--- a/packages/flutter/lib/src/material/shadows.dart
+++ b/packages/flutter/lib/src/material/shadows.dart
@@ -6,7 +6,7 @@ import 'dart:ui' show Color, Offset;
 
 import 'package:flutter/painting.dart';
 
-// Based on http://material.google.com/what-is-material/elevation-shadows.html
+// Based on https://material.io/design/environment/elevation.html
 // Currently, only the elevation values that are bound to one or more widgets are
 // defined here.
 
@@ -20,7 +20,7 @@ import 'package:flutter/painting.dart';
 /// See also:
 ///
 ///  * [Material]
-///  * <https://material.google.com/what-is-material/elevation-shadows.html>
+///  * <https://material.io/design/environment/elevation.html>
 const Map<int, List<BoxShadow>> kElevationToShadow = _elevationToShadow; // to hide the literal from the docs
 
 const Color _kKeyUmbraOpacity = Color(0x33000000); // alpha = 0.2

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -85,7 +85,7 @@ typedef SemanticFormatterCallback = String Function(double value);
 ///    the visual appearance of the slider.
 ///  * [Radio], for selecting among a set of explicit values.
 ///  * [Checkbox] and [Switch], for toggling a particular value on or off.
-///  * <https://material.google.com/components/sliders.html>
+///  * <https://material.io/design/components/sliders.html>
 ///  * [MediaQuery], from which the text scale factor is obtained.
 class Slider extends StatefulWidget {
   /// Creates a material design slider.

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -73,7 +73,7 @@ const double _kTriangleHeight = _kStepSize * 0.866025; // Triangle height. sqrt(
 /// See also:
 ///
 ///  * [Stepper]
-///  * <https://material.google.com/components/steppers.html>
+///  * <https://material.io/archive/guidelines/components/steppers.html>
 @immutable
 class Step {
   /// Creates a step for a [Stepper].
@@ -123,7 +123,7 @@ class Step {
 /// See also:
 ///
 ///  * [Step]
-///  * <https://material.google.com/components/steppers.html>
+///  * <https://material.io/archive/guidelines/components/steppers.html>
 class Stepper extends StatefulWidget {
   /// Creates a stepper from a list of steps.
   ///
@@ -676,7 +676,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         throw FlutterError(
           'Steppers must not be nested. The material specification advises '
           'that one should avoid embedding steppers within steppers. '
-          'https://material.google.com/components/steppers.html#steppers-usage\n'
+          'https://material.io/archive/guidelines/components/steppers.html#steppers-usage\n'
         );
       return true;
     }());

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -49,7 +49,7 @@ enum _SwitchType { material, adaptive }
 ///  * [Checkbox], another widget with similar semantics.
 ///  * [Radio], for selecting among a set of explicit values.
 ///  * [Slider], for selecting a value in a range.
-///  * <https://material.google.com/components/selection-controls.html#selection-controls-switch>
+///  * <https://material.io/design/components/selection-controls.html#switches>
 class Switch extends StatefulWidget {
   /// Creates a material design switch.
   ///

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -53,7 +53,7 @@ enum TabBarIndicatorSize {
 ///  * [TabBar], which displays a row of tabs.
 ///  * [TabBarView], which displays a widget for the currently selected tab.
 ///  * [TabController], which coordinates tab selection between a [TabBar] and a [TabBarView].
-///  * <https://material.google.com/components/tabs.html>
+///  * <https://material.io/design/components/tabs.html>
 class Tab extends StatelessWidget {
   /// Creates a material design [TabBar] tab. At least one of [text], [icon],
   /// and [child] must be non-null. The [text] and [child] arguments must not be

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -68,7 +68,7 @@ typedef InputCounterWidgetBuilder = Widget Function(
 ///
 /// See also:
 ///
-///  * <https://material.google.com/components/text-fields.html>
+///  * <https://material.io/design/components/text-fields.html>
 ///  * [TextFormField], which integrates with the [Form] widget.
 ///  * [InputDecorator], which shows the labels and other visual elements that
 ///    surround the actual text editing widget.

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -55,7 +55,7 @@ import 'theme.dart';
 ///
 /// See also:
 ///
-///  * <https://material.google.com/components/text-fields.html>
+///  * <https://material.io/design/components/text-fields.html>
 ///  * [TextField], which is the underlying text field without the [Form]
 ///    integration.
 ///  * [InputDecorator], which shows the labels and other visual elements that

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -93,7 +93,7 @@ import 'typography.dart';
 ///  * [Typography], the class that generates [TextTheme]s appropriate for a platform.
 ///  * [Theme], for other aspects of a material design application that can be
 ///    globally adjusted, such as the color scheme.
-///  * <http://material.google.com/style/typography.html>
+///  * <https://material.io/design/typography/>
 @immutable
 class TextTheme extends Diagnosticable {
   /// Creates a text theme that uses the given values.
@@ -102,7 +102,7 @@ class TextTheme extends Diagnosticable {
   /// or [Typography.white], which implement the typography styles in the
   /// material design specification:
   ///
-  /// <https://material.google.com/style/typography.html#typography-styles>
+  /// <https://material.io/design/typography/#type-scale>
   ///
   /// If you do decide to create your own text theme, consider using one of
   /// those predefined themes as a starting point for [copyWith] or [apply].

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -104,7 +104,7 @@ class ThemeData extends Diagnosticable {
   ///    ([accentColorBrightness]), so that the right contrasting text
   ///    color will be used over the accent color.
   ///
-  /// See <https://material.google.com/style/color.html> for
+  /// See <https://material.io/design/color/> for
   /// more discussion on how to pick the right colors.
   factory ThemeData({
     Brightness brightness,
@@ -532,7 +532,7 @@ class ThemeData extends Diagnosticable {
 
   /// The color of the header of a [PaginatedDataTable] when there are selected rows.
   // According to the spec for data tables:
-  // https://material.google.com/components/data-tables.html#data-tables-tables-within-cards
+  // https://material.io/archive/guidelines/components/data-tables.html#data-tables-tables-within-cards
   // ...this should be the "50-value of secondary app color".
   final Color secondaryHeaderColor;
 

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -32,7 +32,7 @@ const Duration _kShowDuration = Duration(milliseconds: 1500);
 ///
 /// See also:
 ///
-///  * <https://material.google.com/components/tooltips.html>
+///  * <https://material.io/design/components/tooltips.html>
 class Tooltip extends StatefulWidget {
   /// Creates a tooltip.
   ///

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -296,7 +296,7 @@ class _AccountDetailsLayout extends MultiChildLayoutDelegate {
 /// See also:
 ///
 ///  * [DrawerHeader], for a drawer header that doesn't show user accounts.
-///  * <https://material.google.com/patterns/navigation-drawer.html>
+///  * <https://material.io/design/components/navigation-drawer.html#anatomy>
 class UserAccountsDrawerHeader extends StatefulWidget {
   /// Creates a material design drawer header.
   ///

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -15,7 +15,7 @@ import 'framework.dart';
 /// See also:
 ///
 ///  * [BottomNavigationBar]
-///  * <https://material.google.com/components/bottom-navigation.html>
+///  * <https://material.io/design/components/bottom-navigation.html>
 ///  * [CupertinoTabBar]
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/bars/tab-bars>
 class BottomNavigationBarItem {


### PR DESCRIPTION
I checked all links to `material.google.com` and updated/fixed them after understanding the context.

In some cases, the only possible link was from `https://material.io/archive/` (Example: [Steppers](https://material.io/archive/guidelines/components/steppers.html)).
In some other cases, the link was for Android even though the component is available for both Android and iOS (Example: [Swipe to refresh](https://material.io/design/platform-guidance/android-swipe-to-refresh.html)).

Fixes #19060 
Fixes #22863