### PR TITLE
[Material] Update the card demo in the Gallery to demonstrate different uses of the Card widget

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -16,25 +16,26 @@ enum CardDemoType {
 }
 
 class TravelDestination {
-  const TravelDestination({
-    this.assetName,
-    this.assetPackage,
-    this.title,
-    this.description,
+  TravelDestination({
+    @required this.assetName,
+    @required this.assetPackage,
+    @required this.title,
+    @required this.description,
     this.type = CardDemoType.standard,
-  });
+  }) : assert(assetName != null),
+       assert(assetPackage != null),
+       assert(title != null),
+       assert(description != null && description?.length == 3);
 
   final String assetName;
   final String assetPackage;
   final String title;
   final List<String> description;
   final CardDemoType type;
-
-  bool get isValid => assetName != null && title != null && description?.length == 3;
 }
 
 final List<TravelDestination> destinations = <TravelDestination>[
-  const TravelDestination(
+  TravelDestination(
     assetName: 'places/india_thanjavur_market.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Top 10 Cities to Visit in Tamil Nadu',
@@ -44,7 +45,7 @@ final List<TravelDestination> destinations = <TravelDestination>[
       'Thanjavur, Tamil Nadu',
     ],
   ),
-  const TravelDestination(
+  TravelDestination(
     assetName: 'places/india_chettinad_silk_maker.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Artisans of Southern India',
@@ -55,7 +56,7 @@ final List<TravelDestination> destinations = <TravelDestination>[
     ],
     type: CardDemoType.tappable,
   ),
-  const TravelDestination(
+  TravelDestination(
     assetName: 'places/india_tanjore_thanjavur_temple.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Brihadisvara Temple',
@@ -69,10 +70,11 @@ final List<TravelDestination> destinations = <TravelDestination>[
 ];
 
 class TravelDestinationItem extends StatelessWidget {
-  TravelDestinationItem({ Key key, @required this.destination, this.shape })
-    : assert(destination != null && destination.isValid),
+  const TravelDestinationItem({ Key key, @required this.destination, this.shape })
+    : assert(destination != null),
       super(key: key);
 
+  // This height will allow for all the Card's content to fit comfortably within the card.
   static const double height = 366.0;
   final TravelDestination destination;
   final ShapeBorder shape;
@@ -87,9 +89,10 @@ class TravelDestinationItem extends StatelessWidget {
         child: Column(
           children: <Widget>[
             const SectionTitle(title: 'Card with actions'),
-            Container(
+            SizedBox(
               height: height,
               child: Card(
+                // This ensures that the Card's children are clipped correctly.
                 clipBehavior: Clip.antiAlias,
                 shape: shape,
                 child: TravelDestinationContent(destination: destination),
@@ -103,10 +106,11 @@ class TravelDestinationItem extends StatelessWidget {
 }
 
 class TappableTravelDestinationItem extends StatelessWidget {
-  TappableTravelDestinationItem({ Key key, @required this.destination, this.shape })
-      : assert(destination != null && destination.isValid),
-        super(key: key);
+  const TappableTravelDestinationItem({ Key key, @required this.destination, this.shape })
+    : assert(destination != null),
+      super(key: key);
 
+  // This height will allow for all the Card's content to fit comfortably within the card.
   static const double height = 312.0;
   final TravelDestination destination;
   final ShapeBorder shape;
@@ -121,9 +125,10 @@ class TappableTravelDestinationItem extends StatelessWidget {
         child: Column(
           children: <Widget>[
             const SectionTitle(title: 'Card that can be tapped'),
-            Container(
+            SizedBox(
               height: height,
               child: Card(
+                // This ensures that the Card's children (including the ink splash) are clipped correctly.
                 clipBehavior: Clip.antiAlias,
                 shape: shape,
                 child: InkWell(
@@ -143,9 +148,9 @@ class TappableTravelDestinationItem extends StatelessWidget {
 }
 
 class SelectableTravelDestinationItem extends StatefulWidget {
-  SelectableTravelDestinationItem({ Key key, @required this.destination, this.shape })
-      : assert(destination != null && destination.isValid),
-        super(key: key);
+  const SelectableTravelDestinationItem({ Key key, @required this.destination, this.shape })
+    : assert(destination != null),
+      super(key: key);
 
   final TravelDestination destination;
   final ShapeBorder shape;
@@ -156,6 +161,7 @@ class SelectableTravelDestinationItem extends StatefulWidget {
 
 class _SelectableTravelDestinationItemState extends State<SelectableTravelDestinationItem> {
 
+  // This height will allow for all the Card's content to fit comfortably within the card.
   static const double height = 312.0;
   bool _isSelected = false;
 
@@ -169,9 +175,10 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
         child: Column(
           children: <Widget>[
             const SectionTitle(title: 'Card that can be selected'),
-            Container(
+            SizedBox(
               height: height,
               child: Card(
+                // This ensures that the Card's children (including the ink splash) are clipped correctly.
                 clipBehavior: Clip.antiAlias,
                 shape: widget.shape,
                 child: InkWell(
@@ -185,21 +192,20 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
                   child: Stack(
                     children: <Widget>[
                       TravelDestinationContent(destination: widget.destination),
-                      Opacity(
-                        opacity: _isSelected ? 1 : 0,
-                        child: Container(
-                          color: Theme.of(context).colorScheme.primary.withAlpha(41),
-                        ),
+                      Container(
+                        color: _isSelected
+                          ? Theme.of(context).colorScheme.primary.withAlpha(41)
+                          : Colors.transparent,
                       ),
-                      Opacity(
-                        opacity: _isSelected ? 1 : 0,
-                        child: const Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: EdgeInsets.all(4.0),
-                              child: Icon(Icons.check_circle, color: Colors.white,),
-                            )
-                        ),
+                      Align(
+                        alignment: Alignment.topRight,
+                        child: Padding(
+                          padding: EdgeInsets.all(4.0),
+                          child: Icon(
+                            Icons.check_circle,
+                            color: _isSelected ? Colors.white : Colors.transparent,
+                          ),
+                        )
                       ),
                     ],
                   )
@@ -234,9 +240,9 @@ class SectionTitle extends StatelessWidget {
 }
 
 class TravelDestinationContent extends StatelessWidget {
-  TravelDestinationContent({ Key key, @required this.destination })
-      : assert(destination != null && destination.isValid),
-        super(key: key);
+  const TravelDestinationContent({ Key key, @required this.destination })
+    : assert(destination != null),
+      super(key: key);
 
   final TravelDestination destination;
 
@@ -246,7 +252,10 @@ class TravelDestinationContent extends StatelessWidget {
     final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
     final TextStyle descriptionStyle = theme.textTheme.subhead;
 
-    // Use Ink.image in order for the ink ripple to appear over the image.
+    // In order to have the ink splash appear above the child image, you must
+    // use Ink.image. This allows the image to become part of the Material and
+    // display ink effects above it. Using a standard Image will obscure the ink
+    // splash.
     final Widget image = destination.type == CardDemoType.standard
       ? Image.asset(
           destination.assetName,

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -246,6 +246,7 @@ class TravelDestinationContent extends StatelessWidget {
     final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
     final TextStyle descriptionStyle = theme.textTheme.subhead;
 
+    // Use Ink.image in order for the ink ripple to appear over the image
     final Widget image = destination.type == CardDemoType.static
         ? Image.asset(destination.assetName, package: destination.assetPackage, fit: BoxFit.cover,)
         : Ink.image(image: AssetImage(destination.assetName, package: destination.assetPackage), fit: BoxFit.cover, child: Container(),);

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -88,7 +88,7 @@ class TravelDestinationItem extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            const SectionTitle(title: 'Card with actions'),
+            const SectionTitle(title: 'Normal'),
             SizedBox(
               height: height,
               child: Card(
@@ -124,7 +124,7 @@ class TappableTravelDestinationItem extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            const SectionTitle(title: 'Card that can be tapped'),
+            const SectionTitle(title: 'Tappable'),
             SizedBox(
               height: height,
               child: Card(
@@ -174,7 +174,7 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            const SectionTitle(title: 'Card that can be selected (long press)'),
+            const SectionTitle(title: 'Selectable (long press)'),
             SizedBox(
               height: height,
               child: Card(
@@ -252,22 +252,6 @@ class TravelDestinationContent extends StatelessWidget {
     final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
     final TextStyle descriptionStyle = theme.textTheme.subhead;
 
-    // In order to have the ink splash appear above the child image, you must
-    // use Ink.image. This allows the image to become part of the Material and
-    // display ink effects above it. Using a standard Image will obscure the ink
-    // splash.
-    final Widget image = destination.type == CardDemoType.standard
-      ? Image.asset(
-          destination.assetName,
-          package: destination.assetPackage,
-          fit: BoxFit.cover,
-        )
-      : Ink.image(
-          image: AssetImage(destination.assetName, package: destination.assetPackage),
-          fit: BoxFit.cover,
-          child: Container(),
-        );
-
     final List<Widget> children = <Widget>[
       // Photo and title.
       SizedBox(
@@ -275,7 +259,15 @@ class TravelDestinationContent extends StatelessWidget {
         child: Stack(
           children: <Widget>[
             Positioned.fill(
-              child: image,
+              // In order to have the ink splash appear above the image, you
+              // must use Ink.image. This allows the image to be painted as part
+              // of the Material and display ink effects above it. Using a
+              // standard Image will obscure the ink splash.
+              child: Ink.image(
+                image: AssetImage(destination.assetName, package: destination.assetPackage),
+                fit: BoxFit.cover,
+                child: Container(),
+              )
             ),
             Positioned(
               bottom: 16.0,

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -16,55 +16,55 @@ enum CardDemoType {
 }
 
 class TravelDestination {
-  TravelDestination({
+  const TravelDestination({
     @required this.assetName,
     @required this.assetPackage,
     @required this.title,
     @required this.description,
+    @required this.city,
+    @required this.location,
     this.type = CardDemoType.standard,
   }) : assert(assetName != null),
        assert(assetPackage != null),
        assert(title != null),
-       assert(description != null && description?.length == 3);
+       assert(description != null),
+       assert(city != null),
+       assert(location != null);
 
   final String assetName;
   final String assetPackage;
   final String title;
-  final List<String> description;
+  final String description;
+  final String city;
+  final String location;
   final CardDemoType type;
 }
 
-final List<TravelDestination> destinations = <TravelDestination>[
+const List<TravelDestination> destinations = <TravelDestination>[
   TravelDestination(
     assetName: 'places/india_thanjavur_market.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Top 10 Cities to Visit in Tamil Nadu',
-    description: <String>[
-      'Number 10',
-      'Thanjavur',
-      'Thanjavur, Tamil Nadu',
-    ],
+    description: 'Number 10',
+    city: 'Thanjavur',
+    location: 'Thanjavur, Tamil Nadu',
   ),
   TravelDestination(
     assetName: 'places/india_chettinad_silk_maker.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Artisans of Southern India',
-    description: <String>[
-      'Silk Spinners',
-      'Chettinad',
-      'Sivaganga, Tamil Nadu',
-    ],
+    description: 'Silk Spinners',
+    city: 'Chettinad',
+    location: 'Sivaganga, Tamil Nadu',
     type: CardDemoType.tappable,
   ),
   TravelDestination(
     assetName: 'places/india_tanjore_thanjavur_temple.png',
     assetPackage: _kGalleryAssetsPackage,
     title: 'Brihadisvara Temple',
-    description: <String>[
-      'Temples',
-      'Thanjavur',
-      'Thanjavur, Tamil Nadu',
-    ],
+    description: 'Temples',
+    city: 'Thanjavur',
+    location: 'Thanjavur, Tamil Nadu',
     type: CardDemoType.selectable,
   )
 ];
@@ -174,7 +174,7 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            const SectionTitle(title: 'Card that can be selected'),
+            const SectionTitle(title: 'Card that can be selected (long press)'),
             SizedBox(
               height: height,
               child: Card(
@@ -308,12 +308,12 @@ class TravelDestinationContent extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8.0),
                   child: Text(
-                    destination.description[0],
+                    destination.description,
                     style: descriptionStyle.copyWith(color: Colors.black54),
                   ),
                 ),
-                Text(destination.description[1]),
-                Text(destination.description[2]),
+                Text(destination.city),
+                Text(destination.location),
               ],
             ),
           ),

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -191,12 +191,12 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
                   splashColor: Theme.of(context).colorScheme.primary.withAlpha(30),
                   child: Stack(
                     children: <Widget>[
-                      TravelDestinationContent(destination: widget.destination),
                       Container(
                         color: _isSelected
                           ? Theme.of(context).colorScheme.primary.withAlpha(41)
                           : Colors.transparent,
                       ),
+                      TravelDestinationContent(destination: widget.destination),
                       Align(
                         alignment: Alignment.topRight,
                         child: Padding(

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -10,7 +10,7 @@ import '../../gallery/demo.dart';
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
 
 enum CardDemoType {
-  static,
+  standard,
   tappable,
   selectable,
 }
@@ -21,7 +21,7 @@ class TravelDestination {
     this.assetPackage,
     this.title,
     this.description,
-    this.type = CardDemoType.static,
+    this.type = CardDemoType.standard,
   });
 
   final String assetName;
@@ -224,10 +224,10 @@ class SectionTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(4, 4, 4, 12),
+      padding: const EdgeInsets.fromLTRB(4.0, 4.0, 4.0, 12.0),
       child: Align(
         alignment: Alignment.centerLeft,
-        child: Text(title, style: Theme.of(context).textTheme.subhead,),
+        child: Text(title, style: Theme.of(context).textTheme.subhead),
       ),
     );
   }
@@ -246,13 +246,21 @@ class TravelDestinationContent extends StatelessWidget {
     final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
     final TextStyle descriptionStyle = theme.textTheme.subhead;
 
-    // Use Ink.image in order for the ink ripple to appear over the image
-    final Widget image = destination.type == CardDemoType.static
-        ? Image.asset(destination.assetName, package: destination.assetPackage, fit: BoxFit.cover,)
-        : Ink.image(image: AssetImage(destination.assetName, package: destination.assetPackage), fit: BoxFit.cover, child: Container(),);
+    // Use Ink.image in order for the ink ripple to appear over the image.
+    final Widget image = destination.type == CardDemoType.standard
+      ? Image.asset(
+          destination.assetName,
+          package: destination.assetPackage,
+          fit: BoxFit.cover,
+        )
+      : Ink.image(
+          image: AssetImage(destination.assetName, package: destination.assetPackage),
+          fit: BoxFit.cover,
+          child: Container(),
+        );
 
     final List<Widget> children = <Widget>[
-      // photo and title
+      // Photo and title.
       SizedBox(
         height: 184.0,
         child: Stack(
@@ -267,7 +275,8 @@ class TravelDestinationContent extends StatelessWidget {
               child: FittedBox(
                 fit: BoxFit.scaleDown,
                 alignment: Alignment.centerLeft,
-                child: Text(destination.title,
+                child: Text(
+                  destination.title,
                   style: titleStyle,
                 ),
               ),
@@ -275,7 +284,7 @@ class TravelDestinationContent extends StatelessWidget {
           ],
         ),
       ),
-      // description and share/explore buttons
+      // Description and share/explore buttons.
       Expanded(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
@@ -303,7 +312,7 @@ class TravelDestinationContent extends StatelessWidget {
       ),
     ];
 
-    if (destination.type == CardDemoType.static) {
+    if (destination.type == CardDemoType.standard) {
       children.add(
         // share, explore buttons
         ButtonTheme.bar(
@@ -313,12 +322,12 @@ class TravelDestinationContent extends StatelessWidget {
               FlatButton(
                 child: Text('SHARE', semanticsLabel: 'Share ${destination.title}'),
                 textColor: Colors.amber.shade500,
-                onPressed: () { /* do nothing */ },
+                onPressed: () { print('pressed'); },
               ),
               FlatButton(
                 child: Text('EXPLORE', semanticsLabel: 'Explore ${destination.title}'),
                 textColor: Colors.amber.shade500,
-                onPressed: () { /* do nothing */ },
+                onPressed: () { print('pressed'); },
               ),
             ],
           ),
@@ -375,14 +384,14 @@ class _CardsDemoState extends State<CardsDemo> {
         children: destinations.map<Widget>((TravelDestination destination) {
           Widget child;
           switch (destination.type) {
-            case CardDemoType.static:
-              child = TravelDestinationItem(destination: destination, shape: _shape,);
+            case CardDemoType.standard:
+              child = TravelDestinationItem(destination: destination, shape: _shape);
               break;
             case CardDemoType.tappable:
-              child = TappableTravelDestinationItem(destination: destination, shape: _shape,);
+              child = TappableTravelDestinationItem(destination: destination, shape: _shape);
               break;
             case CardDemoType.selectable:
-              child = SelectableTravelDestinationItem(destination: destination, shape: _shape,);
+              child = SelectableTravelDestinationItem(destination: destination, shape: _shape);
               break;
           }
 

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -200,7 +200,7 @@ class _SelectableTravelDestinationItemState extends State<SelectableTravelDestin
                       Align(
                         alignment: Alignment.topRight,
                         child: Padding(
-                          padding: EdgeInsets.all(4.0),
+                          padding: const EdgeInsets.all(4.0),
                           child: Icon(
                             Icons.check_circle,
                             color: _isSelected ? Colors.white : Colors.transparent,

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -75,7 +75,7 @@ class TravelDestinationItem extends StatelessWidget {
       super(key: key);
 
   // This height will allow for all the Card's content to fit comfortably within the card.
-  static const double height = 366.0;
+  static const double height = 338.0;
   final TravelDestination destination;
   final ShapeBorder shape;
 
@@ -111,7 +111,7 @@ class TappableTravelDestinationItem extends StatelessWidget {
       super(key: key);
 
   // This height will allow for all the Card's content to fit comfortably within the card.
-  static const double height = 312.0;
+  static const double height = 298.0;
   final TravelDestination destination;
   final ShapeBorder shape;
 
@@ -162,7 +162,7 @@ class SelectableTravelDestinationItem extends StatefulWidget {
 class _SelectableTravelDestinationItemState extends State<SelectableTravelDestinationItem> {
 
   // This height will allow for all the Card's content to fit comfortably within the card.
-  static const double height = 312.0;
+  static const double height = 298.0;
   bool _isSelected = false;
 
   @override
@@ -294,28 +294,26 @@ class TravelDestinationContent extends StatelessWidget {
         ),
       ),
       // Description and share/explore buttons.
-      Expanded(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
-          child: DefaultTextStyle(
-            softWrap: false,
-            overflow: TextOverflow.ellipsis,
-            style: descriptionStyle,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                // three line description
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8.0),
-                  child: Text(
-                    destination.description,
-                    style: descriptionStyle.copyWith(color: Colors.black54),
-                  ),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
+        child: DefaultTextStyle(
+          softWrap: false,
+          overflow: TextOverflow.ellipsis,
+          style: descriptionStyle,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              // three line description
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  destination.description,
+                  style: descriptionStyle.copyWith(color: Colors.black54),
                 ),
-                Text(destination.city),
-                Text(destination.location),
-              ],
-            ),
+              ),
+              Text(destination.city),
+              Text(destination.location),
+            ],
           ),
         ),
       ),

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -251,7 +251,7 @@ class TravelDestinationContent extends StatelessWidget {
         ? Image.asset(destination.assetName, package: destination.assetPackage, fit: BoxFit.cover,)
         : Ink.image(image: AssetImage(destination.assetName, package: destination.assetPackage), fit: BoxFit.cover, child: Container(),);
 
-    final List<Widget> children = [
+    final List<Widget> children = <Widget>[
       // photo and title
       SizedBox(
         height: 184.0,

--- a/examples/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -9,18 +9,26 @@ import '../../gallery/demo.dart';
 
 const String _kGalleryAssetsPackage = 'flutter_gallery_assets';
 
+enum CardDemoType {
+  static,
+  tappable,
+  selectable,
+}
+
 class TravelDestination {
   const TravelDestination({
     this.assetName,
     this.assetPackage,
     this.title,
     this.description,
+    this.type = CardDemoType.static,
   });
 
   final String assetName;
   final String assetPackage;
   final String title;
   final List<String> description;
+  final CardDemoType type;
 
   bool get isValid => assetName != null && title != null && description?.length == 3;
 }
@@ -45,6 +53,18 @@ final List<TravelDestination> destinations = <TravelDestination>[
       'Chettinad',
       'Sivaganga, Tamil Nadu',
     ],
+    type: CardDemoType.tappable,
+  ),
+  const TravelDestination(
+    assetName: 'places/india_tanjore_thanjavur_temple.png',
+    assetPackage: _kGalleryAssetsPackage,
+    title: 'Brihadisvara Temple',
+    description: <String>[
+      'Temples',
+      'Thanjavur',
+      'Thanjavur, Tamil Nadu',
+    ],
+    type: CardDemoType.selectable,
   )
 ];
 
@@ -59,101 +79,258 @@ class TravelDestinationItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
-    final TextStyle descriptionStyle = theme.textTheme.subhead;
-
     return SafeArea(
       top: false,
       bottom: false,
-      child: Container(
+      child: Padding(
         padding: const EdgeInsets.all(8.0),
-        height: height,
-        child: Card(
-          clipBehavior: Clip.antiAlias,
-          shape: shape,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              // photo and title
-              SizedBox(
-                height: 184.0,
-                child: Stack(
-                  children: <Widget>[
-                    Positioned.fill(
-                      child: Image.asset(
-                        destination.assetName,
-                        package: destination.assetPackage,
-                        fit: BoxFit.cover,
-                      ),
-                    ),
-                    Positioned(
-                      bottom: 16.0,
-                      left: 16.0,
-                      right: 16.0,
-                      child: FittedBox(
-                        fit: BoxFit.scaleDown,
-                        alignment: Alignment.centerLeft,
-                        child: Text(destination.title,
-                          style: titleStyle,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+        child: Column(
+          children: <Widget>[
+            const SectionTitle(title: 'Card with actions'),
+            Container(
+              height: height,
+              child: Card(
+                clipBehavior: Clip.antiAlias,
+                shape: shape,
+                child: TravelDestinationContent(destination: destination),
               ),
-              // description and share/explore buttons
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
-                  child: DefaultTextStyle(
-                    softWrap: false,
-                    overflow: TextOverflow.ellipsis,
-                    style: descriptionStyle,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        // three line description
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
-                          child: Text(
-                            destination.description[0],
-                            style: descriptionStyle.copyWith(color: Colors.black54),
-                          ),
-                        ),
-                        Text(destination.description[1]),
-                        Text(destination.description[2]),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              // share, explore buttons
-              ButtonTheme.bar(
-                child: ButtonBar(
-                  alignment: MainAxisAlignment.start,
-                  children: <Widget>[
-                    FlatButton(
-                      child: Text('SHARE', semanticsLabel: 'Share ${destination.title}'),
-                      textColor: Colors.amber.shade500,
-                      onPressed: () { /* do nothing */ },
-                    ),
-                    FlatButton(
-                      child: Text('EXPLORE', semanticsLabel: 'Explore ${destination.title}'),
-                      textColor: Colors.amber.shade500,
-                      onPressed: () { /* do nothing */ },
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
+class TappableTravelDestinationItem extends StatelessWidget {
+  TappableTravelDestinationItem({ Key key, @required this.destination, this.shape })
+      : assert(destination != null && destination.isValid),
+        super(key: key);
+
+  static const double height = 312.0;
+  final TravelDestination destination;
+  final ShapeBorder shape;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: <Widget>[
+            const SectionTitle(title: 'Card that can be tapped'),
+            Container(
+              height: height,
+              child: Card(
+                clipBehavior: Clip.antiAlias,
+                shape: shape,
+                child: InkWell(
+                  onTap: () {
+                    print('Card was tapped');
+                  },
+                  splashColor: Theme.of(context).colorScheme.primary.withAlpha(30),
+                  child: TravelDestinationContent(destination: destination),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SelectableTravelDestinationItem extends StatefulWidget {
+  SelectableTravelDestinationItem({ Key key, @required this.destination, this.shape })
+      : assert(destination != null && destination.isValid),
+        super(key: key);
+
+  final TravelDestination destination;
+  final ShapeBorder shape;
+
+  @override
+  _SelectableTravelDestinationItemState createState() => _SelectableTravelDestinationItemState();
+}
+
+class _SelectableTravelDestinationItemState extends State<SelectableTravelDestinationItem> {
+
+  static const double height = 312.0;
+  bool _isSelected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: <Widget>[
+            const SectionTitle(title: 'Card that can be selected'),
+            Container(
+              height: height,
+              child: Card(
+                clipBehavior: Clip.antiAlias,
+                shape: widget.shape,
+                child: InkWell(
+                  onLongPress: () {
+                    print('Selectable card state changed');
+                    setState(() {
+                      _isSelected = !_isSelected;
+                    });
+                  },
+                  splashColor: Theme.of(context).colorScheme.primary.withAlpha(30),
+                  child: Stack(
+                    children: <Widget>[
+                      TravelDestinationContent(destination: widget.destination),
+                      Opacity(
+                        opacity: _isSelected ? 1 : 0,
+                        child: Container(
+                          color: Theme.of(context).colorScheme.primary.withAlpha(41),
+                        ),
+                      ),
+                      Opacity(
+                        opacity: _isSelected ? 1 : 0,
+                        child: const Align(
+                            alignment: Alignment.topRight,
+                            child: Padding(
+                              padding: EdgeInsets.all(4.0),
+                              child: Icon(Icons.check_circle, color: Colors.white,),
+                            )
+                        ),
+                      ),
+                    ],
+                  )
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SectionTitle extends StatelessWidget {
+  const SectionTitle({
+    Key key,
+    this.title
+  }) : super(key: key);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 12),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(title, style: Theme.of(context).textTheme.subhead,),
+      ),
+    );
+  }
+}
+
+class TravelDestinationContent extends StatelessWidget {
+  TravelDestinationContent({ Key key, @required this.destination })
+      : assert(destination != null && destination.isValid),
+        super(key: key);
+
+  final TravelDestination destination;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle titleStyle = theme.textTheme.headline.copyWith(color: Colors.white);
+    final TextStyle descriptionStyle = theme.textTheme.subhead;
+
+    final Widget image = destination.type == CardDemoType.static
+        ? Image.asset(destination.assetName, package: destination.assetPackage, fit: BoxFit.cover,)
+        : Ink.image(image: AssetImage(destination.assetName, package: destination.assetPackage), fit: BoxFit.cover, child: Container(),);
+
+    final List<Widget> children = [
+      // photo and title
+      SizedBox(
+        height: 184.0,
+        child: Stack(
+          children: <Widget>[
+            Positioned.fill(
+              child: image,
+            ),
+            Positioned(
+              bottom: 16.0,
+              left: 16.0,
+              right: 16.0,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerLeft,
+                child: Text(destination.title,
+                  style: titleStyle,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      // description and share/explore buttons
+      Expanded(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
+          child: DefaultTextStyle(
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+            style: descriptionStyle,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                // three line description
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(
+                    destination.description[0],
+                    style: descriptionStyle.copyWith(color: Colors.black54),
+                  ),
+                ),
+                Text(destination.description[1]),
+                Text(destination.description[2]),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ];
+
+    if (destination.type == CardDemoType.static) {
+      children.add(
+        // share, explore buttons
+        ButtonTheme.bar(
+          child: ButtonBar(
+            alignment: MainAxisAlignment.start,
+            children: <Widget>[
+              FlatButton(
+                child: Text('SHARE', semanticsLabel: 'Share ${destination.title}'),
+                textColor: Colors.amber.shade500,
+                onPressed: () { /* do nothing */ },
+              ),
+              FlatButton(
+                child: Text('EXPLORE', semanticsLabel: 'Explore ${destination.title}'),
+                textColor: Colors.amber.shade500,
+                onPressed: () { /* do nothing */ },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+}
 
 class CardsDemo extends StatefulWidget {
   static const String routeName = '/material/cards';
@@ -169,7 +346,7 @@ class _CardsDemoState extends State<CardsDemo> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Travel stream'),
+        title: const Text('Cards'),
         actions: <Widget>[
           MaterialDemoDocumentationButton(CardsDemo.routeName),
           IconButton(
@@ -193,15 +370,24 @@ class _CardsDemoState extends State<CardsDemo> {
         ],
       ),
       body: ListView(
-        itemExtent: TravelDestinationItem.height,
         padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
         children: destinations.map<Widget>((TravelDestination destination) {
+          Widget child;
+          switch (destination.type) {
+            case CardDemoType.static:
+              child = TravelDestinationItem(destination: destination, shape: _shape,);
+              break;
+            case CardDemoType.tappable:
+              child = TappableTravelDestinationItem(destination: destination, shape: _shape,);
+              break;
+            case CardDemoType.selectable:
+              child = SelectableTravelDestinationItem(destination: destination, shape: _shape,);
+              break;
+          }
+
           return Container(
             margin: const EdgeInsets.only(bottom: 8.0),
-            child: TravelDestinationItem(
-              destination: destination,
-              shape: _shape,
-            ),
+            child: child,
           );
         }).toList()
       )

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -57,11 +57,13 @@ import 'theme.dart';
 /// {@end-tool}
 ///
 /// Sometimes the primary action area of a card is the card itself. Cards can be
-/// one large touch target to a detail screen on a subject.
+/// one large touch target that shows a detail screen when tapped.
 ///
 /// {@tool snippet --template=stateless_widget}
 ///
-/// This sample shows creation of a [Card] widget that can be tapped.
+/// This sample shows creation of a [Card] widget that can be tapped. When
+/// tapped this [Card]'s [InkWell] displays an "ink splash" that fills the
+/// entire card.
 ///
 /// ```dart
 /// Card(

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -56,6 +56,25 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 ///
+/// Sometimes the primary action area of a card is the card itself. Cards can be
+/// one large touch target to a detail screen on a subject.
+///
+/// {@tool snippet --template=stateless_widget}
+///
+/// This sample shows creation of a [Card] widget that can be tapped.
+///
+/// ```dart
+/// Card(
+///   child: InkWell(
+///     splashColor: Colors.blue.withAlpha(30),
+///     onTap: () { /* ... */ },
+///     child: Text('A card that can be tapped'),
+///   ),
+/// )
+/// ```
+///
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ListTile], to display icons and text in a card.


### PR DESCRIPTION
Additionally, this adds a tappable Card example to the Card documentation.

Screenshots of the demo now:

| Tappable | Selectable |
| - | - |
|![](https://user-images.githubusercontent.com/2364772/52507725-6170ac00-2bc0-11e9-984c-74b6910ab58d.png)|![](https://user-images.githubusercontent.com/2364772/52507717-5d448e80-2bc0-11e9-80ab-f7c357337f58.png)|
