### PR TITLE
PageView.builder with viewport fraction not working properly 🚧

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -58,21 +58,6 @@ class RenderSliverFillViewport extends RenderSliverFixedExtentBoxAdaptor {
   }
 
   @override
-  double indexToLayoutOffset(double itemExtent, int index) {
-    return  super.indexToLayoutOffset(itemExtent, index);
-  }
-
-  @override
-  int getMinChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
-    return super.getMinChildIndexForScrollOffset(math.max(scrollOffset , 0.0), itemExtent);
-  }
-
-  @override
-  int getMaxChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
-    return super.getMaxChildIndexForScrollOffset(math.max(scrollOffset, 0.0), itemExtent);
-  }
-
-  @override
   double estimateMaxScrollOffset(SliverConstraints constraints, {
     int firstIndex,
     int lastIndex,

--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -25,7 +25,7 @@ import 'sliver_multi_box_adaptor.dart';
 ///    remaining space rather than the viewport itself.
 ///  * [RenderSliverFixedExtentList], which has a configurable [itemExtent].
 ///  * [RenderSliverList], which does not require its children to have the same
-///    extent in the main axis.
+///  * /// extent in the main axis.
 class RenderSliverFillViewport extends RenderSliverFixedExtentBoxAdaptor {
   /// Creates a sliver that contains multiple box children that each fill the
   /// viewport.
@@ -57,21 +57,19 @@ class RenderSliverFillViewport extends RenderSliverFixedExtentBoxAdaptor {
     markNeedsLayout();
   }
 
-  double get _padding => (1.0 - viewportFraction) * constraints.viewportMainAxisExtent * 0.5;
-
   @override
   double indexToLayoutOffset(double itemExtent, int index) {
-    return _padding + super.indexToLayoutOffset(itemExtent, index);
+    return  super.indexToLayoutOffset(itemExtent, index);
   }
 
   @override
   int getMinChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
-    return super.getMinChildIndexForScrollOffset(math.max(scrollOffset - _padding, 0.0), itemExtent);
+    return super.getMinChildIndexForScrollOffset(math.max(scrollOffset , 0.0), itemExtent);
   }
 
   @override
   int getMaxChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
-    return super.getMaxChildIndexForScrollOffset(math.max(scrollOffset - _padding, 0.0), itemExtent);
+    return super.getMaxChildIndexForScrollOffset(math.max(scrollOffset, 0.0), itemExtent);
   }
 
   @override
@@ -81,14 +79,13 @@ class RenderSliverFillViewport extends RenderSliverFixedExtentBoxAdaptor {
     double leadingScrollOffset,
     double trailingScrollOffset,
   }) {
-    final double padding = _padding;
     return childManager.estimateMaxScrollOffset(
       constraints,
       firstIndex: firstIndex,
       lastIndex: lastIndex,
-      leadingScrollOffset: leadingScrollOffset - padding,
-      trailingScrollOffset: trailingScrollOffset - padding,
-    ) + padding + padding;
+      leadingScrollOffset: leadingScrollOffset,
+      trailingScrollOffset: trailingScrollOffset,
+    );
   }
 }
 


### PR DESCRIPTION
When using `PageView.builder` with single item containing Inkwell with viewport fraction, Inkwell wont trigger. 

You can run this gist for better understanding what is the issue
https://gist.github.com/Suraj-Tiwari/2320e3ff973bab0cbbe3ec3b9498b3ef 

### Here is a detailed reason why this is happening: 

![image](https://user-images.githubusercontent.com/22210490/52812708-1eca3a80-30be-11e9-8727-85574aabed02.png)

as you can see the SilverFillViewport width is 40% of screen width because view port fraction is 0.4
so it did it's job. and that area is clickable

Width of card is equal to view port but it's in center instead of left side of the screen where is SilverFillViewport 

so i investigated and found this line which gives padding to that card 

https://github.com/flutter/flutter/blob/e99c881f8d0e63042af6e2a3f6182c3ca6967442/packages/flutter/lib/src/rendering/sliver_fill.dart#L60

if i replace that code with following line 
`double get _padding => (1.0 - 1.0) * constraints.viewportMainAxisExtent * 0.5;`
which is equal to:
`double get _padding => 0`

This is how it looks after that, and this (card with inkwell) works perfectly. 

![image](https://user-images.githubusercontent.com/22210490/52813372-a49ab580-30bf-11e9-8c29-5d8499696d9d.png)

