### PR TITLE
Refactor to make FlutterError and FlutterErrorDetails return structured data using the existing DiagnosticsNode concepts.

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -428,10 +428,12 @@ class AnimationController extends Animation<double>
   TickerFuture forward({ double from }) {
     assert(() {
       if (duration == null) {
-        throw FlutterError(
-          'AnimationController.forward() called with no default Duration.\n'
-          'The "duration" property should be set, either in the constructor or later, before '
-          'calling the forward() function.'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('AnimationController.forward() called with no default Duration.')
+          ..addHint(
+            'The "duration" property should be set, either in the constructor or later, before '
+            'calling the forward() function.'
+          )
         );
       }
       return true;
@@ -462,8 +464,8 @@ class AnimationController extends Animation<double>
     assert(() {
       if (duration == null) {
         throw FlutterError(
-          'AnimationController.reverse() called with no default Duration.\n'
-          'The "duration" property should be set, either in the constructor or later, before '
+          'AnimationController.reverse() called with no default Duration.',
+          fix: 'The "duration" property should be set, either in the constructor or later, before '
           'calling the reverse() function.'
         );
       }
@@ -544,8 +546,8 @@ class AnimationController extends Animation<double>
       assert(() {
         if (this.duration == null) {
           throw FlutterError(
-            'AnimationController.animateTo() called with no explicit Duration and no default Duration.\n'
-            'Either the "duration" argument to the animateTo() method should be provided, or the '
+            'AnimationController.animateTo() called with no explicit Duration and no default Duration.',
+            fix: 'Either the "duration" argument to the animateTo() method should be provided, or the '
             '"duration" property should be set, either in the constructor or later, before '
             'calling the animateTo() function.'
           );
@@ -598,8 +600,8 @@ class AnimationController extends Animation<double>
     assert(() {
       if (period == null) {
         throw FlutterError(
-          'AnimationController.repeat() called without an explicit period and with no default Duration.\n'
-          'Either the "period" argument to the repeat() method should be provided, or the '
+          'AnimationController.repeat() called without an explicit period and with no default Duration.',
+          fix: 'Either the "period" argument to the repeat() method should be provided, or the '
           '"duration" property should be set, either in the constructor or later, before '
           'calling the repeat() function.'
         );
@@ -714,11 +716,10 @@ class AnimationController extends Animation<double>
   void dispose() {
     assert(() {
       if (_ticker == null) {
-        throw FlutterError(
-          'AnimationController.dispose() called more than once.\n'
-          'A given $runtimeType cannot be disposed more than once.\n'
-          'The following $runtimeType object was disposed multiple times:\n'
-          '  $this'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('AnimationController.dispose() called more than once.')
+          ..addHint('A given $runtimeType cannot be disposed more than once.\n')
+          ..addProperty('The following $runtimeType object was disposed multiple times', this)
         );
       }
       return true;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -440,11 +440,12 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
         final double transformedValue = activeCurve.transform(t);
         final double roundedTransformedValue = transformedValue.round().toDouble();
         if (roundedTransformedValue != t) {
-          throw FlutterError(
-            'Invalid curve endpoint at $t.\n'
-            'Curves must map 0.0 to near zero and 1.0 to near one but '
+          throw FlutterError.from(FlutterErrorBuilder()
+            ..addError('Invalid curve endpoint at $t.')
+            ..addViolation('Curves must map 0.0 to near zero and 1.0 to near one but '
             '${activeCurve.runtimeType} mapped $t to $transformedValue, which '
-            'is near $roundedTransformedValue.'
+            'is near $roundedTransformedValue.')
+            ..addDebugProperty('Active curve', activeCurve)
           );
         }
         return true;

--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -129,11 +129,9 @@ mixin AnimationLocalListenersMixin {
           exception: exception,
           stack: stack,
           library: 'animation library',
-          context: 'while notifying listeners for $runtimeType',
-          informationCollector: (StringBuffer information) {
-            information.writeln('The $runtimeType notifying listeners was:');
-            information.write('  $this');
-          }
+          context: 'while notifying listeners for',
+          contextObject: runtimeType,
+          errorBuilder: FlutterErrorBuilder()..addProperty('The $runtimeType notifying listeners was', this),
         ));
       }
     }
@@ -196,10 +194,7 @@ mixin AnimationLocalStatusListenersMixin {
           stack: stack,
           library: 'animation library',
           context: 'while notifying status listeners for $runtimeType',
-          informationCollector: (StringBuffer information) {
-            information.writeln('The $runtimeType notifying status listeners was:');
-            information.write('  $this');
-          }
+          errorBuilder: FlutterErrorBuilder()..addProperty('The $runtimeType notifying status listeners was', this)
         ));
       }
     }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -255,8 +255,8 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     assert(() {
       if (result == null) {
         throw FlutterError(
-          'The builder for route "${settings.name}" returned null.\n'
-          'Route builders must never return null.'
+          'The builder for route "${settings.name}" returned null.',
+          fix: 'Route builders must never return null.'
         );
       }
       return true;

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -184,8 +184,8 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     assert(() {
       if (widget.onUnknownRoute == null) {
         throw FlutterError(
-          'Could not find a generator for route $settings in the $runtimeType.\n'
-          'Generators for routes are searched for in the following order:\n'
+          'Could not find a generator for route $settings in the $runtimeType.',
+          hint: 'Generators for routes are searched for in the following order:\n'
           ' 1. For the "/" route, the "builder" property, if non-null, is used.\n'
           ' 2. Otherwise, the "routes" table is used, if it has an entry for '
           'the route.\n'
@@ -201,8 +201,8 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     assert(() {
       if (result == null) {
         throw FlutterError(
-          'The onUnknownRoute callback returned null.\n'
-          'When the $runtimeType requested the route $settings from its '
+          'The onUnknownRoute callback returned null.',
+          contract: 'When the $runtimeType requested the route $settings from its '
           'onUnknownRoute callback, the callback returned null. Such callbacks '
           'must never return null.'
         );

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -2,15 +2,69 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import 'basic_types.dart';
+import 'diagnostics.dart';
 import 'print.dart';
 
 /// Signature for [FlutterError.onError] handler.
 typedef FlutterExceptionHandler = void Function(FlutterErrorDetails details);
 
+//ignore: deprecated_member_use_from_same_package
 /// Signature for [FlutterErrorDetails.informationCollector] callback
 /// and other callbacks that collect information into a string buffer.
 typedef InformationCollector = void Function(StringBuffer information);
+
+/// Diagnostic with a [StackTrace] [value] suitable for displaying stacktraces
+/// as part of a [FlutterError] object.
+///
+/// See also:
+///
+///  * [FlutterErrorBuilder.addStackTrace], which is the typical way StackTrace
+///    objects are added to a [FlutterError].
+class DiagnosticsStackTrace extends DiagnosticsBlock {
+
+  /// Creates a diagnostic for a stack trace.
+  ///
+  /// [name] describes a name the stacktrace is given, e.g.
+  /// `When the exception was thrown, this was the stack`.
+  /// [stackFilter] provides an optional filter to use to filter which frames
+  /// are included. If no filter is specified, [FlutterError.defaultStackFilter]
+  /// is used.
+  /// [showSeparator] indicates whether to include a ':' after the [name].
+  DiagnosticsStackTrace(
+    String name,
+    StackTrace stack, {
+    IterableFilter<String> stackFilter,
+    bool showSeparator = true,
+  }) : super(
+    name: name,
+    value: stack,
+    properties: (stackFilter ?? FlutterError.defaultStackFilter)(stack.toString().trimRight().split('\n'))
+      .map<DiagnosticsNode>(_createStackFrame)
+      .toList(),
+    style: DiagnosticsTreeStyle.flat,
+    showSeparator: showSeparator,
+    allowTruncate: true,
+  );
+
+  /// Creates a diagnostic describing a single frame from a StackTrace.
+  DiagnosticsStackTrace.singleFrame(
+    String name, {
+    @required String frame,
+    bool showSeparator = true,
+  }) : super(
+    name: name,
+    properties: <DiagnosticsNode>[_createStackFrame(frame)],
+    style: DiagnosticsTreeStyle.indentedSingleLine,
+    showSeparator: showSeparator,
+  );
+
+  static DiagnosticsNode _createStackFrame(String frame) {
+    return DiagnosticsNode.message(frame, allowWrap: false);
+  }
+}
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
@@ -29,12 +83,15 @@ class FlutterErrorDetails {
     this.exception,
     this.stack,
     this.library = 'Flutter framework',
-    this.context,
     this.stackFilter,
     this.informationCollector,
+    FlutterErrorBuilder errorBuilder,
+    String context,
+    Object contextObject,
     this.silent = false
-  });
-
+  }) : _contextName = context,
+       _contextObject = contextObject,
+       _errorBuilder = errorBuilder;
   /// The exception. Often this will be an [AssertionError], maybe specifically
   /// a [FlutterError]. However, this could be any value at all.
   final dynamic exception;
@@ -59,7 +116,47 @@ class FlutterErrorDetails {
 
   /// A human-readable description of where the error was caught (as opposed to
   /// where it was thrown).
-  final String context;
+  String get context {
+    if (_contextName == null && _contextObject == null)
+      return null;
+    return _diagnosticContext('')?.toStringDeep();
+  }
+
+  DiagnosticsNode _diagnosticContext(String namePrefix) {
+    final List<String> parts = <String>[];
+    if (namePrefix.isNotEmpty) {
+      parts.add(namePrefix);
+    }
+    if (_contextName != null && _contextName.isNotEmpty) {
+      parts.add(_contextName);
+    }
+    final String name = parts.join(' ');
+    if (_contextObject == null)
+      return DiagnosticsNode.message(name, style: DiagnosticsTreeStyle.headerLine);
+
+    if (_contextObject is Diagnosticable) {
+      return DiagnosticsProperty<Object>(
+        name,
+        _contextObject,
+        showName: name.isNotEmpty,
+        showSeparator: false,
+        expandableValue: true,
+        allowNameWrap: true,
+        style: DiagnosticsTreeStyle.headerLine,
+      );
+    }
+
+    return DiagnosticsProperty<Object>(
+      name,
+      _contextObject,
+      allowNameWrap: true,
+      showSeparator: false,
+      style: DiagnosticsTreeStyle.headerLine,
+    );
+  }
+
+  final String _contextName;
+  final Object _contextObject;
 
   /// A callback which filters the [stack] trace. Receives an iterable of
   /// strings representing the frames encoded in the way that
@@ -85,7 +182,10 @@ class FlutterErrorDetails {
   ///
   /// The text written to the information argument may contain newlines but should
   /// not end with a newline.
+  @Deprecated('Use errorBuilder instead to write more structured debug information.')
   final InformationCollector informationCollector;
+
+  final FlutterErrorBuilder _errorBuilder;
 
   /// Whether this error should be ignored by the default error reporting
   /// behavior in release mode.
@@ -143,34 +243,287 @@ class FlutterErrorDetails {
 
   @override
   String toString() {
-    final StringBuffer buffer = StringBuffer();
-    if ((library != null && library != '') || (context != null && context != '')) {
+    // TODO(jacobr): this logic has a fair amount of overlap with
+    // FlutterError.dumpToDiagnostic. It would  be reasonable to merge the two
+    // methods if there is not legitimate reason to preserve the slight
+    // differences in how the messages are displayed.
+    final FlutterErrorBuilder builder = FlutterErrorBuilder();
+    final StringBuffer prefix = StringBuffer();
+    final bool hasContext = context?.isNotEmpty == true;
+    if ((library != null && library != '') || hasContext) {
       if (library != null && library != '') {
-        buffer.write('Error caught by $library');
+        prefix.write('Error caught by $library');
         if (context != null && context != '')
-          buffer.write(', ');
+          prefix.write(',');
       } else {
-        buffer.writeln('Exception ');
+        prefix.write('Exception');
       }
-      if (context != null && context != '')
-        buffer.write('thrown $context');
-      buffer.writeln('.');
+
+      if (hasContext) {
+        prefix.write(' thrown');
+      }
+      builder.addDiagnostic(_diagnosticContext(prefix.toString()));
     } else {
-      buffer.write('An error was caught.');
+      builder.addDescription('An error was caught.');
     }
-    buffer.writeln(exceptionAsString());
-    if (informationCollector != null)
-      informationCollector(buffer);
+    builder.addDescription(exceptionAsString());
+    if (informationCollector != null) { //ignore: deprecated_member_use_from_same_package
+      final StringBuffer information = StringBuffer();
+      informationCollector(information); //ignore: deprecated_member_use_from_same_package
+      builder.addDescription(information.toString().trimRight());
+    }
+    if (_errorBuilder != null) {
+      builder.addAll(_errorBuilder.toDiagnostics());
+    }
     if (stack != null) {
-      Iterable<String> stackLines = stack.toString().trimRight().split('\n');
-      if (stackFilter != null) {
-        stackLines = stackFilter(stackLines);
-      } else {
-        stackLines = FlutterError.defaultStackFilter(stackLines);
-      }
-      buffer.writeAll(stackLines, '\n');
+      builder.addStackTrace(null, stack, stackFilter: stackFilter);
     }
-    return buffer.toString().trimRight();
+    return builder.toDiagnostics().map((DiagnosticsNode node) => node.toStringDeep().trimRight()).join('\n').trimRight();
+  }
+}
+
+typedef ErrorBuilderCallback<B extends FlutterErrorBuilder> = B Function();
+
+/// Helper class used for collecting different pieces of information
+/// for constructing an instance of [FlutterError]. It provides a number
+/// of methods with names starting with 'add' to make it
+/// convenient to add different parts to an error report.
+/// In general, the client (e.g., an IDE) displays error parts in the same order
+/// of adding them to the error builder.
+/// {@tool sample}
+/// ```dart
+/// throw FlutterErrorBuilder()
+///   ..addError('A short summary of the error. This is usually required.')
+///   ..addDescription('A more detailed description of the error.')
+///   ..addFix('A resolution that is straightforward to implement.')
+///   ..addHint('A suggestion about a potential approach to resolving the error.')
+///   ..addHint('You can add another suggestion if needed.')
+///   ..addProperty('name of the object', object)
+///   // adds a named object.The client can display it appropriated based on its type.
+///   ..build(); // returns a FlutterError with all the specified parts.
+/// ```
+/// {@end-tool}
+/// {@tool sample}
+///
+/// See also:
+///
+///  * [WidgetErrorBuilder], which adds a few ready-made error elements
+///    for reporting errors at the widget layer.
+///  * [RenderErrorBuilder], which adds a few ready-made error elements
+///    for reporting errors at the rendering layer.
+class FlutterErrorBuilder {
+  /// Creates a [FlutterErrorBuilder]
+  FlutterErrorBuilder() : _buildErrorCallback = null;
+
+  /// Creates a [FlutterErrorBuilder] with its details computed only when needed.
+  /// Use if computing the error details may throw an exception or is expensive.
+  FlutterErrorBuilder.lazy(this._buildErrorCallback);
+
+  /// Function called when building the error parts lazily.
+  final ErrorBuilderCallback<FlutterErrorBuilder> _buildErrorCallback;
+
+  /// Overall error message.
+  String error;
+
+  final List<DiagnosticsNode> _parts = <DiagnosticsNode>[];
+
+  /// Whether the error report is empty.
+  bool get isEmpty => _parts.isEmpty && error == null && _buildErrorCallback == null;
+
+  /// Adds a short summary of the error to the report.
+  ///
+  /// The [summary] should usually be no longer than 2 lines and should
+  /// concisely states what the assertion failure or contract violation was.
+  ///
+  /// The client (e.g., an IDE) usually displays the error summary in red.
+  void addError(String sumnmary) {
+    _parts.add(DiagnosticsNode.message(
+      sumnmary.trimRight(),
+      style: DiagnosticsTreeStyle.flat,
+      level: DiagnosticLevel.error,
+    ));
+  }
+
+  /// Adds a more elaborate description of the error.
+  ///
+  /// It's strongly encouraged to show a summary of the error
+  /// using [addError] before showing more details.
+  /// The description should include at least the following elements
+  /// * Claim: Explanation of the assertion failure or contract violation.
+  /// * Grounds: Facts about the user's code that led to the error.
+  /// * Warranty: Connections between the grounds and the claim.
+  void addDescription(String description) {
+    _parts.add(DiagnosticsNode.message(description.trimRight(), style: DiagnosticsTreeStyle.flat));
+  }
+
+  /// Adds one or more suggestions for resolving the error.
+  ///
+  /// An optional [url] may be included in the hint to reference external
+  /// material.
+  void addHint(String description, {String url}) {
+    if (url != null)
+      _parts.add(UrlProperty(
+        description.trimRight(),
+        url: url,
+        level:
+        DiagnosticLevel.hint,
+        style: DiagnosticsTreeStyle.indentedSingleLine,
+      ));
+    else
+      _parts.add(DiagnosticsNode.message(
+        description.trimRight(),
+        style: DiagnosticsTreeStyle.flat,
+        level: DiagnosticLevel.hint,
+      ));
+  }
+
+  /// Adds a straightforward fix for resolving the error.
+  /// A fix should be unambiguous and context-agnostic.
+  ///
+  /// If there isn't enough confidence in the general applicability of the fix,
+  /// consider adding it as a hint using [addHint].
+  void addFix(String description) {
+    _parts.add(DiagnosticsNode.message(
+      description.trimRight(),
+      style: DiagnosticsTreeStyle.flat,
+      level: DiagnosticLevel.fix,
+    ));
+  }
+
+  /// Adds a formal contract that has been violated.
+  void addContract(String description) {
+    _parts.add(DiagnosticsNode.message(
+      description.trimRight(),
+      style: DiagnosticsTreeStyle.flat,
+      level: DiagnosticLevel.contract,
+    ));
+  }
+
+  /// Adds a statement of contract violation.
+  void addViolation(String description) {
+    _parts.add(DiagnosticsNode.message(
+      description.trimRight(),
+      style: DiagnosticsTreeStyle.flat,
+      level: DiagnosticLevel.violation,
+    ));
+  }
+
+  /// Adds a [StringProperty] to the error report.
+  void addStringProperty(String name, String value, {DiagnosticLevel level = DiagnosticLevel.info}) {
+    _parts.add(StringProperty(name, value, level: level));
+  }
+
+  /// Property constructor with nice defaults for a property of an error object.
+  void addProperty<T>(
+    String name,
+    T value, {
+    bool showName = true,
+    bool showSeparator = true,
+    Object defaultValue = kNoDefaultValue,
+    DiagnosticsTreeStyle style = DiagnosticsTreeStyle.indentedSingleLine,
+    DiagnosticLevel level = DiagnosticLevel.info,
+    String linePrefix,
+  }) {
+    _parts.add(DiagnosticsProperty<T>(
+      name,
+      value,
+      showName: showName,
+      showSeparator: showSeparator,
+      defaultValue: defaultValue,
+      style: style,
+      level: level,
+      linePrefix: linePrefix,
+      expandableValue: true,
+    ));
+  }
+
+  /// Adds a named property with a [value] of type [T]
+  /// to the error report.
+  void addErrorProperty<T>(
+    String name,
+    T value, {
+    DiagnosticsTreeStyle style = DiagnosticsTreeStyle.indentedSingleLine,
+    String linePrefix,
+  }) {
+    addProperty<T>(name, value, level: DiagnosticLevel.error, style: style, linePrefix: linePrefix);
+  }
+
+  /// Returns a list of DiagnosticsNode objects including all parts of
+  /// the error report.
+  List<DiagnosticsNode> toDiagnostics() {
+    if (error == null && _buildErrorCallback == null) {
+      return _parts;
+    }
+
+    List<DiagnosticsNode> diagnostics;
+    if (_buildErrorCallback != null) {
+      diagnostics = _buildErrorCallback().toDiagnostics();
+    } else {
+      diagnostics = <DiagnosticsNode>[];
+    }
+    if (error != null) {
+      diagnostics.insert(0, DiagnosticsNode.message(error, level: DiagnosticLevel.error));
+    }
+    diagnostics.addAll(_parts);
+    return diagnostics;
+  }
+  
+  /// Adds a property only displayed in GUI debugging tools and not in text
+  /// messages.
+  void addDebugProperty<T>(String name, T value) {
+    _parts.add(DiagnosticsProperty<T>(name, value, level: DiagnosticLevel.debug));
+  }
+
+  /// Adds a property with an `Iterable<T>` [value] to the error report.
+  void addIterable<T>(String name, Iterable<T> children, {DiagnosticLevel level = DiagnosticLevel.info}) {
+    _parts.add(IterableProperty<T>(
+      name,
+      children,
+      style: DiagnosticsTreeStyle.whitespace,
+      level: level,
+    ));
+  }
+
+  /// Adds a [StackTrace] relevant to the error.
+  void addStackTrace(String name, StackTrace stackTrace, {IterableFilter<String> stackFilter}) {
+    _parts.add(DiagnosticsStackTrace(name, stackTrace, stackFilter: stackFilter));
+  }
+
+  /// Adds an [IntProperty]
+  void addIntProperty(String name, int value) {
+    _parts.add(IntProperty(name, value));
+  }
+
+  /// Adds extra space between two parts of the error report.
+  ///
+  /// The client can decide how the "separator" is rendered.
+  /// It falls back to an extra line break in the console.
+  void addSeparator() {
+    _parts.add(DiagnosticsNode.message(''));
+  }
+
+  /// Adds an instance of [DiagnosticNode] to the error report.
+  ///
+  /// In general, other methods that add specific error parts should be used
+  /// before resorting to this method, since the other methods will by default
+  /// use styles consistent with other error displays.
+  /// For example, indenting values to show on the next line, etc.
+  void addDiagnostic(DiagnosticsNode diagnostic) {
+    _parts.add(diagnostic);
+  }
+
+  /// Adds a list of [DiagnosticNode] instances to the error report.
+  /// See also:
+  ///
+  ///  * [addDiagnostic], which adds a single diagnostic.
+  void addAll(Iterable<DiagnosticsNode> diagnostics) {
+    _parts.addAll(diagnostics);
+  }
+
+  /// Builds a FlutterError based on the message parts collected by
+  /// this instance of FlutterErrorBuilder.
+  FlutterError build() {
+    return FlutterError.from(this);
   }
 }
 
@@ -179,13 +532,75 @@ class FlutterErrorDetails {
 class FlutterError extends AssertionError {
   /// Creates a [FlutterError].
   ///
-  /// See [message] for details on the format that the message should
-  /// take.
-  ///
   /// Include as much detail as possible in the full error message,
   /// including specifics about the state of the app that might be
   /// relevant to debugging the error.
-  FlutterError(String message) : super(message);
+  /// [error] describes the error that occurred.
+  /// [description] provides more details about the error that occurred.
+  /// [hint] explains the cause of the issue.
+  /// [fix] explains a way to fix the issue.
+  ///
+  /// See also:
+  ///
+  ///  * [FlutterErrorBuilder], which should be used to generate [FlutterError]
+  ///    objects with more structure than this constructor allows.
+  FlutterError(
+    String error, {
+    String violation,
+    String description,
+    String fix,
+    String contract,
+    String hint,
+  }) : messageParts = _createDiagnosticsList(
+    error: error,
+    violation: violation,
+    description: description,
+    fix: fix,
+    contract: contract,
+    hint: hint,
+  );
+
+  /// Creates an [FlutterError] from a [FlutterErrorBuilder].
+  ///
+  /// Use this named constructor to create errors with structured debugging
+  /// information. Prefer the default constructor for cases where the error
+  /// only consists of a sequence of string messages in an order consistent with
+  /// the default constructor.
+  FlutterError.from(FlutterErrorBuilder builder) :
+        messageParts = builder.toDiagnostics();
+
+  static List<DiagnosticsNode> _createDiagnosticsList({
+    @required String error,
+    String violation,
+    String description,
+    String fix,
+    String contract,
+    String hint,
+  }) {
+    final FlutterErrorBuilder errorBuilder = FlutterErrorBuilder();
+    errorBuilder.addError(error);
+
+    if (violation?.isNotEmpty == true)
+      errorBuilder.addViolation(violation);
+
+    if (description?.isNotEmpty == true)
+      errorBuilder.addDescription(description);
+
+    if (fix?.isNotEmpty == true)
+      errorBuilder.addFix(fix);
+
+    if (hint?.isNotEmpty == true)
+      errorBuilder.addHint(hint);
+
+    if (contract?.isNotEmpty == true)
+      errorBuilder.addContract(contract);
+
+    return errorBuilder.toDiagnostics();
+  }
+
+  /// Diagnostics providing a tool friendly description of the cause of the
+  /// FlutterError.
+  final List<DiagnosticsNode> messageParts;
 
   /// The message associated with this error.
   ///
@@ -203,10 +618,16 @@ class FlutterError extends AssertionError {
   /// All sentences in the error should be correctly punctuated (i.e.,
   /// do end the error message with a period).
   @override
-  String get message => super.message;
+  String get message {
+    if (messageParts == null) {
+      return super.message;
+    }
+    final TextRenderer renderer = TextRenderer(wrapWidth: wrapWidth);
+    return messageParts.map((DiagnosticsNode node) => renderer.render(node).trimRight()).join('\n');
+  }
 
   @override
-  String toString() => message;
+  String toString({DiagnosticLevel minLevel}) => message;
 
   /// Called whenever the Flutter framework catches an error.
   ///
@@ -238,6 +659,112 @@ class FlutterError extends AssertionError {
   /// they will wrap, e.g. when placing ASCII art diagrams in messages.
   static const int wrapWidth = 100;
 
+  /// Converts the given exception details to a tree of [DiagnosticsNode]
+  /// objects.
+  ///
+  /// The returned [DiagnosticsNode] should be used to log FlutterErrorDetails
+  /// objects to the console and by debugging tools that display rich
+  /// interactive versions of error objects.
+  ///
+  /// See also:
+  ///
+  ///  * [FlutterError.dumpErrorToConsole], which uses this DiagnosticsNode to
+  ///    dump the error to the console.
+  ///  * [InspectorService], which uses this method to send errors to GUI
+  ///    clients in a structured manner.
+  static DiagnosticsNode errorToDiagnostic(FlutterErrorDetails details) {
+    final FlutterErrorBuilder errorBuilder = FlutterErrorBuilder();
+
+    void addContextHeader(String namePrefix, [String nameSuffix = ':']) {
+      // Hixie, we are ingoring suffix for now. Can we just standardize to
+      // all header lines ending with ':' or is that a step backwards?
+      // XXX resolve this question before submitting. See the calls to this
+      // method that indicate what the header should be in each case if we care.
+      errorBuilder.addDiagnostic(details._diagnosticContext('$namePrefix thrown'));
+    }
+    if (details.exception is NullThrownError) {
+      addContextHeader('The null value was', '.');
+    } else if (details.exception is num) {
+      addContextHeader('The number ${details.exception} was', '.');
+    } else if (details.exception is FlutterError) {
+      final FlutterError flutterError = details.exception;
+      addContextHeader('The following assertion was');
+      errorBuilder.addAll(flutterError.messageParts);
+    }
+    else {
+      String errorName;
+      if (details.exception is AssertionError) {
+        errorName = 'assertion';
+      } else if (details.exception is String) {
+        errorName = 'message';
+      } else if (details.exception is Error || details.exception is Exception) {
+        errorName = '${details.exception.runtimeType}';
+      } else {
+        errorName = '${details.exception.runtimeType} object';
+      }
+      // Many exception classes put their type at the head of their message.
+      // This is redundant with the way we display exceptions, so attempt to
+      // strip out that header when we see it.
+      final String prefix = '${details.exception.runtimeType}: ';
+      String message = details.exceptionAsString();
+      if (message.startsWith(prefix))
+        message = message.substring(prefix.length);
+      addContextHeader('The following $errorName was');
+      errorBuilder.addDescription(message);
+    }
+    final Iterable<String> stackLines = (details.stack != null) ? details.stack.toString().trimRight().split('\n') : null;
+    if ((details.exception is AssertionError) && (details.exception is! FlutterError)) {
+      bool ourFault = true;
+      if (stackLines != null) {
+        final List<String> stackList = stackLines.take(2).toList();
+        if (stackList.length >= 2) {
+          // TODO(ianh): This has bitrotted and is no longer matching. https://github.com/flutter/flutter/issues/4021
+          final RegExp throwPattern = RegExp(
+              r'^#0 +_AssertionError._throwNew \(dart:.+\)$');
+          final RegExp assertPattern = RegExp(
+              r'^#1 +[^(]+ \((.+?):([0-9]+)(?::[0-9]+)?\)$');
+          if (throwPattern.hasMatch(stackList[0])) {
+            final Match assertMatch = assertPattern.firstMatch(stackList[1]);
+            if (assertMatch != null) {
+              assert(assertMatch.groupCount == 2);
+              final RegExp ourLibraryPattern = RegExp(r'^package:flutter/');
+              ourFault = ourLibraryPattern.hasMatch(assertMatch.group(1));
+            }
+          }
+        }
+      }
+      if (ourFault) {
+        errorBuilder.addSeparator();
+        errorBuilder.addHint(
+          'Either the assertion indicates an error in the framework itself, or we should '
+          'provide substantially more information in this error message to help you determine '
+          'and fix the underlying cause.\n'
+          'In either case, please report this assertion by filing a bug on GitHub',
+          url: 'https://github.com/flutter/flutter/issues/new?template=BUG.md',
+        );
+      }
+    }
+    if (details.stack != null) {
+      errorBuilder.addSeparator();
+      errorBuilder.addStackTrace('When the exception was thrown, this was the stack', details.stack, stackFilter: details.stackFilter);
+      if (details.informationCollector != null || details._errorBuilder != null) //ignore: deprecated_member_use_from_same_package
+        errorBuilder.addSeparator();
+    }
+    if (details.informationCollector != null) { //ignore: deprecated_member_use_from_same_package
+      final StringBuffer information = StringBuffer();
+      details.informationCollector(information); //ignore: deprecated_member_use_from_same_package
+      errorBuilder.addDescription(information.toString().trimRight());
+    }
+    if (details._errorBuilder != null) {
+      errorBuilder.addAll(details._errorBuilder.toDiagnostics());
+    }
+    return DiagnosticsBlock(name: 'EXCEPTION CAUGHT BY', description: details.library.toUpperCase(),
+      properties: errorBuilder.toDiagnostics(),
+      showSeparator: false,
+      style: DiagnosticsTreeStyle.error,
+    );
+  }
+
   /// Prints the given exception details to the console.
   ///
   /// The first time this is called, it dumps a very verbose message to the
@@ -262,77 +789,7 @@ class FlutterError extends AssertionError {
     if (!reportError && !forceReport)
       return;
     if (_errorCount == 0 || forceReport) {
-      final String header = '\u2550\u2550\u2561 EXCEPTION CAUGHT BY ${details.library} \u255E'.toUpperCase();
-      final String footer = '\u2550' * wrapWidth;
-      debugPrint('$header${"\u2550" * (footer.length - header.length)}');
-      final String verb = 'thrown${ details.context != null ? " ${details.context}" : ""}';
-      if (details.exception is NullThrownError) {
-        debugPrint('The null value was $verb.', wrapWidth: wrapWidth);
-      } else if (details.exception is num) {
-        debugPrint('The number ${details.exception} was $verb.', wrapWidth: wrapWidth);
-      } else {
-        String errorName;
-        if (details.exception is AssertionError) {
-          errorName = 'assertion';
-        } else if (details.exception is String) {
-          errorName = 'message';
-        } else if (details.exception is Error || details.exception is Exception) {
-          errorName = '${details.exception.runtimeType}';
-        } else {
-          errorName = '${details.exception.runtimeType} object';
-        }
-        // Many exception classes put their type at the head of their message.
-        // This is redundant with the way we display exceptions, so attempt to
-        // strip out that header when we see it.
-        final String prefix = '${details.exception.runtimeType}: ';
-        String message = details.exceptionAsString();
-        if (message.startsWith(prefix))
-          message = message.substring(prefix.length);
-        debugPrint('The following $errorName was $verb:\n$message', wrapWidth: wrapWidth);
-      }
-      Iterable<String> stackLines = (details.stack != null) ? details.stack.toString().trimRight().split('\n') : null;
-      if ((details.exception is AssertionError) && (details.exception is! FlutterError)) {
-        bool ourFault = true;
-        if (stackLines != null) {
-          final List<String> stackList = stackLines.take(2).toList();
-          if (stackList.length >= 2) {
-            // TODO(ianh): This has bitrotted and is no longer matching. https://github.com/flutter/flutter/issues/4021
-            final RegExp throwPattern = RegExp(r'^#0 +_AssertionError._throwNew \(dart:.+\)$');
-            final RegExp assertPattern = RegExp(r'^#1 +[^(]+ \((.+?):([0-9]+)(?::[0-9]+)?\)$');
-            if (throwPattern.hasMatch(stackList[0])) {
-              final Match assertMatch = assertPattern.firstMatch(stackList[1]);
-              if (assertMatch != null) {
-                assert(assertMatch.groupCount == 2);
-                final RegExp ourLibraryPattern = RegExp(r'^package:flutter/');
-                ourFault = ourLibraryPattern.hasMatch(assertMatch.group(1));
-              }
-            }
-          }
-        }
-        if (ourFault) {
-          debugPrint('\nEither the assertion indicates an error in the framework itself, or we should '
-                     'provide substantially more information in this error message to help you determine '
-                     'and fix the underlying cause.', wrapWidth: wrapWidth);
-          debugPrint('In either case, please report this assertion by filing a bug on GitHub:', wrapWidth: wrapWidth);
-          debugPrint('  https://github.com/flutter/flutter/issues/new?template=BUG.md');
-        }
-      }
-      if (details.stack != null) {
-        debugPrint('\nWhen the exception was thrown, this was the stack:', wrapWidth: wrapWidth);
-        if (details.stackFilter != null) {
-          stackLines = details.stackFilter(stackLines);
-        } else {
-          stackLines = defaultStackFilter(stackLines);
-        }
-        for (String line in stackLines)
-          debugPrint(line, wrapWidth: wrapWidth);
-      }
-      if (details.informationCollector != null) {
-        final StringBuffer information = StringBuffer();
-        details.informationCollector(information);
-        debugPrint('\n${information.toString().trimRight()}', wrapWidth: wrapWidth);
-      }
-      debugPrint(footer);
+      debugPrint(TextRenderer(wrapWidth: wrapWidth, wrapWidthProperties: wrapWidth, maxDescendentsTruncatableNode: 5).render(errorToDiagnostic(details)));
     } else {
       debugPrint('Another exception was thrown: ${details.exceptionAsString().split("\n")[0].trimLeft()}');
     }

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -497,7 +497,7 @@ abstract class BindingBase {
         FlutterError.reportError(FlutterErrorDetails(
           exception: caughtException,
           stack: caughtStack,
-          context: 'during a service extension callback for "$method"'
+          context: 'during a service extension callback for: "$method"',
         ));
         return developer.ServiceExtensionResponse.error(
           developer.ServiceExtensionResponse.extensionError,

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -103,8 +103,8 @@ class ChangeNotifier implements Listenable {
     assert(() {
       if (_listeners == null) {
         throw FlutterError(
-          'A $runtimeType was used after being disposed.\n'
-          'Once you have called dispose() on a $runtimeType, it can no longer be used.'
+          'A $runtimeType was used after being disposed.',
+          contract: 'Once you have called dispose() on a $runtimeType, it can no longer be used.'
         );
       }
       return true;
@@ -208,11 +208,9 @@ class ChangeNotifier implements Listenable {
             exception: exception,
             stack: stack,
             library: 'foundation library',
-            context: 'while dispatching notifications for $runtimeType',
-            informationCollector: (StringBuffer information) {
-              information.writeln('The $runtimeType sending notification was:');
-              information.write('  $this');
-            }
+            context: 'while dispatching notifications for',
+            contextObject: runtimeType,
+            errorBuilder: FlutterErrorBuilder ()..addProperty('The $runtimeType sending notification', this)
           ));
         }
       }

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -66,9 +66,9 @@ TargetPlatform get defaultTargetPlatform {
     result = debugDefaultTargetPlatformOverride;
   if (result == null) {
     throw FlutterError(
-      'Unknown platform.\n'
-      '${Platform.operatingSystem} was not recognized as a target platform. '
-      'Consider updating the list of TargetPlatforms to include this platform.'
+      'Unknown platform.',
+      description: '${Platform.operatingSystem} was not recognized as a target platform.',
+      hint: 'Consider updating the list of TargetPlatforms to include this platform.'
     );
   }
   return result;

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -164,12 +164,9 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
           context: 'while dispatching a pointer event',
           event: event,
           hitTestEntry: entry,
-          informationCollector: (StringBuffer information) {
-            information.writeln('Event:');
-            information.writeln('  $event');
-            information.writeln('Target:');
-            information.write('  ${entry.target}');
-          }
+          errorBuilder: FlutterErrorBuilder()
+            ..addProperty('Event', event)
+            ..addProperty('Target', entry.target)
         ));
       }
     }
@@ -202,16 +199,20 @@ class FlutterErrorDetailsForPointerEventDispatcher extends FlutterErrorDetails {
     StackTrace stack,
     String library,
     String context,
+    Object contextObject,
     this.event,
     this.hitTestEntry,
     InformationCollector informationCollector,
+    FlutterErrorBuilder errorBuilder,
     bool silent = false
   }) : super(
     exception: exception,
     stack: stack,
     library: library,
     context: context,
+    contextObject: contextObject,
     informationCollector: informationCollector,
+    errorBuilder: errorBuilder,
     silent: silent
   );
 

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -80,10 +80,7 @@ class PointerRouter {
         router: this,
         route: route,
         event: event,
-        informationCollector: (StringBuffer information) {
-          information.writeln('Event:');
-          information.write('  $event');
-        }
+        errorBuilder: FlutterErrorBuilder()..addProperty('Event', event),
       ));
     }
   }
@@ -124,17 +121,21 @@ class FlutterErrorDetailsForPointerRouter extends FlutterErrorDetails {
     StackTrace stack,
     String library,
     String context,
+    Object contextObject,
     this.router,
     this.route,
     this.event,
     InformationCollector informationCollector,
+    FlutterErrorBuilder errorBuilder,
     bool silent = false
   }) : super(
     exception: exception,
     stack: stack,
     library: library,
     context: context,
+    contextObject: contextObject,
     informationCollector: informationCollector,
+    errorBuilder: errorBuilder,
     silent: silent
   );
 

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -124,11 +124,9 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
         stack: stack,
         library: 'gesture',
         context: 'while handling a gesture',
-        informationCollector: (StringBuffer information) {
-          information.writeln('Handler: $name');
-          information.writeln('Recognizer:');
-          information.writeln('  $this');
-        }
+        errorBuilder: FlutterErrorBuilder()
+          ..addStringProperty('Handler', name)
+          ..addProperty('Recognizer', this)
       ));
     }
     return result;

--- a/packages/flutter/lib/src/material/debug.dart
+++ b/packages/flutter/lib/src/material/debug.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'material.dart';
@@ -23,45 +24,27 @@ import 'material_localizations.dart';
 bool debugCheckHasMaterial(BuildContext context) {
   assert(() {
     if (context.widget is! Material && context.ancestorWidgetOfExactType(Material) == null) {
-      final StringBuffer message = StringBuffer();
-      message.writeln('No Material widget found.');
-      message.writeln(
-        '${context.widget.runtimeType} widgets require a Material '
-        'widget ancestor.'
-      );
-      message.writeln(
-        'In material design, most widgets are conceptually "printed" on '
-        'a sheet of material. In Flutter\'s material library, that '
-        'material is represented by the Material widget. It is the '
-        'Material widget that renders ink splashes, for instance. '
-        'Because of this, many material library widgets require that '
-        'there be a Material widget in the tree above them.'
-      );
-      message.writeln(
-        'To introduce a Material widget, you can either directly '
-        'include one, or use a widget that contains Material itself, '
-        'such as a Card, Dialog, Drawer, or Scaffold.'
-      );
-      message.writeln(
-        'The specific widget that could not find a Material ancestor was:'
-      );
-      message.writeln('  ${context.widget}');
-      final List<Widget> ancestors = <Widget>[];
-      context.visitAncestorElements((Element element) {
-        ancestors.add(element.widget);
-        return true;
-      });
-      if (ancestors.isNotEmpty) {
-        message.write('The ancestors of this widget were:');
-        for (Widget ancestor in ancestors)
-          message.write('\n  $ancestor');
-      } else {
-        message.writeln(
-          'This widget is the root of the tree, so it has no '
-          'ancestors, let alone a "Material" ancestor.'
-        );
-      }
-      throw FlutterError(message.toString());
+      final WidgetErrorBuilder errorBuilder = WidgetErrorBuilder()
+        ..addError(
+          '${context.widget.runtimeType} widgets require a Material '
+          'widget ancestor, but we couldn\'t find any.'
+        )
+        ..addDescription(
+          'In material design, most widgets are conceptually "printed" on '
+          'a sheet of material. In Flutter\'s material library, that '
+          'material is represented by the Material widget. It is the '
+          'Material widget that renders ink splashes, for instance. '
+          'Because of this, many material library widgets require that '
+          'there be a Material widget in the tree above them.'
+        )
+        ..addHint(
+          'To introduce a Material widget, you can either directly '
+          'include one, or use a widget that contains Material itself, '
+          'such as a Card, Dialog, Drawer, or Scaffold.',
+        )
+        ..describeMissingAncestor(context, expectedAncestorType: Material);
+
+      throw errorBuilder.build();
     }
     return true;
   }());
@@ -86,42 +69,22 @@ bool debugCheckHasMaterial(BuildContext context) {
 bool debugCheckHasMaterialLocalizations(BuildContext context) {
   assert(() {
     if (Localizations.of<MaterialLocalizations>(context, MaterialLocalizations) == null) {
-      final StringBuffer message = StringBuffer();
-      message.writeln('No MaterialLocalizations found.');
-      message.writeln(
-        '${context.widget.runtimeType} widgets require MaterialLocalizations '
-        'to be provided by a Localizations widget ancestor.'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('No MaterialLocalizations found.')
+        ..addDescription(
+          '${context.widget.runtimeType} widgets require MaterialLocalizations '
+          'to be provided by a Localizations widget ancestor.\n'
+          'Localizations are used to generate many different messages, labels,'
+          'and abbreviations which are used by the material library.\n'
+        )
+        ..addFix(
+          'To introduce a MaterialLocalizations, either use a '
+          ' MaterialApp at the root of your application to include them '
+          'automatically, or add a Localization widget with a '
+          'MaterialLocalizations delegate.'
+        )
+        ..describeMissingAncestor(context, expectedAncestorType: MaterialLocalizations)
       );
-      message.writeln(
-        'Localizations are used to generate many different messages, labels,'
-        'and abbreviations which are used by the material library. '
-      );
-      message.writeln(
-        'To introduce a MaterialLocalizations, either use a '
-        ' MaterialApp at the root of your application to include them '
-        'automatically, or add a Localization widget with a '
-        'MaterialLocalizations delegate.'
-      );
-      message.writeln(
-        'The specific widget that could not find a MaterialLocalizations ancestor was:'
-      );
-      message.writeln('  ${context.widget}');
-      final List<Widget> ancestors = <Widget>[];
-      context.visitAncestorElements((Element element) {
-        ancestors.add(element.widget);
-        return true;
-      });
-      if (ancestors.isNotEmpty) {
-        message.write('The ancestors of this widget were:');
-        for (Widget ancestor in ancestors)
-          message.write('\n  $ancestor');
-      } else {
-        message.writeln(
-          'This widget is the root of the tree, so it has no '
-          'ancestors, let alone a "Localizations" ancestor.'
-        );
-      }
-      throw FlutterError(message.toString());
     }
     return true;
   }());

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -87,8 +87,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     assert(() {
       if (result == null) {
         throw FlutterError(
-          'The builder for route "${settings.name}" returned null.\n'
-          'Route builders must never return null.'
+          'The builder for route "${settings.name}" returned null.',
+          description: 'Route builders must never return null.'
         );
       }
       return true;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -359,8 +359,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
             if (refreshResult == null)
               FlutterError.reportError(FlutterErrorDetails(
                 exception: FlutterError(
-                  'The onRefresh callback returned null.\n'
-                  'The RefreshIndicator onRefresh callback must return a Future.'
+                  'The onRefresh callback returned null.',
+                  hint: 'The RefreshIndicator onRefresh callback must return a Future.'
                 ),
                 context: 'when calling onRefresh',
                 library: 'material library',

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -252,8 +252,8 @@ class _ScaffoldGeometryNotifier extends ChangeNotifier implements ValueListenabl
       final RenderObject renderObject = context.findRenderObject();
       if (renderObject == null || !renderObject.owner.debugDoingPaint)
         throw FlutterError(
-            'Scaffold.geometryOf() must only be accessed during the paint phase.\n'
-            'The ScaffoldGeometry is only available during the paint phase, because\n'
+            'Scaffold.geometryOf() must only be accessed during the paint phase.',
+            hint: 'The ScaffoldGeometry is only available during the paint phase, because\n'
             'its value is computed during the animation and layout phases prior to painting.'
         );
       return true;
@@ -1016,24 +1016,27 @@ class Scaffold extends StatefulWidget {
     final ScaffoldState result = context.ancestorStateOfType(const TypeMatcher<ScaffoldState>());
     if (nullOk || result != null)
       return result;
-    throw FlutterError(
-      'Scaffold.of() called with a context that does not contain a Scaffold.\n'
-      'No Scaffold ancestor could be found starting from the context that was passed to Scaffold.of(). '
+    throw FlutterError.from(FlutterErrorBuilder()
+      ..addError('Scaffold.of() called with a context that does not contain a Scaffold.')
+      ..addDescription(
+        'No Scaffold ancestor could be found starting from the context that was passed to Scaffold.of(). '
       'This usually happens when the context provided is from the same StatefulWidget as that '
-      'whose build function actually creates the Scaffold widget being sought.\n'
-      'There are several ways to avoid this problem. The simplest is to use a Builder to get a '
-      'context that is "under" the Scaffold. For an example of this, please see the '
-      'documentation for Scaffold.of():\n'
-      '  https://docs.flutter.io/flutter/material/Scaffold/of.html\n'
-      'A more efficient solution is to split your build function into several widgets. This '
+      'whose build function actually creates the Scaffold widget being sought.')
+      ..addHint(
+        'There are several ways to avoid this problem. The simplest is to use a Builder to get a '
+        'context that is "under" the Scaffold. For an example of this, please see the '
+        'documentation for Scaffold.of()',
+        url: 'https://docs.flutter.io/flutter/material/Scaffold/of.html'
+      )
+      ..addHint('A more efficient solution is to split your build function into several widgets. This '
       'introduces a new context from which you can obtain the Scaffold. In this solution, '
       'you would have an outer widget that creates the Scaffold populated by instances of '
       'your new inner widgets, and then in these inner widgets you would use Scaffold.of().\n'
       'A less elegant but more expedient solution is assign a GlobalKey to the Scaffold, '
       'then use the key.currentState property to obtain the ScaffoldState rather than '
-      'using the Scaffold.of() function.\n'
-      'The context used was:\n'
-      '  $context'
+      'using the Scaffold.of() function.')
+      ..addSeparator()
+      ..addProperty('The context used was', context)
     );
   }
 
@@ -1060,20 +1063,24 @@ class Scaffold extends StatefulWidget {
   static ValueListenable<ScaffoldGeometry> geometryOf(BuildContext context) {
     final _ScaffoldScope scaffoldScope = context.inheritFromWidgetOfExactType(_ScaffoldScope);
     if (scaffoldScope == null)
-      throw FlutterError(
-        'Scaffold.geometryOf() called with a context that does not contain a Scaffold.\n'
-        'This usually happens when the context provided is from the same StatefulWidget as that '
-        'whose build function actually creates the Scaffold widget being sought.\n'
-        'There are several ways to avoid this problem. The simplest is to use a Builder to get a '
-        'context that is "under" the Scaffold. For an example of this, please see the '
-        'documentation for Scaffold.of():\n'
-        '  https://docs.flutter.io/flutter/material/Scaffold/of.html\n'
-        'A more efficient solution is to split your build function into several widgets. This '
+      throw FlutterError.from(FlutterErrorBuilder()
+        ..addError('Scaffold.geometryOf() called with a context that does not contain a Scaffold.')
+        ..addDescription(
+          'This usually happens when the context provided is from the same StatefulWidget as that '
+          'whose build function actually creates the Scaffold widget being sought.\n'
+        )
+        ..addHint(
+          'There are several ways to avoid this problem. The simplest is to use a Builder to get a '
+          'context that is "under" the Scaffold. For an example of this, please see the '
+          'documentation for Scaffold.of():\n'
+          '  https://docs.flutter.io/flutter/material/Scaffold/of.html'
+        )
+        ..addHint('A more efficient solution is to split your build function into several widgets. This '
         'introduces a new context from which you can obtain the Scaffold. In this solution, '
         'you would have an outer widget that creates the Scaffold populated by instances of '
-        'your new inner widgets, and then in these inner widgets you would use Scaffold.geometryOf().\n'
-        'The context used was:\n'
-        '  $context'
+        'your new inner widgets, and then in these inner widgets you would use Scaffold.geometryOf().\n',
+        )
+        ..addProperty('The context used was', context)
       );
 
     return scaffoldScope.geometryNotifier;
@@ -1511,7 +1518,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         if (widget.bottomSheet != null && _currentBottomSheet?._isLocalHistoryEntry == true) {
           throw FlutterError(
             'Scaffold.bottomSheet cannot be specified while a bottom sheet displayed '
-            'with showBottomSheet() is still visible.\n Use the PersistentBottomSheetController '
+            'with showBottomSheet() is still visible.',
+            fix: 'Use the PersistentBottomSheetController '
             'returned by showBottomSheet() to close the old bottom sheet before creating '
             'a Scaffold with a (non null) bottomSheet.'
           );

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -674,7 +674,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     assert(() {
       if (context.ancestorWidgetOfExactType(Stepper) != null)
         throw FlutterError(
-          'Steppers must not be nested. The material specification advises '
+          'Steppers must not be nested.',
+          hint: 'The material specification advises '
           'that one should avoid embedding steppers within steppers. '
           'https://material.google.com/components/steppers.html#steppers-usage\n'
         );

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -746,12 +746,14 @@ class _TabBarState extends State<TabBar> {
     final TabController newController = widget.controller ?? DefaultTabController.of(context);
     assert(() {
       if (newController == null) {
-        throw FlutterError(
-          'No TabController for ${widget.runtimeType}.\n'
-          'When creating a ${widget.runtimeType}, you must either provide an explicit '
-          'TabController using the "controller" property, or you must ensure that there '
-          'is a DefaultTabController above the ${widget.runtimeType}.\n'
-          'In this case, there was neither an explicit controller nor a default controller.'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('No TabController for ${widget.runtimeType}.')
+          ..addHint(
+            'When creating a ${widget.runtimeType}, you must either provide an explicit '
+            'TabController using the "controller" property, or you must ensure that there '
+            'is a DefaultTabController above the ${widget.runtimeType}.'
+          )
+          ..addViolation('In this case, there was neither an explicit controller nor a default controller.')
         );
       }
       return true;
@@ -1088,12 +1090,14 @@ class _TabBarViewState extends State<TabBarView> {
     final TabController newController = widget.controller ?? DefaultTabController.of(context);
     assert(() {
       if (newController == null) {
-        throw FlutterError(
-          'No TabController for ${widget.runtimeType}.\n'
-          'When creating a ${widget.runtimeType}, you must either provide an explicit '
-          'TabController using the "controller" property, or you must ensure that there '
-          'is a DefaultTabController above the ${widget.runtimeType}.\n'
-          'In this case, there was neither an explicit controller nor a default controller.'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('No TabController for ${widget.runtimeType}.')
+          ..addHint(
+            'When creating a ${widget.runtimeType}, you must either provide an explicit '
+            'TabController using the "controller" property, or you must ensure that there '
+            'is a DefaultTabController above the ${widget.runtimeType}.'
+          )
+          ..addViolation('In this case, there was neither an explicit controller nor a default controller.')
         );
       }
       return true;
@@ -1344,12 +1348,14 @@ class TabPageSelector extends StatelessWidget {
     final TabController tabController = controller ?? DefaultTabController.of(context);
     assert(() {
       if (tabController == null) {
-        throw FlutterError(
-          'No TabController for $runtimeType.\n'
-          'When creating a $runtimeType, you must either provide an explicit TabController '
-          'using the "controller" property, or you must ensure that there is a '
-          'DefaultTabController above the $runtimeType.\n'
-          'In this case, there was neither an explicit controller nor a default controller.'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('No TabController for $runtimeType.')
+          ..addHint(
+            'When creating a $runtimeType, you must either provide an explicit TabController '
+            'using the "controller" property, or you must ensure that there is a '
+            'DefaultTabController above the $runtimeType.'
+          )
+          ..addViolation('In this case, there was neither an explicit controller nor a default controller.')
         );
       }
       return true;

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -152,13 +152,15 @@ abstract class BoxBorder extends ShapeBorder {
         bottom: BorderSide.lerp(a.bottom, b.bottom, t),
       );
     }
+    // XXX can we rewrite this message to be more consistent with
+    // others?
     throw FlutterError(
-      'BoxBorder.lerp can only interpolate Border and BorderDirectional classes.\n'
-      'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
+      'BoxBorder.lerp can only interpolate Border and BorderDirectional classes.',
+      description: 'BoxBorder.lerp() was called with two objects of type ${a.runtimeType} and ${b.runtimeType}:\n'
       '  $a\n'
       '  $b\n'
-      'However, only Border and BorderDirectional classes are supported by this method. '
-      'For a more general interpolation method, consider using ShapeBorder.lerp instead.'
+      'However, only Border and BorderDirectional classes are supported by this method.',
+      hint: 'For a more general interpolation method, consider using ShapeBorder.lerp instead.',
     );
   }
 

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -220,14 +220,14 @@ class DecorationImagePainter {
         // We check this first so that the assert will fire immediately, not just
         // when the image is ready.
         if (configuration.textDirection == null) {
-          throw FlutterError(
-            'ImageDecoration.matchTextDirection can only be used when a TextDirection is available.\n'
-            'When DecorationImagePainter.paint() was called, there was no text direction provided '
-            'in the ImageConfiguration object to match.\n'
-            'The DecorationImage was:\n'
-            '  $_details\n'
-            'The ImageConfiguration was:\n'
-            '  $configuration'
+          throw FlutterError.from(FlutterErrorBuilder()
+            ..addError('ImageDecoration.matchTextDirection can only be used when a TextDirection is available.')
+            ..addViolation(
+              'When DecorationImagePainter.paint() was called, there was no text direction provided '
+              'in the ImageConfiguration object to match.'
+            )
+            ..addProperty('The DecorationImage was', _details)
+            ..addProperty('The ImageConfiguration was', configuration)
           );
         }
         return true;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -269,15 +269,12 @@ abstract class ImageProvider<T> {
       imageCompleter.setError(
         exception: exception,
         stack: stack,
-        context: 'while resolving an image',
+        contextName: 'while resolving an image',
         silent: true, // could be a network error or whatnot
-        informationCollector: (StringBuffer information) {
-          information.writeln('Image provider: $this');
-          information.writeln('Image configuration: $configuration');
-          if (obtainedKey != null) {
-            information.writeln('Image key: $obtainedKey');
-          }
-        }
+        errorBuilder: FlutterErrorBuilder()
+          ..addProperty('Image provider', this, style: DiagnosticsTreeStyle.singleLine)
+          ..addProperty('Image configuration', configuration)
+          ..addProperty('Image key', obtainedKey, defaultValue: null)
       );
     }
     obtainKey(configuration).then<void>((T key) {
@@ -417,10 +414,9 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,
-      informationCollector: (StringBuffer information) {
-        information.writeln('Image provider: $this');
-        information.write('Image key: $key');
-      }
+      errorBuilder: FlutterErrorBuilder()
+        ..addProperty('Image provider', this, style: DiagnosticsTreeStyle.singleLine)
+        ..addProperty('Image key', key, style: DiagnosticsTreeStyle.singleLine)
     );
   }
 
@@ -474,10 +470,9 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,
-      informationCollector: (StringBuffer information) {
-        information.writeln('Image provider: $this');
-        information.write('Image key: $key');
-      }
+      errorBuilder: FlutterErrorBuilder()
+        ..addProperty('Image provider', this, style: DiagnosticsTreeStyle.singleLine)
+        ..addProperty('Image key', key, style: DiagnosticsTreeStyle.singleLine)
     );
   }
 
@@ -548,9 +543,7 @@ class FileImage extends ImageProvider<FileImage> {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,
-      informationCollector: (StringBuffer information) {
-        information.writeln('Path: ${file?.path}');
-      }
+      errorBuilder: FlutterErrorBuilder()..addProperty('Path', file?.path, style: DiagnosticsTreeStyle.singleLine)
     );
   }
 
@@ -783,17 +776,19 @@ class _ErrorImageCompleter extends ImageStreamCompleter {
   _ErrorImageCompleter();
 
   void setError({
-    String context,
+    String contextName,
+    Object contextObject,
     dynamic exception,
     StackTrace stack,
-    InformationCollector informationCollector,
+    FlutterErrorBuilder errorBuilder,
     bool silent = false,
   }) {
     reportError(
-      context: context,
+      contextName: contextName,
+      contextObject: contextObject,
       exception: exception,
       stack: stack,
-      informationCollector: informationCollector,
+      errorBuilder: errorBuilder,
       silent: silent,
     );
   }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -379,8 +379,8 @@ class TextPainter {
     assert(() {
       if (_needsLayout) {
         throw FlutterError(
-          'TextPainter.paint called when text geometry was not yet calculated.\n'
-          'Please call layout() before paint() to position the text before painting it.'
+          'TextPainter.paint called when text geometry was not yet calculated.',
+          fix: 'Please call layout() before paint() to position the text before painting it.',
         );
       }
       return true;

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -269,11 +269,10 @@ class TextSpan extends DiagnosticableTree {
         }
         return true;
       })) {
-        throw FlutterError(
-          'TextSpan contains a null child.\n'
-          'A TextSpan object with a non-null child list should not have any nulls in its child list.\n'
-          'The full text in question was:\n'
-          '${toStringDeep(prefixLineOne: '  ')}'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('TextSpan contains a null child.')
+          ..addContract('A TextSpan object with a non-null child list should not have any nulls in its child list.')
+          ..addProperty('The full text in question was', text, style: DiagnosticsTreeStyle.whitespace)
         );
       }
       return true;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -182,7 +182,7 @@ class BoxConstraints extends Constraints {
   /// Returns new box constraints that are smaller by the given edge dimensions.
   BoxConstraints deflate(EdgeInsets edges) {
     assert(edges != null);
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     final double horizontal = edges.horizontal;
     final double vertical = edges.vertical;
     final double deflatedMinWidth = math.max(0.0, minWidth - horizontal);
@@ -197,7 +197,7 @@ class BoxConstraints extends Constraints {
 
   /// Returns new box constraints that remove the minimum width and height requirements.
   BoxConstraints loosen() {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     return BoxConstraints(
       minWidth: 0.0,
       maxWidth: maxWidth,
@@ -248,14 +248,14 @@ class BoxConstraints extends Constraints {
   /// Returns the width that both satisfies the constraints and is as close as
   /// possible to the given width.
   double constrainWidth([double width = double.infinity]) {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     return width.clamp(minWidth, maxWidth);
   }
 
   /// Returns the height that both satisfies the constraints and is as close as
   /// possible to the given height.
   double constrainHeight([double height = double.infinity]) {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     return height.clamp(minHeight, maxHeight);
   }
 
@@ -399,7 +399,7 @@ class BoxConstraints extends Constraints {
 
   /// Whether the given size satisfies the constraints.
   bool isSatisfiedBy(Size size) {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     return (minWidth <= size.width) && (size.width <= maxWidth) &&
            (minHeight <= size.height) && (size.height <= maxHeight);
   }
@@ -458,8 +458,8 @@ class BoxConstraints extends Constraints {
       return b * t;
     if (b == null)
       return a * (1.0 - t);
-    assert(a.debugAssertIsValid());
-    assert(b.debugAssertIsValid());
+    assert(a.debugAssertIsValidStructured());
+    assert(b.debugAssertIsValidStructured());
     assert((a.minWidth.isFinite && b.minWidth.isFinite) || (a.minWidth == double.infinity && b.minWidth == double.infinity), 'Cannot interpolate between finite constraints and unbounded constraints.');
     assert((a.maxWidth.isFinite && b.maxWidth.isFinite) || (a.maxWidth == double.infinity && b.maxWidth == double.infinity), 'Cannot interpolate between finite constraints and unbounded constraints.');
     assert((a.minHeight.isFinite && b.minHeight.isFinite) || (a.minHeight == double.infinity && b.minHeight == double.infinity), 'Cannot interpolate between finite constraints and unbounded constraints.');
@@ -492,16 +492,25 @@ class BoxConstraints extends Constraints {
   }
 
   @override
-  bool debugAssertIsValid({
+  bool debugAssertIsValidStructured({
     bool isAppliedConstraint = false,
     InformationCollector informationCollector,
+    FlutterErrorBuilder errorBuilder,
   }) {
     assert(() {
       void throwError(String message) {
-        final StringBuffer information = StringBuffer();
-        if (informationCollector != null)
+        final RenderErrorBuilder builder = RenderErrorBuilder()
+          ..addError(message);
+        if (informationCollector != null) {
+          final StringBuffer information = StringBuffer();
           informationCollector(information);
-        throw FlutterError('$message\n${information}The offending constraints were:\n  $this');
+          builder.addDescription(information.toString());
+        }
+        if (errorBuilder != null)
+          builder.addAll(errorBuilder.toDiagnostics());
+
+        builder.addConstraintsProperty('The offending constraints were', this);
+        throw FlutterError.from(builder);
       }
       if (minWidth.isNaN || maxWidth.isNaN || minHeight.isNaN || maxHeight.isNaN) {
         final List<String> affectedFieldsList = <String>[];
@@ -571,13 +580,13 @@ class BoxConstraints extends Constraints {
 
   @override
   bool operator ==(dynamic other) {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     if (identical(this, other))
       return true;
     if (other is! BoxConstraints)
       return false;
     final BoxConstraints typedOther = other;
-    assert(typedOther.debugAssertIsValid());
+    assert(typedOther.debugAssertIsValidStructured());
     return minWidth == typedOther.minWidth &&
            maxWidth == typedOther.maxWidth &&
            minHeight == typedOther.minHeight &&
@@ -586,7 +595,7 @@ class BoxConstraints extends Constraints {
 
   @override
   int get hashCode {
-    assert(debugAssertIsValid());
+    assert(debugAssertIsValidStructured());
     return hashValues(minWidth, maxWidth, minHeight, maxHeight);
   }
 
@@ -1123,16 +1132,16 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (height == null) {
         throw FlutterError(
-          'The height argument to getMinIntrinsicWidth was null.\n'
-          'The argument to getMinIntrinsicWidth must not be negative or null. '
-          'If you do not have a specific height in mind, then pass double.infinity instead.'
+          'The height argument to getMinIntrinsicWidth was null.',
+          description: 'The argument to getMinIntrinsicWidth must not be negative or null.',
+          hint: 'If you do not have a specific height in mind, then pass double.infinity instead.'
         );
       }
       if (height < 0.0) {
         throw FlutterError(
-          'The height argument to getMinIntrinsicWidth was negative.\n'
-          'The argument to getMinIntrinsicWidth must not be negative or null. '
-          'If you perform computations on another height before passing it to '
+          'The height argument to getMinIntrinsicWidth was negative.',
+          description: 'The argument to getMinIntrinsicWidth must not be negative or null.',
+          hint: 'If you perform computations on another height before passing it to '
           'getMinIntrinsicWidth, consider using math.max() or double.clamp() '
           'to force the value into the valid range.'
         );
@@ -1262,16 +1271,16 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (height == null) {
         throw FlutterError(
-          'The height argument to getMaxIntrinsicWidth was null.\n'
-          'The argument to getMaxIntrinsicWidth must not be negative or null. '
-          'If you do not have a specific height in mind, then pass double.infinity instead.'
+          'The height argument to getMaxIntrinsicWidth was null.',
+          contract: 'The argument to getMaxIntrinsicWidth must not be negative or null.',
+          hint: 'If you do not have a specific height in mind, then pass double.infinity instead.'
         );
       }
       if (height < 0.0) {
         throw FlutterError(
-          'The height argument to getMaxIntrinsicWidth was negative.\n'
-          'The argument to getMaxIntrinsicWidth must not be negative or null. '
-          'If you perform computations on another height before passing it to '
+          'The height argument to getMaxIntrinsicWidth was negative.',
+          contract: 'The argument to getMaxIntrinsicWidth must not be negative or null.',
+          hint: 'If you perform computations on another height before passing it to '
           'getMaxIntrinsicWidth, consider using math.max() or double.clamp() '
           'to force the value into the valid range.'
         );
@@ -1338,16 +1347,16 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (width == null) {
         throw FlutterError(
-          'The width argument to getMinIntrinsicHeight was null.\n'
-          'The argument to getMinIntrinsicHeight must not be negative or null. '
-          'If you do not have a specific width in mind, then pass double.infinity instead.'
+          'The width argument to getMinIntrinsicHeight was null.',
+          contract: 'The argument to getMinIntrinsicHeight must not be negative or null.',
+          hint: 'If you do not have a specific width in mind, then pass double.infinity instead.'
         );
       }
       if (width < 0.0) {
         throw FlutterError(
-          'The width argument to getMinIntrinsicHeight was negative.\n'
-          'The argument to getMinIntrinsicHeight must not be negative or null. '
-          'If you perform computations on another width before passing it to '
+          'The width argument to getMinIntrinsicHeight was negative.',
+          contract: 'The argument to getMinIntrinsicHeight must not be negative or null.',
+          hint: 'If you perform computations on another width before passing it to '
           'getMinIntrinsicHeight, consider using math.max() or double.clamp() '
           'to force the value into the valid range.'
         );
@@ -1411,16 +1420,16 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (width == null) {
         throw FlutterError(
-          'The width argument to getMaxIntrinsicHeight was null.\n'
-          'The argument to getMaxIntrinsicHeight must not be negative or null. '
-          'If you do not have a specific width in mind, then pass double.infinity instead.'
+          'The width argument to getMaxIntrinsicHeight was null.',
+          description: 'The argument to getMaxIntrinsicHeight must not be negative or null.',
+          hint: 'If you do not have a specific width in mind, then pass double.infinity instead.'
         );
       }
       if (width < 0.0) {
         throw FlutterError(
-          'The width argument to getMaxIntrinsicHeight was negative.\n'
-          'The argument to getMaxIntrinsicHeight must not be negative or null. '
-          'If you perform computations on another width before passing it to '
+          'The width argument to getMaxIntrinsicHeight was negative.',
+          description: 'The argument to getMaxIntrinsicHeight must not be negative or null.',
+          hint: 'If you perform computations on another width before passing it to '
           'getMaxIntrinsicHeight, consider using math.max() or double.clamp() '
           'to force the value into the valid range.'
         );
@@ -1512,28 +1521,23 @@ abstract class RenderBox extends RenderObject {
           (!sizedByParent && debugDoingThisLayout))
         return true;
       assert(!debugDoingThisResize);
-      String contract, violation, hint;
+      final FlutterErrorBuilder errorBuilder = FlutterErrorBuilder()
+        ..addError('RenderBox size setter called incorrectly.');
       if (debugDoingThisLayout) {
         assert(sizedByParent);
-        violation = 'It appears that the size setter was called from performLayout().';
-        hint = '';
+        errorBuilder.addViolation('It appears that the size setter was called from performLayout().');
       } else {
-        violation = 'The size setter was called from outside layout (neither performResize() nor performLayout() were being run for this object).';
+        errorBuilder.addViolation(
+          'The size setter was called from outside layout (neither performResize() nor performLayout() were being run for this object).'
+        );
         if (owner != null && owner.debugDoingLayout)
-          hint = 'Only the object itself can set its size. It is a contract violation for other objects to set it.';
+          errorBuilder.addHint('Only the object itself can set its size. It is a contract violation for other objects to set it.');
       }
       if (sizedByParent)
-        contract = 'Because this RenderBox has sizedByParent set to true, it must set its size in performResize().';
+        errorBuilder.addContract('Because this RenderBox has sizedByParent set to true, it must set its size in performResize().');
       else
-        contract = 'Because this RenderBox has sizedByParent set to false, it must set its size in performLayout().';
-      throw FlutterError(
-        'RenderBox size setter called incorrectly.\n'
-        '$violation\n'
-        '$hint\n'
-        '$contract\n'
-        'The RenderBox in question is:\n'
-        '  $this'
-      );
+        errorBuilder.addContract('Because this RenderBox has sizedByParent set to false, it must set its size in performLayout().');
+      throw errorBuilder.build();
     }());
     assert(() {
       value = debugAdoptSize(value);
@@ -1562,40 +1566,46 @@ abstract class RenderBox extends RenderObject {
       if (value is _DebugSize) {
         if (value._owner != this) {
           if (value._owner.parent != this) {
-            throw FlutterError(
-              'The size property was assigned a size inappropriately.\n'
-              'The following render object:\n'
-              '  $this\n'
-              '...was assigned a size obtained from:\n'
-              '  ${value._owner}\n'
-              'However, this second render object is not, or is no longer, a '
-              'child of the first, and it is therefore a violation of the '
-              'RenderBox layout protocol to use that size in the layout of the '
-              'first render object.\n'
-              'If the size was obtained at a time where it was valid to read '
-              'the size (because the second render object above was a child '
-              'of the first at the time), then it should be adopted using '
-              'debugAdoptSize at that time.\n'
-              'If the size comes from a grandchild or a render object from an '
-              'entirely different part of the render tree, then there is no '
-              'way to be notified when the size changes and therefore attempts '
-              'to read that size are almost certainly a source of bugs. A different '
-              'approach should be used.'
+            throw FlutterError.from(FlutterErrorBuilder()
+              ..addError('The size property was assigned a size inappropriately.')
+              ..addProperty('The following render object', this)
+              ..addProperty('...was assigned a size obtained from', value._owner)
+              ..addViolation(
+                'However, this second render object is not, or is no longer, a '
+                'child of the first, and it is therefore a violation of the '
+                'RenderBox layout protocol to use that size in the layout of the '
+                'first render object.'
+              )
+              ..addHint(
+                'If the size was obtained at a time where it was valid to read '
+                'the size (because the second render object above was a child '
+                'of the first at the time), then it should be adopted using '
+                'debugAdoptSize at that time.'
+              )
+              ..addHint(
+                'If the size comes from a grandchild or a render object from an '
+                'entirely different part of the render tree, then there is no '
+                'way to be notified when the size changes and therefore attempts '
+                'to read that size are almost certainly a source of bugs. A different '
+                'approach should be used.'
+              )
             );
           }
           if (!value._canBeUsedByParent) {
-            throw FlutterError(
-              'A child\'s size was used without setting parentUsesSize.\n'
-              'The following render object:\n'
-              '  $this\n'
-              '...was assigned a size obtained from its child:\n'
-              '  ${value._owner}\n'
-              'However, when the child was laid out, the parentUsesSize argument '
-              'was not set or set to false. Subsequently this transpired to be '
-              'inaccurate: the size was nonetheless used by the parent.\n'
-              'It is important to tell the framework if the size will be used or not '
-              'as several important performance optimizations can be made if the '
-              'size will not be used by the parent.'
+            throw FlutterError.from(FlutterErrorBuilder()
+              ..addError('A child\'s size was used without setting parentUsesSize.')
+              ..addProperty('The following render object', this)
+              ..addProperty('...was assigned a size obtained from its child', value._owner)
+              ..addDescription(
+                'However, when the child was laid out, the parentUsesSize argument '
+                'was not set or set to false. Subsequently this transpired to be '
+                'inaccurate: the size was nonetheless used by the parent.'
+              )
+              ..addHint(
+                'It is important to tell the framework if the size will be used or not '
+                'as several important performance optimizations can be made if the '
+                'size will not be used by the parent.'
+              )
             );
           }
         }
@@ -1715,76 +1725,69 @@ abstract class RenderBox extends RenderObject {
         assert(!debugNeedsLayout); // this is called in the size= setter during layout, but in that case we have a size
         String contract;
         if (sizedByParent)
-          contract = 'Because this RenderBox has sizedByParent set to true, it must set its size in performResize().\n';
+          contract = 'Because this RenderBox has sizedByParent set to true, it must set its size in performResize().';
         else
-          contract = 'Because this RenderBox has sizedByParent set to false, it must set its size in performLayout().\n';
-        throw FlutterError(
-          'RenderBox did not set its size during layout.\n'
-          '$contract'
-          'It appears that this did not happen; layout completed, but the size property is still null.\n'
-          'The RenderBox in question is:\n'
-          '  $this'
+          contract = 'Because this RenderBox has sizedByParent set to false, it must set its size in performLayout().';
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('RenderBox did not set its size during layout.')
+          ..addContract(contract)
+          ..addDescription('It appears that this did not happen; layout completed, but the size property is still null.')
+          ..addProperty('The RenderBox in question is', this)
         );
       }
       // verify that the size is not infinite
       if (!_size.isFinite) {
-        final StringBuffer information = StringBuffer();
+        final RenderErrorBuilder errorBuilder = RenderErrorBuilder()
+          ..addError('$runtimeType object was given an infinite size during layout.')
+          ..addHint(
+              'This probably means that it is a render object that tries to be '
+                  'as big as possible, but it was put inside another render object '
+                  'that allows its children to pick their own size.'
+          );
         if (!constraints.hasBoundedWidth) {
           RenderBox node = this;
           while (!node.constraints.hasBoundedWidth && node.parent is RenderBox)
             node = node.parent;
-          information.writeln('The nearest ancestor providing an unbounded width constraint is:');
-          information.write('  ');
-          information.writeln(node.toStringShallow(joiner: '\n  '));
+
+          errorBuilder.addRenderObject('The nearest ancestor providing an unbounded width constraint is', node);
         }
         if (!constraints.hasBoundedHeight) {
           RenderBox node = this;
           while (!node.constraints.hasBoundedHeight && node.parent is RenderBox)
             node = node.parent;
-          information.writeln('The nearest ancestor providing an unbounded height constraint is:');
-          information.write('  ');
-          information.writeln(node.toStringShallow(joiner: '\n  '));
 
+          errorBuilder.addRenderObject('The nearest ancestor providing an unbounded height constraint is', node);
         }
-        throw FlutterError(
-          '$runtimeType object was given an infinite size during layout.\n'
-          'This probably means that it is a render object that tries to be '
-          'as big as possible, but it was put inside another render object '
-          'that allows its children to pick their own size.\n'
-          '$information'
-          'The constraints that applied to the $runtimeType were:\n'
-          '  $constraints\n'
-          'The exact size it was given was:\n'
-          '  $_size\n'
-          'See https://flutter.io/layout/ for more information.'
-        );
-      }
+        errorBuilder.addConstraintsProperty('The constraints that applied to the $runtimeType were', constraints);
+        errorBuilder.addProperty('The exact size it was given was', _size);
+        errorBuilder.addHint('See https://flutter.io/layout/ for more information.');
+        throw errorBuilder.build();
+     }
       // verify that the size is within the constraints
       if (!constraints.isSatisfiedBy(_size)) {
-        throw FlutterError(
-          '$runtimeType does not meet its constraints.\n'
-          'Constraints: $constraints\n'
-          'Size: $_size\n'
-          'If you are not writing your own RenderBox subclass, then this is not '
-          'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('$runtimeType does not meet its constraints.')
+          ..addProperty('Constraints', constraints)
+          ..addProperty('Size', _size)
+          ..addHint(
+            'If you are not writing your own RenderBox subclass, then this is not '
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+          )
         );
       }
       if (debugCheckIntrinsicSizes) {
         // verify that the intrinsics are sane
         assert(!RenderObject.debugCheckingIntrinsics);
         RenderObject.debugCheckingIntrinsics = true;
-        final StringBuffer failures = StringBuffer();
-        int failureCount = 0;
+        final FlutterErrorBuilder failureBuilder = FlutterErrorBuilder();
 
         double testIntrinsic(double function(double extent), String name, double constraint) {
           final double result = function(constraint);
           if (result < 0) {
-            failures.writeln(' * $name($constraint) returned a negative value: $result');
-            failureCount += 1;
+            failureBuilder.addErrorProperty(' * $name($constraint) returned a negative value', result);
           }
           if (!result.isFinite) {
-            failures.writeln(' * $name($constraint) returned a non-finite value: $result');
-            failureCount += 1;
+            failureBuilder.addErrorProperty(' * $name($constraint) returned a non-finite value', result);
           }
           return result;
         }
@@ -1793,8 +1796,7 @@ abstract class RenderBox extends RenderObject {
           final double min = testIntrinsic(getMin, 'getMinIntrinsic$name', constraint);
           final double max = testIntrinsic(getMax, 'getMaxIntrinsic$name', constraint);
           if (min > max) {
-            failures.writeln(' * getMinIntrinsic$name($constraint) returned a larger value ($min) than getMaxIntrinsic$name($constraint) ($max)');
-            failureCount += 1;
+            failureBuilder.addError(' * getMinIntrinsic$name($constraint) returned a larger value ($min) than getMaxIntrinsic$name($constraint) ($max)');
           }
         }
 
@@ -1808,14 +1810,17 @@ abstract class RenderBox extends RenderObject {
         // TODO(ianh): Test that values are internally consistent in more ways than the above.
 
         RenderObject.debugCheckingIntrinsics = false;
-        if (failures.isNotEmpty) {
-          assert(failureCount > 0);
-          throw FlutterError(
-            'The intrinsic dimension methods of the $runtimeType class returned values that violate the intrinsic protocol contract.\n'
-            'The following ${failureCount > 1 ? "failures" : "failure"} was detected:\n'
-            '$failures'
-            'If you are not writing your own RenderBox subclass, then this is not\n'
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+        if (!failureBuilder.isEmpty) {
+          // TODO(jacobr): consider nesting the failures object so it is collapsible.
+          final List<DiagnosticsNode> failures = failureBuilder.toDiagnostics();
+          throw FlutterError.from(FlutterErrorBuilder()
+            ..addError('The intrinsic dimension methods of the $runtimeType class returned values that violate the intrinsic protocol contract.')
+            ..addDescription('The following ${failures.length > 1 ? "failures" : "failure"} was detected:') // should this be tagged as an error or not?
+            ..addAll(failures)
+            ..addHint(
+              'If you are not writing your own RenderBox subclass, then this is not\n'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+            )
           );
         }
       }
@@ -1854,8 +1859,8 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (!sizedByParent) {
         throw FlutterError(
-          '$runtimeType did not implement performLayout().\n'
-          'RenderBox subclasses need to either override performLayout() to '
+          '$runtimeType did not implement performLayout().',
+          fix: 'RenderBox subclasses need to either override performLayout() to '
           'set a size and lay out any children, or, set sizedByParent to true '
           'so that performResize() sizes the render object.'
         );
@@ -1886,26 +1891,34 @@ abstract class RenderBox extends RenderObject {
     assert(() {
       if (!hasSize) {
         if (debugNeedsLayout) {
-          throw FlutterError(
-            'Cannot hit test a render box that has never been laid out.\n'
-            'The hitTest() method was called on this RenderBox:\n'
-            '  $this\n'
-            'Unfortunately, this object\'s geometry is not known at this time, '
-            'probably because it has never been laid out. '
-            'This means it cannot be accurately hit-tested. If you are trying '
-            'to perform a hit test during the layout phase itself, make sure '
-            'you only hit test nodes that have completed layout (e.g. the node\'s '
-            'children, after their layout() method has been called).'
+          throw FlutterError.from(RenderErrorBuilder()
+            ..addError('Cannot hit test a render box that has never been laid out.')
+            ..addRenderObject('The hitTest() method was called on this RenderBox', this)
+            ..addDescription(
+                'Unfortunately, this object\'s geometry is not known at this time, '
+                    'probably because it has never been laid out. '
+                    'This means it cannot be accurately hit-tested.'
+            )
+            ..addHint(
+                'If you are trying '
+                    'to perform a hit test during the layout phase itself, make sure '
+                    'you only hit test nodes that have completed layout (e.g. the node\'s '
+                    'children, after their layout() method has been called).'
+            )
           );
         }
-        throw FlutterError(
-          'Cannot hit test a render box with no size.\n'
-          'The hitTest() method was called on this RenderBox:\n'
-          '  $this\n'
-          'Although this node is not marked as needing layout, '
-          'its size is not set. A RenderBox object must have an '
-          'explicit size before it can be hit-tested. Make sure '
-          'that the RenderBox in question sets its size during layout.'
+        throw FlutterError.from(RenderErrorBuilder()
+          ..addError('Cannot hit test a render box with no size.')
+          ..addRenderObject('The hitTest() method was called on this RenderBox', this)
+          ..addDescription(
+            'Although this node is not marked as needing layout, '
+            'its size is not set.'
+          )
+          ..addHint(
+            'A RenderBox object must have an '
+            'explicit size before it can be hit-tested. Make sure '
+            'that the RenderBox in question sets its size during layout.'
+          )
         );
       }
       return true;
@@ -1965,18 +1978,18 @@ abstract class RenderBox extends RenderObject {
     assert(child.parent == this);
     assert(() {
       if (child.parentData is! BoxParentData) {
-        throw FlutterError(
-          '$runtimeType does not implement applyPaintTransform.\n'
-          'The following $runtimeType object:\n'
-          '  ${toStringShallow()}\n'
-          '...did not use a BoxParentData class for the parentData field of the following child:\n'
-          '  ${child.toStringShallow()}\n'
-          'The $runtimeType class inherits from RenderBox. '
-          'The default applyPaintTransform implementation provided by RenderBox assumes that the '
-          'children all use BoxParentData objects for their parentData field. '
-          'Since $runtimeType does not in fact use that ParentData class for its children, it must '
-          'provide an implementation of applyPaintTransform that supports the specific ParentData '
-          'subclass used by its children (which apparently is ${child.parentData.runtimeType}).'
+        throw FlutterError.from(RenderErrorBuilder()
+         ..addError('$runtimeType does not implement applyPaintTransform.')
+         ..addProperty('The following $runtimeType object', this, style: DiagnosticsTreeStyle.shallow)
+         ..addRenderObject('...did not use a BoxParentData class for the parentData field of the following child', child)
+         ..addDescription('The $runtimeType class inherits from RenderBox.')
+         ..addHint(
+            'The default applyPaintTransform implementation provided by RenderBox assumes that the '
+            'children all use BoxParentData objects for their parentData field. '
+            'Since $runtimeType does not in fact use that ParentData class for its children, it must '
+            'provide an implementation of applyPaintTransform that supports the specific ParentData '
+            'subclass used by its children (which apparently is ${child.parentData.runtimeType}).'
+          )
         );
       }
       return true;

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -533,9 +533,9 @@ class RenderCustomPaint extends RenderProxyBox {
           'The $painter custom painter called canvas.save() or canvas.saveLayer() at least '
           '${debugNewCanvasSaveCount - debugPreviousCanvasSaveCount} more '
           'time${debugNewCanvasSaveCount - debugPreviousCanvasSaveCount == 1 ? '' : 's' } '
-          'than it called canvas.restore().\n'
-          'This leaves the canvas in an inconsistent state and will probably result in a broken display.\n'
-          'You must pair each call to save()/saveLayer() with a later matching call to restore().'
+          'than it called canvas.restore().',
+          description: 'This leaves the canvas in an inconsistent state and will probably result in a broken display.',
+          hint: 'You must pair each call to save()/saveLayer() with a later matching call to restore().'
         );
       }
       if (debugNewCanvasSaveCount < debugPreviousCanvasSaveCount) {
@@ -543,9 +543,9 @@ class RenderCustomPaint extends RenderProxyBox {
           'The $painter custom painter called canvas.restore() '
           '${debugPreviousCanvasSaveCount - debugNewCanvasSaveCount} more '
           'time${debugPreviousCanvasSaveCount - debugNewCanvasSaveCount == 1 ? '' : 's' } '
-          'than it called canvas.save() or canvas.saveLayer().\n'
-          'This leaves the canvas in an inconsistent state and will result in a broken display.\n'
-          'You should only call restore() if you first called save() or saveLayer().'
+          'than it called canvas.save() or canvas.saveLayer().',
+          description: 'This leaves the canvas in an inconsistent state and will result in a broken display.',
+          hint: 'You should only call restore() if you first called save() or saveLayer().'
         );
       }
       return debugNewCanvasSaveCount == debugPreviousCanvasSaveCount;
@@ -601,9 +601,12 @@ class RenderCustomPaint extends RenderProxyBox {
   ) {
     assert(() {
       if (child == null && children.isNotEmpty) {
-        throw FlutterError(
-          '$runtimeType does not have a child widget but received a non-empty list of child SemanticsNode:\n'
-          '${children.join('\n')}'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addIterable<SemanticsNode>(
+            '$runtimeType does not have a child widget but received a non-empty list of child SemanticsNode',
+            children,
+            level: DiagnosticLevel.error,
+          )
         );
       }
       return true;
@@ -668,24 +671,20 @@ class RenderCustomPaint extends RenderProxyBox {
 
     assert(() {
       final Map<Key, int> keys = HashMap<Key, int>();
-      final StringBuffer errors = StringBuffer();
+      final FlutterErrorBuilder errorBuilder = FlutterErrorBuilder();
       for (int i = 0; i < newChildSemantics.length; i += 1) {
         final CustomPainterSemantics child = newChildSemantics[i];
         if (child.key != null) {
           if (keys.containsKey(child.key)) {
-            errors.writeln(
-              '- duplicate key ${child.key} found at position $i',
-            );
+            errorBuilder.addError('- duplicate key ${child.key} found at position $i');
           }
           keys[child.key] = i;
         }
       }
 
-      if (errors.isNotEmpty) {
-        throw FlutterError(
-          'Failed to update the list of CustomPainterSemantics:\n'
-          '$errors'
-        );
+      if (!errorBuilder.isEmpty) {
+        errorBuilder.error = 'Failed to update the list of CustomPainterSemantics:';
+        throw errorBuilder.build();
       }
 
       return true;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -655,14 +655,13 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           final String axis = _direction == Axis.horizontal ? 'horizontal' : 'vertical';
           final String dimension = _direction == Axis.horizontal ? 'width' : 'height';
           String error, message;
-          String addendum = '';
+          final RenderErrorBuilder addendum = RenderErrorBuilder();
           if (!canFlex && (mainAxisSize == MainAxisSize.max || _getFit(child) == FlexFit.tight)) {
             error = 'RenderFlex children have non-zero flex but incoming $dimension constraints are unbounded.';
             message = 'When a $identity is in a parent that does not provide a finite $dimension constraint, for example '
                       'if it is in a $axis scrollable, it will try to shrink-wrap its children along the $axis '
                       'axis. Setting a flex on a child (e.g. using Expanded) indicates that the child is to '
                       'expand to fill the remaining space in the $axis direction.';
-            final StringBuffer information = StringBuffer();
             RenderBox node = this;
             switch (_direction) {
               case Axis.horizontal:
@@ -679,35 +678,36 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                 break;
             }
             if (node != null) {
-              information.writeln('The nearest ancestor providing an unbounded width constraint is:');
-              information.write('  ');
-              information.writeln(node.toStringShallow(joiner: '\n  '));
+              addendum.addRenderObject('The nearest ancestor providing an unbounded width constraint is', node);
             }
-            information.writeln('See also: https://flutter.io/layout/');
-            addendum = information.toString();
+            addendum.addHint('See also: https://flutter.io/layout/');
           } else {
             return true;
           }
-          throw FlutterError(
-            '$error\n'
-            '$message\n'
-            'These two directives are mutually exclusive. If a parent is to shrink-wrap its child, the child '
-            'cannot simultaneously expand to fit its parent.\n'
-            'Consider setting mainAxisSize to MainAxisSize.min and using FlexFit.loose fits for the flexible '
-            'children (using Flexible rather than Expanded). This will allow the flexible children '
-            'to size themselves to less than the infinite remaining space they would otherwise be '
-            'forced to take, and then will cause the RenderFlex to shrink-wrap the children '
-            'rather than expanding to fit the maximum constraints provided by the parent.\n'
-            'The affected RenderFlex is:\n'
-            '  $this\n'
-            'The creator information is set to:\n'
-            '  $debugCreator\n'
-            '$addendum'
-            'If this message did not help you determine the problem, consider using debugDumpRenderTree():\n'
-            '  https://flutter.io/debugging/#rendering-layer\n'
-            '  http://docs.flutter.io/flutter/rendering/debugDumpRenderTree.html\n'
-            'If none of the above helps enough to fix this problem, please don\'t hesitate to file a bug:\n'
-            '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+          throw FlutterError.from(RenderErrorBuilder()
+            ..addError(error)
+            ..addDescription(message)
+            ..addContract(
+              'These two directives are mutually exclusive. If a parent is to shrink-wrap its child, the child '
+              'cannot simultaneously expand to fit its parent.'
+            )
+            ..addHint(
+                'Consider setting mainAxisSize to MainAxisSize.min and using FlexFit.loose fits for the flexible '
+                'children (using Flexible rather than Expanded). This will allow the flexible children '
+                'to size themselves to less than the infinite remaining space they would otherwise be '
+                'forced to take, and then will cause the RenderFlex to shrink-wrap the children '
+                'rather than expanding to fit the maximum constraints provided by the parent.'
+            )
+            ..addRenderObject('The affected RenderFlex is', this, style: DiagnosticsTreeStyle.indentedSingleLine)
+            ..addProperty<dynamic>('The creator information is set to', debugCreator, style: DiagnosticsTreeStyle.indentedSingleLine)
+            ..addAll(addendum.toDiagnostics())
+            ..addHint(
+              'If this message did not help you determine the problem, consider using debugDumpRenderTree():\n'
+              '  https://flutter.io/debugging/#rendering-layer\n'
+              '  http://docs.flutter.io/flutter/rendering/debugDumpRenderTree.html\n'
+              'If none of the above helps enough to fix this problem, please don\'t hesitate to file a bug:\n'
+              '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+             )
           );
         }());
         totalFlex += childParentData.flex;
@@ -942,19 +942,25 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     assert(() {
       // Only set this if it's null to save work. It gets reset to null if the
       // _direction changes.
-      final String debugOverflowHints =
-        'The overflowing $runtimeType has an orientation of $_direction.\n'
+      final RenderErrorBuilder debugOverflowHints = RenderErrorBuilder()
+      ..addDescription(
+        'The overflowing $runtimeType has an orientation of $_direction.'
+      )
+      ..addHint(
         'The edge of the $runtimeType that is overflowing has been marked '
         'in the rendering with a yellow and black striped pattern. This is '
         'usually caused by the contents being too big for the $runtimeType. '
         'Consider applying a flex factor (e.g. using an Expanded widget) to '
         'force the children of the $runtimeType to fit within the available '
-        'space instead of being sized to their natural size.\n'
+        'space instead of being sized to their natural size.'
+      )
+      ..addHint(
         'This is considered an error condition because it indicates that there '
         'is content that cannot be seen. If the content is legitimately bigger '
         'than the available space, consider clipping it with a ClipRect widget '
         'before putting it in the flex, or using a scrollable container rather '
-        'than a Flex, like a ListView.';
+        'than a Flex, like a ListView.'
+      );
 
       // Simulate a child rect that overflows by the right amount. This child
       // rect is never used for drawing, just for determining the overflow
@@ -968,7 +974,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           overflowChildRect = Rect.fromLTWH(0.0, 0.0, 0.0, size.height + _overflow);
           break;
       }
-      paintOverflowIndicator(context, offset, Offset.zero & size, overflowChildRect, overflowHints: debugOverflowHints);
+      paintOverflowIndicator(context, offset, Offset.zero & size, overflowChildRect, overflowHintsBuilder: debugOverflowHints);
       return true;
     }());
   }

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -235,7 +235,7 @@ class RenderFlow extends RenderBox
   }
 
   Size _getSize(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsValid());
+    assert(constraints.debugAssertIsValidStructured());
     return constraints.constrain(_delegate.getSize(constraints));
   }
 
@@ -320,8 +320,8 @@ class RenderFlow extends RenderBox
     assert(() {
       if (childParentData._transform != null) {
         throw FlutterError(
-          'Cannot call paintChild twice for the same child.\n'
-          'The flow delegate of type ${_delegate.runtimeType} attempted to '
+          'Cannot call paintChild twice for the same child.',
+          contract: 'The flow delegate of type ${_delegate.runtimeType} attempted to '
           'paint child $i multiple times, which is not permitted.'
         );
       }

--- a/packages/flutter/lib/src/rendering/list_body.dart
+++ b/packages/flutter/lib/src/rendering/list_body.dart
@@ -75,10 +75,11 @@ class RenderListBody extends RenderBox
           break;
       }
       throw FlutterError(
-        'RenderListBody must have unlimited space along its main axis.\n'
-        'RenderListBody does not clip or resize its children, so it must be '
+        'RenderListBody must have unlimited space along its main axis.',
+        contract: 'RenderListBody does not clip or resize its children, so it must be '
         'placed in a parent that does not constrain the main '
-        'axis. You probably want to put the RenderListBody inside a '
+        'axis.',
+        hint: 'You probably want to put the RenderListBody inside a '
         'RenderViewport with a matching main axis.'
       );
     }());
@@ -97,10 +98,11 @@ class RenderListBody extends RenderBox
       // more specific to the exact situation in that case, and don't mention
       // nesting blocks in the negative case.
       throw FlutterError(
-        'RenderListBody must have a bounded constraint for its cross axis.\n'
-        'RenderListBody forces its children to expand to fit the RenderListBody\'s container, '
+        'RenderListBody must have a bounded constraint for its cross axis.',
+        contract: 'RenderListBody forces its children to expand to fit the RenderListBody\'s container, '
         'so it must be placed in a parent that constrains the cross '
-        'axis to a finite dimension. If you are attempting to nest a RenderListBody with '
+        'axis to a finite dimension.',
+        hint: 'If you are attempting to nest a RenderListBody with '
         'one direction inside one of another direction, you will want to '
         'wrap the inner one inside a box that fixes the dimension in that direction, '
         'for example, a RenderIntrinsicWidth or RenderIntrinsicHeight object. '

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -234,7 +234,7 @@ class RenderParagraph extends RenderBox {
   double computeDistanceToActualBaseline(TextBaseline baseline) {
     assert(!debugNeedsLayout);
     assert(constraints != null);
-    assert(constraints.debugAssertIsValid());
+    assert(constraints.debugAssertIsValidStructured());
     _layoutTextWithConstraints(constraints);
     return _textPainter.computeDistanceToActualBaseline(baseline);
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -192,7 +192,7 @@ class RenderConstrainedBox extends RenderProxyBox {
     RenderBox child,
     @required BoxConstraints additionalConstraints,
   }) : assert(additionalConstraints != null),
-       assert(additionalConstraints.debugAssertIsValid()),
+       assert(additionalConstraints.debugAssertIsValidStructured()),
        _additionalConstraints = additionalConstraints,
        super(child);
 
@@ -201,7 +201,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   BoxConstraints _additionalConstraints;
   set additionalConstraints(BoxConstraints value) {
     assert(value != null);
-    assert(value.debugAssertIsValid());
+    assert(value.debugAssertIsValidStructured());
     if (_additionalConstraints == value)
       return;
     _additionalConstraints = value;
@@ -452,15 +452,16 @@ class RenderAspectRatio extends RenderProxyBox {
   }
 
   Size _applyAspectRatio(BoxConstraints constraints) {
-    assert(constraints.debugAssertIsValid());
+    assert(constraints.debugAssertIsValidStructured());
     assert(() {
       if (!constraints.hasBoundedWidth && !constraints.hasBoundedHeight) {
         throw FlutterError(
-          '$runtimeType has unbounded constraints.\n'
-          'This $runtimeType was given an aspect ratio of $aspectRatio but was given '
-          'both unbounded width and unbounded height constraints. Because both '
-          'constraints were unbounded, this render object doesn\'t know how much '
-          'size to consume.'
+          '$runtimeType has unbounded constraints.',
+          violation:
+            'This $runtimeType was given an aspect ratio of $aspectRatio but was given '
+            'both unbounded width and unbounded height constraints. Because both '
+            'constraints were unbounded, this render object doesn\'t know how much '
+            'size to consume.'
         );
       }
       return true;
@@ -1961,15 +1962,17 @@ class RenderDecoratedBox extends RenderProxyBox {
       _painter.paint(context.canvas, offset, filledConfiguration);
       assert(() {
         if (debugSaveCount != context.canvas.getSaveCount()) {
-          throw FlutterError(
-            '${_decoration.runtimeType} painter had mismatching save and restore calls.\n'
-            'Before painting the decoration, the canvas save count was $debugSaveCount. '
-            'After painting it, the canvas save count was ${context.canvas.getSaveCount()}. '
-            'Every call to save() or saveLayer() must be matched by a call to restore().\n'
-            'The decoration was:\n'
-            '  $decoration\n'
-            'The painter was:\n'
-            '  $_painter'
+          throw FlutterError.from(RenderErrorBuilder()
+            ..addError('${_decoration.runtimeType} painter had mismatching save and restore calls.')
+            ..addDescription(
+              'Before painting the decoration, the canvas save count was $debugSaveCount. '
+              'After painting it, the canvas save count was ${context.canvas.getSaveCount()}.'
+            )
+            ..addHint(
+              'Every call to save() or saveLayer() must be matched by a call to restore().'
+            )
+            ..addProperty('The decoration was', decoration)
+            ..addProperty('The painter was', _painter)
           );
         }
         return true;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -1111,7 +1111,7 @@ class RenderCustomSingleChildLayoutBox extends RenderShiftedBox {
     size = _getSize(constraints);
     if (child != null) {
       final BoxConstraints childConstraints = delegate.getConstraintsForChild(constraints);
-      assert(childConstraints.debugAssertIsValid(isAppliedConstraint: true));
+      assert(childConstraints.debugAssertIsValidStructured(isAppliedConstraint: true));
       child.layout(childConstraints, parentUsesSize: !childConstraints.isTight);
       final BoxParentData childParentData = child.parentData;
       childParentData.offset = delegate.getPositionForChild(size, childConstraints.isTight ? childConstraints.smallest : child.size);

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -133,10 +133,10 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
     assert(() {
       if (minExtent <= maxExtent)
         return true;
-      throw FlutterError(
-        'The maxExtent for this $runtimeType is less than its minExtent.\n'
-        'The specified maxExtent was: ${maxExtent.toStringAsFixed(1)}\n'
-        'The specified minExtent was: ${minExtent.toStringAsFixed(1)}\n'
+      throw FlutterError.from(RenderErrorBuilder()
+        ..addError('The maxExtent for this $runtimeType is less than its minExtent.')
+        ..addDiagnostic(DoubleProperty('The specified maxExtent was', maxExtent))
+        ..addDiagnostic(DoubleProperty('The specified minExtent was', minExtent))
       );
     }());
     child?.layout(

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -297,10 +297,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       if (!RenderObject.debugCheckingIntrinsics) {
         assert(this is! RenderShrinkWrappingViewport); // it has its own message
         throw FlutterError(
-          '$runtimeType does not support returning intrinsic dimensions.\n'
-          'Calculating the intrinsic dimensions would require instantiating every child of '
-          'the viewport, which defeats the point of viewports being lazy.\n'
-          'If you are merely trying to shrink-wrap the viewport in the main axis direction, '
+          '$runtimeType does not support returning intrinsic dimensions.',
+          description: 'Calculating the intrinsic dimensions would require instantiating every child of '
+          'the viewport, which defeats the point of viewports being lazy.',
+          hint: 'If you are merely trying to shrink-wrap the viewport in the main axis direction, '
           'consider a RenderShrinkWrappingViewport render object (ShrinkWrappingViewport widget), '
           'which achieves that effect without implementing the intrinsic dimension API.'
         );
@@ -1132,12 +1132,12 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
           case Axis.vertical:
             if (!constraints.hasBoundedHeight) {
               throw FlutterError(
-                'Vertical viewport was given unbounded height.\n'
-                'Viewports expand in the scrolling direction to fill their container.'
+                'Vertical viewport was given unbounded height.',
+                description: 'Viewports expand in the scrolling direction to fill their container.'
                 'In this case, a vertical viewport was given an unlimited amount of '
                 'vertical space in which to expand. This situation typically happens '
-                'when a scrollable widget is nested inside another scrollable widget.\n'
-                'If this widget is always nested in a scrollable widget there '
+                'when a scrollable widget is nested inside another scrollable widget.',
+                hint: 'If this widget is always nested in a scrollable widget there '
                 'is no need to use a viewport because there will always be enough '
                 'vertical space for the children. In this case, consider using a '
                 'Column instead. Otherwise, consider using the "shrinkWrap" property '
@@ -1146,38 +1146,51 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
               );
             }
             if (!constraints.hasBoundedWidth) {
-              throw FlutterError(
-                'Vertical viewport was given unbounded width.\n'
-                'Viewports expand in the cross axis to fill their container and '
-                'constrain their children to match their extent in the cross axis. '
-                'In this case, a vertical viewport was given an unlimited amount of '
-                'horizontal space in which to expand.'
+              throw FlutterError.from(RenderErrorBuilder()
+                ..addError('Vertical viewport was given unbounded width.')
+                // TODO(jacobr): this refactor is a judgment call. XXX review
+                ..addDescription(
+                  'Viewports expand in the cross axis to fill their container and '
+                  'constrain their children to match their extent in the cross axis.'
+                )
+                ..addViolation(
+                  'In this case, a vertical viewport was given an unlimited amount of '
+                  'horizontal space in which to expand.'
+                )
               );
             }
             break;
           case Axis.horizontal:
             if (!constraints.hasBoundedWidth) {
-              throw FlutterError(
-                'Horizontal viewport was given unbounded width.\n'
-                'Viewports expand in the scrolling direction to fill their container.'
-                'In this case, a horizontal viewport was given an unlimited amount of '
-                'horizontal space in which to expand. This situation typically happens '
-                'when a scrollable widget is nested inside another scrollable widget.\n'
-                'If this widget is always nested in a scrollable widget there '
-                'is no need to use a viewport because there will always be enough '
-                'horizontal space for the children. In this case, consider using a '
-                'Row instead. Otherwise, consider using the "shrinkWrap" property '
-                '(or a ShrinkWrappingViewport) to size the width of the viewport '
-                'to the sum of the widths of its children.'
+              throw FlutterError.from(RenderErrorBuilder()
+                ..addError('Horizontal viewport was given unbounded width.')
+                ..addDescription(
+                  'Viewports expand in the scrolling direction to fill their container.'
+                  'In this case, a horizontal viewport was given an unlimited amount of '
+                  'horizontal space in which to expand. This situation typically happens '
+                  'when a scrollable widget is nested inside another scrollable widget.'
+                )
+                ..addHint(
+                  'If this widget is always nested in a scrollable widget there '
+                  'is no need to use a viewport because there will always be enough '
+                  'horizontal space for the children. In this case, consider using a '
+                  'Row instead. Otherwise, consider using the "shrinkWrap" property '
+                  '(or a ShrinkWrappingViewport) to size the width of the viewport '
+                  'to the sum of the widths of its children.'
+                )
               );
             }
             if (!constraints.hasBoundedHeight) {
-              throw FlutterError(
-                'Horizontal viewport was given unbounded height.\n'
-                'Viewports expand in the cross axis to fill their container and '
-                'constrain their children to match their extent in the cross axis. '
-                'In this case, a horizontal viewport was given an unlimited amount of '
-                'vertical space in which to expand.'
+              throw FlutterError.from(RenderErrorBuilder()
+                ..addError('Horizontal viewport was given unbounded height.')
+                ..addDescription(
+                  'Viewports expand in the cross axis to fill their container and '
+                  'constrain their children to match their extent in the cross axis.'
+                )
+                ..addViolation(
+                  'In this case, a horizontal viewport was given an unlimited amount of '
+                  'vertical space in which to expand.'
+                )
               );
             }
             break;
@@ -1251,9 +1264,11 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     assert(() {
       if (count >= _maxLayoutCycles) {
         assert(count != 1);
+        // XXX
+        // TODO(jacobr): should this message be broken up to include 3 hints?
         throw FlutterError(
-          'A RenderViewport exceeded its maximum number of layout cycles.\n'
-          'RenderViewport render objects, during layout, can retry if either their '
+          'A RenderViewport exceeded its maximum number of layout cycles.',
+          description: 'RenderViewport render objects, during layout, can retry if either their '
           'slivers or their ViewportOffset decide that the offset should be corrected '
           'to take into account information collected during that layout.\n'
           'In the case of this RenderViewport object, however, this happened $count '
@@ -1552,10 +1567,10 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     assert(() {
       if (!RenderObject.debugCheckingIntrinsics) {
         throw FlutterError(
-          '$runtimeType does not support returning intrinsic dimensions.\n'
-          'Calculating the intrinsic dimensions would require instantiating every child of '
-          'the viewport, which defeats the point of viewports being lazy.\n'
-          'If you are merely trying to shrink-wrap the viewport in the main axis direction, '
+          '$runtimeType does not support returning intrinsic dimensions.',
+          description: 'Calculating the intrinsic dimensions would require instantiating every child of '
+          'the viewport, which defeats the point of viewports being lazy.',
+          hint: 'If you are merely trying to shrink-wrap the viewport in the main axis direction, '
           'you should be able to achieve that effect by just giving the viewport loose '
           'constraints, without needing to measure its intrinsic dimensions.'
         );

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -53,6 +53,7 @@ abstract class TickerProvider {
 ///
 /// Tickers are driven by the [SchedulerBinding]. See
 /// [SchedulerBinding.scheduleFrameCallback].
+// TODO(jacobr): make Ticker Diagnosticable. XXX and then cleanup all uses of it. XXX The Diagnosticable version should include the stack.
 class Ticker {
   /// Creates a ticker that will call the provided callback once per frame while
   /// running.
@@ -145,10 +146,10 @@ class Ticker {
   TickerFuture start() {
     assert(() {
       if (isActive) {
-        throw FlutterError(
-          'A ticker was started twice.\n'
-          'A ticker that is already active cannot be started again without first stopping it.\n'
-          'The affected ticker was: ${ toString(debugIncludeStack: true) }'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('A ticker was started twice.')
+          ..addContract('A ticker that is already active cannot be started again without first stopping it.')
+          ..addDiagnostic(DiagnosticsProperty<Ticker>('The affected ticker was', this, description: toString(debugIncludeStack: true)))
         );
       }
       return true;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1264,11 +1264,10 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
           }
         }
         if (mutationErrors.isNotEmpty) {
-          throw FlutterError(
-            'Failed to replace child semantics nodes because the list of `SemanticsNode`s was mutated.\n'
-            'Instead of mutating the existing list, create a new list containing the desired `SemanticsNode`s.\n'
-            'Error details:\n'
-            '$mutationErrors'
+          throw FlutterError.from(FlutterErrorBuilder()
+            ..addError('Failed to replace child semantics nodes because the list of `SemanticsNode`s was mutated.')
+            ..addHint('Instead of mutating the existing list, create a new list containing the desired `SemanticsNode`s.')
+            ..addProperty('Error details', mutationErrors)
           );
         }
       }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -66,7 +66,7 @@ abstract class AssetBundle {
   Future<String> loadString(String key, { bool cache = true }) async {
     final ByteData data = await load(key);
     if (data == null)
-      throw FlutterError('Unable to load asset: $key');
+      throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unable to load asset', key));
     if (data.lengthInBytes < 10 * 1024) {
       // 10KB takes about 3ms to parse on a Pixel 2 XL.
       // See: https://github.com/dart-lang/sdk/issues/31954
@@ -116,9 +116,9 @@ class NetworkAssetBundle extends AssetBundle {
     final HttpClientRequest request = await _httpClient.getUrl(_urlFromKey(key));
     final HttpClientResponse response = await request.close();
     if (response.statusCode != HttpStatus.ok)
-      throw FlutterError(
-        'Unable to load asset: $key\n'
-        'HTTP status code: ${response.statusCode}'
+      throw FlutterError.from(FlutterErrorBuilder()
+        ..addStringProperty('Unable to load asset', key, level: DiagnosticLevel.error)
+        ..addIntProperty('HTTP status code', response.statusCode)
       );
     final Uint8List bytes = await consolidateHttpClientResponseBytes(response);
     return bytes.buffer.asByteData();
@@ -218,7 +218,7 @@ class PlatformAssetBundle extends CachingAssetBundle {
     final ByteData asset =
         await BinaryMessages.send('flutter/assets', encoded.buffer.asByteData());
     if (asset == null)
-      throw FlutterError('Unable to load asset: $key');
+      throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unable to load asset', key));
     return asset;
   }
 }

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -493,7 +493,8 @@ class EventChannel {
           exception: exception,
           stack: stack,
           library: 'services library',
-          context: 'while activating platform stream on channel $name',
+          context: 'while activating platform stream on channel',
+          contextObject: name,
         ));
       }
     }, onCancel: () async {
@@ -505,7 +506,8 @@ class EventChannel {
           exception: exception,
           stack: stack,
           library: 'services library',
-          context: 'while de-activating platform stream on channel $name',
+          context: 'while de-activating platform stream on channel',
+          contextObject: name,
         ));
       }
     });

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -216,7 +216,7 @@ abstract class RawKeyEvent {
         // We don't yet implement raw key events on iOS or other platforms, but
         // we don't hit this exception because the engine never sends us these
         // messages.
-        throw FlutterError('Unknown keymap for key events: $keymap');
+        throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unknown keymap for key events', keymap));
     }
 
     final String type = message['type'];
@@ -226,7 +226,7 @@ abstract class RawKeyEvent {
       case 'keyup':
         return RawKeyUpEvent(data: data);
       default:
-        throw FlutterError('Unknown key event type: $type');
+        throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unknown key event type', type));
     }
   }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -682,7 +682,7 @@ TextInputAction _toTextInputAction(String action) {
     case 'TextInputAction.newline':
       return TextInputAction.newline;
   }
-  throw FlutterError('Unknown text input action: $action');
+  throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unknown text input action', action));
 }
 
 FloatingCursorDragState _toTextCursorAction(String state) {
@@ -694,7 +694,7 @@ FloatingCursorDragState _toTextCursorAction(String state) {
     case 'FloatingCursorDragState.end':
       return FloatingCursorDragState.End;
   }
-  throw FlutterError('Unknown text cursor action: $state');
+  throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Unknown text cursor action',  state));
 }
 
 RawFloatingCursorPoint _toTextPoint(FloatingCursorDragState state, Map<String, dynamic> encoded) {

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -5,6 +5,7 @@
 import 'package:collection/collection.dart' show binarySearch;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -165,15 +166,16 @@ class AnimatedList extends StatefulWidget {
     final AnimatedListState result = context.ancestorStateOfType(const TypeMatcher<AnimatedListState>());
     if (nullOk || result != null)
       return result;
-    throw FlutterError(
-      'AnimatedList.of() called with a context that does not contain an AnimatedList.\n'
-      'No AnimatedList ancestor could be found starting from the context that was passed to AnimatedList.of(). '
-      'This can happen when the context provided is from the same StatefulWidget that '
-      'built the AnimatedList. Please see the AnimatedList documentation for examples '
-      'of how to refer to an AnimatedListState object: '
-      '  https://docs.flutter.io/flutter/widgets/AnimatedListState-class.html \n'
-      'The context used was:\n'
-      '  $context'
+    throw FlutterError.from(FlutterErrorBuilder()
+      ..addError('AnimatedList.of() called with a context that does not contain an AnimatedList.')
+      ..addViolation('No AnimatedList ancestor could be found starting from the context that was passed to AnimatedList.of().')
+      ..addHint(
+        'This can happen when the context provided is from the same StatefulWidget that '
+        'built the AnimatedList. Please see the AnimatedList documentation for examples '
+        'of how to refer to an AnimatedListState object',
+        url: 'https://docs.flutter.io/flutter/widgets/AnimatedListState-class.html',
+      )
+      ..addProperty('The context used was', context)
     );
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -769,8 +769,8 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     assert(() {
       if (widget.onUnknownRoute == null) {
         throw FlutterError(
-          'Could not find a generator for route $settings in the $runtimeType.\n'
-          'Generators for routes are searched for in the following order:\n'
+          'Could not find a generator for route $settings in the $runtimeType.',
+          hint: 'Generators for routes are searched for in the following order:\n'
           ' 1. For the "/" route, the "home" property, if non-null, is used.\n'
           ' 2. Otherwise, the "routes" table is used, if it has an entry for '
           'the route.\n'
@@ -786,8 +786,8 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
     assert(() {
       if (result == null) {
         throw FlutterError(
-          'The onUnknownRoute callback returned null.\n'
-          'When the $runtimeType requested the route $settings from its '
+          'The onUnknownRoute callback returned null.',
+          violation: 'When the $runtimeType requested the route $settings from its '
           'onUnknownRoute callback, the callback returned null. Such callbacks '
           'must never return null.'
         );

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -144,8 +144,8 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
       assert(() {
         if (!mounted) {
           throw FlutterError(
-            'AutomaticKeepAlive handle triggered after AutomaticKeepAlive was disposed.'
-            'Widgets should always trigger their KeepAliveNotification handle when they are '
+            'AutomaticKeepAlive handle triggered after AutomaticKeepAlive was disposed.',
+            hint: 'Widgets should always trigger their KeepAliveNotification handle when they are '
             'deactivated, so that they (or their handle) do not send spurious events later '
             'when they are no longer in the tree.'
           );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -16,6 +16,7 @@ export 'package:flutter/animation.dart';
 export 'package:flutter/foundation.dart' show
   ChangeNotifier,
   FlutterErrorDetails,
+  FlutterErrorBuilder,
   Listenable,
   TargetPlatform,
   ValueNotifier;
@@ -1923,7 +1924,7 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
     @required this.constraints,
     Widget child
   }) : assert(constraints != null),
-       assert(constraints.debugAssertIsValid()),
+       assert(constraints.debugAssertIsValidStructured()),
        super(key: key, child: child);
 
   /// The additional constraints to impose on the child.

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -583,22 +583,26 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
     // should not trigger a new frame.
     assert(() {
       if (debugBuildingDirtyElements) {
-        throw FlutterError(
-          'Build scheduled during frame.\n'
-          'While the widget tree was being built, laid out, and painted, '
-          'a new frame was scheduled to rebuild the widget tree. '
-          'This might be because setState() was called from a layout or '
-          'paint callback. '
-          'If a change is needed to the widget tree, it should be applied '
-          'as the tree is being built. Scheduling a change for the subsequent '
-          'frame instead results in an interface that lags behind by one frame. '
-          'If this was done to make your build dependent on a size measured at '
-          'layout time, consider using a LayoutBuilder, CustomSingleChildLayout, '
-          'or CustomMultiChildLayout. If, on the other hand, the one frame delay '
-          'is the desired effect, for example because this is an '
-          'animation, consider scheduling the frame in a post-frame callback '
-          'using SchedulerBinding.addPostFrameCallback or '
-          'using an AnimationController to trigger the animation.'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('Build scheduled during frame.')
+          ..addViolation(
+            'While the widget tree was being built, laid out, and painted, '
+            'a new frame was scheduled to rebuild the widget tree.'
+          )
+          ..addHint(
+            'This might be because setState() was called from a layout or '
+            'paint callback. '
+            'If a change is needed to the widget tree, it should be applied '
+            'as the tree is being built. Scheduling a change for the subsequent '
+            'frame instead results in an interface that lags behind by one frame. '
+            'If this was done to make your build dependent on a size measured at '
+            'layout time, consider using a LayoutBuilder, CustomSingleChildLayout, '
+            'or CustomMultiChildLayout. If, on the other hand, the one frame delay '
+            'is the desired effect, for example because this is an '
+            'animation, consider scheduling the frame in a post-frame callback '
+            'using SchedulerBinding.addPostFrameCallback or '
+            'using an AnimationController to trigger the animation.',
+          )
         );
       }
       return true;

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -265,7 +265,7 @@ class Container extends StatelessWidget {
   }) : assert(margin == null || margin.isNonNegative),
        assert(padding == null || padding.isNonNegative),
        assert(decoration == null || decoration.debugAssertIsValid()),
-       assert(constraints == null || constraints.debugAssertIsValid()),
+       assert(constraints == null || constraints.debugAssertIsValidStructured()),
        assert(color == null || decoration == null,
          'Cannot provide both a color and a decoration\n'
          'The color argument is just a shorthand for "decoration: new BoxDecoration(color: color)".'

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -5,6 +5,10 @@
 import 'dart:collection';
 import 'dart:developer' show Timeline; // to disambiguate reference in dartdocs below
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart' show Ticker;
+import 'package:flutter/rendering.dart' show RenderErrorBuilder;
+
 import 'basic.dart';
 import 'framework.dart';
 import 'media_query.dart';
@@ -107,6 +111,106 @@ Key _firstNonUniqueKey(Iterable<Widget> widgets) {
   return null;
 }
 
+/// Variant of [FlutterErrorBuilder] with extra methods for describing widget
+/// errors.
+///
+/// It is important to add basic parts to the error report using base class
+/// methods such as addError, addDescription, addHint, etc.
+///
+/// If the error you want to report is from the rendering layer, consider using
+/// [RenderErrorBuilder] instead.
+/// See also:
+///
+///  * [RenderErrorBuilder], which should be used instead if the error you want
+///    to report only deals with the rendering layer.
+class WidgetErrorBuilder extends RenderErrorBuilder {
+  /// Creates a [WidgetErrorBuilder]
+  WidgetErrorBuilder();
+
+  /// Creates a [RenderErrorBuilder] with its details computed only when needed.
+  /// Use if computing the error details may throw an exception or is expensive.
+  WidgetErrorBuilder.lazy(ErrorBuilderCallback<WidgetErrorBuilder> callback) : super.lazy(callback);
+
+  /// Adds a description of a specific type of widget missing from the current
+  /// build context's ancestry tree.
+  ///
+  /// You can find an example of using this method in [debugCheckHasMaterial].
+  void describeMissingAncestor(
+    BuildContext context, {
+    @required Type expectedAncestorType,
+  }) {
+    final List<Element> ancestors = <Element>[];
+    context.visitAncestorElements((Element element) {
+      ancestors.add(element);
+      return true;
+    });
+
+    // TODO(jacobr): indicate this is the context on the error.
+    addDiagnostic(DiagnosticsProperty<Element>(
+      'The specific widget that could not find a $expectedAncestorType ancestor was',
+      context,
+      style: DiagnosticsTreeStyle.indentedSingleLine,
+    ));
+
+    if (ancestors.isNotEmpty) {
+      describeElements('The ancestors of this widget were', ancestors);
+    } else {
+      addDiagnostic(DiagnosticsNode.message(
+          'This widget is the root of the tree, so it has no '
+              'ancestors, let alone a "$expectedAncestorType" ancestor.'
+      ));
+    }
+  }
+
+  /// Adds a description of the specific widget the error is originated from
+  /// to the error report.
+  ///
+  /// The description will include the widget's type and its properties.
+  /// Technically this method logs the [Element] rather than just the [Widget]
+  /// so that GUI tools can jump to the exact location in the Element tree where
+  /// the widget was created.
+  ///
+  /// {@tool sample}
+  /// ```dart
+  /// WidgetErrorBuilder()
+  ///   ..addWidgetContext('The specific widget that could not find a Table ancestor was', context)
+  /// ```
+  /// {@end-tool}
+  /// {@tool sample}
+  void addWidgetContext(String name, BuildContext context) {
+    addDiagnostic(DiagnosticsProperty<Element>(name, context, style: DiagnosticsTreeStyle.indentedSingleLine));
+  }
+  
+  /// Adds a description of an [Element] from the current build context
+  /// to the error report.
+  void describeElement(String name, Element element, {DiagnosticsTreeStyle style = DiagnosticsTreeStyle.indentedSingleLine}) {
+    addDiagnostic(DiagnosticsProperty<Element>(name, element, style: style));
+  }
+
+  /// Adds a list of [Element]s from the current build context to the error report.
+  void describeElements(String name, Iterable<Element> elements) {
+    addDiagnostic(DiagnosticsBlock(
+      name: name,
+      children: elements.map<DiagnosticsNode>((Element element) => DiagnosticsProperty<Element>('', element)).toList(),
+      allowTruncate: true,
+    ));
+  }
+
+  /// Adds a description of a specific [Ticker] to the error report. 
+  void describeTicker(String name, Ticker ticker) {
+    // TODO(jacobr): this toString includes a StackTrace. create a TickerProperty DiagnosticsNode.
+    addDiagnostic(DiagnosticsProperty<Ticker>('The offending ticker was', ticker, description: ticker.toString(debugIncludeStack: true)));
+  }
+
+  /// Adds a description of the ownership chain from a specific [Element]
+  /// to the error report. It's useful for debugging the source of an element.
+  void describeOwnershipChain(String name, Element element) {
+    // XXX make this structured so clients can allow clicks on individual entries.
+    // For example, is this an iterable with arrows as the separators?
+    addDiagnostic(StringProperty(name, element.debugGetCreatorChain(10)));
+  }
+}
+
 /// Asserts if the given child list contains any duplicate non-null keys.
 ///
 /// To invoke this function, use the following pattern, typically in the
@@ -125,10 +229,11 @@ bool debugChildrenHaveDuplicateKeys(Widget parent, Iterable<Widget> children) {
   assert(() {
     final Key nonUniqueKey = _firstNonUniqueKey(children);
     if (nonUniqueKey != null) {
-      throw FlutterError(
-        'Duplicate keys found.\n'
-        'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
-        '$parent has multiple children with key $nonUniqueKey.'
+      throw FlutterError.from(FlutterErrorBuilder()
+        ..addError('Duplicate keys found.')
+        ..addContract('If multiple keyed nodes exist as children of another node, they must have unique keys.')
+        // TODO(jacobr): expose both the parent and key as structured objects.
+        ..addViolation('$parent has multiple children with key $nonUniqueKey.')
       );
     }
     return true;
@@ -152,7 +257,7 @@ bool debugItemsHaveDuplicateKeys(Iterable<Widget> items) {
   assert(() {
     final Key nonUniqueKey = _firstNonUniqueKey(items);
     if (nonUniqueKey != null)
-      throw FlutterError('Duplicate key found: $nonUniqueKey.');
+      throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('Duplicate key found', nonUniqueKey, style: DiagnosticsTreeStyle.singleLine));
     return true;
   }());
   return false;
@@ -174,13 +279,11 @@ bool debugCheckHasTable(BuildContext context) {
   assert(() {
     if (context.widget is! Table && context.ancestorWidgetOfExactType(Table) == null) {
       final Element element = context;
-      throw FlutterError(
-        'No Table widget found.\n'
-        '${context.widget.runtimeType} widgets require a Table widget ancestor.\n'
-        'The specific widget that could not find a Table ancestor was:\n'
-        '  ${context.widget}\n'
-        'The ownership chain for the affected widget is:\n'
-        '  ${element.debugGetCreatorChain(10)}'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('No Table widget found.')
+        ..addContract('${context.widget.runtimeType} widgets require a Table widget ancestor.')
+        ..addWidgetContext('The specific widget that could not find a Table ancestor was', context)
+        ..describeOwnershipChain('The ownership chain for the affected widget is', element)
       );
     }
     return true;
@@ -205,15 +308,15 @@ bool debugCheckHasMediaQuery(BuildContext context) {
   assert(() {
     if (context.widget is! MediaQuery && context.ancestorWidgetOfExactType(MediaQuery) == null) {
       final Element element = context;
-      throw FlutterError(
-        'No MediaQuery widget found.\n'
-        '${context.widget.runtimeType} widgets require a MediaQuery widget ancestor.\n'
-        'The specific widget that could not find a MediaQuery ancestor was:\n'
-        '  ${context.widget}\n'
-        'The ownership chain for the affected widget is:\n'
-        '  ${element.debugGetCreatorChain(10)}\n'
-        'Typically, the MediaQuery widget is introduced by the MaterialApp or '
-        'WidgetsApp widget at the top of your application widget tree.'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('No MediaQuery widget found.')
+        ..addViolation('${context.widget.runtimeType} widgets require a MediaQuery widget ancestor.')
+        ..addWidgetContext('The specific widget that could not find a MediaQuery ancestor was', context)
+        ..describeOwnershipChain('The ownership chain for the affected widget is', element)
+        ..addHint(
+          'Typically, the MediaQuery widget is introduced by the MaterialApp or '
+          'WidgetsApp widget at the top of your application widget tree.'
+        )
       );
     }
     return true;
@@ -238,19 +341,19 @@ bool debugCheckHasDirectionality(BuildContext context) {
   assert(() {
     if (context.widget is! Directionality && context.ancestorWidgetOfExactType(Directionality) == null) {
       final Element element = context;
-      throw FlutterError(
-        'No Directionality widget found.\n'
-        '${context.widget.runtimeType} widgets require a Directionality widget ancestor.\n'
-        'The specific widget that could not find a Directionality ancestor was:\n'
-        '  ${context.widget}\n'
-        'The ownership chain for the affected widget is:\n'
-        '  ${element.debugGetCreatorChain(10)}\n'
-        'Typically, the Directionality widget is introduced by the MaterialApp '
-        'or WidgetsApp widget at the top of your application widget tree. It '
-        'determines the ambient reading direction and is used, for example, to '
-        'determine how to lay out text, how to interpret "start" and "end" '
-        'values, and to resolve EdgeInsetsDirectional, '
-        'AlignmentDirectional, and other *Directional objects.'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('No Directionality widget found.')
+        ..addContract('${context.widget.runtimeType} widgets require a Directionality widget ancestor.\n')
+        ..addWidgetContext('The specific widget that could not find a Directionality ancestor was', context)
+        ..describeOwnershipChain('The ownership chain for the affected widget is', element)
+        ..addHint(
+          'Typically, the Directionality widget is introduced by the MaterialApp '
+          'or WidgetsApp widget at the top of your application widget tree. It '
+          'determines the ambient reading direction and is used, for example, to '
+          'determine how to lay out text, how to interpret "start" and "end" '
+          'values, and to resolve EdgeInsetsDirectional, '
+          'AlignmentDirectional, and other *Directional objects.'
+        )
       );
     }
     return true;
@@ -267,20 +370,23 @@ bool debugCheckHasDirectionality(BuildContext context) {
 void debugWidgetBuilderValue(Widget widget, Widget built) {
   assert(() {
     if (built == null) {
-      throw FlutterError(
-        'A build function returned null.\n'
-        'The offending widget is: $widget\n'
-        'Build functions must never return null. '
-        'To return an empty space that causes the building widget to fill available room, return "new Container()". '
-        'To return an empty space that takes as little room as possible, return "new Container(width: 0.0, height: 0.0)".'
+      // XXX review how this message looks.
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('A build function returned null.')
+        ..addProperty('The offending widget is', widget)
+        ..addContract('Build functions must never return null.')
+        ..addHint('To return an empty space that causes the building widget to fill available room, return "new Container()".')
+        ..addHint('To return an empty space that takes as little room as possible, return "new Container(width: 0.0, height: 0.0)".')
       );
     }
     if (widget == built) {
-      throw FlutterError(
-        'A build function returned context.widget.\n'
-        'The offending widget is: $widget\n'
-        'Build functions must never return their BuildContext parameter\'s widget or a child that contains "context.widget". '
-        'Doing so introduces a loop in the widget tree that can cause the app to crash.'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('A build function returned context.widget.')
+        ..addProperty('The offending widget is', widget)
+        ..addContract(
+          'Build functions must never return their BuildContext parameter\'s widget or a child that contains "context.widget". '
+          'Doing so introduces a loop in the widget tree that can cause the app to crash.'
+        )
       );
     }
     return true;

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -523,8 +523,8 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         if (_resizeAnimation.status != AnimationStatus.forward) {
           assert(_resizeAnimation.status == AnimationStatus.completed);
           throw FlutterError(
-            'A dismissed Dismissible widget is still part of the tree.\n'
-            'Make sure to implement the onDismissed handler and to immediately remove the Dismissible\n'
+            'A dismissed Dismissible widget is still part of the tree.',
+            hint: 'Make sure to implement the onDismissed handler and to immediately remove the Dismissible\n'
             'widget from the application once that handler has fired.'
           );
         }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -96,7 +96,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// actions, not during the build, layout, or paint phases.
   set selection(TextSelection newSelection) {
     if (newSelection.start > text.length || newSelection.end > text.length)
-      throw FlutterError('invalid text selection: $newSelection');
+      throw FlutterError.from(FlutterErrorBuilder()..addErrorProperty('invalid text selection', newSelection));
     value = value.copyWith(selection: newSelection, composing: TextRange.empty);
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -197,15 +197,16 @@ class GestureDetector extends StatelessWidget {
          if (havePan || haveScale) {
            if (havePan && haveScale) {
              throw FlutterError(
-               'Incorrect GestureDetector arguments.\n'
-               'Having both a pan gesture recognizer and a scale gesture recognizer is redundant; scale is a superset of pan. Just use the scale gesture recognizer.'
+               'Incorrect GestureDetector arguments.',
+               violation:'Having both a pan gesture recognizer and a scale gesture recognizer is redundant; scale is a superset of pan.',
+               hint: 'Just use the scale gesture recognizer.'
              );
            }
            final String recognizer = havePan ? 'pan' : 'scale';
            if (haveVerticalDrag && haveHorizontalDrag) {
              throw FlutterError(
-               'Incorrect GestureDetector arguments.\n'
-               'Simultaneously having a vertical drag gesture recognizer, a horizontal drag gesture recognizer, and a $recognizer gesture recognizer '
+               'Incorrect GestureDetector arguments.',
+               violation: 'Simultaneously having a vertical drag gesture recognizer, a horizontal drag gesture recognizer, and a $recognizer gesture recognizer '
                'will result in the $recognizer gesture recognizer being ignored, since the other two will catch all drags.'
              );
            }
@@ -652,9 +653,9 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
     assert(() {
       if (!context.findRenderObject().owner.debugDoingLayout) {
         throw FlutterError(
-          'Unexpected call to replaceGestureRecognizers() method of RawGestureDetectorState.\n'
-          'The replaceGestureRecognizers() method can only be called during the layout phase. '
-          'To set the gesture recognizers at other times, trigger a new build using setState() '
+          'Unexpected call to replaceGestureRecognizers() method of RawGestureDetectorState.',
+          violation: 'The replaceGestureRecognizers() method can only be called during the layout phase.',
+          hint: 'To set the gesture recognizers at other times, trigger a new build using setState() '
           'and provide the new gesture recognizers as constructor arguments to the corresponding '
           'RawGestureDetector or GestureDetector object.'
         );
@@ -687,8 +688,8 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
       final Element element = context;
       if (element.owner.debugBuilding) {
         throw FlutterError(
-          'Unexpected call to replaceSemanticsActions() method of RawGestureDetectorState.\n'
-          'The replaceSemanticsActions() method can only be called outside of the build phase.'
+          'Unexpected call to replaceSemanticsActions() method of RawGestureDetectorState.',
+          fix: 'The replaceSemanticsActions() method can only be called outside of the build phase.'
         );
       }
       return true;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
 import 'binding.dart';
+import 'debug.dart';
 import 'framework.dart';
 import 'navigator.dart';
 import 'overlay.dart';
@@ -207,13 +208,15 @@ class Hero extends StatefulWidget {
           assert(tag != null);
           assert(() {
             if (result.containsKey(tag)) {
-              throw FlutterError(
-                'There are multiple heroes that share the same tag within a subtree.\n'
-                'Within each subtree for which heroes are to be animated (typically a PageRoute subtree), '
-                'each Hero must have a unique non-null tag.\n'
-                'In this case, multiple heroes had the following tag: $tag\n'
-                'Here is the subtree for one of the offending heroes:\n'
-                '${element.toStringDeep(prefixLineOne: "# ")}'
+              throw FlutterError.from(WidgetErrorBuilder()
+                ..addError('There are multiple heroes that share the same tag within a subtree.')
+                ..addContract(
+                  'Within each subtree for which heroes are to be animated (typically a PageRoute subtree), '
+                  'each Hero must have a unique non-null tag.'
+                )
+                ..addProperty('In this case, multiple heroes had the following tag', tag, level: DiagnosticLevel.violation)
+              // TODO(jacobr): prefix every line in the subtree with '# '.
+                ..describeElement('Here is the subtree for one of the offending heroes', element, style: DiagnosticsTreeStyle.truncateChildren)
               );
             }
             return true;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -443,7 +443,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   }) : assert(margin == null || margin.isNonNegative),
        assert(padding == null || padding.isNonNegative),
        assert(decoration == null || decoration.debugAssertIsValid()),
-       assert(constraints == null || constraints.debugAssertIsValid()),
+       assert(constraints == null || constraints.debugAssertIsValidStructured()),
        assert(color == null || decoration == null,
          'Cannot provide both a color and a decoration\n'
          'The color argument is just a shorthand for "decoration: new BoxDecoration(backgroundColor: color)".'

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -111,14 +111,14 @@ class _LayoutBuilderElement extends RenderObjectElement {
           built = widget.builder(this, constraints);
           debugWidgetBuilderValue(widget, built);
         } catch (e, stack) {
-          built = ErrorWidget.builder(_debugReportException('building $widget', e, stack));
+          built = ErrorWidget.builder(_debugReportException('building', widget, e, stack));
         }
       }
       try {
         _child = updateChild(_child, built, null);
         assert(_child != null);
       } catch (e, stack) {
-        built = ErrorWidget.builder(_debugReportException('building $widget', e, stack));
+        built = ErrorWidget.builder(_debugReportException('building', widget, e, stack));
         _child = updateChild(null, built, slot);
       }
     });
@@ -165,8 +165,8 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
     assert(() {
       if (!RenderObject.debugCheckingIntrinsics) {
         throw FlutterError(
-          'LayoutBuilder does not support returning intrinsic dimensions.\n'
-          'Calculating the intrinsic dimensions would require running the layout '
+          'LayoutBuilder does not support returning intrinsic dimensions.',
+          description: 'Calculating the intrinsic dimensions would require running the layout '
           'callback speculatively, which might mutate the live render object tree.'
         );
       }
@@ -224,7 +224,8 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
 }
 
 FlutterErrorDetails _debugReportException(
-  String context,
+  String contextName,
+  Object contextObject,
   dynamic exception,
   StackTrace stack,
 ) {
@@ -232,7 +233,8 @@ FlutterErrorDetails _debugReportException(
     exception: exception,
     stack: stack,
     library: 'widgets library',
-    context: context
+    context: contextName,
+    contextObject: contextObject,
   );
   FlutterError.reportError(details);
   return details;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -7,6 +7,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 
 /// Whether in portrait or landscape.
@@ -506,14 +507,15 @@ class MediaQuery extends InheritedWidget {
       return query.data;
     if (nullOk)
       return null;
-    throw FlutterError(
-      'MediaQuery.of() called with a context that does not contain a MediaQuery.\n'
-      'No MediaQuery ancestor could be found starting from the context that was passed '
-      'to MediaQuery.of(). This can happen because you do not have a WidgetsApp or '
-      'MaterialApp widget (those widgets introduce a MediaQuery), or it can happen '
-      'if the context you use comes from a widget above those widgets.\n'
-      'The context used was:\n'
-      '  $context'
+    throw FlutterError.from(WidgetErrorBuilder()
+      ..addError('MediaQuery.of() called with a context that does not contain a MediaQuery.')
+      ..addViolation(
+        'No MediaQuery ancestor could be found starting from the context that was passed '
+        'to MediaQuery.of(). This can happen because you do not have a WidgetsApp or '
+        'MaterialApp widget (those widgets introduce a MediaQuery), or it can happen '
+        'if the context you use comes from a widget above those widgets.'
+      )
+      ..describeElement('The context used was', context),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -10,6 +10,7 @@ import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'binding.dart';
+import 'debug.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
@@ -1289,7 +1290,7 @@ class Navigator extends StatefulWidget {
     assert(() {
       if (navigator == null && !nullOk) {
         throw FlutterError(
-          'Navigator operation requested with a context that does not include a Navigator.\n'
+          'Navigator operation requested with a context that does not include a Navigator.'
           'The context used to push or pop routes from the Navigator must be that of a '
           'widget that is a descendant of a Navigator widget.'
         );
@@ -1427,12 +1428,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     if (route == null && !allowNull) {
       assert(() {
         if (widget.onUnknownRoute == null) {
-          throw FlutterError(
-            'If a Navigator has no onUnknownRoute, then its onGenerateRoute must never return null.\n'
-            'When trying to build the route "$name", onGenerateRoute returned null, but there was no '
-            'onUnknownRoute callback specified.\n'
-            'The Navigator was:\n'
-            '  $this'
+          throw FlutterError.from(WidgetErrorBuilder()
+            ..addError('If a Navigator has no onUnknownRoute, then its onGenerateRoute must never return null.')
+            ..addViolation(
+              'When trying to build the route "$name", onGenerateRoute returned null, but there was no '
+              'onUnknownRoute callback specified.'
+            )
+            ..addProperty<NavigatorState>('The Navigator was', this),
           );
         }
         return true;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -238,17 +238,16 @@ class Overlay extends StatefulWidget {
     final OverlayState result = context.ancestorStateOfType(const TypeMatcher<OverlayState>());
     assert(() {
       if (debugRequiredFor != null && result == null) {
-        final String additional = context.widget != debugRequiredFor
-          ? '\nThe context from which that widget was searching for an overlay was:\n  $context'
-          : '';
-        throw FlutterError(
-          'No Overlay widget found.\n'
-          '${debugRequiredFor.runtimeType} widgets require an Overlay widget ancestor for correct operation.\n'
-          'The most common way to add an Overlay to an application is to include a MaterialApp or Navigator widget in the runApp() call.\n'
-          'The specific widget that failed to find an overlay was:\n'
-          '  $debugRequiredFor'
-          '$additional'
-        );
+        final WidgetErrorBuilder errorBuilder = WidgetErrorBuilder()
+          ..addError('No Overlay widget found.')
+          ..addContract('${debugRequiredFor.runtimeType} widgets require an Overlay widget ancestor for correct operation.')
+          ..addFix('The most common way to add an Overlay to an application is to include a MaterialApp or Navigator widget in the runApp() call.')
+          ..addProperty<Widget>('The specific widget that failed to find an overlay was', debugRequiredFor);
+
+        if (context.widget != debugRequiredFor) {
+          errorBuilder.describeElement('The context from which that widget was searching for an overlay was', context);
+        }
+        throw errorBuilder.build();
       }
       return true;
     }());

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -390,16 +390,18 @@ class ClampingScrollPhysics extends ScrollPhysics {
   double applyBoundaryConditions(ScrollMetrics position, double value) {
     assert(() {
       if (value == position.pixels) {
-        throw FlutterError(
-          '$runtimeType.applyBoundaryConditions() was called redundantly.\n'
-          'The proposed new position, $value, is exactly equal to the current position of the '
-          'given ${position.runtimeType}, ${position.pixels}.\n'
-          'The applyBoundaryConditions method should only be called when the value is '
-          'going to actually change the pixels, otherwise it is redundant.\n'
-          'The physics object in question was:\n'
-          '  $this\n'
-          'The position object in question was:\n'
-          '  $position\n'
+        throw FlutterError.from(FlutterErrorBuilder()
+          ..addError('$runtimeType.applyBoundaryConditions() was called redundantly.')
+          ..addViolation(
+            'The proposed new position, $value, is exactly equal to the current position of the '
+            'given ${position.runtimeType}, ${position.pixels}.'
+          )
+          ..addContract(
+            'The applyBoundaryConditions method should only be called when the value is '
+            'going to actually change the pixels, otherwise it is redundant.',
+          )
+          ..addProperty<ScrollPhysics>('The physics object in question was', this)
+          ..addProperty<ScrollMetrics>('The position object in question was', position)
         );
       }
       return true;

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
 import 'page_storage.dart';
@@ -203,11 +204,12 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       assert(() {
         final double delta = newPixels - pixels;
         if (overscroll.abs() > delta.abs()) {
-          throw FlutterError(
-            '$runtimeType.applyBoundaryConditions returned invalid overscroll value.\n'
-            'setPixels() was called to change the scroll offset from $pixels to $newPixels.\n'
-            'That is a delta of $delta units.\n'
-            '$runtimeType.applyBoundaryConditions reported an overscroll of $overscroll units.'
+          throw FlutterError.from(WidgetErrorBuilder()
+            ..addError('$runtimeType.applyBoundaryConditions returned invalid overscroll value.')
+            ..addViolation('setPixels() was called to change the scroll offset from $pixels to $newPixels.')
+            ..addDescription('That is a delta of $delta units.')
+            // TODO(jacobr): make this a doubleProperty with custom formatting.
+            ..addError('$runtimeType.applyBoundaryConditions reported an overscroll of $overscroll units.')
           );
         }
         return true;
@@ -375,12 +377,13 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       final double delta = value - pixels;
       if (result.abs() > delta.abs()) {
         throw FlutterError(
-          '${physics.runtimeType}.applyBoundaryConditions returned invalid overscroll value.\n'
-          'The method was called to consider a change from $pixels to $value, which is a '
+          '${physics.runtimeType}.applyBoundaryConditions returned invalid overscroll value.',
+          violation: 'The method was called to consider a change from $pixels to $value, which is a '
           'delta of ${delta.toStringAsFixed(1)} units. However, it returned an overscroll of '
           '${result.toStringAsFixed(1)} units, which has a greater magnitude than the delta. '
           'The applyBoundaryConditions method is only supposed to reduce the possible range '
-          'of movement, not increase it.\n'
+          'of movement, not increase it.',
+          description:
           'The scroll extents are $minScrollExtent .. $maxScrollExtent, and the '
           'viewport dimension is $viewportDimension.'
         );

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1293,7 +1293,6 @@ ErrorWidget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
     stack: stackTrace,
     library: 'widgets library',
     context: 'building',
-    informationCollector: null,
   );
   FlutterError.reportError(details);
   return ErrorWidget.builder(details);

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -108,8 +108,8 @@ class Table extends RenderObjectWidget {
        assert(() {
          if (children.any((TableRow row) => row.children.any((Widget cell) => cell == null))) {
            throw FlutterError(
-             'One of the children of one of the rows of the table was null.\n'
-             'The children of a TableRow must not be null.'
+             'One of the children of one of the rows of the table was null.',
+             contract: 'The children of a TableRow must not be null.'
            );
          }
          return true;
@@ -117,8 +117,8 @@ class Table extends RenderObjectWidget {
        assert(() {
          if (children.any((TableRow row1) => row1.key != null && children.any((TableRow row2) => row1 != row2 && row1.key == row2.key))) {
            throw FlutterError(
-             'Two or more TableRow children of this Table had the same key.\n'
-             'All the keyed TableRow children of a Table must have different Keys.'
+             'Two or more TableRow children of this Table had the same key.',
+             contract: 'All the keyed TableRow children of a Table must have different Keys.'
            );
          }
          return true;
@@ -128,8 +128,8 @@ class Table extends RenderObjectWidget {
            final int cellCount = children.first.children.length;
            if (children.any((TableRow row) => row.children.length != cellCount)) {
              throw FlutterError(
-               'Table contains irregular row lengths.\n'
-               'Every TableRow in a Table must have the same number of children, so that every cell is filled. '
+               'Table contains irregular row lengths.',
+               contract: 'Every TableRow in a Table must have the same number of children, so that every cell is filled. '
                'Otherwise, the table will contain holes.'
              );
            }
@@ -144,8 +144,8 @@ class Table extends RenderObjectWidget {
       final List<Widget> flatChildren = children.expand<Widget>((TableRow row) => row.children).toList(growable: false);
       if (debugChildrenHaveDuplicateKeys(this, flatChildren)) {
         throw FlutterError(
-          'Two or more cells in this Table contain widgets with the same key.\n'
-          'Every widget child of every TableRow in a Table must have different keys. The cells of a Table are '
+          'Two or more cells in this Table contain widgets with the same key.',
+          contract: 'Every widget child of every TableRow in a Table must have different keys. The cells of a Table are '
           'flattened out for processing, so separate cells cannot have duplicate keys even if they are in '
           'different rows.'
         );

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
+import 'debug.dart';
 import 'framework.dart';
 
 export 'package:flutter/scheduler.dart' show TickerProvider;
@@ -83,9 +84,10 @@ mixin SingleTickerProviderStateMixin<T extends StatefulWidget> on State<T> imple
       if (_ticker == null)
         return true;
       throw FlutterError(
-        '$runtimeType is a SingleTickerProviderStateMixin but multiple tickers were created.\n'
-        'A SingleTickerProviderStateMixin can only be used as a TickerProvider once. If a '
-        'State is used for multiple AnimationController objects, or if it is passed to other '
+        '$runtimeType is a SingleTickerProviderStateMixin but multiple tickers were created.',
+        contract:
+        'A SingleTickerProviderStateMixin can only be used as a TickerProvider once.',
+        hint: 'If a State is used for multiple AnimationController objects, or if it is passed to other '
         'objects and those objects might use it more than one time in total, then instead of '
         'mixing in a SingleTickerProviderStateMixin, use a regular TickerProviderStateMixin.'
       );
@@ -103,14 +105,19 @@ mixin SingleTickerProviderStateMixin<T extends StatefulWidget> on State<T> imple
     assert(() {
       if (_ticker == null || !_ticker.isActive)
         return true;
-      throw FlutterError(
-        '$this was disposed with an active Ticker.\n'
-        '$runtimeType created a Ticker via its SingleTickerProviderStateMixin, but at the time '
-        'dispose() was called on the mixin, that Ticker was still active. The Ticker must '
-        'be disposed before calling super.dispose(). Tickers used by AnimationControllers '
-        'should be disposed by calling dispose() on the AnimationController itself. '
-        'Otherwise, the ticker will leak.\n'
-        'The offending ticker was: ${_ticker.toString(debugIncludeStack: true)}'
+      throw FlutterError.from(WidgetErrorBuilder()
+        ..addError('$this was disposed with an active Ticker.')
+        ..addViolation(
+          '$runtimeType created a Ticker via its SingleTickerProviderStateMixin, but at the time '
+          'dispose() was called on the mixin, that Ticker was still active. The Ticker must '
+          'be disposed before calling super.dispose().'
+        )
+        ..addHint(
+          'Tickers used by AnimationControllers '
+          'should be disposed by calling dispose() on the AnimationController itself. '
+          'Otherwise, the ticker will leak.'
+        )
+        ..describeTicker('The offending ticker was', _ticker)
       );
     }());
     super.dispose();
@@ -175,14 +182,20 @@ mixin TickerProviderStateMixin<T extends StatefulWidget> on State<T> implements 
       if (_tickers != null) {
         for (Ticker ticker in _tickers) {
           if (ticker.isActive) {
-            throw FlutterError(
-              '$this was disposed with an active Ticker.\n'
-              '$runtimeType created a Ticker via its TickerProviderStateMixin, but at the time '
-              'dispose() was called on the mixin, that Ticker was still active. All Tickers must '
-              'be disposed before calling super.dispose(). Tickers used by AnimationControllers '
-              'should be disposed by calling dispose() on the AnimationController itself. '
-              'Otherwise, the ticker will leak.\n'
-              'The offending ticker was: ${ticker.toString(debugIncludeStack: true)}'
+            throw FlutterError.from(WidgetErrorBuilder()
+              ..addError('$this was disposed with an active Ticker.')
+              ..addViolation(
+                '$runtimeType created a Ticker via its TickerProviderStateMixin, but at the time '
+                'dispose() was called on the mixin, that Ticker was still active. All Tickers must '
+                'be disposed before calling super.dispose().'
+              )
+              ..addHint(
+                'Tickers used by AnimationControllers '
+                'should be disposed by calling dispose() on the AnimationController itself. '
+                'Otherwise, the ticker will leak.'
+              )
+              ..describeTicker('The offending ticker was', ticker),
+              // TODO(jacobr): expose this as a diagnostic as well.
             );
           }
         }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -680,6 +680,8 @@ class _SerializeConfig {
     this.pathToInclude,
     this.includeProperties = false,
     this.expandPropertyValues = true,
+    this.includeToStringDeep = false,
+    this.maxDescendentsTruncatableNode = -1,
   });
 
   _SerializeConfig.merge(
@@ -692,7 +694,10 @@ class _SerializeConfig {
     subtreeDepth = subtreeDepth ?? base.subtreeDepth,
     pathToInclude = pathToInclude ?? base.pathToInclude,
     includeProperties = base.includeProperties,
-    expandPropertyValues = base.expandPropertyValues;
+    expandPropertyValues = base.expandPropertyValues,
+    includeToStringDeep = base.includeToStringDeep,
+    maxDescendentsTruncatableNode = base.maxDescendentsTruncatableNode;
+
 
   /// Optional object group name used to manage manage lifetimes of object
   /// references in the returned JSON.
@@ -726,6 +731,11 @@ class _SerializeConfig {
   /// If [interactive] is true, a call to `ext.flutter.inspector.disposeGroup`
   /// is required before objects in the tree will ever be garbage collected.
   bool get interactive => groupName != null;
+
+  /// Include the text rendering of the nodes (helpful for debugging).
+  final bool includeToStringDeep;
+
+  final int maxDescendentsTruncatableNode;
 }
 
 // Production implementation of [WidgetInspectorService].
@@ -958,6 +968,22 @@ mixin WidgetInspectorService {
     return Future<void>.value();
   }
 
+  static const String _consoleObjectGroup = 'console-group';
+
+  void _reportError(FlutterErrorDetails details) {
+    postEvent('Flutter.Error', _nodeToJson(
+      FlutterError.errorToDiagnostic(details),
+      _SerializeConfig(
+        groupName: _consoleObjectGroup,
+        includeToStringDeep: true,
+        subtreeDepth: 5,
+        includeProperties: true,
+        expandPropertyValues: true,
+        maxDescendentsTruncatableNode: 5,
+      ),
+    ));
+  }
+
   /// Called to register service extensions.
   ///
   /// See also:
@@ -972,6 +998,21 @@ mixin WidgetInspectorService {
     assert(() { _debugServiceExtensionsRegistered = true; return true; }());
 
     SchedulerBinding.instance.addPersistentFrameCallback(_onFrameStart);
+
+    // We should only actually do this once a service extension enabling it is
+    // turned on but this is a prototype. XXXX.
+
+    final FlutterExceptionHandler structuredExceptionHandler = _reportError;
+    final FlutterExceptionHandler defaultExceptionHandler = FlutterError.onError;
+
+    _registerBoolServiceExtension(
+      name: 'structuredErrors',
+      getter: () async => FlutterError.onError == structuredExceptionHandler,
+      setter: (bool value) {
+        FlutterError.onError = value ? structuredExceptionHandler : defaultExceptionHandler;
+        return Future<void>.value();
+      },
+    );
 
     _registerBoolServiceExtension(
       name: 'show',
@@ -1314,11 +1355,13 @@ mixin WidgetInspectorService {
           return false;
         }
         selection.currentElement = object;
+        developer.inspect(selection.currentElement);
       } else {
         if (object == selection.current) {
           return false;
         }
         selection.current = object;
+        developer.inspect(selection.current);
       }
       if (selectionChangedCallback != null) {
         if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) {
@@ -1368,7 +1411,7 @@ mixin WidgetInspectorService {
       return null;
     return <String, Object>{
       'node': _nodeToJson(pathNode.node, config),
-      'children': _nodesToJson(pathNode.children, config),
+      'children': _nodesToJson(pathNode.children, config, parent: pathNode.node),
       'childIndex': pathNode.childIndex,
     };
   }
@@ -1442,15 +1485,20 @@ mixin WidgetInspectorService {
 
     if (config.subtreeDepth > 0 ||
         (config.pathToInclude != null && config.pathToInclude.isNotEmpty)) {
-      json['children'] = _nodesToJson(_getChildrenHelper(node, config), config);
+      json['children'] = _nodesToJson(_getChildrenHelper(node, config), config, parent: node);
     }
 
     if (config.includeProperties) {
+      List<DiagnosticsNode> properties = node.getProperties();
+      if (properties.isEmpty && value is Diagnosticable) {
+        properties = value.toDiagnosticsNode().getProperties();
+      }
       json['properties'] = _nodesToJson(
-        node.getProperties().where(
+        properties.where(
           (DiagnosticsNode node) => !node.isFiltered(createdByLocalProject ? DiagnosticLevel.fine : DiagnosticLevel.info),
         ),
-        _SerializeConfig(groupName: config.groupName, subtreeDepth: 1, expandPropertyValues: true),
+        _SerializeConfig.merge(config, subtreeDepth: math.max(0, config.subtreeDepth - 1)),
+        parent: node,
       );
     }
 
@@ -1478,6 +1526,7 @@ mixin WidgetInspectorService {
               subtreeDepth: 0,
               expandPropertyValues: false,
           ),
+          parent: node,
         );
       }
     }
@@ -1521,13 +1570,30 @@ mixin WidgetInspectorService {
     return jsonString;
   }
 
+  List<DiagnosticsNode> _truncateNodes(Iterable<DiagnosticsNode> nodes, _SerializeConfig config) {
+    if (nodes.every((DiagnosticsNode node) => node.value is Element) && isWidgetCreationTracked()) {
+      final List<DiagnosticsNode> localNodes = nodes.where((DiagnosticsNode node) =>
+          _isValueCreatedByLocalProject(node.value)).toList();
+      if (localNodes.isNotEmpty) {
+        return localNodes;
+      }
+    }
+    return nodes.take(config.maxDescendentsTruncatableNode).toList();
+  }
+
   List<Map<String, Object>> _nodesToJson(
     Iterable<DiagnosticsNode> nodes,
-    _SerializeConfig config,
-  ) {
+    _SerializeConfig config, {
+    @required DiagnosticsNode parent,
+  }) {
+    bool truncated = false;
     if (nodes == null)
       return <Map<String, Object>>[];
-    return nodes.map<Map<String, Object>>(
+    if (config.maxDescendentsTruncatableNode >= 0 && parent?.allowTruncate == true && nodes.length > config.maxDescendentsTruncatableNode) {
+      nodes = _truncateNodes(nodes, config)..add(DiagnosticsNode.message('...'));
+      truncated = true;
+    }
+    final List<Map<String, Object>> json = nodes.map<Map<String, Object>>(
       (DiagnosticsNode node) {
         if (config.pathToInclude != null && config.pathToInclude.isNotEmpty) {
           if (config.pathToInclude.first == node.value) {
@@ -1550,6 +1616,9 @@ mixin WidgetInspectorService {
               _SerializeConfig.merge(config, subtreeDepth: config.subtreeDepth - 1) : config,
         );
       }).toList();
+    if (truncated)
+      json.last['truncated'] = true;
+    return json;
   }
 
   /// Returns a JSON representation of the properties of the [DiagnosticsNode]
@@ -1561,7 +1630,7 @@ mixin WidgetInspectorService {
 
   List<Object> _getProperties(String diagnosticsNodeId, String groupName) {
     final DiagnosticsNode node = toObject(diagnosticsNodeId);
-    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : node.getProperties(), _SerializeConfig(groupName: groupName));
+    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : node.getProperties(), _SerializeConfig(groupName: groupName), parent: null);
   }
 
   /// Returns a JSON representation of the children of the [DiagnosticsNode]
@@ -1573,7 +1642,7 @@ mixin WidgetInspectorService {
   List<Object> _getChildren(String diagnosticsNodeId, String groupName) {
     final DiagnosticsNode node = toObject(diagnosticsNodeId);
     final _SerializeConfig config = _SerializeConfig(groupName: groupName);
-    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config);
+    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config, parent: node);
   }
 
   /// Returns a JSON representation of the children of the [DiagnosticsNode]
@@ -1595,7 +1664,7 @@ mixin WidgetInspectorService {
   List<Object> _getChildrenSummaryTree(String diagnosticsNodeId, String groupName) {
     final DiagnosticsNode node = toObject(diagnosticsNodeId);
     final _SerializeConfig config = _SerializeConfig(groupName: groupName, summaryTree: true);
-    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config);
+    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config, parent: node);
   }
 
   /// Returns a JSON representation of the children of the [DiagnosticsNode]
@@ -1612,7 +1681,7 @@ mixin WidgetInspectorService {
     final DiagnosticsNode node = toObject(diagnosticsNodeId);
     // With this value of minDepth we only expand one extra level of important nodes.
     final _SerializeConfig config = _SerializeConfig(groupName: groupName, subtreeDepth: 1,  includeProperties: true);
-    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config);
+    return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenHelper(node, config), config, parent: node);
   }
 
   List<DiagnosticsNode> _getChildrenHelper(DiagnosticsNode node, _SerializeConfig config) {
@@ -1620,6 +1689,9 @@ mixin WidgetInspectorService {
   }
 
   bool _shouldShowInSummaryTree(DiagnosticsNode node) {
+    if (node.level == DiagnosticLevel.error) {
+      return true;
+    }
     final Object value = node.value;
     if (value is! Diagnosticable) {
       return true;
@@ -1632,12 +1704,21 @@ mixin WidgetInspectorService {
     return _isValueCreatedByLocalProject(value);
   }
 
+  bool _isDeepStyle(DiagnosticsTreeStyle style) => false;
+
   List<DiagnosticsNode> _getChildrenFiltered(
     DiagnosticsNode node,
     _SerializeConfig config,
   ) {
     final List<DiagnosticsNode> children = <DiagnosticsNode>[];
-    for (DiagnosticsNode child in node.getChildren()) {
+    final Object value = node.value;
+    List<DiagnosticsNode> rawChildren = node.getChildren();
+    if (rawChildren.isEmpty && node is DiagnosticsProperty && value is Diagnosticable && config.expandPropertyValues &&
+        _isDeepStyle(node.style)) {
+      rawChildren = value.toDiagnosticsNode().getChildren();
+    }
+
+    for (DiagnosticsNode child in rawChildren) {
       if (!config.summaryTree || _shouldShowInSummaryTree(child)) {
         children.add(child);
       } else {
@@ -2178,7 +2259,6 @@ class _WidgetInspectorState extends State<WidgetInspector>
         // changed.
       });
     };
-    assert(WidgetInspectorService.instance.selectionChangedCallback == null);
     WidgetInspectorService.instance.selectionChangedCallback = _selectionChangedCallback;
   }
 

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -23,9 +23,7 @@ void main() {
         stack: StackTrace.current,
         library: 'Example library',
         context: 'Example context',
-        informationCollector: (StringBuffer information) {
-          information.writeln('Example information');
-        },
+        errorBuilder: FlutterErrorBuilder ()..addDescription('Example information'),
       );
 
       FlutterError.dumpErrorToConsole(details);
@@ -47,11 +45,9 @@ void main() {
         exception: 'MESSAGE',
         library: 'LIBRARY',
         context: 'CONTEXTING',
-        informationCollector: (StringBuffer information) {
-          information.writeln('INFO');
-        },
+        errorBuilder: FlutterErrorBuilder()..addDescription('INFO'),
       ).toString(),
-      'Error caught by LIBRARY, thrown CONTEXTING.\n'
+      'Error caught by LIBRARY, thrown CONTEXTING:\n'
       'MESSAGE\n'
       'INFO',
     );
@@ -59,11 +55,9 @@ void main() {
       FlutterErrorDetails(
         library: 'LIBRARY',
         context: 'CONTEXTING',
-        informationCollector: (StringBuffer information) {
-          information.writeln('INFO');
-        },
+        errorBuilder: FlutterErrorBuilder()..addDescription('INFO'),
       ).toString(),
-      'Error caught by LIBRARY, thrown CONTEXTING.\n'
+      'Error caught by LIBRARY, thrown CONTEXTING:\n'
       '  null\n'
       'INFO',
     );
@@ -71,24 +65,33 @@ void main() {
       FlutterErrorDetails(
         exception: 'MESSAGE',
         context: 'CONTEXTING',
-        informationCollector: (StringBuffer information) {
-          information.writeln('INFO');
-        },
+        errorBuilder: FlutterErrorBuilder()..addDescription('INFO'),
       ).toString(),
-      'Error caught by Flutter framework, thrown CONTEXTING.\n'
+      'Error caught by Flutter framework, thrown CONTEXTING:\n'
       'MESSAGE\n'
       'INFO',
+    );
+    expect(
+      FlutterErrorDetails(
+        exception: 'MESSAGE',
+        context: 'CONTEXTING',
+        contextObject: 'SomeContext(BlaBla)',
+        errorBuilder: FlutterErrorBuilder()..addDescription('INFO'),
+      ).toString(),
+      'Error caught by Flutter framework, thrown CONTEXTING SomeContext(BlaBla):\n'
+          'MESSAGE\n'
+          'INFO',
     );
     expect(
       const FlutterErrorDetails(
         exception: 'MESSAGE',
       ).toString(),
-      'Error caught by Flutter framework.\n'
+      'Error caught by Flutter framework:\n'
       'MESSAGE'
     );
     expect(
       const FlutterErrorDetails().toString(),
-      'Error caught by Flutter framework.\n'
+      'Error caught by Flutter framework:\n'
       '  null'
     );
   });

--- a/packages/flutter/test/foundation/diagnostics_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_test.dart
@@ -60,16 +60,14 @@ void validateNodeJsonSerialization(DiagnosticsNode node) {
 
 void validateNodeJsonSerializationHelper(Map<String, Object> json, DiagnosticsNode node) {
   expect(json['name'], equals(node.name));
-  expect(json['showSeparator'], equals(node.showSeparator));
+  expect(json['showSeparator'] ?? true, equals(node.showSeparator));
   expect(json['description'], equals(node.toDescription()));
-  expect(json['level'], equals(describeEnum(node.level)));
-  expect(json['showName'], equals(node.showName));
+  expect(json['level'] ?? describeEnum(DiagnosticLevel.info), equals(describeEnum(node.level)));
+  expect(json['showName'] ?? true, equals(node.showName));
   expect(json['emptyBodyDescription'], equals(node.emptyBodyDescription));
-  expect(json['style'], equals(describeEnum(node.style)));
-  final String valueToString = node is DiagnosticsProperty ? node.valueToString() : node.value.toString();
-  expect(json['valueToString'], equals(valueToString));
+  expect(json['style'] ?? describeEnum(DiagnosticsTreeStyle.sparse), equals(describeEnum(node.style)));
   expect(json['type'], equals(node.runtimeType.toString()));
-  expect(json['hasChildren'], equals(node.getChildren().isNotEmpty));
+  expect(json['hasChildren'] ?? false, equals(node.getChildren().isNotEmpty));
 }
 
 void validatePropertyJsonSerialization(DiagnosticsProperty<Object> property) {
@@ -168,7 +166,6 @@ void validatePropertyJsonSerializationHelper(final Map<String, Object> json, Dia
     expect(json.containsKey('exception'), isFalse);
   }
   expect(json['propertyType'], equals(property.propertyType.toString()));
-  expect(json['valueToString'], equals(property.valueToString()));
   expect(json.containsKey('defaultLevel'), isTrue);
   if (property.value is Diagnosticable) {
     expect(json['isDiagnosticableValue'], isTrue);
@@ -264,12 +261,28 @@ void main() {
       '   ╚═══════════\n',
     );
 
-    // You would never really want to make everything a leaf child like this
-    // but you can and still get a readable tree.
+    goldenStyleTest(
+      'error children',
+      style: DiagnosticsTreeStyle.sparse,
+      lastChildStyle: DiagnosticsTreeStyle.error,
+      golden:
+      'TestTree#00000\n'
+      ' ├─child node A: TestTree#00000\n'
+      ' ├─child node B: TestTree#00000\n'
+      ' │ ├─child node B1: TestTree#00000\n'
+      ' │ ├─child node B2: TestTree#00000\n'
+      ' │ ╘═╦══╡ child node B3: TestTree#00000 ╞═══════════════════════════════\n'
+      ' │   ╚══════════════════════════════════════════════════════════════════\n'
+      ' ╘═╦══╡ child node C: TestTree#00000 ╞════════════════════════════════\n'
+      '   ╚══════════════════════════════════════════════════════════════════\n',
+    );
+
+    // You would never really want to make everything a transition child like
+    // this but you can and still get a readable tree.
     // The joint between single and double lines here is a bit clunky
     // but we could correct that if there is any real use for this style.
     goldenStyleTest(
-      'leaf',
+      'transition',
       style: DiagnosticsTreeStyle.transition,
       golden:
       'TestTree#00000:\n'
@@ -294,6 +307,26 @@ void main() {
     );
 
     goldenStyleTest(
+      'error',
+      style: DiagnosticsTreeStyle.error,
+      golden:
+      '══╡ TestTree#00000 ╞═════════════════════════════════════════════\n'
+      '╞═╦══╡ child node A: TestTree#00000 ╞════════════════════════════════\n'
+      '│ ╚══════════════════════════════════════════════════════════════════\n'
+      '╞═╦══╡ child node B: TestTree#00000 ╞════════════════════════════════\n'
+      '│ ║ ╞═╦══╡ child node B1: TestTree#00000 ╞═══════════════════════════════\n'
+      '│ ║ │ ╚══════════════════════════════════════════════════════════════════\n'
+      '│ ║ ╞═╦══╡ child node B2: TestTree#00000 ╞═══════════════════════════════\n'
+      '│ ║ │ ╚══════════════════════════════════════════════════════════════════\n'
+      '│ ║ ╘═╦══╡ child node B3: TestTree#00000 ╞═══════════════════════════════\n'
+      '│ ║   ╚══════════════════════════════════════════════════════════════════\n'
+      '│ ╚══════════════════════════════════════════════════════════════════\n'
+      '╘═╦══╡ child node C: TestTree#00000 ╞════════════════════════════════\n'
+      '  ╚══════════════════════════════════════════════════════════════════\n'
+      '═════════════════════════════════════════════════════════════════\n',
+    );
+
+    goldenStyleTest(
       'whitespace',
       style: DiagnosticsTreeStyle.whitespace,
       golden:
@@ -312,44 +345,53 @@ void main() {
       style: DiagnosticsTreeStyle.singleLine,
       golden: 'TestTree#00000',
     );
+
+    // Header line mode does not display children.
+    goldenStyleTest(
+      'header line',
+      style: DiagnosticsTreeStyle.headerLine,
+      golden: 'TestTree#00000:',
+    );
   });
 
   test('TreeDiagnosticsMixin tree with properties test', () async {
     void goldenStyleTest(String description, {
+      String name,
       DiagnosticsTreeStyle style,
       DiagnosticsTreeStyle lastChildStyle,
+      DiagnosticsTreeStyle propertyStyle = DiagnosticsTreeStyle.singleLine,
       @required String golden,
     }) {
       final TestTree tree = TestTree(
         properties: <DiagnosticsNode>[
-          StringProperty('stringProperty1', 'value1', quoted: false),
-          DoubleProperty('doubleProperty1', 42.5),
-          DoubleProperty('roundedProperty', 1.0 / 3.0),
-          StringProperty('DO_NOT_SHOW', 'DO_NOT_SHOW', level: DiagnosticLevel.hidden, quoted: false),
-          DiagnosticsProperty<Object>('DO_NOT_SHOW_NULL', null, defaultValue: null),
-          DiagnosticsProperty<Object>('nullProperty', null),
-          StringProperty('node_type', '<root node>', showName: false, quoted: false),
+          StringProperty('stringProperty1', 'value1', quoted: false, style: propertyStyle),
+          DoubleProperty('doubleProperty1', 42.5, style: propertyStyle),
+          DoubleProperty('roundedProperty', 1.0 / 3.0, style: propertyStyle),
+          StringProperty('DO_NOT_SHOW', 'DO_NOT_SHOW', level: DiagnosticLevel.hidden, quoted: false, style: propertyStyle),
+          DiagnosticsProperty<Object>('DO_NOT_SHOW_NULL', null, defaultValue: null, style: propertyStyle),
+          DiagnosticsProperty<Object>('nullProperty', null, style: propertyStyle),
+          StringProperty('node_type', '<root node>', showName: false, quoted: false, style: propertyStyle),
         ],
         children: <TestTree>[
           TestTree(name: 'node A', style: style),
           TestTree(
             name: 'node B',
             properties: <DiagnosticsNode>[
-              StringProperty('p1', 'v1', quoted: false),
-              StringProperty('p2', 'v2', quoted: false),
+              StringProperty('p1', 'v1', quoted: false, style: propertyStyle),
+              StringProperty('p2', 'v2', quoted: false, style: propertyStyle),
             ],
             children: <TestTree>[
               TestTree(name: 'node B1', style: style),
               TestTree(
                 name: 'node B2',
-                properties: <DiagnosticsNode>[StringProperty('property1', 'value1', quoted: false)],
+                properties: <DiagnosticsNode>[StringProperty('property1', 'value1', quoted: false, style: propertyStyle)],
                 style: style,
               ),
               TestTree(
                 name: 'node B3',
                 properties: <DiagnosticsNode>[
-                  StringProperty('node_type', '<leaf node>', showName: false, quoted: false),
-                  IntProperty('foo', 42),
+                  StringProperty('node_type', '<leaf node>', showName: false, quoted: false, style: propertyStyle),
+                  IntProperty('foo', 42, style: propertyStyle),
                 ],
                 style: lastChildStyle ?? style,
               ),
@@ -359,7 +401,7 @@ void main() {
           TestTree(
             name: 'node C',
             properties: <DiagnosticsNode>[
-              StringProperty('foo', 'multi\nline\nvalue!', quoted: false),
+              StringProperty('foo', 'multi\nline\nvalue!', quoted: false, style: propertyStyle),
             ],
             style: lastChildStyle ?? style,
           ),
@@ -367,11 +409,14 @@ void main() {
         style: lastChildStyle,
       );
 
-      if (tree.style != DiagnosticsTreeStyle.singleLine)
+      if (tree.style != DiagnosticsTreeStyle.singleLine &&
+          tree.style != DiagnosticsTreeStyle.headerLine &&
+          tree.style != DiagnosticsTreeStyle.indentedSingleLine) {
         expect(tree, hasAGoodToStringDeep);
+      }
 
       expect(
-        tree.toDiagnosticsNode(style: style).toStringDeep(),
+        tree.toDiagnosticsNode(name: name, style: style).toStringDeep(),
         equalsIgnoringHashCodes(golden),
         reason: description,
       );
@@ -397,6 +442,45 @@ void main() {
       ' │ ├─child node B1: TestTree#00000\n'
       ' │ ├─child node B2: TestTree#00000\n'
       ' │ │   property1: value1\n'
+      ' │ │\n'
+      ' │ └─child node B3: TestTree#00000\n'
+      ' │     <leaf node>\n'
+      ' │     foo: 42\n'
+      ' │\n'
+      ' └─child node C: TestTree#00000\n'
+      '     foo:\n'
+      '       multi\n'
+      '       line\n'
+      '       value!\n',
+    );
+
+    goldenStyleTest(
+      'sparse with indented single line properties',
+      style: DiagnosticsTreeStyle.sparse,
+      propertyStyle: DiagnosticsTreeStyle.indentedSingleLine,
+      golden:
+      'TestTree#00000\n'
+      ' │ stringProperty1:\n'
+      ' │   value1\n'
+      ' │ doubleProperty1:\n'
+      ' │   42.5\n'
+      ' │ roundedProperty:\n'
+      ' │   0.3\n'
+      ' │ nullProperty:\n'
+      ' │   null\n'
+      ' │ <root node>\n'
+      ' │\n'
+      ' ├─child node A: TestTree#00000\n'
+      ' ├─child node B: TestTree#00000\n'
+      ' │ │ p1:\n'
+      ' │ │   v1\n'
+      ' │ │ p2:\n'
+      ' │ │   v2\n'
+      ' │ │\n'
+      ' │ ├─child node B1: TestTree#00000\n'
+      ' │ ├─child node B2: TestTree#00000\n'
+      ' │ │   property1:\n'
+      ' │ │     value1\n'
       ' │ │\n'
       ' │ └─child node B3: TestTree#00000\n'
       ' │     <leaf node>\n'
@@ -454,7 +538,7 @@ void main() {
     );
 
     goldenStyleTest(
-      'leaf children',
+      'transition children',
       style: DiagnosticsTreeStyle.sparse,
       lastChildStyle: DiagnosticsTreeStyle.transition,
       golden:
@@ -487,6 +571,40 @@ void main() {
       '   ║     value!\n'
       '   ╚═══════════\n',
     );
+
+    goldenStyleTest(
+      'error children',
+      style: DiagnosticsTreeStyle.sparse,
+      lastChildStyle: DiagnosticsTreeStyle.error,
+      golden:
+      'TestTree#00000\n'
+      ' │ stringProperty1: value1\n'
+      ' │ doubleProperty1: 42.5\n'
+      ' │ roundedProperty: 0.3\n'
+      ' │ nullProperty: null\n'
+      ' │ <root node>\n'
+      ' │\n'
+      ' ├─child node A: TestTree#00000\n'
+      ' ├─child node B: TestTree#00000\n'
+      ' │ │ p1: v1\n'
+      ' │ │ p2: v2\n'
+      ' │ │\n'
+      ' │ ├─child node B1: TestTree#00000\n'
+      ' │ ├─child node B2: TestTree#00000\n'
+      ' │ │   property1: value1\n'
+      ' │ │\n'
+      ' │ ╘═╦══╡ child node B3: TestTree#00000 ╞═══════════════════════════════\n'
+      ' │   ║ <leaf node>\n'
+      ' │   ║ foo: 42\n'
+      ' │   ╚══════════════════════════════════════════════════════════════════\n'
+      ' ╘═╦══╡ child node C: TestTree#00000 ╞════════════════════════════════\n'
+      '   ║ foo:\n'
+      '   ║   multi\n'
+      '   ║   line\n'
+      '   ║   value!\n'
+      '   ╚══════════════════════════════════════════════════════════════════\n',
+    );
+
 
     // You would never really want to make everything a transition child like
     // this but you can and still get a readable tree.
@@ -556,6 +674,32 @@ void main() {
         '      value!\n',
     );
 
+    goldenStyleTest(
+      'flat',
+      style: DiagnosticsTreeStyle.flat,
+      golden:
+      'TestTree#00000:\n'
+      'stringProperty1: value1\n'
+      'doubleProperty1: 42.5\n'
+      'roundedProperty: 0.3\n'
+      'nullProperty: null\n'
+      '<root node>\n'
+      'child node A: TestTree#00000\n'
+      'child node B: TestTree#00000:\n'
+      'p1: v1\n'
+      'p2: v2\n'
+      'child node B1: TestTree#00000\n'
+      'child node B2: TestTree#00000:\n'
+      'property1: value1\n'
+      'child node B3: TestTree#00000:\n'
+      '<leaf node>\n'
+      'foo: 42\n'
+      'child node C: TestTree#00000:\n'
+      'foo:\n'
+      '  multi\n'
+      '  line\n'
+      '  value!\n',
+    );
     // Single line mode does not display children.
     goldenStyleTest(
       'single line',
@@ -563,10 +707,48 @@ void main() {
       golden: 'TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>)',
     );
 
+    goldenStyleTest(
+      'single line',
+      name: 'some name',
+      style: DiagnosticsTreeStyle.singleLine,
+      golden: 'some name: TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>)',
+    );
+
+    // Header line mode does not display children and acts like the line is a
+    // header describing the rest of the content.
+    goldenStyleTest(
+      'header line',
+      style: DiagnosticsTreeStyle.headerLine,
+      golden: 'TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>):',
+    );
+
+    goldenStyleTest(
+      'header line',
+      name: 'some name',
+      style: DiagnosticsTreeStyle.headerLine,
+      golden: 'some name: TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>):',
+    );
+
+    // No name so we don't indent.
+    goldenStyleTest(
+      'indented single line',
+      style: DiagnosticsTreeStyle.indentedSingleLine,
+      golden: 'TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>)\n',
+    );
+
+    goldenStyleTest(
+      'indented single line',
+      name: 'some name',
+      style: DiagnosticsTreeStyle.indentedSingleLine,
+      golden:
+      'some name:\n'
+      '  TestTree#00000(stringProperty1: value1, doubleProperty1: 42.5, roundedProperty: 0.3, nullProperty: null, <root node>)\n',
+    );
+
     // TODO(jacobr): this is an ugly test case.
     // There isn't anything interesting for this case as the children look the
-    // same with and without children. Only difference is odd not clearly
-    // desirable density of B3 being right next to node C.
+    // same with and without children. Only difference is the odd and
+    // undesirable density of B3 being right next to node C.
     goldenStyleTest(
       'single line last child',
       style: DiagnosticsTreeStyle.sparse,
@@ -590,6 +772,72 @@ void main() {
       ' │ │\n'
       ' │ └─child node B3: TestTree#00000(<leaf node>, foo: 42)\n'
       ' └─child node C: TestTree#00000(foo: multi\\nline\\nvalue!)\n',
+    );
+
+    // TODO(jacobr): this is an ugly test case.
+    // There isn't anything interesting for this case as the children look the
+    // same with and without children. Only difference is the odd and
+    // undesirable density of B3 being right next to node C.
+    // Typically header lines should not be places as leaves in the tree and
+    // should instead be places in front of other nodes that they
+    // function as a header for.
+    goldenStyleTest(
+      'header single line last child',
+      style: DiagnosticsTreeStyle.sparse,
+      lastChildStyle: DiagnosticsTreeStyle.headerLine,
+      golden:
+      'TestTree#00000\n'
+      ' │ stringProperty1: value1\n'
+      ' │ doubleProperty1: 42.5\n'
+      ' │ roundedProperty: 0.3\n'
+      ' │ nullProperty: null\n'
+      ' │ <root node>\n'
+      ' │\n'
+      ' ├─child node A: TestTree#00000\n'
+      ' ├─child node B: TestTree#00000\n'
+      ' │ │ p1: v1\n'
+      ' │ │ p2: v2\n'
+      ' │ │\n'
+      ' │ ├─child node B1: TestTree#00000\n'
+      ' │ ├─child node B2: TestTree#00000\n'
+      ' │ │   property1: value1\n'
+      ' │ │\n'
+      ' │ └─child node B3: TestTree#00000(<leaf node>, foo: 42):\n'
+      ' └─child node C: TestTree#00000(foo: multi\\nline\\nvalue!):\n',
+    );
+
+    // TODO(jacobr): this is an ugly test case.
+    // There isn't anything interesting for this case as the children look the
+    // same with and without children. Only difference is the odd and
+    // undesirable density of B3 being right next to node C.
+    // Typically header lines should not be places as leaves in the tree and
+    // should instead be places in front of other nodes that they
+    // function as a header for.
+    goldenStyleTest(
+      'indented single line last child',
+      style: DiagnosticsTreeStyle.sparse,
+      lastChildStyle: DiagnosticsTreeStyle.indentedSingleLine,
+      golden:
+      'TestTree#00000\n'
+      ' │ stringProperty1: value1\n'
+      ' │ doubleProperty1: 42.5\n'
+      ' │ roundedProperty: 0.3\n'
+      ' │ nullProperty: null\n'
+      ' │ <root node>\n'
+      ' │\n'
+      ' ├─child node A: TestTree#00000\n'
+      ' ├─child node B: TestTree#00000\n'
+      ' │ │ p1: v1\n'
+      ' │ │ p2: v2\n'
+      ' │ │\n'
+      ' │ ├─child node B1: TestTree#00000\n'
+      ' │ ├─child node B2: TestTree#00000\n'
+      ' │ │   property1: value1\n'
+      ' │ │\n'
+      ' │ └─child node B3:\n'
+      ' │     TestTree#00000(<leaf node>, foo: 42)\n'
+      ' └─child node C:\n'
+      '     TestTree#00000(foo: multi\\nline\\nvalue!)\n',
     );
   });
 
@@ -1506,6 +1754,16 @@ void main() {
       ),
     );
 
+    expect(
+      TestTree(
+        properties: <DiagnosticsNode>[objectsProperty, IntProperty('foo', 42)],
+        style: DiagnosticsTreeStyle.headerLine,
+      ).toStringDeep(),
+      equalsIgnoringHashCodes(
+        'TestTree#00000(objects: [Rect.fromLTRB(0.0, 0.0, 20.0, 20.0), Color(0xffffffff)], foo: 42):',
+      ),
+    );
+
     // Iterable with a single entry. Verify that rendering is sensible and that
     // multi line rendering isn't used even though it is not helpful.
     final List<Object> singleElementList = <Object>[const Color.fromARGB(255, 255, 255, 255)];
@@ -1546,11 +1804,339 @@ void main() {
     expect(message.showName, isFalse);
     validateNodeJsonSerialization(message);
 
+    final DiagnosticsNode headerMessage = DiagnosticsNode.message('hello world', style: DiagnosticsTreeStyle.headerLine);
+    expect(headerMessage.toString(), equals('hello world:'));
+    expect(headerMessage.style, equals(DiagnosticsTreeStyle.headerLine));
+    expect(headerMessage.name, isEmpty);
+    expect(headerMessage.value, isNull);
+    expect(headerMessage.showName, isFalse);
+    validateNodeJsonSerialization(headerMessage);
+
     final DiagnosticsNode messageProperty = MessageProperty('diagnostics', 'hello world');
     expect(messageProperty.toString(), equals('diagnostics: hello world'));
     expect(messageProperty.name, equals('diagnostics'));
     expect(messageProperty.value, isNull);
     expect(messageProperty.showName, isTrue);
     validatePropertyJsonSerialization(messageProperty);
+  });
+
+  test('error message style wrap test', () {
+    // This tests wrapping of properties with styles typical for error messages.
+    DiagnosticsNode createTreeWithWrappingNodes({
+      DiagnosticsTreeStyle rootStyle,
+      DiagnosticsTreeStyle propertyStyle,
+    }) {
+      return TestTree(
+        name: 'Test tree',
+        properties: <DiagnosticsNode>[
+          DiagnosticsNode.message(
+          '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            'This is a very long message that must wrap as it cannot fit on one line. '
+            'This is a very long message that must wrap as it cannot fit on one line. '
+            'This is a very long message that must wrap as it cannot fit on one line.',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          DiagnosticsProperty<void>(null,
+              'Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap.',
+              allowWrap: false),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          UrlProperty(
+            'This property has a very long property name that will be allowed to wrap unlike most property names. This property has a very long property name that will be allowed to wrap unlike most property names',
+            url: 'https://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html',
+            style: propertyStyle,
+          ),
+          UrlProperty(
+            'This property has a very long property name that will be allowed to wrap unlike most property names. This property has a very long property name that will be allowed to wrap unlike most property names',
+            url: 'https://goo.gl/',
+            style: propertyStyle,
+          ),
+          UrlProperty(
+            'Click on the following url',
+            url: 'http://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html',
+            style: propertyStyle,
+          ),
+          UrlProperty(
+            'Click on the following url',
+            url: 'https://goo.gl/',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          DiagnosticsProperty<String>(
+            'multi-line value',
+            '[1.0, 0.0, 0.0, 0.0]\n'
+            '[1.0, 1.0, 0.0, 0.0]\n'
+            '[1.0, 0.0, 1.0, 0.0]\n'
+            '[1.0, 0.0, 0.0, 1.0]\n',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          DiagnosticsProperty<String>(
+            'This property has a very long property name that will be allowed to wrap unlike most property names. This property has a very long property name that will be allowed to wrap unlike most property names',
+            'This is a very long message that must wrap as it cannot fit on one line. '
+            'This is a very long message that must wrap as it cannot fit on one line. '
+            'This is a very long message that must wrap as it cannot fit on one line.',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          DiagnosticsProperty<String>(
+            'This property has a very long property name that will be allowed to wrap unlike most property names. This property has a very long property name that will be allowed to wrap unlike most property names',
+            '[1.0, 0.0, 0.0, 0.0]\n'
+            '[1.0, 1.0, 0.0, 0.0]\n'
+            '[1.0, 0.0, 1.0, 0.0]\n'
+            '[1.0, 0.0, 0.0, 1.0]\n',
+            style: propertyStyle,
+          ),
+          DiagnosticsNode.message(
+            '--- example property at max length --',
+            style: propertyStyle,
+          ),
+          MessageProperty(
+            'diagnosis',
+            'insufficient data to draw conclusion (less than five repaints)',
+            style: propertyStyle,
+          ),
+        ],
+      ).toDiagnosticsNode(style: rootStyle);
+    }
+
+    final TextRenderer renderer = TextRenderer(wrapWidth: 40, wrapWidthProperties: 40);
+    expect(
+      renderer.render(createTreeWithWrappingNodes(
+        rootStyle: DiagnosticsTreeStyle.error,
+        propertyStyle: DiagnosticsTreeStyle.singleLine,
+      )),
+      equalsIgnoringHashCodes(
+        '══╡ TestTree#00000 ╞════════════════════\n'
+        '--- example property at max length --\n'
+        'This is a very long message that must\n'
+        'wrap as it cannot fit on one line. This\n'
+        'is a very long message that must wrap as\n'
+        'it cannot fit on one line. This is a\n'
+        'very long message that must wrap as it\n'
+        'cannot fit on one line.\n'
+        '--- example property at max length --\n'
+        'Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap.\n'
+        '--- example property at max length --\n'
+        'This property has a very long property\n'
+        'name that will be allowed to wrap unlike\n'
+        'most property names. This property has a\n'
+        'very long property name that will be\n'
+        'allowed to wrap unlike most property\n'
+        'names:\n'
+        '  https://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+        'This property has a very long property\n'
+        'name that will be allowed to wrap unlike\n'
+        'most property names. This property has a\n'
+        'very long property name that will be\n'
+        'allowed to wrap unlike most property\n'
+        'names:\n'
+        '  https://goo.gl/\n'
+        'Click on the following url:\n'
+        '  http://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+        'Click on the following url:\n'
+        '  https://goo.gl/\n'
+        '--- example property at max length --\n'
+        'multi-line value:\n'
+        '  [1.0, 0.0, 0.0, 0.0]\n'
+        '  [1.0, 1.0, 0.0, 0.0]\n'
+        '  [1.0, 0.0, 1.0, 0.0]\n'
+        '  [1.0, 0.0, 0.0, 1.0]\n'
+        '--- example property at max length --\n'
+        'This property has a very long property\n'
+        'name that will be allowed to wrap unlike\n'
+        'most property names. This property has a\n'
+        'very long property name that will be\n'
+        'allowed to wrap unlike most property\n'
+        'names:\n'
+        '  This is a very long message that must\n'
+        '  wrap as it cannot fit on one line.\n'
+        '  This is a very long message that must\n'
+        '  wrap as it cannot fit on one line.\n'
+        '  This is a very long message that must\n'
+        '  wrap as it cannot fit on one line.\n'
+        '--- example property at max length --\n'
+        'This property has a very long property\n'
+        'name that will be allowed to wrap unlike\n'
+        'most property names. This property has a\n'
+        'very long property name that will be\n'
+        'allowed to wrap unlike most property\n'
+        'names:\n'
+        '  [1.0, 0.0, 0.0, 0.0]\n'
+        '  [1.0, 1.0, 0.0, 0.0]\n'
+        '  [1.0, 0.0, 1.0, 0.0]\n'
+        '  [1.0, 0.0, 0.0, 1.0]\n'
+        '--- example property at max length --\n'
+        'diagnosis: insufficient data to draw\n'
+        '  conclusion (less than five repaints)\n'
+        '════════════════════════════════════════\n',
+      )
+    );
+
+    // This output looks ugly but verifies that no indentation on word wrap
+    // leaks in if the style is flat.
+    expect(
+      renderer.render(createTreeWithWrappingNodes(
+        rootStyle: DiagnosticsTreeStyle.sparse,
+        propertyStyle: DiagnosticsTreeStyle.flat,
+      )),
+      equalsIgnoringHashCodes(
+        'TestTree#00000\n'
+        '   --- example property at max length --\n'
+        '   This is a very long message that must\n'
+        '   wrap as it cannot fit on one line. This\n'
+        '   is a very long message that must wrap as\n'
+        '   it cannot fit on one line. This is a\n'
+        '   very long message that must wrap as it\n'
+        '   cannot fit on one line.\n'
+        '   --- example property at max length --\n'
+        '   Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap.\n'
+        '   --- example property at max length --\n'
+        '   This property has a very long property\n'
+        '   name that will be allowed to wrap unlike\n'
+        '   most property names. This property has a\n'
+        '   very long property name that will be\n'
+        '   allowed to wrap unlike most property\n'
+        '   names:\n'
+        '   https://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+        '   This property has a very long property\n'
+        '   name that will be allowed to wrap unlike\n'
+        '   most property names. This property has a\n'
+        '   very long property name that will be\n'
+        '   allowed to wrap unlike most property\n'
+        '   names:\n'
+        '   https://goo.gl/\n'
+        '   Click on the following url:\n'
+        '   http://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+        '   Click on the following url:\n'
+        '   https://goo.gl/\n'
+        '   --- example property at max length --\n'
+        '   multi-line value:\n'
+        '   [1.0, 0.0, 0.0, 0.0]\n'
+        '   [1.0, 1.0, 0.0, 0.0]\n'
+        '   [1.0, 0.0, 1.0, 0.0]\n'
+        '   [1.0, 0.0, 0.0, 1.0]\n'
+        '   --- example property at max length --\n'
+        '   This property has a very long property\n'
+        '   name that will be allowed to wrap unlike\n'
+        '   most property names. This property has a\n'
+        '   very long property name that will be\n'
+        '   allowed to wrap unlike most property\n'
+        '   names:\n'
+        '   This is a very long message that must\n'
+        '   wrap as it cannot fit on one line. This\n'
+        '   is a very long message that must wrap as\n'
+        '   it cannot fit on one line. This is a\n'
+        '   very long message that must wrap as it\n'
+        '   cannot fit on one line.\n'
+        '   --- example property at max length --\n'
+        '   This property has a very long property\n'
+        '   name that will be allowed to wrap unlike\n'
+        '   most property names. This property has a\n'
+        '   very long property name that will be\n'
+        '   allowed to wrap unlike most property\n'
+        '   names:\n'
+        '   [1.0, 0.0, 0.0, 0.0]\n'
+        '   [1.0, 1.0, 0.0, 0.0]\n'
+        '   [1.0, 0.0, 1.0, 0.0]\n'
+        '   [1.0, 0.0, 0.0, 1.0]\n'
+        '   --- example property at max length --\n'
+        '   diagnosis: insufficient data to draw\n'
+        '   conclusion (less than five repaints)\n'
+      )
+    );
+
+    // This case matches the styles that should generally be used for error
+    // messages
+    expect(
+        renderer.render(createTreeWithWrappingNodes(
+          rootStyle: DiagnosticsTreeStyle.error,
+          propertyStyle: DiagnosticsTreeStyle.indentedSingleLine,
+        )),
+        equalsIgnoringHashCodes(
+          '══╡ TestTree#00000 ╞════════════════════\n'
+          '--- example property at max length --\n'
+          'This is a very long message that must\n'
+          'wrap as it cannot fit on one line. This\n'
+          'is a very long message that must wrap as\n'
+          'it cannot fit on one line. This is a\n'
+          'very long message that must wrap as it\n'
+          'cannot fit on one line.\n'
+          '--- example property at max length --\n'
+          'Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap even though it is very long. Message that is not allowed to wrap.\n'
+          '--- example property at max length --\n'
+          'This property has a very long property\n'
+          'name that will be allowed to wrap unlike\n'
+          'most property names. This property has a\n'
+          'very long property name that will be\n'
+          'allowed to wrap unlike most property\n'
+          'names:\n'
+          '  https://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+          'This property has a very long property\n'
+          'name that will be allowed to wrap unlike\n'
+          'most property names. This property has a\n'
+          'very long property name that will be\n'
+          'allowed to wrap unlike most property\n'
+          'names:\n'
+          '  https://goo.gl/\n'
+          'Click on the following url:\n'
+          '  http://someverylongurl.com/that might be tempting to wrap even though it is a url so should not wrap.html\n'
+          'Click on the following url:\n'
+          '  https://goo.gl/\n'
+          '--- example property at max length --\n'
+          'multi-line value:\n'
+          '  [1.0, 0.0, 0.0, 0.0]\n'
+          '  [1.0, 1.0, 0.0, 0.0]\n'
+          '  [1.0, 0.0, 1.0, 0.0]\n'
+          '  [1.0, 0.0, 0.0, 1.0]\n'
+          '--- example property at max length --\n'
+          'This property has a very long property\n'
+          'name that will be allowed to wrap unlike\n'
+          'most property names. This property has a\n'
+          'very long property name that will be\n'
+          'allowed to wrap unlike most property\n'
+          'names:\n'
+          '  This is a very long message that must\n'
+          '  wrap as it cannot fit on one line.\n'
+          '  This is a very long message that must\n'
+          '  wrap as it cannot fit on one line.\n'
+          '  This is a very long message that must\n'
+          '  wrap as it cannot fit on one line.\n'
+          '--- example property at max length --\n'
+          'This property has a very long property\n'
+          'name that will be allowed to wrap unlike\n'
+          'most property names. This property has a\n'
+          'very long property name that will be\n'
+          'allowed to wrap unlike most property\n'
+          'names:\n'
+          '  [1.0, 0.0, 0.0, 0.0]\n'
+          '  [1.0, 1.0, 0.0, 0.0]\n'
+          '  [1.0, 0.0, 1.0, 0.0]\n'
+          '  [1.0, 0.0, 0.0, 1.0]\n'
+          '--- example property at max length --\n'
+          'diagnosis:\n'
+          '  insufficient data to draw conclusion\n'
+          '  (less than five repaints)\n'
+          '════════════════════════════════════════\n'
+        )
+    );
   });
 }

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -57,18 +57,20 @@ Future<void> main() async {
       stack: sampleStack,
       library: 'error handling test',
       context: 'testing the error handling logic',
-      informationCollector: (StringBuffer information) {
-        information.writeln('line 1 of extra information');
-        information.writeln('line 2 of extra information\n'); // the double trailing newlines here are intentional
-      },
+      errorBuilder: FlutterErrorBuilder.lazy(() {
+        return FlutterErrorBuilder()
+          ..addContract('line 1 of extra information')
+          ..addHint('line 2 of extra information\n');
+      }),
     ));
     expect(console.join('\n'), matches(
       '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
       'The following assertion was thrown testing the error handling logic:\n'
       'Message goes here\\.\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
+      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':\n'
+      'Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
       '\n'
-      'Either the assertion indicates an error in the framework itself, or we should provide substantially '
+      'Either the assertion indicates an error in the framework itself, or we should provide substantially\n'
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
       'In either case, please report this assertion by filing a bug on GitHub:\n'
       '  https://github\\.com/flutter/flutter/issues/new\\?template=BUG\\.md\n'
@@ -83,7 +85,8 @@ Future<void> main() async {
       '\n'
       'line 1 of extra information\n'
       'line 2 of extra information\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      '════════════════════════════════════════════════════════════════════════════════════════════════════\n'
+      '\$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -102,18 +105,20 @@ Future<void> main() async {
     expect(console.join('\n'), matches(
       '^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
       'The following assertion was thrown:\n'
-      'word word word word word word word word word word word word word word word word word word word word '
-      'word word word word word word word word word word word word word word word word word word word word '
-      'word word word word word word word word word word word word word word word word word word word word '
-      'word word word word word word word word word word word word word word word word word word word word '
       'word word word word word word word word word word word word word word word word word word word word\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
+      'word word word word word word word word word word word word word word word word word word word word\n'
+      'word word word word word word word word word word word word word word word word word word word word\n'
+      'word word word word word word word word word word word word word word word word word word word word\n'
+      'word word word word word word word word word word word word word word word word word word word word\n'
+      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':\n'
+      'Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
       '\n'
-      'Either the assertion indicates an error in the framework itself, or we should provide substantially '
+      'Either the assertion indicates an error in the framework itself, or we should provide substantially\n'
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
       'In either case, please report this assertion by filing a bug on GitHub:\n'
       '  https://github\\.com/flutter/flutter/issues/new\\?template=BUG\\.md\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      '════════════════════════════════════════════════════════════════════════════════════════════════════\n'
+      '\$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -139,17 +144,17 @@ Future<void> main() async {
       stack: sampleStack,
       library: 'error handling test',
       context: 'testing the error handling logic',
-      informationCollector: (StringBuffer information) {
-        information.writeln('line 1 of extra information');
-        information.writeln('line 2 of extra information\n'); // the double trailing newlines here are intentional
-      },
+      errorBuilder: FlutterErrorBuilder()
+        ..addContract('line 1 of extra information')
+        ..addDescription('line 2 of extra information\n') // the double trailing newlines here are intentional
     ));
     expect(console.join('\n'), matches(
       '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
       'The following assertion was thrown testing the error handling logic:\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\': Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.\n'
+      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':\n'
+      'Failed assertion: line [0-9]+ pos [0-9]+: \'false\': is not true\\.\n'
       '\n'
-      'Either the assertion indicates an error in the framework itself, or we should provide substantially '
+      'Either the assertion indicates an error in the framework itself, or we should provide substantially\n'
       'more information in this error message to help you determine and fix the underlying cause\\.\n'
       'In either case, please report this assertion by filing a bug on GitHub:\n'
       '  https://github\\.com/flutter/flutter/issues/new\\?template=BUG\\.md\n'
@@ -164,7 +169,8 @@ Future<void> main() async {
       '\n'
       'line 1 of extra information\n'
       'line 2 of extra information\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      '════════════════════════════════════════════════════════════════════════════════════════════════════\n'
+      '\$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -186,7 +192,8 @@ Future<void> main() async {
       'The following NoSuchMethodError was thrown:\n'
       'Receiver: 5\n'
       'Tried calling: foo = 2, 4\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      '════════════════════════════════════════════════════════════════════════════════════════════════════\n'
+      '\$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -206,7 +213,8 @@ Future<void> main() async {
       '^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
       'The following message was thrown:\n'
       'hello\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      '════════════════════════════════════════════════════════════════════════════════════════════════════\n'
+      '\$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(const FlutterErrorDetails(

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -621,7 +621,7 @@ void main() {
   test('Service extensions - posttest', () async {
     // See widget_inspector_test.dart for tests of the ext.flutter.inspector
     // service extensions included in this count.
-    int widgetInspectorExtensionCount = 15;
+    int widgetInspectorExtensionCount = 16;
     if (WidgetInspectorService.instance.isWidgetCreationTracked()) {
       // Some inspector extensions are only exposed if widget creation locations
       // are tracked.

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -10,7 +10,7 @@ void main() {
     await tester.pumpWidget(const ListTile());
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
-    expect(exception.toString(), startsWith('No Material widget found.'));
+    expect(exception.toString(), startsWith('ListTile widgets require a Material widget ancestor, but we couldn\'t find any.\n'));
     expect(exception.toString(), endsWith(':\n  ListTile\nThe ancestors of this widget were:\n  [root]'));
   });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3081,7 +3081,7 @@ void main() {
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
-    expect(exception.toString(), startsWith('No Material widget found.'));
+    expect(exception.toString(), startsWith('TextField widgets require a Material widget ancestor, but we couldn\'t find any.\n'));
     expect(exception.toString(), endsWith(':\n  $textField\nThe ancestors of this widget were:\n  [root]'));
   });
 

--- a/packages/flutter/test/rendering/constraints_test.dart
+++ b/packages/flutter/test/rendering/constraints_test.dart
@@ -37,7 +37,7 @@ void main() {
     result = 'no exception';
     try {
       const BoxConstraints constraints = BoxConstraints(minWidth: double.nan, maxWidth: double.nan, minHeight: 2.0, maxHeight: double.nan);
-      assert(constraints.debugAssertIsValid());
+      assert(constraints.debugAssertIsValidStructured());
     } on FlutterError catch (e) {
       result = '$e';
     }
@@ -50,7 +50,7 @@ void main() {
     result = 'no exception';
     try {
       const BoxConstraints constraints = BoxConstraints(minHeight: double.nan);
-      assert(constraints.debugAssertIsValid());
+      assert(constraints.debugAssertIsValidStructured());
     } on FlutterError catch (e) {
       result = '$e';
     }
@@ -63,7 +63,7 @@ void main() {
     result = 'no exception';
     try {
       const BoxConstraints constraints = BoxConstraints(minHeight: double.nan, maxWidth: 0.0/0.0);
-      assert(constraints.debugAssertIsValid());
+      assert(constraints.debugAssertIsValidStructured());
     } on FlutterError catch (e) {
       result = '$e';
     }

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -82,7 +82,7 @@ void main() {
     expect(error.toString(), contains('The following GlobalKey was specified multiple times'));
     // The following line is verifying the grammar is correct in this common case.
     // We should probably also verify the three other combinations that can be generated...
-    expect(error.toString(), contains('This was determined by noticing that after the widget with the above global key was moved out of its previous parent, that previous parent never updated during this frame, meaning that it either did not update at all or updated before the widget was moved, in either case implying that it still thinks that it should have a child with that global key.'));
+    expect(error.toString().split('\n').join(' '), contains('This was determined by noticing that after the widget with the above global key was moved out of its previous parent, that previous parent never updated during this frame, meaning that it either did not update at all or updated before the widget was moved, in either case implying that it still thinks that it should have a child with that global key.'));
     expect(error.toString(), contains('[GlobalObjectKey ${describeIdentity(0)}]'));
     expect(error.toString(), contains('Container'));
     expect(error.toString(), endsWith('\nA GlobalKey can only be specified on one widget at a time in the widget tree.'));

--- a/packages/flutter_test/lib/src/stack_manipulation.dart
+++ b/packages/flutter_test/lib/src/stack_manipulation.dart
@@ -4,14 +4,17 @@
 
 // See also test_async_utils.dart which has some stack manipulation code.
 
+import 'package:flutter/foundation.dart';
+
 /// Report call site for `expect()` call. Returns the number of frames that
 /// should be elided if a stack were to be modified to hide the expect call, or
 /// zero if no such call was found.
 ///
 /// If the head of the stack trace consists of a failure as a result of calling
-/// the test_widgets [expect] function, this will fill the given StringBuffer
-/// with the precise file and line number that called that function.
-int reportExpectCall(StackTrace stack, StringBuffer information) {
+/// the test_widgets [expect] function, this will fill the given
+/// FlutterErrorBuilder with the precise file and line number that called that
+/// function.
+int reportExpectCallErrorBuilder(StackTrace stack, FlutterErrorBuilder information) {
   final RegExp line0 = RegExp(r'^#0 +fail \(.+\)$');
   final RegExp line1 = RegExp(r'^#1 +_expect \(.+\)$');
   final RegExp line2 = RegExp(r'^#2 +expect \(.+\)$');
@@ -23,6 +26,42 @@ int reportExpectCall(StackTrace stack, StringBuffer information) {
       line2.firstMatch(stackLines[2]) != null &&
       line3.firstMatch(stackLines[3]) != null
       ) {
+    final Match expectMatch = line4.firstMatch(stackLines[4]);
+    assert(expectMatch != null);
+    assert(expectMatch.groupCount == 2);
+    information.addDiagnostic(DiagnosticsStackTrace.singleFrame(
+      'This was caught by the test expectation on the following line',
+      frame: '${expectMatch.group(1)} line ${expectMatch.group(2)}',
+    ));
+
+    return 4;
+  }
+  return 0;
+}
+
+/// Report call site for `expect()` call. Returns the number of frames that
+/// should be elided if a stack were to be modified to hide the expect call, or
+/// zero if no such call was found.
+///
+/// If the head of the stack trace consists of a failure as a result of calling
+/// the test_widgets [expect] function, this will fill the given StringBuffer
+/// with the precise file and line number that called that function.
+///
+/// Use reportExpectCallErrorBuilder instead to get a more structured view of
+/// the error that was caught.
+@deprecated
+int reportExpectCall(StackTrace stack, StringBuffer information) {
+  final RegExp line0 = RegExp(r'^#0 +fail \(.+\)$');
+  final RegExp line1 = RegExp(r'^#1 +_expect \(.+\)$');
+  final RegExp line2 = RegExp(r'^#2 +expect \(.+\)$');
+  final RegExp line3 = RegExp(r'^#3 +expect \(.+\)$');
+  final RegExp line4 = RegExp(r'^#4 +[^(]+ \((.+?):([0-9]+)(?::[0-9]+)?\)$');
+  final List<String> stackLines = stack.toString().split('\n');
+  if (line0.firstMatch(stackLines[0]) != null &&
+      line1.firstMatch(stackLines[1]) != null &&
+      line2.firstMatch(stackLines[2]) != null &&
+      line3.firstMatch(stackLines[3]) != null
+  ) {
     final Match expectMatch = line4.firstMatch(stackLines[4]);
     assert(expectMatch != null);
     assert(expectMatch.groupCount == 2);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -565,12 +565,16 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     if (_tickers != null) {
       for (Ticker ticker in _tickers) {
         if (ticker.isActive) {
-          throw FlutterError(
-            'A Ticker was active $when.\n'
-            'All Tickers must be disposed. Tickers used by AnimationControllers '
-            'should be disposed by calling dispose() on the AnimationController itself. '
-            'Otherwise, the ticker will leak.\n'
-            'The offending ticker was: ${ticker.toString(debugIncludeStack: true)}'
+          throw FlutterError.from(WidgetErrorBuilder()
+            ..addError('A Ticker was active $when.')
+            ..addContract('All Tickers must be disposed.')
+            ..addHint(
+              'Tickers used by AnimationControllers '
+              'should be disposed by calling dispose() on the AnimationController itself. '
+              'Otherwise, the ticker will leak.'
+            )
+            // XXX fixup this line.
+            ..describeTicker('The offending ticker was', ticker)
           );
         }
       }
@@ -585,10 +589,13 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   void _verifySemanticsHandlesWereDisposed() {
     assert(_lastRecordedSemanticsHandles != null);
     if (binding.pipelineOwner.debugOutstandingSemanticsHandles > _lastRecordedSemanticsHandles) {
+      // TODO(jacobr): The hint for this one causes a change in line breaks but
+      // I think it is for the best.
       throw FlutterError(
-        'A SemanticsHandle was active at the end of the test.\n'
-        'All SemanticsHandle instances must be disposed by calling dispose() on '
-        'the SemanticsHandle. If your test uses SemanticsTester, it is '
+        'A SemanticsHandle was active at the end of the test.',
+        contract: 'All SemanticsHandle instances must be disposed by calling dispose() on '
+        'the SemanticsHandle.',
+        hint: 'If your test uses SemanticsTester, it is '
         'sufficient to call dispose() on SemanticsTester. Otherwise, the '
         'existing handle will leak into another test and alter its behavior.'
       );

--- a/packages/flutter_test/test/stack_manipulation_test.dart
+++ b/packages/flutter_test/test/stack_manipulation_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -10,9 +11,10 @@ void main() {
       expect(false, isTrue);
       throw 'unexpectedly did not throw';
     } catch (e, stack) {
-      final StringBuffer information = StringBuffer();
-      expect(reportExpectCall(stack, information), 4);
-      final List<String> lines = information.toString().split('\n');
+      final FlutterErrorBuilder information = FlutterErrorBuilder();
+      expect(reportExpectCallErrorBuilder(stack, information), 4);
+      final TextRenderer renderer = TextRenderer();
+      final List<String> lines = information.toDiagnostics().map((DiagnosticsNode node) => renderer.render(node).trimRight()).join('\n').split('\n');
       expect(lines[0], 'This was caught by the test expectation on the following line:');
       expect(lines[1], matches(r'^  .*stack_manipulation_test.dart line [0-9]+$'));
     }
@@ -20,9 +22,9 @@ void main() {
     try {
       throw null;
     } catch (e, stack) {
-      final StringBuffer information = StringBuffer();
-      expect(reportExpectCall(stack, information), 0);
-      expect(information.toString(), '');
+      final FlutterErrorBuilder information = FlutterErrorBuilder();
+      expect(reportExpectCallErrorBuilder(stack, information), 0);
+      expect(information.toDiagnostics(), isEmpty);
     }
   });
 }

--- a/packages/flutter_test/test/test_async_utils_test.dart
+++ b/packages/flutter_test/test/test_async_utils_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -43,12 +44,13 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Guarded function conflict. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.'));
-      real_test.expect(lines[2], matches(r'Then, the "testGuard2" method \(also from class TestAPI\) was called from .*test_async_utils_test.dart on line [0-9]+\.'));
-      real_test.expect(lines[3], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPI.testGuard2) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
-      real_test.expect(lines[4], '');
-      real_test.expect(lines[5], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.'));
+      real_test.expect(lines[3], matches(r'Then, the "testGuard2" method \(also from class TestAPI\) was called from .*test_async_utils_test.dart on line [0-9]+\.'));
+      real_test.expect(lines[4], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPI.testGuard2) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
+      real_test.expect(lines[5], '');
+      real_test.expect(lines[6], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
       real_test.expect(lines.length, greaterThan(6));
     }
     expect(await f1, isNull);
@@ -64,13 +66,14 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Guarded function conflict. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[2], matches(r'^Then, the "testGuard2" method \(also from class TestAPI\) was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[3], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPI.testGuard2) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
-      real_test.expect(lines[4], '');
-      real_test.expect(lines[5], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
-      real_test.expect(lines.length, greaterThan(6));
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[3], matches(r'^Then, the "testGuard2" method \(also from class TestAPI\) was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[4], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPI.testGuard2) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
+      real_test.expect(lines[5], '');
+      real_test.expect(lines[6], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
+      real_test.expect(lines.length, greaterThan(7));
     }
     expect(await f1, isNull);
     expect(f2, isNull);
@@ -85,13 +88,14 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Guarded function conflict. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[2], matches(r'^Then, the "testGuard3" method from class TestAPISubclass was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[3], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPISubclass.testGuard3) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
-      real_test.expect(lines[4], '');
-      real_test.expect(lines[5], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
-      real_test.expect(lines.length, greaterThan(6));
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[3], matches(r'^Then, the "testGuard3" method from class TestAPISubclass was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[4], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second method (TestAPISubclass.testGuard3) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
+      real_test.expect(lines[5], '');
+      real_test.expect(lines[6], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
+      real_test.expect(lines.length, greaterThan(7));
     }
     expect(await f1, isNull);
     expect(f2, isNull);
@@ -106,13 +110,14 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Guarded function conflict. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[2], matches(r'^Then, the "expect" function was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[3], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second function (expect) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
-      real_test.expect(lines[4], 'If you are confident that all test APIs are being called using "await", and this expect() call is not being called at the top level but is itself being called from some sort of callback registered before the testGuard1 method was called, then consider using expectSync() instead.');
-      real_test.expect(lines[5], '');
-      real_test.expect(lines[6], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "testGuard1" from class TestAPI was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[3], matches(r'^Then, the "expect" function was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[4], 'The first method (TestAPI.testGuard1) had not yet finished executing at the time that the second function (expect) was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
+      real_test.expect(lines[5], 'If you are confident that all test APIs are being called using "await", and this expect() call is not being called at the top level but is itself being called from some sort of callback registered before the testGuard1 method was called, then consider using expectSync() instead.');
+      real_test.expect(lines[6], '');
+      real_test.expect(lines[7], 'When the first method (TestAPI.testGuard1) was called, this was the stack:');
       real_test.expect(lines.length, greaterThan(7));
     }
     expect(await f1, isNull);
@@ -126,13 +131,33 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Guarded function conflict. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[2], matches(r'^Then, it was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
-      real_test.expect(lines[3], 'The first method had not yet finished executing at the time that the second method was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
-      real_test.expect(lines[4], '');
-      real_test.expect(lines[5], 'When the first method was called, this was the stack:');
-      real_test.expect(lines.length, greaterThan(6));
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[3], matches(r'^Then, it was called from .*test_async_utils_test.dart on line [0-9]+\.$'));
+      real_test.expect(lines[4], 'The first method had not yet finished executing at the time that the second method was called. Since both are guarded, and the second was not a nested call inside the first, the first must complete its execution before the second can be called. Typically, this is achieved by putting an "await" statement in front of the call to the first.');
+      real_test.expect(lines[5], '');
+      real_test.expect(lines[6], 'When the first method was called, this was the stack:');
+      real_test.expect(lines.length, greaterThan(7));
+      // TODO(jacobr): add more tests like this if they are useful.
+      real_test.expect(e.messageParts.length, 7);
+      real_test.expect(e.messageParts[0].level, DiagnosticLevel.error);
+      real_test.expect(e.messageParts[1].level, DiagnosticLevel.hint);
+      real_test.expect(e.messageParts[2].level, DiagnosticLevel.info);
+      real_test.expect(e.messageParts[3].level, DiagnosticLevel.info);
+      real_test.expect(e.messageParts[4].level, DiagnosticLevel.info);
+      real_test.expect(e.messageParts[5].level, DiagnosticLevel.info);
+      real_test.expect(e.messageParts[6].level, DiagnosticLevel.info);
+      real_test.expect(e.messageParts[0], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[1], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[2], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[3], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[4], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[5], isInstanceOf<DiagnosticsProperty<void>>());
+      real_test.expect(e.messageParts[6], isInstanceOf<DiagnosticsStackTrace>());
+      final DiagnosticsStackTrace stackTraceProperty = e.messageParts[6];
+      real_test.expect(stackTraceProperty.name, 'When the first method was called, this was the stack');
+      real_test.expect(stackTraceProperty.value, isInstanceOf<StackTrace>());
     }
     await f1;
     await f2;
@@ -146,10 +171,16 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Asynchronous call to guarded function leaked. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+, but never completed before its parent scope closed\.$'));
-      real_test.expect(lines[2], matches(r'^The guarded method "pump" from class AutomatedTestWidgetsFlutterBinding was called from [^ ]+ on line [0-9]+, but never completed before its parent scope closed\.'));
-      real_test.expect(lines.length, 3);
+      real_test.expect(lines[0], 'Asynchronous call to guarded function leaked.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+, but never completed before its parent scope closed\.$'));
+      real_test.expect(lines[3], matches(r'^The guarded method "pump" from class AutomatedTestWidgetsFlutterBinding was called from [^ ]+ on line [0-9]+, but never completed before its parent scope closed\.'));
+      real_test.expect(lines.length, 4);
+      real_test.expect(e.messageParts.length, 4);
+      real_test.expect(e.messageParts[0].level, DiagnosticLevel.error);
+      real_test.expect(e.messageParts[1].level, DiagnosticLevel.hint);
+      real_test.expect(e.messageParts[2].level, DiagnosticLevel.violation);
+      real_test.expect(e.messageParts[3].level, DiagnosticLevel.violation);
     }
     await f1;
   });
@@ -162,10 +193,16 @@ void main() {
       throw 'unexpectedly did not throw';
     } on FlutterError catch (e) {
       final List<String> lines = e.message.split('\n');
-      real_test.expect(lines[0], 'Asynchronous call to guarded function leaked. You must use "await" with all Future-returning test APIs.');
-      real_test.expect(lines[1], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+, but never completed before its parent scope closed\.$'));
-      real_test.expect(lines[2], matches(r'^The guarded method "pump" from class AutomatedTestWidgetsFlutterBinding was called from [^ ]+ on line [0-9]+, but never completed before its parent scope closed\.'));
-      real_test.expect(lines.length, 3);
+      real_test.expect(lines[0], 'Asynchronous call to guarded function leaked.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], matches(r'^The guarded method "pump" from class WidgetTester was called from .*test_async_utils_test.dart on line [0-9]+, but never completed before its parent scope closed\.$'));
+      real_test.expect(lines[3], matches(r'^The guarded method "pump" from class AutomatedTestWidgetsFlutterBinding was called from [^ ]+ on line [0-9]+, but never completed before its parent scope closed\.'));
+      real_test.expect(lines.length, 4);
+      real_test.expect(e.messageParts.length, 4);
+      real_test.expect(e.messageParts[0].level, DiagnosticLevel.error);
+      real_test.expect(e.messageParts[1].level, DiagnosticLevel.hint);
+      real_test.expect(e.messageParts[2].level, DiagnosticLevel.violation);
+      real_test.expect(e.messageParts[3].level, DiagnosticLevel.violation);
     }
     await f1;
   });


### PR DESCRIPTION
The key new classes added are:
FlutterErrorBuilder, RenderErrorBuilder, and WidgetErrorBuilder which are used to make it simpler
to generate beautiful errors than if the standard DiagnosticsProperty constructors were used directly.

Changes to widget_inspector.dart and diagnostics.dart are not ready for a full review as that code can be cleaned up and the diagnostics.dart code mainly just contains implementation details for the text rendering..
Additional styles and levels of DiagnosticsNodes have been added so this change exactly matches the existing rendering of errors for all cases I'm aware of. If is possible some of these styles should be removed for cases where the existing UI diverged in ways that were not useful but generally my goal is to exactly match the existing output and then worry about beautifying the output in follow on CLs.

The motivation for this CL is to generate beautiful interactive structured versions of flutter errors when rendering error messages in Intellij and the upcoming devtools web app.
Here are screenshots from the devtools web app showing how these structured error objects let us explain flutter errors better.
<img width="1090" alt="screen shot 2019-01-22 at 7 51 08 pm" src="https://user-images.githubusercontent.com/1226812/51869405-4d49c680-2305-11e9-8ae3-a26e845b54e2.png">
<img width="1491" alt="screen shot 2019-01-21 at 9 09 01 pm" src="https://user-images.githubusercontent.com/1226812/51869411-53d83e00-2305-11e9-8323-84262daedfa0.png">
