### PR TITLE
prevent _computeColumnWidths from getting stuck due to double precision

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -916,7 +916,10 @@ class RenderTable extends RenderBox {
       // columns shrinking them proportionally until we have no
       // available columns, then do the same to the non-flexible ones.
       int availableColumns = columns;
-      while (deficit > 0.0 && totalFlex > 0.0) {
+      // Handle double precision errors which causes this loop to become
+      // stuck in certain configurations.
+      const double minimumDeficit = 0.00000001;
+      while (deficit > minimumDeficit && totalFlex > minimumDeficit) {
         double newTotalFlex = 0.0;
         for (int x = 0; x < columns; x += 1) {
           if (flexes[x] != null) {

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -297,6 +297,31 @@ void main() {
     expect(boxG1, isNot(equals(boxG2)));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/27083
+  testWidgets('Really small deficit double precision error', (WidgetTester tester) async {
+    const SizedBox cell = SizedBox(width: 16, height: 16);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Table(
+          children: const <TableRow>[
+            TableRow(
+              children: <Widget>[
+                cell, cell, cell, cell, cell, cell,
+              ],
+            ),
+            TableRow(
+              children: <Widget>[
+                cell, cell, cell, cell, cell, cell,
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(true, true);
+  });
+
   testWidgets('Table widget - repump test', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -297,8 +297,8 @@ void main() {
     expect(boxG1, isNot(equals(boxG2)));
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/27083
   testWidgets('Really small deficit double precision error', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/27083
     const SizedBox cell = SizedBox(width: 16, height: 16);
     await tester.pumpWidget(
       Directionality(
@@ -319,7 +319,7 @@ void main() {
         ),
       ),
     );
-    expect(true, true);
+    // If the above bug is present this test will never terminate.
   });
 
   testWidgets('Table widget - repump test', (WidgetTester tester) async {


### PR DESCRIPTION
Certain table arrangements can cause _computeColumnWidths to end up with a very small deficit value like 1e-14. Because we check for > 0, this can get stuck in an infinite loop.

Instead changed 0 to a small value.

Added regression test.

Fixes https://github.com/flutter/flutter/issues/27083