### PR TITLE
Use CP_REPOS_DIR if it's set

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -91,6 +91,9 @@ class CocoaPods {
   ///
   /// A user can override the default location via the CP_REPOS_DIR environment
   /// variable.
+  ///
+  /// See https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/config.rb#L138
+  /// for details of this variable.
   Future<bool> get isCocoaPodsInitialized {
     final String cocoapodsReposDir = platform.environment['CP_REPOS_DIR'] ?? fs.path.join(homeDirPath, '.cocoapods', 'repos');
     return fs.isDirectory(fs.path.join(cocoapodsReposDir, 'master'));

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -11,6 +11,7 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../base/version.dart';
@@ -85,8 +86,15 @@ class CocoaPods {
     }
   }
 
-  /// Whether CocoaPods ran 'pod setup' once where the costly pods' specs are cloned.
-  Future<bool> get isCocoaPodsInitialized => fs.isDirectory(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master'));
+  /// Whether CocoaPods ran 'pod setup' once where the costly pods' specs are
+  /// cloned.
+  ///
+  /// A user can override the default location via the CP_REPOS_DIR environment
+  /// variable.
+  Future<bool> get isCocoaPodsInitialized {
+    final String cocoapodsReposDir = platform.environment['CP_REPOS_DIR'] ?? fs.path.join(homeDirPath, '.cocoapods', 'repos');
+    return fs.isDirectory(fs.path.join(cocoapodsReposDir, 'master'));
+  }
 
   Future<bool> processPods({
     @required IosProject iosProject,

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -41,6 +42,16 @@ void main() {
     resultOfPodVersion = () async => exitsHappy(versionText);
   }
 
+  void podsIsInHomeDir() {
+    fs.directory(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master')).createSync(recursive: true);
+  }
+
+  String podsIsInCustomDir({String cocoapodsReposDir}) {
+    cocoapodsReposDir ??= fs.path.join(homeDirPath, 'cache', 'cocoapods', 'repos');
+    fs.directory(fs.path.join(cocoapodsReposDir, 'master')).createSync(recursive: true);
+    return cocoapodsReposDir;
+  }
+
   setUp(() async {
     Cache.flutterRoot = 'flutter';
     fs = MemoryFileSystem();
@@ -60,7 +71,6 @@ void main() {
     ))
         ..createSync(recursive: true)
         ..writeAsStringSync('Swift podfile template');
-    fs.directory(fs.path.join(homeDirPath, '.cocoapods', 'repos', 'master')).createSync(recursive: true);
     when(mockProcessManager.run(
       <String>['pod', '--version'],
       workingDirectory: anyNamed('workingDirectory'),
@@ -232,6 +242,10 @@ void main() {
   });
 
   group('Process pods', () {
+    setUp(() {
+      podsIsInHomeDir();
+    });
+
     testUsingContext('prints error, if CocoaPods is not installed', () async {
       pretendPodIsNotInstalled();
       projectUnderTest.ios.podfile.createSync();
@@ -517,6 +531,40 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       ProcessManager: () => mockProcessManager,
+    });
+  });
+
+  group('Pods repos dir is custom', () {
+    String cocoapodsRepoDir;
+    Map<String, String> environment;
+    setUp(() {
+      cocoapodsRepoDir = podsIsInCustomDir();
+      environment = <String, String>{
+        'FLUTTER_FRAMEWORK_DIR': 'engine/path',
+        'COCOAPODS_DISABLE_STATS': 'true',
+        'CP_REPOS_DIR': cocoapodsRepoDir,
+      };
+    });
+
+    testUsingContext('succeeds, if specs repo is in CP_REPOS_DIR.', () async {
+      fs.file(fs.path.join('project', 'ios', 'Podfile'))
+        ..createSync()
+        ..writeAsStringSync('Existing Podfile');
+
+      when(mockProcessManager.run(
+        <String>['pod', 'install', '--verbose'],
+        workingDirectory: 'project/ios',
+        environment: environment,
+      )).thenAnswer((_) async => exitsHappy());
+      final bool success = await cocoaPodsUnderTest.processPods(
+        iosProject: projectUnderTest.ios,
+        iosEngineDir: 'engine/path',
+      );
+      expect(success, true);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
+      Platform: () => FakePlatform(environment: environment),
     });
   });
 }


### PR DESCRIPTION
I'll need this for LUCI, where I'd rather put the pods repo in a cached dir than the home dir.

Either way we should support this option for users.