### PR TITLE
Add convex path and non-AA paint to shader warm-up

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -49,6 +49,10 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// Currently the warm-up happens synchronously on the GPU thread which means
   /// the rendering of the first frame on the GPU thread will be postponed until
   /// the warm-up is finished.
+  ///
+  /// See also
+  ///
+  ///  * [ShaderWarmUp], the interface of how this warm up works.
   static ShaderWarmUp shaderWarmUp = const DefaultShaderWarmUp();
 
   /// The singleton that implements the Flutter framework's image cache.

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -38,8 +38,8 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// shaders that are not covered by [DefaultShaderWarmUp], it may cause jank
   /// in the middle of an animation or interaction. In that case, set
   /// [shaderWarmUp] to a custom [ShaderWarmUp] before calling [initInstances]
-  /// (usually before [runApp] for normal flutter apps, and before
-  /// [enableFlutterDriverExtension] for flutter drive tests). Paint the scene
+  /// (usually before [runApp] for normal Flutter apps, and before
+  /// [enableFlutterDriverExtension] for Flutter drive tests). Paint the scene
   /// in the custom [ShaderWarmUp] so Flutter can pre-compile and cache the
   /// shaders during startup. The warm up is only costly (100ms-200ms,
   /// depending on the shaders to compile) during the first run after the
@@ -50,7 +50,7 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// the rendering of the first frame on the GPU thread will be postponed until
   /// the warm-up is finished.
   ///
-  /// See also
+  /// See also:
   ///
   ///  * [ShaderWarmUp], the interface of how this warm up works.
   static ShaderWarmUp shaderWarmUp = const DefaultShaderWarmUp();

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -16,10 +16,24 @@ import 'package:flutter/foundation.dart';
 ///
 /// Therefore, we use this during the [PaintingBinding.initInstances] call to
 /// move common shader compilations from animation time to startup time. By
-/// default, a [DefaultShaderWarmUp] is used. Create a custom [ShaderWarmUp]
-/// subclass to replace [PaintingBinding.shaderWarmUp] before
-/// [PaintingBinding.initInstances] is called. Usually, that can be done before
-/// calling [runApp].
+/// default, a [DefaultShaderWarmUp] is used. If needed, create a custom
+/// [ShaderWarmUp] subclass and give it to [PaintingBinding.shaderWarmUp]
+/// (so it replaces [DefaultShaderWarmUp]) before
+/// [PaintingBinding.initInstances] is called. Usually, that can be done
+/// before calling [runApp].
+///
+/// To determine whether a draw operation is useful for warming up shaders,
+/// check the difference in the worst_frame_rasterizer_time_millis benchmarks.
+/// Also, tracing with `flutter run --profile --trace-skia` could reveal if
+/// there are shader compilation related janks. If there are, some long
+/// `GrGLProgramBuilder::finalize` calls would appear in the middle of an
+/// animation. Their parent calls which look like `XyzOp` would suggest Xyz
+/// draw operations are causing the shaders to be compiled. A useful shader
+/// warm-up draw operation would eliminate such long compilation calls in the
+/// animation. To double check the warm-up, trace with `flutter run --profile
+/// --trace-skia --start-paused`. The `GrGLProgramBuilder` with the associated
+/// `XyzOp` should appear during the startup rather than in the middle of a
+/// later animation.
 ///
 /// This warm up needs to be run on each individual device because the shader
 /// compilation depends on the specific GPU hardware and driver a device has. It
@@ -29,6 +43,11 @@ import 'package:flutter/foundation.dart';
 /// If no warm up is desired (e.g., when the startup latency is crucial), set
 /// [PaintingBinding.shaderWarmUp] either to a custom ShaderWarmUp with an empty
 /// [warmUpOnCanvas] or null.
