### PR TITLE
Ignore cancel events for untracked pointers

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -257,7 +257,15 @@ class PointerEventConverter {
           break;
         case ui.PointerChange.up:
         case ui.PointerChange.cancel:
-          assert(_pointers.containsKey(datum.device));
+          if (!_pointers.containsKey(datum.device)) {
+            // Canceling a pointer that the framework never tracked is a no-op.
+            // This can happen on certain phones (e.g. OnePlus A5000) when the
+            // user activates the three-finger screenshot gesture: We may get
+            // down events for the first two fingers, followed by a cancel event
+            // for all three fingers without ever getting a down for the third
+            // finger.
+            break;
+          }
           final _PointerState state = _pointers[datum.device];
           assert(state.down);
           if (position != state.lastPosition) {

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -174,6 +174,9 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
       _finalPosition = event.position;
       _checkUp();
     } else if (event is PointerCancelEvent) {
+      if (_sentTapDown && onTapCancel != null) {
+        invokeCallback<void>('onTapCancel', onTapCancel);
+      }
       _reset();
     }
   }

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -203,4 +203,19 @@ void main() {
     expect(events[3].runtimeType, equals(PointerCancelEvent));
     expect(events[4].runtimeType, equals(PointerRemovedEvent));
   });
+
+  test('Cancelling an untracked pointer is no-op', () {
+    // Regression test for https://github.com/flutter/flutter/issues/20517.
+
+    const ui.PointerDataPacket packet = ui.PointerDataPacket(
+      data: <ui.PointerData>[
+        ui.PointerData(change: ui.PointerChange.cancel, device: 24),
+      ],
+    );
+
+    final List<PointerEvent> events = PointerEventConverter.expand(
+        packet.data, ui.window.devicePixelRatio).toList();
+
+    expect(events.length, 0);
+  });
 }

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -404,4 +404,40 @@ void main() {
       'disposed B',
     ]);
   });
+
+  testGesture('PointerCancelEvent cancels tab', (GestureTester tester) {
+    const PointerDownEvent down = PointerDownEvent(
+        pointer: 5,
+        position: Offset(10.0, 10.0)
+    );
+    const PointerCancelEvent cancel = PointerCancelEvent(
+        pointer: 5,
+        position: Offset(10.0, 10.0)
+    );
+
+    final TapGestureRecognizer tap = TapGestureRecognizer();
+
+    final List<String> recognized = <String>[];
+    tap.onTapDown = (_) {
+      recognized.add('down');
+    };
+    tap.onTapUp = (_) {
+      recognized.add('up');
+    };
+    tap.onTap = () {
+      recognized.add('tap');
+    };
+    tap.onTapCancel = () {
+      recognized.add('cancel');
+    };
+
+    tap.addPointer(down);
+    tester.closeArena(5);
+    tester.route(down);
+    expect(recognized, <String>['down']);
+    tester.route(cancel);
+    expect(recognized, <String>['down', 'cancel']);
+
+    tap.dispose();
+  });
 }


### PR DESCRIPTION
## Description

Certain phones (e.g. OnePlus A5000) support a three-finger screenshot gesture where the user can take a screenshot by placing three fingers on the screen. The gesture itself is supposed to be ignored by the app. Here's the sequence of pointer events that Flutter is seeing when the user performs this gesture:

Pointer 1 down
Pointer 2 down
Cancel Pointer 1, 2, **and 3**

Flutter would previously crash because we tried to cancel the untracked pointer 3. This change just ignores that cancel event.

In addition to that, the InkResponse would also not remove any Ink splashes when the pointer causing the splash got cancelled (in the example above, pointer 1 and 2 may have caused ink splashes). This PR fixes this by invoking the `onTapCancel` of the `TapGestureRecognizer` if a pointer, that previously caused an `onTapDown`, gets cancelled.

## Related Issues

https://github.com/flutter/flutter/issues/20517

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
