### PR TITLE
Inject KernelCompiler via KernelCompilerFactory

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -302,6 +302,7 @@ class AOTSnapshotter {
       printTrace('Extra front-end options: $extraFrontEndOptions');
 
     final String depfilePath = fs.path.join(outputPath, 'kernel_compile.d');
+    final KernelCompiler kernelCompiler = await kernelCompilerFactory.create();
     final CompilerOutput compilerOutput = await kernelCompiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       mainPath: mainPath,

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -99,6 +99,7 @@ Future<void> build({
     if ((extraFrontEndOptions != null) && extraFrontEndOptions.isNotEmpty)
       printTrace('Extra front-end options: $extraFrontEndOptions');
     ensureDirectoryExists(applicationKernelFilePath);
+    final KernelCompiler kernelCompiler = await kernelCompilerFactory.create();
     final CompilerOutput compilerOutput = await kernelCompiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       incrementalCompilerByteStorePath: compilationTraceFilePath != null ? null :

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -20,9 +20,20 @@ import 'convert.dart';
 import 'dart/package_map.dart';
 import 'globals.dart';
 
-KernelCompiler get kernelCompiler => context[KernelCompiler];
+KernelCompilerFactory get kernelCompilerFactory => context[KernelCompilerFactory];
 
 typedef CompilerMessageConsumer = void Function(String message, {bool emphasis, TerminalColor color});
+
+/// Injectable factory to allow async construction of a [KernelCompiler].
+class KernelCompilerFactory {
+  const KernelCompilerFactory();
+
+  /// Return the correct [KernelCompiler] instance for the given project
+  /// configuration.
+  FutureOr<KernelCompiler> create() async {
+    return const KernelCompiler();
+  }
+}
 
 /// The target model describes the set of core libraries that are availible within
 /// the SDK.

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -81,7 +81,7 @@ Future<T> runInContext<T>(
       IOSSimulatorUtils: () => IOSSimulatorUtils(),
       IOSWorkflow: () => const IOSWorkflow(),
       IOSValidator: () => const IOSValidator(),
-      KernelCompiler: () => const KernelCompiler(),
+      KernelCompilerFactory: () => const KernelCompilerFactory(),
       LinuxWorkflow: () => const LinuxWorkflow(),
       Logger: () => platform.isWindows ? WindowsStdoutLogger() : StdoutLogger(),
       MacOSWorkflow: () => const MacOSWorkflow(),

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -95,6 +95,7 @@ example:file:///example/lib/
               'result abc\nline1\nline2\nabc /path/to/main.dart.dill 0'
             ))
           ));
+      final KernelCompiler kernelCompiler = await kernelCompilerFactory.create();
       final CompilerOutput output = await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
         mainPath: '/path/to/main.dart',
         trackWidgetCreation: false,
@@ -118,7 +119,7 @@ example:file:///example/lib/
               'result abc\nline1\nline2\nabc'
             ))
           ));
-
+      final KernelCompiler kernelCompiler = await kernelCompilerFactory.create();
       final CompilerOutput output = await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
         mainPath: '/path/to/main.dart',
         trackWidgetCreation: false,
@@ -144,7 +145,7 @@ example:file:///example/lib/
               'result abc\nline1\nline2\nabc'
           ))
       ));
-
+      final KernelCompiler kernelCompiler = await kernelCompilerFactory.create();
       final CompilerOutput output = await kernelCompiler.compile(
         sdkRoot: '/path/to/sdkroot',
         mainPath: '/path/to/main.dart',

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -102,6 +102,7 @@ void main() {
       MockArtifacts mockArtifacts;
       MockKernelCompiler mockKernelCompiler;
       MockProcessManager mockProcessManager;
+      MockKernelCompilerFactory mockKernelCompilerFactory;
       MockProcess mockProcess;
 
       final Map<Type, Generator> startOverrides = <Type, Generator>{
@@ -109,7 +110,7 @@ void main() {
         FileSystem: () => fs,
         Cache: () => Cache(rootOverride: fs.directory(flutterRoot)),
         ProcessManager: () => mockProcessManager,
-        KernelCompiler: () => mockKernelCompiler,
+        KernelCompilerFactory: () => mockKernelCompilerFactory,
         Artifacts: () => mockArtifacts,
       };
 
@@ -135,6 +136,9 @@ void main() {
         when(mockArtifacts.getArtifactPath(any)).thenReturn(artifactPath);
 
         mockKernelCompiler = MockKernelCompiler();
+        when(mockKernelCompilerFactory.create()).thenAnswer((Invocation invocation) async {
+          return mockKernelCompiler;
+        });
       });
 
       testUsingContext('not debug', () async {
@@ -194,3 +198,4 @@ Hello!
 
 class MockArtifacts extends Mock implements Artifacts {}
 class MockKernelCompiler extends Mock implements KernelCompiler {}
+class MockKernelCompilerFactory extends Mock implements KernelCompilerFactory {}

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -136,6 +136,7 @@ void main() {
         when(mockArtifacts.getArtifactPath(any)).thenReturn(artifactPath);
 
         mockKernelCompiler = MockKernelCompiler();
+        mockKernelCompilerFactory = MockKernelCompilerFactory();
         when(mockKernelCompilerFactory.create()).thenAnswer((Invocation invocation) async {
           return mockKernelCompiler;
         });


### PR DESCRIPTION
Required for https://github.com/flutter/flutter/issues/27141 to look up configuration asynchronously and return a different kernel compiler type.