### PR TITLE
[Material] Add ability to set shadow color and selected shadow color for chips and for chip themes

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -314,6 +314,12 @@ abstract class SelectableChipAttributes {
   /// The chip is selected when [selected] is true.
   Color get selectedColor;
 
+  /// Color to be used for the chip's shadow when the elevation is greater than
+  /// 0 and the chip is selected.
+  ///
+  /// The default is [Colors.black].
+  Color get selectedShadowColor;
+
   /// Tooltip string to be used for the body area (where the label and avatar
   /// are) of the chip.
   String get tooltip;
@@ -638,6 +644,7 @@ class InputChip extends StatelessWidget
     this.materialTapTargetSize,
     this.elevation,
     this.shadowColor,
+    this.selectedShadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(isEnabled != null),
@@ -694,6 +701,8 @@ class InputChip extends StatelessWidget
   @override
   final Color shadowColor;
   @override
+  final Color selectedShadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -723,6 +732,7 @@ class InputChip extends StatelessWidget
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
       shadowColor: shadowColor,
+      selectedShadowColor: selectedShadowColor,
       isEnabled: isEnabled && (onSelected != null || onDeleted != null || onPressed != null),
       avatarBorder: avatarBorder,
     );
@@ -812,6 +822,7 @@ class ChoiceChip extends StatelessWidget
     this.materialTapTargetSize,
     this.elevation,
     this.shadowColor,
+    this.selectedShadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(label != null),
@@ -855,6 +866,8 @@ class ChoiceChip extends StatelessWidget
   @override
   final Color shadowColor;
   @override
+  final Color selectedShadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -885,6 +898,7 @@ class ChoiceChip extends StatelessWidget
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
       shadowColor: shadowColor,
+      selectedShadowColor: selectedShadowColor,
       avatarBorder: avatarBorder,
     );
   }
@@ -1005,6 +1019,7 @@ class FilterChip extends StatelessWidget
     this.materialTapTargetSize,
     this.elevation,
     this.shadowColor,
+    this.selectedShadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(label != null),
@@ -1048,6 +1063,8 @@ class FilterChip extends StatelessWidget
   @override
   final Color shadowColor;
   @override
+  final Color selectedShadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -1075,6 +1092,7 @@ class FilterChip extends StatelessWidget
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
       shadowColor: shadowColor,
+      selectedShadowColor: selectedShadowColor,
       avatarBorder: avatarBorder,
     );
   }
@@ -1283,6 +1301,7 @@ class RawChip extends StatefulWidget
     this.materialTapTargetSize,
     this.elevation,
     this.shadowColor,
+    this.selectedShadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(label != null),
        assert(isEnabled != null),
@@ -1338,6 +1357,8 @@ class RawChip extends StatefulWidget
   final double elevation;
   @override
   final Color shadowColor;
+  @override
+  final Color selectedShadowColor;
   @override
   final CircleBorder avatarBorder;
 
@@ -1578,6 +1599,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
 
   static const double _defaultElevation = 0.0;
   static const double _defaultPressElevation = 8.0;
+  static const Color _defaultShadowColor = Colors.black;
 
   @override
   Widget build(BuildContext context) {
@@ -1592,11 +1614,13 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     final ShapeBorder shape = widget.shape ?? chipTheme.shape;
     final double elevation = widget.elevation ?? chipTheme.elevation ?? _defaultElevation;
     final double pressElevation = widget.pressElevation ?? chipTheme.pressElevation ?? _defaultPressElevation;
-    final Color shadowColor = widget.shadowColor ?? chipTheme.shadowColor ?? Colors.black;
+    final Color shadowColor = widget.shadowColor ?? chipTheme.shadowColor ?? _defaultShadowColor;
+    final Color selectedShadowColor = widget.selectedShadowColor ?? chipTheme.selectedShadowColor ?? _defaultShadowColor;
+    final bool selected = widget.selected ?? false;
 
     Widget result = Material(
       elevation: isTapping ? pressElevation : elevation,
-      shadowColor: shadowColor,
+      shadowColor: selected ? selectedShadowColor : shadowColor,
       animationDuration: pressedAnimationDuration,
       shape: shape,
       clipBehavior: widget.clipBehavior,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -118,6 +118,11 @@ abstract class ChipAttributes {
   ///
   /// Defaults to 0. The value is always non-negative.
   double get elevation;
+
+  /// Color to be used for the chip's shadow when the elevation is greater than 0.
+  ///
+  /// The default is [Colors.black].
+  Color get shadowColor;
 }
 
 /// An interface for material design chips that can be deleted.
@@ -486,6 +491,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.padding,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
   }) : assert(label != null),
        assert(clipBehavior != null),
        assert(elevation == null || elevation >= 0.0),