+///
+/// See also
+///
+///  * [PaintingBinding.shaderWarmUp], the actual instance of [ShaderWarmUp]
+///    that's used to warm up the shaders.
 abstract class ShaderWarmUp {
   /// Allow const constructors for subclasses.
   const ShaderWarmUp();
@@ -109,6 +128,10 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
     convexPath.lineTo(20.0, 60.0);
     convexPath.close();
 
+    // Skia uses different shaders based on the kinds of paths being drawn and
+    // the associated paint configurations. According to our experience and
+    // tracing, drawing the following paths/paints generates various of
+    // shaders that are commonly used.
     final List<ui.Path> paths = <ui.Path>[rrectPath, circlePath, path, convexPath];
 
     final List<ui.Paint> paints = <ui.Paint>[

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -101,11 +101,22 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
     path.moveTo(60.0, 20.0);
     path.quadraticBezierTo(60.0, 60.0, 20.0, 60.0);
 
-    final List<ui.Path> paths = <ui.Path>[rrectPath, circlePath, path];
+    final ui.Path convexPath = ui.Path();
+    convexPath.moveTo(20.0, 30.0);
+    convexPath.lineTo(40.0, 20.0);
+    convexPath.lineTo(60.0, 30.0);
+    convexPath.lineTo(60.0, 60.0);
+    convexPath.lineTo(20.0, 60.0);
+    convexPath.close();
+
+    final List<ui.Path> paths = <ui.Path>[rrectPath, circlePath, path, convexPath];
 
     final List<ui.Paint> paints = <ui.Paint>[
       ui.Paint()
         ..isAntiAlias = true
+        ..style = ui.PaintingStyle.fill,
+      ui.Paint()
+        ..isAntiAlias = false
         ..style = ui.PaintingStyle.fill,
       ui.Paint()
         ..isAntiAlias = true

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -9,42 +9,42 @@ import 'package:flutter/foundation.dart';
 
 /// Interface for drawing an image to warm up Skia shader compilations.
 ///
-/// When Skia first sees a certain type of draw operations on GPU, it needs to
-/// compile the corresponding shader. The compilation can be slow (20ms-200ms).
-/// Having that time as a startup latency is often better than having a jank in
-/// the middle of an animation.
+/// When Skia first sees a certain type of draw operation on the GPU, it needs
+/// to compile the corresponding shader. The compilation can be slow (20ms-
+/// 200ms). Having that time as startup latency is often better than having
+/// jank in the middle of an animation.
 ///
 /// Therefore, we use this during the [PaintingBinding.initInstances] call to
 /// move common shader compilations from animation time to startup time. By
-/// default, a [DefaultShaderWarmUp] is used. If needed, create a custom
-/// [ShaderWarmUp] subclass and give it to [PaintingBinding.shaderWarmUp]
-/// (so it replaces [DefaultShaderWarmUp]) before
-/// [PaintingBinding.initInstances] is called. Usually, that can be done
-/// before calling [runApp].
+/// default, a [DefaultShaderWarmUp] is used. If needed, app developers can
+/// create a custom [ShaderWarmUp] subclass and hand it to
+/// [PaintingBinding.shaderWarmUp] (so it replaces [DefaultShaderWarmUp])
+/// before [PaintingBinding.initInstances] is called. Usually, that can be
+/// done before calling [runApp].
 ///
 /// To determine whether a draw operation is useful for warming up shaders,
-/// check the difference in the worst_frame_rasterizer_time_millis benchmarks.
-/// Also, tracing with `flutter run --profile --trace-skia` could reveal if
-/// there are shader compilation related janks. If there are, some long
+/// check the difference in the `worst_frame_rasterizer_time_millis` benchmarks.
+/// Also, tracing with `flutter run --profile --trace-skia` may reveal whether
+/// there is shader-compilation-related jank. If there is such jank, some long
 /// `GrGLProgramBuilder::finalize` calls would appear in the middle of an
-/// animation. Their parent calls which look like `XyzOp` would suggest Xyz
-/// draw operations are causing the shaders to be compiled. A useful shader
-/// warm-up draw operation would eliminate such long compilation calls in the
-/// animation. To double check the warm-up, trace with `flutter run --profile
-/// --trace-skia --start-paused`. The `GrGLProgramBuilder` with the associated
-/// `XyzOp` should appear during the startup rather than in the middle of a
-/// later animation.
+/// animation. Their parent calls, which look like `XyzOp` (e.g., `FillRecOp`,
+/// `CircularRRectOp`) would suggest Xyz draw operations are causing the shaders
+/// to be compiled. A useful shader warm-up draw operation would eliminate such
+/// long compilation calls in the animation. To double-check the warm-up, trace
+/// with `flutter run --profile --trace-skia --start-paused`. The
+/// `GrGLProgramBuilder` with the associated `XyzOp` should appear during
+/// startup rather than in the middle of a later animation.
 ///
-/// This warm up needs to be run on each individual device because the shader
+/// This warm-up needs to be run on each individual device because the shader
 /// compilation depends on the specific GPU hardware and driver a device has. It
 /// can't be pre-computed during the Flutter engine compilation as the engine is
-/// device agnostic.
+/// device-agnostic.
 ///
-/// If no warm up is desired (e.g., when the startup latency is crucial), set
+/// If no warm-up is desired (e.g., when the startup latency is crucial), set
 /// [PaintingBinding.shaderWarmUp] either to a custom ShaderWarmUp with an empty
 /// [warmUpOnCanvas] or null.
 ///
-/// See also
+/// See also:
 ///
 ///  * [PaintingBinding.shaderWarmUp], the actual instance of [ShaderWarmUp]
 ///    that's used to warm up the shaders.


### PR DESCRIPTION
## Description

One of our important client's SKP shows that this could improve one of
their janky frame by 20ms. This also improves our
flutter_gallery__transition_perf's worst frame time by ~20ms.

On the other hand, 15ms has been added to the start-up latency. I guess
it's a little faster to compile the shader on the start-up because we're
compiling a lot of shaders there and the CPU cache must be hot.

## Related Issues

https://github.com/flutter/flutter/issues/813

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
