### PR TITLE
only perform multi-root mapping if there are multiple roots

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -117,7 +117,8 @@ class PackageUriMapper {
 
     for (String packageName in packageMap.keys) {
       final String prefix = packageMap[packageName].toString();
-      if (fileSystemScheme != null && fileSystemRoots != null && prefix.contains(fileSystemScheme)) {
+      // Only perform a multi-root mapping if there are multiple roots.
+      if (fileSystemScheme != null && fileSystemRoots != null && fileSystemRoots.length > 1 && prefix.contains(fileSystemScheme)) {
         _packageName = packageName;
         _uriPrefixes = fileSystemRoots
           .map((String name) => Uri.file(name, windows: platform.isWindows).toString())

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -118,7 +118,10 @@ class PackageUriMapper {
     for (String packageName in packageMap.keys) {
       final String prefix = packageMap[packageName].toString();
       // Only perform a multi-root mapping if there are multiple roots.
-      if (fileSystemScheme != null && fileSystemRoots != null && fileSystemRoots.length > 1 && prefix.contains(fileSystemScheme)) {
+      if (fileSystemScheme != null
+        && fileSystemRoots != null
+        && fileSystemRoots.length > 1
+        && prefix.contains(fileSystemScheme)) {
         _packageName = packageName;
         _uriPrefixes = fileSystemRoots
           .map((String name) => Uri.file(name, windows: platform.isWindows).toString())


### PR DESCRIPTION
## Description

In google3 a multiroot scheme is used with a single filesystem root. We need to handle the mapping slightly differently in this case
