### PR TITLE
[Material] Add the ability to theme trailing app bar actions independently from leading

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -307,9 +307,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// if that is also null, then [ThemeData.primaryIconTheme] is used.
   final IconThemeData iconTheme;
 
-  /// The color, opacity, and size to use for trailing app bar icons. This
-  /// should only be used when the trailing icons should be themed differently
-  /// than the leading icons.
+  /// The color, opacity, and size to use for the icons that appear in the app
+  /// bar's [actions]. This should only be used when the [actions] should be
+  /// themed differently than the icon that appears in the app bar's [leading]
+  /// widget.
   ///
   /// If this property is null, then [ThemeData.appBarTheme.actionsIconTheme] is
   /// used, if that is also null, then this falls back to [iconTheme].
@@ -412,7 +413,6 @@ class _AppBarState extends State<AppBar> {
     IconThemeData overallIconTheme = widget.iconTheme
       ?? appBarTheme.iconTheme
       ?? themeData.primaryIconTheme;
-    // If no actionsIconTheme is specified, then fallback on the overallIconTheme.
     IconThemeData actionsIconTheme = widget.actionsIconTheme
       ?? appBarTheme.actionsIconTheme
       ?? overallIconTheme;
@@ -433,7 +433,7 @@ class _AppBarState extends State<AppBar> {
         opacity: opacity * (overallIconTheme.opacity ?? 1.0)
       );
       actionsIconTheme = actionsIconTheme.copyWith(
-          opacity: opacity * (actionsIconTheme.opacity ?? 1.0)
+        opacity: opacity * (actionsIconTheme.opacity ?? 1.0)
       );
     }
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -135,10 +135,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// and [automaticallyImplyLeading] must not be null. Additionally, if
   /// [elevation] is specified, it must be non-negative.
   ///
