### PR TITLE
Added support for `loadDartLibrarySources` VM service RPC.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:file/file.dart';
@@ -19,7 +18,6 @@ import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/io.dart' as io;
-import 'base/platform.dart';
 import 'base/utils.dart';
 import 'convert.dart' show base64;
 import 'globals.dart';

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -14,6 +14,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import 'artifacts.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
@@ -378,13 +379,8 @@ class VMService {
   }
 
   Future<Map<String, dynamic>> _handleLoadDartLibrarySources() async {
-    // We assume that the current program is being run using the dart executable
-    // from the dart-sdk packaged with Flutter.
-    const relativeKernelPath =
-      '../../artifacts/engine/common/flutter_patched_sdk/platform_strong.dill';
-    final Uri exePath =
-      Uri.directory(fs.path.dirname(platform.resolvedExecutable));
-    final Uri kernelPath = exePath.resolve(relativeKernelPath);
+    final String kernelPath =
+      Artifacts.instance.getArtifactPath(Artifact.platformKernelDill);
     try {
       final List<int> bytes = await fs.file(kernelPath).readAsBytes();
       final String result = base64.encode(bytes);

--- a/packages/flutter_tools/test/vmservice_test.dart
+++ b/packages/flutter_tools/test/vmservice_test.dart
@@ -47,7 +47,9 @@ class MockPeer implements rpc.Peer {
 
   @override
   void sendNotification(String method, [ dynamic parameters ]) {
-    throw 'unexpected call to sendNotification';
+    if (method != '_registerService') {
+      throw 'unexpected call to sendNotification';
+    }
   }
 
   bool isolatesEnabled = false;


### PR DESCRIPTION
`loadDartLibrarySources` allows for dart:* sources to be loaded from an unstripped platform_strong.dill, making debugging with dart:* sources possible. This change allows for the VM to delegate loading the unstripped kernel file to flutter_tools on the host before processing the loaded kernel on the device.

Depends on [this CL](https://dart-review.googlesource.com/c/sdk/+/92407).