### PR TITLE
remove super_goes_last

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -151,7 +151,7 @@ linter:
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
-    - super_goes_last
+    # - super_goes_last # no longer needed w/ Dart 2
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -67,7 +67,7 @@ linter:
     - slash_for_doc_comments
     # - sort_constructors_first
     # - sort_unnamed_constructors_first
-    - super_goes_last
+    # - super_goes_last # no longer needed w/ Dart 2
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types


### PR DESCRIPTION
In Dart 2, it is a compile-time error if a superinitializer
appears in an initializer list at any other position than at the end so this
rule is made redundant by the Dart analyzer's basic checks and is no longer
necessary.

Also note that with the latest linter, this lint is deprecated and will cause analysis errors:

https://ci.chromium.org/p/dart/builders/luci.dart.try/flutter-analyze-try/24

/cc @dnfield @Hixie 