-  /// If [backgroundColor], [elevation], [brightness], [iconTheme], or
-  /// [textTheme] are null, their [AppBarTheme] values will be used. If the
-  /// corresponding [AppBarTheme] property is null, then the default specified
-  /// in the property's documentation will be used.
+  /// If [backgroundColor], [elevation], [brightness], [iconTheme],
+  /// [actionsIconTheme], or [textTheme] are null, their [AppBarTheme] values
+  /// will be used. If the corresponding [AppBarTheme] property is null, then
+  /// the default specified in the property's documentation will be used.
   ///
   /// Typically used in the [Scaffold.appBar] property.
   AppBar({
@@ -153,6 +153,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.backgroundColor,
     this.brightness,
     this.iconTheme,
+    this.actionsIconTheme,
     this.textTheme,
     this.primary = true,
     this.centerTitle,
@@ -306,6 +307,14 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// if that is also null then [ThemeData.primaryIconTheme] is used.
   final IconThemeData iconTheme;
 
+  /// The color, opacity, and size to use for trailing app bar icons. This
+  /// should only be used when the trailing icons should be themed differently
+  /// than the leading icons.
+  ///
+  /// If this property is null then [ThemeData.appBarTheme.actionsIconTheme] is
+  /// used, if that is also null then this falls back to [iconTheme].
+  final IconThemeData actionsIconTheme;
+
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [brightness] [backgroundColor], [iconTheme].
   ///
@@ -403,6 +412,9 @@ class _AppBarState extends State<AppBar> {
     IconThemeData appBarIconTheme = widget.iconTheme
       ?? appBarTheme.iconTheme
       ?? themeData.primaryIconTheme;
+    IconThemeData appBarActionsIconTheme = widget.actionsIconTheme
+        ?? appBarTheme.actionsIconTheme
+        ?? appBarIconTheme;
     TextStyle centerStyle = widget.textTheme?.title
       ?? appBarTheme.textTheme?.title
       ?? themeData.primaryTextTheme.title;
@@ -418,6 +430,9 @@ class _AppBarState extends State<AppBar> {
         sideStyle = sideStyle.copyWith(color: sideStyle.color.withOpacity(opacity));
       appBarIconTheme = appBarIconTheme.copyWith(
         opacity: opacity * (appBarIconTheme.opacity ?? 1.0)
+      );
+      appBarActionsIconTheme = appBarActionsIconTheme.copyWith(
+          opacity: opacity * (appBarActionsIconTheme.opacity ?? 1.0)
       );
     }
 
@@ -476,6 +491,14 @@ class _AppBarState extends State<AppBar> {
         icon: const Icon(Icons.menu),
         onPressed: _handleDrawerButtonEnd,
         tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
+      );
+    }
+
+    // Allow the trailing actions to have their own theme if necessary.
+    if (actions != null) {
+      actions = IconTheme.merge(
+        data: appBarActionsIconTheme,
+        child: actions,
       );
     }
 
@@ -634,6 +657,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.backgroundColor,
     @required this.brightness,
     @required this.iconTheme,
+    @required this.actionsIconTheme,
     @required this.textTheme,
     @required this.primary,
     @required this.centerTitle,
@@ -658,6 +682,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final Color backgroundColor;
   final Brightness brightness;
   final IconThemeData iconTheme;
+  final IconThemeData actionsIconTheme;
   final TextTheme textTheme;
   final bool primary;
   final bool centerTitle;
@@ -716,6 +741,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         backgroundColor: backgroundColor,
         brightness: brightness,
         iconTheme: iconTheme,
+        actionsIconTheme: actionsIconTheme,
         textTheme: textTheme,
         primary: primary,
         centerTitle: centerTitle,
@@ -740,6 +766,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         || backgroundColor != oldDelegate.backgroundColor
         || brightness != oldDelegate.brightness
         || iconTheme != oldDelegate.iconTheme
+        || actionsIconTheme != oldDelegate.actionsIconTheme
         || textTheme != oldDelegate.textTheme
         || primary != oldDelegate.primary
         || centerTitle != oldDelegate.centerTitle
@@ -851,6 +878,7 @@ class SliverAppBar extends StatefulWidget {
     this.backgroundColor,
     this.brightness,
     this.iconTheme,
+    this.actionsIconTheme,
     this.textTheme,
     this.primary = true,
     this.centerTitle,
@@ -980,6 +1008,13 @@ class SliverAppBar extends StatefulWidget {
   ///
   /// Defaults to [ThemeData.primaryIconTheme].
   final IconThemeData iconTheme;
+
+  /// The color, opacity, and size to use for trailing app bar icons. This
+  /// should only be used when the trailing icons should be themed differently
+  /// than the leading icons.
+  ///
+  /// If this property is null then this falls back to [iconTheme].
+  final IconThemeData actionsIconTheme;
 
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [brightness] [backgroundColor], [iconTheme].
@@ -1148,6 +1183,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           backgroundColor: widget.backgroundColor,
           brightness: widget.brightness,
           iconTheme: widget.iconTheme,
+          actionsIconTheme: widget.actionsIconTheme,
           textTheme: widget.textTheme,
           primary: widget.primary,
           centerTitle: widget.centerTitle,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -412,6 +412,7 @@ class _AppBarState extends State<AppBar> {
     IconThemeData appBarIconTheme = widget.iconTheme
       ?? appBarTheme.iconTheme
       ?? themeData.primaryIconTheme;
+    // If no actionsIconTheme is specified, then fallback on the existing iconTheme.
     IconThemeData appBarActionsIconTheme = widget.actionsIconTheme
         ?? appBarTheme.actionsIconTheme
         ?? appBarIconTheme;

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -409,13 +409,13 @@ class _AppBarState extends State<AppBar> {
     final bool canPop = parentRoute?.canPop ?? false;
     final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
-    IconThemeData appBarIconTheme = widget.iconTheme
+    IconThemeData overallIconTheme = widget.iconTheme
       ?? appBarTheme.iconTheme
       ?? themeData.primaryIconTheme;
-    // If no actionsIconTheme is specified, then fallback on the existing iconTheme.
-    IconThemeData appBarActionsIconTheme = widget.actionsIconTheme
+    // If no actionsIconTheme is specified, then fallback on the overallIconTheme.
+    IconThemeData actionsIconTheme = widget.actionsIconTheme
       ?? appBarTheme.actionsIconTheme
-      ?? appBarIconTheme;
+      ?? overallIconTheme;
     TextStyle centerStyle = widget.textTheme?.title
       ?? appBarTheme.textTheme?.title
       ?? themeData.primaryTextTheme.title;
@@ -429,11 +429,11 @@ class _AppBarState extends State<AppBar> {
         centerStyle = centerStyle.copyWith(color: centerStyle.color.withOpacity(opacity));
       if (sideStyle?.color != null)
         sideStyle = sideStyle.copyWith(color: sideStyle.color.withOpacity(opacity));
-      appBarIconTheme = appBarIconTheme.copyWith(
-        opacity: opacity * (appBarIconTheme.opacity ?? 1.0)
+      overallIconTheme = overallIconTheme.copyWith(
+        opacity: opacity * (overallIconTheme.opacity ?? 1.0)
       );
-      appBarActionsIconTheme = appBarActionsIconTheme.copyWith(
-          opacity: opacity * (appBarActionsIconTheme.opacity ?? 1.0)
+      actionsIconTheme = actionsIconTheme.copyWith(
+          opacity: opacity * (actionsIconTheme.opacity ?? 1.0)
       );
     }
 
@@ -498,7 +498,7 @@ class _AppBarState extends State<AppBar> {
     // Allow the trailing actions to have their own theme if necessary.
     if (actions != null) {
       actions = IconTheme.merge(
-        data: appBarActionsIconTheme,
+        data: actionsIconTheme,
         child: actions,
       );
     }
@@ -517,7 +517,7 @@ class _AppBarState extends State<AppBar> {
       child: CustomSingleChildLayout(
         delegate: const _ToolbarContainerLayout(),
         child: IconTheme.merge(
-          data: appBarIconTheme,
+          data: overallIconTheme,
           child: DefaultTextStyle(
             style: sideStyle,
             child: toolbar,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -136,9 +136,9 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [elevation] is specified, it must be non-negative.
   ///
   /// If [backgroundColor], [elevation], [brightness], [iconTheme],
-  /// [actionsIconTheme], or [textTheme] are null, their [AppBarTheme] values
-  /// will be used. If the corresponding [AppBarTheme] property is null, then
-  /// the default specified in the property's documentation will be used.
+  /// [actionsIconTheme], or [textTheme] are null, then their [AppBarTheme]
+  /// values will be used. If the corresponding [AppBarTheme] property is null,
+  /// then the default specified in the property's documentation will be used.
   ///
   /// Typically used in the [Scaffold.appBar] property.
   AppBar({
@@ -281,7 +281,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// The value is non-negative.
   ///
-  /// If this property is null then [ThemeData.appBarTheme.elevation] is used,
+  /// If this property is null, then [ThemeData.appBarTheme.elevation] is used,
   /// if that is also null, the default value is 4, the appropriate elevation
   /// for app bars.
   final double elevation;
@@ -289,37 +289,37 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// The color to use for the app bar's material. Typically this should be set
   /// along with [brightness], [iconTheme], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.color] is used,
-  /// if that is also null then [ThemeData.primaryColor] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.color] is used,
+  /// if that is also null, then [ThemeData.primaryColor] is used.
   final Color backgroundColor;
 
   /// The brightness of the app bar's material. Typically this is set along
   /// with [backgroundColor], [iconTheme], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.brightness] is used,
-  /// if that is also null then [ThemeData.primaryColorBrightness] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.brightness] is used,
+  /// if that is also null, then [ThemeData.primaryColorBrightness] is used.
   final Brightness brightness;
 
   /// The color, opacity, and size to use for app bar icons. Typically this
   /// is set along with [backgroundColor], [brightness], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.iconTheme] is used,
-  /// if that is also null then [ThemeData.primaryIconTheme] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.iconTheme] is used,
+  /// if that is also null, then [ThemeData.primaryIconTheme] is used.
   final IconThemeData iconTheme;
 
   /// The color, opacity, and size to use for trailing app bar icons. This
   /// should only be used when the trailing icons should be themed differently
   /// than the leading icons.
   ///
-  /// If this property is null then [ThemeData.appBarTheme.actionsIconTheme] is
-  /// used, if that is also null then this falls back to [iconTheme].
+  /// If this property is null, then [ThemeData.appBarTheme.actionsIconTheme] is
+  /// used, if that is also null, then this falls back to [iconTheme].
   final IconThemeData actionsIconTheme;
 
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [brightness] [backgroundColor], [iconTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.textTheme] is used,
-  /// if that is also null then [ThemeData.primaryTextTheme] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.textTheme] is used,
+  /// if that is also null, then [ThemeData.primaryTextTheme] is used.
   final TextTheme textTheme;
 
   /// Whether this app bar is being displayed at the top of the screen.
@@ -414,8 +414,8 @@ class _AppBarState extends State<AppBar> {
       ?? themeData.primaryIconTheme;
     // If no actionsIconTheme is specified, then fallback on the existing iconTheme.
     IconThemeData appBarActionsIconTheme = widget.actionsIconTheme
-        ?? appBarTheme.actionsIconTheme
-        ?? appBarIconTheme;
+      ?? appBarTheme.actionsIconTheme
+      ?? appBarIconTheme;
     TextStyle centerStyle = widget.textTheme?.title
       ?? appBarTheme.textTheme?.title
       ?? themeData.primaryTextTheme.title;
@@ -973,7 +973,7 @@ class SliverAppBar extends StatefulWidget {
   /// The z-coordinate at which to place this app bar when it is above other
   /// content. This controls the size of the shadow below the app bar.
   ///
-  /// If this property is null then [ThemeData.appBarTheme.elevation] is used,
+  /// If this property is null, then [ThemeData.appBarTheme.elevation] is used,
   /// if that is also null, the default value is 4, the appropriate elevation
   /// for app bars.
   ///
@@ -997,37 +997,37 @@ class SliverAppBar extends StatefulWidget {
   /// The color to use for the app bar's material. Typically this should be set
   /// along with [brightness], [iconTheme], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.color] is used,
-  /// if that is also null then [ThemeData.primaryColor] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.color] is used,
+  /// if that is also null, then [ThemeData.primaryColor] is used.
   final Color backgroundColor;
 
   /// The brightness of the app bar's material. Typically this is set along
   /// with [backgroundColor], [iconTheme], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.brightness] is used,
-  /// if that is also null then [ThemeData.primaryColorBrightness] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.brightness] is used,
+  /// if that is also null, then [ThemeData.primaryColorBrightness] is used.
   final Brightness brightness;
 
   /// The color, opacity, and size to use for app bar icons. Typically this
   /// is set along with [backgroundColor], [brightness], [textTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.iconTheme] is used,
-  /// if that is also null then [ThemeData.primaryIconTheme] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.iconTheme] is used,
+  /// if that is also null, then [ThemeData.primaryIconTheme] is used.
   final IconThemeData iconTheme;
 
   /// The color, opacity, and size to use for trailing app bar icons. This
   /// should only be used when the trailing icons should be themed differently
   /// than the leading icons.
   ///
-  /// If this property is null then [ThemeData.appBarTheme.actionsIconTheme] is
-  /// used, if that is also null then this falls back to [iconTheme].
+  /// If this property is null, then [ThemeData.appBarTheme.actionsIconTheme] is
+  /// used, if that is also null, then this falls back to [iconTheme].
   final IconThemeData actionsIconTheme;
 
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [brightness] [backgroundColor], [iconTheme].
   ///
-  /// If this property is null then [ThemeData.appBarTheme.textTheme] is used,
-  /// if that is also null then [ThemeData.primaryTextTheme] is used.
+  /// If this property is null, then [ThemeData.appBarTheme.textTheme] is used,
+  /// if that is also null, then [ThemeData.primaryTextTheme] is used.
   final TextTheme textTheme;
 
   /// Whether this app bar is being displayed at the top of the screen.

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -972,7 +972,9 @@ class SliverAppBar extends StatefulWidget {
   /// The z-coordinate at which to place this app bar when it is above other
   /// content. This controls the size of the shadow below the app bar.
   ///
-  /// Defaults to 4, the appropriate elevation for app bars.
+  /// If this property is null then [ThemeData.appBarTheme.elevation] is used,
+  /// if that is also null, the default value is 4, the appropriate elevation
+  /// for app bars.
   ///
   /// If [forceElevated] is false, the elevation is ignored when the app bar has
   /// no content underneath it. For example, if the app bar is [pinned] but no
@@ -994,32 +996,37 @@ class SliverAppBar extends StatefulWidget {
   /// The color to use for the app bar's material. Typically this should be set
   /// along with [brightness], [iconTheme], [textTheme].
   ///
-  /// Defaults to [ThemeData.primaryColor].
+  /// If this property is null then [ThemeData.appBarTheme.color] is used,
+  /// if that is also null then [ThemeData.primaryColor] is used.
   final Color backgroundColor;
 
   /// The brightness of the app bar's material. Typically this is set along
   /// with [backgroundColor], [iconTheme], [textTheme].
   ///
-  /// Defaults to [ThemeData.primaryColorBrightness].
+  /// If this property is null then [ThemeData.appBarTheme.brightness] is used,
+  /// if that is also null then [ThemeData.primaryColorBrightness] is used.
   final Brightness brightness;
 
   /// The color, opacity, and size to use for app bar icons. Typically this
   /// is set along with [backgroundColor], [brightness], [textTheme].
   ///
-  /// Defaults to [ThemeData.primaryIconTheme].
+  /// If this property is null then [ThemeData.appBarTheme.iconTheme] is used,
+  /// if that is also null then [ThemeData.primaryIconTheme] is used.
   final IconThemeData iconTheme;
 
   /// The color, opacity, and size to use for trailing app bar icons. This
   /// should only be used when the trailing icons should be themed differently
   /// than the leading icons.
   ///
-  /// If this property is null then this falls back to [iconTheme].
+  /// If this property is null then [ThemeData.appBarTheme.actionsIconTheme] is
+  /// used, if that is also null then this falls back to [iconTheme].
   final IconThemeData actionsIconTheme;
 
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [brightness] [backgroundColor], [iconTheme].
   ///
-  /// Defaults to [ThemeData.primaryTextTheme].
+  /// If this property is null then [ThemeData.appBarTheme.textTheme] is used,
+  /// if that is also null then [ThemeData.primaryTextTheme] is used.
   final TextTheme textTheme;
 
   /// Whether this app bar is being displayed at the top of the screen.

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -30,12 +30,18 @@ import 'theme.dart';
 class AppBarTheme extends Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.AppBarTheme].
   const AppBarTheme({
+    this.actionsIconTheme,
     this.brightness,
     this.color,
     this.elevation,
     this.iconTheme,
     this.textTheme,
   });
+
+  /// Default value for [AppBar.actionsIconTheme].
+  ///
+  /// If null, [AppBar] uses [ThemeData.primaryIconTheme].
+  final IconThemeData actionsIconTheme;
 
   /// Default value for [AppBar.brightness].
   ///
@@ -65,6 +71,7 @@ class AppBarTheme extends Diagnosticable {
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   AppBarTheme copyWith({
+    IconThemeData actionsIconTheme,
     Brightness brightness,
     Color color,
     double elevation,
@@ -72,6 +79,7 @@ class AppBarTheme extends Diagnosticable {
     TextTheme textTheme,
   }) {
     return AppBarTheme(
+      actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
       brightness: brightness ?? this.brightness,
       color: color ?? this.color,
       elevation: elevation ?? this.elevation,
@@ -93,6 +101,7 @@ class AppBarTheme extends Diagnosticable {
   static AppBarTheme lerp(AppBarTheme a, AppBarTheme b, double t) {
     assert(t != null);
     return AppBarTheme(
+      actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
       brightness: t < 0.5 ? a?.brightness : b?.brightness,
       color: Color.lerp(a?.color, b?.color, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
@@ -104,6 +113,7 @@ class AppBarTheme extends Diagnosticable {
   @override
   int get hashCode {
     return hashValues(
+      actionsIconTheme,
       brightness,
       color,
       elevation,
@@ -119,7 +129,8 @@ class AppBarTheme extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final AppBarTheme typedOther = other;
-    return typedOther.brightness == brightness
+    return typedOther.actionsIconTheme == actionsIconTheme
+        && typedOther.brightness == brightness
         && typedOther.color == color
         && typedOther.elevation == elevation
         && typedOther.iconTheme == iconTheme
@@ -129,6 +140,7 @@ class AppBarTheme extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<IconThemeData>('actionsIconTheme', actionsIconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: null));
     properties.add(DiagnosticsProperty<Color>('color', color, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -30,18 +30,13 @@ import 'theme.dart';
 class AppBarTheme extends Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.AppBarTheme].
   const AppBarTheme({
-    this.actionsIconTheme,
     this.brightness,
     this.color,
     this.elevation,
     this.iconTheme,
+    this.actionsIconTheme,
     this.textTheme,
   });
-
-  /// Default value for [AppBar.actionsIconTheme].
-  ///
-  /// If null, [AppBar] uses [ThemeData.primaryIconTheme].
-  final IconThemeData actionsIconTheme;
 
   /// Default value for [AppBar.brightness].
   ///
@@ -63,6 +58,11 @@ class AppBarTheme extends Diagnosticable {
   /// If null, [AppBar] uses [ThemeData.primaryIconTheme].
   final IconThemeData iconTheme;
 
+  /// Default value for [AppBar.actionsIconTheme].
+  ///
+  /// If null, [AppBar] uses [ThemeData.primaryIconTheme].
+  final IconThemeData actionsIconTheme;
+
   /// Default value for [AppBar.textTheme].
   ///
   /// If null, [AppBar] uses [ThemeData.primaryTextTheme].
@@ -79,11 +79,11 @@ class AppBarTheme extends Diagnosticable {
     TextTheme textTheme,
   }) {
     return AppBarTheme(
-      actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
       brightness: brightness ?? this.brightness,
       color: color ?? this.color,
       elevation: elevation ?? this.elevation,
       iconTheme: iconTheme ?? this.iconTheme,
+      actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
       textTheme: textTheme ?? this.textTheme,
     );
   }
@@ -101,11 +101,11 @@ class AppBarTheme extends Diagnosticable {
   static AppBarTheme lerp(AppBarTheme a, AppBarTheme b, double t) {
     assert(t != null);
     return AppBarTheme(
-      actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
       brightness: t < 0.5 ? a?.brightness : b?.brightness,
       color: Color.lerp(a?.color, b?.color, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       iconTheme: IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t),
+      actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
       textTheme: TextTheme.lerp(a?.textTheme, b?.textTheme, t),
     );
   }
@@ -113,11 +113,11 @@ class AppBarTheme extends Diagnosticable {
   @override
   int get hashCode {
     return hashValues(
-      actionsIconTheme,
       brightness,
       color,
       elevation,
       iconTheme,
+      actionsIconTheme,
       textTheme,
     );
   }
@@ -129,22 +129,22 @@ class AppBarTheme extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final AppBarTheme typedOther = other;
-    return typedOther.actionsIconTheme == actionsIconTheme
-        && typedOther.brightness == brightness
+    return typedOther.brightness == brightness
         && typedOther.color == color
         && typedOther.elevation == elevation
         && typedOther.iconTheme == iconTheme
+        && typedOther.actionsIconTheme == actionsIconTheme
         && typedOther.textTheme == textTheme;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<IconThemeData>('actionsIconTheme', actionsIconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: null));
     properties.add(DiagnosticsProperty<Color>('color', color, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));
     properties.add(DiagnosticsProperty<IconThemeData>('iconTheme', iconTheme, defaultValue: null));
+    properties.add(DiagnosticsProperty<IconThemeData>('actionsIconTheme', actionsIconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<TextTheme>('textTheme', textTheme, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -15,17 +15,23 @@ void main() {
 
   testWidgets('Passing no AppBarTheme returns defaults', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
-      home: Scaffold(appBar: AppBar()),
+      home: Scaffold(appBar: AppBar(
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share))
+        ],
+      )),
     ));
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, Brightness.dark);
     expect(widget.color, Colors.blue);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, const IconThemeData(color: Colors.white));
+    expect(actionsIconTheme.data, const IconThemeData(color: Colors.white));
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1));
   });
 
@@ -34,17 +40,24 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(appBarTheme: appBarTheme),
-      home: Scaffold(appBar: AppBar(title: const Text('App Bar Title'),)),
+      home: Scaffold(appBar: AppBar(
+        title: const Text('App Bar Title'),
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share))
+        ],
+      )),
     ));
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, appBarTheme.brightness);
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
+    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
     expect(text.style, appBarTheme.textTheme.body1);
   });
 
@@ -53,6 +66,7 @@ void main() {
     const Color color = Colors.orange;
     const double elevation = 3.0;
     const IconThemeData iconThemeData = IconThemeData(color: Colors.green);
+    const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.lightBlue);
     const TextTheme textTheme = TextTheme(title: TextStyle(color: Colors.orange), body1: TextStyle(color: Colors.pink));
 
     final ThemeData themeData = _themeData().copyWith(appBarTheme: _appBarTheme());
@@ -64,18 +78,24 @@ void main() {
         brightness: brightness,
         elevation: elevation,
         iconTheme: iconThemeData,
-        textTheme: textTheme,)
-      ),
+        actionsIconTheme: actionsIconThemeData,
+        textTheme: textTheme,
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share))
+        ],
+      )),
     ));
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, brightness);
     expect(widget.color, color);
     expect(widget.elevation, elevation);
     expect(iconTheme.data, iconThemeData);
+    expect(actionsIconTheme.data, actionsIconThemeData);
     expect(text.style, textTheme.body1);
   });
 
@@ -85,17 +105,23 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
-      home: Scaffold(appBar: AppBar()),
+      home: Scaffold(appBar: AppBar(
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share))
+        ],
+      )),
     ));
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, appBarTheme.brightness);
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
+    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
     expect(text.style, appBarTheme.textTheme.body1);
   });
 
