### PR TITLE
Use Diagnosticable a bit more.

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1455,15 +1455,18 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
   /// [defaultValue] is used to indicate that a specific concrete value is not
   /// interesting to display.
   ///
-  /// The [style], [showName], and [level] arguments must not be null.
+  /// The [separator], [style], [showName], and [level] arguments must not be
+  /// null.
   IterableProperty(String name, Iterable<T> value, {
     Object defaultValue = kNoDefaultValue,
     String ifNull,
     String ifEmpty = '[]',
+    this.separator = ', ',
     DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
     bool showName = true,
     DiagnosticLevel level = DiagnosticLevel.info,
-  }) : assert(style != null),
+  }) : assert(separator != null),
+       assert(style != null),
        assert(showName != null),
        assert(level != null),
        super(
@@ -1476,6 +1479,9 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
     showName: showName,
     level: level,
   );
+
+  /// Separator to include between items in the iterable.
+  final String separator;
 
   @override
   String valueToString({ TextTreeConfiguration parentConfiguration }) {
@@ -1491,7 +1497,7 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
       return '[${value.join(', ')}]';
     }
 
-    return value.join(style == DiagnosticsTreeStyle.singleLine ? ', ' : '\n');
+    return value.join(style == DiagnosticsTreeStyle.singleLine ? separator : '\n');
   }
 
   /// Priority level of the diagnostic used to control which diagnostics should
