### PR TITLE
Don't cache result for homeDirPath.

### DIFF
--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -7,16 +7,14 @@ import 'platform.dart';
 
 /// Return the absolute path of the user's home directory
 String get homeDirPath {
-  if (_homeDirPath == null) {
-    _homeDirPath = platform.isWindows
-        ? platform.environment['USERPROFILE']
-        : platform.environment['HOME'];
-    if (_homeDirPath != null)
-      _homeDirPath = fs.path.absolute(_homeDirPath);
+  String _homeDirPath = platform.isWindows
+      ? platform.environment['USERPROFILE']
+      : platform.environment['HOME'];
+  if (_homeDirPath != null) {
+    _homeDirPath = fs.path.absolute(_homeDirPath);
   }
   return _homeDirPath;
 }
-String _homeDirPath;
 
 /// Throw a specialized exception for expected situations
 /// where the tool should exit with a clear message to the user

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -7,13 +7,13 @@ import 'platform.dart';
 
 /// Return the absolute path of the user's home directory
 String get homeDirPath {
-  String _homeDirPath = platform.isWindows
+  String path = platform.isWindows
       ? platform.environment['USERPROFILE']
       : platform.environment['HOME'];
-  if (_homeDirPath != null) {
-    _homeDirPath = fs.path.absolute(_homeDirPath);
+  if (path != null) {
+    path = fs.path.absolute(path);
   }
-  return _homeDirPath;
+  return path;
 }
 
 /// Throw a specialized exception for expected situations


### PR DESCRIPTION
This pr original comes from a failure when writing tests for https://github.com/flutter/flutter/pull/27687
When multiple FakePlatforms are used, homeDirPath would give cached result instead of the one specified in FakePlatform. Henceforth, expect fails. 
Besides,I think it's not expensive to call and calculate homeDirPath again.