### PR TITLE
Increase minimum slop of _CupertinoBackGestureDetector so regular gesture detectors on the page take precedence

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -476,7 +476,9 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
   @override
   void initState() {
     super.initState();
-    _recognizer = HorizontalDragGestureRecognizer(debugOwner: this)
+    // Use a slop larger than the default to give gesture detectors (e.g. a slider)
+    // below our Listener precedence.
+    _recognizer = HorizontalDragGestureRecognizer(slop: kPagingTouchSlop, debugOwner: this)
       ..onStart = _handleDragStart
       ..onUpdate = _handleDragUpdate
       ..onEnd = _handleDragEnd

--- a/packages/flutter/lib/src/gestures/constants.dart
+++ b/packages/flutter/lib/src/gestures/constants.dart
@@ -59,11 +59,10 @@ const Duration kZoomControlsTimeout = Duration(milliseconds: 3000);
 const double kTouchSlop = 18.0; // Logical pixels
 
 /// The distance a touch has to travel for the framework to be confident that
-/// the gesture is a paging gesture. (Currently not used, because paging uses a
-/// regular drag gesture, which uses kTouchSlop.)
-// TODO(ianh): Create variants of HorizontalDragGestureRecognizer et al for
-// paging, which use this constant.
-const double kPagingTouchSlop = kTouchSlop * 2.0; // Logical pixels
+/// the gesture is a paging gesture.
+// This value is larger than kPanSlop to give regular gesture detectors on
+// a page precedence over paging.
+const double kPagingTouchSlop = kTouchSlop * 3.0; // Logical pixels
 
 /// The distance a touch has to travel for the framework to be confident that
 /// the gesture is a panning gesture.

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -296,7 +296,12 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 ///    track each touch point independently.
 class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the vertical axis.
-  VerticalDragGestureRecognizer({ Object debugOwner }) : super(debugOwner: debugOwner);
+  VerticalDragGestureRecognizer({ this.slop = kTouchSlop, Object debugOwner })
+      : super(debugOwner: debugOwner);
+
+  /// The minimum distance over which the pointer must have been dragged for
+  /// being considered by this recognizer.
+  final double slop;
 
   @override
   bool _isFlingGesture(VelocityEstimate estimate) {
@@ -306,7 +311,7 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   }
 
   @override
-  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragOffset.dy.abs() > kTouchSlop;
+  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragOffset.dy.abs() > slop;
 
   @override
   Offset _getDeltaForDetails(Offset delta) => Offset(0.0, delta.dy);
@@ -330,7 +335,12 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
 ///    track each touch point independently.
 class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the horizontal axis.
-  HorizontalDragGestureRecognizer({ Object debugOwner }) : super(debugOwner: debugOwner);
+  HorizontalDragGestureRecognizer({ this.slop = kTouchSlop, Object debugOwner })
+      : super(debugOwner: debugOwner);
+
+  /// The minimum distance over which the pointer must have been dragged for
+  /// being considered by this recognizer.
+  final double slop;
 
   @override
   bool _isFlingGesture(VelocityEstimate estimate) {
@@ -340,7 +350,7 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   }
 
   @override
-  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragOffset.dx.abs() > kTouchSlop;
+  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragOffset.dx.abs() > slop;
 
   @override
   Offset _getDeltaForDetails(Offset delta) => Offset(delta.dx, 0.0);


### PR DESCRIPTION
Addresses #28045.

Alternatively to having `HorizontalDragGestureRecognizer` expose its slop as a parameter, a new `HorizontalPagingGestureRecognizer` could be created. That would lead to some extent of duplication, so I didn't opted for this approach.

I implemented the same change for `VerticalDragGestureRecognizer` for consistency and because we want to create a vertical "back gesture" in our project.