### PR TITLE
Create unsupported bitfield implementation

### DIFF
--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -9,6 +9,9 @@ import 'dart:collection';
 
 export 'dart:ui' show VoidCallback;
 
+export 'bitfield.dart'
+  if (dart.html) 'bitfield_unsupported.dart';
+
 /// Signature for callbacks that report that an underlying value has changed.
 ///
 /// See also [ValueSetter].
@@ -65,69 +68,6 @@ typedef AsyncValueSetter<T> = Future<void> Function(T value);
 ///  * [ValueGetter], a synchronous version of this signature.
 ///  * [AsyncValueSetter], the setter equivalent of this signature.
 typedef AsyncValueGetter<T> = Future<T> Function();
-
-
-// BITFIELD
-
-/// The largest SMI value.
-///
-/// See <https://www.dartlang.org/articles/numeric-computation/#smis-and-mints>
-const int kMaxUnsignedSMI = 0x3FFFFFFFFFFFFFFF;
-
-/// A BitField over an enum (or other class whose values implement "index").
-/// Only the first 62 values of the enum can be used as indices.
-class BitField<T extends dynamic> {
-  /// Creates a bit field of all zeros.
-  ///
-  /// The given length must be at most 62.
-  BitField(this._length)
-    : assert(_length <= _smiBits),
-      _bits = _allZeros;
-
-  /// Creates a bit field filled with a particular value.
-  ///
-  /// If the value argument is true, the bits are filled with ones. Otherwise,
-  /// the bits are filled with zeros.
-  ///
-  /// The given length must be at most 62.
-  BitField.filled(this._length, bool value)
-    : assert(_length <= _smiBits),
-      _bits = value ? _allOnes : _allZeros;
-
-  final int _length;
-  int _bits;
-
-  static const int _smiBits = 62; // see https://www.dartlang.org/articles/numeric-computation/#smis-and-mints
-  static const int _allZeros = 0;
-  static const int _allOnes = kMaxUnsignedSMI; // 2^(_kSMIBits+1)-1
-
-  /// Returns whether the bit with the given index is set to one.
-  bool operator [](T index) {
-    assert(index.index < _length);
-    return (_bits & 1 << index.index) > 0;
-  }
-
-  /// Sets the bit with the given index to the given value.
-  ///
-  /// If value is true, the bit with the given index is set to one. Otherwise,
-  /// the bit is set to zero.
-  void operator []=(T index, bool value) {
-    assert(index.index < _length);
-    if (value)
-      _bits = _bits | (1 << index.index);
-    else
-      _bits = _bits & ~(1 << index.index);
-  }
-
-  /// Sets all the bits to the given value.
-  ///
-  /// If the value is true, the bits are all set to one. Otherwise, the bits are
-  /// all set to zero. Defaults to setting all the bits to zero.
-  void reset([ bool value = false ]) {
-    _bits = value ? _allOnes : _allZeros;
-  }
-}
-
 
 // LAZY CACHING ITERATOR
 

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -69,6 +69,67 @@ typedef AsyncValueSetter<T> = Future<void> Function(T value);
 ///  * [AsyncValueSetter], the setter equivalent of this signature.
 typedef AsyncValueGetter<T> = Future<T> Function();
 
+ // BITFIELD	
+
+ /// The largest SMI value.	
+///	
+/// See <https://www.dartlang.org/articles/numeric-computation/#smis-and-mints>	
+const int kMaxUnsignedSMI = identical(1, 1.0) ?  2,147,483,647 : 0x3FFFFFFFFFFFFFFF;	
+
+ /// A BitField over an enum (or other class whose values implement "index").	
+/// Only the first 62 values of the enum can be used as indices.	
+class BitField<T extends dynamic> {	
+  /// Creates a bit field of all zeros.	
+  ///	
+  /// The given length must be at most 62.	
+  BitField(this._length)	
+    : assert(_length <= _smiBits),	
+      _bits = _allZeros;	
+
+   /// Creates a bit field filled with a particular value.	
+  ///	
+  /// If the value argument is true, the bits are filled with ones. Otherwise,	
+  /// the bits are filled with zeros.	
+  ///	
+  /// The given length must be at most 62.	
+  BitField.filled(this._length, bool value)	
+    : assert(_length <= _smiBits),	
+      _bits = value ? _allOnes : _allZeros;	
+
+   final int _length;	
+  int _bits;	
+
+   static const int _smiBits = 62; // see https://www.dartlang.org/articles/numeric-computation/#smis-and-mints	
+  static const int _allZeros = 0;	
+  static const int _allOnes = kMaxUnsignedSMI; // 2^(_kSMIBits+1)-1	
+
+   /// Returns whether the bit with the given index is set to one.	
+  bool operator [](T index) {	
+    assert(index.index < _length);	
+    return (_bits & 1 << index.index) > 0;	
+  }	
+
+   /// Sets the bit with the given index to the given value.	
+  ///	
+  /// If value is true, the bit with the given index is set to one. Otherwise,	
+  /// the bit is set to zero.	
+  void operator []=(T index, bool value) {	
+    assert(index.index < _length);	
+    if (value)	
+      _bits = _bits | (1 << index.index);	
+    else	
+      _bits = _bits & ~(1 << index.index);	
+  }	
+
+   /// Sets all the bits to the given value.	
+  ///	
+  /// If the value is true, the bits are all set to one. Otherwise, the bits are	
+  /// all set to zero. Defaults to setting all the bits to zero.	
+  void reset([ bool value = false ]) {	
+    _bits = value ? _allOnes : _allZeros;	
+  }	
+}	
+
 // LAZY CACHING ITERATOR
 
 /// A lazy caching version of [Iterable].

