### PR TITLE
Updated focus handling for nested FocusScopes

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -19,7 +19,6 @@ import 'focus_scope.dart';
 import 'framework.dart';
 import 'localizations.dart';
 import 'media_query.dart';
-import 'routes.dart';
 import 'scroll_controller.dart';
 import 'scroll_physics.dart';
 import 'scrollable.dart';

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -19,6 +19,7 @@ import 'focus_scope.dart';
 import 'framework.dart';
 import 'localizations.dart';
 import 'media_query.dart';
+import 'routes.dart';
 import 'scroll_controller.dart';
 import 'scroll_physics.dart';
 import 'scrollable.dart';
@@ -873,10 +874,14 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// focus, the control will then attach to the keyboard and request that the
   /// keyboard become visible.
   void requestKeyboard() {
-    if (_hasFocus)
+    if (_hasFocus) {
       _openInputConnection();
-    else
+    } else {
+      final List<FocusScopeNode> ancestorScopes = FocusScope.ancestorsOf(context);
+      for (int i = ancestorScopes.length - 1; i >= 1; i -= 1)
+        ancestorScopes[i].setFirstFocus(ancestorScopes[i - 1]);
       FocusScope.of(context).requestFocus(widget.focusNode);
+    }
   }
 
   void _hideSelectionOverlayIfNeeded() {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -140,9 +140,22 @@ class FocusScopeNode extends Object with DiagnosticableTreeMixin {
   FocusScopeNode _lastChild;
 
   FocusNode _focus;
+  List<FocusScopeNode> _focusPath;
 
   /// Whether this scope is currently active in its parent scope.
   bool get isFirstFocus => _parent == null || _parent._firstChild == this;
+
+  // Returns this FocusScopeNode's ancestors, starting with the node
+  // below the FocusManager's rootScope.
+  List<FocusScopeNode> _getFocusPath() {
+    final List<FocusScopeNode> nodes = <FocusScopeNode>[this];
+    FocusScopeNode node = _parent;
+    while(node != null && node != _manager?.rootScope) {
+      nodes.add(node);
+      node = node._parent;
+    }
+    return nodes;
+  }
 
   void _prepend(FocusScopeNode child) {
     assert(child != this);
@@ -246,7 +259,7 @@ class FocusScopeNode extends Object with DiagnosticableTreeMixin {
   /// has received the overall focus in a microtask.
   void requestFocus(FocusNode node) {
     assert(node != null);
-    if (_focus == node)
+    if (_focus == node && listEquals<FocusScopeNode>(_focusPath, _manager?._getCurrentFocusPath()))
       return;
     _focus?.unfocus();
     node._hasKeyboardToken = true;
@@ -292,6 +305,7 @@ class FocusScopeNode extends Object with DiagnosticableTreeMixin {
     _focus._parent = this;
     _focus._manager = _manager;
     _focus._hasKeyboardToken = true;
+    _focusPath = _getFocusPath();
     _didChangeFocusChain();
   }
 
@@ -412,7 +426,7 @@ class FocusManager {
 
   /// The root [FocusScopeNode] in the focus tree.
   ///
-  /// This field is rarely used direction. Instead, to find the
+  /// This field is rarely used directly. Instead, to find the
   /// [FocusScopeNode] for a given [BuildContext], use [FocusScope.of].
   final FocusScopeNode rootScope = FocusScopeNode();
 
@@ -449,6 +463,8 @@ class FocusManager {
     previousFocus?._notify();
     _currentFocus?._notify();
   }
+
+  List<FocusScopeNode> _getCurrentFocusPath() => _currentFocus?._parent?._getFocusPath();
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -72,9 +72,38 @@ class FocusScope extends StatefulWidget {
 
   /// Returns the [node] of the [FocusScope] that most tightly encloses the
   /// given [BuildContext].
+  ///
+  /// The [context] argument must not be null.
   static FocusScopeNode of(BuildContext context) {
+    assert(context != null);
     final _FocusScopeMarker scope = context.inheritFromWidgetOfExactType(_FocusScopeMarker);
     return scope?.node ?? context.owner.focusManager.rootScope;
+  }
+
+  /// A list of the [FocusScopeNode]s for each [FocusScope] ancestor of
+  /// the given [BuildContext]. The first element of the list is the
+  /// nearest ancestor's [FocusScopeNode].
+  ///
+  /// The returned list does not include the [FocusManager]'s `rootScope`.
+  /// Only the [FocusScopeNode]s that belong to [FocusScope] widgets are
+  /// returned.
+  ///
+  /// The [context] argument must not be null.
+  static List<FocusScopeNode> ancestorsOf(BuildContext context) {
+    assert(context != null);
+    final List<FocusScopeNode> ancestors = [];
+    while (true) {
+      context = context.ancestorInheritedElementForWidgetOfExactType(_FocusScopeMarker);
+      if (context == null)
+        return ancestors;
+      final _FocusScopeMarker scope = context.widget;
+      ancestors.add(scope.node);
+      context.visitAncestorElements((Element parent) {
+        context = parent;
+        return false;
+      });
+    }
+    return ancestors;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -91,7 +91,7 @@ class FocusScope extends StatefulWidget {
   /// The [context] argument must not be null.
   static List<FocusScopeNode> ancestorsOf(BuildContext context) {
     assert(context != null);
-    final List<FocusScopeNode> ancestors = [];
+    final List<FocusScopeNode> ancestors = <FocusScopeNode>[];
     while (true) {
       context = context.ancestorInheritedElementForWidgetOfExactType(_FocusScopeMarker);
       if (context == null)
@@ -103,7 +103,6 @@ class FocusScope extends StatefulWidget {
         return false;
       });
     }
-    return ancestors;
   }
 
   @override

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -227,4 +227,145 @@ void main() {
     await tester.idle();
     expect(tester.testTextInput.isVisible, isTrue);
   });
+
+  testWidgets('Sibling FocusScopes', (WidgetTester tester) async {
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    final FocusScopeNode focusScopeNode0 = FocusScopeNode();
+    final FocusScopeNode focusScopeNode1 = FocusScopeNode();
+    final Key textField0 = UniqueKey();
+    final Key textField1 = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                FocusScope(
+                  node: focusScopeNode0,
+                  child: Builder(
+                    builder: (BuildContext context) => TextField(key: textField0)
+                  ),
+                ),
+                FocusScope(
+                  node: focusScopeNode1,
+                  child: Builder(
+                    builder: (BuildContext context) => TextField(key: textField1),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    tester.testTextInput.hide();
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField1));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.tap(find.byKey(textField1));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    tester.testTextInput.hide();
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.pumpWidget(Container());
+    expect(tester.testTextInput.isVisible, isFalse);
+  });
+
+  testWidgets('Sibling Navigators', (WidgetTester tester) async {
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    final Key textField0 = UniqueKey();
+    final Key textField1 = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Column(
+              children: <Widget>[
+                Expanded(
+                  child: Navigator(
+                    onGenerateRoute: (RouteSettings settings) {
+                      return new MaterialPageRoute(
+                        builder: (BuildContext context) {
+                          return TextField(key: textField0);
+                        },
+                        settings: settings,
+                      );
+                    },
+                  ),
+                ),
+                Expanded(
+                  child: Navigator(
+                    onGenerateRoute: (RouteSettings settings) {
+                      return new MaterialPageRoute(
+                        builder: (BuildContext context) {
+                          return TextField(key: textField1);
+                        },
+                        settings: settings,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    tester.testTextInput.hide();
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField1));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.tap(find.byKey(textField1));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    tester.testTextInput.hide();
+    expect(tester.testTextInput.isVisible, isFalse);
+
+    await tester.tap(find.byKey(textField0));
+    await tester.idle();
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.pumpWidget(Container());
+    expect(tester.testTextInput.isVisible, isFalse);
+  });
 }

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -309,7 +309,7 @@ void main() {
                 Expanded(
                   child: Navigator(
                     onGenerateRoute: (RouteSettings settings) {
-                      return new MaterialPageRoute(
+                      return MaterialPageRoute<void>(
                         builder: (BuildContext context) {
                           return TextField(key: textField0);
                         },
@@ -321,7 +321,7 @@ void main() {
                 Expanded(
                   child: Navigator(
                     onGenerateRoute: (RouteSettings settings) {
-                      return new MaterialPageRoute(
+                      return MaterialPageRoute<void>(
                         builder: (BuildContext context) {
                           return TextField(key: textField1);
                         },


### PR DESCRIPTION
Updated focus handling in FocusManager et al and EditableText so that TextFields within nested FocusScopes can gain the focus and show the keybaord.

Fixes https://github.com/flutter/flutter/issues/11183
Fixes https://github.com/flutter/flutter/issues/11753
Fixes https://github.com/flutter/flutter/issues/12339
Fixes https://github.com/flutter/flutter/issues/14792
Fixes https://github.com/flutter/flutter/issues/17098
Fixes https://github.com/flutter/flutter/issues/25933
Fixes https://github.com/flutter/flutter/issues/26810

When a TextField's EditableText requests the focus, set the firstFocus property of all of the FocusScope ancestor FocusScopeNodes, so that it can actually get the focus.  In most cases this has no effect because ModalRoute.didPush automatically sets its focusScopeNode's first focus. It is necessary when there are nested FocusScopes, like the ones introduced by additional Navigator widgets.

FocusScopeNode shows the keyboard when its focus node has changed or when then the FocusScopeNode path to the focus manager's rootScope has changed.




