### PR TITLE
use primaryTextTheme instead of textTheme to ensure contrast to AppBar in search

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -433,7 +433,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           title: TextField(
             controller: queryTextController,
             focusNode: widget.delegate._focusNode,
-            style: theme.textTheme.title,
+            style: theme.primaryTextTheme.title,
             textInputAction: TextInputAction.search,
             onSubmitted: (String _) {
               widget.delegate.showResults(context);

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -433,7 +433,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           title: TextField(
             controller: queryTextController,
             focusNode: widget.delegate._focusNode,
-            style: theme.primaryTextTheme.title,
+            style: theme.textTheme.title,
             textInputAction: TextInputAction.search,
             onSubmitted: (String _) {
               widget.delegate.showResults(context);
@@ -441,7 +441,6 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             decoration: InputDecoration(
               border: InputBorder.none,
               hintText: searchFieldLabel,
-              hintStyle: theme.primaryTextTheme.title,
             ),
           ),
           actions: widget.delegate.buildActions(context),

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -441,6 +441,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             decoration: InputDecoration(
               border: InputBorder.none,
               hintText: searchFieldLabel,
+              hintStyle: theme.primaryTextTheme.title,
             ),
           ),
           actions: widget.delegate.buildActions(context),

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -441,6 +441,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             decoration: InputDecoration(
               border: InputBorder.none,
               hintText: searchFieldLabel,
+              hintStyle: theme.inputDecorationTheme.hintStyle,
             ),
           ),
           actions: widget.delegate.buildActions(context),


### PR DESCRIPTION
## Description

Because the TextField is shown in the AppBar we should use the primaryTextTheme to ensure the contrast between them. In addition hintText should also has this TextStyle. 

### before
![screenshot from 2019-02-25 20-39-48](https://user-images.githubusercontent.com/33162310/53363782-a1b08800-393d-11e9-8186-23be67551493.png)

### after
![screenshot from 2019-02-25 20-36-47](https://user-images.githubusercontent.com/33162310/53363794-aaa15980-393d-11e9-8ca9-b7647de3304a.png)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
