### PR TITLE
[flutter_driver] Use async call to run SSH cmds w/o deadlock.

### DIFF
--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -49,7 +49,13 @@ class _DummySshCommandRunner implements SshCommandRunner {
       final List<String> splitCommand = command.split(' ');
       final String exe = splitCommand[0];
       final List<String> args = splitCommand.skip(1).toList();
-      final ProcessResult r = Process.runSync(exe, args);
+      // This needs to remain async in the event that this command attempts to
+      // access something (like the hub) that requires interaction with this
+      // process's event loop. A specific example is attempting to run `find`, a
+      // synchronous command, on this own process's `out` directory. As `find`
+      // will wait indefinitely for the `out` directory to be serviced, causing
+      // a deadlock.
+      final ProcessResult r = await Process.run(exe, args);
       return r.stdout.split('\n');
     } on ProcessException catch (e) {
       _log.warning("Error running '$command': $e");
@@ -93,7 +99,7 @@ class FuchsiaCompat {
   /// [FuchsiaRemoteConnection.stop].
   static Future<FuchsiaRemoteConnection> connect() async {
     FuchsiaCompat._init();
-    return FuchsiaRemoteConnection
-        .connectWithSshCommandRunner(_DummySshCommandRunner());
+    return FuchsiaRemoteConnection.connectWithSshCommandRunner(
+        _DummySshCommandRunner());
   }
 }


### PR DESCRIPTION
For `fuchsia_compat.dart` Instead of using `runSync`, use `run` to avoid
deadlock when attempting to access specific resources like the Hub in Fuchsia.

The specific example is that in Fuchsia, the `find` command is
attempting to explore `out` which hasn't yet been serviced, as `find` is
blocking on it, causing a deadlock.