### PR TITLE
Remove remaining "## Sample code" segments, and fix the snippet generator.

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -90,9 +90,35 @@ void main(List<String> arguments) {
     tempDirectory = Directory(parsedArguments['temp']);
     if (!tempDirectory.existsSync()) {
       tempDirectory.createSync(recursive: true);
+    } else {
+      tempDirectory.deleteSync(recursive: true);
+      tempDirectory.createSync(recursive: true);
     }
   }
-  exitCode = SampleChecker(flutterPackage, tempDirectory: tempDirectory).checkSamples();
+  try {
+    exitCode = SampleChecker(flutterPackage, tempDirectory: tempDirectory).checkSamples();
+  } on SampleCheckerException catch (e) {
+    stderr.write(e);
+    exit(1);
+  }
+}
+
+class SampleCheckerException implements Exception {
+  SampleCheckerException(this.message, {this.file, this.line});
+  final String message;
+  final String file;
+  final int line;
+
+  @override
+  String toString() {
+    if (file != null || line != null) {
+      final String fileStr = file == null ? '' : '$file:';
+      final String lineStr = line == null ? '' : '$line:';
+      return '$fileStr$lineStr Error: $message';
+    } else {
+      return 'Error: $message';
+    }
+  }
 }
 
 /// Checks samples and code snippets for analysis errors.
