### PR TITLE
Allow PointerEnterEvent and PointerExitEvents to be created from any PointerEvent

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -515,10 +515,16 @@ class PointerEnterEvent extends PointerEvent {
     synthesized: synthesized,
   );
 
+  /// Creates an enter event from a [PointerHoverEvent].
+  ///
+  /// Deprecated. Please use [PointerEnterEvent.fromMouseEvent] instead.
+  @deprecated
+  PointerEnterEvent.fromHoverEvent(PointerHoverEvent event) : this.fromMouseEvent(event);
+
   /// Creates an enter event from a [PointerEvent].
   ///
   /// This is used by the [MouseTracker] to synthesize enter events.
-  PointerEnterEvent.fromHoverEvent(PointerEvent event) : super(
+  PointerEnterEvent.fromMouseEvent(PointerEvent event) : super(
     timeStamp: event?.timeStamp,
     kind: event?.kind,
     device: event?.device,
@@ -602,10 +608,16 @@ class PointerExitEvent extends PointerEvent {
     synthesized: synthesized,
   );
 
+  /// Creates an exit event from a [PointerHoverEvent].
+  ///
+  /// Deprecated. Please use [PointerExitEvent.fromMouseEvent] instead.
+  @deprecated
+  PointerExitEvent.fromHoverEvent(PointerHoverEvent event) : this.fromMouseEvent(event);
+
   /// Creates an exit event from a [PointerEvent].
   ///
   /// This is used by the [MouseTracker] to synthesize exit events.
-  PointerExitEvent.fromHoverEvent(PointerEvent event) : super(
+  PointerExitEvent.fromMouseEvent(PointerEvent event) : super(
     timeStamp: event?.timeStamp,
     kind: event?.kind,
     device: event?.device,

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -518,7 +518,7 @@ class PointerEnterEvent extends PointerEvent {
   /// Creates an enter event from a [PointerHoverEvent].
   ///
   /// Deprecated. Please use [PointerEnterEvent.fromMouseEvent] instead.
-  @deprecated
+  @Deprecated('use PointerEnterEvent.fromMouseEvent instead')
   PointerEnterEvent.fromHoverEvent(PointerHoverEvent event) : this.fromMouseEvent(event);
 
   /// Creates an enter event from a [PointerEvent].
@@ -611,7 +611,7 @@ class PointerExitEvent extends PointerEvent {
   /// Creates an exit event from a [PointerHoverEvent].
   ///
   /// Deprecated. Please use [PointerExitEvent.fromMouseEvent] instead.
-  @deprecated
+  @Deprecated('use PointerExitEvent.fromMouseEvent instead')
   PointerExitEvent.fromHoverEvent(PointerHoverEvent event) : this.fromMouseEvent(event);
 
   /// Creates an exit event from a [PointerEvent].

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -515,32 +515,31 @@ class PointerEnterEvent extends PointerEvent {
     synthesized: synthesized,
   );
 
-  /// Creates an enter event from a [PointerHoverEvent].
+  /// Creates an enter event from a [PointerEvent].
   ///
-  /// This is used by the [MouseTracker] to synthesize enter events, since it
-  /// only actually receives hover events.
-  PointerEnterEvent.fromHoverEvent(PointerHoverEvent hover) : super(
-    timeStamp: hover?.timeStamp,
-    kind: hover?.kind,
-    device: hover?.device,
-    position: hover?.position,
-    delta: hover?.delta,
-    buttons: hover?.buttons,
-    down: hover?.down,
-    obscured: hover?.obscured,
-    pressure: hover?.pressure,
-    pressureMin: hover?.pressureMin,
-    pressureMax: hover?.pressureMax,
-    distance: hover?.distance,
-    distanceMax: hover?.distanceMax,
-    size: hover?.size,
-    radiusMajor: hover?.radiusMajor,
-    radiusMinor: hover?.radiusMinor,
-    radiusMin: hover?.radiusMin,
-    radiusMax: hover?.radiusMax,
-    orientation: hover?.orientation,
-    tilt: hover?.tilt,
-    synthesized: hover?.synthesized,
+  /// This is used by the [MouseTracker] to synthesize enter events.
+  PointerEnterEvent.fromHoverEvent(PointerEvent event) : super(
+    timeStamp: event?.timeStamp,
+    kind: event?.kind,
+    device: event?.device,
+    position: event?.position,
+    delta: event?.delta,
+    buttons: event?.buttons,
+    down: event?.down,
+    obscured: event?.obscured,
+    pressure: event?.pressure,
+    pressureMin: event?.pressureMin,
+    pressureMax: event?.pressureMax,
+    distance: event?.distance,
+    distanceMax: event?.distanceMax,
+    size: event?.size,
+    radiusMajor: event?.radiusMajor,
+    radiusMinor: event?.radiusMinor,
+    radiusMin: event?.radiusMin,
+    radiusMax: event?.radiusMax,
+    orientation: event?.orientation,
+    tilt: event?.tilt,
+    synthesized: event?.synthesized,
   );
 }
 
@@ -603,32 +602,31 @@ class PointerExitEvent extends PointerEvent {
     synthesized: synthesized,
   );
 
-  /// Creates an exit event from a [PointerHoverEvent].
+  /// Creates an exit event from a [PointerEvent].
   ///
-  /// This is used by the [MouseTracker] to synthesize exit events, since it
-  /// only actually receives hover events.
-  PointerExitEvent.fromHoverEvent(PointerHoverEvent hover) : super(
-    timeStamp: hover?.timeStamp,
-    kind: hover?.kind,
-    device: hover?.device,
-    position: hover?.position,
-    delta: hover?.delta,
-    buttons: hover?.buttons,
-    down: hover?.down,
-    obscured: hover?.obscured,
-    pressure: hover?.pressure,
-    pressureMin: hover?.pressureMin,
-    pressureMax: hover?.pressureMax,
-    distance: hover?.distance,
-    distanceMax: hover?.distanceMax,
-    size: hover?.size,
-    radiusMajor: hover?.radiusMajor,
-    radiusMinor: hover?.radiusMinor,
-    radiusMin: hover?.radiusMin,
-    radiusMax: hover?.radiusMax,
-    orientation: hover?.orientation,
-    tilt: hover?.tilt,
-    synthesized: hover?.synthesized,
+  /// This is used by the [MouseTracker] to synthesize exit events.
+  PointerExitEvent.fromHoverEvent(PointerEvent event) : super(
+    timeStamp: event?.timeStamp,
+    kind: event?.kind,
+    device: event?.device,
+    position: event?.position,
+    delta: event?.delta,
+    buttons: event?.buttons,
+    down: event?.down,
+    obscured: event?.obscured,
+    pressure: event?.pressure,
+    pressureMin: event?.pressureMin,
+    pressureMax: event?.pressureMax,
+    distance: event?.distance,
+    distanceMax: event?.distanceMax,
+    size: event?.size,
+    radiusMajor: event?.radiusMajor,
+    radiusMinor: event?.radiusMinor,
+    radiusMin: event?.radiusMin,
+    radiusMax: event?.radiusMax,
+    orientation: event?.orientation,
+    tilt: event?.tilt,
+    synthesized: event?.synthesized,
   );
 }
 

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -229,7 +229,7 @@ class MouseTracker {
           hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
         }
       }
-      if (hitAnnotation.annotation?.onHover != null) {
+      if (hitAnnotation.annotation?.onHover != null && lastEvent is PointerHoverEvent) {
         hitAnnotation.annotation.onHover(lastEvent);
       }
 

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -122,7 +122,7 @@ class MouseTracker {
     final _TrackedAnnotation trackedAnnotation = _findAnnotation(annotation);
     assert(trackedAnnotation != null, "Tried to detach an annotation that wasn't attached: $annotation");
     for (int deviceId in trackedAnnotation.activeDevices) {
-      annotation.onExit(PointerExitEvent.fromHoverEvent(_lastMouseEvent[deviceId]));
+      annotation.onExit(PointerExitEvent.fromMouseEvent(_lastMouseEvent[deviceId]));
     }
     _trackedAnnotations.remove(trackedAnnotation);
   }
@@ -184,7 +184,7 @@ class MouseTracker {
   void collectMousePositions() {
     void exitAnnotation(_TrackedAnnotation trackedAnnotation, int deviceId) {
       if (trackedAnnotation.annotation?.onExit != null && trackedAnnotation.activeDevices.contains(deviceId)) {
-        trackedAnnotation.annotation.onExit(PointerExitEvent.fromHoverEvent(_lastMouseEvent[deviceId]));
+        trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(_lastMouseEvent[deviceId]));
         trackedAnnotation.activeDevices.remove(deviceId);
       }
     }
@@ -226,7 +226,7 @@ class MouseTracker {
         // event sent to it.
         hitAnnotation.activeDevices.add(deviceId);
         if (hitAnnotation.annotation?.onEnter != null) {
-          hitAnnotation.annotation.onEnter(PointerEnterEvent.fromHoverEvent(lastEvent));
+          hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
         }
       }
       if (hitAnnotation.annotation?.onHover != null) {
@@ -241,7 +241,7 @@ class MouseTracker {
         }
         if (trackedAnnotation.activeDevices.contains(deviceId)) {
           if (trackedAnnotation.annotation?.onExit != null) {
-            trackedAnnotation.annotation.onExit(PointerExitEvent.fromHoverEvent(lastEvent));
+            trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(lastEvent));
           }
           trackedAnnotation.activeDevices.remove(deviceId);
         }

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -256,5 +256,50 @@ void main() {
       expect(exit.first.device, isNull);
       expect(exit.first.runtimeType, equals(PointerExitEvent));
     });
+    test('handles mouse down and move', () {
+      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.hover,
+          physicalX: 0.0 * ui.window.devicePixelRatio,
+          physicalY: 0.0 * ui.window.devicePixelRatio,
+          kind: PointerDeviceKind.mouse,
+        ),
+        ui.PointerData(
+          change: ui.PointerChange.hover,
+          physicalX: 1.0 * ui.window.devicePixelRatio,
+          physicalY: 101.0 * ui.window.devicePixelRatio,
+          kind: PointerDeviceKind.mouse,
+        ),
+      ]);
+      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.down,
+          physicalX: 1.0 * ui.window.devicePixelRatio,
+          physicalY: 101.0 * ui.window.devicePixelRatio,
+          kind: PointerDeviceKind.mouse,
+        ),
+        ui.PointerData(
+          change: ui.PointerChange.move,
+          physicalX: 1.0 * ui.window.devicePixelRatio,
+          physicalY: 201.0 * ui.window.devicePixelRatio,
+          kind: PointerDeviceKind.mouse,
+        ),
+      ]);
+      isInHitRegion = true;
+      tracker.attachAnnotation(annotation);
+      ui.window.onPointerDataPacket(packet1);
+      tracker.collectMousePositions();
+      ui.window.onPointerDataPacket(packet2);
+      tracker.collectMousePositions();
+      expect(enter.length, equals(1), reason: 'enter contains $enter');
+      expect(enter.first.position, equals(const Offset(1.0, 101.0)));
+      expect(enter.first.device, equals(0));
+      expect(enter.first.runtimeType, equals(PointerEnterEvent));
+      expect(move.length, equals(1), reason: 'move contains $move');
+      expect(move.first.position, equals(const Offset(1.0, 101.0)));
+      expect(move.first.device, equals(0));
+      expect(move.first.runtimeType, equals(PointerHoverEvent));
+      expect(exit.length, equals(0), reason: 'exit contains $exit');
+    });
   });
 }


### PR DESCRIPTION
## Description

When testing mouse hover support in a custom embedder, I noticed crashes in MouseTracker due to an implicit downcast from PointerEvent to PointerHoverEvent. The `_lastMouseEvent` map can contain PointerMoveEvents and PointerDownEvents, in addition to PointerHoverEvents, so changing the type of event handled by PointerEnter/ExitEvent.fromHoverEvent seems like the best course of action. Renaming the constructor would be a breaking change however.

Should I include tests for converting other pointer events into PointerEnter/ExitEvents?

## Related Issues

#29696

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
