### PR TITLE
Pass --verify-entry-points in debug mode.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -429,8 +429,10 @@ class AndroidDevice extends Device {
     if (debuggingOptions.traceSkia)
       cmd.addAll(<String>['--ez', 'trace-skia', 'true']);
     if (debuggingOptions.debuggingEnabled) {
-      if (debuggingOptions.buildInfo.isDebug)
+      if (debuggingOptions.buildInfo.isDebug) {
         cmd.addAll(<String>['--ez', 'enable-checked-mode', 'true']);
+        cmd.addAll(<String>['--ez', 'verify-entry-points', 'true']);
+      }
       if (debuggingOptions.startPaused)
         cmd.addAll(<String>['--ez', 'start-paused', 'true']);
       if (debuggingOptions.useTestFonts)

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -277,8 +277,10 @@ class IOSDevice extends Device {
     if (debuggingOptions.useTestFonts)
       launchArguments.add('--use-test-fonts');
 
-    if (debuggingOptions.debuggingEnabled)
+    if (debuggingOptions.debuggingEnabled) {
       launchArguments.add('--enable-checked-mode');
+      launchArguments.add('--verify-entry-points');
+    }
 
     if (debuggingOptions.enableSoftwareRendering)
       launchArguments.add('--enable-software-rendering');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -320,7 +320,10 @@ class IOSSimulator extends Device {
 
     if (debuggingOptions.debuggingEnabled) {
       if (debuggingOptions.buildInfo.isDebug)
-        args.add('--enable-checked-mode');
+        args.addAll(<String>[
+          '--enable-checked-mode',
+          '--verify-entry-points'
+        ]);
       if (debuggingOptions.startPaused)
         args.add('--start-paused');
       if (debuggingOptions.skiaDeterministicRendering)

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -926,8 +926,9 @@ class _FlutterPlatform extends PlatformPlugin {
       command.add('--ipv6');
     }
 
-    command.add('--enable-checked-mode');
     command.addAll(<String>[
+      '--enable-checked-mode',
+      '--verify-entry-points',
       '--enable-software-rendering',
       '--skia-deterministic-rendering',
       '--enable-dart-profiling',


### PR DESCRIPTION
This will enable us to catch bugs similar to `https://github.com/flutter/engine/pull/7522` during testing (in debug mode), and they will surface with a readable error message, rather than just an obscure crash in profile and release mode.