### PR TITLE
Add support for multiroot scheme to PackageUriMapper

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -78,8 +78,7 @@ class StdoutHandler {
 
   void handler(String message) {
     const String kResultPrefix = 'result ';
-    if (boundaryKey == null) {
-      if (message.startsWith(kResultPrefix))
+    if (boundaryKey == null && message.startsWith(kResultPrefix)) {
         boundaryKey = message.substring(kResultPrefix.length);
     } else if (message.startsWith(boundaryKey)) {
       if (message.length <= boundaryKey.length) {
@@ -112,36 +111,45 @@ class StdoutHandler {
 
 /// Converts filesystem paths to package URIs.
 class PackageUriMapper {
-  PackageUriMapper(String scriptPath, String packagesPath) {
+  PackageUriMapper(String scriptPath, String packagesPath, String fileSystemScheme, List<String> fileSystemRoots) {
     final Map<String, Uri> packageMap = PackageMap(fs.path.absolute(packagesPath)).map;
     final String scriptUri = Uri.file(scriptPath, windows: platform.isWindows).toString();
 
     for (String packageName in packageMap.keys) {
       final String prefix = packageMap[packageName].toString();
+      if (fileSystemScheme != null && fileSystemRoots != null && prefix.contains(fileSystemScheme)) {
+        _packageName = packageName;
+        _uriPrefixes = fileSystemRoots
+          .map((String name) => Uri.file('$name/lib/', windows: platform.isWindows).toString())
+          .toList();
+        return;
+      }
       if (scriptUri.startsWith(prefix)) {
         _packageName = packageName;
-        _uriPrefix = prefix;
+        _uriPrefixes = <String>[prefix];
         return;
       }
     }
   }
 
   String _packageName;
-  String _uriPrefix;
+  List<String> _uriPrefixes;
 
   Uri map(String scriptPath) {
-    if (_packageName == null)
+    if (_packageName == null) {
       return null;
-    final String scriptUri = Uri.file(scriptPath, windows: platform.isWindows).toString();
-    if (scriptUri.startsWith(_uriPrefix)) {
-      return Uri.parse('package:$_packageName/${scriptUri.substring(_uriPrefix.length)}');
     }
-
+    final String scriptUri = Uri.file(scriptPath, windows: platform.isWindows).toString();
+    for (String uriPrefix in _uriPrefixes) {
+      if (scriptUri.startsWith(uriPrefix)) {
+        return Uri.parse('package:$_packageName/${scriptUri.substring(uriPrefix.length)}');
+      }
+    }
     return null;
   }
 
-  static Uri findUri(String scriptPath, String packagesPath) {
-    return PackageUriMapper(scriptPath, packagesPath).map(scriptPath);
+  static Uri findUri(String scriptPath, String packagesPath, String fileSystemScheme, List<String> fileSystemRoots) {
+    return PackageUriMapper(scriptPath, packagesPath, fileSystemScheme, fileSystemRoots).map(scriptPath);
   }
 }
 
@@ -223,7 +231,7 @@ class KernelCompiler {
     Uri mainUri;
     if (packagesPath != null) {
       command.addAll(<String>['--packages', packagesPath]);
-      mainUri = PackageUriMapper.findUri(mainPath, packagesPath);
+      mainUri = PackageUriMapper.findUri(mainPath, packagesPath, fileSystemScheme, fileSystemRoots);
     }
     if (outputFilePath != null) {
       command.addAll(<String>['--output-dill', outputFilePath]);
@@ -256,7 +264,7 @@ class KernelCompiler {
 
     server.stderr
       .transform<String>(utf8.decoder)
-      .listen((String message) { printError(message); });
+      .listen(printError);
     server.stdout
       .transform<String>(utf8.decoder)
       .transform<String>(const LineSplitter())
@@ -387,15 +395,20 @@ class ResidentCompiler {
     // First time recompile is called we actually have to compile the app from
     // scratch ignoring list of invalidated files.
     PackageUriMapper packageUriMapper;
-    if (request.packagesFilePath != null) {
-      packageUriMapper = PackageUriMapper(request.mainPath, request.packagesFilePath);
+    if (request.packagesFilePath != null || _packagesPath != null) {
+      packageUriMapper = PackageUriMapper(
+        request.mainPath,
+        request.packagesFilePath ?? _packagesPath,
+        _fileSystemScheme,
+        _fileSystemRoots,
+      );
     }
 
     if (_server == null) {
       return _compile(
           _mapFilename(request.mainPath, packageUriMapper),
           request.outputPath,
-          _mapFilename(request.packagesFilePath, /* packageUriMapper= */ null)
+          _mapFilename(request.packagesFilePath ?? _packagesPath, /* packageUriMapper= */ null)
       );
     }
 

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -22,36 +22,58 @@ final Generator _kNoColorTerminalPlatform = () => FakePlatform.fromPlatform(cons
 
 void main() {
   group(PackageUriMapper, () {
-    const String packagesContents = r'''
+    group('single-root', () {
+      const String packagesContents = r'''
 xml:file:///Users/flutter_user/.pub-cache/hosted/pub.dartlang.org/xml-3.2.3/lib/
 yaml:file:///Users/flutter_user/.pub-cache/hosted/pub.dartlang.org/yaml-2.1.15/lib/
 example:file:///example/lib/
 ''';
-    final MockFileSystem mockFileSystem = MockFileSystem();
-    final MockFile mockFile = MockFile();
-    when(mockFileSystem.path).thenReturn(fs.path);
-    when(mockFileSystem.file(any)).thenReturn(mockFile);
-    when(mockFile.readAsBytesSync()).thenReturn(utf8.encode(packagesContents));
+      final MockFileSystem mockFileSystem = MockFileSystem();
+      final MockFile mockFile = MockFile();
+      when(mockFileSystem.path).thenReturn(fs.path);
+      when(mockFileSystem.file(any)).thenReturn(mockFile);
+      when(mockFile.readAsBytesSync()).thenReturn(utf8.encode(packagesContents));
+      testUsingContext('Can map main.dart to correct package', () async {
+        final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages', null, null);
+        expect(packageUriMapper.map('/example/lib/main.dart').toString(), 'package:example/main.dart');
+      }, overrides: <Type, Generator>{
+        FileSystem: () => mockFileSystem,
+      });
 
-    testUsingContext('Can map main.dart to correct package', () async {
-      final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages');
-      expect(packageUriMapper.map('/example/lib/main.dart').toString(), 'package:example/main.dart');
-    }, overrides: <Type, Generator>{
-      FileSystem: () => mockFileSystem,
+      testUsingContext('Maps file from other package to null', () async {
+        final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages', null, null);
+        expect(packageUriMapper.map('/xml/lib/xml.dart'),  null);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => mockFileSystem,
+      });
+
+      testUsingContext('Maps non-main file from same package', () async {
+        final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages', null, null);
+        expect(packageUriMapper.map('/example/lib/src/foo.dart').toString(), 'package:example/src/foo.dart');
+      }, overrides: <Type, Generator>{
+        FileSystem: () => mockFileSystem,
+      });
     });
 
-    testUsingContext('Maps file from other package to null', () async {
-      final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages');
-      expect(packageUriMapper.map('/xml/lib/xml.dart'),  null);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => mockFileSystem,
-    });
+    group('multi-root', () {
+      final MockFileSystem mockFileSystem = MockFileSystem();
+      final MockFile mockFile = MockFile();
+      when(mockFileSystem.path).thenReturn(fs.path);
+      when(mockFileSystem.file(any)).thenReturn(mockFile);
 
-    testUsingContext('Maps non-main file from same package', () async {
-      final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages');
-      expect(packageUriMapper.map('/example/lib/src/foo.dart').toString(), 'package:example/src/foo.dart');
-    }, overrides: <Type, Generator>{
-      FileSystem: () => mockFileSystem,
+      const String multiRootPackagesContents = r'''
+xml:file:///Users/flutter_user/.pub-cache/hosted/pub.dartlang.org/xml-3.2.3/lib/
+yaml:file:///Users/flutter_user/.pub-cache/hosted/pub.dartlang.org/yaml-2.1.15/lib/
+example:org-dartlang-app:///lib/
+''';
+      when(mockFile.readAsBytesSync()).thenReturn(utf8.encode(multiRootPackagesContents));
+
+      testUsingContext('Maps main file from same package on multiroot scheme', () async {
+        final PackageUriMapper packageUriMapper = PackageUriMapper('/example/lib/main.dart', '.packages', 'org-dartlang-app', <String>['/example', '/gen']);
+        expect(packageUriMapper.map('/example/lib/main.dart').toString(), 'package:example/main.dart');
+      }, overrides: <Type, Generator>{
+        FileSystem: () => mockFileSystem,
+      });
     });
   });
 


### PR DESCRIPTION
Allows codegen to use a multiroot scheme over .dart_tool/build/generated for https://github.com/flutter/flutter/issues/27141

Also fallback to packages provided when resident compiler is created if request packages is null.