### PR TITLE
Add WorkspaceSettings.xcsettings for stocks app

### DIFF
--- a/examples/stocks/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/examples/stocks/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
This file gets generated whenever you `flutter run` the stocks app and dirties the tree. Looks like we are checking those files in for the other example apps as well, e.g. https://github.com/flutter/flutter/blob/master/examples/flutter_gallery/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings