### PR TITLE
Fix immediately overriding the user's chosen AM/PM selection

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -360,7 +360,11 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
   // range from 1-24.
   int selectedHour;
 
-  // The previous selection index of the hour column
+  // The previous selection index of the hour column.
+  //
+  // This ranges from 0-23 even if [widget.use24hFormat] is false. As a result,
+  // it can be used for determining if we just changed from AM -> PM or vice
+  // versa.
   int previousHourIndex;
 
   // The current selection of the minute picker. Values range from 0 to 59.

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -342,25 +342,37 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
   int textDirectionFactor;
   CupertinoLocalizations localizations;
 
-  // Alignment based on text direction. The variable name is self descriptive,
-  // however, when text direction is rtl, alignment is reversed.
+  /// Alignment based on text direction. The variable name is self descriptive,
+  /// however, when text direction is rtl, alignment is reversed.
   Alignment alignCenterLeft;
   Alignment alignCenterRight;
 
-  // Read this out when the state is initially created. Changes in initialDateTime
-  // in the widget after first build is ignored.
+  /// Read this out when the state is initially created. Changes in initialDateTime
+  /// in the widget after first build is ignored.
   DateTime initialDateTime;
 
-  // The currently selected values of the date picker.
-  int selectedDayFromInitial; // The difference in days between the initial date and the currently selected date.
-  int selectedHour;
-  int selectedMinute;
-  int selectedAmPm; // 0 means AM, 1 means PM.
+  /// The difference in days between the initial date and the currently selected date.
+  int selectedDayFromInitial;
 
-  // The controller of the AM/PM column.
+  /// The current selection of the hour picker.
+  ///
+  /// If [widget.use24hFormat] is true, values range from 1-12. Otherwise values
+  /// range from 1-24.
+  int selectedHour;
+
+  /// The current selection of the minute picker. Values range from 0 to 59.
+  int selectedMinute;
+
+  /// The current selection of the AM/PM picker.
+  ///
+  /// - 0 means AM
+  /// - 1 means PM
+  int selectedAmPm;
+
+  /// The controller of the AM/PM column.
   FixedExtentScrollController amPmController;
 
-  // Estimated width of columns.
+  /// The estimated width of columns.
   final Map<int, double> estimatedColumnWidths = <int, double>{};
 
   @override

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -360,6 +360,9 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
   /// range from 1-24.
   int selectedHour;
 
+  /// The previous value of [selectedHour].
+  int prevSelectedHour;
+
   /// The current selection of the minute picker. Values range from 0 to 59.
   int selectedMinute;
 
