### PR TITLE
Adding horizontal and vertical scale parameter to ScaleUpdateDetails.

### DIFF
--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -64,24 +64,47 @@ class ScaleUpdateDetails {
        assert(verticalScale != null && verticalScale >= 0.0),
        assert(rotation != null);
 
-  /// The focal point of the pointers in contact with the screen. Reported in
-  /// global coordinates.
+  /// The focal point of the pointers in contact with the screen.
+  ///
+  /// Reported in global coordinates.
   final Offset focalPoint;
 
-  /// The scale implied by the pointers in contact with the screen. A value
-  /// greater than or equal to zero.
+  /// The scale implied by the average distance between the pointers in contact
+  /// with the screen.
+  ///
+  /// This value must be greater than or equal to zero.
+  ///
+  /// See also:
+  ///
+  ///  * [horizontalScale], which is the scale along the horizontal axis.
+  ///  * [verticalScale], which is the scale along the vertical axis.
   final double scale;
 
-  /// The scale along the horizontal axis implied by the pointers in contact
-  /// with the screen. A value greater than or equal to zero.
+  /// The scale implied by the average distance along the horizontal axis
+  /// between the pointers in contact with the screen.
+  ///
+  /// This value must be greater than or equal to zero.
+  ///
+  /// See also:
+  ///
+  ///  * [scale], which is the general scale implied by the pointers.
+  ///  * [verticalScale], which is the scale along the vertical axis.
   final double horizontalScale;
 
-  /// The scale along the vertical axis implied by the pointers in contact
-  /// with the screen. A value greater than or equal to zero.
+  /// The scale implied by the average distance along the vertical axis
+  /// between the pointers in contact with the screen.
+  ///
+  /// This value must be greater than or equal to zero.
+  ///
+  /// See also:
+  ///
+  ///  * [scale], which is the general scale implied by the pointers.
+  ///  * [horizontalScale], which is the scale along the horizontal axis.
   final double verticalScale;
 
   /// The angle implied by the first two pointers to enter in contact with
-  /// the screen. Expressed in radians.
+  ///
+  /// Expressed in radians.
   final double rotation;
 
   @override
@@ -363,7 +386,15 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     }
 
     if (_state == _ScaleState.started && onUpdate != null)
