### PR TITLE
Add scroll performance test for flutter_gallery

### DIFF
--- a/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
@@ -1,0 +1,15 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createHomeScrollPerfTest());
+}
+

--- a/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
@@ -12,4 +12,3 @@ Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
   await task(createHomeScrollPerfTest());
 }
-

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -30,6 +30,14 @@ TaskFunction createTilesScrollPerfTest() {
   ).run;
 }
 
+TaskFunction createHomeScrollPerfTest() {
+  return PerfTest(
+    '${flutterDirectory.path}/examples/flutter_gallery',
+    'test_driver/scroll_perf.dart',
+    'home_scroll_perf',
+  ).run;
+}
+
 TaskFunction createCullOpacityPerfTest() {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -112,6 +112,14 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  home_scroll_perf__timeline_summary:
+    description: >
+      Measures the runtime performance of scrolling the material page in the
+      flutter_gallery app on Android.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+    flaky: true
+
   cull_opacity_perf__timeline_summary:
     description: >
       Measures the runtime performance of culling opacity widgets on Android.


### PR DESCRIPTION
Previously, we had a scroll_perf drive test but we were not exercising
it on our device lab. This helps us tracking issues like:
https://github.com/flutter/flutter/issues/24782