### PR TITLE
Update CupertinoActionSheet actions' background.

### DIFF
--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -176,6 +176,7 @@ class CupertinoActionSheet extends StatelessWidget {
       );
     }
     return Container(
+      color: _kBackgroundColor,
       child: _CupertinoAlertActionSection(
         children: actions,
         scrollController: actionScrollController,


### PR DESCRIPTION
**Issue:** the background of the `CupertinoActionSheet`'s `actions` would be opaque and let the background bleed through the action sheet's actions when used in `showCupertinoModalPopup`.

**What was changed:** apply `_kBackgroundColor` to the `_buildActions`'s container's `color` property. I was initially going to add a property like `actionsBackgroundColor` but after reading [_kBackgroundColor's docstring](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/cupertino/action_sheet.dart#L42), `as the action sheet's background color`, it sounded like this was the intended behavior. I can change it to support a color if that would be better.

**Testing:** Using [this code (gist)](https://gist.github.com/JeffScaturro/8ec824121b0bf76152428dba100700e8) display a CupertinoActionSheet over a white and blue background to verify expected behavior.

**Testing results:**
- [Incorrect (before this PR) over blue background](https://user-images.githubusercontent.com/3655571/51950703-ed881400-2407-11e9-88f1-3a9b5312fefe.PNG)
- [Incorrect (before this PR) over white background](https://user-images.githubusercontent.com/3655571/51950709-f11b9b00-2407-11e9-86a0-0f62c8b40041.PNG)
 _notice slight color difference between action & title's background color_
- [Correct (this PR) over blue background](https://user-images.githubusercontent.com/3655571/51950715-f4af2200-2407-11e9-8c72-5b978ec7fd03.PNG)
- [Correct (this PR) over white background](https://user-images.githubusercontent.com/3655571/51950720-fa0c6c80-2407-11e9-8d5b-7783fbf957fb.PNG)