@@ -104,17 +130,23 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
-      home: Scaffold(appBar: AppBar()),
+      home: Scaffold(appBar: AppBar(
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share))
+        ],
+      )),
     ));
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, themeData.brightness);
     expect(widget.color, themeData.primaryColor);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, themeData.primaryIconTheme);
+    expect(actionsIconTheme.data, themeData.primaryIconTheme);
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1).merge(themeData.primaryTextTheme.body1));
   });
 }
@@ -124,13 +156,15 @@ AppBarTheme _appBarTheme() {
   const Color color = Colors.lightBlue;
   const double elevation = 6.0;
   const IconThemeData iconThemeData = IconThemeData(color: Colors.black);
+  const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.pink);
   const TextTheme textTheme = TextTheme(body1: TextStyle(color: Colors.yellow));
   return const AppBarTheme(
+    actionsIconTheme: actionsIconThemeData,
     brightness: brightness,
     color: color,
     elevation: elevation,
     iconTheme: iconThemeData,
-    textTheme: textTheme
+    textTheme: textTheme,
   );
 }
 
@@ -157,7 +191,16 @@ IconTheme _getAppBarIconTheme(WidgetTester tester) {
     find.descendant(
       of: find.byType(AppBar),
       matching: find.byType(IconTheme),
-    ),
+    ).first,
+  );
+}
+
+IconTheme _getAppBarActionsIconTheme(WidgetTester tester) {
+  return tester.widget<IconTheme>(
+    find.descendant(
+      of: find.byType(NavigationToolbar),
+      matching: find.byType(IconTheme),
+    ).first,
   );
 }
 

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -24,14 +24,14 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+    final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, Brightness.dark);
     expect(widget.color, Colors.blue);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, const IconThemeData(color: Colors.white));
