### PR TITLE
Fix crash when disposing nested Scrollables while holding in overscroll position

### DIFF
--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -53,9 +53,11 @@ abstract class Notification {
   ///
   /// The notification will be delivered to any [NotificationListener] widgets
   /// with the appropriate type parameters that are ancestors of the given
-  /// [BuildContext]. If the [BuildContext] is null, the notification is
-  /// dropped on the floor.
+  /// [BuildContext]. If the [BuildContext] is null, the notification is not
+  /// dispatched.
   void dispatch(BuildContext target) {
+    // The `target` may be null if the subtree the notification is supposed to be
+    // dispatched in is in the process of being disposed.
     target?.visitAncestorElements(visitAncestor);
   }
 

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -53,10 +53,10 @@ abstract class Notification {
   ///
   /// The notification will be delivered to any [NotificationListener] widgets
   /// with the appropriate type parameters that are ancestors of the given
-  /// [BuildContext].
+  /// [BuildContext]. If the [BuildContext] is null, the notification is
+  /// dropped on the floor.
   void dispatch(BuildContext target) {
-    assert(target != null); // Only call dispatch if the widget's State is still mounted.
-    target.visitAncestorElements(visitAncestor);
+    target?.visitAncestorElements(visitAncestor);
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27707, which has a detailed analysis.