### PR TITLE
Make sure everything in the Cupertino page transition can be linear when back swiping

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -180,10 +180,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     return nextRoute is CupertinoPageRoute && !nextRoute.fullscreenDialog;
   }
 
-  /// True if a Cupertino pop gesture is currently underway for [route].
+  /// True if an iOS-style back swipe pop gesture is currently underway for [route].
   ///
-  /// This returns true for both the top route and the bottom route of a
-  /// pop gesture.
+  /// This just check for the route's [NavigatorState.userGestureInProgress].
   ///
   /// See also:
   ///
@@ -193,7 +192,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     return route.navigator.userGestureInProgress;
   }
 
-  /// True if a Cupertino pop gesture is currently underway for this route.
+  /// True if an iOS-style back swipe pop gesture is currently underway for this route.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -182,7 +182,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
 
   /// True if an iOS-style back swipe pop gesture is currently underway for [route].
   ///
-  /// This just check for the route's [NavigatorState.userGestureInProgress].
+  /// This just check the route's [NavigatorState.userGestureInProgress].
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -271,10 +271,10 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     return result;
   }
 
-  static Animation _animationControllerForTransitionAnimation(Animation animation) {
-    Animation controller = animation;
+  static Animation<double> _animationControllerForTransitionAnimation(Animation<double> animation) {
+    Animation<double> controller = animation;
     while(controller is ProxyAnimation || controller is TrainHoppingAnimation) {
-      final Animation proxy = controller;
+      final Animation<double> proxy = controller;
       if (proxy is ProxyAnimation)
         controller = proxy.parent;
 
@@ -288,7 +288,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   // gesture is detected. The returned controller handles all of the subsequent
   // drag events.
   static _CupertinoBackGestureController<T> _startPopGesture<T>(PageRoute<T> route) {
-    final Animation controller = _animationControllerForTransitionAnimation(route.animation);
+    final Animation<double> controller = _animationControllerForTransitionAnimation(route.animation);
 
     assert(!_popGestureInProgress.contains(controller));
     assert(_isPopGestureEnabled(route));

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -116,7 +116,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
 
   /// The animation for the route being pushed on top of this route. This
   /// animation lets this route coordinate with the entrance and exit transition
-  /// of routes pushed on top of this route.
+  /// of route pushed on top of this route.
   Animation<double> get secondaryAnimation => _secondaryAnimation;
   final ProxyAnimation _secondaryAnimation = ProxyAnimation(kAlwaysDismissedAnimation);
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -114,6 +114,12 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   AnimationController get controller => _controller;
   AnimationController _controller;
 
+  /// The animation for the route being pushed on top of this route. This
+  /// animation lets this route coordinate with the entrance and exit transition
+  /// of routes pushed on top of this route.
+  Animation<double> get secondaryAnimation => _secondaryAnimation;
+  final ProxyAnimation _secondaryAnimation = ProxyAnimation(kAlwaysDismissedAnimation);
+
   /// Called to create the animation controller that will drive the transitions to
   /// this route from the previous one, and back to the previous route from this
   /// one.
@@ -163,12 +169,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
     }
     changedInternalState();
   }
-
-  /// The animation for the route being pushed on top of this route. This
-  /// animation lets this route coordinate with the entrance and exit transition
-  /// of routes pushed on top of this route.
-  Animation<double> get secondaryAnimation => _secondaryAnimation;
-  final ProxyAnimation _secondaryAnimation = ProxyAnimation(kAlwaysDismissedAnimation);
 
   @override
   void install(OverlayEntry insertionPoint) {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -499,33 +499,28 @@ void main() {
 
     tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
 
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 400));
-    await tester.pump();
-    debugDumpApp();
+    await tester.pumpAndSettle();
 
     expect(find.text('1'), findsNothing);
-    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(301, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(0, epsilon: 1));
 
-    await tester.pump(const Duration(milliseconds: 50));
+    final TestGesture swipeGesture = await tester.startGesture(const Offset(5, 100));
 
-    await tester.pump(const Duration(milliseconds: 50));
-    // Translation slows down as time goes on.
-    expect(tester.getTopLeft(find.text('x')).dx, moreOrLessEquals(141, epsilon: 1));
-
-    // Finish the rest of the animation
-    await tester.pump(const Duration(milliseconds: 250));
-
-    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await swipeGesture.moveBy(const Offset(100, 0));
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
-    expect(tester.getTopLeft(find.text('x')).dx, moreOrLessEquals(262, epsilon: 1));
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-233, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(100, epsilon: 1));
 
-    await tester.pump(const Duration(milliseconds: 50));
-    expect(tester.getTopLeft(find.text('x')).dx, moreOrLessEquals(499, epsilon: 1));
+    await swipeGesture.moveBy(const Offset(100, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-200, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(200, epsilon: 1));
 
-    await tester.pump(const Duration(milliseconds: 50));
-    // Translation slows down as time goes on.
-    expect(tester.getTopLeft(find.text('x')).dx, moreOrLessEquals(659, epsilon: 1));
+    // Moving by the same distance each time produces linear movements on both
+    // routes.
+    await swipeGesture.moveBy(const Offset(100, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-166, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(300, epsilon: 1));
   });
 }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -309,9 +309,9 @@ void main() {
     expect(find.text('route'), findsNothing);
 
 
-    // Run the dismiss animation 75%, which exposes the route "push" button,
-    // and then press the button. MaterialPageTransition duration is 300ms,
-    // 275 = 300 * 0.75.
+    // Run the dismiss animation 60%, which exposes the route "push" button,
+    // and then press the button. A drag dropped animation is 400ms when dropped
+    // exactly halfway. It follows a curve that is very steep initially.
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
@@ -319,10 +319,19 @@ void main() {
     expect(find.text('push'), findsNothing);
 
     gesture = await tester.startGesture(const Offset(5, 300));
-    await gesture.moveBy(const Offset(400, 0)); // drag halfway
+    await gesture.moveBy(const Offset(400, 0)); // Drag halfway.
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 275)); // partially dismiss "route"
-    expect(find.text('route'), findsOneWidget);
+    await tester.pump(); // Trigger the dropped snapping animation.
+    expect(
+      tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(CupertinoPageScaffold))),
+      const Offset(400, 0),
+    );
+    // Let the dismissing snapping animation go 60%.
+    await tester.pump(const Duration(milliseconds: 240));
+    expect(
+      tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(CupertinoPageScaffold))).dx,
+      moreOrLessEquals(798, epsilon: 1),
+    );
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('route'), findsOneWidget);
@@ -522,5 +531,88 @@ void main() {
     await tester.pump();
     expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-166, epsilon: 1));
     expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(300, epsilon: 1));
