### PR TITLE
Don't send accept/reject if compilation never started.

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -608,7 +608,7 @@ class ResidentCompiler {
 
   Future<CompilerOutput> _reject() {
     if (!_reloadRequestNeedsConfirmation) {
-      return Future.value(null);
+      return Future<CompilerOutput>.value(null);
     }
     _stdoutHandler.reset();
     _server.stdin.writeln('reject');

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -397,7 +397,7 @@ class ResidentCompiler {
   String _initializeFromDill;
   bool _unsafePackageSerialization;
   final List<String> _experimentalFlags;
-  bool _reloadRequestNeedsConfirmation = false;
+  bool _compileRequestNeedsConfirmation = false;
 
   final StreamController<_CompilationRequest> _controller;
 
@@ -437,6 +437,8 @@ class ResidentCompiler {
       );
     }
 
+    _compileRequestNeedsConfirmation = true;
+
     if (_server == null) {
       return _compile(
           _mapFilename(request.mainPath, packageUriMapper),
@@ -454,8 +456,6 @@ class ResidentCompiler {
       _server.stdin.writeln(_mapFileUri(fileUri, packageUriMapper));
     }
     _server.stdin.writeln(inputKey);
-
-    _reloadRequestNeedsConfirmation = true;
 
     return _stdoutHandler.compilerOutput.future;
   }
@@ -587,10 +587,10 @@ class ResidentCompiler {
   ///
   /// Either [accept] or [reject] should be called after every [recompile] call.
   void accept() {
-    if (_reloadRequestNeedsConfirmation) {
+    if (_compileRequestNeedsConfirmation) {
       _server.stdin.writeln('accept');
     }
-    _reloadRequestNeedsConfirmation = false;
+    _compileRequestNeedsConfirmation = false;
   }
 
   /// Should be invoked when results of compilation are rejected by the client.
@@ -607,12 +607,12 @@ class ResidentCompiler {
   }
 
   Future<CompilerOutput> _reject() {
-    if (!_reloadRequestNeedsConfirmation) {
+    if (!_compileRequestNeedsConfirmation) {
       return Future<CompilerOutput>.value(null);
     }
     _stdoutHandler.reset();
     _server.stdin.writeln('reject');
-    _reloadRequestNeedsConfirmation = false;
+    _compileRequestNeedsConfirmation = false;
     return _stdoutHandler.compilerOutput.future;
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -428,11 +428,11 @@ class FlutterDevice {
     return report;
   }
 
-  void updateReloadStatus(bool wasReloadSuccessful) {
+  Future<void> updateReloadStatus(bool wasReloadSuccessful) async {
     if (wasReloadSuccessful)
       generator?.accept();
     else
-      generator?.reject();
+      await generator?.reject();
   }
 }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -681,13 +681,13 @@ class HotRunner extends ResidentRunner {
         final List<Future<Map<String, dynamic>>> reportFutures = device.reloadSources(
           entryPath, pause: pause
         );
-        Future.wait(reportFutures).then((List<Map<String, dynamic>> reports) { // ignore: unawaited_futures
+        Future.wait(reportFutures).then((List<Map<String, dynamic>> reports) async { // ignore: unawaited_futures
           // TODO(aam): Investigate why we are validating only first reload report,
           // which seems to be current behavior
           final Map<String, dynamic> firstReport = reports.first;
           // Don't print errors because they will be printed further down when
           // `validateReloadReport` is called again.
-          device.updateReloadStatus(validateReloadReport(firstReport, printErrors: false));
+          await device.updateReloadStatus(validateReloadReport(firstReport, printErrors: false));
           completer.complete(DeviceReloadReport(device, reports));
         });
       }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -483,7 +483,7 @@ class HotRunner extends ResidentRunner {
     if (!updatedDevFS.success) {
       for (FlutterDevice device in flutterDevices) {
         if (device.generator != null)
-          device.generator.reject();
+          await device.generator.reject();
       }
       return OperationResult(1, 'DevFS synchronization failed');
     }

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -277,8 +277,7 @@ example:org-dartlang-app:///lib/
       // No accept or reject commands should be issued until we
       // send recompile request.
       await _accept(streamController, generator, mockFrontendServerStdIn, '');
-      await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\n',
-          '');
+      await _reject(streamController, generator, mockFrontendServerStdIn, '', '');
 
       await _recompile(streamController, generator, mockFrontendServerStdIn,
         'result abc\nline1\nline2\nabc /path/to/main.dart.dill 0\n');
@@ -524,7 +523,7 @@ Future<void> _accept(StreamController<List<int>> streamController,
     String expected) async {
   // Put content into the output stream after generator.recompile gets
   // going few lines below, resets completer.
-  await generator.accept();
+  generator.accept();
   final String commands = mockFrontendServerStdIn.getAndClear();
   final RegExp re = RegExp(expected);
   expect(commands, matches(re));

--- a/packages/flutter_tools/test/compile_test.dart
+++ b/packages/flutter_tools/test/compile_test.dart
@@ -274,13 +274,28 @@ example:org-dartlang-app:///lib/
       );
       expect(mockFrontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
 
+      // No accept or reject commands should be issued until we
+      // send recompile request.
+      await _accept(streamController, generator, mockFrontendServerStdIn, '');
+      await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\n',
+          '');
+
       await _recompile(streamController, generator, mockFrontendServerStdIn,
         'result abc\nline1\nline2\nabc /path/to/main.dart.dill 0\n');
+
+      await _accept(streamController, generator, mockFrontendServerStdIn, '^accept\\n\$');
+
+      await _recompile(streamController, generator, mockFrontendServerStdIn,
+          'result abc\nline1\nline2\nabc /path/to/main.dart.dill 0\n');
+
+      await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\n',
+          '^reject\\n\$');
 
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
       expect(logger.errorText, equals(
         '\nCompiler message:\nline0\nline1\n'
+        '\nCompiler message:\nline1\nline2\n'
         '\nCompiler message:\nline1\nline2\n'
       ));
     }, overrides: <Type, Generator>{
@@ -501,6 +516,34 @@ Future<void> _recompile(StreamController<List<int>> streamController,
   expect(commands, matches(re));
   final Match match = re.firstMatch(commands);
   expect(match[1] == match[2], isTrue);
+  mockFrontendServerStdIn._stdInWrites.clear();
+}
+
+Future<void> _accept(StreamController<List<int>> streamController,
+    ResidentCompiler generator, MockStdIn mockFrontendServerStdIn,
+    String expected) async {
+  // Put content into the output stream after generator.recompile gets
+  // going few lines below, resets completer.
+  await generator.accept();
+  final String commands = mockFrontendServerStdIn.getAndClear();
+  final RegExp re = RegExp(expected);
+  expect(commands, matches(re));
+  mockFrontendServerStdIn._stdInWrites.clear();
+}
+
+Future<void> _reject(StreamController<List<int>> streamController,
+    ResidentCompiler generator, MockStdIn mockFrontendServerStdIn,
+    String mockCompilerOutput, String expected) async {
+  // Put content into the output stream after generator.recompile gets
+  // going few lines below, resets completer.
+  scheduleMicrotask(() {
+    streamController.add(utf8.encode(mockCompilerOutput));
+  });
+  final CompilerOutput output = await generator.reject();
+  expect(output, isNull);
+  final String commands = mockFrontendServerStdIn.getAndClear();
+  final RegExp re = RegExp(expected);
+  expect(commands, matches(re));
   mockFrontendServerStdIn._stdInWrites.clear();
 }
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -462,7 +462,7 @@ class MockResidentCompiler extends BasicMock implements ResidentCompiler {
   void accept() {}
 
   @override
-  void reject() {}
+  Future<CompilerOutput> reject() async { return null; }
 
   @override
   void reset() {}


### PR DESCRIPTION
`accept`/`reject` commands should be sent to the compiler only if `recompile` request has been sent. This change ensures that.

Also this change ensures that we wait for reject's response since that is asynchronous operation.

Fixes https://github.com/flutter/flutter/issues/27120.