### PR TITLE
[Material] Allow slider shapes to be easily resized

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -601,7 +601,7 @@ class _RenderSlider extends RenderBox {
     _sliderTheme.thumbShape.getPreferredSize(isInteractive, isDiscrete),
     _sliderTheme.tickMarkShape.getPreferredSize(isEnabled: isInteractive, sliderTheme: sliderTheme),
   ];
-  double get _minPreferredTrackHeight =>_sliderTheme.trackHeight;
+  double get _minPreferredTrackHeight => _sliderTheme.trackHeight;
 
   _SliderState _state;
   Animation<double> _overlayAnimation;

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -847,18 +847,13 @@ abstract class SliderComponentShape {
 ///    shapes.
 class RectangularSliderTrackShape extends SliderTrackShape {
   /// Create a slider track that draws 2 rectangles.
-  const RectangularSliderTrackShape({this.disabledThumbGap});
+  const RectangularSliderTrackShape({this.disabledThumbGap = 2.0});
 
   /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///
   /// This is only used when the thumb is disabled. The Material spec defaults
   /// to 2, which is half of the disabled thumb radius.
   final double disabledThumbGap;
-  double get _disabledThumbGap => disabledThumbGap ?? _defaultDisabledThumbGap;
-
-  // The Material spec default which is a difference of the radii from the gray
-  // circle and the thumb.
-  static const double _defaultDisabledThumbGap = 2.0;
 
   @override
   Rect getPreferredRect({
@@ -924,7 +919,7 @@ class RectangularSliderTrackShape extends SliderTrackShape {
     double horizontalAdjustment = 0.0;
     if (!isEnabled) {
       final double disabledThumbRadius = sliderTheme.thumbShape.getPreferredSize(false, isDiscrete).width / 2.0;
-      final double gap = _disabledThumbGap * (1.0 - enableAnimation.value);
+      final double gap = disabledThumbGap * (1.0 - enableAnimation.value);
       horizontalAdjustment = disabledThumbRadius + gap;
     }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1031,16 +1031,13 @@ class RoundSliderThumbShape extends SliderComponentShape {
 
   /// The preferred radius of the round thumb shape when the slider is disabled.
   ///
-  /// If it is not provided, then the material default is used.
+  /// If no disabledRadius is provided, then it is is derived from the enabled
+  /// thumb radius and has the same ratio of enabled size to disabled size as
+  /// the Material spec. The default resolves to 4, which is 2 / 3 of the
+  /// default enabled thumb.
   final double disabledThumbRadius;
-  // If no disabledRadius is provided, use a default that is derived from the
-  // actual thumb radius and has the same ratio as the default disabled to
-  // enabled thumb radius.
-  // TODO(clocksmith): This needs to be updated once the thumb size is updated.
+  // TODO(clocksmith): This needs to be updated once the thumb size is updated to the Material spec.
   double get _disabledThumbRadius =>  disabledThumbRadius ?? enabledThumbRadius * 2 / 3;
-
-  // The Material spec default.
-  static const double _defaultDisabledThumbRadius = 4.0;
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -846,10 +846,10 @@ abstract class SliderComponentShape {
 ///  * [SliderTrackShape] Base component for creating other custom track
 ///    shapes.
 class RectangularSliderTrackShape extends SliderTrackShape {
-  /// Create a slider track that draws a circle 2 rectangles.
+  /// Create a slider track that draws 2 rectangles.
   const RectangularSliderTrackShape({this.disabledThumbGap});
 
-  /// Spacing, or gap, between disabled thumb and the track.
+  /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///
   /// This is only used when the thumb is disabled. The material spec defaults
   /// it to 2, which is half of its disabled thumb radius, which is 4.

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -847,13 +847,15 @@ abstract class SliderComponentShape {
 ///    shapes.
 class RectangularSliderTrackShape extends SliderTrackShape {
   /// Create a slider track that draws 2 rectangles.
-  const RectangularSliderTrackShape({this.disabledThumbGap = 2.0});
+  const RectangularSliderTrackShape({ this.disabledThumbGapWidth = 2.0 });
 
   /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///
-  /// This is only used when the thumb is disabled. The Material spec defaults
-  /// to 2, which is half of the disabled thumb radius.
-  final double disabledThumbGap;
+  /// This is only used when the slider is disabled. There is no gap around
+  /// the thumb and any part of the track when the slider is enabled. The
+  /// Material spec defaults this gap width 2, which is half of the disabled
+  /// thumb radius.
+  final double disabledThumbGapWidth;
 
   @override
   Rect getPreferredRect({
@@ -913,13 +915,13 @@ class RectangularSliderTrackShape extends SliderTrackShape {
 
     // Used to create a gap around the thumb iff the slider is disabled.
     // If the slider is enabled, the track can be drawn beneath the thumb
-    // without gaps. But when the slider is disabled, the track is shortened
+    // without a gap. But when the slider is disabled, the track is shortened
     // and this gap helps determine how much shorter it should be.
     // TODO(clocksmith): The new Material spec has a gray circle in place of this gap.
     double horizontalAdjustment = 0.0;
     if (!isEnabled) {
       final double disabledThumbRadius = sliderTheme.thumbShape.getPreferredSize(false, isDiscrete).width / 2.0;
-      final double gap = disabledThumbGap * (1.0 - enableAnimation.value);
+      final double gap = disabledThumbGapWidth * (1.0 - enableAnimation.value);
       horizontalAdjustment = disabledThumbRadius + gap;
     }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -851,12 +851,12 @@ class RectangularSliderTrackShape extends SliderTrackShape {
 
   /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///
-  /// This is only used when the thumb is disabled. The material spec defaults
+  /// This is only used when the thumb is disabled. The Material spec defaults
   /// it to 2, which is half of its disabled thumb radius, which is 4.
   final double disabledThumbGap;
   double get _disabledThumbGap => disabledThumbGap ?? _defaultDisabledThumbGap;
 
-  // The material spec default which is a difference of the radii from the gray
+  // The Material spec default which is a difference of the radii from the gray
   // circle and the thumb.
   static const double _defaultDisabledThumbGap = 2.0;
 
@@ -920,7 +920,7 @@ class RectangularSliderTrackShape extends SliderTrackShape {
     // If the slider is enabled, the track can be drawn beneath the thumb
     // without gaps. But when the slider is disabled, the track is shortened
     // and this gap helps determine how much shorter it should be.
-    // TODO(clocksmith): The new material spec has a gray circle in place of this gap.
+    // TODO(clocksmith): The new Material spec has a gray circle in place of this gap.
     double horizontalAdjustment = 0.0;
     if (!isEnabled) {
       final double disabledThumbRadius = sliderTheme.thumbShape.getPreferredSize(false, isDiscrete).width / 2.0;
@@ -1046,10 +1046,10 @@ class RoundSliderThumbShape extends SliderComponentShape {
   double get _disabledThumbRadius =>  disabledThumbRadius ?? _enabledThumbRadius * _defaultDisabledThumbRadius / _defaultEnabledThumbRadius;
 
   // TODO(clocksmith): This needs to be changed to 10 according to spec.
-  // The material spec default.
+  // The Material spec default.
   static const double _defaultEnabledThumbRadius = 6.0;
 
-  // The material spec default.
+  // The Material spec default.
   static const double _defaultDisabledThumbRadius = 4.0;
 
   @override
@@ -1113,7 +1113,7 @@ class RoundSliderOverlayShape extends SliderComponentShape {
   double get _overlayRadius =>  overlayRadius ?? _defaultOverlayRadius;
 
   // TODO(clocksmith): This needs to be changed to 24 according to spec.
-  // The material spec default.
+  // The Material spec default.
   static const double _defaultOverlayRadius = 16.0;
 
   @override

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -957,7 +957,7 @@ class RectangularSliderTrackShape extends SliderTrackShape {
 ///    sliders in a widget subtree.
 class RoundSliderTickMarkShape extends SliderTickMarkShape {
   /// Create a slider tick mark that draws a circle.
-  const RoundSliderTickMarkShape({this.tickMarkRadius});
+  const RoundSliderTickMarkShape({ this.tickMarkRadius });
 
   /// The preferred radius of the round tick mark.
   ///
@@ -1022,7 +1022,10 @@ class RoundSliderTickMarkShape extends SliderTickMarkShape {
 class RoundSliderThumbShape extends SliderComponentShape {
   /// Create a slider thumb that draws a circle.
   // TODO(clocksmith): This needs to be changed to 10 according to spec.
-  const RoundSliderThumbShape({this.enabledThumbRadius = 6.0, this.disabledThumbRadius});
+  const RoundSliderThumbShape({
+    this.enabledThumbRadius = 6.0,
+    this.disabledThumbRadius
+  });
 
   /// The preferred radius of the round thumb shape when the slider is enabled.
   ///
@@ -1092,7 +1095,7 @@ class RoundSliderThumbShape extends SliderComponentShape {
 class RoundSliderOverlayShape extends SliderComponentShape {
   /// Create a slider thumb overlay that draws a circle.
   // TODO(clocksmith): This needs to be changed to 24 according to spec.
-  const RoundSliderOverlayShape({this.overlayRadius = 16.0});
+  const RoundSliderOverlayShape({ this.overlayRadius = 16.0 });
 
   /// The preferred radius of the round thumb shape when enabled.
   ///

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -852,7 +852,7 @@ class RectangularSliderTrackShape extends SliderTrackShape {
   /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///
   /// This is only used when the thumb is disabled. The Material spec defaults
-  /// it to 2, which is half of its disabled thumb radius, which is 4.
+  /// to 2, which is half of the disabled thumb radius.
   final double disabledThumbGap;
   double get _disabledThumbGap => disabledThumbGap ?? _defaultDisabledThumbGap;
 
@@ -1010,8 +1010,8 @@ class RoundSliderTickMarkShape extends SliderTickMarkShape {
 
     // The tick marks are tiny circles that are the same height as the track.
     final double tickMarkRadius = getPreferredSize(
-        isEnabled: isEnabled,
-        sliderTheme: sliderTheme
+      isEnabled: isEnabled,
+      sliderTheme: sliderTheme,
     ).width / 2;
     context.canvas.drawCircle(center, tickMarkRadius, paint);
   }
@@ -1026,7 +1026,8 @@ class RoundSliderTickMarkShape extends SliderTickMarkShape {
 ///    sliders in a widget subtree.
 class RoundSliderThumbShape extends SliderComponentShape {
   /// Create a slider thumb that draws a circle.
-  const RoundSliderThumbShape({this.enabledThumbRadius, this.disabledThumbRadius});
+  // TODO(clocksmith): This needs to be changed to 10 according to spec.
+  const RoundSliderThumbShape({this.enabledThumbRadius = 6.0, this.disabledThumbRadius});
 
   /// The preferred radius of the round thumb shape when the slider is enabled.
   ///
@@ -1037,24 +1038,18 @@ class RoundSliderThumbShape extends SliderComponentShape {
   ///
   /// If it is not provided, then the material default is used.
   final double disabledThumbRadius;
-
-  double get _enabledThumbRadius =>  enabledThumbRadius ?? _defaultEnabledThumbRadius;
-
   // If no disabledRadius is provided, use a default that is derived from the
   // actual thumb radius and has the same ratio as the default disabled to
   // enabled thumb radius.
-  double get _disabledThumbRadius =>  disabledThumbRadius ?? _enabledThumbRadius * _defaultDisabledThumbRadius / _defaultEnabledThumbRadius;
-
-  // TODO(clocksmith): This needs to be changed to 10 according to spec.
-  // The Material spec default.
-  static const double _defaultEnabledThumbRadius = 6.0;
+  // TODO(clocksmith): This needs to be updated once the thumb size is updated.
+  double get _disabledThumbRadius =>  disabledThumbRadius ?? enabledThumbRadius * 2 / 3;
 
   // The Material spec default.
   static const double _defaultDisabledThumbRadius = 4.0;
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
-    return Size.fromRadius(isEnabled ? _enabledThumbRadius : _disabledThumbRadius);
+    return Size.fromRadius(isEnabled ? enabledThumbRadius : _disabledThumbRadius);
   }
 
   @override
@@ -1073,7 +1068,7 @@ class RoundSliderThumbShape extends SliderComponentShape {
     final Canvas canvas = context.canvas;
     final Tween<double> radiusTween = Tween<double>(
       begin: _disabledThumbRadius,
-      end: _enabledThumbRadius,
+      end: enabledThumbRadius,
     );
     final ColorTween colorTween = ColorTween(
       begin: sliderTheme.disabledThumbColor,
@@ -1104,21 +1099,17 @@ class RoundSliderThumbShape extends SliderComponentShape {
 ///    sliders in a widget subtree.
 class RoundSliderOverlayShape extends SliderComponentShape {
   /// Create a slider thumb overlay that draws a circle.
-  const RoundSliderOverlayShape({this.overlayRadius});
+  // TODO(clocksmith): This needs to be changed to 24 according to spec.
+  const RoundSliderOverlayShape({this.overlayRadius = 16.0});
 
   /// The preferred radius of the round thumb shape when enabled.
   ///
   /// If it is not provided, then half of the track height is used.
   final double overlayRadius;
-  double get _overlayRadius =>  overlayRadius ?? _defaultOverlayRadius;
-
-  // TODO(clocksmith): This needs to be changed to 24 according to spec.
-  // The Material spec default.
-  static const double _defaultOverlayRadius = 16.0;
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
-    return Size.fromRadius(_overlayRadius);
+    return Size.fromRadius(overlayRadius);
   }
 
   @override
@@ -1137,7 +1128,7 @@ class RoundSliderOverlayShape extends SliderComponentShape {
     final Canvas canvas = context.canvas;
     final Tween<double> radiusTween = Tween<double>(
       begin: 0.0,
-      end: _overlayRadius,
+      end: overlayRadius,
     );
 
     // TODO(gspencer): We don't really follow the spec here for overlays.

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -548,4 +548,244 @@ void main() {
     );
     await gesture.up();
   });
+
+  testWidgets('The slider track height can be overriden', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(trackHeight: 16);
+    double value = 0.25;
+    Widget buildApp({ bool enabled = true }) {
+      final ValueChanged<double> onChanged = enabled
+          ? (double d) => value = d
+          : null;
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SliderTheme(
+              data: sliderTheme,
+              child: Slider(
+                value: value,
+                label: '$value',
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    // Top and bottom are centerY (300) + and - trackRadius (8).
+    expect(
+      sliderBox,
+      paints
+        ..rect(rect: Rect.fromLTRB(16.0, 292.0, 208.0, 308.0), color: sliderTheme.activeTrackColor)
+        ..rect(rect: Rect.fromLTRB(208.0, 292.0, 784.0, 308.0), color: sliderTheme.inactiveTrackColor)
+    );
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle(); // wait for disable animation
+    // The disabled thumb is smaller so the active track has to paint longer to
+    // get to the edge.
+    expect(
+      sliderBox,
+      paints
+        ..rect(rect: Rect.fromLTRB(16.0, 292.0, 202.0, 308.0), color: sliderTheme.disabledActiveTrackColor)
+        ..rect(rect: Rect.fromLTRB(214.0, 292.0, 784.0, 308.0), color: sliderTheme.disabledInactiveTrackColor)
+    );
+  });
+
+  testWidgets('The default slider thumb shape sizes can be overriden', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+        thumbShape: const RoundSliderThumbShape(
+          enabledThumbRadius: 7,
+          disabledThumbRadius: 11,
+        ),
+    );
+    double value = 0.25;
+    Widget buildApp({ bool enabled = true }) {
+      final ValueChanged<double> onChanged = enabled
+          ? (double d) => value = d
+          : null;
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SliderTheme(
+              data: sliderTheme,
+              child: Slider(
+                value: value,
+                label: '$value',
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(
+      sliderBox,
+      paints..circle(x: 208, y: 300, radius: 7, color: sliderTheme.thumbColor)
+    );
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle(); // wait for disable animation
+    expect(
+      sliderBox,
+      paints..circle(x: 208, y: 300, radius: 11, color: sliderTheme.disabledThumbColor)
+    );
+  });
+
+  testWidgets('The default slider thumb shape disabled size can be inferred from the enabled size', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+      thumbShape: const RoundSliderThumbShape(
+        enabledThumbRadius: 9,
+      ),
+    );
+    double value = 0.25;
+    Widget buildApp({ bool enabled = true }) {
+      final ValueChanged<double> onChanged = enabled
+          ? (double d) => value = d
+          : null;
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SliderTheme(
+              data: sliderTheme,
+              child: Slider(
+                value: value,
+                label: '$value',
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(
+      sliderBox,
+      paints..circle(x: 208, y: 300, radius: 9, color: sliderTheme.thumbColor)
+    );
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle(); // wait for disable animation
+    // Radius should be 6, or 2/3 of 9. 2/3 because the default disabled thumb
+    // radius us 4 and the default enabled thumb radius is 6.
+    // TODO(clocksmith): This ratio will change once thumb sizes are updated to spec.
+    expect(
+      sliderBox,
+      paints..circle(x: 208, y: 300, radius: 6, color: sliderTheme.disabledThumbColor)
+    );
+  });
+
+
+  testWidgets('The default slider tick mark shape size cen be overriden', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+      tickMarkShape: RoundSliderTickMarkShape(
+        tickMarkRadius: 5
+      ),
+      activeTickMarkColor: Color(0xff00ff00),
+      inactiveTickMarkColor: Color(0xffff0000),
+      disabledActiveTickMarkColor: Color(0xff0000ff),
+      disabledInactiveTickMarkColor: Color(0xffffff00),
+    );
+    double value = 0.5;
+    Widget buildApp({ bool enabled = true }) {
+      final ValueChanged<double> onChanged = enabled
+          ? (double d) => value = d
+          : null;
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SliderTheme(
+              data: sliderTheme,
+              child: Slider(
+                value: value,
+                label: '$value',
+                onChanged: onChanged,
+                divisions: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    expect(
+      sliderBox,
+      paints
+        ..circle(x: 21, y: 300, radius: 5, color: sliderTheme.activeTickMarkColor)
+        ..circle(x: 400, y: 300, radius: 5, color: sliderTheme.activeTickMarkColor)
+        ..circle(x: 779, y: 300, radius: 5, color: sliderTheme.inactiveTickMarkColor)
+    );
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+
+    expect(
+      sliderBox,
+      paints
+        ..circle(x: 21, y: 300, radius: 5, color: sliderTheme.disabledActiveTickMarkColor)
+        ..circle(x: 400, y: 300, radius: 5, color: sliderTheme.disabledActiveTickMarkColor)
+        ..circle(x: 779, y: 300, radius: 5, color: sliderTheme.disabledInactiveTickMarkColor)
+    );
+  });
+
+  testWidgets('The default slider overlay shape size cen be overriden', (WidgetTester tester) async {
+    const double uniqueOverlayRadius = 23;
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+      overlayShape: const RoundSliderOverlayShape(
+        overlayRadius: uniqueOverlayRadius,
+      ),
+    );
+    double value = 0.5;
+    Widget buildApp() {
+      final ValueChanged<double> onChanged = (double d) => value = d;
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SliderTheme(
+              data: sliderTheme,
+              child: Slider(
+                value: value,
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+
+    // Tap center and wait for animation.
+    Offset center = tester.getCenter(find.byType(Slider));
+    await tester.startGesture(center);
+    await tester.pumpAndSettle();
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+    expect(
+      sliderBox,
+      paints..circle(
+        x: center.dx,
+        y: center.dy,
+        radius: uniqueOverlayRadius,
+        color: sliderTheme.overlayColor,
+      )
+    );
+  });
 }

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -515,7 +515,7 @@ void main() {
     await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
     // Radius should be 6, or 2/3 of 9. 2/3 because the default disabled thumb
-    // radius us 4 and the default enabled thumb radius is 6.
+    // radius is 4 and the default enabled thumb radius is 6.
     // TODO(clocksmith): This ratio will change once thumb sizes are updated to spec.
     expect(
       sliderBox,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -30,32 +30,15 @@ void main() {
     );
     final SliderThemeData sliderTheme = theme.sliderTheme;
 
-    Widget buildSlider(SliderThemeData data) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(window),
-          child: Material(
-            child: Center(
-              child: Theme(
-                data: theme,
-                child: const Slider(
-                  value: 0.5,
-                  label: '0.5',
-                  onChanged: null,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildSlider(sliderTheme));
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, enabled: false));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
-    expect(sliderBox, paints..rect(color: sliderTheme.disabledActiveTrackColor)..rect(color: sliderTheme.disabledInactiveTrackColor));
+    expect(
+      sliderBox,
+      paints
+        ..rect(color: sliderTheme.disabledActiveTrackColor)
+        ..rect(color: sliderTheme.disabledInactiveTrackColor),
+    );
   });
 
   testWidgets('Slider overrides ThemeData theme if SliderTheme present', (WidgetTester tester) async {
@@ -69,35 +52,15 @@ void main() {
       inactiveTrackColor: Colors.purple.withAlpha(0x3d),
     );
 
-    Widget buildSlider(SliderThemeData data) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(window),
-          child: Material(
-            child: Center(
-              child: Theme(
-                data: theme,
-                child: SliderTheme(
-                  data: customTheme,
-                  child: const Slider(
-                    value: 0.5,
-                    label: '0.5',
-                    onChanged: null,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildSlider(sliderTheme));
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, enabled: false));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
-    expect(sliderBox, paints..rect(color: customTheme.disabledActiveTrackColor)..rect(color: customTheme.disabledInactiveTrackColor));
+    expect(
+      sliderBox,
+      paints
+        ..rect(color: customTheme.disabledActiveTrackColor)
+        ..rect(color: customTheme.disabledInactiveTrackColor),
+    );
   });
 
   testWidgets('SliderThemeData assigns the correct default shapes', (WidgetTester tester) async {
@@ -180,31 +143,8 @@ void main() {
       primarySwatch: Colors.blue,
     );
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(thumbColor: Colors.red.shade500);
-    double value = 0.25;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(window),
-          child: Material(
-            child: Center(
-              child: SliderTheme(
-                data: sliderTheme,
-                child: Slider(
-                  value: value,
-                  label: '$value',
-                  onChanged: onChanged,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
     expect(
@@ -214,8 +154,9 @@ void main() {
         ..rect(rect: Rect.fromLTRB(208.0, 299.0, 784.0, 301.0), color: sliderTheme.inactiveTrackColor)
     );
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
+
     // The disabled thumb is smaller so the track has to paint longer to get
     // to the edge.
     expect(
@@ -232,31 +173,8 @@ void main() {
       primarySwatch: Colors.blue,
     );
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(thumbColor: Colors.red.shade500);
-    double value = 0.25;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(window),
-          child: Material(
-            child: Center(
-              child: SliderTheme(
-                data: sliderTheme,
-                child: Slider(
-                  value: value,
-                  label: '$value',
-                  onChanged: onChanged,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
     // With no touch, paints only the thumb.
@@ -296,6 +214,7 @@ void main() {
 
     await gesture.up();
     await tester.pumpAndSettle();
+
     // After the gesture is up and complete, it again paints only the thumb.
     expect(
       sliderBox,
@@ -315,45 +234,20 @@ void main() {
       primarySwatch: Colors.blue,
     );
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(thumbColor: Colors.red.shade500);
-    double value = 0.45;
-    Widget buildApp({
-      int divisions,
-      bool enabled = true,
-    }) {
-      final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(window),
-          child: Material(
-            child: Center(
-              child: SliderTheme(
-                data: sliderTheme,
-                child: Slider(
-                  value: value,
-                  label: '$value',
-                  divisions: divisions,
-                  onChanged: onChanged,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.45));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
     expect(sliderBox, paints..circle(color: sliderTheme.thumbColor, radius: 6.0));
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.45, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
+
     expect(sliderBox, paints..circle(color: sliderTheme.disabledThumbColor, radius: 4.0));
 
-    await tester.pumpWidget(buildApp(divisions: 3));
-    await tester.pumpAndSettle(); // wait for disable animation
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.45, divisions: 3));
+    await tester.pumpAndSettle(); // wait for enable animation
+
     expect(
       sliderBox,
       paints
@@ -364,8 +258,9 @@ void main() {
         ..circle(color: sliderTheme.thumbColor, radius: 6.0)
     );
 
-    await tester.pumpWidget(buildApp(divisions: 3, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.45, divisions: 3, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
+
     expect(
       sliderBox,
       paints
@@ -551,28 +446,8 @@ void main() {
 
   testWidgets('The slider track height can be overriden', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(trackHeight: 16);
-    double value = 0.25;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled
-          ? (double d) => value = d
-          : null;
-      return MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SliderTheme(
-              data: sliderTheme,
-              child: Slider(
-                value: value,
-                label: '$value',
-                onChanged: onChanged,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
 
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
@@ -584,8 +459,9 @@ void main() {
         ..rect(rect: Rect.fromLTRB(208.0, 292.0, 784.0, 308.0), color: sliderTheme.inactiveTrackColor)
     );
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
+
     // The disabled thumb is smaller so the active track has to paint longer to
     // get to the edge.
     expect(
@@ -603,29 +479,8 @@ void main() {
           disabledThumbRadius: 11,
         ),
     );
-    double value = 0.25;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled
-          ? (double d) => value = d
-          : null;
-      return MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SliderTheme(
-              data: sliderTheme,
-              child: Slider(
-                value: value,
-                label: '$value',
-                onChanged: onChanged,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
     expect(
@@ -633,8 +488,9 @@ void main() {
       paints..circle(x: 208, y: 300, radius: 7, color: sliderTheme.thumbColor)
     );
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
+
     expect(
       sliderBox,
       paints..circle(x: 208, y: 300, radius: 11, color: sliderTheme.disabledThumbColor)
@@ -647,29 +503,8 @@ void main() {
         enabledThumbRadius: 9,
       ),
     );
-    double value = 0.25;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled
-          ? (double d) => value = d
-          : null;
-      return MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SliderTheme(
-              data: sliderTheme,
-              child: Slider(
-                value: value,
-                label: '$value',
-                onChanged: onChanged,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
     expect(
@@ -677,7 +512,7 @@ void main() {
       paints..circle(x: 208, y: 300, radius: 9, color: sliderTheme.thumbColor)
     );
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
     // Radius should be 6, or 2/3 of 9. 2/3 because the default disabled thumb
     // radius us 4 and the default enabled thumb radius is 6.
@@ -694,34 +529,13 @@ void main() {
       tickMarkShape: const RoundSliderTickMarkShape(
         tickMarkRadius: 5
       ),
-      activeTickMarkColor: const Color(0xff00ff00),
-      inactiveTickMarkColor: const Color(0xffff0000),
-      disabledActiveTickMarkColor: const Color(0xff0000ff),
-      disabledInactiveTickMarkColor: const Color(0xffffff00),
+      activeTickMarkColor: const Color(0xfadedead),
+      inactiveTickMarkColor: const Color(0xfadebeef),
+      disabledActiveTickMarkColor: const Color(0xfadecafe),
+      disabledInactiveTickMarkColor: const Color(0xfadeface),
     );
-    double value = 0.5;
-    Widget buildApp({ bool enabled = true }) {
-      final ValueChanged<double> onChanged = enabled
-          ? (double d) => value = d
-          : null;
-      return MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SliderTheme(
-              data: sliderTheme,
-              child: Slider(
-                value: value,
-                label: '$value',
-                onChanged: onChanged,
-                divisions: 2,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, divisions: 2));
 
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
@@ -733,7 +547,7 @@ void main() {
         ..circle(x: 779, y: 300, radius: 5, color: sliderTheme.inactiveTickMarkColor)
     );
 
-    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, divisions: 2,  enabled: false));
     await tester.pumpAndSettle();
 
     expect(
@@ -752,26 +566,8 @@ void main() {
         overlayRadius: uniqueOverlayRadius,
       ),
     );
-    double value = 0.5;
-    Widget buildApp() {
-      final ValueChanged<double> onChanged = (double d) => value = d;
-      return MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SliderTheme(
-              data: sliderTheme,
-              child: Slider(
-                value: value,
-                onChanged: onChanged,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
 
-    await tester.pumpWidget(buildApp());
-
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5));
     // Tap center and wait for animation.
     final Offset center = tester.getCenter(find.byType(Slider));
     await tester.startGesture(center);
@@ -788,4 +584,28 @@ void main() {
       )
     );
   });
+}
+
+Widget _buildApp(
+  SliderThemeData sliderTheme, {
+  double value = 0.0,
+  bool enabled = true,
+  int divisions,
+}) {
+  final ValueChanged<double> onChanged = enabled ? (double d) => value = d : null;
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: SliderTheme(
+          data: sliderTheme,
+          child: Slider(
+            value: value,
+            label: '$value',
+            onChanged: onChanged,
+            divisions: divisions,
+          ),
+        ),
+      ),
+    ),
+  );
 }

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -444,7 +444,7 @@ void main() {
     await gesture.up();
   });
 
-  testWidgets('The slider track height can be overriden', (WidgetTester tester) async {
+  testWidgets('The slider track height can be overridden', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(trackHeight: 16);
 
     await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
@@ -472,7 +472,7 @@ void main() {
     );
   });
 
-  testWidgets('The default slider thumb shape sizes can be overriden', (WidgetTester tester) async {
+  testWidgets('The default slider thumb shape sizes can be overridden', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
         thumbShape: const RoundSliderThumbShape(
           enabledThumbRadius: 7,
@@ -524,7 +524,7 @@ void main() {
   });
 
 
-  testWidgets('The default slider tick mark shape size cen be overriden', (WidgetTester tester) async {
+  testWidgets('The default slider tick mark shape size can be overridden', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
       tickMarkShape: const RoundSliderTickMarkShape(
         tickMarkRadius: 5
@@ -559,7 +559,7 @@ void main() {
     );
   });
 
-  testWidgets('The default slider overlay shape size cen be overriden', (WidgetTester tester) async {
+  testWidgets('The default slider overlay shape size can be overridden', (WidgetTester tester) async {
     const double uniqueOverlayRadius = 23;
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
       overlayShape: const RoundSliderOverlayShape(

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -147,6 +147,8 @@ void main() {
     await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
 
+    // The enabled slider thumb has track segments that extend to and from
+    // the center of the thumb.
     expect(
       sliderBox,
       paints
@@ -157,8 +159,12 @@ void main() {
     await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
 
-    // The disabled thumb is smaller so the track has to paint longer to get
-    // to the edge.
+    // The disabled slider thumb has a horizontal gap between itself and the
+    // track segments. Therefore, the track segments are shorter since they do
+    // not extend to the center of the thumb, but rather the outer edge of th
+    // gap. As a result, the `right` value of the first segment is less than it
+    // is above, and the `left` value of the second segment is more than it is
+    // above.
     expect(
       sliderBox,
       paints

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -691,13 +691,13 @@ void main() {
 
   testWidgets('The default slider tick mark shape size cen be overriden', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
-      tickMarkShape: RoundSliderTickMarkShape(
+      tickMarkShape: const RoundSliderTickMarkShape(
         tickMarkRadius: 5
       ),
-      activeTickMarkColor: Color(0xff00ff00),
-      inactiveTickMarkColor: Color(0xffff0000),
-      disabledActiveTickMarkColor: Color(0xff0000ff),
-      disabledInactiveTickMarkColor: Color(0xffffff00),
+      activeTickMarkColor: const Color(0xff00ff00),
+      inactiveTickMarkColor: const Color(0xffff0000),
+      disabledActiveTickMarkColor: const Color(0xff0000ff),
+      disabledInactiveTickMarkColor: const Color(0xffffff00),
     );
     double value = 0.5;
     Widget buildApp({ bool enabled = true }) {
@@ -773,7 +773,7 @@ void main() {
     await tester.pumpWidget(buildApp());
 
     // Tap center and wait for animation.
-    Offset center = tester.getCenter(find.byType(Slider));
+    final Offset center = tester.getCenter(find.byType(Slider));
     await tester.startGesture(center);
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
Add the ability to change the size of tick mark, thumb, and overlay shapes. This change makes it easier for developers to expand on the existing shapes.

Included
- Add radii ctor params for round thumb shape (enabled thumb and disabled thumb)
- Add radius ctor param for round overlay shape
- Add radius ctor param for round tick mark shape
- Add tests for configuring the size of the track, tick mark, thumb, and overlay shapes

Not Included
- Value Indicator because the multi-lobe shape is not trivial, but may be included in a future PR