### PR TITLE
Convert PointerEvent's toString to Diagnosticable

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -318,7 +318,7 @@ abstract class PointerEvent extends Diagnosticable {
 
   /// Returns a complete textual description of this event.
   String toStringFull() {
-    return toString(minLevel: DiagnosticLevel.hidden);
+    return toString(minLevel: DiagnosticLevel.fine);
   }
 }
 

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -290,15 +290,14 @@ abstract class PointerEvent extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Offset>('position', position));
+    properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero));
     properties.add(DiagnosticsProperty<Duration>('timeStamp', timeStamp, defaultValue: Duration.zero));
     properties.add(IntProperty('pointer', pointer));
     properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(IntProperty('device', device, defaultValue: 0));
-    properties.add(DiagnosticsProperty<Offset>('position', position));
-    properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero));
     properties.add(IntProperty('buttons', buttons, defaultValue: 0));
     properties.add(DiagnosticsProperty<bool>('down', down));
-    properties.add(FlagProperty('obscured', value: obscured, ifTrue: 'obscured'));
     properties.add(DoubleProperty('pressure', pressure, defaultValue: 1.0));
     properties.add(DoubleProperty('pressureMin', pressureMin, defaultValue: 1.0));
     properties.add(DoubleProperty('pressureMax', pressureMax, defaultValue: 1.0));
