### PR TITLE
Add android studio process logic for JetBrainsToolbox

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -28,6 +28,7 @@ final RegExp _dotHomeStudioVersionMatcher =
     RegExp(r'^\.(AndroidStudio[^\d]*)([\d.]+)');
 final RegExp _pathsSelectorMatcher =
     RegExp(r'"idea.paths.selector" = "AndroidStudio[^;]+"');
+const String kJetBrainsToolboxAppKey = 'JetBrainsToolboxApp';
 
 String get javaPath => androidStudio?.javaPath;
 
@@ -39,8 +40,18 @@ class AndroidStudio implements Comparable<AndroidStudio> {
   }
 
   factory AndroidStudio.fromMacOSBundle(String bundlePath) {
-    final String studioPath = fs.path.join(bundlePath, 'Contents');
-    final String plistFile = fs.path.join(studioPath, 'Info.plist');
+    String studioPath = fs.path.join(bundlePath, 'Contents');
+    String plistFile = fs.path.join(studioPath, 'Info.plist');
+
+    final String jetBrainsToolboxAppBundlePath = iosWorkflow.getPlistValueFromFile(
+      plistFile,
+      kJetBrainsToolboxAppKey,
+    );
+    if (jetBrainsToolboxAppBundlePath != null) {
+      studioPath = fs.path.join(jetBrainsToolboxAppBundlePath, 'Contents');
+      plistFile = fs.path.join(studioPath, 'Info.plist');
+    }
+
     final String versionString = iosWorkflow.getPlistValueFromFile(
       plistFile,
       plist.kCFBundleShortVersionStringKey,

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -54,7 +54,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       plistFile,
       null,
     );
-    final String pathsSelectorValue = _pathsSelectorMatcher.stringMatch(plistValue).split('=').last.trim().replaceAll('"', '');
+    final String pathsSelectorValue = _pathsSelectorMatcher.stringMatch(plistValue)?.split('=')?.last?.trim()?.replaceAll('"', '');
     return AndroidStudio(studioPath, version: version, pathsSelectorPath: pathsSelectorValue);
   }
 
@@ -107,11 +107,19 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       final int major = version.major;
       final int minor = version.minor;
       if (platform.isMacOS) {
-        _pluginsPath = fs.path.join(
-            homeDirPath,
-            'Library',
-            'Application Support',
-            '$pathsSelectorPath');
+        if (pathsSelectorPath != null) {
+          _pluginsPath = fs.path.join(
+              homeDirPath,
+              'Library',
+              'Application Support',
+              '$pathsSelectorPath');
+        } else {
+          _pluginsPath = fs.path.join(
+              homeDirPath,
+              'Library',
+              'Application Support',
+              'AndroidStudio$major.$minor');
+        }
       } else {
         _pluginsPath = fs.path.join(homeDirPath,
             '.$studioAppName$major.$minor',

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -26,10 +26,6 @@ AndroidStudio get androidStudio => context[AndroidStudio];
 
 final RegExp _dotHomeStudioVersionMatcher =
     RegExp(r'^\.(AndroidStudio[^\d]*)([\d.]+)');
-final RegExp _pathsSelectorMatcher =
-    RegExp(r'"idea.paths.selector" = "[^;]+"');
-final RegExp _jetBrainsToolboxAppMatcher =
-    RegExp(r'JetBrainsToolboxApp = "[^;]+"');
 
 String get javaPath => androidStudio?.javaPath;
 
@@ -47,6 +43,8 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       plistFile,
       null,
     );
+    final RegExp _pathsSelectorMatcher = RegExp(r'"idea.paths.selector" = "[^;]+"');
+    final RegExp _jetBrainsToolboxAppMatcher = RegExp(r'JetBrainsToolboxApp = "[^;]+"');
     // As AndroidStudio managed by JetBrainsToolbox could have a wrapper pointing to the real Android Studio.
     // Check if we've found a JetBrainsToolbox wrapper and deal with it properly.
     final String jetBrainsToolboxAppBundlePath = extractStudioPlistValueWithMatcher(plistValue, _jetBrainsToolboxAppMatcher);
@@ -69,8 +67,9 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       version = Version.parse(versionString);
 
     final String pathsSelectorValue = extractStudioPlistValueWithMatcher(plistValue, _pathsSelectorMatcher);
-    final String presetPluginsPath = pathsSelectorValue == null ? null :
-                                      fs.path.join(homeDirPath, 'Library', 'Application Support', '$pathsSelectorValue');
+    final String presetPluginsPath = pathsSelectorValue == null
+        ? null
+        : fs.path.join(homeDirPath, 'Library', 'Application Support', '$pathsSelectorValue');
     return AndroidStudio(studioPath, version: version, presetPluginsPath: presetPluginsPath);
   }
 


### PR DESCRIPTION
When searching for android studio plugins path, use the 'idea.paths.selector' as first priority, but when it doesn't exist, use the old version logic.
This will fix: https://github.com/flutter/flutter/issues/27670
https://github.com/flutter/flutter/issues/27136
https://github.com/flutter/flutter/issues/27762
Also see: https://github.com/flutter/flutter/issues/26928