### PR TITLE
Disable usage of bare instructions in AOT

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -444,6 +444,7 @@ class JITSnapshotter {
     final String depfilePath = fs.path.join(outputDir.path, 'snapshot.d');
     final List<String> genSnapshotArgs = <String>[
       '--deterministic',
+      '--no-use-bare-instructions',
     ];
     if (buildMode == BuildMode.debug) {
       genSnapshotArgs.add('--enable_asserts');


### PR DESCRIPTION

The compressed hello world application regressed. One of the reasons is less efficient compression of the AOT output (instructions and isolate snapshot)

This change temporarily disables usage of bare instructions.

Issue https://github.com/flutter/flutter/issues/27250