@@ -486,24 +489,27 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       magnification: _kMagnification,
       backgroundColor: _kBackgroundColor,
       onSelectedItemChanged: (int index) {
+        prevSelectedHour = selectedHour;
+
         if (widget.use24hFormat) {
           selectedHour = index;
           widget.onDateTimeChanged(_getDateTime());
-        }
-        else {
+        } else {
           selectedHour = index % 12;
 
-          final int currentHourIn24h = selectedHour + selectedAmPm * 12;
           // Automatically scrolls the am/pm column when the hour column value
-          // goes far enough. This behavior is similar to
-          // iOS picker version.
+          // goes far enough.
 
-          if (currentHourIn24h ~/ 12 != index ~/ 12) {
+          if (
+            (prevSelectedHour == 0 && selectedHour == 11) ||
+            (prevSelectedHour == 11 && selectedHour == 0)
+          ) {
+            // Animation values obtained by comparing with iOS version.
             amPmController.animateToItem(
               1 - amPmController.selectedItem,
-              duration: const Duration(milliseconds: 300), // Set by comparing with iOS version.
+              duration: const Duration(milliseconds: 300),
               curve: Curves.easeOut,
-            ); // Set by comparing with iOS version.
+            );
           }
           else {
             widget.onDateTimeChanged(_getDateTime());

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -500,10 +500,10 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
           // Automatically scrolls the am/pm column when the hour column value
           // goes far enough.
 
-          if (
-            ((previousHourIndex >= 0 && previousHourIndex <= 11) && (index >= 12 && index <= 23)) ||
-            ((previousHourIndex >= 12 && previousHourIndex <= 23) && (index >= 0 && index <= 11))
-          ) {
+          final bool wasAm = previousHourIndex >=0 && previousHourIndex <= 11;
+          final bool isAm = index >= 0 && index <= 11;
+
+          if (wasAm != isAm) {
               // Animation values obtained by comparing with iOS version.
               amPmController.animateToItem(
                 1 - amPmController.selectedItem,

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -508,12 +508,12 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
           final bool isAm = index >= 0 && index <= 11;
 
           if (wasAm != isAm) {
-              // Animation values obtained by comparing with iOS version.
-              amPmController.animateToItem(
-                1 - amPmController.selectedItem,
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOut,
-              );
+            // Animation values obtained by comparing with iOS version.
+            amPmController.animateToItem(
+              1 - amPmController.selectedItem,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeOut,
+            );
           }
           else {
             widget.onDateTimeChanged(_getDateTime());

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -342,40 +342,40 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
   int textDirectionFactor;
   CupertinoLocalizations localizations;
 
-  /// Alignment based on text direction. The variable name is self descriptive,
-  /// however, when text direction is rtl, alignment is reversed.
+  // Alignment based on text direction. The variable name is self descriptive,
+  // however, when text direction is rtl, alignment is reversed.
   Alignment alignCenterLeft;
   Alignment alignCenterRight;
 
-  /// Read this out when the state is initially created. Changes in initialDateTime
-  /// in the widget after first build is ignored.
+  // Read this out when the state is initially created. Changes in initialDateTime
+  // in the widget after first build is ignored.
   DateTime initialDateTime;
 
-  /// The difference in days between the initial date and the currently selected date.
+  // The difference in days between the initial date and the currently selected date.
   int selectedDayFromInitial;
 
-  /// The current selection of the hour picker.
-  ///
-  /// If [widget.use24hFormat] is true, values range from 1-12. Otherwise values
-  /// range from 1-24.
+  // The current selection of the hour picker.
+  //
+  // If [widget.use24hFormat] is true, values range from 1-12. Otherwise values
+  // range from 1-24.
   int selectedHour;
 
-  /// The previous selection index of the hour column
+  // The previous selection index of the hour column
   int previousHourIndex;
 
-  /// The current selection of the minute picker. Values range from 0 to 59.
+  // The current selection of the minute picker. Values range from 0 to 59.
   int selectedMinute;
 
-  /// The current selection of the AM/PM picker.
-  ///
-  /// - 0 means AM
-  /// - 1 means PM
+  // The current selection of the AM/PM picker.
+  //
+  // - 0 means AM
+  // - 1 means PM
   int selectedAmPm;
 
-  /// The controller of the AM/PM column.
+  // The controller of the AM/PM column.
   FixedExtentScrollController amPmController;
 
-  /// The estimated width of columns.
+  // The estimated width of columns.
   final Map<int, double> estimatedColumnWidths = <int, double>{};
 
   @override

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -491,12 +491,14 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
           widget.onDateTimeChanged(_getDateTime());
         }
         else {
+          selectedHour = index % 12;
+
           final int currentHourIn24h = selectedHour + selectedAmPm * 12;
           // Automatically scrolls the am/pm column when the hour column value
           // goes far enough. This behavior is similar to
           // iOS picker version.
+
           if (currentHourIn24h ~/ 12 != index ~/ 12) {
-            selectedHour = index % 12;
             amPmController.animateToItem(
               1 - amPmController.selectedItem,
               duration: const Duration(milliseconds: 300), // Set by comparing with iOS version.
@@ -504,7 +506,6 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
             ); // Set by comparing with iOS version.
           }
           else {
-            selectedHour = index % 12;
             widget.onDateTimeChanged(_getDateTime());
           }
         }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -360,8 +360,8 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
   /// range from 1-24.
   int selectedHour;
 
-  /// The previous value of [selectedHour].
-  int prevSelectedHour;
+  /// The previous selection index of the hour column
+  int previousHourIndex;
 
   /// The current selection of the minute picker. Values range from 0 to 59.
   int selectedMinute;
@@ -395,6 +395,8 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
 
       amPmController = FixedExtentScrollController(initialItem: selectedAmPm);
     }
+
+    previousHourIndex = selectedHour;
   }
 
   @override
@@ -489,8 +491,6 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       magnification: _kMagnification,
       backgroundColor: _kBackgroundColor,
       onSelectedItemChanged: (int index) {
-        prevSelectedHour = selectedHour;
-
         if (widget.use24hFormat) {
           selectedHour = index;
           widget.onDateTimeChanged(_getDateTime());
@@ -501,20 +501,22 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
           // goes far enough.
 
           if (
-            (prevSelectedHour == 0 && selectedHour == 11) ||
-            (prevSelectedHour == 11 && selectedHour == 0)
+            ((previousHourIndex >= 0 && previousHourIndex <= 11) && (index >= 12 && index <= 23)) ||
+            ((previousHourIndex >= 12 && previousHourIndex <= 23) && (index >= 0 && index <= 11))
           ) {
-            // Animation values obtained by comparing with iOS version.
-            amPmController.animateToItem(
-              1 - amPmController.selectedItem,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOut,
-            );
+              // Animation values obtained by comparing with iOS version.
+              amPmController.animateToItem(
+                1 - amPmController.selectedItem,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOut,
+              );
           }
           else {
             widget.onDateTimeChanged(_getDateTime());
           }
         }
+
+        previousHourIndex = index;
       },
       children: List<Widget>.generate(24, (int index) {
         int hour = index;

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -356,8 +356,8 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
 
   // The current selection of the hour picker.
   //
-  // If [widget.use24hFormat] is true, values range from 1-12. Otherwise values
-  // range from 1-24.
+  // If [widget.use24hFormat] is true, values range from 1-24. Otherwise values
+  // range from 1-12.
   int selectedHour;
 
   // The previous selection index of the hour column.

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -7,6 +7,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// scrolling by this offset will move the picker to the next item
+const Offset _kRowOffset = Offset(0.0, -32.0);
+
 void main() {
   group('Countdown timer picker', () {
     testWidgets('onTimerDurationChanged is not null', (WidgetTester tester) async {
@@ -541,6 +544,57 @@ void main() {
       );
     });
 
+    testWidgets('picker persists am/pm value when scrolling hours', (WidgetTester tester) async {
+      DateTime date;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: SizedBox(
+            height: 400.0,
+            width: 400.0,
+            child: CupertinoDatePicker(
+              mode: CupertinoDatePickerMode.time,
+              onDateTimeChanged: (DateTime newDate) {
+                date = newDate;
+              },
+              initialDateTime: DateTime(2019, 1, 1, 3),
+            ),
+          ),
+        ),
+      );
+
+      // 3:00 -> 15:00
+
+      await tester.drag(find.text('AM'), _kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 15));
+
+      // 15:00 -> 16:00
+
+      await tester.drag(find.text('3'), _kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 16));
+
+      // 16:00 -> 4:00
+
+      await tester.drag(find.text('PM'), -_kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 4));
+
+      // 4:00 -> 3:00
+
+      await tester.drag(find.text('4'), -_kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 3));
+    });
+
     testWidgets('picker automatically scrolls the am/pm column when the hour column changes enough', (WidgetTester tester) async {
       DateTime date;
       await tester.pumpWidget(
@@ -559,12 +613,9 @@ void main() {
         ),
       );
 
-      // scrolling by this offset will increase the hour column by 1
-      const Offset hourOffset = Offset(0.0, -32.0);
-
       // 11:59 -> 12:59
 
-      await tester.drag(find.text('11'), hourOffset);
+      await tester.drag(find.text('11'), _kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -572,7 +623,7 @@ void main() {
 
       // 12:59 -> 11:59
 
-      await tester.drag(find.text('12'), -hourOffset);
+      await tester.drag(find.text('12'), -_kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -580,7 +631,7 @@ void main() {
 
       // 11:59 -> 9:59
 
-      await tester.drag(find.text('11'), -hourOffset * 2);
+      await tester.drag(find.text('11'), -_kRowOffset * 2);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -588,7 +639,7 @@ void main() {
 
       // 9:59 -> 15:59
 
-      await tester.drag(find.text('9'), hourOffset * 6);
+      await tester.drag(find.text('9'), _kRowOffset * 6);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -559,25 +559,36 @@ void main() {
         ),
       );
 
-      await tester.drag(find.text('11'), const Offset(0.0, -32.0));
+      // scrolling by this offset will increase the hour column by 1
+      const Offset hourOffset = Offset(0.0, -32.0);
+
+      // 11:59 -> 12:59
+
+      await tester.drag(find.text('11'), hourOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       expect(date, DateTime(2018, 1, 1, 12, 59));
 
-      await tester.drag(find.text('12'), const Offset(0.0, 32.0));
+      // 12:59 -> 11:59
+
+      await tester.drag(find.text('12'), -hourOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       expect(date, DateTime(2018, 1, 1, 11, 59));
 
-      await tester.drag(find.text('11'), const Offset(0.0, 64.0));
+      // 11:59 -> 9:59
+
+      await tester.drag(find.text('11'), -hourOffset * 2);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       expect(date, DateTime(2018, 1, 1, 9, 59));
 
-      await tester.drag(find.text('9'), const Offset(0.0, -192.0));
+      // 9:59 -> 15:59
+
+      await tester.drag(find.text('9'), hourOffset * 6);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -563,7 +563,6 @@ void main() {
       );
 
       // 3:00 -> 15:00
-
       await tester.drag(find.text('AM'), _kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -571,7 +570,6 @@ void main() {
       expect(date, DateTime(2019, 1, 1, 15));
 
       // 15:00 -> 16:00
-
       await tester.drag(find.text('3'), _kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -579,7 +577,6 @@ void main() {
       expect(date, DateTime(2019, 1, 1, 16));
 
       // 16:00 -> 4:00
-
       await tester.drag(find.text('PM'), -_kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -587,7 +584,6 @@ void main() {
       expect(date, DateTime(2019, 1, 1, 4));
 
       // 4:00 -> 3:00
-
       await tester.drag(find.text('4'), -_kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -614,7 +610,6 @@ void main() {
       );
 
       // 11:59 -> 12:59
-
       await tester.drag(find.text('11'), _kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -622,7 +617,6 @@ void main() {
       expect(date, DateTime(2018, 1, 1, 12, 59));
 
       // 12:59 -> 11:59
-
       await tester.drag(find.text('12'), -_kRowOffset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -630,7 +624,6 @@ void main() {
       expect(date, DateTime(2018, 1, 1, 11, 59));
 
       // 11:59 -> 9:59
-
       await tester.drag(find.text('11'), -_kRowOffset * 2);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -638,7 +631,6 @@ void main() {
       expect(date, DateTime(2018, 1, 1, 9, 59));
 
       // 9:59 -> 15:59
-
       await tester.drag(find.text('9'), _kRowOffset * 6);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));


### PR DESCRIPTION
This fixes the problem where the user has manually set their AM/PM selection, but then scroll to a different hour in the same 12-hour range and have their AM/PM selection reverted to the previous value.