@@ -313,7 +312,13 @@ abstract class PointerEvent extends Diagnosticable {
     properties.add(DoubleProperty('orientation', orientation, defaultValue: 0.0));
     properties.add(DoubleProperty('tilt', tilt, defaultValue: 0.0));
     properties.add(IntProperty('platformData', platformData, defaultValue: 0));
+    properties.add(FlagProperty('obscured', value: obscured, ifTrue: 'obscured'));
     properties.add(FlagProperty('synthesized', value: synthesized, ifTrue: 'synthesized'));
+  }
+
+  /// Returns a complete textual description of this event.
+  String toStringFull() {
+    return toString(minLevel: DiagnosticLevel.hidden);
   }
 }
 

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -291,29 +291,29 @@ abstract class PointerEvent extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('position', position));
-    properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero));
-    properties.add(DiagnosticsProperty<Duration>('timeStamp', timeStamp, defaultValue: Duration.zero));
-    properties.add(IntProperty('pointer', pointer));
-    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
-    properties.add(IntProperty('device', device, defaultValue: 0));
-    properties.add(IntProperty('buttons', buttons, defaultValue: 0));
-    properties.add(DiagnosticsProperty<bool>('down', down));
-    properties.add(DoubleProperty('pressure', pressure, defaultValue: 1.0));
-    properties.add(DoubleProperty('pressureMin', pressureMin, defaultValue: 1.0));
-    properties.add(DoubleProperty('pressureMax', pressureMax, defaultValue: 1.0));
-    properties.add(DoubleProperty('distance', distance, defaultValue: 0.0));
-    properties.add(DoubleProperty('distanceMin', distanceMin, defaultValue: 0.0));
-    properties.add(DoubleProperty('distanceMax', distanceMax, defaultValue: 0.0));
-    properties.add(DoubleProperty('size', size, defaultValue: 0.0));
-    properties.add(DoubleProperty('radiusMajor', radiusMajor, defaultValue: 0.0));
-    properties.add(DoubleProperty('radiusMinor', radiusMinor, defaultValue: 0.0));
-    properties.add(DoubleProperty('radiusMin', radiusMin, defaultValue: 0.0));
-    properties.add(DoubleProperty('radiusMax', radiusMax, defaultValue: 0.0));
-    properties.add(DoubleProperty('orientation', orientation, defaultValue: 0.0));
-    properties.add(DoubleProperty('tilt', tilt, defaultValue: 0.0));
-    properties.add(IntProperty('platformData', platformData, defaultValue: 0));
-    properties.add(FlagProperty('obscured', value: obscured, ifTrue: 'obscured'));
-    properties.add(FlagProperty('synthesized', value: synthesized, ifTrue: 'synthesized'));
+    properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<Duration>('timeStamp', timeStamp, defaultValue: Duration.zero, level: DiagnosticLevel.debug));
+    properties.add(IntProperty('pointer', pointer, level: DiagnosticLevel.debug));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind, level: DiagnosticLevel.debug));
+    properties.add(IntProperty('device', device, defaultValue: 0, level: DiagnosticLevel.debug));
+    properties.add(IntProperty('buttons', buttons, defaultValue: 0, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<bool>('down', down, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('pressure', pressure, defaultValue: 1.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('pressureMin', pressureMin, defaultValue: 1.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('pressureMax', pressureMax, defaultValue: 1.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('distance', distance, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('distanceMin', distanceMin, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('distanceMax', distanceMax, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('size', size, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('radiusMajor', radiusMajor, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('radiusMinor', radiusMinor, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('radiusMin', radiusMin, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('radiusMax', radiusMax, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('orientation', orientation, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(DoubleProperty('tilt', tilt, defaultValue: 0.0, level: DiagnosticLevel.debug));
+    properties.add(IntProperty('platformData', platformData, defaultValue: 0, level: DiagnosticLevel.debug));
+    properties.add(FlagProperty('obscured', value: obscured, ifTrue: 'obscured', level: DiagnosticLevel.debug));
+    properties.add(FlagProperty('synthesized', value: synthesized, ifTrue: 'synthesized', level: DiagnosticLevel.debug));
   }
 
   /// Returns a complete textual description of this event.

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -90,7 +90,7 @@ int nthStylusButton(int number) => (kPrimaryStylusButton << (number - 1)) & kMax
 ///
 ///  * [Window.devicePixelRatio], which defines the device's current resolution.
 @immutable
-abstract class PointerEvent {
+abstract class PointerEvent extends Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const PointerEvent({
@@ -288,36 +288,32 @@ abstract class PointerEvent {
   final bool synthesized;
 
   @override
-  String toString() => '$runtimeType($position)';
-
-  /// Returns a complete textual description of this event.
-  String toStringFull() {
-    return '$runtimeType('
-             'timeStamp: $timeStamp, '
-             'pointer: $pointer, '
-             'kind: $kind, '
-             'device: $device, '
-             'position: $position, '
-             'delta: $delta, '
-             'buttons: $buttons, '
-             'down: $down, '
-             'obscured: $obscured, '
-             'pressure: $pressure, '
-             'pressureMin: $pressureMin, '
-             'pressureMax: $pressureMax, '
-             'distance: $distance, '
-             'distanceMin: $distanceMin, '
-             'distanceMax: $distanceMax, '
-             'size: $size, '
-             'radiusMajor: $radiusMajor, '
-             'radiusMinor: $radiusMinor, '
-             'radiusMin: $radiusMin, '
-             'radiusMax: $radiusMax, '
-             'orientation: $orientation, '
-             'tilt: $tilt, '
-             'platformData: $platformData, '
-             'synthesized: $synthesized'
-           ')';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Duration>('timeStamp', timeStamp, defaultValue: Duration.zero));
+    properties.add(IntProperty('pointer', pointer));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
+    properties.add(IntProperty('device', device, defaultValue: 0));
+    properties.add(DiagnosticsProperty<Offset>('position', position));
+    properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero));
+    properties.add(IntProperty('buttons', buttons, defaultValue: 0));
+    properties.add(DiagnosticsProperty<bool>('down', down));
+    properties.add(FlagProperty('obscured', value: obscured, ifTrue: 'obscured'));
+    properties.add(DoubleProperty('pressure', pressure, defaultValue: 1.0));
+    properties.add(DoubleProperty('pressureMin', pressureMin, defaultValue: 1.0));
+    properties.add(DoubleProperty('pressureMax', pressureMax, defaultValue: 1.0));
+    properties.add(DoubleProperty('distance', distance, defaultValue: 0.0));
+    properties.add(DoubleProperty('distanceMin', distanceMin, defaultValue: 0.0));
+    properties.add(DoubleProperty('distanceMax', distanceMax, defaultValue: 0.0));
+    properties.add(DoubleProperty('size', size, defaultValue: 0.0));
+    properties.add(DoubleProperty('radiusMajor', radiusMajor, defaultValue: 0.0));
+    properties.add(DoubleProperty('radiusMinor', radiusMinor, defaultValue: 0.0));
+    properties.add(DoubleProperty('radiusMin', radiusMin, defaultValue: 0.0));
+    properties.add(DoubleProperty('radiusMax', radiusMax, defaultValue: 0.0));
+    properties.add(DoubleProperty('orientation', orientation, defaultValue: 0.0));
+    properties.add(DoubleProperty('tilt', tilt, defaultValue: 0.0));
+    properties.add(IntProperty('platformData', platformData, defaultValue: 0));
+    properties.add(FlagProperty('synthesized', value: synthesized, ifTrue: 'synthesized'));
   }
 }
 

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -12,6 +12,7 @@ void main() {
 
   testGesture('toString control tests', (GestureTester tester) {
     expect(const PointerDownEvent(), hasOneLineDescription);
+    expect(const PointerDownEvent().toStringFull(), hasOneLineDescription);
   });
 
   testGesture('nthMouseButton control tests', (GestureTester tester) {

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -12,7 +12,6 @@ void main() {
 
   testGesture('toString control tests', (GestureTester tester) {
     expect(const PointerDownEvent(), hasOneLineDescription);
-    expect(const PointerDownEvent().toStringFull(), hasOneLineDescription);
   });
 
   testGesture('nthMouseButton control tests', (GestureTester tester) {


### PR DESCRIPTION
Rather than building a description string by hand, use Diagnosticable
properties. Simplifies output, since many fields have uninteresting
default values in many cases, and makes it easier to add more loggable
properties in subclasses.

Issue #28014