-    expect(actionsIconTheme.data, const IconThemeData(color: Colors.white));
+    expect(actionIconText.text.style.color, Colors.white);
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1));
   });
 
@@ -50,14 +50,14 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+    final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, appBarTheme.brightness);
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
-    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
+    expect(actionIconText.text.style.color, appBarTheme.actionsIconTheme.color);
     expect(text.style, appBarTheme.textTheme.body1);
   });
 
@@ -88,15 +88,38 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+    final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, brightness);
     expect(widget.color, color);
     expect(widget.elevation, elevation);
     expect(iconTheme.data, iconThemeData);
-    expect(actionsIconTheme.data, actionsIconThemeData);
+    expect(actionIconText.text.style.color, actionsIconThemeData.color);
     expect(text.style, textTheme.body1);
+  });
+
+  testWidgets('AppBar icon color takes priority over everything', (WidgetTester tester) async {
+    const Color color = Colors.lime;
+    const IconThemeData iconThemeData = IconThemeData(color: Colors.green);
+    const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.lightBlue);
+
+    final ThemeData themeData = _themeData().copyWith(appBarTheme: _appBarTheme());
+
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: Scaffold(appBar: AppBar(
+        backgroundColor: color,
+        iconTheme: iconThemeData,
+        actionsIconTheme: actionsIconThemeData,
+        actions: <Widget>[
+          IconButton(icon: const Icon(Icons.share), color: color, onPressed: () {})
+        ],
+      )),
+    ));
+
+    final RichText actionIconText = _getAppBarIconRichText(tester);
+    expect(actionIconText.text.style.color, color);
   });
 
   testWidgets('AppBarTheme properties take priority over ThemeData properties', (WidgetTester tester) async {
@@ -114,14 +137,14 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+    final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, appBarTheme.brightness);
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
-    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
+    expect(actionIconText.text.style.color, appBarTheme.actionsIconTheme.color);
     expect(text.style, appBarTheme.textTheme.body1);
   });
 
