### PR TITLE
Optimize flutter run logic for iOS by "ONLY_ACTIVE_ARCH=YES" if possible

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -243,6 +243,9 @@ class IOSDevice extends Device {
       // TODO(chinmaygarde): Use mainPath, route.
       printTrace('Building ${package.name} for $id');
 
+      final String cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
+      final IOSArch iosArch = getIOSArchForName(cpuArchitecture);
+
       // Step 1: Build the precompiled/DBC application if necessary.
       final XcodeBuildResult buildResult = await buildXcodeProject(
           app: package,
@@ -250,6 +253,7 @@ class IOSDevice extends Device {
           targetOverride: mainPath,
           buildForDevice: true,
           usesTerminalUi: usesTerminalUi,
+          activeArch: iosArch
       );
       if (!buildResult.success) {
         printError('Could not build the precompiled application for the device.');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -134,7 +134,7 @@ class IMobileDevice {
 
   Future<String> getInfoForDevice(String deviceID, String key) async {
     try {
-      final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key, '--simple']);
+      final ProcessResult result = await processManager.run(<String>['ideviceinfo', '-u', deviceID, '-k', key]);
       if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
         throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}');
       if (result.exitCode != 0)
@@ -294,6 +294,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   BuildInfo buildInfo,
   String targetOverride,
   bool buildForDevice,
+  IOSArch activeArch,
   bool codesign = true,
   bool usesTerminalUi = true,
 }) async {
@@ -433,6 +434,12 @@ Future<XcodeBuildResult> buildXcodeProject({
     buildCommands.addAll(<String>['-sdk', 'iphoneos']);
   } else {
     buildCommands.addAll(<String>['-sdk', 'iphonesimulator', '-arch', 'x86_64']);
+  }
+
+  final String activeArchName = getNameForIOSArch(activeArch);
+  if (activeArchName !=null) {
+    buildCommands.add('ONLY_ACTIVE_ARCH=YES');
+    buildCommands.add('ARCHS=$activeArchName');
   }
 
   if (!codesign) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -436,10 +436,12 @@ Future<XcodeBuildResult> buildXcodeProject({
     buildCommands.addAll(<String>['-sdk', 'iphonesimulator', '-arch', 'x86_64']);
   }
 
-  final String activeArchName = getNameForIOSArch(activeArch);
-  if (activeArchName !=null) {
-    buildCommands.add('ONLY_ACTIVE_ARCH=YES');
-    buildCommands.add('ARCHS=$activeArchName');
+  if (activeArch != null) {
+    final String activeArchName = getNameForIOSArch(activeArch);
+    if (activeArchName != null) {
+      buildCommands.add('ONLY_ACTIVE_ARCH=YES');
+      buildCommands.add('ARCHS=$activeArchName');
+    }
   }
 
   if (!codesign) {

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -130,7 +130,7 @@ void main() {
     });
 
     testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when ideviceinfo returns specific error code and message', () async {
-      when(mockProcessManager.run(<String>['ideviceinfo', '-u', 'foo', '-k', 'bar', '--simple']))
+      when(mockProcessManager.run(<String>['ideviceinfo', '-u', 'foo', '-k', 'bar']))
           .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 255, 'No device found with udid foo, is it plugged in?', '')));
       expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotFoundError>()));
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
```
This newly added logic optimize the `flutter run` logic so that when the target device is an arm64(armv7) device, it will generate products for arm64(armv7) only.
Henceforth, it will speed up the build process and doesn't create unnecessary products.

Besides, when using `flutter build ios --release`, this logic will not be triggered, and the result app is as expected.
```

This is exactly a copy of  https://github.com/flutter/flutter/pull/25846
As I did an improper rebase and the git log seems broken, use this pr instead of https://github.com/flutter/flutter/pull/25846