### PR TITLE
fix typo : antiaias to antialias

### DIFF
--- a/packages/flutter/lib/src/painting/clip.dart
+++ b/packages/flutter/lib/src/painting/clip.dart
@@ -54,6 +54,6 @@ abstract class ClipContext {
   ///
   /// `bounds` is the saveLayer bounds used for [Clip.antiAliasWithSaveLayer].
   void clipRectAndPaint(Rect rect, Clip clipBehavior, Rect bounds, void painter()) {
-    _clipAndPaint((bool doAntiAias) => canvas.clipRect(rect, doAntiAlias: doAntiAias), clipBehavior, bounds, painter);
+    _clipAndPaint((bool doAntiAlias) => canvas.clipRect(rect, doAntiAlias: doAntiAlias), clipBehavior, bounds, painter);
   }
 }


### PR DESCRIPTION
## Description

the word `antiaias` seems to be a typo
