### PR TITLE
Check powershell version.

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -23,6 +23,15 @@ $engineVersion = (Get-Content "$flutterRoot\bin\internal\engine.version")
 
 $oldDartSdkPrefix = "dart-sdk.old"
 
+# Make sure that PowerShell has expected version.
+$psMajorVersionRequired = 5
+$psMajorVersionLocal = $PSVersionTable.PSVersion.Major
+if ($psMajorVersionLocal -lt $psMajorVersionRequired) {
+    Write-Host "Flutter requires PowerShell $psMajorVersionRequired.0 or newer."
+    Write-Host "See https://flutter.io/docs/get-started/install/windows for more."
+    return
+}
+
 if ((Test-Path $engineStamp) -and ($engineVersion -eq (Get-Content $engineStamp))) {
     return
 }


### PR DESCRIPTION
Now flutter requires powershell 5.0 and newer.
However, this is only documented and if a developer is using PowerShell with oldversion, like 2.0, as Invoke-WebRequest is not introduced, the error message would be quite unclear and misleading:
Like 
```
.\flutter\bin\internal\update_dart_sdk.psl:53 字符：22

* Invoke-WebRequest <<<< -uri $dartsdkUrl -OutFile $dartSdkZip
* CategoryInfo : ObjectNotFound:(Invoke-WebRequest: Strg)[], P
* FullyQualifiedErrorId : CommandNotFoundException
  Error: Unable to update Dart SDK. Retrying...
```
in https://github.com/flutter/flutter/issues/27276
See: https://flutter.io/docs/get-started/install/windows