### PR TITLE
Support iOS devices reporting pressure data of 0

### DIFF
--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -206,12 +206,10 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   void addPointer(PointerEvent event) {
-    assert(event.pressureMax >= 1.0);
-    // If the device has a maximum pressure of less than or equal to 1,
-    // indicating a faux pressure sensor on this device or a device without a
-    // pressure sensor (ie. on a non iOS device) we want do not want any
-    // callbacks to be called.
-    if (!(event is PointerUpEvent) && event.pressureMax == 1.0) {
+    // If the device has a maximum pressure of less than or equal to 1, it
+    // doesn't have touch pressure sensing capabilities. Do not participate
+    // in the gesture arena.
+    if (!(event is PointerUpEvent) && event.pressureMax <= 1.0) {
       resolve(GestureDisposition.rejected);
     } else {
       startTrackingPointer(event.pointer);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1537,6 +1537,7 @@ void main() {
         controller.selection,
         const TextSelection(baseOffset: 8, extentOffset: 12),
       );
+      // Shows toolbar.
       expect(find.byType(CupertinoButton), findsNWidgets(3));
     },
   );
@@ -1642,6 +1643,7 @@ void main() {
 
     await gesture.up();
     await tester.pump();
+    // Shows toolbar.
     expect(find.byType(CupertinoButton), findsNWidgets(3));
   });
 
@@ -1682,6 +1684,7 @@ void main() {
     );
 
     await tester.pump();
+    // Falling back to a single tap doesn't trigger a toolbar.
     expect(find.byType(CupertinoButton), findsNothing);
   });
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1641,7 +1641,7 @@ void main() {
     );
 
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     expect(find.byType(CupertinoButton), findsNWidgets(3));
   });
 
@@ -1681,7 +1681,7 @@ void main() {
       const TextSelection.collapsed(offset: 8),
     );
 
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     expect(find.byType(CupertinoButton), findsNothing);
   });
 

--- a/packages/flutter/test/gestures/force_press_test.dart
+++ b/packages/flutter/test/gestures/force_press_test.dart
@@ -109,8 +109,7 @@ void main() {
     expect(ended, 1);
   });
 
