### PR TITLE
Material.border type is now BorderRadiusGeometry

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -257,14 +257,16 @@ class Material extends StatefulWidget {
   /// The default value is [kThemeChangeDuration].
   final Duration animationDuration;
 
-  /// If non-null, the corners of this box are rounded by this [BorderRadius].
+  /// If non-null, the corners of this box are rounded by this
+  /// [BorderRadiusGeometry] value.
+  ///
   /// Otherwise, the corners specified for the current [type] of material are
   /// used.
   ///
   /// If [shape] is non null then the border radius is ignored.
   ///
   /// Must be null if [type] is [MaterialType.circle].
-  final BorderRadius borderRadius;
+  final BorderRadiusGeometry borderRadius;
 
   /// The ink controller from the closest instance of this class that
   /// encloses the given context.
@@ -292,7 +294,7 @@ class Material extends StatefulWidget {
     textStyle?.debugFillProperties(properties, prefix: 'textStyle.');
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('borderOnForeground', borderOnForeground, defaultValue: true));
-    properties.add(EnumProperty<BorderRadius>('borderRadius', borderRadius, defaultValue: null));
+    properties.add(DiagnosticsProperty<BorderRadiusGeometry>('borderRadius', borderRadius, defaultValue: null));
   }
 
   /// The default radius of an ink splash in logical pixels.

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -56,6 +56,41 @@ class PaintRecorder extends CustomPainter {
 }
 
 void main() {
+  testWidgets('default Material debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const Material().debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
+
+    expect(description, <String>['type: canvas']);
+  });
+
+  testWidgets('Material implements debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const Material(
+      type: MaterialType.canvas,
+      color: Color(0xFFFFFFFF),
+      textStyle: TextStyle(color: Color(0xff00ff00)),
+      borderRadius: BorderRadiusDirectional.all(Radius.circular(10)),
+    ).debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
+
+    expect(description, <String>[
+      'type: canvas',
+      'color: Color(0xffffffff)',
+      'textStyle.inherit: true',
+      'textStyle.color: Color(0xff00ff00)',
+      'borderRadius: BorderRadiusDirectional.circular(10.0)'
+    ]);
+  });
+
   testWidgets('LayoutChangedNotification test', (WidgetTester tester) async {
     await tester.pumpWidget(
       Material(


### PR DESCRIPTION
This change was contributed by @p30arena in https://github.com/flutter/flutter/pull/27224

Without this change a BorderRadiusDirectional value can't be assigned to Material.borderRadius.

This PR also fixes a bug in Material's debugFillProperties method.

Fixes https://github.com/flutter/flutter/issues/27223