### PR TITLE
Warn when gradle builds fail because of AndroidX

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -432,14 +432,18 @@ Future<void> _buildGradleProjectV2(
     workingDirectory: flutterProject.android.hostAppGradleRoot.path,
     allowReentrantFlutter: true,
     environment: _gradleEnv,
+    // TODO(mklim): if AndroidX warnings are no longer required, this
+    // mapFunction and all its associated variabled can be replaced with just
+    // `filter: ndkMessagefilter`.
     mapFunction: (String line) {
-      if (androidXFailureRegex.hasMatch(line)) {
+      final bool isAndroidXPluginWarning = androidXPluginWarningRegex.hasMatch(line);
+      if (!isAndroidXPluginWarning && androidXFailureRegex.hasMatch(line)) {
         potentialAndroidXFailure = true;
       }
       // Always print the full line in verbose mode.
       if (logger.isVerbose) {
         return line;
-      } else if (androidXPluginWarningRegex.hasMatch(line) || !ndkMessageFilter.hasMatch(line)) {
+      } else if (isAndroidXPluginWarning || !ndkMessageFilter.hasMatch(line)) {
         return null;
       }
 
@@ -452,7 +456,7 @@ Future<void> _buildGradleProjectV2(
     if (potentialAndroidXFailure) {
       printError('*******************************************************************************************');
       printError('The Gradle failure may have been because of AndroidX incompatibilities in this Flutter app.');
-      printError('See [WIP link] for more information on the problem and how to fix it.');
+      printError('See https://goo.gl/CP92wY for more information on the problem and how to fix it.');
       printError('*******************************************************************************************');
     }
     throwToolExit('Gradle task $assembleTask failed with exit code $exitCode', exitCode: exitCode);

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -42,9 +42,30 @@ enum FlutterPluginVersion {
 // Investigation documented in #13975 suggests the filter should be a subset
 // of the impact of -q, but users insist they see the error message sometimes
 // anyway.  If we can prove it really is impossible, delete the filter.
+// This technically matches everything *except* the NDK message, since it's
+// passed to a function that filters out all lines that don't match a filter.
 final RegExp ndkMessageFilter = RegExp(r'^(?!NDK is missing a ".*" directory'
   r'|If you are not using NDK, unset the NDK variable from ANDROID_NDK_HOME or local.properties to remove this warning'
   r'|If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to .*)');
+
+// This regex is intentionally broad. AndroidX errors can manifest in multiple
+// different ways and each one depends on the specific code config and
+// filesystem paths of the project. Throwing the broadest net possible here to
+// catch all known and likely cases.
+//
+// Example stack traces:
+//
+// https://github.com/flutter/flutter/issues/27226 "AAPT: error: resource android:attr/fontVariationSettings not found."
+// https://github.com/flutter/flutter/issues/27106 "Android resource linking failed|Daemon: AAPT2|error: failed linking references"
+// https://github.com/flutter/flutter/issues/27493 "error: cannot find symbol import androidx.annotation.NonNull;"
+// https://github.com/flutter/flutter/issues/23995 "error: package android.support.annotation does not exist import android.support.annotation.NonNull;"
+final RegExp androidXFailureRegex = RegExp(r'(AAPT|androidx|android\.support)');
+
+final RegExp androidXPluginWarningRegex = RegExp(r'\*{57}'
+  r"|WARNING: This version of (\w+) will break your Android build if it or its dependencies aren't compatible with AndroidX."
+  r'|https://goo.gl/y9dCcU describes AndroidX and how to migrate to it using Android Studio.'
+  r"|https://goo.gl/n2E4mD describes how to open a Flutter app's Android files for refactoring in Android Studio."
+  r'|This warning prints for all Android build failures. The real root cause of the error may be unrelated.');
 
 FlutterPluginVersion getFlutterPluginVersion(AndroidProject project) {
   final File plugin = project.hostAppGradleRoot.childFile(
@@ -405,17 +426,37 @@ Future<void> _buildGradleProjectV2(
     command.add('-Ptarget-platform=${getNameForTargetPlatform(buildInfo.targetPlatform)}');
 
   command.add(assembleTask);
+  bool potentialAndroidXFailure = false;
   final int exitCode = await runCommandAndStreamOutput(
     command,
     workingDirectory: flutterProject.android.hostAppGradleRoot.path,
     allowReentrantFlutter: true,
     environment: _gradleEnv,
-    filter: logger.isVerbose ? null : ndkMessageFilter,
+    mapFunction: (String line) {
+      if (androidXFailureRegex.hasMatch(line)) {
+        potentialAndroidXFailure = true;
+      }
+      // Always print the full line in verbose mode.
+      if (logger.isVerbose) {
+        return line;
+      } else if (androidXPluginWarningRegex.hasMatch(line) || !ndkMessageFilter.hasMatch(line)) {
+        return null;
+      }
+
+      return line;
+    }
   );
   status.stop();
 
-  if (exitCode != 0)
+  if (exitCode != 0) {
+    if (potentialAndroidXFailure) {
+      printError('*******************************************************************************************');
+      printError('The Gradle failure may have been because of AndroidX incompatibilities in this Flutter app.');
+      printError('See [WIP link] for more information on the problem and how to fix it.');
+      printError('*******************************************************************************************');
+    }
     throwToolExit('Gradle task $assembleTask failed with exit code $exitCode', exitCode: exitCode);
+  }
 
   if(!isBuildingBundle) {
     final File apkFile = _findApkFile(project, buildInfo);

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -63,8 +63,7 @@ final RegExp androidXFailureRegex = RegExp(r'(AAPT|androidx|android\.support)');
 
 final RegExp androidXPluginWarningRegex = RegExp(r'\*{57}'
   r"|WARNING: This version of (\w+) will break your Android build if it or its dependencies aren't compatible with AndroidX."
-  r'|https://goo.gl/y9dCcU describes AndroidX and how to migrate to it using Android Studio.'
-  r"|https://goo.gl/n2E4mD describes how to open a Flutter app's Android files for refactoring in Android Studio."
+  r'|See https://goo.gl/CP92wY for more information on the problem and how to fix it.'
   r'|This warning prints for all Android build failures. The real root cause of the error may be unrelated.');
 
 FlutterPluginVersion getFlutterPluginVersion(AndroidProject project) {

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -122,6 +122,12 @@ Future<Process> runCommand(List<String> cmd, {
 
 /// This runs the command and streams stdout/stderr from the child process to
 /// this process' stdout/stderr. Completes with the process's exit code.
+///
+/// If [filter] is null, no lines are removed.
+///
+/// If [filter] is non-null, all lines that do not match it are removed. If
+/// [mapFunction] is present, all lines that match [filter] are also forwarded
+/// to [mapFunction] for further processing.
 Future<int> runCommandAndStreamOutput(List<String> cmd, {
   String workingDirectory,
   bool allowReentrantFlutter = false,

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -41,7 +41,51 @@ void main() {
       expect(shouldBeToolExit, isToolExit);
     });
 
-    test('regexp should only match lines without the error message', () {
+    test('androidXFailureRegex should match lines with likely AndroidX errors', () {
+      final List<String> nonMatchingLines = <String>[
+        ':app:preBuild UP-TO-DATE',
+        'BUILD SUCCESSFUL in 0s',
+        '',
+      ];
+      final List<String> matchingLines = <String>[
+        'AAPT: error: resource android:attr/fontVariationSettings not found.',
+        'AAPT: error: resource android:attr/ttcIndex not found.',
+        'error: package android.support.annotation does not exist',
+        'import android.support.annotation.NonNull;',
+        'import androidx.annotation.NonNull;',
+        'Daemon:  AAPT2 aapt2-3.2.1-4818971-linux Daemon #0',
+      ];
+      for (String m in nonMatchingLines) {
+        expect(androidXFailureRegex.hasMatch(m), isFalse);
+      }
+      for (String m in matchingLines) {
+        expect(androidXFailureRegex.hasMatch(m), isTrue);
+      }
+    });
+
+    test('androidXPluginWarningRegex should match lines with the AndroidX plugin warnings', () {
+      final List<String> nonMatchingLines = <String>[
+        ':app:preBuild UP-TO-DATE',
+        'BUILD SUCCESSFUL in 0s',
+        'Generic plugin AndroidX text',
+        '',
+      ];
+      final List<String> matchingLines = <String>[
+        '*********************************************************************************************************************************',
+        "WARNING: This version of image_picker will break your Android build if it or its dependencies aren't compatible with AndroidX.",
+        'https://goo.gl/y9dCcU describes AndroidX and how to migrate to it using Android Studio.',
+        "https://goo.gl/n2E4mD describes how to open a Flutter app's Android files for refactoring in Android Studio.",
+        'This warning prints for all Android build failures. The real root cause of the error may be unrelated.',
+      ];
+      for (String m in nonMatchingLines) {
+        expect(androidXPluginWarningRegex.hasMatch(m), isFalse);
+      }
+      for (String m in matchingLines) {
+        expect(androidXPluginWarningRegex.hasMatch(m), isTrue);
+      }
+    });
+
+    test('ndkMessageFilter should only match lines without the error message', () {
       final List<String> nonMatchingLines = <String>[
         'NDK is missing a "platforms" directory.',
         'If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to /usr/local/company/home/username/Android/Sdk/ndk-bundle.',

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -73,8 +73,7 @@ void main() {
       final List<String> matchingLines = <String>[
         '*********************************************************************************************************************************',
         "WARNING: This version of image_picker will break your Android build if it or its dependencies aren't compatible with AndroidX.",
-        'https://goo.gl/y9dCcU describes AndroidX and how to migrate to it using Android Studio.',
-        "https://goo.gl/n2E4mD describes how to open a Flutter app's Android files for refactoring in Android Studio.",
+        'See https://goo.gl/CP92wY for more information on the problem and how to fix it.',
         'This warning prints for all Android build failures. The real root cause of the error may be unrelated.',
       ];
       for (String m in nonMatchingLines) {


### PR DESCRIPTION
Try to detect Gradle error messages that hint at AndroidX problems, and
warn in the logs about the potential problem and point to documentation
on how to fix the issue.

Unfortunately the Gradle errors based on this root issue are varied and
project dependent. It's probably better to still leave the message
intact in case the problem is unrelated.

Also filters out the plugin warning message pending in
flutter/plugins#1138. It's still valuable to add that for people on
previous versions of Flutter, but this link should override that message
for anyone on an up to date version of Flutter.

flutter/flutter#27106