### PR TITLE
1. Use '--no-use-bare-instructions' to not use this feature as it

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -125,6 +125,8 @@ class AOTSnapshotter {
     final String depfilePath = fs.path.join(outputDir.path, 'snapshot.d');
     final List<String> genSnapshotArgs = <String>[
       '--deterministic',
+      '--no-use-bare-instructions',
+      '--inlining_small_leaf_size_threshold=1',
     ];
     if (extraGenSnapshotOptions != null && extraGenSnapshotOptions.isNotEmpty) {
       printTrace('Extra gen_snapshot options: $extraGenSnapshotOptions');

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -193,6 +193,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
         '--no-sim-use-hardfp',
@@ -232,6 +234,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
         'main.dill',
@@ -271,6 +275,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-blobs',
         '--vm_snapshot_data=build/foo/vm_snapshot_data',
         '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
@@ -315,6 +321,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-blobs',
         '--vm_snapshot_data=build/foo/vm_snapshot_data',
         '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
@@ -355,6 +363,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
         '--no-sim-use-hardfp',
@@ -394,6 +404,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
         'main.dill',
@@ -451,6 +463,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-blobs',
         '--vm_snapshot_data=build/foo/vm_snapshot_data',
         '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
@@ -495,6 +509,8 @@ void main() {
       expect(genSnapshot.packagesPath, '.packages');
       expect(genSnapshot.additionalArgs, <String>[
         '--deterministic',
+        '--no-use-bare-instructions',
+        '--inlining_small_leaf_size_threshold=1',
         '--snapshot_kind=app-aot-blobs',
         '--vm_snapshot_data=build/foo/vm_snapshot_data',
         '--isolate_snapshot_data=build/foo/isolate_snapshot_data',


### PR DESCRIPTION
results in a size regression in the compressed APK size.

2. Use '--inlining_small_leaf_size_threshold=1' to limit inlining and
avoid an increase in the size of hello_world application.

(Please see issue https://github.com/flutter/flutter/issues/27250)