### PR TITLE
Add @isTest to Flutter's wrappers over group/test

### DIFF
--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports
 import 'package:test_api/src/frontend/timeout.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
@@ -155,6 +156,7 @@ Future<void> _runSkippedTest(Suite suiteConfig, Test test, List<Group> parents, 
 /// suite*—tests in other suites will run as normal. We recommend that users
 /// avoid this flag if possible and instead use the test runner flag `-n` to
 /// filter tests by name.
+@isTest
 void test(Object description, Function body, {
   String testOn,
   Timeout timeout,
@@ -227,6 +229,7 @@ void test(Object description, Function body, {
 /// suite*—tests in other suites will run as normal. We recommend that users
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
+@isTest
 void group(Object description, Function body) {
   _declarer.group(description.toString(), body);
 }


### PR DESCRIPTION
These methods that wrap `group`/`test` aren't currently detected as test methods by the analyzer so we don't get the necessary info to show the Run/Debug CodeLens links in VS Code:

<img width="272" alt="screenshot 2019-02-05 at 9 22 03 am" src="https://user-images.githubusercontent.com/1078012/52263626-84346380-2927-11e9-8df4-58e2ba492374.png">

This adds them in, which solves the issue (the screenshot above is taken after I added them).

I don't believe there are any negative consequences of adding this and we already have it on `testWidget` (see #17772).

@gspencergoog @scheglov 

Fixes https://github.com/Dart-Code/Dart-Code/issues/1421.

