### PR TITLE
Clean up flutter_gallery.cmx's sandbox

### DIFF
--- a/examples/flutter_gallery/meta/flutter_gallery.cmx
+++ b/examples/flutter_gallery/meta/flutter_gallery.cmx
@@ -3,8 +3,6 @@
         "data": "data/flutter_gallery"
     },
     "sandbox": {
-        "system": [ "data" ],
-        "features": [ "persistent-storage" ],
         "services": [
             "fuchsia.cobalt.LoggerFactory",
             "fuchsia.fonts.Provider",


### PR DESCRIPTION
The "persistent-storage" Fuchsia component manifest feature is being replaced with "isolated-persistent-storage". See https://fuchsia-review.googlesource.com/c/fuchsia/+/250019