### PR TITLE
[flutter_tool,fuchsia_tester] Only require a test source dir for coverage

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -34,7 +34,6 @@ const String _kOptionCoverageDirectory = 'coverage-directory';
 const List<String> _kRequiredOptions = <String>[
   _kOptionPackages,
   _kOptionShell,
-  _kOptionTestDirectory,
   _kOptionSdkRoot,
   _kOptionIcudtl,
   _kOptionTests,
@@ -75,8 +74,6 @@ Future<void> run(List<String> args) async {
       fs.systemTempDirectory.createTempSync('flutter_fuchsia_tester.');
   try {
     Cache.flutterRoot = tempDir.path;
-    final Directory testDirectory =
-        fs.directory(argResults[_kOptionTestDirectory]);
 
     final String shellPath = argResults[_kOptionShell];
     if (!fs.isFileSync(shellPath)) {
@@ -101,9 +98,9 @@ Future<void> run(List<String> args) async {
     final Link testerDestLink =
         fs.link(artifacts.getArtifactPath(Artifact.flutterTester));
     testerDestLink.parent.createSync(recursive: true);
-    testerDestLink.createSync(shellPath);
+    testerDestLink.createSync(fs.path.absolute(shellPath));
     final Link icudtlLink = testerDestLink.parent.childLink('icudtl.dat');
-    icudtlLink.createSync(argResults[_kOptionIcudtl]);
+    icudtlLink.createSync(fs.path.absolute(argResults[_kOptionIcudtl]));
     final Directory sdkRootDest =
         fs.directory(artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath));
     sdkRootDest.createSync(recursive: true);
@@ -116,9 +113,14 @@ Future<void> run(List<String> args) async {
     PackageMap.globalPackagesPath =
         fs.path.normalize(fs.path.absolute(argResults[_kOptionPackages]));
 
+    Directory testDirectory;
     CoverageCollector collector;
     if (argResults['coverage']) {
       collector = CoverageCollector();
+      if (!argResults.options.contains(_kOptionTestDirectory)) {
+        throwToolExit('Use of --coverage requires setting --test-directory');
+      }
+      testDirectory = fs.directory(argResults[_kOptionTestDirectory]);
     }
 
 


### PR DESCRIPTION
This avoids some confusion that tests are running from source rather than pre-compiled kernel for Fuchsia.