### PR TITLE
don't pass the --packages-dir flag

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -43,7 +43,7 @@ function retry_upgrade {
   local total_tries="10"
   local remaining_tries=$(($total_tries - 1))
   while [[ "$remaining_tries" > 0 ]]; do
-    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY" --no-packages-dir) && break
+    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY") && break
     echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$(($remaining_tries - 1))
     sleep 5

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -136,7 +136,7 @@ GOTO :after_subroutine
       SET /A remaining_tries=%total_tries%-1
       :retry_pub_upgrade
         ECHO Running pub upgrade...
-        CALL "%pub%" upgrade "%VERBOSITY%" --no-packages-dir
+        CALL "%pub%" upgrade "%VERBOSITY%"
         IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
         ECHO Error Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left)
         timeout /t 5 /nobreak 2>NUL


### PR DESCRIPTION
Don't pass the `--packages-dir` flag into pub - it has no effect now (and just prints `The --packages-dir flag is no longer used and does nothing.`).