@@ -2073,6 +2079,62 @@ class DiagnosticPropertiesBuilder {
   /// Add a property to the list of properties.
   void add(DiagnosticsNode property) {
     properties.add(property);
+  }
+
+  /// Adds a diagnostic containing just a string `message` and not a concrete
+  /// name or value.
+  ///
+  /// The [style] and [level] arguments must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [MessageProperty], which is better suited to messages that are to be
+  ///    formatted like a property with a separate name and message.
+  void addMessage(
+    String message, {
+    DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
+    DiagnosticLevel level = DiagnosticLevel.info,
+  }) {
+    properties.add(DiagnosticsNode.message(message, style: style, level: level));
+  }
+
+  /// Adds a diagnostics property.
+  ///
+  /// The [showName], [showSeparator], [style], [missingIfNull], and [level]
+  /// arguments must not be null.
+  ///
+  /// The [level] argument is just a suggestion and can be overridden if
+  /// something else about the property causes it to have a lower or higher
+  /// level. For example, if the property value is null and [missingIfNull] is
+  /// true, [level] is raised to [DiagnosticLevel.warning].
+  void addProperty<T>(
+    String name,
+    T value, {
+    String description,
+    String ifNull,
+    Object ifEmpty,
+    bool showName = true,
+    bool showSeparator = true,
+    Object defaultValue = kNoDefaultValue,
+    String tooltip,
+    bool missingIfNull = false,
+    DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
+    DiagnosticLevel level = DiagnosticLevel.info,
+  }) {
+    properties.add(DiagnosticsProperty<T>(
+      name,
+      value,
+      description: description,
+      ifNull: ifNull,
+      ifEmpty: ifEmpty,
+      showName: showName,
+      showSeparator: showSeparator,
+      defaultValue: defaultValue,
+      tooltip: tooltip,
+      missingIfNull: missingIfNull,
+      style: style,
+      level: level,
+    ));
   }
 
   /// List of properties accumulated so far.

--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -145,7 +147,9 @@ class BeveledRectangleBorder extends ShapeBorder {
   int get hashCode => hashValues(side, borderRadius);
 
   @override
-  String toString() {
-    return '$runtimeType($side, $borderRadius)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.addProperty<BorderRadiusGeometry>('borderRadius', borderRadius, showName: false);
   }
 }

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -265,10 +265,13 @@ class BorderSide {
 ///
 /// This class handles how to add multiple borders together.
 @immutable
-abstract class ShapeBorder {
+abstract class ShapeBorder extends Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const ShapeBorder();
+
+  @override
+  String toStringShort() => '$runtimeType';
 
   /// The widths of the sides of this border represented as an [EdgeInsets].
   ///
@@ -465,11 +468,6 @@ abstract class ShapeBorder {
   /// of "start" and "end" instead of "left" and "right"). It may be null if
   /// the border will not need the text direction to paint itself.
   void paint(Canvas canvas, Rect rect, { TextDirection textDirection });
-
-  @override
-  String toString() {
-    return '$runtimeType()';
-  }
 }
 
 /// Represents the addition of two otherwise-incompatible borders.
@@ -615,12 +613,13 @@ class _CompoundBorder extends ShapeBorder {
   int get hashCode => hashList(borders);
 
   @override
-  String toString() {
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
     // We list them in reverse order because when adding two borders they end up
     // in the list in the opposite order of what the source looks like: a + b =>
     // [b, a]. We do this to make the painting code more optimal, and most of
-    // the rest of the code doesn't care, except toString() (for debugging).
-    return borders.reversed.map<String>((ShapeBorder border) => border.toString()).join(' + ');
+    // the rest of the code doesn't care, except for debugging.
+    properties.add(IterableProperty<ShapeBorder>('borders', borders.reversed, separator: ' + ', showName: false));
   }
 }
 

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -516,19 +516,17 @@ class Border extends BoxBorder {
   int get hashCode => hashValues(top, right, bottom, left);
 
   @override
-  String toString() {
-    if (isUniform)
-      return '$runtimeType.all($top)';
-    final List<String> arguments = <String>[];
-    if (top != BorderSide.none)
-      arguments.add('top: $top');
-    if (right != BorderSide.none)
-      arguments.add('right: $right');
-    if (bottom != BorderSide.none)
-      arguments.add('bottom: $bottom');
-    if (left != BorderSide.none)
-      arguments.add('left: $left');
-    return '$runtimeType(${arguments.join(", ")})';
+  String toStringShort() => isUniform ? '$runtimeType.all' : '$runtimeType';
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    final DiagnosticLevel level = isUniform ? DiagnosticLevel.hidden : DiagnosticLevel.info;
+
+    properties.addProperty('top', top, defaultValue: BorderSide.none, level: DiagnosticLevel.info, showName: !isUniform);
+    properties.addProperty('right', top, defaultValue: BorderSide.none, level: level);
+    properties.addProperty('bottom', top, defaultValue: BorderSide.none, level: level);
+    properties.addProperty('left', top, defaultValue: BorderSide.none, level: level);
   }
 }
 
@@ -821,16 +819,11 @@ class BorderDirectional extends BoxBorder {
   int get hashCode => hashValues(top, start, end, bottom);
 
   @override
-  String toString() {
-    final List<String> arguments = <String>[];
-    if (top != BorderSide.none)
-      arguments.add('top: $top');
-    if (start != BorderSide.none)
-      arguments.add('start: $start');
-    if (end != BorderSide.none)
-      arguments.add('end: $end');
-    if (bottom != BorderSide.none)
-      arguments.add('bottom: $bottom');
-    return '$runtimeType(${arguments.join(", ")})';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty('top', top, defaultValue: BorderSide.none);
+    properties.addProperty('right', top, defaultValue: BorderSide.none);
+    properties.addProperty('bottom', top, defaultValue: BorderSide.none);
+    properties.addProperty('left', top, defaultValue: BorderSide.none);
   }
 }

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
@@ -92,7 +94,8 @@ class CircleBorder extends ShapeBorder {
   int get hashCode => side.hashCode;
 
   @override
-  String toString() {
-    return '$runtimeType($side)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
   }
 }

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -135,8 +135,10 @@ class RoundedRectangleBorder extends ShapeBorder {
   int get hashCode => hashValues(side, borderRadius);
 
   @override
-  String toString() {
-    return '$runtimeType($side, $borderRadius)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.addProperty<BorderRadiusGeometry>('borderRadius', borderRadius, showName: false);
   }
 }
 
@@ -296,7 +298,13 @@ class _RoundedRectangleToCircleBorder extends ShapeBorder {
   int get hashCode => hashValues(side, borderRadius, circleness);
 
   @override
-  String toString() {
-    return 'RoundedRectangleBorder($side, $borderRadius, ${(circleness * 100).toStringAsFixed(1)}% of the way to being a CircleBorder)';
+  String toStringShort() => 'RoundedRectangleBorder';
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.addProperty<BorderRadiusGeometry>('borderRadius', borderRadius, showName: false);
+    properties.add(PercentProperty('circleness', circleness, showName: false, tooltip: 'of the way to being a CircleBorder'));
   }
 }

--- a/packages/flutter/lib/src/painting/stadium_border.dart
+++ b/packages/flutter/lib/src/painting/stadium_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' as ui show lerpDouble;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -121,8 +123,9 @@ class StadiumBorder extends ShapeBorder {
   int get hashCode => side.hashCode;
 
   @override
-  String toString() {
-    return '$runtimeType($side)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
   }
 }
 
@@ -269,9 +272,13 @@ class _StadiumToCircleBorder extends ShapeBorder {
   int get hashCode => hashValues(side, circleness);
 
   @override
-  String toString() {
-    return 'StadiumBorder($side, ${(circleness * 100).toStringAsFixed(1)}% '
-           'of the way to being a CircleBorder)';
+  String toStringShort() => 'StadiumBorder';
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.add(PercentProperty('circleness', circleness, showName: false, tooltip: 'of the way to being a CircleBorder'));
   }
 }
 
@@ -411,10 +418,15 @@ class _StadiumToRoundedRectangleBorder extends ShapeBorder {
   @override
   int get hashCode => hashValues(side, borderRadius, rectness);
 
+
   @override
-  String toString() {
-    return 'StadiumBorder($side, $borderRadius, '
-           '${(rectness * 100).toStringAsFixed(1)}% of the way to being a '
-           'RoundedRectangleBorder)';
+  String toStringShort() => 'StadiumBorder';
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.addProperty<BorderRadius>('borderRadius', borderRadius, showName: false);
+    properties.add(PercentProperty('circleness', rectness, showName: false, tooltip: 'of the way to being a RoundedRectangleBorder'));
   }
 }

--- a/packages/flutter/lib/src/painting/superellipse_shape.dart
+++ b/packages/flutter/lib/src/painting/superellipse_shape.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -160,7 +162,9 @@ class SuperellipseShape extends ShapeBorder {
   int get hashCode => hashValues(side, borderRadius);
 
   @override
-  String toString() {
-    return '$runtimeType($side, $borderRadius)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.addProperty<BorderSide>('side', side, showName: false);
+    properties.addProperty<BorderRadius>('borderRadius', borderRadius, showName: false);
   }
 }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1151,6 +1151,32 @@ mixin WidgetInspectorService {
         };
       },
     );
