### PR TITLE
Add2App: Fix crash resulted from hard-code module 'app' 

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -429,8 +429,16 @@ class FlutterPlugin implements Plugin<Project> {
             }
 
             if (packageAssets) {
+                String mainModuleName = "app"
+                try {
+                    String tmpModuleName = project.rootProject.ext.mainModuleName
+                    if (tmpModuleName != null && !tmpModuleName.empty) {
+                        mainModuleName = tmpModuleName
+                    }
+                } catch (Exception e) {
+                }
                 // Only include configurations that exist in parent project.
-                Task mergeAssets = project.tasks.findByPath(":app:merge${variant.name.capitalize()}Assets")
+                Task mergeAssets = project.tasks.findByPath(":${mainModuleName}:merge${variant.name.capitalize()}Assets")
                 if (mergeAssets) {
                     mergeAssets.dependsOn(copyFlutterAssetsTask)
                 }

--- a/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
@@ -19,6 +19,12 @@ plugins.each { name, path ->
 }
 
 gradle.getGradle().projectsLoaded { g ->
+    g.rootProject.beforeEvaluate { p ->
+        _mainModuleName = binding.variables['mainModuleName']
+        if (_mainModuleName != null && !_mainModuleName.empty) {
+            p.ext.mainModuleName = _mainModuleName
+        }
+    }
     g.rootProject.afterEvaluate { p ->
         p.subprojects { sp ->
             if (sp.name != 'flutter') {


### PR DESCRIPTION
Currently, hard coded resource copy can't handle the case when developers use a Application module with name other than 'app'.
This will fix: https://github.com/flutter/flutter/issues/26948
Besides, 
wiki: https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps 
should be updated when this fix is finally landed if possible.
```
include ':example'
setBinding(new Binding([gradle: this, mainModuleName: 'example']))// new
evaluate(new File(                                                      // new
        settingsDir.parentFile,                                               // new
        'my_flutter/.android/include_flutter.groovy'                          // new
))// new
```