### PR TITLE
Added floating option to SnackBar

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -6,12 +6,12 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_theme.dart';
+import 'card.dart';
 import 'flat_button.dart';
 import 'material.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 import 'theme_data.dart';
-import 'card.dart';
 
 const double _kSnackBarPadding = 24.0;
 const double _kSingleLineVerticalPadding = 14.0;

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -11,6 +11,7 @@ import 'material.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 import 'theme_data.dart';
+import 'card.dart';
 
 const double _kSnackBarPadding = 24.0;
 const double _kSingleLineVerticalPadding = 14.0;

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -259,7 +259,7 @@ class SnackBar extends StatelessWidget {
         onDismissed: (DismissDirection direction) {
           Scaffold.of(context).removeCurrentSnackBar(reason: SnackBarClosedReason.swipe);
         },
-        child: this.floating ? Card(
+        child: floating ? Card(
           elevation: 6.0,
           color: backgroundColor ?? _kSnackBackground,
           child: Theme(

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -163,6 +163,7 @@ class SnackBar extends StatelessWidget {
     @required this.content,
     this.backgroundColor,
     this.action,
+    this.floating = false,
     this.duration = _kSnackBarDisplayDuration,
     this.animation,
   }) : assert(content != null),
@@ -184,6 +185,10 @@ class SnackBar extends StatelessWidget {
   ///
   /// The action should not be "dismiss" or "cancel".
   final SnackBarAction action;
+  
+  /// If this variable is true the SnackBar will be displayed as floating
+  /// default is false so old project don't break.
+  final bool floating;
 
   /// The amount of time the snack bar should be displayed.
   ///
@@ -253,7 +258,19 @@ class SnackBar extends StatelessWidget {
         onDismissed: (DismissDirection direction) {
           Scaffold.of(context).removeCurrentSnackBar(reason: SnackBarClosedReason.swipe);
         },
-        child: Material(
+        child: this.floating ? Card(
+          elevation: 6.0,
+          color: backgroundColor ?? _kSnackBackground,
+          child: Theme(
+            data: darkTheme,
+            child: mediaQueryData.accessibleNavigation
+                ? snackbar
+                : FadeTransition(
+              opacity: fadeAnimation,
+              child: snackbar,
+            ),
+          ),
+        ) : Material(
           elevation: 6.0,
           color: backgroundColor ?? _kSnackBackground,
           child: Theme(
@@ -302,6 +319,7 @@ class SnackBar extends StatelessWidget {
       content: content,
       backgroundColor: backgroundColor,
       action: action,
+      floating: floating,
       duration: duration,
       animation: newAnimation,
     );


### PR DESCRIPTION
## Description

This PR enables the user to change the SnackBar to appear as floating.
Before: 
![Imgur](https://i.imgur.com/o7BEEpT.jpg)

After:
![Imgur](https://i.imgur.com/CbhwTdu.jpg)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
