### PR TITLE
Use site-shared as canonical source for Flutter logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# <img src="https://flutter.io/images/flutter-mark-square-100.png" alt="Flutter" width="40" height="40" /> Flutter [![Join Gitter Chat Channel -](https://badges.gitter.im/flutter/flutter.svg)](https://gitter.im/flutter/flutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status - Cirrus](https://api.cirrus-ci.com/github/flutter/flutter.svg)](https://cirrus-ci.com/github/flutter/flutter/master)
+# Flutter ![Flutter logo][]
+
+[![Join Gitter Chat Channel -](https://badges.gitter.im/flutter/flutter.svg)](https://gitter.im/flutter/flutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status - Cirrus](https://api.cirrus-ci.com/github/flutter/flutter.svg)](https://cirrus-ci.com/github/flutter/flutter/master)
 
 # Build beautiful native apps in record time
 
@@ -141,4 +144,5 @@ Join us in our [Gitter chat room](https://gitter.im/flutter/flutter) or join our
 
 To join the team working on Flutter, see our [contributor guide](CONTRIBUTING.md).
 
-[flutter.io]: https://flutter.io/
+[flutter.io]: https://flutter.io
+[Flutter logo]: https://github.com/dart-lang/site-shared/blob/master/src/_assets/image/flutter/icon/64.png?raw=1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flutter ![Flutter logo][]
 
-[![Join Gitter Chat Channel -](https://badges.gitter.im/flutter/flutter.svg)](https://gitter.im/flutter/flutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status - Cirrus](https://api.cirrus-ci.com/github/flutter/flutter.svg)](https://cirrus-ci.com/github/flutter/flutter/master)
+[![Gitter Channel][]][Gitter badge]
+[![Build Status - Cirrus][]][Build status]
 
 # Build beautiful native apps in record time
 
@@ -144,5 +144,9 @@ Join us in our [Gitter chat room](https://gitter.im/flutter/flutter) or join our
 
 To join the team working on Flutter, see our [contributor guide](CONTRIBUTING.md).
 
+[Build Status - Cirrus]: https://api.cirrus-ci.com/github/flutter/flutter.svg
+[Build status]: https://cirrus-ci.com/github/flutter/flutter/master
 [flutter.io]: https://flutter.io
 [Flutter logo]: https://github.com/dart-lang/site-shared/blob/master/src/_assets/image/flutter/icon/64.png?raw=1
+[Gitter Channel]: https://badges.gitter.im/flutter/flutter.svg
+[Gitter badge]: https://gitter.im/flutter/flutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Also, move badges out of the page title/heading.

cc @sfshaza2 @kwalrath @filiph