### PR TITLE
Re-enable use of ParagraphConstrains const ctor

### DIFF
--- a/examples/layers/raw/text.dart
+++ b/examples/layers/raw/text.dart
@@ -84,9 +84,7 @@ void main() {
     // Next, we supply a width that the text is permitted to occupy and we ask
     // the paragraph to the visual position of each its glyphs as well as its
     // overall size, subject to its sizing constraints.
-    // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
-    // ignore:prefer_const_constructors
-    ..layout(ui.ParagraphConstraints(width: 180.0));
+    ..layout(const ui.ParagraphConstraints(width: 180.0));
 
   // Finally, we register our beginFrame callback and kick off the first frame.
   ui.window.onBeginFrame = beginFrame;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -242,9 +242,7 @@ class TextPainter {
         builder.pushStyle(text.style.getTextStyle(textScaleFactor: textScaleFactor));
       builder.addText(' ');
       _layoutTemplate = builder.build()
-        // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
-        // ignore:prefer_const_constructors
-        ..layout(ui.ParagraphConstraints(width: double.infinity));
+        ..layout(const ui.ParagraphConstraints(width: double.infinity));
     }
     return _layoutTemplate.height;
   }

--- a/packages/flutter/test/engine/paragraph_builder_test.dart
+++ b/packages/flutter/test/engine/paragraph_builder_test.dart
@@ -13,9 +13,7 @@ void main() {
     final Paragraph paragraph = builder.build();
     expect(paragraph, isNotNull);
 
-    // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
-    // ignore:prefer_const_constructors
-    paragraph.layout(ParagraphConstraints(width: 800.0));
+    paragraph.layout(const ParagraphConstraints(width: 800.0));
     expect(paragraph.width, isNonZero);
     expect(paragraph.height, isNonZero);
   });

--- a/packages/flutter/test/engine/paragraph_test.dart
+++ b/packages/flutter/test/engine/paragraph_test.dart
@@ -20,9 +20,7 @@ void main() {
       ));
       builder.addText('Test');
       final Paragraph paragraph = builder.build();
-      // TODO(cbracken): use const constructor. https://github.com/flutter/flutter/issues/26390
-      // ignore:prefer_const_constructors
-      paragraph.layout(ParagraphConstraints(width: 400.0));
+      paragraph.layout(const ParagraphConstraints(width: 400.0));
 
       expect(paragraph.height, closeTo(fontSize, 0.001));
       expect(paragraph.width, closeTo(400.0, 0.001));


### PR DESCRIPTION
All embedders of Flutter within Google have all been updated to an
engine version that includes the const constructor added in
flutter/engine#7346 and rolled into the framework in
flutter/flutter#26252.

This reverts commit 88b77a7d0fe5b00baaf63280d48398cf85a99ce6.

This fixes https://github.com/flutter/flutter/issues/26390.