### PR TITLE
Fix window bug in _sendPlatformMessage() (#27541).

### DIFF
--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -37,7 +37,13 @@ class BinaryMessages {
 
   static Future<ByteData> _sendPlatformMessage(String channel, ByteData message) {
     final Completer<ByteData> completer = Completer<ByteData>();
-    ServicesBinding.instance.window.sendPlatformMessage(channel, message, (ByteData reply) {
+    // ui.window is accessed directly instead of using ServicesBinding.instance.window
+    // because this method might be invoked before any binding is initialized.
+    // This issue was reported in #27541. It is not ideal to statically access
+    // ui.window because the Window may be dependency injected elsewhere with
+    // a different instance. However, static access at this location seems to be
+    // the least bad option.
+    ui.window.sendPlatformMessage(channel, message, (ByteData reply) {
       try {
         completer.complete(reply);
       } catch (exception, stack) {


### PR DESCRIPTION
Fix window bug in _sendPlatformMessage() (#27541).

The fix I chose was to simply revert the window reference within _sendPlatformMessage().  This is not ideal, but probably the least bad solution at this time.