### PR TITLE
Add Support for attaching device with remote url

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -70,6 +70,8 @@ class HotRunner extends ResidentRunner {
     bool saveCompilationTrace = false,
     bool stayResident = true,
     bool ipv6 = false,
+    // Restart fully after attach
+    this.restartAfterAttach = false,
   }) : super(devices,
              target: target,
              debuggingOptions: debuggingOptions,
@@ -86,6 +88,7 @@ class HotRunner extends ResidentRunner {
   bool _didAttach = false;
   Set<String> _dartDependencies;
   final String dillOutputPath;
+  final bool restartAfterAttach;
 
   final Map<String, List<int>> benchmarkData = <String, List<int>>{};
   // The initial launch is from a snapshot.
@@ -259,6 +262,10 @@ class HotRunner extends ResidentRunner {
       final File benchmarkOutput = fs.file('hot_benchmark.json');
       benchmarkOutput.writeAsStringSync(toPrettyJson(benchmarkData));
       return 0;
+    }
+
+    if (restartAfterAttach) {
+      await restart(fullRestart: true);
     }
 
     int result = 0;

--- a/packages/flutter_tools/test/commands/attach_test.dart
+++ b/packages/flutter_tools/test/commands/attach_test.dart
@@ -120,6 +120,7 @@ void main() {
             packagesFilePath: anyNamed('packagesFilePath'),
             usesTerminalUI: anyNamed('usesTerminalUI'),
             ipv6: false,
+            restartAfterAttach: anyNamed('restartAfterAttach'),
           ),
         ).thenReturn(mockHotRunner);
 
@@ -151,6 +152,7 @@ void main() {
             packagesFilePath: anyNamed('packagesFilePath'),
             usesTerminalUI: anyNamed('usesTerminalUI'),
             ipv6: false,
+            restartAfterAttach: anyNamed('restartAfterAttach'),
           ),
         )..called(1);
 
@@ -225,6 +227,7 @@ void main() {
         packagesFilePath: anyNamed('packagesFilePath'),
         usesTerminalUI: anyNamed('usesTerminalUI'),
         ipv6: false,
+        restartAfterAttach: anyNamed('restartAfterAttach'),
       )).thenReturn(mockHotRunner);
 
       testDeviceManager.addDevice(device);
@@ -254,6 +257,7 @@ void main() {
         packagesFilePath: anyNamed('packagesFilePath'),
         usesTerminalUI: anyNamed('usesTerminalUI'),
         ipv6: false,
+        restartAfterAttach: anyNamed('restartAfterAttach'),
       )).called(1);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,


### PR DESCRIPTION
Use attach command to connect a remote device via http url.

```shell
flutter attach --device ios --url http://x.x.x.x:xxxx --restart
```

This maybe useful for those apps that embed flutter to implement part of the app not the whole app.