### PR TITLE
Adds a template for Pull Requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,10 +33,10 @@ to accommodate your change?
 - [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
 - [ ] No, this is *not* a breaking change.
 
-
-[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
+<!-- Links -->
 [Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
-[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
 [Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
+[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
 [Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
 [CLA]: https://cla.developers.google.com/
+[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,9 @@ you're changing visual properties, consider including before/after screenshots
 
 ## Checklist
 
-To ensure high-quality PRs and a smooth reviewing process to land your PR as
-quickly a possible, please confirm the following by checking the relevant
-checkboxes (`[x]`). PRs, that do not check all boxes, may be rejected.
+Before you submit this PR confirm that it meets all requirements listed below
+by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick
+review process.
 
 - [ ] I read the [Contributor Guide] and followed the process outlined there for
       submitting PRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,16 @@
 ## Description
 
-Replace this paragraph with a description of what this PR is doing. Include
-links to relevant issues. If you're modifying existing behavior, describe the
-existing behavior, how this PR is changing it, and what motivated the change. If
-you're changing visual properties, consider including before/after screenshots
-(and runnable code snippets to reproduce them).
+*Replace this paragraph with a description of what this PR is doing. If you're
+modifying existing behavior, describe the existing behavior, how this PR is
+changing it, and what motivated the change. If you're changing visual
+properties, consider including before/after screenshots (and runnable code
+snippets to reproduce them).*
+
+## Related issues Issues
+
+*Replace this paragraph with a list of issues related to this PR from our
+[issue database]. Indicate, which of these issues are resolved or fixed by this
+PR.*
 
 ## Checklist
 
@@ -20,7 +26,7 @@ review process.
 - [ ] I updated/added relevant documentation (doc comments with `///`).
 - [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any
       problems on my PR.
-- [ ] I read and followed the [Flutter Style Guide], especially
+- [ ] I read and followed the [Flutter Style Guide], including
       [Features we expect every widget to implement].
 - [ ] I signed the [CLA].
 - [ ] I am willing to follow-up on review comments in a timely manner.
@@ -34,6 +40,7 @@ to accommodate your change?
 - [ ] No, this is *not* a breaking change.
 
 <!-- Links -->
+[issue database]: https://github.com/flutter/flutter/issues
 [Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
 [Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
 [Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ you're changing visual properties, consider including before/after screenshots
 ## Checklist
 
 To ensure high-quality PRs and a smooth reviewing process to land your PR as
-quickly a possible, we ask you to confirm the following by checking the relevant
+quickly a possible, please confirm the following by checking the relevant
 checkboxes (`[x]`). PRs, that do not check all boxes, may be rejected.
 
 - [ ] I read the [Contributor Guide] and followed the process outlined there for
@@ -17,7 +17,7 @@ checkboxes (`[x]`). PRs, that do not check all boxes, may be rejected.
 - [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See
       [Test Coverage]).
 - [ ] All existing and new tests are passing.
-- [ ] I updated/added relevant documentation (doc comments with `\\\`).
+- [ ] I updated/added relevant documentation (doc comments with `///`).
 - [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any
       problems on my PR.
 - [ ] I read and followed the [Flutter Style Guide], especially

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ you're changing visual properties, consider including before/after screenshots
 
 ## Checklist
 
-Before you submit this PR confirm that it meets all requirements listed below
+Before you create this PR confirm that it meets all requirements listed below
 by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick
 review process.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ changing it, and what motivated the change. If you're changing visual
 properties, consider including before/after screenshots (and runnable code
 snippets to reproduce them).*
 
-## Related issues Issues
+## Related Issues
 
 *Replace this paragraph with a list of issues related to this PR from our
 [issue database]. Indicate, which of these issues are resolved or fixed by this

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Description
+
+Replace this paragraph with a description of what this PR is doing. Include
+links to relevant issues. If you're modifying existing behavior, describe the
+existing behavior, how this PR is changing it, and what motivated the change. If
+you're changing visual properties, consider including before/after screenshots
+(and runnable code snippets to reproduce them).
+
+## Checklist
+
+To ensure high-quality PRs and a smooth reviewing process to land your PR as
+quickly a possible, we ask you to confirm the following by checking the relevant
+checkboxes (`[x]`). PRs, that do not check all boxes, may be rejected.
+
+- [ ] I read the [Contributor Guide] and followed the process outlined there for
+      submitting PRs.
+- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See
+      [Test Coverage]).
+- [ ] All existing and new tests are passing.
+- [ ] I updated/added relevant documentation (doc comments with `\\\`).
+- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any
+      problems on my PR.
+- [ ] I read and followed the [Flutter Style Guide], especially
+      [Features we expect every widget to implement].
+- [ ] I signed the [CLA].
+- [ ] I am willing to follow-up on review comments in a timely manner.
+
+## Breaking Change
+
+Does your PR require Flutter developers to manually update their apps
+to accommodate your change?
+
+- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
+- [ ] No, this is *not* a breaking change.
+
+
+[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
+[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
+[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
+[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
+[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
+[CLA]: https://cla.developers.google.com/


### PR DESCRIPTION
This template will show up as the default description whenever somebody opens a new pull request against flutter/flutter.

See https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/.