### PR TITLE
fix red build for analysis

### DIFF
--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -331,8 +331,8 @@ class StrutStyle extends Diagnosticable {
   /// Equivalent to having no strut at all. All lines will be laid out according to
   /// the properties defined in [TextStyle].
   static const StrutStyle disabled = StrutStyle(
-    height: 0,
-    leading: 0,
+    height: 0.0,
+    leading: 0.0,
   );
 
   /// The name of the font to use when calcualting the strut (e.g., Roboto). If the


### PR DESCRIPTION
Fixes redness in the build.  Filed https://github.com/dart-lang/sdk/issues/36013 to track - this case doesn't fail in simpler scenarios and shouldn't fail here.

Will land TBR @GaryQian @stereotype441 