### PR TITLE
TextView was not scrolling into view when autoselecting the text upon focus

### DIFF
--- a/dev/integration_tests/ui/lib/keyboard_textfield.dart
+++ b/dev/integration_tests/ui/lib/keyboard_textfield.dart
@@ -33,6 +33,9 @@ class _MyHomePageState extends State<MyHomePage> {
   final ScrollController _controller = ScrollController();
   double offset = 0.0;
 
+  TextEditingController _textEditingController;
+  FocusNode _focusNode;
+
   @override
   void initState() {
     super.initState();
@@ -41,6 +44,22 @@ class _MyHomePageState extends State<MyHomePage> {
         offset = _controller.offset;
       });
     });
+    _textEditingController = TextEditingController(
+      text: 'initial value',
+    );
+    _focusNode = FocusNode();
+    _focusNode.addListener(() {
+      if (_focusNode.hasFocus) {
+        _textEditingController.selection = TextSelection(baseOffset: 0, extentOffset: _textEditingController.text.length);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    _textEditingController.dispose();
+    super.dispose();
   }
 
   @override
@@ -59,8 +78,20 @@ class _MyHomePageState extends State<MyHomePage> {
                 Container(
                   height: MediaQuery.of(context).size.height,
                 ),
+                RaisedButton(
+                  key: const ValueKey<String>(keys.kDismissButton),
+                  child: const Text('Dismiss Keyboard'),
+                  onPressed: () {
+                    FocusScope.of(context).requestFocus(FocusNode());
+                  },
+                ),
                 const TextField(
                   key: ValueKey<String>(keys.kDefaultTextField),
+                ),
+                TextField(
+                  key: const ValueKey<String>(keys.kAutoSelectTextField),
+                  controller: _textEditingController,
+                  focusNode: _focusNode,
                 ),
               ],
             ),

--- a/dev/integration_tests/ui/lib/keys.dart
+++ b/dev/integration_tests/ui/lib/keys.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 const String kDefaultTextField = 'default_textfield';
+const String kAutoSelectTextField = 'auto_select_textfield';
+const String kDismissButton = 'dismiss_button';
 const String kHeightText = 'height_text';
 const String kUnfocusButton = 'unfocus_button';
 const String kOffsetText = 'offset_text';

--- a/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
+++ b/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
@@ -26,6 +26,8 @@ void main() {
 
       final SerializableFinder listViewFinder = find.byValueKey(keys.kListView);
       final SerializableFinder textFieldFinder = find.byValueKey(keys.kDefaultTextField);
+      final SerializableFinder autoSelectTextFieldFinder = find.byValueKey(keys.kAutoSelectTextField);
+      final SerializableFinder dismissButtonFinder = find.byValueKey(keys.kDismissButton);
       final SerializableFinder offsetFinder = find.byValueKey(keys.kOffsetText);
 
       // Align TextField with bottom edge to ensure it would be covered when keyboard comes up.
@@ -49,6 +51,32 @@ void main() {
 
       // Ensure the scroll offset changed appropriately when TextField scrolled back into view.
       expect(scrollOffsetWithKeyboard, greaterThan(scrollOffsetWithoutKeyboard));
+
+      // now do the same for the TextField with auto select
+      await driver.tap(dismissButtonFinder);
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      await driver.scrollUntilVisible(
+        listViewFinder,
+        autoSelectTextFieldFinder,
+        alignment: 1.0,
+        dyScroll: -20.0,
+      );
+      await driver.waitFor(autoSelectTextFieldFinder);
+      final double autoSelectScrollOffsetWithoutKeyboard = double.parse(await driver.getText(offsetFinder));
+
+      // Bring up keyboard
+      await driver.tap(autoSelectTextFieldFinder);
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      // Ensure that TextField is visible again
+      await driver.waitFor(autoSelectTextFieldFinder);
+      final double autoSelectScrollOffsetWithKeyboard = double.parse(await driver.getText(offsetFinder));
+
+      // Ensure the scroll offset changed appropriately when TextField scrolled back into view.
+      expect(autoSelectScrollOffsetWithKeyboard, greaterThan(autoSelectScrollOffsetWithoutKeyboard));
+
+
     });
   });
 }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -921,10 +921,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       final Rect newCaretRect = _getCaretRectAtScrollOffset(rectToScrollTo, scrollOffsetForCaret);
       // Enlarge newCaretRect by scrollPadding to ensure that caret is not positioned directly at the edge after scrolling.
       final Rect inflatedRect = Rect.fromLTRB(
-        newCaretRect.left - widget.scrollPadding.left,
-        newCaretRect.top - widget.scrollPadding.top,
-        newCaretRect.right + widget.scrollPadding.right,
-        newCaretRect.bottom + widget.scrollPadding.bottom
+          newCaretRect.left - widget.scrollPadding.left,
+          newCaretRect.top - widget.scrollPadding.top,
+          newCaretRect.right + widget.scrollPadding.right,
+          newCaretRect.bottom + widget.scrollPadding.bottom
       );
       _editableKey.currentContext.findRenderObject().showOnScreen(
         rect: inflatedRect,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -911,7 +911,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if ((_currentCaretRect == null && _selectionOverlay == null) || !_scrollController.hasClients){
         return;
       }
-      final rectToScrollTo = _currentCaretRect ?? _selectionOverlay.renderObject.getLocalRectForCaret(TextPosition(offset: 0));
+      final Rect rectToScrollTo = _currentCaretRect ?? _selectionOverlay.renderObject.getLocalRectForCaret(const TextPosition(offset: 0));
       final double scrollOffsetForCaret =  _getScrollOffsetForCaret(rectToScrollTo);
       _scrollController.animateTo(
         scrollOffsetForCaret,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -908,22 +908,23 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _showCaretOnScreenScheduled = true;
     SchedulerBinding.instance.addPostFrameCallback((Duration _) {
       _showCaretOnScreenScheduled = false;
-      if (_currentCaretRect == null || !_scrollController.hasClients){
+      if ((_currentCaretRect == null && _selectionOverlay == null) || !_scrollController.hasClients){
         return;
       }
-      final double scrollOffsetForCaret =  _getScrollOffsetForCaret(_currentCaretRect);
+      final rectToScrollTo = _currentCaretRect ?? _selectionOverlay.renderObject.getLocalRectForCaret(TextPosition(offset: 0));
+      final double scrollOffsetForCaret =  _getScrollOffsetForCaret(rectToScrollTo);
       _scrollController.animateTo(
         scrollOffsetForCaret,
         duration: _caretAnimationDuration,
         curve: _caretAnimationCurve,
       );
-      final Rect newCaretRect = _getCaretRectAtScrollOffset(_currentCaretRect, scrollOffsetForCaret);
+      final Rect newCaretRect = _getCaretRectAtScrollOffset(rectToScrollTo, scrollOffsetForCaret);
       // Enlarge newCaretRect by scrollPadding to ensure that caret is not positioned directly at the edge after scrolling.
       final Rect inflatedRect = Rect.fromLTRB(
-          newCaretRect.left - widget.scrollPadding.left,
-          newCaretRect.top - widget.scrollPadding.top,
-          newCaretRect.right + widget.scrollPadding.right,
-          newCaretRect.bottom + widget.scrollPadding.bottom
+        newCaretRect.left - widget.scrollPadding.left,
+        newCaretRect.top - widget.scrollPadding.top,
+        newCaretRect.right + widget.scrollPadding.right,
+        newCaretRect.bottom + widget.scrollPadding.bottom
       );
       _editableKey.currentContext.findRenderObject().showOnScreen(
         rect: inflatedRect,
@@ -932,7 +933,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       );
     });
   }
-
+  
   double _lastBottomViewInset;
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -933,7 +933,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       );
     });
   }
-  
+
   double _lastBottomViewInset;
 
   @override


### PR DESCRIPTION
Normally, a TextField inside a SingleChildScrollView scrolls into view when the keyboard appears after getting focus. It fails to scroll into view under these conditions:

- The TextField has a TextEditingController with an initial value.
- The TextField has a FocusNode that immediately makes a text selection upon focus.

This prevents the caret from ever showing. The scroll-into-view algorithm depends on the caret's rect. I created an integration test that fails without this fix. 

I could not write unit tests as I don't fully get what's going on in https://github.com/flutter/flutter/blob/ad2e3eb3b54839f73c5f2b193675e7979e77bd47/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart

Adding the initial value code to the TextEditingController/FocusNode in those tests break the tests, but my fix won't make them pass. Probably should file an issue?

I also demonstrated this bug in https://github.com/gazialankus/focus_scroll_bug