### PR TITLE
Improve documentation on decodeSyslog

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -387,7 +387,7 @@ class IOSDevice extends Device {
   }
 }
 
-/// Decodes an encoded syslog string to a UTF-8 representation.
+/// Decodes a vis-encoded syslog string to a UTF-8 representation.
 ///
 /// Apple's syslog logs are encoded in 7-bit form. Input bytes are encoded as follows:
 /// 1. 0x00 to 0x19: non-printing range. Some ignored, some encoded as <...>.
@@ -397,6 +397,8 @@ class IOSDevice extends Device {
 /// 5. 0xa0: octal representation \240.
 /// 6. 0xa1 to 0xf7: \M-x (where x is the input byte stripped of its high-order bit).
 /// 7. 0xf8 to 0xff: unused in 4-byte UTF-8.
+///
+/// See: [vis(3) manpage](https://www.freebsd.org/cgi/man.cgi?query=vis&sektion=3)
 String decodeSyslog(String line) {
   // UTF-8 values for \, M, -, ^.
   const int kBackslash = 0x5c;


### PR DESCRIPTION
It appears that the encoding Apple is using to ensure their syslog
conforms with the syslog requirement for seven-bit ASCII encoding (see:
RFC 5424) is `vis`.

Details: https://www.freebsd.org/cgi/man.cgi?query=vis&sektion=3