@@ -139,14 +162,14 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+    final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
     expect(SystemChrome.latestStyle.statusBarBrightness, themeData.brightness);
     expect(widget.color, themeData.primaryColor);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, themeData.primaryIconTheme);
-    expect(actionsIconTheme.data, themeData.primaryIconTheme);
+    expect(actionIconText.text.style.color, themeData.primaryIconTheme.color);
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1).merge(themeData.primaryTextTheme.body1));
   });
 }
@@ -195,15 +218,14 @@ IconTheme _getAppBarIconTheme(WidgetTester tester) {
   );
 }
 
-IconTheme _getAppBarActionsIconTheme(WidgetTester tester) {
-  return tester.widget<IconTheme>(
+RichText _getAppBarIconRichText(WidgetTester tester) {
+  return tester.widget<RichText>(
     find.descendant(
-      of: find.byType(NavigationToolbar),
-      matching: find.byType(IconTheme),
+      of: find.byType(Icon),
+      matching: find.byType(RichText),
     ).first,
   );
 }
-
 DefaultTextStyle _getAppBarText(WidgetTester tester) {
   return tester.widget<DefaultTextStyle>(
     find.descendant(

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -115,7 +115,6 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(appBar: AppBar(
-        backgroundColor: color,
         iconTheme: iconThemeData,
         actionsIconTheme: actionsIconThemeData,
         actions: <Widget>[

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -17,7 +17,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(appBar: AppBar(
         actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share))
+          IconButton(icon: const Icon(Icons.share), onPressed: () {})
         ],
       )),
     ));
@@ -43,7 +43,7 @@ void main() {
       home: Scaffold(appBar: AppBar(
         title: const Text('App Bar Title'),
         actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share))
+          IconButton(icon: const Icon(Icons.share), onPressed: () {})
         ],
       )),
     ));