+    registerServiceExtension(
+      name: 'inspectAt',
+      callback: (Map<String, String> parameters) async {
+        assert(parameters.containsKey('x'));
+        assert(parameters.containsKey('y'));
+        //   XXX impl
+        final ui.Image image = await screenshot(
+          toObject(parameters['id']),
+          width: double.parse(parameters['x']),
+          height: double.parse(parameters['y']),
+          margin: parameters.containsKey('margin') ?
+          double.parse(parameters['margin']) : 0.0,
+          maxPixelRatio: parameters.containsKey('maxPixelRatio') ?
+          double.parse(parameters['maxPixelRatio']) : 1.0,
+          debugPaint: parameters['debugPaint'] == 'true',
+        );
+        if (image == null) {
+          return <String, Object>{'result': null};
+        }
+        final ByteData byteData = await image.toByteData(format:ui.ImageByteFormat.png);
+
+        return <String, Object>{
+          'result': base64.encoder.convert(Uint8List.view(byteData.buffer)),
+        };
+      },
+    );
   }
 
   void _clearStats() {


### PR DESCRIPTION
For discussion before I add more convenience helpers to the property builder. I think adding more helpers for the common cases to the builder makes the correct patterns more discoverable and reduces the amount of boilerplate. If this looks reasonable I'm happing to add a bunch more common property patterns to the builder and refactor existing code to use them instead of creating the properties directly.