### PR TITLE
Fix a problem that: `PODS_ROOT` not defined because that Debug.xcconfig misses Flutter environment

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -193,6 +193,12 @@ class CocoaPods {
       ));
       podfileTemplate.copySync(podfile.path);
     }
+    addPodsDependencyToFlutterXcconfig(iosProject);
+  }
+
+  /// Ensures all `Flutter/Xxx.xcconfig` files for the given iOS sub-project of
+  /// a parent Flutter project include pods configuration.
+  void addPodsDependencyToFlutterXcconfig(IosProject iosProject) {
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Debug');
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Release');
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -300,8 +300,11 @@ Future<void> injectPlugins(FlutterProject project) async {
   if (!project.isModule && project.ios.hostAppRoot.existsSync()) {
     final IosProject iosProject = IosProject.fromFlutter(project);
     final CocoaPods cocoaPods = CocoaPods();
-    if (plugins.isNotEmpty || iosProject.podfile.existsSync())
+    if (plugins.isNotEmpty) {
       cocoaPods.setupPodfile(project.ios);
+    } else if (iosProject.podfile.existsSync() && iosProject.podfileLock.existsSync()) {
+      cocoaPods.addPodsDependencyToFlutterXcconfig(iosProject);
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -302,7 +302,10 @@ Future<void> injectPlugins(FlutterProject project) async {
     final CocoaPods cocoaPods = CocoaPods();
     if (plugins.isNotEmpty) {
       cocoaPods.setupPodfile(project.ios);
-    } else if (iosProject.podfile.existsSync() && iosProject.podfileLock.existsSync()) {
+    }
+    /// The user may have a custom maintained Podfile that they're running `pod install`
+    /// on themselves.
+    else if (iosProject.podfile.existsSync() && iosProject.podfileLock.existsSync()) {
       cocoaPods.addPodsDependencyToFlutterXcconfig(iosProject);
     }
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -298,8 +298,9 @@ Future<void> injectPlugins(FlutterProject project) async {
   await _writeAndroidPluginRegistrant(project, plugins);
   await _writeIOSPluginRegistrant(project, plugins);
   if (!project.isModule && project.ios.hostAppRoot.existsSync()) {
+    final IosProject iosProject = IosProject.fromFlutter(project);
     final CocoaPods cocoaPods = CocoaPods();
-    if (plugins.isNotEmpty)
+    if (plugins.isNotEmpty || iosProject.podfile.existsSync())
       cocoaPods.setupPodfile(project.ios);
   }
 }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -89,7 +89,7 @@ class FlutterProject {
   }
 
   /// The iOS sub project of this project.
-  IosProject get ios => IosProject._(this);
+  IosProject get ios => IosProject.fromFlutter(this);
 
   /// The Android sub project of this project.
   AndroidProject get android => AndroidProject._(this);
@@ -148,7 +148,7 @@ class FlutterProject {
 /// Instances will reflect the contents of the `ios/` sub-folder of
 /// Flutter applications and the `.ios/` sub-folder of Flutter module projects.
 class IosProject {
-  IosProject._(this.parent);
+  IosProject.fromFlutter(this.parent);
 
   /// The parent of this project.
   final FlutterProject parent;

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -204,9 +204,9 @@ void main() {
   });
 
   group('Update xcconfig', () {
-    testUsingContext('includes Pod config in xcconfig files, if there is a Pod dependency', () async {
-      projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Existing Podfile');
-      projectUnderTest.ios.podfileLock..createSync()..writeAsStringSync('Existing Podfile');
+    testUsingContext('includes Pod config in xcconfig files, if the user manually added Pod dependencies without using Flutter plugins', () async {
+      projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Custom Podfile');
+      projectUnderTest.ios.podfileLock..createSync()..writeAsStringSync('Podfile.lock from user executed `pod install`');
       projectUnderTest.packagesFile..createSync()..writeAsStringSync('');
       projectUnderTest.ios.xcodeConfigFor('Debug')
         ..createSync(recursive: true)


### PR DESCRIPTION
The prior logic to edit debug/release.xcconfig(add pods-runner-debug/release.xcconfig) has logic below:
```
Future<void> injectPlugins(FlutterProject project) async {
  final List<Plugin> plugins = findPlugins(project);
  await _writeAndroidPluginRegistrant(project, plugins);
  await _writeIOSPluginRegistrant(project, plugins);
  if (!project.isModule && project.ios.hostAppRoot.existsSync()) {
    final CocoaPods cocoaPods = CocoaPods();
    if (plugins.isNotEmpty)
      cocoaPods.setupPodfile(project.ios);
  }
}
```
However, there is some user cases that they don't define a Plugin but create a Podfile and run it directly. If the Debug.xcconfig can't be updated, the Pod related environment will be not defined and fail the `[CP] Check Pods Manifest.lock` logic.
See: https://github.com/flutter/flutter/issues/26890 
for more.