@@ -519,6 +525,8 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   final MaterialTapTargetSize materialTapTargetSize;
   @override
   final double elevation;
+  @override
+  final Color shadowColor;
 
   @override
   Widget build(BuildContext context) {
@@ -539,6 +547,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
       padding: padding,
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
+      shadowColor: shadowColor,
       isEnabled: true,
     );
   }
@@ -628,6 +637,7 @@ class InputChip extends StatelessWidget
     this.padding,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(isEnabled != null),
@@ -682,6 +692,8 @@ class InputChip extends StatelessWidget
   @override
   final double elevation;
   @override
+  final Color shadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -710,6 +722,7 @@ class InputChip extends StatelessWidget
       padding: padding,
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
+      shadowColor: shadowColor,
       isEnabled: isEnabled && (onSelected != null || onDeleted != null || onPressed != null),
       avatarBorder: avatarBorder,
     );
@@ -798,6 +811,7 @@ class ChoiceChip extends StatelessWidget
     this.padding,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(label != null),
@@ -839,6 +853,8 @@ class ChoiceChip extends StatelessWidget
   @override
   final double elevation;
   @override
+  final Color shadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -868,6 +884,7 @@ class ChoiceChip extends StatelessWidget
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
+      shadowColor: shadowColor,
       avatarBorder: avatarBorder,
     );
   }
@@ -987,6 +1004,7 @@ class FilterChip extends StatelessWidget
     this.padding,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(selected != null),
        assert(label != null),
@@ -1028,6 +1046,8 @@ class FilterChip extends StatelessWidget
   @override
   final double elevation;
   @override
+  final Color shadowColor;
+  @override
   final ShapeBorder avatarBorder;
 
   @override
@@ -1054,6 +1074,7 @@ class FilterChip extends StatelessWidget
       isEnabled: isEnabled,
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
+      shadowColor: shadowColor,
       avatarBorder: avatarBorder,
     );
   }
@@ -1127,6 +1148,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
     this.padding,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
   }) : assert(label != null),
        assert(
          onPressed != null,
@@ -1163,6 +1185,8 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
   final MaterialTapTargetSize materialTapTargetSize;
   @override
   final double elevation;
+  @override
+  final Color shadowColor;
 
   @override
   Widget build(BuildContext context) {
@@ -1182,6 +1206,7 @@ class ActionChip extends StatelessWidget implements ChipAttributes, TappableChip
       isEnabled: true,
       materialTapTargetSize: materialTapTargetSize,
       elevation: elevation,
+      shadowColor: shadowColor,
     );
   }
 }
@@ -1257,6 +1282,7 @@ class RawChip extends StatefulWidget
     this.backgroundColor,
     this.materialTapTargetSize,
     this.elevation,
+    this.shadowColor,
     this.avatarBorder = const CircleBorder(),
   }) : assert(label != null),
        assert(isEnabled != null),
@@ -1310,6 +1336,8 @@ class RawChip extends StatefulWidget
   final MaterialTapTargetSize materialTapTargetSize;
   @override
   final double elevation;
+  @override
+  final Color shadowColor;
   @override
   final CircleBorder avatarBorder;
 
@@ -1564,9 +1592,11 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     final ShapeBorder shape = widget.shape ?? chipTheme.shape;
     final double elevation = widget.elevation ?? chipTheme.elevation ?? _defaultElevation;
     final double pressElevation = widget.pressElevation ?? chipTheme.pressElevation ?? _defaultPressElevation;