-  testGesture('Force presses are not recognized on devices with low maxmium pressure', (GestureTester tester) {
-    // Device specific constants that represent those from the iPhone X
+  testGesture('Force presses are not recognized on devices with maxmium pressure of 1', (GestureTester tester) {
     const double pressureMin = 0;
     const double pressureMax = 1.0;
 
@@ -196,6 +195,54 @@ void main() {
     tester.route(pointer.up());
 
     // We have ended the gesture so ended should be true.
+    expect(started, 0);
+    expect(updated, 0);
+    expect(peaked, 0);
+    expect(ended, 0);
+  });
+
+  testGesture('Force presses are not recognized on devices with maxmium pressure of zero', (GestureTester tester) {
+    // Device specific constants that represent those from the iPhone X
+    const double pressureMin = 0;
+    const double pressureMax = 0;
+
+    int started = 0;
+    int peaked = 0;
+    int updated = 0;
+    int ended = 0;
+
+    final ForcePressGestureRecognizer force = ForcePressGestureRecognizer();
+
+    force.onStart = (ForcePressDetails details) => started += 1;
+    force.onPeak = (ForcePressDetails details) => peaked += 1;
+    force.onUpdate = (ForcePressDetails details) => updated += 1;
+    force.onEnd = (ForcePressDetails details) => ended += 1;
+
+    const int pointerValue = 1;
+    final TestPointer pointer = TestPointer(pointerValue);
+    const PointerDownEvent down = PointerDownEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 0, pressureMin: pressureMin, pressureMax: pressureMax);
+    pointer.setDownInfo(down, const Offset(10.0, 10.0));
+    force.addPointer(down);
+    tester.closeArena(pointerValue);
+
+    expect(started, 0);
+    expect(peaked, 0);
+    expect(updated, 0);
+    expect(ended, 0);
+
+    // Pressure fed into the test environment simulates the values received directly from the device.
+    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 10, pressureMin: pressureMin, pressureMax: pressureMax));
+
+    // Regardless of current pressure, this recognizer shouldn't participate or
+    // trigger any callbacks.
+    expect(started, 0);
+    expect(peaked, 0);
+    expect(updated, 0);
+    expect(ended, 0);
+
+    tester.route(pointer.up());
+
+    // There should still be no callbacks.
     expect(started, 0);
     expect(updated, 0);
     expect(peaked, 0);

--- a/packages/flutter/test/gestures/force_press_test.dart
+++ b/packages/flutter/test/gestures/force_press_test.dart
@@ -109,144 +109,55 @@ void main() {
     expect(ended, 1);
   });
 
-  testGesture('Force presses are not recognized on devices with maxmium pressure of 1', (GestureTester tester) {
-    const double pressureMin = 0;
-    const double pressureMax = 1.0;
+  testGesture('Invalid pressure ranges capabilities are not recognized', (GestureTester tester) {
+    void testGestureWithMaxPressure(double pressureMax) {
+      int started = 0;
+      int peaked = 0;
+      int updated = 0;
+      int ended = 0;
 
-    // Interpolated Flutter pressure values.
-    const double startPressure = 0.4; // = Device pressure of 2.66.
-    const double peakPressure = 0.85; // = Device pressure of 5.66.
+      final ForcePressGestureRecognizer force = ForcePressGestureRecognizer();
 
-    int started = 0;
-    int peaked = 0;
-    int updated = 0;
-    int ended = 0;
+      force.onStart = (ForcePressDetails details) => started += 1;
+      force.onPeak = (ForcePressDetails details) => peaked += 1;
+      force.onUpdate = (ForcePressDetails details) => updated += 1;
+      force.onEnd = (ForcePressDetails details) => ended += 1;
 
-    void onStart(ForcePressDetails details) {
-      started += 1;
+      const int pointerValue = 1;
+      final TestPointer pointer = TestPointer(pointerValue);
+      final PointerDownEvent down = PointerDownEvent(pointer: pointerValue, position: const Offset(10.0, 10.0), pressure: 0, pressureMin: 0, pressureMax: pressureMax);
+      pointer.setDownInfo(down, const Offset(10.0, 10.0));
+      force.addPointer(down);
+      tester.closeArena(pointerValue);
+
+      expect(started, 0);
+      expect(peaked, 0);
+      expect(updated, 0);
+      expect(ended, 0);
+
+      // Pressure fed into the test environment simulates the values received directly from the device.
+      tester.route(PointerMoveEvent(pointer: pointerValue, position: const Offset(10.0, 10.0), pressure: 10, pressureMin: 0, pressureMax: pressureMax));
+
+      // Regardless of current pressure, this recognizer shouldn't participate or
+      // trigger any callbacks.
+      expect(started, 0);
+      expect(peaked, 0);
+      expect(updated, 0);
+      expect(ended, 0);
+
+      tester.route(pointer.up());
+
+      // There should still be no callbacks.
+      expect(started, 0);
+      expect(updated, 0);
+      expect(peaked, 0);
+      expect(ended, 0);
     }
 
-    final ForcePressGestureRecognizer force = ForcePressGestureRecognizer(startPressure: startPressure, peakPressure: peakPressure);
-
-    force.onStart = onStart;
-    force.onPeak = (ForcePressDetails details) => peaked += 1;
-    force.onUpdate = (ForcePressDetails details) => updated += 1;
-    force.onEnd = (ForcePressDetails details) => ended += 1;
-
-    const int pointerValue = 1;
-    final TestPointer pointer = TestPointer(pointerValue);
-    const PointerDownEvent down = PointerDownEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 0, pressureMin: pressureMin, pressureMax: pressureMax);
-    pointer.setDownInfo(down, const Offset(10.0, 10.0));
-    force.addPointer(down);
-    tester.closeArena(pointerValue);
-
-    expect(started, 0);
-    expect(peaked, 0);
-    expect(updated, 0);
-    expect(ended, 0);
-
-    // Pressure fed into the test environment simulates the values received directly from the device.
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 2.5, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // We have not hit the start pressure, so no events should be true.
-    expect(started, 0);
-    expect(peaked, 0);
-    expect(updated, 0);
-    expect(ended, 0);
-
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 2.8, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // We have just hit the start pressure so just the start event should be triggered and one update call should have occurred.
-    expect(started, 0);
-    expect(peaked, 0);
-    expect(updated, 0);
-    expect(ended, 0);
-
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 3.3, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 4.0, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 5.0, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 1.0, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // We have exceeded the start pressure so update should be greater than 0.
-    expect(started, 0);
-    expect(updated, 0);
-    expect(peaked, 0);
-    expect(ended, 0);
-
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 6.0, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // We have exceeded the peak pressure so peak pressure should be true.
-    expect(started, 0);
-    expect(updated, 0);
-    expect(peaked, 0);
-    expect(ended, 0);
-
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 3.3, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 4.0, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 5.0, pressureMin: pressureMin, pressureMax: pressureMax));
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 1.0, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // Update is still called.
-    expect(started, 0);
-    expect(updated, 0);
-    expect(peaked, 0);
-    expect(ended, 0);
-
-    tester.route(pointer.up());
-
-    // We have ended the gesture so ended should be true.
-    expect(started, 0);
-    expect(updated, 0);
-    expect(peaked, 0);
-    expect(ended, 0);
-  });
-
-  testGesture('Force presses are not recognized on devices with maxmium pressure of zero', (GestureTester tester) {
-    // Device specific constants that represent those from the iPhone X
-    const double pressureMin = 0;
-    const double pressureMax = 0;
-
-    int started = 0;
-    int peaked = 0;
-    int updated = 0;
-    int ended = 0;
-
-    final ForcePressGestureRecognizer force = ForcePressGestureRecognizer();
-
-    force.onStart = (ForcePressDetails details) => started += 1;
-    force.onPeak = (ForcePressDetails details) => peaked += 1;
-    force.onUpdate = (ForcePressDetails details) => updated += 1;
-    force.onEnd = (ForcePressDetails details) => ended += 1;
-
-    const int pointerValue = 1;
-    final TestPointer pointer = TestPointer(pointerValue);
-    const PointerDownEvent down = PointerDownEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 0, pressureMin: pressureMin, pressureMax: pressureMax);
-    pointer.setDownInfo(down, const Offset(10.0, 10.0));
-    force.addPointer(down);
-    tester.closeArena(pointerValue);
-
-    expect(started, 0);
-    expect(peaked, 0);
-    expect(updated, 0);
-    expect(ended, 0);
-
-    // Pressure fed into the test environment simulates the values received directly from the device.
-    tester.route(const PointerMoveEvent(pointer: pointerValue, position: Offset(10.0, 10.0), pressure: 10, pressureMin: pressureMin, pressureMax: pressureMax));
-
-    // Regardless of current pressure, this recognizer shouldn't participate or
-    // trigger any callbacks.
-    expect(started, 0);
-    expect(peaked, 0);
-    expect(updated, 0);
-    expect(ended, 0);
-
-    tester.route(pointer.up());
-
-    // There should still be no callbacks.
-    expect(started, 0);
-    expect(updated, 0);
-    expect(peaked, 0);
-    expect(ended, 0);
+    testGestureWithMaxPressure(0);
+    testGestureWithMaxPressure(1);
+    testGestureWithMaxPressure(-1);
+    testGestureWithMaxPressure(0.5);
   });
 
   testGesture('If minimum pressure is not reached, start and end callbacks are not called', (GestureTester tester) {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4587,7 +4587,7 @@ void main() {
     expect(controller.selection, const TextSelection.collapsed(offset: -1));
 
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     expect(find.byType(FlatButton), findsNothing);
   });
 
@@ -4630,7 +4630,7 @@ void main() {
     );
 
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     expect(find.byType(CupertinoButton), findsNWidgets(3));
   });
 
