### PR TITLE
Update OutlineButton on-pressed fill color

### DIFF
--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -343,10 +343,7 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
   }
 
   Color _getFillColor() {
-    final bool themeIsDark = widget.brightness == Brightness.dark;
-    final Color color = widget.color ?? (themeIsDark
-      ? const Color(0x00000000)
-      : const Color(0x00FFFFFF));
+    final Color color = widget.color ?? Theme.of(context).canvasColor;
     final Tween<Color> colorTween = ColorTween(
       begin: color.withAlpha(0x00),
       end: color.withAlpha(0xFF),

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -121,7 +121,7 @@ void main() {
     // Wait for the border color to change from disabled to enabled.
     await tester.pumpAndSettle();
 
-    // Expect that the button is disabled and painted with the enabled border color.
+    // Expect that the button is enabled and painted with the enabled border color.
     expect(tester.widget<OutlineButton>(outlineButton).enabled, true);
     expect(
       outlineButton,
@@ -313,5 +313,64 @@ void main() {
       'highlightColor: Color(0xff1565c0)',
       'splashColor: Color(0xff9e9e9e)',
     ]);
+  });
+
+  testWidgets('OutlineButton pressed fillColor default', (WidgetTester tester) async {
+    Widget buildFrame(ThemeData theme) {
+      return MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Center(
+            child: OutlineButton(
+              onPressed: () {},
+              child: const Text('Hello'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(ThemeData.dark()));
+    final Finder button = find.byType(OutlineButton);
+    final Offset center = tester.getCenter(button);
+
+    // Default value for dark Theme.of(context).canvasColor as well as
+    // the OutlineButton fill color when the button has been pressed.
+    Color fillColor = Colors.grey[850];
+
+    // Initially the interior of the button is transparent.
+    expect(button, paints..path(color: fillColor.withAlpha(0x00)));
+
+    // Tap-press gesture on the button triggers the fill animation.
+    TestGesture gesture = await tester.startGesture(center);
+    await tester.pump(); // Start the button fill animation.
+    await tester.pump(const Duration(milliseconds: 200)); // Animation is complete.
+    expect(button, paints..path(color: fillColor.withAlpha(0xFF)));
+
+    // Tap gesture completes, button returns to its initial configuration.
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(button,  paints..path(color: fillColor.withAlpha(0x00)));
+
+    await tester.pumpWidget(buildFrame(ThemeData.light()));
+    await tester.pumpAndSettle(); // Finish the theme change animation.
+
+    // Default value for light Theme.of(context).canvasColor as well as
+    // the OutlineButton fill color when the button has been pressed.
+    fillColor = Colors.grey[50];
+
+    // Initially the interior of the button is transparent.
+    expect(button, paints..path(color: fillColor.withAlpha(0x00)));
+
+    // Tap-press gesture on the button triggers the fill animation.
+    gesture = await tester.startGesture(center);
+    await tester.pump(); // Start the button fill animation.
+    await tester.pump(const Duration(milliseconds: 200)); // Animation is complete.
+    expect(button, paints..path(color: fillColor.withAlpha(0xFF)));
+
+    // Tap gesture completes, button returns to its initial configuration.
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(button,  paints..path(color: fillColor.withAlpha(0x00)));
   });
 }

--- a/packages/flutter/test/material/theme_defaults_test.dart
+++ b/packages/flutter/test/material/theme_defaults_test.dart
@@ -143,7 +143,7 @@ void main() {
 
       final RawMaterialButton raw = tester.widget<RawMaterialButton>(find.byType(RawMaterialButton));
       expect(raw.textStyle.color, const Color(0xdd000000));
-      expect(raw.fillColor, const Color(0x00ffffff));
+      expect(raw.fillColor, const Color(0x00fafafa));
       expect(raw.highlightColor, const Color(0x29000000)); // Was Color(0x66bcbcbc)
       expect(raw.splashColor, const Color(0x1f000000)); // Was Color(0x66c8c8c8)
       expect(raw.elevation, 0.0);


### PR DESCRIPTION
Changed the color pressed OutlineButtons are filled with. Instead of black for dark themes and white for light themes, the theme's `canvasColor` is used.

Eliminates a particularly noticeable flash that occurs with the dark theme when the button is released.

Fixes https://github.com/flutter/flutter/issues/22755
