### PR TITLE
Modify offline docs platform family for Dash/Zeal

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -42,12 +42,13 @@ function create_offline_zip() {
 function create_docset() {
   # Must be run from "$FLUTTER_ROOT/dev/docs"
   # Must have dashing installed: go get -u github.com/technosophos/dashing
-  # Dashing produces a LOT of output (~30MB), so we redirect it, and just show
-  # the end of it if there was a problem.
+  # Dashing produces a LOT of log output (~30MB), so we redirect it, and just
+  # show the end of it if there was a problem.
   echo "Building Flutter docset."
   rm -rf flutter.docset
   (dashing build --source ./doc --config ./dashing.json > /tmp/dashing.log 2>&1 || (tail -100 /tmp/dashing.log; false)) && \
   cp ./doc/flutter/static-assets/favicon.png ./flutter.docset/icon.png && \
+  "$DART" ./dashing_postprocess.dart && \
   tar cf flutter.docset.tar.gz --use-compress-program="gzip --best" flutter.docset
 }
 

--- a/dev/docs/dashing_postprocess.dart
+++ b/dev/docs/dashing_postprocess.dart
@@ -1,0 +1,29 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+/// This changes the DocSetPlatformFamily key to be "dartlang" instead of the
+/// name of the package (usually "flutter").
+///
+/// This is so that the IntelliJ plugin for Dash will be able to go directly to
+/// the docs for a symbol from a keystroke. Without this, flutter isn't part
+/// of the list of package names it searches. After this, it finds the flutter
+/// docs because they're declared here to be part of the "dartlang" family of
+/// docs.
+///
+/// Dashing doesn't have a way to configure this, so we modify the Info.plist
+/// directly to make the change.
+void main(List<String> args) {
+  final File infoPlist = File('flutter.docset/Contents/Info.plist');
+  String contents = infoPlist.readAsStringSync();
+
+  // Since I didn't want to add the XML package as a dependency just for this,
+  // I just used a regular expression to make this simple change.
+  final RegExp findRe = RegExp(r'''(\s*<key>DocSetPlatformFamily</key>\s*<string>)[^<]+(</string>)''', multiLine: true);
+  contents = contents.replaceAllMapped(findRe, (Match match) {
+    return '${match.group(1)}dartlang${match.group(2)}';
+  });
+  infoPlist.writeAsStringSync(contents);
+}


### PR DESCRIPTION
This changes the DocSetPlatformFamily key to be "dartlang" instead of the name of the package (usually "flutter"). This is so that the IntelliJ plugin for Dash will be able to go directly to the docs for a symbol from a keystroke, instead of needing to search all the docsets each time.

Without this, flutter isn't part of the list of package names it searches. After this, it finds the flutter docs because they're declared to be part of the "dartlang" family of docs.

Dashing doesn't have a way to configure this, so we modify the Info.plist directly to make the change.