--- a/packages/flutter/lib/src/foundation/bitfield.dart
+++ b/packages/flutter/lib/src/foundation/bitfield.dart
@@ -1,0 +1,64 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// BITFIELD
+
+/// The largest SMI value.
+///
+/// See <https://www.dartlang.org/articles/numeric-computation/#smis-and-mints>
+const int kMaxUnsignedSMI = 0x3FFFFFFFFFFFFFFF;
+
+/// A BitField over an enum (or other class whose values implement "index").
+/// Only the first 62 values of the enum can be used as indices.
+class BitField<T extends dynamic> {
+  /// Creates a bit field of all zeros.
+  ///
+  /// The given length must be at most 62.
+  BitField(this._length)
+    : assert(_length <= _smiBits),
+      _bits = _allZeros;
+
+  /// Creates a bit field filled with a particular value.
+  ///
+  /// If the value argument is true, the bits are filled with ones. Otherwise,
+  /// the bits are filled with zeros.
+  ///
+  /// The given length must be at most 62.
+  BitField.filled(this._length, bool value)
+    : assert(_length <= _smiBits),
+      _bits = value ? _allOnes : _allZeros;
+
+  final int _length;
+  int _bits;
+
+  static const int _smiBits = 62; // see https://www.dartlang.org/articles/numeric-computation/#smis-and-mints
+  static const int _allZeros = 0;
+  static const int _allOnes = kMaxUnsignedSMI; // 2^(_kSMIBits+1)-1
+
+  /// Returns whether the bit with the given index is set to one.
+  bool operator [](T index) {
+    assert(index.index < _length);
+    return (_bits & 1 << index.index) > 0;
+  }
+
+  /// Sets the bit with the given index to the given value.
+  ///
+  /// If value is true, the bit with the given index is set to one. Otherwise,
+  /// the bit is set to zero.
+  void operator []=(T index, bool value) {
+    assert(index.index < _length);
+    if (value)
+      _bits = _bits | (1 << index.index);
+    else
+      _bits = _bits & ~(1 << index.index);
+  }
+
+  /// Sets all the bits to the given value.
+  ///
+  /// If the value is true, the bits are all set to one. Otherwise, the bits are
+  /// all set to zero. Defaults to setting all the bits to zero.
+  void reset([ bool value = false ]) {
+    _bits = value ? _allOnes : _allZeros;
+  }
+}

--- a/packages/flutter/lib/src/foundation/bitfield_unsupported.dart
+++ b/packages/flutter/lib/src/foundation/bitfield_unsupported.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /// Unsupported.
-int get kMaxUnsignedSMI => throw UnsupportedError('');
+int get kMaxUnsignedSMI => throw UnsupportedError('Not supported in environments without 64 bit ints');
 
 /// A BitField over an enum (or other class whose values implement "index").
 /// Only the first 62 values of the enum can be used as indices.
@@ -25,7 +25,7 @@ class BitField<T extends dynamic> {
 
   /// Returns whether the bit with the given index is set to one.
   bool operator [](T index) {
-    throw UnsupportedError('');
+    throw UnsupportedError('Not supported in environments without 64 bit ints');
   }
 
   /// Sets the bit with the given index to the given value.
@@ -33,7 +33,7 @@ class BitField<T extends dynamic> {
   /// If value is true, the bit with the given index is set to one. Otherwise,
   /// the bit is set to zero.
   void operator []=(T index, bool value) {
-    throw UnsupportedError('');
+    throw UnsupportedError('Not supported in environments without 64 bit ints');
   }
 
   /// Sets all the bits to the given value.
@@ -41,6 +41,6 @@ class BitField<T extends dynamic> {
   /// If the value is true, the bits are all set to one. Otherwise, the bits are
   /// all set to zero. Defaults to setting all the bits to zero.
   void reset([ bool value = false ]) {
-    throw UnsupportedError('');
+    throw UnsupportedError('Not supported in environments without 64 bit ints');
   }
 }

--- a/packages/flutter/lib/src/foundation/bitfield_unsupported.dart
+++ b/packages/flutter/lib/src/foundation/bitfield_unsupported.dart
@@ -1,0 +1,46 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Unsupported.
+int get kMaxUnsignedSMI => throw UnsupportedError('');
+
+/// A BitField over an enum (or other class whose values implement "index").
+/// Only the first 62 values of the enum can be used as indices.
+class BitField<T extends dynamic> {
+  /// Creates a bit field of all zeros.
+  ///
+  /// The given length must be at most 62.
+  BitField(int _length)
+    : assert(_length <= 62);
+
+  /// Creates a bit field filled with a particular value.
+  ///
+  /// If the value argument is true, the bits are filled with ones. Otherwise,
+  /// the bits are filled with zeros.
+  ///
+  /// The given length must be at most 62.
+  BitField.filled(int length, bool _) // ignore: avoid_unused_constructor_parameters
+    : assert(length <= 62);
+
+  /// Returns whether the bit with the given index is set to one.
+  bool operator [](T index) {
+    throw UnsupportedError('');
+  }
+
+  /// Sets the bit with the given index to the given value.
+  ///
+  /// If value is true, the bit with the given index is set to one. Otherwise,
+  /// the bit is set to zero.
+  void operator []=(T index, bool value) {
+    throw UnsupportedError('');
+  }
+
+  /// Sets all the bits to the given value.
+  ///
+  /// If the value is true, the bits are all set to one. Otherwise, the bits are
+  /// all set to zero. Defaults to setting all the bits to zero.
+  void reset([ bool value = false ]) {
+    throw UnsupportedError('');
+  }
+}


### PR DESCRIPTION
allows compiling flutter in environments without 64 bit ints.