### PR TITLE
increase timeout

### DIFF
--- a/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
+++ b/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
@@ -11,7 +11,7 @@
 
 static void waitForInitialFlutterRender() {
   // TODO(dnfield,jamesderlin): actually sync with Flutter rendering.
-  CFRunLoopRunInMode(kCFRunLoopDefaultMode, 3, false);
+  CFRunLoopRunInMode(kCFRunLoopDefaultMode, 10, false);
 }
 
 @interface FlutterTests : XCTestCase


### PR DESCRIPTION
## Description

Increases the timeout for Flutter to render from 3 seconds to 10 seconds.

EarlGrey does not yet know how to properly wait for Flutter to start rendering.  Internal usage of this test actually sets it to 5 seconds.  10 should be enough.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