@@ -4675,7 +4675,7 @@ void main() {
       const TextSelection.collapsed(offset: 8),
     );
 
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     // Single taps shouldn't trigger the toolbar.
     expect(find.byType(CupertinoButton), findsNothing);
   });

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4083,6 +4083,7 @@ void main() {
         controller.selection,
         const TextSelection(baseOffset: 8, extentOffset: 12),
       );
+      // The toolbar is still showing.
       expect(find.byType(CupertinoButton), findsNWidgets(3));
     },
   );
@@ -4272,6 +4273,7 @@ void main() {
         controller.selection,
         const TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream),
       );
+      // Cursor move doesn't trigger a toolbar initially.
       expect(find.byType(CupertinoButton), findsNothing);
 
       await gesture.moveBy(const Offset(50, 0));
@@ -4282,6 +4284,7 @@ void main() {
         controller.selection,
         const TextSelection.collapsed(offset: 6, affinity: TextAffinity.downstream),
       );
+      // Still no toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
 
       await gesture.moveBy(const Offset(50, 0));
@@ -4292,6 +4295,7 @@ void main() {
         controller.selection,
         const TextSelection.collapsed(offset: 9, affinity: TextAffinity.downstream),
       );
+      // Still no toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
 
       await gesture.up();


### PR DESCRIPTION
## Description

iOS devices can actually report pressure data of 0. 

## Related Issues

Fixes #28447 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