@@ -81,7 +81,7 @@ void main() {
         actionsIconTheme: actionsIconThemeData,
         textTheme: textTheme,
         actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share))
+          IconButton(icon: const Icon(Icons.share), onPressed: () {})
         ],
       )),
     ));
@@ -107,7 +107,7 @@ void main() {
       theme: themeData,
       home: Scaffold(appBar: AppBar(
         actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share))
+          IconButton(icon: const Icon(Icons.share), onPressed: () {})
         ],
       )),
     ));
@@ -132,7 +132,7 @@ void main() {
       theme: themeData,
       home: Scaffold(appBar: AppBar(
         actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share))
+          IconButton(icon: const Icon(Icons.share), onPressed: () {})
         ],
       )),
     ));

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -24,6 +24,7 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
@@ -31,6 +32,7 @@ void main() {
     expect(widget.color, Colors.blue);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, const IconThemeData(color: Colors.white));
+    expect(actionsIconTheme.data, const IconThemeData(color: Colors.white));
     expect(actionIconText.text.style.color, Colors.white);
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1));
   });
@@ -50,6 +52,7 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
@@ -57,6 +60,7 @@ void main() {
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
+    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
     expect(actionIconText.text.style.color, appBarTheme.actionsIconTheme.color);
     expect(text.style, appBarTheme.textTheme.body1);
   });