-      invokeCallback<void>('onUpdate', () => onUpdate(ScaleUpdateDetails(scale: _scaleFactor, horizontalScale: _horizontalScaleFactor, verticalScale: _verticalScaleFactor, focalPoint: _currentFocalPoint, rotation: _computeRotationFactor())));
+      invokeCallback<void>(
+        'onUpdate',
+        () => onUpdate(
+          ScaleUpdateDetails(scale: _scaleFactor, horizontalScale: _horizontalScaleFactor,
+            verticalScale: _verticalScaleFactor, focalPoint: _currentFocalPoint,
+            rotation: _computeRotationFactor(),
+          ),
+        ),
+      );
   }
 
   void _dispatchOnStartCallbackIfNeeded() {

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -49,7 +49,8 @@ class ScaleStartDetails {
 class ScaleUpdateDetails {
   /// Creates details for [GestureScaleUpdateCallback].
   ///
-  /// The [focalPoint], [scale], [rotation] arguments must not be null. The [scale]
+  /// The [focalPoint], [scale], [horizontalScale], [verticalScale], [rotation]
+  /// arguments must not be null. The [scale], [horizontalScale], and [verticalScale]
   /// argument must be greater than or equal to zero.
   ScaleUpdateDetails({
     this.focalPoint = Offset.zero,
@@ -80,7 +81,9 @@ class ScaleUpdateDetails {
 
   @override
   String toString() =>
-      'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, rotation: $rotation)';
+      'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, '
+      'horizontalScale: $horizontalScale, verticalScale: $verticalScale, '
+      'rotation: $rotation)';
 }
 
 /// Details for [GestureScaleEndCallback].
@@ -168,6 +171,10 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   Offset _currentFocalPoint;
   double _initialSpan;
   double _currentSpan;
+  double _initialHorizontalSpan;
+  double _currentHorizontalSpan;
+  double _initialVerticalSpan;
+  double _currentVerticalSpan;
   _LineBetweenPointers _initialLine;
   _LineBetweenPointers _currentLine;
   Map<int, Offset> _pointerLocations;
@@ -176,6 +183,14 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
 
   double get _scaleFactor =>
       _initialSpan > 0.0 ? _currentSpan / _initialSpan : 1.0;
+
+  double get _horizontalScaleFactor => _initialHorizontalSpan > 0.0
+      ? _currentHorizontalSpan / _initialHorizontalSpan
+      : 1.0;
+
+  double get _verticalScaleFactor => _initialVerticalSpan > 0.0
+      ? _currentVerticalSpan / _initialVerticalSpan
+      : 1.0;
 
   double _computeRotationFactor() {
     if (_initialLine == null || _currentLine == null) {
@@ -205,6 +220,10 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
       _state = _ScaleState.possible;
       _initialSpan = 0.0;
       _currentSpan = 0.0;
+      _initialHorizontalSpan = 0.0;
+      _currentHorizontalSpan = 0.0;
+      _initialVerticalSpan = 0.0;
+      _currentVerticalSpan = 0.0;
       _pointerLocations = <int, Offset>{};
       _pointerQueue = <int>[];
     }
@@ -319,7 +338,8 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _advanceStateMachine(bool shouldStartIfAccepted) {
-    if (_state == _ScaleState.ready) _state = _ScaleState.possible;
+    if (_state == _ScaleState.ready)
+      _state = _ScaleState.possible;
 
     if (_state == _ScaleState.possible) {
       final double spanDelta = (_currentSpan - _initialSpan).abs();
@@ -341,6 +361,8 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
           'onUpdate',
           () => onUpdate(ScaleUpdateDetails(
               scale: _scaleFactor,
+              horizontalScale: _horizontalScaleFactor,
+              verticalScale: _verticalScaleFactor,
               focalPoint: _currentFocalPoint,
               rotation: _computeRotationFactor())));
   }

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -54,9 +54,13 @@ class ScaleUpdateDetails {
   ScaleUpdateDetails({
     this.focalPoint = Offset.zero,
     this.scale = 1.0,
+    this.horizontalScale = 1.0,
+    this.verticalScale = 1.0,
     this.rotation = 0.0,
   })  : assert(focalPoint != null),
         assert(scale != null && scale >= 0.0),
+        assert(horizontalScale != null && horizontalScale >= 0.0),
+        assert(verticalScale != null && verticalScale >= 0.0),
         assert(rotation != null);
 
   /// The focal point of the pointers in contact with the screen. Reported in
@@ -66,6 +70,9 @@ class ScaleUpdateDetails {
   /// The scale implied by the pointers in contact with the screen. A value
   /// greater than or equal to zero.
   final double scale;
+
+  final double horizontalScale;
+  final double verticalScale;
 
   /// The angle implied by the first two pointers to enter in contact with
   /// the screen. Expressed in radians.

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -34,8 +34,8 @@ class ScaleStartDetails {
   /// Creates details for [GestureScaleStartCallback].
   ///
   /// The [focalPoint] argument must not be null.
-  ScaleStartDetails({this.focalPoint = Offset.zero})
-      : assert(focalPoint != null);
+  ScaleStartDetails({ this.focalPoint = Offset.zero })
+    : assert(focalPoint != null);
 
   /// The initial focal point of the pointers in contact with the screen.
   /// Reported in global coordinates.
@@ -58,11 +58,11 @@ class ScaleUpdateDetails {
     this.horizontalScale = 1.0,
     this.verticalScale = 1.0,
     this.rotation = 0.0,
-  })  : assert(focalPoint != null),
-        assert(scale != null && scale >= 0.0),
-        assert(horizontalScale != null && horizontalScale >= 0.0),
-        assert(verticalScale != null && verticalScale >= 0.0),
-        assert(rotation != null);
+  }) : assert(focalPoint != null),
+       assert(scale != null && scale >= 0.0),
+       assert(horizontalScale != null && horizontalScale >= 0.0),
+       assert(verticalScale != null && verticalScale >= 0.0),
+       assert(rotation != null);
 
   /// The focal point of the pointers in contact with the screen. Reported in
   /// global coordinates.
@@ -85,10 +85,7 @@ class ScaleUpdateDetails {
   final double rotation;
 
   @override
-  String toString() =>
-      'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, '
-      'horizontalScale: $horizontalScale, verticalScale: $verticalScale, '
-      'rotation: $rotation)';
+  String toString() => 'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, horizontalScale: $horizontalScale, verticalScale: $verticalScale, rotation: $rotation)';
 }
 
 /// Details for [GestureScaleEndCallback].
@@ -96,7 +93,8 @@ class ScaleEndDetails {
   /// Creates details for [GestureScaleEndCallback].
   ///
   /// The [velocity] argument must not be null.
-  ScaleEndDetails({this.velocity = Velocity.zero}) : assert(velocity != null);
+  ScaleEndDetails({ this.velocity = Velocity.zero })
+    : assert(velocity != null);
 
   /// The velocity of the last pointer to be lifted off of the screen.
   final Velocity velocity;
@@ -122,22 +120,24 @@ bool _isFlingGesture(Velocity velocity) {
   return speedSquared > kMinFlingVelocity * kMinFlingVelocity;
 }
 
+
 /// Defines a line between two pointers on screen.
 ///
 /// [_LineBetweenPointers] is an abstraction of a line between two pointers in
 /// contact with the screen. Used to track the rotation of a scale gesture.
 class _LineBetweenPointers {
+
   /// Creates a [_LineBetweenPointers]. None of the [pointerStartLocation], [pointerStartId]
   /// [pointerEndLocation] and [pointerEndId] must be null. [pointerStartId] and [pointerEndId]
   /// should be different.
-  _LineBetweenPointers(
-      {this.pointerStartLocation = Offset.zero,
-      this.pointerStartId = 0,
-      this.pointerEndLocation = Offset.zero,
-      this.pointerEndId = 1})
-      : assert(pointerStartLocation != null && pointerEndLocation != null),
-        assert(pointerStartId != null && pointerEndId != null),
-        assert(pointerStartId != pointerEndId);
+  _LineBetweenPointers({
+    this.pointerStartLocation = Offset.zero,
+    this.pointerStartId = 0,
+    this.pointerEndLocation = Offset.zero,
+    this.pointerEndId = 1
+  }) : assert(pointerStartLocation != null && pointerEndLocation != null),
+       assert(pointerStartId != null && pointerEndId != null),
+       assert(pointerStartId != pointerEndId);
 
   // The location and the id of the pointer that marks the start of the line.
   final Offset pointerStartLocation;
@@ -146,7 +146,9 @@ class _LineBetweenPointers {
   // The location and the id of the pointer that marks the end of the line.
   final Offset pointerEndLocation;
   final int pointerEndId;
+
 }
+
 
 /// Recognizes a scale gesture.
 ///
@@ -157,7 +159,7 @@ class _LineBetweenPointers {
 /// are no longer in contact with the screen, the recognizer calls [onEnd].
 class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Create a gesture recognizer for interactions intended for scaling content.
-  ScaleGestureRecognizer({Object debugOwner}) : super(debugOwner: debugOwner);
+  ScaleGestureRecognizer({ Object debugOwner }) : super(debugOwner: debugOwner);
 
   /// The pointers in contact with the screen have established a focal point and
   /// initial scale of 1.0.
@@ -186,16 +188,11 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   List<int> _pointerQueue; // A queue to sort pointers in order of entrance
   final Map<int, VelocityTracker> _velocityTrackers = <int, VelocityTracker>{};
 
-  double get _scaleFactor =>
-      _initialSpan > 0.0 ? _currentSpan / _initialSpan : 1.0;
+  double get _scaleFactor => _initialSpan > 0.0 ? _currentSpan / _initialSpan : 1.0;
 
-  double get _horizontalScaleFactor => _initialHorizontalSpan > 0.0
-      ? _currentHorizontalSpan / _initialHorizontalSpan
-      : 1.0;
+  double get _horizontalScaleFactor => _initialHorizontalSpan > 0.0 ? _currentHorizontalSpan / _initialHorizontalSpan : 1.0;
 
-  double get _verticalScaleFactor => _initialVerticalSpan > 0.0
-      ? _currentVerticalSpan / _initialVerticalSpan
-      : 1.0;
+  double get _verticalScaleFactor => _initialVerticalSpan > 0.0 ? _currentVerticalSpan / _initialVerticalSpan : 1.0;
 
   double _computeRotationFactor() {
     if (_initialLine == null || _currentLine == null) {
@@ -272,26 +269,20 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     Offset focalPoint = Offset.zero;
     for (int pointer in _pointerLocations.keys)
       focalPoint += _pointerLocations[pointer];
-    _currentFocalPoint =
-        count > 0 ? focalPoint / count.toDouble() : Offset.zero;
+    _currentFocalPoint = count > 0 ? focalPoint / count.toDouble() : Offset.zero;
 
-    // Span is the average deviation from focal point
+    // Span is the average deviation from focal point. Horizontal and vertical
+    // spans are the average deviations from the focal point's horizontal and
+    // vertical coordinates, respectively.
     double totalDeviation = 0.0;
-    for (int pointer in _pointerLocations.keys)
-      totalDeviation +=
-          (_currentFocalPoint - _pointerLocations[pointer]).distance;
-    _currentSpan = count > 0 ? totalDeviation / count : 0.0;
-
-    // Horizontal and vertical span are the average deviations from the
-    // focal point's horizontal and vertical coordinates, respectively.
     double totalHorizontalDeviation = 0.0;
     double totalVerticalDeviation = 0.0;
     for (int pointer in _pointerLocations.keys) {
-      totalHorizontalDeviation +=
-          (_currentFocalPoint.dx - _pointerLocations[pointer].dx).abs();
-      totalVerticalDeviation +=
-          (_currentFocalPoint.dy - _pointerLocations[pointer].dy).abs();
+      totalDeviation += (_currentFocalPoint - _pointerLocations[pointer]).distance;
+      totalHorizontalDeviation += (_currentFocalPoint.dx - _pointerLocations[pointer].dx).abs();
+      totalVerticalDeviation += (_currentFocalPoint.dy - _pointerLocations[pointer].dy).abs();
     }
+    _currentSpan = count > 0 ? totalDeviation / count : 0.0;
     _currentHorizontalSpan = count > 0 ? totalHorizontalDeviation / count : 0.0;
     _currentVerticalSpan = count > 0 ? totalVerticalDeviation / count : 0.0;
   }
@@ -301,26 +292,25 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   void _updateLines() {
     final int count = _pointerLocations.keys.length;
     assert(_pointerQueue.length >= count);
-
     /// In case of just one pointer registered, reconfigure [_initialLine]
     if (count < 2) {
       _initialLine = _currentLine;
     } else if (_initialLine != null &&
-        _initialLine.pointerStartId == _pointerQueue[0] &&
-        _initialLine.pointerEndId == _pointerQueue[1]) {
+      _initialLine.pointerStartId == _pointerQueue[0] &&
+      _initialLine.pointerEndId == _pointerQueue[1]) {
       /// Rotation updated, set the [_currentLine]
       _currentLine = _LineBetweenPointers(
-          pointerStartId: _pointerQueue[0],
-          pointerStartLocation: _pointerLocations[_pointerQueue[0]],
-          pointerEndId: _pointerQueue[1],
-          pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
+        pointerStartId: _pointerQueue[0],
+        pointerStartLocation: _pointerLocations[_pointerQueue[0]],
+        pointerEndId: _pointerQueue[1],
+        pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
     } else {
       /// A new rotation process is on the way, set the [_initialLine]
       _initialLine = _LineBetweenPointers(
-          pointerStartId: _pointerQueue[0],
-          pointerStartLocation: _pointerLocations[_pointerQueue[0]],
-          pointerEndId: _pointerQueue[1],
-          pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
+        pointerStartId: _pointerQueue[0],
+        pointerStartLocation: _pointerLocations[_pointerQueue[0]],
+        pointerEndId: _pointerQueue[1],
+        pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
       _currentLine = null;
     }
   }
@@ -339,16 +329,11 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
         Velocity velocity = tracker.getVelocity();
         if (_isFlingGesture(velocity)) {
           final Offset pixelsPerSecond = velocity.pixelsPerSecond;
-          if (pixelsPerSecond.distanceSquared >
-              kMaxFlingVelocity * kMaxFlingVelocity)
-            velocity = Velocity(
-                pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) *
-                    kMaxFlingVelocity);
-          invokeCallback<void>(
-              'onEnd', () => onEnd(ScaleEndDetails(velocity: velocity)));
+          if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
+            velocity = Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
+          invokeCallback<void>('onEnd', () => onEnd(ScaleEndDetails(velocity: velocity)));
         } else {
-          invokeCallback<void>(
-              'onEnd', () => onEnd(ScaleEndDetails(velocity: Velocity.zero)));
+          invokeCallback<void>('onEnd', () => onEnd(ScaleEndDetails(velocity: Velocity.zero)));
         }
       }
       _state = _ScaleState.accepted;
@@ -358,12 +343,12 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _advanceStateMachine(bool shouldStartIfAccepted) {
-    if (_state == _ScaleState.ready) _state = _ScaleState.possible;
+    if (_state == _ScaleState.ready)
+      _state = _ScaleState.possible;
 
     if (_state == _ScaleState.possible) {
       final double spanDelta = (_currentSpan - _initialSpan).abs();
-      final double focalPointDelta =
-          (_currentFocalPoint - _initialFocalPoint).distance;
+      final double focalPointDelta = (_currentFocalPoint - _initialFocalPoint).distance;
       if (spanDelta > kScaleSlop || focalPointDelta > kPanSlop)
         resolve(GestureDisposition.accepted);
     } else if (_state.index >= _ScaleState.accepted.index) {
@@ -376,21 +361,13 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     }
 
     if (_state == _ScaleState.started && onUpdate != null)
-      invokeCallback<void>(
-          'onUpdate',
-          () => onUpdate(ScaleUpdateDetails(
-              scale: _scaleFactor,
-              horizontalScale: _horizontalScaleFactor,
-              verticalScale: _verticalScaleFactor,
-              focalPoint: _currentFocalPoint,
-              rotation: _computeRotationFactor())));
+      invokeCallback<void>('onUpdate', () => onUpdate(ScaleUpdateDetails(scale: _scaleFactor, horizontalScale: _horizontalScaleFactor, verticalScale: _verticalScaleFactor, focalPoint: _currentFocalPoint, rotation: _computeRotationFactor())));
   }
 
   void _dispatchOnStartCallbackIfNeeded() {
     assert(_state == _ScaleState.started);
     if (onStart != null)
-      invokeCallback<void>('onStart',
-          () => onStart(ScaleStartDetails(focalPoint: _currentFocalPoint)));
+      invokeCallback<void>('onStart', () => onStart(ScaleStartDetails(focalPoint: _currentFocalPoint)));
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -103,6 +103,7 @@ class ScaleUpdateDetails {
   final double verticalScale;
 
   /// The angle implied by the first two pointers to enter in contact with
+  /// the screen.
   ///
   /// Expressed in radians.
   final double rotation;

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -72,7 +72,12 @@ class ScaleUpdateDetails {
   /// greater than or equal to zero.
   final double scale;
 
+  /// The scale along the horizontal axis implied by the pointers in contact
+  /// with the screen. A value greater than or equal to zero.
   final double horizontalScale;
+
+  /// The scale along the vertical axis implied by the pointers in contact
+  /// with the screen. A value greater than or equal to zero.
   final double verticalScale;
 
   /// The angle implied by the first two pointers to enter in contact with

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -276,6 +276,19 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
       totalDeviation +=
           (_currentFocalPoint - _pointerLocations[pointer]).distance;
     _currentSpan = count > 0 ? totalDeviation / count : 0.0;
+
+    // Horizontal and vertical span are the average deviations from the
+    // focal point's horizontal and vertical coordinates, respectively.
+    double totalHorizontalDeviation = 0.0;
+    double totalVerticalDeviation = 0.0;
+    for (int pointer in _pointerLocations.keys) {
+      totalHorizontalDeviation +=
+          (_currentFocalPoint.dx - _pointerLocations[pointer].dx).abs();
+      totalVerticalDeviation +=
+          (_currentFocalPoint.dy - _pointerLocations[pointer].dy).abs();
+    }
+    _currentHorizontalSpan = count > 0 ? totalHorizontalDeviation / count : 0.0;
+    _currentVerticalSpan = count > 0 ? totalVerticalDeviation / count : 0.0;
   }
 
   /// Updates [_initialLine] and [_currentLine] accordingly to the situation of
@@ -311,6 +324,8 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     _initialFocalPoint = _currentFocalPoint;
     _initialSpan = _currentSpan;
     _initialLine = _currentLine;
+    _initialHorizontalSpan = _currentHorizontalSpan;
+    _initialVerticalSpan = _currentVerticalSpan;
     if (_state == _ScaleState.started) {
       if (onEnd != null) {
         final VelocityTracker tracker = _velocityTrackers[pointer];
@@ -338,8 +353,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _advanceStateMachine(bool shouldStartIfAccepted) {
-    if (_state == _ScaleState.ready)
-      _state = _ScaleState.possible;
+    if (_state == _ScaleState.ready) _state = _ScaleState.possible;
 
     if (_state == _ScaleState.possible) {
       final double spanDelta = (_currentSpan - _initialSpan).abs();

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -125,7 +125,7 @@ bool _isFlingGesture(Velocity velocity) {
 ///
 /// [_LineBetweenPointers] is an abstraction of a line between two pointers in
 /// contact with the screen. Used to track the rotation of a scale gesture.
-class _LineBetweenPointers {
+class _LineBetweenPointers{
 
   /// Creates a [_LineBetweenPointers]. None of the [pointerStartLocation], [pointerStartId]
   /// [pointerEndLocation] and [pointerEndId] must be null. [pointerStartId] and [pointerEndId]
@@ -303,14 +303,16 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
         pointerStartId: _pointerQueue[0],
         pointerStartLocation: _pointerLocations[_pointerQueue[0]],
         pointerEndId: _pointerQueue[1],
-        pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
+        pointerEndLocation: _pointerLocations[_pointerQueue[1]]
+      );
     } else {
       /// A new rotation process is on the way, set the [_initialLine]
       _initialLine = _LineBetweenPointers(
         pointerStartId: _pointerQueue[0],
         pointerStartLocation: _pointerLocations[_pointerQueue[0]],
         pointerEndId: _pointerQueue[1],
-        pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
+        pointerEndLocation: _pointerLocations[_pointerQueue[1]]
+      );
       _currentLine = null;
     }
   }

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -34,8 +34,8 @@ class ScaleStartDetails {
   /// Creates details for [GestureScaleStartCallback].
   ///
   /// The [focalPoint] argument must not be null.
-  ScaleStartDetails({ this.focalPoint = Offset.zero })
-    : assert(focalPoint != null);
+  ScaleStartDetails({this.focalPoint = Offset.zero})
+      : assert(focalPoint != null);
 
   /// The initial focal point of the pointers in contact with the screen.
   /// Reported in global coordinates.
@@ -55,9 +55,9 @@ class ScaleUpdateDetails {
     this.focalPoint = Offset.zero,
     this.scale = 1.0,
     this.rotation = 0.0,
-  }) : assert(focalPoint != null),
-       assert(scale != null && scale >= 0.0),
-       assert(rotation != null);
+  })  : assert(focalPoint != null),
+        assert(scale != null && scale >= 0.0),
+        assert(rotation != null);
 
   /// The focal point of the pointers in contact with the screen. Reported in
   /// global coordinates.
@@ -72,7 +72,8 @@ class ScaleUpdateDetails {
   final double rotation;
 
   @override
-  String toString() => 'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, rotation: $rotation)';
+  String toString() =>
+      'ScaleUpdateDetails(focalPoint: $focalPoint, scale: $scale, rotation: $rotation)';
 }
 
 /// Details for [GestureScaleEndCallback].
@@ -80,8 +81,7 @@ class ScaleEndDetails {
   /// Creates details for [GestureScaleEndCallback].
   ///
   /// The [velocity] argument must not be null.
-  ScaleEndDetails({ this.velocity = Velocity.zero })
-    : assert(velocity != null);
+  ScaleEndDetails({this.velocity = Velocity.zero}) : assert(velocity != null);
 
   /// The velocity of the last pointer to be lifted off of the screen.
   final Velocity velocity;
@@ -107,24 +107,22 @@ bool _isFlingGesture(Velocity velocity) {
   return speedSquared > kMinFlingVelocity * kMinFlingVelocity;
 }
 
-
 /// Defines a line between two pointers on screen.
 ///
 /// [_LineBetweenPointers] is an abstraction of a line between two pointers in
 /// contact with the screen. Used to track the rotation of a scale gesture.
-class _LineBetweenPointers{
-
+class _LineBetweenPointers {
   /// Creates a [_LineBetweenPointers]. None of the [pointerStartLocation], [pointerStartId]
   /// [pointerEndLocation] and [pointerEndId] must be null. [pointerStartId] and [pointerEndId]
   /// should be different.
-  _LineBetweenPointers({
-    this.pointerStartLocation = Offset.zero,
-    this.pointerStartId = 0,
-    this.pointerEndLocation = Offset.zero,
-    this.pointerEndId = 1
-  }) : assert(pointerStartLocation != null && pointerEndLocation != null),
-       assert(pointerStartId != null && pointerEndId != null),
-       assert(pointerStartId != pointerEndId);
+  _LineBetweenPointers(
+      {this.pointerStartLocation = Offset.zero,
+      this.pointerStartId = 0,
+      this.pointerEndLocation = Offset.zero,
+      this.pointerEndId = 1})
+      : assert(pointerStartLocation != null && pointerEndLocation != null),
+        assert(pointerStartId != null && pointerEndId != null),
+        assert(pointerStartId != pointerEndId);
 
   // The location and the id of the pointer that marks the start of the line.
   final Offset pointerStartLocation;
@@ -133,9 +131,7 @@ class _LineBetweenPointers{
   // The location and the id of the pointer that marks the end of the line.
   final Offset pointerEndLocation;
   final int pointerEndId;
-
 }
-
 
 /// Recognizes a scale gesture.
 ///
@@ -146,7 +142,7 @@ class _LineBetweenPointers{
 /// are no longer in contact with the screen, the recognizer calls [onEnd].
 class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Create a gesture recognizer for interactions intended for scaling content.
-  ScaleGestureRecognizer({ Object debugOwner }) : super(debugOwner: debugOwner);
+  ScaleGestureRecognizer({Object debugOwner}) : super(debugOwner: debugOwner);
 
   /// The pointers in contact with the screen have established a focal point and
   /// initial scale of 1.0.
@@ -171,7 +167,8 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   List<int> _pointerQueue; // A queue to sort pointers in order of entrance
   final Map<int, VelocityTracker> _velocityTrackers = <int, VelocityTracker>{};
 
-  double get _scaleFactor => _initialSpan > 0.0 ? _currentSpan / _initialSpan : 1.0;
+  double get _scaleFactor =>
+      _initialSpan > 0.0 ? _currentSpan / _initialSpan : 1.0;
 
   double _computeRotationFactor() {
     if (_initialLine == null || _currentLine == null) {
@@ -244,12 +241,14 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     Offset focalPoint = Offset.zero;
     for (int pointer in _pointerLocations.keys)
       focalPoint += _pointerLocations[pointer];
-    _currentFocalPoint = count > 0 ? focalPoint / count.toDouble() : Offset.zero;
+    _currentFocalPoint =
+        count > 0 ? focalPoint / count.toDouble() : Offset.zero;
 
     // Span is the average deviation from focal point
     double totalDeviation = 0.0;
     for (int pointer in _pointerLocations.keys)
-      totalDeviation += (_currentFocalPoint - _pointerLocations[pointer]).distance;
+      totalDeviation +=
+          (_currentFocalPoint - _pointerLocations[pointer]).distance;
     _currentSpan = count > 0 ? totalDeviation / count : 0.0;
   }
 
@@ -258,27 +257,26 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   void _updateLines() {
     final int count = _pointerLocations.keys.length;
     assert(_pointerQueue.length >= count);
+
     /// In case of just one pointer registered, reconfigure [_initialLine]
     if (count < 2) {
       _initialLine = _currentLine;
     } else if (_initialLine != null &&
-      _initialLine.pointerStartId == _pointerQueue[0] &&
-      _initialLine.pointerEndId == _pointerQueue[1]) {
+        _initialLine.pointerStartId == _pointerQueue[0] &&
+        _initialLine.pointerEndId == _pointerQueue[1]) {
       /// Rotation updated, set the [_currentLine]
       _currentLine = _LineBetweenPointers(
-        pointerStartId: _pointerQueue[0],
-        pointerStartLocation: _pointerLocations[_pointerQueue[0]],
-        pointerEndId: _pointerQueue[1],
-        pointerEndLocation: _pointerLocations[ _pointerQueue[1]]
-      );
+          pointerStartId: _pointerQueue[0],
+          pointerStartLocation: _pointerLocations[_pointerQueue[0]],
+          pointerEndId: _pointerQueue[1],
+          pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
     } else {
       /// A new rotation process is on the way, set the [_initialLine]
       _initialLine = _LineBetweenPointers(
-        pointerStartId: _pointerQueue[0],
-        pointerStartLocation: _pointerLocations[_pointerQueue[0]],
-        pointerEndId: _pointerQueue[1],
-        pointerEndLocation: _pointerLocations[ _pointerQueue[1]]
-      );
+          pointerStartId: _pointerQueue[0],
+          pointerStartLocation: _pointerLocations[_pointerQueue[0]],
+          pointerEndId: _pointerQueue[1],
+          pointerEndLocation: _pointerLocations[_pointerQueue[1]]);
       _currentLine = null;
     }
   }
@@ -295,11 +293,16 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
         Velocity velocity = tracker.getVelocity();
         if (_isFlingGesture(velocity)) {
           final Offset pixelsPerSecond = velocity.pixelsPerSecond;
-          if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
-            velocity = Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
-          invokeCallback<void>('onEnd', () => onEnd(ScaleEndDetails(velocity: velocity)));
+          if (pixelsPerSecond.distanceSquared >
+              kMaxFlingVelocity * kMaxFlingVelocity)
+            velocity = Velocity(
+                pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) *
+                    kMaxFlingVelocity);
+          invokeCallback<void>(
+              'onEnd', () => onEnd(ScaleEndDetails(velocity: velocity)));
         } else {
-          invokeCallback<void>('onEnd', () => onEnd(ScaleEndDetails(velocity: Velocity.zero)));
+          invokeCallback<void>(
+              'onEnd', () => onEnd(ScaleEndDetails(velocity: Velocity.zero)));
         }
       }
       _state = _ScaleState.accepted;
@@ -309,12 +312,12 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _advanceStateMachine(bool shouldStartIfAccepted) {
-    if (_state == _ScaleState.ready)
-      _state = _ScaleState.possible;
+    if (_state == _ScaleState.ready) _state = _ScaleState.possible;
 
     if (_state == _ScaleState.possible) {
       final double spanDelta = (_currentSpan - _initialSpan).abs();
-      final double focalPointDelta = (_currentFocalPoint - _initialFocalPoint).distance;
+      final double focalPointDelta =
+          (_currentFocalPoint - _initialFocalPoint).distance;
       if (spanDelta > kScaleSlop || focalPointDelta > kPanSlop)
         resolve(GestureDisposition.accepted);
     } else if (_state.index >= _ScaleState.accepted.index) {
@@ -327,13 +330,19 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     }
 
     if (_state == _ScaleState.started && onUpdate != null)
-      invokeCallback<void>('onUpdate', () => onUpdate(ScaleUpdateDetails(scale: _scaleFactor, focalPoint: _currentFocalPoint, rotation: _computeRotationFactor())));
+      invokeCallback<void>(
+          'onUpdate',
+          () => onUpdate(ScaleUpdateDetails(
+              scale: _scaleFactor,
+              focalPoint: _currentFocalPoint,
+              rotation: _computeRotationFactor())));
   }
 
   void _dispatchOnStartCallbackIfNeeded() {
     assert(_state == _ScaleState.started);
     if (onStart != null)
-      invokeCallback<void>('onStart', () => onStart(ScaleStartDetails(focalPoint: _currentFocalPoint)));
+      invokeCallback<void>('onStart',
+          () => onStart(ScaleStartDetails(focalPoint: _currentFocalPoint)));
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -387,15 +387,15 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     }
 
     if (_state == _ScaleState.started && onUpdate != null)
-      invokeCallback<void>(
-        'onUpdate',
-        () => onUpdate(
-          ScaleUpdateDetails(scale: _scaleFactor, horizontalScale: _horizontalScaleFactor,
-            verticalScale: _verticalScaleFactor, focalPoint: _currentFocalPoint,
-            rotation: _computeRotationFactor(),
-          ),
-        ),
-      );
+      invokeCallback<void>('onUpdate', () {
+        onUpdate(ScaleUpdateDetails(
+          scale: _scaleFactor,
+          horizontalScale: _horizontalScaleFactor,
+          verticalScale: _verticalScaleFactor,
+          focalPoint: _currentFocalPoint,
+          rotation: _computeRotationFactor(),
+        ));
+      });
   }
 
   void _dispatchOnStartCallbackIfNeeded() {

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'gesture_tester.dart';
 
@@ -24,8 +24,12 @@ void main() {
     };
 
     double updatedScale;
+    double updatedHorizontalScale;
+    double updatedVerticalScale;
     scale.onUpdate = (ScaleUpdateDetails details) {
       updatedScale = details.scale;
+      updatedHorizontalScale = details.horizontalScale;
+      updatedVerticalScale = details.verticalScale;
       updatedFocalPoint = details.focalPoint;
     };
 
@@ -91,17 +95,34 @@ void main() {
     expect(updatedFocalPoint, const Offset(10.0, 20.0));
     updatedFocalPoint = null;
     expect(updatedScale, 2.0);
+    expect(updatedHorizontalScale, 2.0);
+    expect(updatedVerticalScale, 2.0);
     updatedScale = null;
+    updatedHorizontalScale = null;
+    updatedVerticalScale = null;
     expect(didEndScale, isFalse);
     expect(didTap, isFalse);
 
     // Zoom out
     tester.route(pointer2.move(const Offset(15.0, 25.0)));
     expect(updatedFocalPoint, const Offset(17.5, 27.5));
-    updatedFocalPoint = null;
     expect(updatedScale, 0.5);
-    updatedScale = null;
+    expect(updatedHorizontalScale, 0.5);
+    expect(updatedVerticalScale, 0.5);
     expect(didTap, isFalse);
+
+    // Horizontal scaling
+    tester.route(pointer2.move(const Offset(0.0, 20.0)));
+    expect(updatedHorizontalScale, 2.0);
+    expect(updatedVerticalScale, 1.0);
+
+    // Vertical scaling
+    tester.route(pointer2.move(const Offset(10.0, 10.0)));
+    expect(updatedHorizontalScale, 1.0);
+    expect(updatedVerticalScale, 2.0);
+    tester.route(pointer2.move(const Offset(15.0, 25.0)));
+    updatedFocalPoint = null;
+    updatedScale = null;
 
     // Three-finger scaling
     final TestPointer pointer3 = TestPointer(3);
@@ -201,16 +222,27 @@ void main() {
 
   testGesture('Scale gesture competes with drag', (GestureTester tester) {
     final ScaleGestureRecognizer scale = ScaleGestureRecognizer();
-    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer();
+    final HorizontalDragGestureRecognizer drag =
+        HorizontalDragGestureRecognizer();
 
     final List<String> log = <String>[];
 
-    scale.onStart = (ScaleStartDetails details) { log.add('scale-start'); };
-    scale.onUpdate = (ScaleUpdateDetails details) { log.add('scale-update'); };
-    scale.onEnd = (ScaleEndDetails details) { log.add('scale-end'); };
+    scale.onStart = (ScaleStartDetails details) {
+      log.add('scale-start');
+    };
+    scale.onUpdate = (ScaleUpdateDetails details) {
+      log.add('scale-update');
+    };
+    scale.onEnd = (ScaleEndDetails details) {
+      log.add('scale-end');
+    };
 
-    drag.onStart = (DragStartDetails details) { log.add('drag-start'); };
-    drag.onEnd = (DragEndDetails details) { log.add('drag-end'); };
+    drag.onStart = (DragStartDetails details) {
+      log.add('drag-start');
+    };
+    drag.onEnd = (DragEndDetails details) {
+      log.add('drag-end');
+    };
 
     final TestPointer pointer1 = TestPointer(1);
 
@@ -227,7 +259,8 @@ void main() {
 
     // scale will win if focal point delta exceeds 18.0*2
 
-    tester.route(pointer1.move(const Offset(10.0, 50.0))); // delta of 40.0 exceeds 18.0*2
+    tester.route(pointer1
+        .move(const Offset(10.0, 50.0))); // delta of 40.0 exceeds 18.0*2
     expect(log, equals(<String>['scale-start', 'scale-update']));
     log.clear();
 
@@ -347,7 +380,6 @@ void main() {
     expect(updatedRotation, isNull);
     expect(didStartScale, isFalse);
 
-
     // Zoom in
     tester.route(pointer2.move(const Offset(40.0, 50.0)));
     expect(didStartScale, isTrue);
@@ -413,7 +445,6 @@ void main() {
     didEndScale = false;
     expect(didTap, isFalse);
 
-
     // Continue scaling with two fingers
     tester.route(pointer3.move(const Offset(10.0, 20.0)));
     expect(didStartScale, isTrue);
@@ -427,7 +458,7 @@ void main() {
     tester.route(pointer3.move(const Offset(30.0, 40.0)));
     expect(updatedFocalPoint, const Offset(25.0, 35.0));
     updatedFocalPoint = null;
-    expect(updatedRotation, - math.pi);
+    expect(updatedRotation, -math.pi);
     updatedRotation = null;
     tester.route(pointer3.move(const Offset(10.0, 20.0)));
     expect(updatedFocalPoint, const Offset(15.0, 25.0));

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
 
 import 'gesture_tester.dart';
 
@@ -222,27 +222,16 @@ void main() {
 
   testGesture('Scale gesture competes with drag', (GestureTester tester) {
     final ScaleGestureRecognizer scale = ScaleGestureRecognizer();
-    final HorizontalDragGestureRecognizer drag =
-        HorizontalDragGestureRecognizer();
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer();
 
     final List<String> log = <String>[];
 
-    scale.onStart = (ScaleStartDetails details) {
-      log.add('scale-start');
-    };
-    scale.onUpdate = (ScaleUpdateDetails details) {
-      log.add('scale-update');
-    };
-    scale.onEnd = (ScaleEndDetails details) {
-      log.add('scale-end');
-    };
+    scale.onStart = (ScaleStartDetails details) { log.add('scale-start'); };
+    scale.onUpdate = (ScaleUpdateDetails details) { log.add('scale-update'); };
+    scale.onEnd = (ScaleEndDetails details) { log.add('scale-end'); };
 
-    drag.onStart = (DragStartDetails details) {
-      log.add('drag-start');
-    };
-    drag.onEnd = (DragEndDetails details) {
-      log.add('drag-end');
-    };
+    drag.onStart = (DragStartDetails details) { log.add('drag-start'); };
+    drag.onEnd = (DragEndDetails details) { log.add('drag-end'); };
 
     final TestPointer pointer1 = TestPointer(1);
 
@@ -259,8 +248,7 @@ void main() {
 
     // scale will win if focal point delta exceeds 18.0*2
 
-    tester.route(pointer1
-        .move(const Offset(10.0, 50.0))); // delta of 40.0 exceeds 18.0*2
+    tester.route(pointer1.move(const Offset(10.0, 50.0))); // delta of 40.0 exceeds 18.0*2
     expect(log, equals(<String>['scale-start', 'scale-update']));
     log.clear();
 
@@ -380,6 +368,7 @@ void main() {
     expect(updatedRotation, isNull);
     expect(didStartScale, isFalse);
 
+
     // Zoom in
     tester.route(pointer2.move(const Offset(40.0, 50.0)));
     expect(didStartScale, isTrue);
@@ -445,6 +434,7 @@ void main() {
     didEndScale = false;
     expect(didTap, isFalse);
 
+
     // Continue scaling with two fingers
     tester.route(pointer3.move(const Offset(10.0, 20.0)));
     expect(didStartScale, isTrue);
@@ -458,7 +448,7 @@ void main() {
     tester.route(pointer3.move(const Offset(30.0, 40.0)));
     expect(updatedFocalPoint, const Offset(25.0, 35.0));
     updatedFocalPoint = null;
-    expect(updatedRotation, -math.pi);
+    expect(updatedRotation, - math.pi);
     updatedRotation = null;
     tester.route(pointer3.move(const Offset(10.0, 20.0)));
     expect(updatedFocalPoint, const Offset(15.0, 25.0));


### PR DESCRIPTION
This PR adds two new parameters to the `ScaleUpdateDetails` class which track the vertical and horizontal scale of a scale gesture. This is useful if you are creating a widget that should only respond to scales along an axis, i.e. if you are creating a calendar whose days can be made wider by horizontal scaling motions.

My IDE is set to auto-run dartfmt, so I included those changes. Is there a reason the file wasn't already formatted? I can revert those changes if unwanted.