+  });
+
+  testWidgets('Pop gesture snapping is not linear', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Text('1'),
+      ),
+    );
+
+    final CupertinoPageRoute<void> route2 = CupertinoPageRoute<void>(
+      builder: (BuildContext context) {
+        return const CupertinoPageScaffold(
+          child: Text('2'),
+        );
+      }
+    );
+
+    tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
+
+    await tester.pumpAndSettle();
+
+    final TestGesture swipeGesture = await tester.startGesture(const Offset(5, 100));
+
+    await swipeGesture.moveBy(const Offset(500, 0));
+    await swipeGesture.up();
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-100, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(500, epsilon: 1));
+
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-19, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(744, epsilon: 1));
+
+    await tester.pump(const Duration(milliseconds: 50));
+    // Rate of change is slowing down.
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(-4, epsilon: 1));
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(787, epsilon: 1));
+  });
+
+  testWidgets('Snapped drags forwards and backwards should signal didStopUserGesture', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
+    await tester.pumpWidget(
+      CupertinoApp(
+        navigatorKey: navigatorKey,
+        home: const Text('1'),
+      ),
+    );
+
+    final CupertinoPageRoute<void> route2 = CupertinoPageRoute<void>(
+      builder: (BuildContext context) {
+        return const CupertinoPageScaffold(
+          child: Text('2'),
+        );
+      }
+    );
+
+    navigatorKey.currentState.push(route2);
+    await tester.pumpAndSettle();
+
+    await tester.dragFrom(const Offset(5, 100), const Offset(100, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(100, epsilon: 1));
+    expect(navigatorKey.currentState.userGestureInProgress, true);
+
+    // Didn't drag far enough to snap into dismissing this route.
+    // Each 100px distance takes 100ms to snap back.
+    await tester.pump(const Duration(milliseconds: 101));
+    // Back to the page covering the whole screen.
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(0, epsilon: 1));
+    expect(navigatorKey.currentState.userGestureInProgress, false);
+
+    await tester.dragFrom(const Offset(5, 100), const Offset(500, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('2')).dx, moreOrLessEquals(500, epsilon: 1));
+    expect(navigatorKey.currentState.userGestureInProgress, true);
+
+    // Did go far enough to snap out of this route.
+    await tester.pump(const Duration(milliseconds: 301));
+    // Back to the page covering the whole screen.
+    expect(find.text('2'), findsNothing);
+    // First route covers the whole screen.
+    expect(tester.getTopLeft(find.text('1')).dx, moreOrLessEquals(0, epsilon: 1));
+    expect(navigatorKey.currentState.userGestureInProgress, false);
   });
 }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -597,9 +597,9 @@ void main() {
     expect(find.text('route'), findsNothing);
 
 
-    // Run the dismiss animation 75%, which exposes the route "push" button,
-    // and then press the button. MaterialPageTransition duration is 300ms,
-    // 275 = 300 * 0.75.
+    // Run the dismiss animation 60%, which exposes the route "push" button,
+    // and then press the button. A drag dropped animation is 400ms when dropped
+    // exactly halfway. It follows a curve that is very steep initially.
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
@@ -607,10 +607,19 @@ void main() {
     expect(find.text('push'), findsNothing);
 
     gesture = await tester.startGesture(const Offset(5, 300));
-    await gesture.moveBy(const Offset(400, 0)); // drag halfway
+    await gesture.moveBy(const Offset(400, 0)); // Drag halfway.
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 275)); // partially dismiss "route"
-    expect(find.text('route'), findsOneWidget);
+    await tester.pump(); // Trigger the dropped snapping animation.
+    expect(
+      tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(Scaffold))),
+      const Offset(400, 0),
+    );
+    // Let the dismissing snapping animation go 60%.
+    await tester.pump(const Duration(milliseconds: 240));
+    expect(
+      tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(Scaffold))).dx,
+      moreOrLessEquals(798, epsilon: 1),
+    );
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('route'), findsOneWidget);


### PR DESCRIPTION
## Description

Currently, the route transition can become disconnected between the top and the bottom pages of a Cupertino transition because they can follow different curves. They should both be linearToEaseOut if animated but both be linear if driven by a back swipe. 

We should be checking for the participating animations for whether they're part of a swipe rather than checking the route.

## Related Issues

#28529

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.
