### PR TITLE
Update dartdoc to 0.28.1+2 and fix search text alignment

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -104,7 +104,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.28.1+1
+"$PUB" global activate dartdoc 0.28.1+2
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/docs/assets/overrides.css
+++ b/dev/docs/assets/overrides.css
@@ -103,7 +103,6 @@ code {
   background-image: none;
   border: 1px solid #ccc;
   border-radius: 2px;
-  font-family: inherit;
   padding: 4px 6px;
   font-size: 15px;
 }


### PR DESCRIPTION
Fixes #22967.

Dartdoc release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.28.1%2B2

Dartdoc's search box alignment has been off in both the mainline dartdoc for some browsers, and in Flutter for all browsers (#22967).  A combination of style tweaks in Dartdoc and Flutter's overrides fixes this for all platforms I have tested.

Screenshots (all on Mac unless specified):

Safari:
<img width="456" alt="safari" src="https://user-images.githubusercontent.com/14116827/52300692-62de7200-293d-11e9-8cbd-603da57d7641.png">

Firefox:
<img width="475" alt="firefox" src="https://user-images.githubusercontent.com/14116827/52300729-7689d880-293d-11e9-963f-9e3cb744865d.png">

Chrome canary:
<img width="465" alt="chrome-canary" src="https://user-images.githubusercontent.com/14116827/52300710-6c67da00-293d-11e9-9d13-f30d5ba21fcb.png">

Chrome 72:
<img width="465" alt="chrome 72" src="https://user-images.githubusercontent.com/14116827/52300740-7be72300-293d-11e9-8480-a30c57ed9df3.png">

Chrome 72, Linux:
![chrome 72 linux 2](https://user-images.githubusercontent.com/14116827/52301057-59a1d500-293e-11e9-997c-a596a8733e94.png)

