### PR TITLE
Refactor "no ios devices attached" logic.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -114,7 +114,7 @@ class IMobileDevice {
 
     // If no device is attached, we're unable to detect any problems. Assume all is well.
     final ProcessResult result = (await runAsync(<String>['idevice_id', '-l'])).processResult;
-    if (result.exitCode != 0 || result.stdout.isEmpty)
+    if (result.exitCode == 0 && result.stdout.isEmpty)
       return true;
 
     // Check that we can look up the names of any attached devices.


### PR DESCRIPTION
// If no device is attached, we're unable to detect any problems. Assume all is well.
```dart
    final ProcessResult result = (await runAsync(<String>['idevice_id', '-l'])).processResult;
```

In my understanding, `If no device is attached` should be exitCode=0 and empty stdout.
```dart 
   if (result.exitCode == 0 && result.stdout.isEmpty)
      return true;
```
