### PR TITLE
Fixed #27621: CupertinoTimerPicker breaks if minuteInterval > 1

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1150,7 +1150,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       backgroundColor: _kBackgroundColor,
       onSelectedItemChanged: (int index) {
         setState(() {
-          selectedMinute = index;
+          selectedMinute = index * widget.minuteInterval;
           widget.onTimerDurationChanged(
             Duration(
               hours: selectedHour ?? 0,
@@ -1262,7 +1262,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       backgroundColor: _kBackgroundColor,
       onSelectedItemChanged: (int index) {
         setState(() {
-          selectedSecond = index;
+          selectedSecond = index * widget.secondInterval;
           widget.onTimerDurationChanged(
             Duration(
               hours: selectedHour ?? 0,

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -227,9 +227,8 @@ void main() {
 
     expect(
       duration,
-      Duration(hours: 10, minutes: 50, seconds: 30),
+      const Duration(hours: 10, minutes: 50, seconds: 30),
     );
-
   });
 
   group('Date picker', () {

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -198,6 +198,40 @@ void main() {
       );
     });
   });
+
+  testWidgets('picker honors minuteInterval and secondInterval', (WidgetTester tester) async {
+    Duration duration;
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: SizedBox(
+          height: 400.0,
+          width: 400.0,
+          child: CupertinoTimerPicker(
+            minuteInterval: 10,
+            secondInterval: 15,
+            initialTimerDuration: const Duration(hours: 10, minutes: 40, seconds: 45),
+            mode: CupertinoTimerPickerMode.hms,
+            onTimerDurationChanged: (Duration d) {
+              duration = d;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(find.text('40'), _kRowOffset);
+    await tester.pump();
+    await tester.drag(find.text('45'), -_kRowOffset);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(
+      duration,
+      Duration(hours: 10, minutes: 50, seconds: 30),
+    );
+
+  });
+
   group('Date picker', () {
     testWidgets('mode is not null', (WidgetTester tester) async {
       expect(


### PR DESCRIPTION
The bug occurred because minuteInterval was not taken into account when calculating the selected minute from selected index. The same bug, it turns out, exists for seconds. I fixed both. 

I tested my fix by changing the Flutter demo app that uses CupertinoTimePicker by specifying minuteInterval and secondInterval. I am not including my changes to the demo app in this pull request but I can if you want me to.