@@ -129,10 +155,10 @@ class SampleChecker {
   static final RegExp _dartDocSampleEndRegex = RegExp(r'{@end-tool}');
 
   /// A RegExp that matches the start of a code block within dartdoc.
-  static final RegExp _codeBlockStartRegex = RegExp(r'/// ```dart.*$');
+  static final RegExp _codeBlockStartRegex = RegExp(r'///\s+```dart.*$');
 
   /// A RegExp that matches the end of a code block within dartdoc.
-  static final RegExp _codeBlockEndRegex = RegExp(r'/// ```\s*$');
+  static final RegExp _codeBlockEndRegex = RegExp(r'///\s+```\s*$');
 
   /// A RegExp that matches a Dart constructor.
   static final RegExp _constructorRegExp = RegExp(r'[A-Z][a-zA-Z0-9<>.]*\(');
@@ -288,8 +314,12 @@ class SampleChecker {
     print('Generating snippet for ${snippet.start?.filename}:${snippet.start?.line}');
     final ProcessResult process = _runSnippetsScript(args);
     if (process.exitCode != 0) {
-      throw 'Unable to create snippet for ${snippet.start.filename}:${snippet.start.line} '
-          '(using input from ${inputFile.path}):\n${process.stdout}\n${process.stderr}';
+      throw SampleCheckerException(
+        'Unable to create snippet for ${snippet.start.filename}:${snippet.start.line} '
+            '(using input from ${inputFile.path}):\n${process.stdout}\n${process.stderr}',
+        file: snippet.start.filename,
+        line: snippet.start.line,
+      );
     }
     return outputFile;
   }
@@ -304,11 +334,14 @@ class SampleChecker {
       final String relativeFilePath = path.relative(file.path, from: _flutterPackage.path);
       final List<String> sampleLines = file.readAsLinesSync();
       final List<Section> preambleSections = <Section>[];
+      // Whether or not we're in the file-wide preamble section ("Examples can assume").
       bool inPreamble = false;
+      // Whether or not we're in a code sample
       bool inSampleSection = false;
+      // Whether or not we're in a snippet code sample (with template) specifically.
       bool inSnippet = false;
+      // Whether or not we're in a '```dart' segment.
       bool inDart = false;
-      bool foundDart = false;
       int lineNumber = 0;
       final List<String> block = <String>[];
       List<String> snippetArgs = <String>[];
@@ -318,7 +351,7 @@ class SampleChecker {
         final String trimmedLine = line.trim();
         if (inSnippet) {
           if (!trimmedLine.startsWith(_dartDocPrefix)) {
-            throw '$relativeFilePath:$lineNumber: Snippet section unterminated.';
+            throw SampleCheckerException('Snippet section unterminated.', file: relativeFilePath, line: lineNumber);
           }
           if (_dartDocSampleEndRegex.hasMatch(trimmedLine)) {
             snippets.add(
@@ -342,53 +375,51 @@ class SampleChecker {
             preambleSections.add(_processBlock(startLine, block));
             block.clear();
           } else if (!line.startsWith('// ')) {
-            throw '$relativeFilePath:$lineNumber: Unexpected content in sample code preamble.';
+            throw SampleCheckerException('Unexpected content in sample code preamble.', file: relativeFilePath, line: lineNumber);
           } else {
             block.add(line.substring(3));
           }
         } else if (inSampleSection) {
-          if (!trimmedLine.startsWith(_dartDocPrefix) || trimmedLine.startsWith('$_dartDocPrefix ## ')) {
+          if (_dartDocSampleEndRegex.hasMatch(trimmedLine)) {
             if (inDart) {
-              throw '$relativeFilePath:$lineNumber: Dart section inexplicably unterminated.';
-            }
-            if (!foundDart) {
-              throw '$relativeFilePath:$lineNumber: No dart block found in sample code section';
+              throw SampleCheckerException("Dart section didn't terminate before end of sample", file: relativeFilePath, line: lineNumber);
             }
             inSampleSection = false;
-          } else {
-            if (inDart) {
-              if (_codeBlockEndRegex.hasMatch(trimmedLine)) {
-                inDart = false;
-                final Section processed = _processBlock(startLine, block);
-                if (preambleSections.isEmpty) {
-                  sections.add(processed);
-                } else {
-                  sections.add(Section.combine(preambleSections
-                    ..toList()
-                    ..add(processed)));
-                }
-                block.clear();
-              } else if (trimmedLine == _dartDocPrefix) {
-                block.add('');
+          }
+          if (inDart) {
+            if (_codeBlockEndRegex.hasMatch(trimmedLine)) {
+              inDart = false;
+              final Section processed = _processBlock(startLine, block);
+              if (preambleSections.isEmpty) {
+                sections.add(processed);
               } else {
-                final int index = line.indexOf(_dartDocPrefixWithSpace);
-                if (index < 0) {
-                  throw '$relativeFilePath:$lineNumber: Dart section inexplicably did not '
-                      'contain "$_dartDocPrefixWithSpace" prefix.';
-                }
-                block.add(line.substring(index + 4));
+                sections.add(Section.combine(preambleSections
+                  ..toList()
+                  ..add(processed)));
               }
-            } else if (_codeBlockStartRegex.hasMatch(trimmedLine)) {
-              assert(block.isEmpty);
-              startLine = Line(
-                '',
-                filename: relativeFilePath,
-                line: lineNumber + 1,
-                indent: line.indexOf(_dartDocPrefixWithSpace) + _dartDocPrefixWithSpace.length,
-              );
-              inDart = true;
-              foundDart = true;
+              block.clear();
+            } else if (trimmedLine == _dartDocPrefix) {
+              block.add('');
+            } else {
+              final int index = line.indexOf(_dartDocPrefixWithSpace);
+              if (index < 0) {
+                throw SampleCheckerException(
+                  'Dart section inexplicably did not contain "$_dartDocPrefixWithSpace" prefix.',
+                  file: relativeFilePath,
+                  line: lineNumber,
+                );
+              }
+              block.add(line.substring(index + 4));
             }
+          } else if (_codeBlockStartRegex.hasMatch(trimmedLine)) {
+            assert(block.isEmpty);
+            startLine = Line(
+              '',
+              filename: relativeFilePath,
+              line: lineNumber + 1,
+              indent: line.indexOf(_dartDocPrefixWithSpace) + _dartDocPrefixWithSpace.length,
+            );
+            inDart = true;
           }
         }
         if (!inSampleSection) {
@@ -397,11 +428,7 @@ class SampleChecker {
             assert(block.isEmpty);
             startLine = Line('', filename: relativeFilePath, line: lineNumber + 1, indent: 3);
             inPreamble = true;
-          } else if (trimmedLine == '/// ## Sample code' ||
-              trimmedLine.startsWith('/// ## Sample code:') ||
-              trimmedLine == '/// ### Sample code' ||
-              trimmedLine.startsWith('/// ### Sample code:') ||
-              sampleMatch != null) {
+          } else if (sampleMatch != null) {
             inSnippet = sampleMatch != null ? sampleMatch[1] == 'snippet' : false;
             if (inSnippet) {
               startLine = Line(
@@ -418,7 +445,12 @@ class SampleChecker {
               }
             }
             inSampleSection = !inSnippet;
-            foundDart = false;
+          } else if (RegExp(r'///\s*#+\s+[Ss]ample\s+[Cc]ode:?$').hasMatch(trimmedLine)) {
+            throw SampleCheckerException(
+              "Found deprecated '## Sample code' section: use {@tool sample}...{@end-tool} instead.",
+              file: relativeFilePath,
+              line: lineNumber,
+            );
           }
         }
       }
@@ -598,14 +630,17 @@ linter:
               ),
             ),
           );
-          throw 'Cannot analyze dartdocs; analysis errors exist in ${file.path}: $error';
+          throw SampleCheckerException(
+            'Cannot analyze dartdocs; analysis errors exist: $error',
+            file: file.path,
+            line: lineNumber,
+          );
         }
 
         if (errorCode == 'unused_element' || errorCode == 'unused_local_variable') {
           // We don't really care if sample code isn't used!
           continue;
         }
-
         if (isSnippet) {
           addAnalysisError(
             file,
@@ -630,14 +665,20 @@ linter:
                 Line('', filename: file.path, line: lineNumber),
               ),
             );
-            throw 'Failed to parse error message (read line number as $lineNumber; '
-                'total number of lines is ${fileContents.length}): $error';
+            throw SampleCheckerException('Failed to parse error message: $error', file: file.path, line: lineNumber);
           }
 
           final Section actualSection = sections[file.path];
+          if (actualSection == null) {
+            throw SampleCheckerException(
+              "Unknown section for ${file.path}. Maybe the temporary directory wasn't empty?",
+              file: file.path,
+              line: lineNumber,
+            );
+          }
           final Line actualLine = actualSection.code[lineNumber - 1];
 
-          if (actualLine.filename == null) {
+          if (actualLine?.filename == null) {
             if (errorCode == 'missing_identifier' && lineNumber > 1) {
               if (fileContents[lineNumber - 2].endsWith(',')) {
                 final Line actualLine = sections[file.path].code[lineNumber - 2];
@@ -698,7 +739,7 @@ linter:
   /// into valid Dart code.
   Section _processBlock(Line line, List<String> block) {
     if (block.isEmpty) {
-      throw '$line: Empty ```dart block in sample code.';
+      throw SampleCheckerException('$line: Empty ```dart block in sample code.');
     }
     if (block.first.startsWith('new ') || block.first.startsWith('const ') || block.first.startsWith(_constructorRegExp)) {
       _expressionId += 1;
@@ -721,8 +762,8 @@ linter:
         // treated as a separate code block.
         if (block[index] == '' || block[index] == '// ...') {
           if (subline == null)
-            throw '${Line('', filename: line.filename, line: line.line + index, indent: line.indent)}: '
-                'Unexpected blank line or "// ..." line near start of subblock in sample code.';
+            throw SampleCheckerException('${Line('', filename: line.filename, line: line.line + index, indent: line.indent)}: '
+                'Unexpected blank line or "// ..." line near start of subblock in sample code.');
           subblocks += 1;
           subsections.add(_processBlock(subline, buffer));
           buffer.clear();

--- a/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
@@ -18,8 +18,7 @@
 /// blabla 0.0, the penzance blabla is blabla not blabla at all. Bla the blabla
 /// 1.0, the blabla is blabla blabla blabla an blabla blabla.
 ///
-/// ### Sample code
-///
+/// {@tool sample}
 /// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
 /// blabla it when it is blabla:
 ///
@@ -29,9 +28,9 @@
 ///   child: const Text('Poor wandering ones!'),
 /// )
 /// ```
+/// {@end-tool}
 ///
-/// ## Sample code
-///
+/// {@tool sample}
 /// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
 /// blabla finale blabla:
 ///
@@ -41,3 +40,4 @@
 ///   child: const Text('Poor wandering ones!'),
 /// )
 /// ```
+/// {@end-tool}

--- a/dev/bots/test/analyze-sample-code_test.dart
+++ b/dev/bots/test/analyze-sample-code_test.dart
@@ -17,9 +17,9 @@ void main() {
       ..removeWhere((String line) => line.startsWith('Analyzer output:'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
-      'known_broken_documentation.dart:27:9: new Opacity(',
+      'known_broken_documentation.dart:26:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
-      'known_broken_documentation.dart:39:9: new Opacity(',
+      'known_broken_documentation.dart:38:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
       '',
       'Found 1 sample code errors.',

--- a/dev/docs/assets/snippets.css
+++ b/dev/docs/assets/snippets.css
@@ -1,6 +1,6 @@
 /* Styles for handling custom code snippets */
 .snippet-container {
-  background-color: #45aae8;
+  background-color: #2372a3;
   padding: 10px;
   overflow: auto;
 }
@@ -30,8 +30,21 @@
   color: white;
 }
 
+.snippet-description a:link {
+  color: #c7fcf4;
+}
+.snippet-description a:visited {
+  color: #c7dbfc;
+}
+.snippet-description a:hover {
+  color: white;
+}
+.snippet-description a:active {
+  color: #80b0fc;
+}
+
 .snippet-buttons button {
-  background-color: #45aae8;
+  background-color: #2372a3;
   border-style: none;
   color: white;
   padding: 10px 24px;
@@ -82,7 +95,7 @@
   height: 28px;
   width: 28px;
   transition: .3s ease;
-  background-color: #45aae8;
+  background-color: #2372a3;
 }
 
 .copy-button {
@@ -102,7 +115,7 @@
 
 .copy-image {
   opacity: 0.65;
-  color: #45aae8;
+  color: #2372a3;
   font-size: 28px;
   padding-top: 4px;
 }

--- a/dev/docs/assets/snippets.js
+++ b/dev/docs/assets/snippets.js
@@ -2,15 +2,10 @@
  * Scripting for handling custom code snippets
  */
 
-const shortSnippet = 'shortSnippet';
-const longSnippet = 'longSnippet';
-var visibleSnippet = shortSnippet;
-
 /**
- * Shows the requested snippet. Values for "name" can be "shortSnippet" or
- * "longSnippet".
+ * Shows the requested snippet, and stores the current state in visibleSnippet.
  */
-function showSnippet(name) {
+function showSnippet(name, visibleSnippet) {
   if (visibleSnippet == name) return;
   if (visibleSnippet != null) {
     var shown = document.getElementById(visibleSnippet);
@@ -39,6 +34,7 @@ function showSnippet(name) {
   if (button != null) {
     button.setAttributeNode(selectedAttribute);
   }
+  return visibleSnippet;
 }
 
 // Finds a sibling to given element with the given id.
@@ -64,8 +60,8 @@ function supportsCopying() {
 // Copies the text inside the currently visible snippet to the clipboard, or the
 // given element, if any.
 function copyTextToClipboard(element) {
-  if (element == null) {
-    var elementSelector = '#' + visibleSnippet + ' .language-dart';
+  if (typeof element === 'string') {
+    var elementSelector = '#' + element + ' .language-dart';
     element = document.querySelector(elementSelector);
     if (element == null) {
       console.log(

--- a/dev/snippets/README.md
+++ b/dev/snippets/README.md
@@ -7,8 +7,9 @@ snippets.
 This takes code in dartdocs, like this:
 
 ```dart
-/// The following is a skeleton of a stateless widget subclass called `GreenFrog`:
 /// {@tool snippet --template="stateless_widget"}
+/// The following is a skeleton of a stateless widget subclass called `GreenFrog`.
+/// ```dart
 /// class GreenFrog extends StatelessWidget {
 ///   const GreenFrog({ Key key }) : super(key: key);
 ///
@@ -17,6 +18,7 @@ This takes code in dartdocs, like this:
 ///     return Container(color: const Color(0xFF2DBD3A));
 ///   }
 /// }
+/// ```
 /// {@end-tool}
 ```
 

--- a/dev/snippets/config/skeletons/application.html
+++ b/dev/snippets/config/skeletons/application.html
@@ -1,26 +1,30 @@
 {@inject-html}
 <div class="snippet-buttons">
-  <button id="shortSnippetButton" onclick="showSnippet(shortSnippet);" selected>Sample</button>
-  <button id="longSnippetButton" onclick="showSnippet(longSnippet);">Sample in an App</button>
+  <script>var visibleSnippet{{serial}} = "shortSnippet{{serial}}";</script>
+  <button id="shortSnippet{{serial}}Button"
+          onclick="visibleSnippet{{serial}} = showSnippet('shortSnippet{{serial}}', visibleSnippet{{serial}});"
+          selected>Sample</button>
+  <button id="longSnippet{{serial}}Button"
+          onclick="visibleSnippet{{serial}} = showSnippet('longSnippet{{serial}}', visibleSnippet{{serial}});">Sample in an App</button>
 </div>
 <div class="snippet-container">
-  <div class="snippet" id="shortSnippet">
+  <div class="snippet" id="shortSnippet{{serial}}">
     {{description}}
     <div class="copyable-container">
       <button class="copy-button-overlay copy-button" title="Copy to clipboard"
-              onclick="copyTextToClipboard();">
+              onclick="copyTextToClipboard(visibleSnippet{{serial}});">
         <i class="material-icons copy-image">assignment</i>
       </button>
       <pre class="language-{{language}}"><code class="language-{{language}}">{{code}}</code></pre>
     </div>
   </div>
-  <div class="snippet" id="longSnippet" hidden>
+  <div class="snippet" id="longSnippet{{serial}}" hidden>
     <div class="snippet-description">To create a sample project with this code snippet, run:<br/>
       <span class="snippet-create-command">flutter create --sample={{id}} mysample</span>
     </div>
     <div class="copyable-container">
       <button class="copy-button-overlay copy-button" title="Copy to clipboard"
-              onclick="copyTextToClipboard();">
+              onclick="copyTextToClipboard(visibleSnippet{{serial}});">
         <i class="material-icons copy-image">assignment</i>
       </button>
       <pre class="language-{{language}}"><code class="language-{{language}}">{{app}}</code></pre>

--- a/dev/snippets/config/skeletons/sample.html
+++ b/dev/snippets/config/skeletons/sample.html
@@ -1,6 +1,6 @@
 {@inject-html}
 <div class="snippet-buttons">
-  <button id="shortSnippetButton" selected>Sample</button>
+  <button id="shortSnippet{{serial}}Button" selected>Sample</button>
 </div>
 <div class="snippet-container">
   <div class="snippet">{{description}}

--- a/dev/snippets/config/templates/README.md
+++ b/dev/snippets/config/templates/README.md
@@ -63,8 +63,26 @@ follows:
   function calls are not allowed in the preamble.  It also has an `imports`
   section to import additional packages. Please only import things that are part
   of flutter or part of default dependencies for a `flutter create` project.
+  It creates a WidgetsApp around the child stateful widget.
 
 - [`stateless_widget`](stateless_widget.tmpl) :
   Identical to the `stateful_widget` template, except that the default code
-  block is inserted as the return value for a pre-existing `build` function in a
-  StatelessWidget, instead of being at the class level.
+  block is inserted as the `build` function in a
+  StatelessWidget. There is no need to include the @override before the build
+  funciton (the template adds this for you).
+
+- [`stateful_widget_material`](stateful_widget_material.tmpl) : Similar to
+  `stateful_widget`, except that it imports the material library, and uses
+  a MaterialApp instead of WidgetsApp.
+
+- [`stateless_widget_material`](stateless_widget_material.tmpl) : Similar to
+  `stateless_widget`, except that it imports the material library, and uses
+  a MaterialApp instead of WidgetsApp.
+
+- [`stateful_widget_scaffold`](stateful_widget_scaffold.tmpl) : Similar to
+  `stateful_widget_material`, except that it wraps the stateful widget with a
+  Scaffold.
+
+- [`stateless_widget_scaffold`](stateless_widget_scaffold.tmpl) : Similar to
+  `stateless_widget_material`, except that it wraps the stateless widget with a
+  Scaffold.

--- a/dev/snippets/config/templates/README.md
+++ b/dev/snippets/config/templates/README.md
@@ -49,6 +49,11 @@ additional burden, since all code will also be compiled to be sure it compiles).
 The templates available for using as an argument to the snippets tool are as
 follows:
 
+- [`freeform`](freeform.tmpl) :
+  This is a simple template for which you provide everything.  It has no code of
+  its own, just the sections for `imports`, `main`, and `preamble`. You must
+  provide the `main` section in order to have a `main()`.
+
 - [`stateful_widget`](stateful_widget.tmpl) :
   The default code block will be placed as the body of the `State` object of a
   StatefulWidget subclass. Because the default code block is placed as the body

--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -1,0 +1,9 @@
+{{description}}
+
+{{code-imports}}
+
+{{code-main}}
+
+{{code-preamble}}
+
+{{code}}

--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -1,3 +1,5 @@
+// Flutter code sample for {{id}}
+
 {{description}}
 
 {{code-imports}}

--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -10,12 +10,13 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'Flutter Code Sample for {{id}}',
-      theme: new ThemeData(
+      theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: new MyStatefulWidget(),
+      home: Material(child: MyStatefulWidget()),
+      color: Colors.white,
     );
   }
 }
@@ -26,7 +27,7 @@ class MyStatefulWidget extends StatefulWidget {
   MyStatefulWidget({Key key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => new _MyStatefulWidgetState();
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -2,7 +2,7 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 {{code-imports}}
 
@@ -10,19 +10,19 @@ void main() => runApp(new MyApp());
 
 /// This Widget is the main application widget.
 class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
-      title: 'Flutter Code Sample',
+    return MaterialApp(
+      title: _title,
       home: MyStatefulWidget(),
-      color: const Color(0xffffffff),
     );
   }
 }
 
 {{code-preamble}}
 
-/// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
   MyStatefulWidget({Key key}) : super(key: key);
 
@@ -30,7 +30,6 @@ class MyStatefulWidget extends StatefulWidget {
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
 }
 
-// This is the private State class that goes with MyStatefulWidget.
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   {{code}}
 }

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -2,7 +2,7 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 {{code-imports}}
 
@@ -10,19 +10,22 @@ void main() => runApp(new MyApp());
 
 /// This Widget is the main application widget.
 class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
-      title: 'Flutter Code Sample',
-      home: MyStatefulWidget(),
-      color: const Color(0xffffffff),
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: Text(_title)),
+        body: MyStatefulWidget(),
+      ),
     );
   }
 }
 
 {{code-preamble}}
 
-/// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
   MyStatefulWidget({Key key}) : super(key: key);
 
@@ -30,7 +33,6 @@ class MyStatefulWidget extends StatefulWidget {
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
 }
 
-// This is the private State class that goes with MyStatefulWidget.
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   {{code}}
 }

--- a/dev/snippets/config/templates/stateless_widget.tmpl
+++ b/dev/snippets/config/templates/stateless_widget.tmpl
@@ -10,12 +10,13 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'Flutter Code Sample for {{id}}',
-      theme: new ThemeData(
+      theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: new MyStatelessWidget(),
+      home: Material(child: MyStatelessWidget()),
+      color: Colors.white,
     );
   }
 }

--- a/dev/snippets/config/templates/stateless_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material.tmpl
@@ -2,7 +2,7 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 {{code-imports}}
 
@@ -10,17 +10,17 @@ void main() => runApp(new MyApp());
 
 /// This Widget is the main application widget.
 class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
-      title: 'Flutter Code Sample',
-      builder: (BuildContext context, Widget navigator) {
-        return MyStatelessWidget();
-      },
-      color: const Color(0xffffffff),
+    return MaterialApp(
+      title: _title,
+      home: MyStatelessWidget(),
     );
   }
 }
+
 
 {{code-preamble}}
 

--- a/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
@@ -2,7 +2,7 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 {{code-imports}}
 
@@ -10,17 +10,20 @@ void main() => runApp(new MyApp());
 
 /// This Widget is the main application widget.
 class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
-      title: 'Flutter Code Sample',
-      builder: (BuildContext context, Widget navigator) {
-        return MyStatelessWidget();
-      },
-      color: const Color(0xffffffff),
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: Text(_title)),
+        body: MyStatelessWidget(),
+      ),
     );
   }
 }
+
 
 {{code-preamble}}
 

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:platform/platform.dart';
 import 'configuration.dart';
 import 'snippets.dart';
 
+const String _kSerialOption = 'serial';
 const String _kElementOption = 'element';
 const String _kHelpOption = 'help';
 const String _kInputOption = 'input';
@@ -75,6 +76,11 @@ void main(List<String> argList) {
     defaultsTo: environment['ELEMENT_NAME'],
     help: 'The name of the element that this snippet belongs to.',
   );
+  parser.addOption(
+    _kSerialOption,
+    defaultsTo: environment['INVOCATION_INDEX'],
+    help: 'A unique serial number for the snippet invocation.',
+  );
   parser.addFlag(
     _kHelpOption,
     defaultsTo: false,
@@ -117,6 +123,7 @@ void main(List<String> argList) {
   final String packageName = args[_kPackageOption] != null && args[_kPackageOption].isNotEmpty ? args[_kPackageOption] : null;
   final String libraryName = args[_kLibraryOption] != null && args[_kLibraryOption].isNotEmpty ? args[_kLibraryOption] : null;
   final String elementName = args[_kElementOption] != null && args[_kElementOption].isNotEmpty ? args[_kElementOption] : null;
+  final String serial = args[_kSerialOption] != null && args[_kSerialOption].isNotEmpty ? args[_kSerialOption] : null;
   final List<String> id = <String>[];
   if (args[_kOutputOption] != null) {
     id.add(path.basename(path.basenameWithoutExtension(args[_kOutputOption])));
@@ -130,10 +137,13 @@ void main(List<String> argList) {
     if (elementName != null) {
       id.add(elementName);
     }
+    if (serial != null) {
+      id.add(serial);
+    }
     if (id.isEmpty) {
       errorExit('Unable to determine ID. At least one of --$_kPackageOption, '
-          '--$_kLibraryOption, --$_kElementOption, or the environment variables '
-          'PACKAGE_NAME, LIBRARY_NAME, or ELEMENT_NAME must be non-empty.');
+          '--$_kLibraryOption, --$_kElementOption, -$_kSerialOption, or the environment variables '
+          'PACKAGE_NAME, LIBRARY_NAME, ELEMENT_NAME, or INVOCATION_INDEX must be non-empty.');
     }
   }
 
@@ -149,6 +159,7 @@ void main(List<String> argList) {
       'sourceLine': environment['SOURCE_LINE'] != null
           ? int.tryParse(environment['SOURCE_LINE'])
           : null,
+      'serial': serial,
       'package': packageName,
       'library': libraryName,
       'element': elementName,

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -79,7 +79,7 @@ void main(List<String> argList) {
   parser.addOption(
     _kSerialOption,
     defaultsTo: environment['INVOCATION_INDEX'],
-    help: 'A unique serial number for the snippet invocation.',
+    help: 'A unique serial number for this snippet tool invocation.',
   );
   parser.addFlag(
     _kHelpOption,

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -31,7 +31,8 @@ class SnippetGenerator {
   SnippetGenerator({Configuration configuration})
       : configuration = configuration ??
             // Flutter's root is four directories up from this script.
-            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT'] ?? path.canonicalize(path.join(path.dirname(path.fromUri(Platform.script)), '..', '..', '..')))) {
+            Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT']
+                ?? path.canonicalize(path.join(path.dirname(path.fromUri(Platform.script)), '..', '..', '..')))) {
     this.configuration.createOutputDirectory();
   }
 
@@ -181,6 +182,16 @@ class SnippetGenerator {
     return file.readAsStringSync(encoding: Encoding.getByName('utf-8'));
   }
 
+  String _addLineNumbers(String app) {
+    final StringBuffer buffer = StringBuffer();
+    int count = 0;
+    for (String line in app.split('\n')) {
+      count++;
+      buffer.writeln('${count.toString().padLeft(5, ' ')}: $line');
+    }
+    return buffer.toString();
+  }
+
   /// The main routine for generating snippets.
   ///
   /// The [input] is the file containing the dartdoc comments (minus the leading
@@ -221,7 +232,7 @@ class SnippetGenerator {
         try {
           app = formatter.format(app);
         } on FormatterException catch (exception) {
-          stderr.write('Code to format:\n$app\n');
+          stderr.write('Code to format:\n${_addLineNumbers(app)}\n');
           errorExit('Unable to format snippet app template: $exception');
         }
 

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -72,10 +72,10 @@ class SnippetGenerator {
         // Remove any leading/trailing empty comment lines.
         // We don't want to remove ALL empty comment lines, only the ones at the
         // beginning and the end.
-        while (description.last == '// ') {
+        while (description.isNotEmpty && description.last == '// ') {
           description.removeLast();
         }
-        while (description.first == '// ') {
+        while (description.isNotEmpty && description.first == '// ') {
           description.removeAt(0);
         }
         return description.join('\n').trim();
@@ -98,7 +98,7 @@ class SnippetGenerator {
   ///
   /// Takes into account the [type] and doesn't substitute in the id and the app
   /// if not a [SnippetType.application] snippet.
-  String interpolateSkeleton(SnippetType type, List<_ComponentTuple> injections, String skeleton) {
+  String interpolateSkeleton(SnippetType type, List<_ComponentTuple> injections, String skeleton, Map<String, Object> metadata) {
     final List<String> result = <String>[];
     const HtmlEscape htmlEscape = HtmlEscape();
     String language;
@@ -128,12 +128,13 @@ class SnippetGenerator {
       'language': language ?? 'dart',
     }..addAll(type == SnippetType.application
         ? <String, String>{
+            'serial': metadata['serial'].toString() ?? '0',
             'id':
                 injections.firstWhere((_ComponentTuple tuple) => tuple.name == 'id').mergedContent,
             'app':
                 htmlEscape.convert(injections.firstWhere((_ComponentTuple tuple) => tuple.name == 'app').mergedContent),
           }
-        : <String, String>{'id': '', 'app': ''});
+        : <String, String>{'serial': '', 'id': '', 'app': ''});
     return skeleton.replaceAllMapped(RegExp('{{(${substitutions.keys.join('|')})}}'), (Match match) {
       return substitutions[match[1]];
     });
@@ -250,6 +251,6 @@ class SnippetGenerator {
         break;
     }
     final String skeleton = _loadFileAsUtf8(configuration.getHtmlSkeletonFile(type));
-    return interpolateSkeleton(type, snippetData, skeleton);
+    return interpolateSkeleton(type, snippetData, skeleton, metadata);
   }
 }

--- a/dev/tools/gen_keycodes/data/keyboard_key.tmpl
+++ b/dev/tools/gen_keycodes/data/keyboard_key.tmpl
@@ -32,7 +32,7 @@ import 'package:flutter/foundation.dart';
 /// look at the physical key to make sure that regardless of the character the
 /// key produces, you got the key that is in that location on the keyboard.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 /// This example shows how to detect if the user has selected the logical "Q"
 /// key.
 ///
@@ -270,7 +270,7 @@ class LogicalKeyboardKey extends Diagnosticable {
 /// looking for "the key next next to the TAB key", since on a French keyboard,
 /// the key next to the TAB key has an "A" on it.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 /// This example shows how to detect if the user has selected the physical key
 /// to the right of the CAPS LOCK key.
 ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -228,26 +228,28 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// For less common operations, consider using a [PopupMenuButton] as the
   /// last action.
   ///
-  /// {@tool snippet --template=stateless_widget}
+  /// {@tool snippet --template=stateless_widget_material}
   ///
   /// This sample shows adding an action to an [AppBar] that opens a shopping cart.
   ///
   /// ```dart
-  /// Scaffold(
-  ///   appBar: AppBar(
-  ///     title: Text('Hello World'),
-  ///     actions: <Widget>[
-  ///       IconButton(
-  ///         icon: Icon(Icons.shopping_cart),
-  ///         tooltip: 'Open shopping cart',
-  ///         onPressed: () {
-  ///           // Implement navigation to shopping cart page here...
-  ///           print('Shopping cart opened.');
-  ///         },
-  ///       ),
-  ///     ],
-  ///   ),
-  /// )
+  /// Widget build(BuildContext context) {
+  ///   return Scaffold(
+  ///     appBar: AppBar(
+  ///       title: Text('Ready, Set, Shop!'),
+  ///       actions: <Widget>[
+  ///         IconButton(
+  ///           icon: Icon(Icons.shopping_cart),
+  ///           tooltip: 'Open shopping cart',
+  ///           onPressed: () {
+  ///             // Implement navigation to shopping cart page here...
+  ///             print('Shopping cart opened.');
+  ///           },
+  ///         ),
+  ///       ],
+  ///     ),
+  ///   );
+  /// }
   /// ```
   /// {@end-tool}
   final List<Widget> actions;

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -241,7 +241,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///         icon: Icon(Icons.shopping_cart),
   ///         tooltip: 'Open shopping cart',
   ///         onPressed: () {
-  ///           // ...
+  ///           // Implement navigation to shopping cart page here...
+  ///           print('Shopping cart opened.');
   ///         },
   ///       ),
   ///     ],

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -68,7 +68,7 @@ enum BottomNavigationBarType {
 ///    case it's assumed that each item will have a different background color
 ///    and that background color will contrast well with white.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_material}
 /// This example shows a [BottomNavigationBar] as it is used within a [Scaffold]
 /// widget. The [BottomNavigationBar] has three [BottomNavigationBarItem]
 /// widgets and the [currentIndex] is set to index 1. The color of the selected
@@ -78,7 +78,7 @@ enum BottomNavigationBarType {
 ///
 /// ```dart
 /// int _selectedIndex = 1;
-/// final List<Widget> _widgetOptions = <Widget>[
+/// static const List<Widget> _widgetOptions = const <Widget>[
 ///   Text('Index 0: Home'),
 ///   Text('Index 1: Business'),
 ///   Text('Index 2: School'),

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -68,8 +68,7 @@ enum BottomNavigationBarType {
 ///    case it's assumed that each item will have a different background color
 ///    and that background color will contrast well with white.
 ///
-/// ## Sample Code
-///
+/// {@tool snippet --template=stateful_widget}
 /// This example shows a [BottomNavigationBar] as it is used within a [Scaffold]
 /// widget. The [BottomNavigationBar] has three [BottomNavigationBarItem]
 /// widgets and the [currentIndex] is set to index 1. The color of the selected
@@ -78,50 +77,42 @@ enum BottomNavigationBarType {
 /// the [Scaffold].
 ///
 /// ```dart
-/// class MyHomePage extends StatefulWidget {
-///   MyHomePage({Key key}) : super(key: key);
+/// int _selectedIndex = 1;
+/// final List<Widget> _widgetOptions = <Widget>[
+///   Text('Index 0: Home'),
+///   Text('Index 1: Business'),
+///   Text('Index 2: School'),
+/// ];
 ///
-///   @override
-///   _MyHomePageState createState() => _MyHomePageState();
+/// void _onItemTapped(int index) {
+///   setState(() {
+///     _selectedIndex = index;
+///   });
 /// }
 ///
-/// class _MyHomePageState extends State<MyHomePage> {
-///   int _selectedIndex = 1;
-///   final _widgetOptions = [
-///     Text('Index 0: Home'),
-///     Text('Index 1: Business'),
-///     Text('Index 2: School'),
-///   ];
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return Scaffold(
-///       appBar: AppBar(
-///         title: Text('BottomNavigationBar Sample'),
-///       ),
-///       body: Center(
-///         child: _widgetOptions.elementAt(_selectedIndex),
-///       ),
-///       bottomNavigationBar: BottomNavigationBar(
-///         items: <BottomNavigationBarItem>[
-///           BottomNavigationBarItem(icon: Icon(Icons.home), title: Text('Home')),
-///           BottomNavigationBarItem(icon: Icon(Icons.business), title: Text('Business')),
-///           BottomNavigationBarItem(icon: Icon(Icons.school), title: Text('School')),
-///         ],
-///         currentIndex: _selectedIndex,
-///         fixedColor: Colors.deepPurple,
-///         onTap: _onItemTapped,
-///       ),
-///     );
-///   }
-///
-///   void _onItemTapped(int index) {
-///     setState(() {
-///       _selectedIndex = index;
-///     });
-///   }
+/// @override
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     appBar: AppBar(
+///       title: Text('BottomNavigationBar Sample'),
+///     ),
+///     body: Center(
+///       child: _widgetOptions.elementAt(_selectedIndex),
+///     ),
+///     bottomNavigationBar: BottomNavigationBar(
+///       items: <BottomNavigationBarItem>[
+///         BottomNavigationBarItem(icon: Icon(Icons.home), title: Text('Home')),
+///         BottomNavigationBarItem(icon: Icon(Icons.business), title: Text('Business')),
+///         BottomNavigationBarItem(icon: Icon(Icons.school), title: Text('School')),
+///       ],
+///       currentIndex: _selectedIndex,
+///       fixedColor: Colors.deepPurple,
+///       onTap: _onItemTapped,
+///     ),
+///   );
 /// }
 /// ```
+/// {@end-tool}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -19,60 +19,72 @@ import 'theme.dart';
 /// some text describing a musical, and the other with buttons for buying
 /// tickets or listening to the show.](https://flutter.github.io/assets-for-api-docs/assets/material/card.png)
 ///
-/// {@tool snippet --template=stateless_widget}
+/// {@tool snippet --template=stateless_widget_scaffold}
 ///
 /// This sample shows creation of a [Card] widget that shows album information
 /// and two actions.
 ///
 /// ```dart
-/// Center(
-///   child: Card(
-///     child: Column(
-///       mainAxisSize: MainAxisSize.min,
-///       children: <Widget>[
-///         const ListTile(
-///           leading: Icon(Icons.album),
-///           title: Text('The Enchanted Nightingale'),
-///           subtitle: Text('Music by Julie Gable. Lyrics by Sidney Stein.'),
-///         ),
-///         ButtonTheme.bar( // make buttons use the appropriate styles for cards
-///           child: ButtonBar(
-///             children: <Widget>[
-///               FlatButton(
-///                 child: const Text('BUY TICKETS'),
-///                 onPressed: () { /* ... */ },
-///               ),
-///               FlatButton(
-///                 child: const Text('LISTEN'),
-///                 onPressed: () { /* ... */ },
-///               ),
-///             ],
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: Card(
+///       child: Column(
+///         mainAxisSize: MainAxisSize.min,
+///         children: <Widget>[
+///           const ListTile(
+///             leading: Icon(Icons.album),
+///             title: Text('The Enchanted Nightingale'),
+///             subtitle: Text('Music by Julie Gable. Lyrics by Sidney Stein.'),
 ///           ),
-///         ),
-///       ],
+///           ButtonTheme.bar( // make buttons use the appropriate styles for cards
+///             child: ButtonBar(
+///               children: <Widget>[
+///                 FlatButton(
+///                   child: const Text('BUY TICKETS'),
+///                   onPressed: () { /* ... */ },
+///                 ),
+///                 FlatButton(
+///                   child: const Text('LISTEN'),
+///                   onPressed: () { /* ... */ },
+///                 ),
+///               ],
+///             ),
+///           ),
+///         ],
+///       ),
 ///     ),
-///   ),
-/// )
+///   );
+/// }
 /// ```
 /// {@end-tool}
 ///
 /// Sometimes the primary action area of a card is the card itself. Cards can be
 /// one large touch target that shows a detail screen when tapped.
 ///
-/// {@tool snippet --template=stateless_widget}
+/// {@tool snippet --template=stateless_widget_scaffold}
 ///
 /// This sample shows creation of a [Card] widget that can be tapped. When
 /// tapped this [Card]'s [InkWell] displays an "ink splash" that fills the
 /// entire card.
 ///
 /// ```dart
-/// Card(
-///   child: InkWell(
-///     splashColor: Colors.blue.withAlpha(30),
-///     onTap: () { /* ... */ },
-///     child: Text('A card that can be tapped'),
-///   ),
-/// )
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: Card(
+///       child: InkWell(
+///         splashColor: Colors.blue.withAlpha(30),
+///         onTap: () {
+///           print('Card tapped.');
+///         },
+///         child: Container(
+///           width: 300,
+///           height: 100,
+///           child: Text('A card that can be tapped'),
+///         ),
+///       ),
+///     ),
+///   );
+/// }
 /// ```
 ///
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -207,7 +207,7 @@ abstract class DeletableChipAttributes {
   /// ```dart
   /// @override
   /// Widget build(BuildContext context) {
-  ///   return CastList();
+  ///   return Center(child: CastList());
   /// }
   /// ```
   /// {@end-tool}

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -151,7 +151,7 @@ abstract class DeletableChipAttributes {
   /// that the user tapped the delete button. In order to delete the chip, you
   /// have to do something similar to the following sample:
   ///
-  /// {@tool snippet --template=stateful_widget}
+  /// {@tool snippet --template=stateful_widget_scaffold}
   ///
   /// This sample shows how to use [onDeleted] to remove an entry when the
   /// delete button is tapped.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -485,7 +485,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// dropdown's value. It should also call [State.setState] to rebuild the
 /// dropdown with the new value.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 ///
 /// This sample shows a `DropdownButton` whose value is one of
 /// "One", "Two", "Free", or "Four".

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -37,7 +37,7 @@ const double _kMinButtonSize = 48.0;
 /// requirements in the Material Design specification. The [alignment] controls
 /// how the icon itself is positioned within the hit region.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 ///
 /// This sample shows an `IconButton` that uses the Material icon "volume_up" to
 /// increase the volume.
@@ -83,7 +83,7 @@ const double _kMinButtonSize = 48.0;
 /// the underlying [Material] along with the splash and highlight
 /// [InkResponse] contributed by descendant widgets.
 ///
-/// {@tool snippet --template=stateless_widget}
+/// {@tool snippet --template=stateless_widget_scaffold}
 ///
 /// In this sample the icon button's background color is defined with an [Ink]
 /// widget whose child is an [IconButton]. The icon button's filled background
@@ -91,23 +91,25 @@ const double _kMinButtonSize = 48.0;
 /// button is.
 ///
 /// ```dart
-/// Center(
-///   child: Container(
-///     child: Ink(
-///       decoration: ShapeDecoration(
-///         color: Colors.lightBlue,
-///         shape: CircleBorder(),
-///       ),
-///       child: IconButton(
-///         icon: Icon(Icons.android),
-///         color: Colors.white,
-///         onPressed: () {
-///           print("filled background");
-///         },
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: Container(
+///       child: Ink(
+///         decoration: ShapeDecoration(
+///           color: Colors.lightBlue,
+///           shape: CircleBorder(),
+///         ),
+///         child: IconButton(
+///           icon: Icon(Icons.android),
+///           color: Colors.white,
+///           onPressed: () {
+///             print("filled background");
+///           },
+///         ),
 ///       ),
 ///     ),
-///   ),
-/// );
+///   );
+/// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -91,17 +91,23 @@ const double _kMinButtonSize = 48.0;
 /// button is.
 ///
 /// ```dart
-/// Ink(
-///   decoration: ShapeDecoration(
-///     color: Colors.purple,
-///     shape: CircleBorder(),
+/// Center(
+///   child: Container(
+///     child: Ink(
+///       decoration: ShapeDecoration(
+///         color: Colors.lightBlue,
+///         shape: CircleBorder(),
+///       ),
+///       child: IconButton(
+///         icon: Icon(Icons.android),
+///         color: Colors.white,
+///         onPressed: () {
+///           print("filled background");
+///         },
+///       ),
+///     ),
 ///   ),
-///   child: IconButton(
-///     icon: Icon(Icons.android),
-///     color: Colors.white,
-///     onPressed: () { print("filled background"); },
-///   ),
-/// )
+/// );
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -31,43 +31,45 @@ import 'theme_data.dart';
 /// Raised buttons have a minimum size of 88.0 by 36.0 which can be overidden
 /// with [ButtonTheme].
 ///
-/// {@tool snippet --template=stateless_widget}
+/// {@tool snippet --template=stateless_widget_scaffold}
 ///
 /// This sample shows how to render a disabled RaisedButton, an enabled RaisedButton
 /// and lastly a RaisedButton with gradient background.
 ///
 /// ```dart
-/// Scaffold(
-///   body: Center(
-///     child: Column(
-///       mainAxisSize: MainAxisSize.min,
-///       children: <Widget>[
-///         RaisedButton(
-///           onPressed: null,
-///           child: const Text('Disabled Button'),
-///         ),
-///         RaisedButton(
-///           onPressed: () {},
-///           child: const Text('Enabled Button'),
-///         ),
-///         RaisedButton(
-///           onPressed: () {},
-///           textColor: Colors.white,
-///           padding: const EdgeInsets.all(0.0),
-///           child: Container(
-///             decoration: const BoxDecoration(
-///               gradient: LinearGradient(
-///                 colors: <Color>[Colors.red, Colors.green, Colors.blue],
-///               ),
-///             ),
-///             padding: const EdgeInsets.all(10.0),
-///             child: Text('Gradient Button'),
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     body: Center(
+///       child: Column(
+///         mainAxisSize: MainAxisSize.min,
+///         children: <Widget>[
+///           RaisedButton(
+///             onPressed: null,
+///             child: const Text('Disabled Button'),
 ///           ),
-///         ),
-///       ],
+///           RaisedButton(
+///             onPressed: () {},
+///             child: const Text('Enabled Button'),
+///           ),
+///           RaisedButton(
+///             onPressed: () {},
+///             textColor: Colors.white,
+///             padding: const EdgeInsets.all(0.0),
+///             child: Container(
+///               decoration: const BoxDecoration(
+///                 gradient: LinearGradient(
+///                   colors: <Color>[Colors.red, Colors.green, Colors.blue],
+///                 ),
+///               ),
+///               padding: const EdgeInsets.all(10.0),
+///               child: Text('Gradient Button'),
+///             ),
+///           ),
+///         ],
+///       ),
 ///     ),
-///   ),
-/// )
+///   );
+/// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -26,11 +26,11 @@ import 'snack_bar.dart';
 import 'theme.dart';
 
 // Examples can assume:
-// TabController tabController
+// TabController tabController;
 // void setState(VoidCallback fn) { }
-// String appBarTitle
-// int tabCount
-// TickerProvider tickerProvider
+// String appBarTitle;
+// int tabCount;
+// TickerProvider tickerProvider;
 
 const FloatingActionButtonLocation _kDefaultFloatingActionButtonLocation = FloatingActionButtonLocation.endFloat;
 const FloatingActionButtonAnimator _kDefaultFloatingActionButtonAnimator = FloatingActionButtonAnimator.scaling;
@@ -669,7 +669,6 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// [ScaffoldState.showSnackBar] and [ScaffoldState.showBottomSheet] functions.
 ///
 /// {@tool snippet --template=stateful_widget}
-///
 /// This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a
 /// [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order
 /// to center the text within the [Scaffold] and the [FloatingActionButton] is
@@ -736,21 +735,21 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// scaffold with a differently titled AppBar. It would be better to add a
 /// listener to the [TabController] that updates the AppBar.
 ///
-/// ## Sample Code
-///
+/// {@tool sample}
 /// Add a listener to the app's tab controller so that the [AppBar] title of the
 /// app's one and only scaffold is reset each time a new tab is selected.
 ///
 /// ```dart
-/// tabController = TabController(vsync: tickerProvider, length: tabCount)..addListener(() {
+/// TabController(vsync: tickerProvider, length: tabCount)..addListener(() {
 ///   if (!tabController.indexIsChanging) {
 ///     setState(() {
 ///       // Rebuild the enclosing scaffold with a new AppBar title
 ///       appBarTitle = 'Tab ${tabController.index}';
 ///     });
 ///   }
-/// });
+/// })
 /// ```
+/// {@end-tool}
 ///
 /// Although there are some use cases, like a presentation app that
 /// shows embedded flutter content, where nested scaffolds are
@@ -949,22 +948,58 @@ class Scaffold extends StatefulWidget {
 
   /// The state from the closest instance of this class that encloses the given context.
   ///
-  /// Typical usage is as follows:
+  /// {@tool snippet --template=freeform}
+  /// Typical usage of the [Scaffold.of] function is to call it from within the
+  /// `build` method of a child of a [Scaffold].
   ///
-  /// ```dart
-  /// @override
-  /// Widget build(BuildContext context) {
-  ///   return RaisedButton(
-  ///     child: Text('SHOW A SNACKBAR'),
-  ///     onPressed: () {
-  ///       Scaffold.of(context).showSnackBar(SnackBar(
-  ///         content: Text('Hello!'),
-  ///       ));
-  ///     },
-  ///   );
+  /// ```dart imports
+  /// import 'package:flutter/material.dart';
+  /// ```
+  ///
+  /// ```dart main
+  /// void main() => runApp(MyApp());
+  /// ```
+  /// 
+  /// ```dart preamble
+  /// class MyApp extends StatelessWidget {
+  ///   // This widget is the root of your application.
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return MaterialApp(
+  ///       title: 'Flutter Code Sample for Scaffold.of.',
+  ///       theme: ThemeData(
+  ///         primarySwatch: Colors.blue,
+  ///       ),
+  ///       home: Scaffold(
+  ///         body: MyScaffoldBody(),
+  ///         appBar: AppBar(title: Text('Demo')),
+  ///       ),
+  ///       color: Colors.white,
+  ///     );
+  ///   }
   /// }
   /// ```
   ///
+  /// ```dart
+  /// class MyScaffoldBody extends StatelessWidget {
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return Center(
+  ///       child: RaisedButton(
+  ///         child: Text('SHOW A SNACKBAR'),
+  ///         onPressed: () {
+  ///           Scaffold.of(context).showSnackBar(SnackBar(
+  ///             content: Text('Hello!'),
+  ///           ));
+  ///         },
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// {@tool snippet --template=stateless_widget}
   /// When the [Scaffold] is actually created in the same `build` function, the
   /// `context` argument to the `build` function can't be used to find the
   /// [Scaffold] (since it's "above" the widget being returned). In such cases,
@@ -972,31 +1007,29 @@ class Scaffold extends StatefulWidget {
   /// scope with a [BuildContext] that is "under" the [Scaffold]:
   ///
   /// ```dart
-  /// @override
-  /// Widget build(BuildContext context) {
-  ///   return Scaffold(
-  ///     appBar: AppBar(
-  ///       title: Text('Demo')
-  ///     ),
-  ///     body: Builder(
-  ///       // Create an inner BuildContext so that the onPressed methods
-  ///       // can refer to the Scaffold with Scaffold.of().
-  ///       builder: (BuildContext context) {
-  ///         return Center(
-  ///           child: RaisedButton(
-  ///             child: Text('SHOW A SNACKBAR'),
-  ///             onPressed: () {
-  ///               Scaffold.of(context).showSnackBar(SnackBar(
-  ///                 content: Text('Hello!'),
-  ///               ));
-  ///             },
-  ///           ),
-  ///         );
-  ///       },
-  ///     ),
-  ///   );
-  /// }
+  /// Scaffold(
+  ///   appBar: AppBar(
+  ///     title: Text('Demo')
+  ///   ),
+  ///   body: Builder(
+  ///     // Create an inner BuildContext so that the onPressed methods
+  ///     // can refer to the Scaffold with Scaffold.of().
+  ///     builder: (BuildContext context) {
+  ///       return Center(
+  ///         child: RaisedButton(
+  ///           child: Text('SHOW A SNACKBAR'),
+  ///           onPressed: () {
+  ///             Scaffold.of(context).showSnackBar(SnackBar(
+  ///               content: Text('Hello!'),
+  ///             ));
+  ///           },
+  ///         ),
+  ///       );
+  ///     },
+  ///   ),
+  /// )
   /// ```
+  /// {@end-tool}
   ///
   /// A more efficient solution is to split your build function into several
   /// widgets. This introduces a new context from which you can obtain the

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -668,7 +668,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// [ScaffoldState] for the current [BuildContext] via [Scaffold.of] and use the
 /// [ScaffoldState.showSnackBar] and [ScaffoldState.showBottomSheet] functions.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_material}
 /// This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a
 /// [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order
 /// to center the text within the [Scaffold] and the [FloatingActionButton] is
@@ -959,7 +959,7 @@ class Scaffold extends StatefulWidget {
   /// ```dart main
   /// void main() => runApp(MyApp());
   /// ```
-  /// 
+  ///
   /// ```dart preamble
   /// class MyApp extends StatelessWidget {
   ///   // This widget is the root of your application.
@@ -972,7 +972,7 @@ class Scaffold extends StatefulWidget {
   ///       ),
   ///       home: Scaffold(
   ///         body: MyScaffoldBody(),
-  ///         appBar: AppBar(title: Text('Demo')),
+  ///         appBar: AppBar(title: Text('Scaffold.of Example')),
   ///       ),
   ///       color: Colors.white,
   ///     );
@@ -988,9 +988,11 @@ class Scaffold extends StatefulWidget {
   ///       child: RaisedButton(
   ///         child: Text('SHOW A SNACKBAR'),
   ///         onPressed: () {
-  ///           Scaffold.of(context).showSnackBar(SnackBar(
-  ///             content: Text('Hello!'),
-  ///           ));
+  ///           Scaffold.of(context).showSnackBar(
+  ///             SnackBar(
+  ///               content: Text('Have a snack!'),
+  ///             ),
+  ///           );
   ///         },
   ///       ),
   ///     );
@@ -999,35 +1001,38 @@ class Scaffold extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@tool snippet --template=stateless_widget}
+  /// {@tool snippet --template=stateless_widget_material}
   /// When the [Scaffold] is actually created in the same `build` function, the
   /// `context` argument to the `build` function can't be used to find the
-  /// [Scaffold] (since it's "above" the widget being returned). In such cases,
-  /// the following technique with a [Builder] can be used to provide a new
-  /// scope with a [BuildContext] that is "under" the [Scaffold]:
+  /// [Scaffold] (since it's "above" the widget being returned in the widget
+  /// tree). In such cases, the following technique with a [Builder] can be used
+  /// to provide a new scope with a [BuildContext] that is "under" the
+  /// [Scaffold]:
   ///
   /// ```dart
-  /// Scaffold(
-  ///   appBar: AppBar(
-  ///     title: Text('Demo')
-  ///   ),
-  ///   body: Builder(
-  ///     // Create an inner BuildContext so that the onPressed methods
-  ///     // can refer to the Scaffold with Scaffold.of().
-  ///     builder: (BuildContext context) {
-  ///       return Center(
-  ///         child: RaisedButton(
-  ///           child: Text('SHOW A SNACKBAR'),
-  ///           onPressed: () {
-  ///             Scaffold.of(context).showSnackBar(SnackBar(
-  ///               content: Text('Hello!'),
-  ///             ));
-  ///           },
-  ///         ),
-  ///       );
-  ///     },
-  ///   ),
-  /// )
+  /// Widget build(BuildContext context) {
+  ///   return Scaffold(
+  ///     appBar: AppBar(
+  ///       title: Text('Demo')
+  ///     ),
+  ///     body: Builder(
+  ///       // Create an inner BuildContext so that the onPressed methods
+  ///       // can refer to the Scaffold with Scaffold.of().
+  ///       builder: (BuildContext context) {
+  ///         return Center(
+  ///           child: RaisedButton(
+  ///             child: Text('SHOW A SNACKBAR'),
+  ///             onPressed: () {
+  ///               Scaffold.of(context).showSnackBar(SnackBar(
+  ///                 content: Text('Have a snack!'),
+  ///               ));
+  ///             },
+  ///           ),
+  ///         );
+  ///       },
+  ///     ),
+  ///   );
+  /// }
   /// ```
   /// {@end-tool}
   ///

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -192,43 +192,45 @@ class Stepper extends StatefulWidget {
   /// This callback which takes in a context and two functions,[onStepContinue]
   /// and [onStepCancel]. These can be used to control the stepper.
   ///
-  /// {@tool snippet --template=stateless_widget}
+  /// {@tool snippet --template=stateless_widget_scaffold}
   /// Creates a stepper control with custom buttons.
   ///
   /// ```dart
-  /// Stepper(
-  ///   controlsBuilder:
-  ///     (BuildContext context, {VoidCallback onStepContinue, VoidCallback onStepCancel}) {
-  ///        return Row(
-  ///          children: <Widget>[
-  ///            FlatButton(
-  ///              onPressed: onStepContinue,
-  ///              child: const Text('My Awesome Continue Message!'),
-  ///            ),
-  ///            FlatButton(
-  ///              onPressed: onStepCancel,
-  ///              child: const Text('My Awesome Cancel Message!'),
-  ///            ),
-  ///          ],
-  ///        );
-  ///     },
-  ///   steps: const <Step>[
-  ///     Step(
-  ///       title: Text('A'),
-  ///       content: SizedBox(
-  ///         width: 100.0,
-  ///         height: 100.0,
+  /// Widget build(BuildContext context) {
+  ///   return Stepper(
+  ///     controlsBuilder:
+  ///       (BuildContext context, {VoidCallback onStepContinue, VoidCallback onStepCancel}) {
+  ///          return Row(
+  ///            children: <Widget>[
+  ///              FlatButton(
+  ///                onPressed: onStepContinue,
+  ///                child: const Text('CONTINUE'),
+  ///              ),
+  ///              FlatButton(
+  ///                onPressed: onStepCancel,
+  ///                child: const Text('CANCEL'),
+  ///              ),
+  ///            ],
+  ///          );
+  ///       },
+  ///     steps: const <Step>[
+  ///       Step(
+  ///         title: Text('A'),
+  ///         content: SizedBox(
+  ///           width: 100.0,
+  ///           height: 100.0,
+  ///         ),
   ///       ),
-  ///     ),
-  ///     Step(
-  ///       title: Text('B'),
-  ///       content: SizedBox(
-  ///         width: 100.0,
-  ///         height: 100.0,
+  ///       Step(
+  ///         title: Text('B'),
+  ///         content: SizedBox(
+  ///           width: 100.0,
+  ///           height: 100.0,
+  ///         ),
   ///       ),
-  ///     ),
-  ///   ],
-  /// )
+  ///     ],
+  ///   );
+  /// }
   /// ```
   /// {@end-tool}
   final ControlsWidgetBuilder controlsBuilder;

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -192,7 +192,7 @@ class Stepper extends StatefulWidget {
   /// This callback which takes in a context and two functions,[onStepContinue]
   /// and [onStepCancel]. These can be used to control the stepper.
   ///
-  /// ## Sample Code:
+  /// {@tool snippet --template=stateless_widget}
   /// Creates a stepper control with custom buttons.
   ///
   /// ```dart
@@ -210,7 +210,7 @@ class Stepper extends StatefulWidget {
   ///              child: const Text('My Awesome Cancel Message!'),
   ///            ),
   ///          ],
-  ///        ),
+  ///        );
   ///     },
   ///   steps: const <Step>[
   ///     Step(
@@ -230,6 +230,7 @@ class Stepper extends StatefulWidget {
   ///   ],
   /// )
   /// ```
+  /// {@end-tool}
   final ControlsWidgetBuilder controlsBuilder;
 
   @override

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -19,6 +19,9 @@ import 'view.dart';
 
 export 'package:flutter/gestures.dart' show HitTestResult;
 
+// Examples can assume:
+// dynamic context;
+
 /// The glue between the render tree and the Flutter engine.
 mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureBinding, SemanticsBinding, HitTestable {
   @override
@@ -175,26 +178,30 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   /// The current platform brightness can be queried either from a Flutter
   /// binding, or from a [MediaQuery] widget.
   ///
-  /// ## Sample Code
-  ///
-  /// Querying [Window.platformBrightness]:
+  /// {@tool sample}
+  /// Querying [Window.platformBrightness].
   ///
   /// ```dart
   /// final Brightness brightness = WidgetsBinding.instance.window.platformBrightness;
   /// ```
+  /// {@end-tool}
   ///
-  /// Querying [MediaQuery] directly:
+  /// {@tool sample}
+  /// Querying [MediaQuery] directly.
   ///
   /// ```dart
   /// final Brightness brightness = MediaQuery.platformBrightnessOf(context);
   /// ```
+  /// {@end-tool}
   ///
-  /// Querying [MediaQueryData]:
+  /// {@tool sample}
+  /// Querying [MediaQueryData].
   ///
   /// ```dart
   /// final MediaQueryData mediaQueryData = MediaQuery.of(context);
   /// final Brightness brightness = mediaQueryData.platformBrightness;
   /// ```
+  /// {@end-tool}
   ///
   /// See [Window.onPlatformBrightnessChanged].
   /// {@endtemplate}

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1550,11 +1550,21 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   /// describes how high the box is that this [SemanticsNode] occupies in three
   /// dimensional space. The two other dimensions are defined by [rect].
   ///
-  /// ## Sample Code
-  ///
+  /// {@tool sample}
   /// The following code stacks three [PhysicalModel]s on top of each other
-  /// separated by none-zero elevations:
+  /// separated by non-zero elevations.
   ///
+  /// [PhysicalModel] C is elevated 10.0 above [PhysicalModel] B, which in turn
+  /// is elevated 5.0 above [PhysicalModel] A. The side view of this
+  /// constellation looks as follows:
+  ///
+  /// ![A diagram illustrating the elevations of three PhysicalModels and their
+  /// corresponding SemanticsNodes.](https://flutter.github.io/assets-for-api-docs/assets/semantics/SemanticsNode.thickness.png)
+  ///
+  /// In this example the [RenderObject]s for [PhysicalModel] C and B share one
+  /// [SemanticsNode] Y. Given the elevations of those [RenderObject]s, this
+  /// [SemanticsNode] has a [thickness] of 10.0 and an elevation of 5.0 over
+  /// its parent [SemanticsNode] X.
   /// ```dart
   /// PhysicalModel( // A
   ///   color: Colors.amber,
@@ -1571,20 +1581,9 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   ///       ),
   ///     ),
   ///   ),
-  /// );
+  /// )
   /// ```
-  ///
-  /// [PhysicalModel] C is elevated 10.0 above [PhysicalModel] B, which in turn
-  /// is elevated 5.0 above [PhysicalModel] A. The side view of this
-  /// constellation looks as follows:
-  ///
-  /// ![A diagram illustrating the elevations of three PhysicalModels and their
-  /// corresponding SemanticsNodes.](https://flutter.github.io/assets-for-api-docs/assets/semantics/SemanticsNode.thickness.png)
-  ///
-  /// In this example the [RenderObject]s for [PhysicalModel] C and B share one
-  /// [SemanticsNode] Y. Given the elevations of those [RenderObject]s, this
-  /// [SemanticsNode] has a [thickness] of 10.0 and an elevation of 5.0 over
-  /// its parent [SemanticsNode] X.
+  /// {@end-tool}
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -32,7 +32,7 @@ import 'package:flutter/foundation.dart';
 /// look at the physical key to make sure that regardless of the character the
 /// key produces, you got the key that is in that location on the keyboard.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 /// This example shows how to detect if the user has selected the logical "Q"
 /// key.
 ///
@@ -1655,7 +1655,7 @@ class LogicalKeyboardKey extends Diagnosticable {
 /// looking for "the key next next to the TAB key", since on a French keyboard,
 /// the key next to the TAB key has an "A" on it.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 /// This example shows how to detect if the user has selected the physical key
 /// to the right of the CAPS LOCK key.
 ///

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -311,15 +311,15 @@ class SystemChrome {
   /// If a particular style is not supported on the platform, selecting it will
   /// have no effect.
   ///
-  /// ## Sample Code
-  ///
+  /// {@tool sample}
   /// ```dart
   /// @override
   /// Widget build(BuildContext context) {
   ///   SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
-  ///   return /* ... */;
+  ///   return Placeholder();
   /// }
   /// ```
+  /// {@end-tool}
   ///
   /// For more complex control of the system overlay styles, consider using
   /// an [AnnotatedRegion] widget instead of calling [setSystemUiOverlayStyle]
@@ -334,42 +334,43 @@ class SystemChrome {
   /// to a random value on Android.
   ///
   /// ```dart imports
-  ///    import 'package:flutter/services.dart';
-  ///    import 'dart:math' as math;
+  /// import 'package:flutter/services.dart';
+  /// import 'dart:math' as math;
   /// ```
   ///
   /// ```dart
-  ///    final _random = math.Random();
-  ///    SystemUiOverlayStyle _currentStyle = SystemUiOverlayStyle.light;
+  /// final _random = math.Random();
+  /// SystemUiOverlayStyle _currentStyle = SystemUiOverlayStyle.light;
   ///
-  ///    void _changeColor() {
-  ///      final color = Color.fromRGBO(
-  ///        _random.nextInt(255),
-  ///        _random.nextInt(255),
-  ///        _random.nextInt(255),
-  ///        1.0,
-  ///      );
-  ///      setState(() {
-  ///        _currentStyle = SystemUiOverlayStyle.dark.copyWith(
-  ///          statusBarColor: color,
-  ///        );
-  ///      });
-  ///    }
+  /// void _changeColor() {
+  ///   final color = Color.fromRGBO(
+  ///     _random.nextInt(255),
+  ///     _random.nextInt(255),
+  ///     _random.nextInt(255),
+  ///     1.0,
+  ///   );
+  ///   setState(() {
+  ///     _currentStyle = SystemUiOverlayStyle.dark.copyWith(
+  ///       statusBarColor: color,
+  ///     );
+  ///   });
+  /// }
   ///
-  ///    @override
-  ///    Widget build(BuildContext context) {
-  ///      return Scaffold(
-  ///        body: AnnotatedRegion(
-  ///          value: _currentStyle,
-  ///           child: Center(
-  ///             child: RaisedButton(
-  ///               child: const Text('Change Color'),
-  ///               onPressed: _changeColor,
-  ///             ),
-  ///           ),
-  ///         ),
-  ///       );
-  ///     }
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return Scaffold(
+  ///     body: AnnotatedRegion(
+  ///       value: _currentStyle,
+  ///        child: Center(
+  ///          child: RaisedButton(
+  ///            child: const Text('Change Color'),
+  ///            onPressed: _changeColor,
+  ///          ),
+  ///        ),
+  ///      ),
+  ///    );
+  ///  }
+  /// ```
   /// {@end-tool}
   ///
   /// See also:

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -329,7 +329,7 @@ class SystemChrome {
   /// navigation bar and synthesize them into a single style. This can be used
   /// to configure the system styles when an app bar is not used.
   ///
-  /// {@tool snippet --template=stateful_widget}
+  /// {@tool snippet --template=stateful_widget_material}
   /// The following example creates a widget that changes the status bar color
   /// to a random value on Android.
   ///
@@ -358,14 +358,12 @@ class SystemChrome {
   ///
   /// @override
   /// Widget build(BuildContext context) {
-  ///   return Scaffold(
-  ///     body: AnnotatedRegion(
-  ///       value: _currentStyle,
-  ///        child: Center(
-  ///          child: RaisedButton(
-  ///            child: const Text('Change Color'),
-  ///            onPressed: _changeColor,
-  ///          ),
+  ///   return AnnotatedRegion(
+  ///     value: _currentStyle,
+  ///     child: Center(
+  ///       child: RaisedButton(
+  ///         child: const Text('Change Color'),
+  ///         onPressed: _changeColor,
   ///        ),
   ///      ),
   ///    );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5046,7 +5046,7 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 /// If it has a child, this widget defers to the child for sizing behavior. If
 /// it does not have a child, it grows to fit the parent instead.
 ///
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet --template=stateful_widget_scaffold}
 /// This example makes a [Container] react to being entered by a mouse
 /// pointer, showing a count of the number of entries and exits.
 ///
@@ -5081,32 +5081,27 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return Scaffold(
-///     appBar: AppBar(
-///       title: Text('Hover Example'),
-///     ),
-///     body: Center(
-///       child: ConstrainedBox(
-///         constraints: new BoxConstraints.tight(Size(300.0, 200.0)),
-///         child: Listener(
-///           onPointerEnter: _incrementCounter,
-///           onPointerHover: _updateLocation,
-///           onPointerExit: _decrementCounter,
-///           child: Container(
-///             color: Colors.lightBlueAccent,
-///             child: Column(
-///               mainAxisAlignment: MainAxisAlignment.center,
-///               children: <Widget>[
-///                 Text('You have pointed at this box this many times:'),
-///                 Text(
-///                   '$_enterCounter Entries\n$_exitCounter Exits',
-///                   style: Theme.of(context).textTheme.display1,
-///                 ),
-///                 Text(
-///                   'The cursor is here: (${x.toStringAsFixed(2)}, ${y.toStringAsFixed(2)})',
-///                 ),
-///               ],
-///             ),
+///   return Center(
+///     child: ConstrainedBox(
+///       constraints: new BoxConstraints.tight(Size(300.0, 200.0)),
+///       child: Listener(
+///         onPointerEnter: _incrementCounter,
+///         onPointerHover: _updateLocation,
+///         onPointerExit: _decrementCounter,
+///         child: Container(
+///           color: Colors.lightBlueAccent,
+///           child: Column(
+///             mainAxisAlignment: MainAxisAlignment.center,
+///             children: <Widget>[
+///               Text('You have pointed at this box this many times:'),
+///               Text(
+///                 '$_enterCounter Entries\n$_exitCounter Exits',
+///                 style: Theme.of(context).textTheme.display1,
+///               ),
+///               Text(
+///                 'The cursor is here: (${x.toStringAsFixed(2)}, ${y.toStringAsFixed(2)})',
+///               ),
+///             ],
 ///           ),
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -627,8 +627,7 @@ class NavigatorObserver {
 ///     );
 ///   }
 /// }
-/// 
-/// // Placeholder for real page.
+///
 /// class HomePage extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -642,8 +641,7 @@ class NavigatorObserver {
 ///     );
 ///   }
 /// }
-/// 
-/// // Placeholder for real page.
+///
 /// class CollectPersonalInfoPage extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -665,15 +663,14 @@ class NavigatorObserver {
 ///     );
 ///   }
 /// }
-/// 
-/// // Placeholder for real page.
+///
 /// class ChooseCredentialsPage extends StatelessWidget {
 ///   const ChooseCredentialsPage({
 ///     this.onSignupComplete,
 ///   });
-/// 
+///
 ///   final VoidCallback onSignupComplete;
-/// 
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return GestureDetector(
@@ -689,7 +686,7 @@ class NavigatorObserver {
 ///     );
 ///   }
 /// }
-/// 
+///
 /// class SignUpPage extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -594,20 +594,30 @@ class NavigatorObserver {
 /// in this situation, but it's a real world example where nested [Navigator]s
 /// are used.
 ///
-/// #### Sample Code
-///
+/// {@tool snippet --template=freeform}
 /// The following example demonstrates how a nested [Navigator] can be used to
 /// present a standalone user registration journey.
 ///
 /// Even though this example uses two [Navigator]s to demonstrate nested
 /// [Navigator]s, a similar result is possible using only a single [Navigator].
 ///
+/// Run this example with `flutter run --route=/signup` to start it with
+/// the signup flow instead of on the home page.
+///
+/// ```dart imports
+/// import 'package:flutter/material.dart';
+/// ```
+///
+/// ```dart main
+/// void main() => runApp(new MyApp());
+/// ```
+///
 /// ```dart
 /// class MyApp extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
-///       // ...some parameters omitted...
+///       title: 'Flutter Code Sample for Navigator',
 ///       // MaterialApp contains our top-level Navigator
 ///       initialRoute: '/',
 ///       routes: {
@@ -617,45 +627,108 @@ class NavigatorObserver {
 ///     );
 ///   }
 /// }
-///
+/// 
+/// // Placeholder for real page.
+/// class HomePage extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return DefaultTextStyle(
+///       style: Theme.of(context).textTheme.display1,
+///       child: Container(
+///         color: Colors.white,
+///         alignment: Alignment.center,
+///         child: Text('Home Page'),
+///       ),
+///     );
+///   }
+/// }
+/// 
+/// // Placeholder for real page.
+/// class CollectPersonalInfoPage extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return DefaultTextStyle(
+///       style: Theme.of(context).textTheme.display1,
+///       child: GestureDetector(
+///         onTap: () {
+///           // This moves from the personal info page to the credentials page,
+///           // replacing this page with that one.
+///           Navigator.of(context)
+///             .pushReplacementNamed('signup/choose_credentials');
+///         },
+///         child: Container(
+///           color: Colors.lightBlue,
+///           alignment: Alignment.center,
+///           child: Text('Collect Personal Info Page'),
+///         ),
+///       ),
+///     );
+///   }
+/// }
+/// 
+/// // Placeholder for real page.
+/// class ChooseCredentialsPage extends StatelessWidget {
+///   const ChooseCredentialsPage({
+///     this.onSignupComplete,
+///   });
+/// 
+///   final VoidCallback onSignupComplete;
+/// 
+///   @override
+///   Widget build(BuildContext context) {
+///     return GestureDetector(
+///       onTap: onSignupComplete,
+///       child: DefaultTextStyle(
+///         style: Theme.of(context).textTheme.display1,
+///         child: Container(
+///           color: Colors.pinkAccent,
+///           alignment: Alignment.center,
+///           child: Text('Choose Credentials Page'),
+///         ),
+///       ),
+///     );
+///   }
+/// }
+/// 
 /// class SignUpPage extends StatelessWidget {
-///  @override
-///  Widget build(BuildContext context) {
-///    // SignUpPage builds its own Navigator which ends up being a nested
-///    // Navigator in our app.
-///    return Navigator(
-///      initialRoute: 'signup/personal_info',
-///      onGenerateRoute: (RouteSettings settings) {
-///        WidgetBuilder builder;
-///        switch (settings.name) {
-///          case 'signup/personal_info':
-///            // Assume CollectPersonalInfoPage collects personal info and then
-///            // navigates to 'signup/choose_credentials'.
-///            builder = (BuildContext _) => CollectPersonalInfoPage();
-///            break;
-///          case 'signup/choose_credentials':
-///            // Assume ChooseCredentialsPage collects new credentials and then
-///            // invokes 'onSignupComplete()'.
-///            builder = (BuildContext _) => ChooseCredentialsPage(
-///              onSignupComplete: () {
-///                // Referencing Navigator.of(context) from here refers to the
-///                // top level Navigator because SignUpPage is above the
-///                // nested Navigator that it created. Therefore, this pop()
-///                // will pop the entire "sign up" journey and return to the
-///                // "/" route, AKA HomePage.
-///                Navigator.of(context).pop();
-///              },
-///            );
-///            break;
-///          default:
-///            throw Exception('Invalid route: ${settings.name}');
-///        }
-///        return MaterialPageRoute(builder: builder, settings: settings);
-///      },
-///    );
-///  }
+///   @override
+///   Widget build(BuildContext context) {
+///     // SignUpPage builds its own Navigator which ends up being a nested
+///     // Navigator in our app.
+///     return Navigator(
+///       initialRoute: 'signup/personal_info',
+///       onGenerateRoute: (RouteSettings settings) {
+///         WidgetBuilder builder;
+///         switch (settings.name) {
+///           case 'signup/personal_info':
+///           // Assume CollectPersonalInfoPage collects personal info and then
+///           // navigates to 'signup/choose_credentials'.
+///             builder = (BuildContext _) => CollectPersonalInfoPage();
+///             break;
+///           case 'signup/choose_credentials':
+///           // Assume ChooseCredentialsPage collects new credentials and then
+///           // invokes 'onSignupComplete()'.
+///             builder = (BuildContext _) => ChooseCredentialsPage(
+///               onSignupComplete: () {
+///                 // Referencing Navigator.of(context) from here refers to the
+///                 // top level Navigator because SignUpPage is above the
+///                 // nested Navigator that it created. Therefore, this pop()
+///                 // will pop the entire "sign up" journey and return to the
+///                 // "/" route, AKA HomePage.
+///                 Navigator.of(context).pop();
+///               },
+///             );
+///             break;
+///           default:
+///             throw Exception('Invalid route: ${settings.name}');
+///         }
+///         return MaterialPageRoute(builder: builder, settings: settings);
+///       },
+///     );
+///   }
 /// }
 /// ```
+/// {@end-tool}
 ///
 /// [Navigator.of] operates on the nearest ancestor [Navigator] from the given
 /// [BuildContext]. Be sure to provide a [BuildContext] below the intended

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -80,8 +80,13 @@ import 'scrollable.dart';
 /// with some remaining space to allocate as specified by its
 /// [Column.mainAxisAlignment] argument.
 ///
-/// In this example, the children are spaced out equally, unless there's no
-/// more room, in which case they stack vertically and scroll.
+/// {@tool snippet --template=stateless_widget}
+/// In this example, the children are spaced out equally, unless there's no more
+/// room, in which case they stack vertically and scroll.
+///
+/// When using this technique, [Expanded] and [Flexible] are not useful, because
+/// in both cases the "available space" is infinite (since this is in a viewport).
+/// The next section describes a technique for providing a maximum height constraint.
 ///
 /// ```dart
 /// LayoutBuilder(
@@ -112,10 +117,7 @@ import 'scrollable.dart';
 ///   },
 /// )
 /// ```
-///
-/// When using this technique, [Expanded] and [Flexible] are not useful, because
-/// in both cases the "available space" is infinite (since this is in a viewport).
-/// The next section describes a technique for providing a maximum height constraint.
+/// {@end-tool}
 ///
 /// ### Expanding content to fit the viewport
 ///
@@ -134,6 +136,18 @@ import 'scrollable.dart';
 ///
 /// The widget that is to grow to fit the remaining space so provided is wrapped
 /// in an [Expanded] widget.
+///
+/// This technique is quite expensive, as it more or less requires that the contents
+/// of the viewport be laid out twice (once to find their intrinsic dimensions, and
+/// once to actually lay them out). The number of widgets within the column should
+/// therefore be kept small. Alternatively, subsets of the children that have known
+/// dimensions can be wrapped in a [SizedBox] that has tight vertical constraints,
+/// so that the intrinsic sizing algorithm can short-circuit the computation when it
+/// reaches those parts of the subtree.
+///
+/// {@tool snippet --template=stateless_widget}
+/// In this example, the column becomes either as big as viewport, or as big as
+/// the contents, whichever is biggest.
 ///
 /// ```dart
 /// LayoutBuilder(
@@ -155,7 +169,7 @@ import 'scrollable.dart';
 ///                 // A flexible child that will grow to fit the viewport but
 ///                 // still be at least as big as necessary to fit its contents.
 ///                 child: Container(
-///                   color: Colors.blue,
+///                   color: Colors.red,
 ///                   height: 120.0,
 ///                 ),
 ///               ),
@@ -167,14 +181,7 @@ import 'scrollable.dart';
 ///   },
 /// )
 /// ```
-///
-/// This technique is quite expensive, as it more or less requires that the contents
-/// of the viewport be laid out twice (once to find their intrinsic dimensions, and
-/// once to actually lay them out). The number of widgets within the column should
-/// therefore be kept small. Alternatively, subsets of the children that have known
-/// dimensions can be wrapped in a [SizedBox] that has tight vertical constraints,
-/// so that the intrinsic sizing algorithm can short-circuit the computation when it
-/// reaches those parts of the subtree.
+/// {@end-tool}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -89,33 +89,35 @@ import 'scrollable.dart';
 /// The next section describes a technique for providing a maximum height constraint.
 ///
 /// ```dart
-/// LayoutBuilder(
-///   builder: (BuildContext context, BoxConstraints viewportConstraints) {
-///     return SingleChildScrollView(
-///       child: ConstrainedBox(
-///         constraints: BoxConstraints(
-///           minHeight: viewportConstraints.maxHeight,
+/// Widget build(BuildContext context) {
+///   return LayoutBuilder(
+///     builder: (BuildContext context, BoxConstraints viewportConstraints) {
+///       return SingleChildScrollView(
+///         child: ConstrainedBox(
+///           constraints: BoxConstraints(
+///             minHeight: viewportConstraints.maxHeight,
+///           ),
+///           child: Column(
+///             mainAxisSize: MainAxisSize.min,
+///             mainAxisAlignment: MainAxisAlignment.spaceAround,
+///             children: <Widget>[
+///               Container(
+///                 // A fixed-height child.
+///                 color: const Color(0xff808000), // Yellow
+///                 height: 120.0,
+///               ),
+///               Container(
+///                 // Another fixed-height child.
+///                 color: const Color(0xff008000), // Green
+///                 height: 120.0,
+///               ),
+///             ],
+///           ),
 ///         ),
-///         child: Column(
-///           mainAxisSize: MainAxisSize.min,
-///           mainAxisAlignment: MainAxisAlignment.spaceAround,
-///           children: <Widget>[
-///             Container(
-///               // A fixed-height child.
-///               color: Colors.yellow,
-///               height: 120.0,
-///             ),
-///             Container(
-///               // Another fixed-height child.
-///               color: Colors.green,
-///               height: 120.0,
-///             ),
-///           ],
-///         ),
-///       ),
-///     );
-///   },
-/// )
+///       );
+///     },
+///   );
+/// }
 /// ```
 /// {@end-tool}
 ///
@@ -150,36 +152,38 @@ import 'scrollable.dart';
 /// the contents, whichever is biggest.
 ///
 /// ```dart
-/// LayoutBuilder(
-///   builder: (BuildContext context, BoxConstraints viewportConstraints) {
-///     return SingleChildScrollView(
-///       child: ConstrainedBox(
-///         constraints: BoxConstraints(
-///           minHeight: viewportConstraints.maxHeight,
-///         ),
-///         child: IntrinsicHeight(
-///           child: Column(
-///             children: <Widget>[
-///               Container(
-///                 // A fixed-height child.
-///                 color: Colors.yellow,
-///                 height: 120.0,
-///               ),
-///               Expanded(
-///                 // A flexible child that will grow to fit the viewport but
-///                 // still be at least as big as necessary to fit its contents.
-///                 child: Container(
-///                   color: Colors.red,
+/// Widget build(BuildContext context) {
+///   return LayoutBuilder(
+///     builder: (BuildContext context, BoxConstraints viewportConstraints) {
+///       return SingleChildScrollView(
+///         child: ConstrainedBox(
+///           constraints: BoxConstraints(
+///             minHeight: viewportConstraints.maxHeight,
+///           ),
+///           child: IntrinsicHeight(
+///             child: Column(
+///               children: <Widget>[
+///                 Container(
+///                   // A fixed-height child.
+///                   color: const Color(0xff808000), // Yellow
 ///                   height: 120.0,
 ///                 ),
-///               ),
-///             ],
+///                 Expanded(
+///                   // A flexible child that will grow to fit the viewport but
+///                   // still be at least as big as necessary to fit its contents.
+///                   child: Container(
+///                     color: const Color(0xff800000), // Red
+///                     height: 120.0,
+///                   ),
+///                 ),
+///               ],
+///             ),
 ///           ),
 ///         ),
-///       ),
-///     );
-///   },
-/// )
+///       );
+///     },
+///   );
+/// }
 /// ```
 /// {@end-tool}
 ///


### PR DESCRIPTION
This converts all remaining "## Sample code" segments into snippets, and fixes the snippet generator to handle multiple snippets in the same dartdoc block properly.

I also generated, compiled, and ran each of the existing application samples, and fixed them up to be more useful and/or just run without errors.

This PR fixes these problems with examples:
1) Switching tabs in a snippet now works if there is more than one snippet in a single dartdoc block.
2) Generation of snippet code now works if there is more than one snippet.
3) Contrast of text and links in the code sample block has been improved to recommended levels.
4) Added five new snippet templates, including a "freeform" template to make it possible to show examples that need to change the app instantiation.
5) Fixed several examples to run properly, a couple by adding the "Scaffold" widget to the template, a couple by just fixing their code.
6) Fixed visual look of some of the samples when they run by placing many samples inside of a Scaffold.
7) In order to make it easier to run locally, changed the sample analyzer to remove the contents of the supplied temp directory before running, since having files that hang around is problematic (only a problem when running locally with the `--temp` argument).
8) Added a `SampleCheckerException` class, and handle sample checking exceptions more gracefully.
9) Deprecated the old "## Sample code" designation, and added enforcement for the deprecation.
10) Removed unnecessary `new` from templates (although they never appeared in the samples thanks to dartfmt, but still).

Fixes #26398 
Fixes #27411