### PR TITLE
Refactor logic to get plugins path for android studio in mac

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -106,7 +106,7 @@ Future<GradleProject> _readGradleProject() async {
       environment: _gradleEnv,
     );
     final RunResult tasksRunResult = await runCheckedAsync(
-      <String>[gradle, 'app:tasks', '--all'],
+      <String>[gradle, 'app:tasks', '--all', '--console=auto'],
       workingDirectory: flutterProject.android.hostAppGradleRoot.path,
       environment: _gradleEnv,
     );

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -106,7 +106,7 @@ Future<GradleProject> _readGradleProject() async {
       environment: _gradleEnv,
     );
     final RunResult tasksRunResult = await runCheckedAsync(
-      <String>[gradle, 'app:tasks', '--all', '--console=auto'],
+      <String>[gradle, 'app:tasks', '--all'],
       workingDirectory: flutterProject.android.hostAppGradleRoot.path,
       environment: _gradleEnv,
     );

--- a/packages/flutter_tools/lib/src/ios/plist_utils.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_utils.dart
@@ -25,9 +25,13 @@ String getValueFromFile(String plistFilePath, String key) {
   final String normalizedPlistPath = fs.path.withoutExtension(fs.path.absolute(plistFilePath));
 
   try {
-    final String value = runCheckedSync(<String>[
-      executable, 'read', normalizedPlistPath, key
-    ]);
+    final List<String> args = <String>[
+      executable, 'read', normalizedPlistPath
+    ];
+    if (key != null && key.isNotEmpty){
+      args.add(key);
+    }
+    final String value = runCheckedSync(args);
     return value.isEmpty ? null : value;
   } catch (error) {
     return null;


### PR DESCRIPTION
Refactor logic to get plugins path for android studio in Mac.
This will fix https://github.com/flutter/flutter/issues/26928
It's better to use 'idea.paths.selector' from Info.plist instead of combine major/minor version.
See: https://github.com/JetBrains/intellij-community/blob/master/platform/util/src/com/intellij/openapi/application/PathManager.java