### PR TITLE
Cupertino text field border is darker

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -14,7 +14,7 @@ export 'package:flutter/services.dart' show TextInputType, TextInputAction, Text
 
 // Value extracted via color reader from iOS simulator.
 const BorderSide _kDefaultRoundedBorderSide = BorderSide(
-  color: CupertinoColors.lightBackgroundGray,
+  color: Color.fromRGBO(204, 204, 204, 1),
   style: BorderStyle.solid,
   width: 0.0,
 );


### PR DESCRIPTION
This is the right color picked from `UITextField`:
![Screenshot](https://user-images.githubusercontent.com/47426255/53343949-d0186e00-3911-11e9-9c38-5e676920c301.png)
 Not Color(0xFFE5E5EA).