### PR TITLE
Add extendBody parameter to Scaffold, body MediaQuery reflects BAB height

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Sander Dalby Larsen <srdlarsen@gmail.com>
 Marco Scannadinari <m@scannadinari.co.uk>
 Frederik Schweiger <mail@flschweiger.net>
 Martin Staadecker <machstg@gmail.com>
+Igor Katsuba <katsuba.igor@gmail.com>

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -305,8 +305,6 @@ class _BodyBoxConstraints extends BoxConstraints {
   bool operator ==(dynamic other) {
     if (super != other)
       return false;
-    if (other is! _BodyBoxConstraints)
-      return false;
     final _BodyBoxConstraints typedOther = other;
     return bottomWidgetsHeight == typedOther.bottomWidgetsHeight;
   }
@@ -336,7 +334,9 @@ class _BodyBuilder extends StatelessWidget {
         final MediaQueryData metrics = MediaQuery.of(context);
         return MediaQuery(
           data: metrics.copyWith(
-            padding: metrics.padding.copyWith(bottom: bodyConstraints.bottomWidgetsHeight),
+            padding: metrics.padding.copyWith(
+              bottom: math.max(metrics.padding.bottom, bodyConstraints.bottomWidgetsHeight),
+            ),
           ),
           child: body,
         );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -884,8 +884,8 @@ class Scaffold extends StatefulWidget {
        assert(drawerDragStartBehavior != null),
        super(key: key);
 
-  /// If true and [bottomNavigationBar] or [persistentFooterButtons]
-  /// are specified then the [body] extends to the bottom of the Scaffold,
+  /// If true, and [bottomNavigationBar] or [persistentFooterButtons]
+  /// is specified, then the [body] extends to the bottom of the Scaffold,
   /// instead of only extending to the top of the [bottomNavigationBar]
   /// or the [persistentFooterButtons].
   ///

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -313,8 +313,7 @@ class _BodyBoxConstraints extends BoxConstraints {
 
   @override
   int get hashCode {
-    assert(debugAssertIsValid());
-    return hashValues(minWidth, maxWidth, minHeight, maxHeight, bottomWidgetsHeight);
+    return hashValues(super.hashCode, bottomWidgetsHeight);
   }
 }
 
@@ -334,8 +333,6 @@ class _BodyBuilder extends StatelessWidget {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final _BodyBoxConstraints bodyConstraints = constraints;
-        if (bodyConstraints.bottomWidgetsHeight == 0.0)
-          return body;
         final MediaQueryData metrics = MediaQuery.of(context);
         return MediaQuery(
           data: metrics.copyWith(
@@ -421,16 +418,15 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
     if (hasChild(_ScaffoldSlot.body)) {
       double bodyMaxHeight = math.max(0.0, contentBottom - contentTop);
 
-      if (extendBody)
+      if (extendBody) {
         bodyMaxHeight += bottomWidgetsHeight;
+        assert(bodyMaxHeight <= math.max(0.0, looseConstraints.maxHeight - contentTop));
+      }
 
       final BoxConstraints bodyConstraints = _BodyBoxConstraints(
         maxWidth: fullWidthConstraints.maxWidth,
         maxHeight: bodyMaxHeight,
-        // If the keyboard is up, minInsets.bottom will match the keyboard's
-        // height (typically it will be > bottomWidgetsHeight) and we
-        // do not want _BodyBuilder to add bottom padding to MediaQuery.
-        bottomWidgetsHeight: math.max(bottomWidgetsHeight - minInsets.bottom , 0.0),
+        bottomWidgetsHeight: extendBody ? bottomWidgetsHeight : 0.0,
       );
       layoutChild(_ScaffoldSlot.body, bodyConstraints);
       positionChild(_ScaffoldSlot.body, Offset(0.0, contentTop));
@@ -893,13 +889,13 @@ class Scaffold extends StatefulWidget {
   /// instead of only extending to the top of the [bottomNavigationBar]
   /// or the [persistentFooterButtons].
   ///
-  /// If true a [MediaQuery] widget whose bottom padding matches the
+  /// If true, a [MediaQuery] widget whose bottom padding matches the
   /// the height of the [bottomNavigationBar] will be added above the
   /// scaffold's [body].
   ///
   /// This property is often useful when the [bottomNavigationBar] has
   /// a non-rectangular shape, like [CircularNotchedRectangle], which
-  /// adds [FloatingActionButton] sized notch to the top edge of the bar.
+  /// adds a [FloatingActionButton] sized notch to the top edge of the bar.
   /// In this case specifying `extendBody: true` ensures that that scaffold's
   /// body will be visible through the bottom navigation bar's notch.
   final bool extendBody;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -574,7 +574,7 @@ class BoxConstraints extends Constraints {
     assert(debugAssertIsValid());
     if (identical(this, other))
       return true;
-    if (other is! BoxConstraints)
+    if (runtimeType != other.runtimeType)
       return false;
     final BoxConstraints typedOther = other;
     assert(typedOther.debugAssertIsValid());

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -574,6 +574,63 @@ void main() {
       expect(tester.element(find.byKey(testKey)).size, const Size(88.0, 48.0));
       expect(tester.renderObject<RenderBox>(find.byKey(testKey)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
     });
+
+    testWidgets('body size with extendBody', (WidgetTester tester) async {
+      final Key bodyKey = UniqueKey();
+      double mediaQueryBottom;
+
+      Widget buildFrame({ bool extendBody, bool resizeToAvoidBottomInset, double viewInsetBottom = 0.0 }) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: MediaQueryData(
+              viewInsets: EdgeInsets.only(bottom: viewInsetBottom),
+            ),
+            child: Scaffold(
+              resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+              extendBody: extendBody,
+              body: Builder(
+                builder: (BuildContext context) {
+                  mediaQueryBottom = MediaQuery.of(context).padding.bottom;
+                  return Container(key: bodyKey);
+                },
+              ),
+              bottomNavigationBar: const BottomAppBar(
+                child: SizedBox(height: 48.0,),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame(extendBody: true));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 600.0));
+      expect(mediaQueryBottom, 48.0);
+
+      await tester.pumpWidget(buildFrame(extendBody: false));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 552.0)); // 552 = 600 - 48 (BAB height)
+      expect(mediaQueryBottom, 0.0);
+
+      // If resizeToAvoidBottomInsets is false, same results as if it was unspecified (null).
+      await tester.pumpWidget(buildFrame(extendBody: true, resizeToAvoidBottomInset: false, viewInsetBottom: 100.0));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 600.0));
+      expect(mediaQueryBottom, 48.0);
+
+      await tester.pumpWidget(buildFrame(extendBody: false, resizeToAvoidBottomInset: false, viewInsetBottom: 100.0));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 552.0));
+      expect(mediaQueryBottom, 0.0);
+
+      // If resizeToAvoidBottomInsets is true and viewInsets.bottom is > the bottom
+      // navigation bar's height then the body always resizes and the MediaQuery
+      // isn't adjusted. This case corresponds to the keyboard appearing.
+      await tester.pumpWidget(buildFrame(extendBody: true, resizeToAvoidBottomInset: true, viewInsetBottom: 100.0));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 500.0));
+      expect(mediaQueryBottom, 0.0);
+
+      await tester.pumpWidget(buildFrame(extendBody: false, resizeToAvoidBottomInset: true, viewInsetBottom: 100.0));
+      expect(tester.getSize(find.byKey(bodyKey)), const Size(800.0, 500.0));
+      expect(mediaQueryBottom, 0.0);
+   });
   });
 
   testWidgets('Open drawer hides underlying semantics tree', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/17555

This PR is based on https://github.com/flutter/flutter/pull/25654 which was contributed by @IKatsuba.

If `Scaffold.extendedBody` is true then the Scaffold's body extends to the bottom of the Scaffold, instead of only extending to the top of `Scaffold.bottomNavigationBar`. This ensures that the scaffold's body will appear behind a non-rectangular or sem-transparent bottom navigation bar of behind the Scaffold's `persistentFooterButtons`.

`Scaffold.extendedBody` is false by default.

This change corrects a long standing problem with "notched" bottom navigation bars.

## Before

<img width="374" alt="before" src="https://user-images.githubusercontent.com/1377460/52827163-7f368900-3078-11e9-9b39-6a4418cace17.png">


## After

```dart
...
Scaffold(extendBody: true, ...)
...
```

<img width="365" alt="after" src="https://user-images.githubusercontent.com/1377460/52827170-85c50080-3078-11e9-9325-28d4bbfa4cb0.png">

If `Scaffold.extendedBody` is true and the bottom navigation bar is specified then a MediaQuery whose bottom padding matches the height of the bottom navigation bar will be added above the scaffold body. Children of the scaffold body that have been enclosed in a SafeArea or that are padded to match the MedaQuery's padding, can still avoid the bottom navigation bar.

## Sample App

Here's a [complete example that demonstrates](https://gist.github.com/HansMuller/8eff4b13792b313a70054777cb701132) how the body's MediaQuery can be used.

![screenshot0](https://user-images.githubusercontent.com/1377460/52882878-ed815700-311d-11e9-8a52-0de64c22f15b.png)

There are 25 (0 - 24) textfield items in the list. Scrolling to the end completely exposes the last one because the list's bottom padding matches the MediaQuery:

```dart
extendBody: true,
body: Builder(
  builder: (BuildContext context) {
    return ListView(
      padding: MediaQuery.of(context).padding,
      children: List<Widget>.generate(25, (int i) {
        ...
      })
    );
  }
  ...
```

![screenshot1](https://user-images.githubusercontent.com/1377460/52882886-f7a35580-311d-11e9-935b-a3d4cfc3ec86.png)

When the keyboard appears the Scaffold's body is resized (the Scaffold's resizeToAvoidBottomInsets is true by default) and the body's MediaQuery no longer includes bottom padding.

![screenshot2](https://user-images.githubusercontent.com/1377460/52883022-5ec10a00-311e-11e9-9ce3-7d3ab6e7797d.png)




