### PR TITLE
Fix duplicate post install hook error #26212

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -66,6 +66,7 @@ def update_configs(installer, framework_dir)
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
             config.build_settings['ENABLE_BITCODE'] = 'NO'
+            next if  config.base_configuration_reference == nil
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|
                 file.puts "#include \"#{File.realpath(File.join(framework_dir, 'Generated.xcconfig'))}\""

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -61,11 +61,11 @@ plugin_pods.map { |r|
 
 # Ensure that ENABLE_BITCODE is set to NO, add a #include to Generated.xcconfig, and
 # add a run script to the Build Phases.
-post_install do |installer|
+def update_configs(installer, framework_dir)
+    
     installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
             config.build_settings['ENABLE_BITCODE'] = 'NO'
-            next if  config.base_configuration_reference == nil
             xcconfig_path = config.base_configuration_reference.real_path
             File.open(xcconfig_path, 'a+') do |file|
                 file.puts "#include \"#{File.realpath(File.join(framework_dir, 'Generated.xcconfig'))}\""


### PR DESCRIPTION
This PR tries to fix issue #26212.

The issue is regarding duplicate `post_install` hook. Since `podhelper.rb` already contains a `post_install`, host projects with custom `post_install` will result in an error. 

With this changes, `podhelper.rb` no longer contains a `post_install` hook, but changed to a function which does same task as before(setting bitcode enable to no and adding an xcconfig). And this function is calling from host projects pod file.

The minimal `Podfile` looks like
```ruby
platform :ios, '9.0'

$flutter_path = 'path/to/flutter/module/'

target '<your target>' do
  use_frameworks!

  #other pods
  flutter_application_path = $flutter_path
  eval(File.read(File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')), binding)

end

post_install do |installer|
    framework_dir = File.join($flutter_path, '.ios', 'Flutter')
    update_configs(installer, framework_dir)
    #custom post install actions.
end
```

If this looks fine and merges, [wiki](https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps) update is required. 

