### PR TITLE
Updated gallery light and dark themes

### DIFF
--- a/examples/flutter_gallery/lib/gallery/themes.dart
+++ b/examples/flutter_gallery/lib/gallery/themes.dart
@@ -25,15 +25,19 @@ TextTheme _buildTextTheme(TextTheme base) {
 ThemeData _buildDarkTheme() {
   const Color primaryColor = Color(0xFF0175c2);
   const Color secondaryColor = Color(0xFF13B9FD);
-  final ThemeData base = ThemeData.dark();
   final ColorScheme colorScheme = const ColorScheme.dark().copyWith(
     primary: primaryColor,
     secondary: secondaryColor,
   );
-  return base.copyWith(
+  final ThemeData base = ThemeData(
+    brightness: Brightness.dark,
+    accentColorBrightness: Brightness.dark,
     primaryColor: primaryColor,
+    primaryColorDark: const Color(0xFF0050a0),
+    primaryColorLight: secondaryColor,
     buttonColor: primaryColor,
     indicatorColor: Colors.white,
+    toggleableActiveColor: const Color(0xFF6997DF),
     accentColor: secondaryColor,
     canvasColor: const Color(0xFF202124),
     scaffoldBackgroundColor: const Color(0xFF202124),
@@ -43,6 +47,8 @@ ThemeData _buildDarkTheme() {
       colorScheme: colorScheme,
       textTheme: ButtonTextTheme.primary,
     ),
+  );
+  return base.copyWith(
     textTheme: _buildTextTheme(base.textTheme),
     primaryTextTheme: _buildTextTheme(base.primaryTextTheme),
     accentTextTheme: _buildTextTheme(base.accentTextTheme),
@@ -56,12 +62,14 @@ ThemeData _buildLightTheme() {
     primary: primaryColor,
     secondary: secondaryColor,
   );
-  final ThemeData base = ThemeData.light();
-  return base.copyWith(
+  final ThemeData base = ThemeData(
+    brightness: Brightness.light,
+    accentColorBrightness: Brightness.dark,
     colorScheme: colorScheme,
     primaryColor: primaryColor,
     buttonColor: primaryColor,
     indicatorColor: Colors.white,
+    toggleableActiveColor: const Color(0xFF1E88E5),
     splashColor: Colors.white24,
     splashFactory: InkRipple.splashFactory,
     accentColor: secondaryColor,
@@ -73,6 +81,8 @@ ThemeData _buildLightTheme() {
       colorScheme: colorScheme,
       textTheme: ButtonTextTheme.primary,
     ),
+  );
+  return base.copyWith(
     textTheme: _buildTextTheme(base.textTheme),
     primaryTextTheme: _buildTextTheme(base.primaryTextTheme),
     accentTextTheme: _buildTextTheme(base.accentTextTheme),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/pull/27266.

This change was initiated by @msal4 in https://github.com/flutter/flutter/pull/28217.

Tweaked the themes so that the sliders are visible in the dark theme, and so that the selection controls' dark theme highlight color is better aligned with the overall theme color. The contrast for the new dark theme selection control highlight color is still > 5.44.

### Dark theme sliders before
![slider0](https://user-images.githubusercontent.com/1377460/53532934-b3b13880-3aad-11e9-921e-701f8f0a056b.png)

### Dark theme sliders after
![slider1](https://user-images.githubusercontent.com/1377460/53532953-c3308180-3aad-11e9-939c-d56997209f29.png)

### Selection controls before
![checkbox0](https://user-images.githubusercontent.com/1377460/53532965-cfb4da00-3aad-11e9-86a7-0a569a0f0a19.png)

![radio0](https://user-images.githubusercontent.com/1377460/53532968-d2afca80-3aad-11e9-9954-033ec7f1afed.png)

![switch0](https://user-images.githubusercontent.com/1377460/53532972-d5aabb00-3aad-11e9-8c68-f43c8bbed238.png)

### Selection controls after
![checkbox1](https://user-images.githubusercontent.com/1377460/53532982-dd6a5f80-3aad-11e9-98eb-8d0c2ff0a148.png)

![radio1](https://user-images.githubusercontent.com/1377460/53532988-e3604080-3aad-11e9-9f7d-680f75037579.png)

![switch1](https://user-images.githubusercontent.com/1377460/53532993-e6f3c780-3aad-11e9-83cc-df0094ba5263.png)

