### PR TITLE
We don't need to catch errors that we are handling at codec level

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -280,12 +280,17 @@ abstract class ImageProvider<T> {
         }
       );
     }
-    obtainKey(configuration).then<void>((T key) {
-      obtainedKey = key;
-      final ImageStreamCompleter completer = PaintingBinding.instance.imageCache.putIfAbsent(key, () => load(key), onError: handleError);
-      if (completer != null) {
-        stream.setCompleter(completer);
-      }
+
+    Future<void>.sync(() {
+      obtainKey(configuration).then<void>((T key) {
+        obtainedKey = key;
+        final ImageStreamCompleter completer = PaintingBinding
+            .instance.imageCache
+            .putIfAbsent(key, () => load(key), onError: handleError);
+        if (completer != null) {
+          stream.setCompleter(completer);
+        }
+      });
     }).catchError(handleError);
     return stream;
   }


### PR DESCRIPTION
- This catch is not neccessary since we handle all these errors in codecs.

- Verified by that codecs do catch valid mime-type, invalid image body errors.