### PR TITLE
Feature/25989 horizontal padding on cupertino segmented control

### DIFF
--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -87,6 +87,7 @@ class CupertinoSegmentedControl<T> extends StatefulWidget {
     this.selectedColor,
     this.borderColor,
     this.pressedColor,
+    this.padding
   }) : assert(children != null),
        assert(children.length >= 2),
        assert(onValueChanged != null),
@@ -178,6 +179,12 @@ class CupertinoSegmentedControl<T> extends StatefulWidget {
   ///
   /// Defaults to the selectedColor at 20% opacity if null.
   final Color pressedColor;
+
+
+  /// The [children], if any, are placed inside this padding.
+  ///
+  /// Defaults to the EdgeInsets.symmetric(horizontal: 16.0)
+  final EdgeInsets padding;
 
   @override
   _SegmentedControlState<T> createState() => _SegmentedControlState<T>();
@@ -407,7 +414,7 @@ class _SegmentedControlState<T> extends State<CupertinoSegmentedControl<T>>
     );
 
     return Padding(
-      padding: _kHorizontalItemPadding.resolve(Directionality.of(context)),
+      padding: widget.padding ?? _kHorizontalItemPadding.resolve(Directionality.of(context)),
       child: UnconstrainedBox(
         constrainedAxis: Axis.horizontal,
         child: box,

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -183,7 +183,7 @@ class CupertinoSegmentedControl<T> extends StatefulWidget {
 
   /// The [children], if any, are placed inside this padding.
   ///
-  /// Defaults to the EdgeInsets.symmetric(horizontal: 16.0)
+  /// Defaults to EdgeInsets.symmetric(horizontal: 16.0)
   final EdgeInsets padding;
 
   @override


### PR DESCRIPTION
Added a configurable padding for the CupertinoSegmentedControl. The default of 16 will still be used if no padding was set

#25989 