### PR TITLE
Fix bugs of Gradle script.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -190,19 +190,19 @@ class FlutterPlugin implements Plugin<Project> {
             def pluginProject = project.rootProject.findProject(":$name")
             if (pluginProject != null) {
                 project.dependencies {
-                    if (project.getConfigurations().findByName("implementation")) {
-                        implementation pluginProject
+                    if (project.getConfigurations().findByName("api")) {
+                        api pluginProject
                     } else {
                         compile pluginProject
                     }
                 }
-		pluginProject.afterEvaluate {
+                pluginProject.afterEvaluate {
                     pluginProject.android.buildTypes {
                         profile {
                             initWith debug
                         }
                     }
-		}
+                }
                 pluginProject.afterEvaluate this.&addFlutterJarCompileOnlyDependency
             } else {
                 project.logger.error("Plugin project :$name not found. Please update settings.gradle.")


### PR DESCRIPTION
1. Change dependencies of plugins from 'implementation' to 'api' to support flutter-as-lib.

The reason for using api instead of implementation is that some plugins may need some configurations or initialization and flutter mudule can't get the configuration or decide when to initialize. So plugin's classes should be accessible to app module.

2. Fix flutterJarFor() method return wrong jar file when build with localEngineOut.