### PR TITLE
Log pub return code on failure on Windows

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -138,7 +138,7 @@ GOTO :after_subroutine
         ECHO Running pub upgrade...
         CALL "%pub%" upgrade "%VERBOSITY%"
         IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
-        ECHO Error Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left)
+        ECHO Error (%ERRORLEVEL%): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left)
         timeout /t 5 /nobreak 2>NUL
         SET /A remaining_tries-=1
         IF "%remaining_tries%" EQU "0" GOTO upgrade_retries_exhausted


### PR DESCRIPTION
When pub fails, log the %ERRRORLEVEL% to help diagnose the root cause of
the pub failure.