### PR TITLE
Make Flow hit testable inside an Opacity widget

### DIFF
--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -371,13 +371,14 @@ class RenderFlow extends RenderBox
   @override
   bool hitTestChildren(HitTestResult result, { Offset position }) {
     final List<RenderBox> children = getChildrenAsList();
-    for (int i = _lastPaintOrder.length - 1; i >= 0; --i) {
-      final int childIndex = _lastPaintOrder[i];
+    final int childrenSize = _lastPaintOrder.isEmpty ? children.length : _lastPaintOrder.length;
+    for (int i = childrenSize - 1; i >= 0; --i) {
+      final int childIndex = _lastPaintOrder.isEmpty ? i : _lastPaintOrder[i];
       if (childIndex >= children.length)
         continue;
       final RenderBox child = children[childIndex];
       final FlowParentData childParentData = child.parentData;
-      final Matrix4 transform = childParentData._transform;
+      final Matrix4 transform = childParentData._transform ?? Matrix4.identity();
       if (transform == null)
         continue;
       final Matrix4 inverse = Matrix4.zero();

--- a/packages/flutter/test/widgets/flow_test.dart
+++ b/packages/flutter/test/widgets/flow_test.dart
@@ -118,4 +118,30 @@ void main() {
     expect(opacityLayer.alpha, equals(opacity * 255));
     expect(layer.firstChild, isInstanceOf<TransformLayer>());
   });
+
+  testWidgets('Transparent Flow hit test', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final UniqueKey widgetKey = UniqueKey();
+
+    await tester.pumpWidget(
+        Opacity(
+            opacity: 0.0,
+            child: Flow(
+                key: widgetKey,
+                delegate: OpacityFlowDelegate(0.0),
+                children: <Widget>[
+                  GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () { log.add('tap'); },
+                  )
+                ]
+            )
+        )
+    );
+    expect(log, equals(<String>[]));
+
+    await tester.tap(find.byKey(widgetKey));
+    expect(log, equals(<String>['tap']));
+    log.clear();
+  });
 }


### PR DESCRIPTION
## Description

When we put a `Flow` inside an `Opacity` with `opacity` set to `0.0`, it makes its children unresponsive to hit testing. This fixes this issue by making `Flow` hit testable event if transparent.

## Related Issues

Fixes #6100 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
