### PR TITLE
Fixes #27151 for RTL cross axis issue.

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -217,6 +217,7 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
       crossAxisStride: tileWidth,
       childMainAxisExtent: tileHeight,
       childCrossAxisExtent: tileWidth,
+      crossAxisExtent: constraints.crossAxisExtent,
       reverseCrossAxis: axisDirectionIsReversed(constraints.crossAxisDirection),
     );
   }

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -153,12 +153,14 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
     @required this.crossAxisStride,
     @required this.childMainAxisExtent,
     @required this.childCrossAxisExtent,
+    @required this.crossAxisExtent,
     @required this.reverseCrossAxis,
   }) : assert(crossAxisCount != null && crossAxisCount > 0),
        assert(mainAxisStride != null && mainAxisStride >= 0),
        assert(crossAxisStride != null && crossAxisStride >= 0),
        assert(childMainAxisExtent != null && childMainAxisExtent >= 0),
        assert(childCrossAxisExtent != null && childCrossAxisExtent >= 0),
+       assert(crossAxisExtent != null && crossAxisExtent >= 0),
        assert(reverseCrossAxis != null);
 
   /// The number of children in the cross axis.
@@ -179,6 +181,11 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
   /// The number of pixels from the leading edge of one tile to the trailing
   /// edge of the same tile in the cross axis.
   final double childCrossAxisExtent;
+
+  /// The number of pixels in the cross-axis.
+  ///
+  /// For a vertical list, this is the width of the sliver.
+  final double crossAxisExtent;
 
   /// Whether the children should be placed in the opposite order of increasing
   /// coordinates in the cross axis.
@@ -206,8 +213,9 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
   }
 
   double _getOffsetFromStartInCrossAxis(double crossAxisStart) {
-    if (reverseCrossAxis)
-      return crossAxisCount * crossAxisStride - crossAxisStart - childCrossAxisExtent;
+    if (reverseCrossAxis){
+      return crossAxisExtent - crossAxisStart - childCrossAxisExtent;
+    }
     return crossAxisStart;
   }
 
@@ -334,6 +342,7 @@ class SliverGridDelegateWithFixedCrossAxisCount extends SliverGridDelegate {
       crossAxisStride: childCrossAxisExtent + crossAxisSpacing,
       childMainAxisExtent: childMainAxisExtent,
       childCrossAxisExtent: childCrossAxisExtent,
+      crossAxisExtent: constraints.crossAxisExtent,
       reverseCrossAxis: axisDirectionIsReversed(constraints.crossAxisDirection),
     );
   }
@@ -432,6 +441,7 @@ class SliverGridDelegateWithMaxCrossAxisExtent extends SliverGridDelegate {
       crossAxisStride: childCrossAxisExtent + crossAxisSpacing,
       childMainAxisExtent: childMainAxisExtent,
       childCrossAxisExtent: childCrossAxisExtent,
+      crossAxisExtent: constraints.crossAxisExtent,
       reverseCrossAxis: axisDirectionIsReversed(constraints.crossAxisDirection),
     );
   }

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -213,7 +213,7 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
   }
 
   double _getOffsetFromStartInCrossAxis(double crossAxisStart) {
-    if (reverseCrossAxis){
+    if (reverseCrossAxis) {
       return crossAxisExtent - crossAxisStart - childCrossAxisExtent;
     }
     return crossAxisStart;

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -536,4 +536,32 @@ void main() {
     expect(tester.getTopLeft(find.byKey(target)), const Offset(600.0, 0.0));
     expect(tester.getBottomRight(find.byKey(target)), const Offset(800.0, 200.0));
   });
+
+  testWidgets('GridView crossAxisSpacing', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/27151.
+    final Key target = UniqueKey();
+
+    Widget build(TextDirection textDirection) {
+      return Directionality(
+        textDirection: textDirection,
+        child: GridView.count(
+          crossAxisCount: 4,
+          crossAxisSpacing: 8.0,
+          children: <Widget>[
+            Container(key: target),
+          ],
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(TextDirection.ltr));
+
+    expect(tester.getTopLeft(find.byKey(target)), Offset.zero);
+    expect(tester.getBottomRight(find.byKey(target)), const Offset(194.0, 194.0));
+
+    await tester.pumpWidget(build(TextDirection.rtl));
+
+    expect(tester.getTopLeft(find.byKey(target)), const Offset(606.0, 0.0));
+    expect(tester.getBottomRight(find.byKey(target)), const Offset(800.0, 194.0));
+  });
 }


### PR DESCRIPTION
This original problem occurs because the Offset for each Widget is calculated from the Left/Top edge as per ui/graphics norm. So the Cross Axis Extent is required to know where the Right/Bottom edge is so that the position of views can be calculated in the reverse.

This PR makes this behaviour explicit and resolves the problem clearly and concisely. The other PR #27945 tries to calculate the extent from the other provided parameters but cannot guarantee that supplied parameters when recombined always add up to the Cross Axis Extent.

Fixes #27151