### PR TITLE
Update readmes for stocks/gallery

### DIFF
--- a/examples/flutter_gallery/README.md
+++ b/examples/flutter_gallery/README.md
@@ -16,7 +16,7 @@ the [Flutter Setup](https://flutter.io/setup/) guide.
 ### Building and installing the Flutter app
 
 * `cd $FLUTTER_ROOT/examples/flutter_gallery`
-* `flutter upgrade`
+* `flutter packages get`
 * `flutter run --release`
 
 The `flutter run --release` command both builds and installs the Flutter app.

--- a/examples/stocks/README.md
+++ b/examples/stocks/README.md
@@ -15,7 +15,7 @@ the [Flutter Setup](https://flutter.io/setup/) guide.
 ### Building and installing the stocks demo app
 
 * `cd $FLUTTER_ROOT/examples/stocks`
-* `flutter upgrade`
+* `flutter packages get`
 * `flutter run --release`
 
 The `flutter run --release` command both builds and installs the Flutter app.


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/24292

We pin all the dependencies of all the pubspecs in the flutter repo.  Telling people to run `flutter upgrade` in the flutter repo (including examples) is not a good idea anymore.