### PR TITLE
Add default values for optional parameters.

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2597,7 +2597,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   }
 
   @override
-  String toString({ DiagnosticLevel minLevel }) => toStringShort();
+  String toString({ DiagnosticLevel minLevel = DiagnosticLevel.debug }) => toStringShort();
 
   /// Returns a description of the tree rooted at this node.
   /// If the prefix argument is provided, then every line in the output
@@ -2633,7 +2633,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// [toStringDeep], but does not recurse to any children.
   @override
   String toStringShallow({
-    String joiner = '; ',
+    String joiner = ', ',
     DiagnosticLevel minLevel = DiagnosticLevel.debug,
   }) {
     RenderObject debugPreviousActiveLayout;

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -85,7 +85,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -40,7 +40,7 @@ class FakeImage implements Image {
   void dispose() {}
 
   @override
-  Future<ByteData> toByteData({ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ImageByteFormat format = ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -23,7 +23,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/painting/shape_decoration_test.dart
+++ b/packages/flutter/test/painting/shape_decoration_test.dart
@@ -125,7 +125,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/rendering/image_test.dart
+++ b/packages/flutter/test/rendering/image_test.dart
@@ -19,7 +19,7 @@ class SquareImage implements ui.Image {
   int get height => 10;
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 
@@ -38,7 +38,7 @@ class WideImage implements ui.Image {
   int get height => 10;
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 
@@ -57,7 +57,7 @@ class TallImage implements ui.Image {
   int get height => 20;
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -103,7 +103,7 @@ class TestRecordingPaintingContext extends ClipContext implements PaintingContex
   }
 
   @override
-  void pushClipRect(bool needsCompositing, Offset offset, Rect clipRect, PaintingContextCallback painter, {Clip clipBehavior = Clip.antiAlias}) {
+  void pushClipRect(bool needsCompositing, Offset offset, Rect clipRect, PaintingContextCallback painter, {Clip clipBehavior = Clip.hardEdge}) {
     clipRectAndPaint(clipRect.shift(offset), clipBehavior, clipRect.shift(offset), () => painter(this, offset));
   }
 

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -26,7 +26,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/widgets/image_rtl_test.dart
+++ b/packages/flutter/test/widgets/image_rtl_test.dart
@@ -37,7 +37,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 }

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -926,7 +926,7 @@ class TestImage implements ui.Image {
   void dispose() { }
 
   @override
-  Future<ByteData> toByteData({ui.ImageByteFormat format}) async {
+  Future<ByteData> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');
   }
 

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -27,7 +27,7 @@ class Alive extends StatefulWidget {
   AliveState createState() => AliveState();
 
   @override
-  String toString({DiagnosticLevel minLevel}) => '$index $alive';
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.debug}) => '$index $alive';
 }
 
 class AliveState extends State<Alive> with AutomaticKeepAliveClientMixin {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -720,7 +720,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<T> runAsync<T>(Future<T> callback(), {
-    Duration additionalTime = const Duration(milliseconds: 1000),
+    Duration additionalTime = const Duration(milliseconds: 250),
   }) {
     assert(additionalTime != null);
     assert(() {

--- a/packages/flutter_tools/lib/src/build_runner/build_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_kernel_compiler.dart
@@ -33,7 +33,7 @@ class BuildKernelCompiler implements KernelCompiler {
     List<String> fileSystemRoots,
     String fileSystemScheme,
     String depFilePath,
-    TargetModel targetModel,
+    TargetModel targetModel = TargetModel.flutter,
   }) async {
     if (fileSystemRoots != null || fileSystemScheme != null || depFilePath != null || targetModel != null || sdkRoot != null || packagesPath != null) {
       printTrace('fileSystemRoots, fileSystemScheme, depFilePath, targetModel,'

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -784,7 +784,7 @@ class NotifyingLogger extends Logger {
     String message, {
     @required Duration timeout,
     String progressId,
-    bool multilineOutput,
+    bool multilineOutput = false,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     assert(timeout != null);
@@ -961,8 +961,8 @@ class _AppRunLogger extends Logger {
     String message, {
     @required Duration timeout,
     String progressId,
-    bool multilineOutput,
-    int progressIndicatorPadding = 52,
+    bool multilineOutput = false,
+    int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     assert(timeout != null);
     final int id = _nextProgressId++;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -185,7 +185,7 @@ class FuchsiaDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool applicationNeedsRebuild = false,
-    bool usesTerminalUi = false,
+    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) => Future<void>.error('unimplemented');
 

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -55,7 +55,7 @@ class _FakeGenSnapshot implements GenSnapshot {
     String packagesPath,
     String depfilePath,
     IOSArch iosArch,
-    Iterable<String> additionalArgs,
+    Iterable<String> additionalArgs = const <String>[],
   }) async {
     _callCount += 1;
     _snapshotType = snapshotType;

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -216,10 +216,10 @@ class _NoopIOSink implements IOSink {
   void write(_) {}
 
   @override
-  void writeAll(_, [__]) {}
+  void writeAll(_, [__ = '']) {}
 
   @override
-  void writeln([_]) {}
+  void writeln([_ = '']) {}
 
   @override
   void writeCharCode(_) {}

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -203,8 +203,8 @@ class MockProcessManager extends Mock implements ProcessManager {
     Map<String, String> environment,
     bool includeParentEnvironment = true,
     bool runInShell = false,
-    Encoding stdoutEncoding,
-    Encoding stderrEncoding
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding
   }) {
     final String program = command[0];
     final List<String> args = command.sublist(1);


### PR DESCRIPTION
Fixes violations when optional parameters specify different default values than the corresponding optional parameters in base classes. Dart SDK issue https://github.com/dart-lang/sdk/issues/34437.

For example, this `a` in `B.foo` is an error, because its default value is `2`, and the default value of `a` in `A.foo` is `1`.

```dart
class A {
  void foo({int a: 1}) {}
}

class B extends A {
  void foo({int a: 2}) {}
}
```