### PR TITLE
Change "Starting Xcode build" status text to "Running xcode build"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -486,7 +486,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   final Stopwatch buildStopwatch = Stopwatch()..start();
-  initialBuildStatus = logger.startProgress('Starting Xcode build...', timeout: kFastOperation);
+  initialBuildStatus = logger.startProgress('Running Xcode build...', timeout: kFastOperation);
   final RunResult buildResult = await runAsync(
     buildCommands,
     workingDirectory: app.project.hostAppRoot.path,


### PR DESCRIPTION
This status shows for the duration of the run, not just while starting. It looks kinda weird in the editors to show a progress bar for "Starting Xcode build" and then removing it once it completes.

I don't know if this is a reasonable change, nor how risky it may be (eg. if there are any automated tests scraping for this), though I did search for "Starting xcode" and it turned up nothing (@pq - you're not relying on this string anywhere, right?).