### PR TITLE
Make reassemble public

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1028,26 +1028,8 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   @mustCallSuper
   @protected
   void didUpdateWidget(covariant T oldWidget) { }
-
-  /// Called whenever the application is reassembled during debugging, for
-  /// example during hot reload.
-  ///
-  /// This method should rerun any initialization logic that depends on global
-  /// state, for example, image loading from asset bundles (since the asset
-  /// bundle may have changed).
-  ///
-  /// In addition to this method being invoked, it is guaranteed that the
-  /// [build] method will be invoked when a reassemble is signaled. Most
-  /// widgets therefore do not need to do anything in the [reassemble] method.
-  ///
-  /// This function will only be called during development. In release builds,
-  /// the `ext.flutter.reassemble` hook is not available, and so this code will
-  /// never execute.
-  ///
-  /// See also:
-  ///
-  ///  * [BindingBase.reassembleApplication]
-  ///  * [Image], which uses this to reload images.
+  
+  /// {@macro flutter.widgets.reassemble}
   @protected
   @mustCallSuper
   void reassemble() { }
@@ -2594,7 +2576,27 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   bool _active = false;
 
-  /// Called when a hot-reload is triggered.
+  /// {@template flutter.widgets.reassemble}
+  /// Called whenever the application is reassembled during debugging, for
+  /// example during hot reload.
+  ///
+  /// This method should rerun any initialization logic that depends on global
+  /// state, for example, image loading from asset bundles (since the asset
+  /// bundle may have changed).
+  ///
+  /// In addition to this method being invoked, it is guaranteed that the
+  /// [build] method will be invoked when a reassemble is signaled. Most
+  /// widgets therefore do not need to do anything in the [reassemble] method.
+  ///
+  /// This function will only be called during development. In release builds,
+  /// the `ext.flutter.reassemble` hook is not available, and so this code will
+  /// never execute.
+  ///
+  /// See also:
+  ///
+  ///  * [BindingBase.reassembleApplication]
+  ///  * [Image], which uses this to reload images.
+  /// {@endtemplate}
   @mustCallSuper
   @protected
   void reassemble() {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1028,15 +1028,15 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   @mustCallSuper
   @protected
   void didUpdateWidget(covariant T oldWidget) { }
-  
+
   /// {@macro flutter.widgets.reassemble}
-  /// 
+  ///
   /// In addition to this method being invoked, it is guaranteed that the
   /// [build] method will be invoked when a reassemble is signaled. Most
   /// widgets therefore do not need to do anything in the [reassemble] method.
   ///
   /// See also:
-  /// 
+  ///
   ///  * [Element.reassemble]
   ///  * [BindingBase.reassembleApplication]
   ///  * [Image], which uses this to reload images.
@@ -2598,9 +2598,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// the `ext.flutter.reassemble` hook is not available, and so this code will
   /// never execute.
   /// {@endtemplate}
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [State.reassemble]
   ///  * [BindingBase.reassembleApplication]
   ///  * [Image], which uses this to reload images.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1030,6 +1030,16 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   void didUpdateWidget(covariant T oldWidget) { }
   
   /// {@macro flutter.widgets.reassemble}
+  /// 
+  /// In addition to this method being invoked, it is guaranteed that the
+  /// [build] method will be invoked when a reassemble is signaled. Most
+  /// widgets therefore do not need to do anything in the [reassemble] method.
+  ///
+  /// See also:
+  /// 
+  ///  * [Element.reassemble]
+  ///  * [BindingBase.reassembleApplication]
+  ///  * [Image], which uses this to reload images.
   @protected
   @mustCallSuper
   void reassemble() { }
@@ -2584,19 +2594,16 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// state, for example, image loading from asset bundles (since the asset
   /// bundle may have changed).
   ///
-  /// In addition to this method being invoked, it is guaranteed that the
-  /// [build] method will be invoked when a reassemble is signaled. Most
-  /// widgets therefore do not need to do anything in the [reassemble] method.
-  ///
   /// This function will only be called during development. In release builds,
   /// the `ext.flutter.reassemble` hook is not available, and so this code will
   /// never execute.
-  ///
+  /// {@endtemplate}
+  /// 
   /// See also:
-  ///
+  /// 
+  ///  * [State.reassemble]
   ///  * [BindingBase.reassembleApplication]
   ///  * [Image], which uses this to reload images.
-  /// {@endtemplate}
   @mustCallSuper
   @protected
   void reassemble() {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -21,7 +21,6 @@ export 'package:flutter/foundation.dart' show
   protected,
   required,
   visibleForTesting;
-
 export 'package:flutter/foundation.dart' show FlutterError, debugPrint, debugPrintStack;
 export 'package:flutter/foundation.dart' show VoidCallback, ValueChanged, ValueGetter, ValueSetter;
 export 'package:flutter/foundation.dart' show DiagnosticLevel;
@@ -2467,7 +2466,7 @@ class BuildOwner {
     try {
       assert(root._parent == null);
       assert(root.owner == this);
-      root._reassemble();
+      root.reassemble();
     } finally {
       Timeline.finishSync();
     }
@@ -2595,11 +2594,13 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   bool _active = false;
 
+  /// Called when a hot-reload is triggered.
   @mustCallSuper
-  void _reassemble() {
+  @protected
+  void reassemble() {
     markNeedsBuild();
     visitChildren((Element child) {
-      child._reassemble();
+      child.reassemble();
     });
   }
 
@@ -3817,9 +3818,9 @@ class StatefulElement extends ComponentElement {
   State<StatefulWidget> _state;
 
   @override
-  void _reassemble() {
+  void reassemble() {
     state.reassemble();
-    super._reassemble();
+    super.reassemble();
   }
 
   @override


### PR DESCRIPTION
`_reassemble` of `Element` made public

That allows [flutter_hooks](https://github.com/rrousselGit/flutter_hooks) to fully implement its `HookElement` without having a dependency on `StatefulElement`.

It matters because the `StatefulElement` dependency makes `HookWidget` create a `State` for no reason.

This both makes an unused object and pollute `debugFillProperties`. 