@@ -88,6 +92,7 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
@@ -95,6 +100,7 @@ void main() {
     expect(widget.color, color);
     expect(widget.elevation, elevation);
     expect(iconTheme.data, iconThemeData);
+    expect(actionsIconTheme.data, actionsIconThemeData);
     expect(actionIconText.text.style.color, actionsIconThemeData.color);
     expect(text.style, textTheme.body1);
   });
@@ -137,6 +143,7 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
@@ -144,6 +151,7 @@ void main() {
     expect(widget.color, appBarTheme.color);
     expect(widget.elevation, appBarTheme.elevation);
     expect(iconTheme.data, appBarTheme.iconTheme);
+    expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
     expect(actionIconText.text.style.color, appBarTheme.actionsIconTheme.color);
     expect(text.style, appBarTheme.textTheme.body1);
   });
@@ -162,6 +170,7 @@ void main() {
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
+    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
@@ -169,6 +178,7 @@ void main() {
     expect(widget.color, themeData.primaryColor);
     expect(widget.elevation, 4.0);
     expect(iconTheme.data, themeData.primaryIconTheme);
+    expect(actionsIconTheme.data, themeData.primaryIconTheme);
     expect(actionIconText.text.style.color, themeData.primaryIconTheme.color);
     expect(text.style, Typography().englishLike.body1.merge(Typography().white.body1).merge(themeData.primaryTextTheme.body1));
   });
@@ -213,6 +223,15 @@ IconTheme _getAppBarIconTheme(WidgetTester tester) {
   return tester.widget<IconTheme>(
     find.descendant(
       of: find.byType(AppBar),
+      matching: find.byType(IconTheme),
+    ).first,
+  );
+}
+
+IconTheme _getAppBarActionsIconTheme(WidgetTester tester) {
+  return tester.widget<IconTheme>(
+    find.descendant(
+      of: find.byType(NavigationToolbar),
       matching: find.byType(IconTheme),
     ).first,
   );


### PR DESCRIPTION
This change allows a developer to theme the app bar's trailing icons independently from leading if they choose. The existing behavior is preserved, so this will only take effect if a developer explicitly specifies a theme for the actions.

Additionally, this change updates the documentation for `SliverAppBar` properties that were missed when the `AppBarTheme` was added.

Screenshot showing different themes for the leading/trailing icons:
![simulator screen shot - iphone xs max - 2019-02-20 at 11 34 14](https://user-images.githubusercontent.com/2364772/53107673-8390f500-3503-11e9-8177-107fb25042ec.png)
