### PR TITLE
DatePicker noon/midnight overflow fix

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -448,7 +448,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       date.year,
       date.month,
       date.day,
-      selectedHour % 12 + selectedAmPm * 12,
+      widget.use24hFormat ? selectedHour : selectedHour % 12 + selectedAmPm * 12,
       selectedMinute,
     );
   }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -448,7 +448,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       date.year,
       date.month,
       date.day,
-      selectedHour + selectedAmPm * 12,
+      selectedHour % 12 + selectedAmPm * 12,
       selectedMinute,
     );
   }

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -560,6 +560,46 @@ void main() {
       );
     });
 
+    testWidgets('picker handles noon/midnight edge cases', (WidgetTester tester) async {
+      DateTime date;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: SizedBox(
+            height: 400.0,
+            width: 400.0,
+            child: CupertinoDatePicker(
+              mode: CupertinoDatePickerMode.time,
+              onDateTimeChanged: (DateTime newDate) {
+                date = newDate;
+              },
+              initialDateTime: DateTime(2019, 1, 1, 0, 15),
+            ),
+          ),
+        ),
+      );
+
+      // 0:15 -> 0:16
+      await tester.drag(find.text('15'), _kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 0, 16));
+
+      // 0:16 -> 12:16
+      await tester.drag(find.text('AM'), _kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 12, 16));
+
+      // 12:16 -> 12:17
+      await tester.drag(find.text('16'), _kRowOffset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(date, DateTime(2019, 1, 1, 12, 17));
+    });
+
     testWidgets('picker persists am/pm value when scrolling hours', (WidgetTester tester) async {
       DateTime date;
       await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -612,6 +612,33 @@ void main() {
 
         expect(date, DateTime(2019, 1, 1, 12, 16));
       });
+
+      testWidgets('noon in 24 hour time', (WidgetTester tester) async {
+        DateTime date;
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoDatePicker(
+                use24hFormat: true,
+                mode: CupertinoDatePickerMode.time,
+                onDateTimeChanged: (DateTime newDate) {
+                  date = newDate;
+                },
+                initialDateTime: DateTime(2019, 1, 1, 12, 25),
+              ),
+            ),
+          ),
+        );
+
+        // 12:25 -> 12:26
+        await tester.drag(find.text('25'), _kRowOffset);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(date, DateTime(2019, 1, 1, 12, 26));
+      });
     });
 
     testWidgets('picker persists am/pm value when scrolling hours', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -560,44 +560,58 @@ void main() {
       );
     });
 
-    testWidgets('picker handles noon/midnight edge cases', (WidgetTester tester) async {
-      DateTime date;
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: SizedBox(
-            height: 400.0,
-            width: 400.0,
-            child: CupertinoDatePicker(
-              mode: CupertinoDatePickerMode.time,
-              onDateTimeChanged: (DateTime newDate) {
-                date = newDate;
-              },
-              initialDateTime: DateTime(2019, 1, 1, 0, 15),
+    group('Picker handles initial noon/midnight times', () {
+      testWidgets('midnight', (WidgetTester tester) async {
+        DateTime date;
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.time,
+                onDateTimeChanged: (DateTime newDate) {
+                  date = newDate;
+                },
+                initialDateTime: DateTime(2019, 1, 1, 0, 15),
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // 0:15 -> 0:16
-      await tester.drag(find.text('15'), _kRowOffset);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 500));
+        // 0:15 -> 0:16
+        await tester.drag(find.text('15'), _kRowOffset);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
 
-      expect(date, DateTime(2019, 1, 1, 0, 16));
+        expect(date, DateTime(2019, 1, 1, 0, 16));
+      });
 
-      // 0:16 -> 12:16
-      await tester.drag(find.text('AM'), _kRowOffset);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 500));
+      testWidgets('noon', (WidgetTester tester) async {
+        DateTime date;
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.time,
+                onDateTimeChanged: (DateTime newDate) {
+                  date = newDate;
+                },
+                initialDateTime: DateTime(2019, 1, 1, 12, 15),
+              ),
+            ),
+          ),
+        );
 
-      expect(date, DateTime(2019, 1, 1, 12, 16));
+        // 12:15 -> 12:16
+        await tester.drag(find.text('15'), _kRowOffset);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
 
-      // 12:16 -> 12:17
-      await tester.drag(find.text('16'), _kRowOffset);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 500));
-
-      expect(date, DateTime(2019, 1, 1, 12, 17));
+        expect(date, DateTime(2019, 1, 1, 12, 16));
+      });
     });
 
     testWidgets('picker persists am/pm value when scrolling hours', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27755. When the Date Picker was scrolled from 12:XX PM to 12:YY PM, the new date was being reported as 0:YY AM. A similar error occurred for 12:XX AM TO 12:YY PM. This was because of an incorrect calculation:
```
selectedHour + selectedAmPm * 12 // If the hour is 12 PM, this becomes 24 PM, which is actually 0 AM.
```
This PR fixes that, and adds two tests for initial noon/midnight times.