+    final Color shadowColor = widget.shadowColor ?? chipTheme.shadowColor ?? Colors.black;
 
     Widget result = Material(
       elevation: isTapping ? pressElevation : elevation,
+      shadowColor: shadowColor,
       animationDuration: pressedAnimationDuration,
       shape: shape,
       clipBehavior: widget.clipBehavior,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -119,7 +119,7 @@ abstract class ChipAttributes {
   /// Defaults to 0. The value is always non-negative.
   double get elevation;
 
-  /// Color to be used for the chip's shadow when the elevation is greater than 0.
+  /// Color of the chip's shadow when the elevation is greater than 0.
   ///
   /// The default is [Colors.black].
   Color get shadowColor;
@@ -314,8 +314,8 @@ abstract class SelectableChipAttributes {
   /// The chip is selected when [selected] is true.
   Color get selectedColor;
 
-  /// Color to be used for the chip's shadow when the elevation is greater than
-  /// 0 and the chip is selected.
+  /// Color of the chip's shadow when the elevation is greater than 0 and the
+  /// chip is selected.
   ///
   /// The default is [Colors.black].
   Color get selectedShadowColor;

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -164,8 +164,8 @@ class ChipTheme extends InheritedWidget {
 ///  * [ThemeData], which has a default [ChipThemeData].
 class ChipThemeData extends Diagnosticable {
   /// Create a [ChipThemeData] given a set of exact values. All the values
-  /// must be specified except for [shadowColor], [elevation], and
-  /// [pressElevation], which may be null.
+  /// must be specified except for [shadowColor], [selectedShadowColor],
+  /// [elevation], and [pressElevation], which may be null.
   ///
   /// This will rarely be used directly. It is used by [lerp] to
   /// create intermediate themes based on two themes.
@@ -176,6 +176,7 @@ class ChipThemeData extends Diagnosticable {
     @required this.selectedColor,
     @required this.secondarySelectedColor,
     this.shadowColor,
+    this.selectedShadowColor,
     @required this.labelPadding,
     @required this.padding,
     @required this.shape,
@@ -305,6 +306,12 @@ class ChipThemeData extends Diagnosticable {
   /// If null, the chip defaults to [Colors.black].
   final Color shadowColor;
 
+  /// Color to be used for the chip's shadow when the elevation is greater than
+  /// 0 and the chip is selected.
+  ///
+  /// If null, the chip defaults to [Colors.black].
+  final Color selectedShadowColor;
+
   /// The padding around the [label] widget.
   ///
   /// By default, this is 4 logical pixels at the beginning and the end of the
@@ -358,6 +365,7 @@ class ChipThemeData extends Diagnosticable {
     Color selectedColor,
     Color secondarySelectedColor,
     Color shadowColor,
+    Color selectedShadowColor,
     EdgeInsetsGeometry labelPadding,
     EdgeInsetsGeometry padding,
     ShapeBorder shape,
@@ -374,6 +382,7 @@ class ChipThemeData extends Diagnosticable {
       selectedColor: selectedColor ?? this.selectedColor,
       secondarySelectedColor: secondarySelectedColor ?? this.secondarySelectedColor,
       shadowColor: shadowColor ?? this.shadowColor,
+      selectedShadowColor: selectedShadowColor ?? this.selectedShadowColor,
       labelPadding: labelPadding ?? this.labelPadding,
       padding: padding ?? this.padding,
       shape: shape ?? this.shape,
@@ -401,6 +410,7 @@ class ChipThemeData extends Diagnosticable {
       selectedColor: Color.lerp(a?.selectedColor, b?.selectedColor, t),
       secondarySelectedColor: Color.lerp(a?.secondarySelectedColor, b?.secondarySelectedColor, t),
       shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
+      selectedShadowColor: Color.lerp(a?.selectedShadowColor, b?.selectedShadowColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
@@ -421,6 +431,7 @@ class ChipThemeData extends Diagnosticable {
       selectedColor,
       secondarySelectedColor,
       shadowColor,
+      selectedShadowColor,
       labelPadding,
       padding,
       shape,
@@ -447,6 +458,7 @@ class ChipThemeData extends Diagnosticable {
         && otherData.selectedColor == selectedColor
         && otherData.secondarySelectedColor == secondarySelectedColor
         && otherData.shadowColor == shadowColor
+        && otherData.selectedShadowColor == selectedShadowColor
         && otherData.labelPadding == labelPadding
         && otherData.padding == padding
         && otherData.shape == shape
@@ -472,6 +484,7 @@ class ChipThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<Color>('selectedColor', selectedColor, defaultValue: defaultData.selectedColor));
     properties.add(DiagnosticsProperty<Color>('secondarySelectedColor', secondarySelectedColor, defaultValue: defaultData.secondarySelectedColor));
     properties.add(DiagnosticsProperty<Color>('shadowColor', shadowColor, defaultValue: defaultData.shadowColor));
+    properties.add(DiagnosticsProperty<Color>('selectedShadowColor', selectedShadowColor, defaultValue: defaultData.selectedShadowColor));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding, defaultValue: defaultData.labelPadding));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: defaultData.padding));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: defaultData.shape));

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -304,12 +304,20 @@ class ChipThemeData extends Diagnosticable {
   /// Color of the chip's shadow when the elevation is greater than 0.
   ///
   /// If null, the chip defaults to [Colors.black].
+  ///
+  /// See also:
+  ///
+  ///  * [selectedShadowColor]
   final Color shadowColor;
 
   /// Color of the chip's shadow when the elevation is greater than 0 and the
   /// chip is selected.
   ///
   /// If null, the chip defaults to [Colors.black].
+  ///
+  /// See also:
+  ///
+  ///  * [shadowColor]
   final Color selectedShadowColor;
 
   /// The padding around the [label] widget.

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -301,13 +301,13 @@ class ChipThemeData extends Diagnosticable {
   /// The chip is selected when [selected] is true.
   final Color secondarySelectedColor;
 
-  /// Color to be used for the chip's shadow when the elevation is greater than 0.
+  /// Color of the chip's shadow when the elevation is greater than 0.
   ///
   /// If null, the chip defaults to [Colors.black].
   final Color shadowColor;
 
-  /// Color to be used for the chip's shadow when the elevation is greater than
-  /// 0 and the chip is selected.
+  /// Color of the chip's shadow when the elevation is greater than 0 and the
+  /// chip is selected.
   ///
   /// If null, the chip defaults to [Colors.black].
   final Color selectedShadowColor;

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -164,8 +164,8 @@ class ChipTheme extends InheritedWidget {
 ///  * [ThemeData], which has a default [ChipThemeData].
 class ChipThemeData extends Diagnosticable {
   /// Create a [ChipThemeData] given a set of exact values. All the values
-  /// must be specified except for [elevation] and [pressElevation], which may
-  /// be null.
+  /// must be specified except for [shadowColor], [elevation], and
+  /// [pressElevation], which may be null.
   ///
   /// This will rarely be used directly. It is used by [lerp] to
   /// create intermediate themes based on two themes.
@@ -175,6 +175,7 @@ class ChipThemeData extends Diagnosticable {
     @required this.disabledColor,
     @required this.selectedColor,
     @required this.secondarySelectedColor,
+    this.shadowColor,
     @required this.labelPadding,
     @required this.padding,
     @required this.shape,
@@ -299,6 +300,11 @@ class ChipThemeData extends Diagnosticable {
   /// The chip is selected when [selected] is true.
   final Color secondarySelectedColor;
 
+  /// Color to be used for the chip's shadow when the elevation is greater than 0.
+  ///
+  /// If null, the chip defaults to [Colors.black].
+  final Color shadowColor;
+
   /// The padding around the [label] widget.
   ///
   /// By default, this is 4 logical pixels at the beginning and the end of the
@@ -351,6 +357,7 @@ class ChipThemeData extends Diagnosticable {
     Color disabledColor,
     Color selectedColor,
     Color secondarySelectedColor,
+    Color shadowColor,
     EdgeInsetsGeometry labelPadding,
     EdgeInsetsGeometry padding,
     ShapeBorder shape,
@@ -366,6 +373,7 @@ class ChipThemeData extends Diagnosticable {
       disabledColor: disabledColor ?? this.disabledColor,
       selectedColor: selectedColor ?? this.selectedColor,
       secondarySelectedColor: secondarySelectedColor ?? this.secondarySelectedColor,
+      shadowColor: shadowColor ?? this.shadowColor,
       labelPadding: labelPadding ?? this.labelPadding,
       padding: padding ?? this.padding,
       shape: shape ?? this.shape,
@@ -392,6 +400,7 @@ class ChipThemeData extends Diagnosticable {
       disabledColor: Color.lerp(a?.disabledColor, b?.disabledColor, t),
       selectedColor: Color.lerp(a?.selectedColor, b?.selectedColor, t),
       secondarySelectedColor: Color.lerp(a?.secondarySelectedColor, b?.secondarySelectedColor, t),
+      shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
@@ -411,6 +420,7 @@ class ChipThemeData extends Diagnosticable {
       disabledColor,
       selectedColor,
       secondarySelectedColor,
+      shadowColor,
       labelPadding,
       padding,
       shape,
@@ -436,6 +446,7 @@ class ChipThemeData extends Diagnosticable {
         && otherData.disabledColor == disabledColor
         && otherData.selectedColor == selectedColor
         && otherData.secondarySelectedColor == secondarySelectedColor
+        && otherData.shadowColor == shadowColor
         && otherData.labelPadding == labelPadding
         && otherData.padding == padding
         && otherData.shape == shape
@@ -460,6 +471,7 @@ class ChipThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<Color>('disabledColor', disabledColor, defaultValue: defaultData.disabledColor));
     properties.add(DiagnosticsProperty<Color>('selectedColor', selectedColor, defaultValue: defaultData.selectedColor));
     properties.add(DiagnosticsProperty<Color>('secondarySelectedColor', secondarySelectedColor, defaultValue: defaultData.secondarySelectedColor));
+    properties.add(DiagnosticsProperty<Color>('shadowColor', shadowColor, defaultValue: defaultData.shadowColor));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding, defaultValue: defaultData.labelPadding));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: defaultData.padding));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: defaultData.shape));

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1485,7 +1485,7 @@ void main() {
     expect(tester.takeException(), null);
   });
 
-  testWidgets('Chip elevation works correctly', (WidgetTester tester) async {
+  testWidgets('Chip elevation and shadow color work correctly', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(
       platform: TargetPlatform.android,
       primarySwatch: Colors.red,
@@ -1508,16 +1508,19 @@ void main() {
     await tester.pumpWidget(buildChip(chipTheme));
     Material material = getMaterial(tester);
     expect(material.elevation, 0.0);
+    expect(material.shadowColor, Colors.black);
 
     inputChip = const InputChip(
       label: Text('Label'),
       elevation: 4.0,
+      shadowColor: Colors.green,
     );
 
     await tester.pumpWidget(buildChip(chipTheme));
     await tester.pumpAndSettle();
     material = getMaterial(tester);
     expect(material.elevation, 4.0);
+    expect(material.shadowColor, Colors.green);
   });
 
   testWidgets('can be tapped outside of chip body', (WidgetTester tester) async {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1514,6 +1514,7 @@ void main() {
       label: Text('Label'),
       elevation: 4.0,
       shadowColor: Colors.green,
+      selectedShadowColor: Colors.blue,
     );
 
     await tester.pumpWidget(buildChip(chipTheme));
@@ -1521,6 +1522,18 @@ void main() {
     material = getMaterial(tester);
     expect(material.elevation, 4.0);
     expect(material.shadowColor, Colors.green);
+
+    inputChip = const InputChip(
+      label: Text('Label'),
+      selected: true,
+      shadowColor: Colors.green,
+      selectedShadowColor: Colors.blue,
+    );
+
+    await tester.pumpWidget(buildChip(chipTheme));
+    await tester.pumpAndSettle();
+    material = getMaterial(tester);
+    expect(material.shadowColor, Colors.blue);
   });
 
   testWidgets('can be tapped outside of chip body', (WidgetTester tester) async {

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -120,6 +120,7 @@ void main() {
       backgroundColor: Colors.purple,
       deleteIconColor: Colors.purple.withAlpha(0x3d),
       elevation: 3.0,
+      shadowColor: Colors.pink,
     );
     const bool value = false;
     Widget buildChip(ChipThemeData data) {
@@ -162,6 +163,7 @@ void main() {
 
     expect(materialBox, paints..path(color: Color(customTheme.backgroundColor.value)));
     expect(material.elevation, customTheme.elevation);
+    expect(material.shadowColor, customTheme.shadowColor);
   });
 
   testWidgets('ChipThemeData generates correct opacities for defaults', (WidgetTester tester) async {
@@ -232,6 +234,7 @@ void main() {
     ).copyWith(
       elevation: 1.0,
       pressElevation: 4.0,
+      shadowColor: Colors.black,
     );
     final ChipThemeData chipThemeWhite = ChipThemeData.fromDefaults(
       secondaryColor: Colors.white,
@@ -242,6 +245,7 @@ void main() {
       labelPadding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
       elevation: 5.0,
       pressElevation: 10.0,
+      shadowColor: Colors.white,
     );
 
     final ChipThemeData lerp = ChipThemeData.lerp(chipThemeBlack, chipThemeWhite, 0.5);
@@ -251,6 +255,7 @@ void main() {
     expect(lerp.disabledColor, equals(middleGrey.withAlpha(0x0c)));
     expect(lerp.selectedColor, equals(middleGrey.withAlpha(0x3d)));
     expect(lerp.secondarySelectedColor, equals(middleGrey.withAlpha(0x3d)));
+    expect(lerp.shadowColor, equals(middleGrey));
     expect(lerp.labelPadding, equals(const EdgeInsets.all(4.0)));
     expect(lerp.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerp.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -268,6 +273,7 @@ void main() {
     expect(lerpANull25.disabledColor, equals(Colors.black.withAlpha(0x03)));
     expect(lerpANull25.selectedColor, equals(Colors.black.withAlpha(0x0f)));
     expect(lerpANull25.secondarySelectedColor, equals(Colors.white.withAlpha(0x0f)));
+    expect(lerpANull25.shadowColor, equals(Colors.white.withAlpha(0x40)));
     expect(lerpANull25.labelPadding, equals(const EdgeInsets.only(left: 0.0, top: 2.0, right: 0.0, bottom: 2.0)));
     expect(lerpANull25.padding, equals(const EdgeInsets.all(0.5)));
     expect(lerpANull25.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -283,6 +289,7 @@ void main() {
     expect(lerpANull75.disabledColor, equals(Colors.black.withAlpha(0x09)));
     expect(lerpANull75.selectedColor, equals(Colors.black.withAlpha(0x2e)));
     expect(lerpANull75.secondarySelectedColor, equals(Colors.white.withAlpha(0x2e)));
+    expect(lerpANull75.shadowColor, equals(Colors.white.withAlpha(0xbf)));
     expect(lerpANull75.labelPadding, equals(const EdgeInsets.only(left: 0.0, top: 6.0, right: 0.0, bottom: 6.0)));
     expect(lerpANull75.padding, equals(const EdgeInsets.all(1.5)));
     expect(lerpANull75.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -298,6 +305,7 @@ void main() {
     expect(lerpBNull25.disabledColor, equals(Colors.white.withAlpha(0x09)));
     expect(lerpBNull25.selectedColor, equals(Colors.white.withAlpha(0x2e)));
     expect(lerpBNull25.secondarySelectedColor, equals(Colors.black.withAlpha(0x2e)));
+    expect(lerpBNull25.shadowColor, equals(Colors.black.withAlpha(0xbf)));
     expect(lerpBNull25.labelPadding, equals(const EdgeInsets.only(left: 6.0, top: 0.0, right: 6.0, bottom: 0.0)));
     expect(lerpBNull25.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerpBNull25.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -313,6 +321,7 @@ void main() {
     expect(lerpBNull75.disabledColor, equals(Colors.white.withAlpha(0x03)));
     expect(lerpBNull75.selectedColor, equals(Colors.white.withAlpha(0x0f)));
     expect(lerpBNull75.secondarySelectedColor, equals(Colors.black.withAlpha(0x0f)));
+    expect(lerpBNull75.shadowColor, equals(Colors.black.withAlpha(0x40)));
     expect(lerpBNull75.labelPadding, equals(const EdgeInsets.only(left: 2.0, top: 0.0, right: 2.0, bottom: 0.0)));
     expect(lerpBNull75.padding, equals(const EdgeInsets.all(1.0)));
     expect(lerpBNull75.shape, equals(isInstanceOf<StadiumBorder>()));

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -235,6 +235,7 @@ void main() {
       elevation: 1.0,
       pressElevation: 4.0,
       shadowColor: Colors.black,
+      selectedShadowColor: Colors.black,
     );
     final ChipThemeData chipThemeWhite = ChipThemeData.fromDefaults(
       secondaryColor: Colors.white,
@@ -246,6 +247,7 @@ void main() {
       elevation: 5.0,
       pressElevation: 10.0,
       shadowColor: Colors.white,
+      selectedShadowColor: Colors.white,
     );
 
     final ChipThemeData lerp = ChipThemeData.lerp(chipThemeBlack, chipThemeWhite, 0.5);
@@ -256,6 +258,7 @@ void main() {
     expect(lerp.selectedColor, equals(middleGrey.withAlpha(0x3d)));
     expect(lerp.secondarySelectedColor, equals(middleGrey.withAlpha(0x3d)));
     expect(lerp.shadowColor, equals(middleGrey));
+    expect(lerp.selectedShadowColor, equals(middleGrey));
     expect(lerp.labelPadding, equals(const EdgeInsets.all(4.0)));
     expect(lerp.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerp.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -274,6 +277,7 @@ void main() {
     expect(lerpANull25.selectedColor, equals(Colors.black.withAlpha(0x0f)));
     expect(lerpANull25.secondarySelectedColor, equals(Colors.white.withAlpha(0x0f)));
     expect(lerpANull25.shadowColor, equals(Colors.white.withAlpha(0x40)));
+    expect(lerpANull25.selectedShadowColor, equals(Colors.white.withAlpha(0x40)));
     expect(lerpANull25.labelPadding, equals(const EdgeInsets.only(left: 0.0, top: 2.0, right: 0.0, bottom: 2.0)));
     expect(lerpANull25.padding, equals(const EdgeInsets.all(0.5)));
     expect(lerpANull25.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -290,6 +294,7 @@ void main() {
     expect(lerpANull75.selectedColor, equals(Colors.black.withAlpha(0x2e)));
     expect(lerpANull75.secondarySelectedColor, equals(Colors.white.withAlpha(0x2e)));
     expect(lerpANull75.shadowColor, equals(Colors.white.withAlpha(0xbf)));
+    expect(lerpANull75.selectedShadowColor, equals(Colors.white.withAlpha(0xbf)));
     expect(lerpANull75.labelPadding, equals(const EdgeInsets.only(left: 0.0, top: 6.0, right: 0.0, bottom: 6.0)));
     expect(lerpANull75.padding, equals(const EdgeInsets.all(1.5)));
     expect(lerpANull75.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -306,6 +311,7 @@ void main() {
     expect(lerpBNull25.selectedColor, equals(Colors.white.withAlpha(0x2e)));
     expect(lerpBNull25.secondarySelectedColor, equals(Colors.black.withAlpha(0x2e)));
     expect(lerpBNull25.shadowColor, equals(Colors.black.withAlpha(0xbf)));
+    expect(lerpBNull25.selectedShadowColor, equals(Colors.black.withAlpha(0xbf)));
     expect(lerpBNull25.labelPadding, equals(const EdgeInsets.only(left: 6.0, top: 0.0, right: 6.0, bottom: 0.0)));
     expect(lerpBNull25.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerpBNull25.shape, equals(isInstanceOf<StadiumBorder>()));
@@ -322,6 +328,7 @@ void main() {
     expect(lerpBNull75.selectedColor, equals(Colors.white.withAlpha(0x0f)));
     expect(lerpBNull75.secondarySelectedColor, equals(Colors.black.withAlpha(0x0f)));
     expect(lerpBNull75.shadowColor, equals(Colors.black.withAlpha(0x40)));
+    expect(lerpBNull75.selectedShadowColor, equals(Colors.black.withAlpha(0x40)));
     expect(lerpBNull75.labelPadding, equals(const EdgeInsets.only(left: 2.0, top: 0.0, right: 2.0, bottom: 0.0)));
     expect(lerpBNull75.padding, equals(const EdgeInsets.all(1.0)));
     expect(lerpBNull75.shape, equals(isInstanceOf<StadiumBorder>()));


### PR DESCRIPTION
Allow developers to specify the shadow color and selected shadow color for chips, either directly or through the `ChipThemeData`.