### PR TITLE
Include git output into error message from channel command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -35,7 +35,10 @@ class ChannelCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     switch (argResults.rest.length) {
       case 0:
-        await _listChannels(showAll: argResults['all']);
+        await _listChannels(
+          showAll: argResults['all'],
+          verbose: globalResults['verbose']
+        );
         return null;
       case 1:
         await _switchChannel(argResults.rest[0]);
@@ -45,7 +48,7 @@ class ChannelCommand extends FlutterCommand {
     }
   }
 
-  Future<void> _listChannels({ bool showAll }) async {
+  Future<void> _listChannels({ bool showAll, bool verbose }) async {
     // Beware: currentBranch could contain PII. See getBranchName().
     final String currentChannel = FlutterVersion.instance.channel;
     final String currentBranch = FlutterVersion.instance.getBranchName();
@@ -59,7 +62,8 @@ class ChannelCommand extends FlutterCommand {
       <String>['git', 'branch', '-r'],
       workingDirectory: Cache.flutterRoot,
       mapFunction: (String line) {
-        rawOutput.add(line);
+        if (verbose)
+          rawOutput.add(line);
         final List<String> split = line.split('/');
         if (split.length < 2)
           return null;
@@ -77,8 +81,8 @@ class ChannelCommand extends FlutterCommand {
       },
     );
     if (result != 0) {
-      throwToolExit('List channels failed: $result\n${rawOutput.join('\n')}',
-          exitCode: result);
+      final String details = verbose ? '\n${rawOutput.join('\n')}' : '';
+      throwToolExit('List channels failed: $result$details', exitCode: result);
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -50,6 +50,7 @@ class ChannelCommand extends FlutterCommand {
     final String currentChannel = FlutterVersion.instance.channel;
     final String currentBranch = FlutterVersion.instance.getBranchName();
     final Set<String> seenChannels = Set<String>();
+    final List<String> rawOutput = <String>[];
 
     showAll = showAll || currentChannel != currentBranch;
 
@@ -58,6 +59,7 @@ class ChannelCommand extends FlutterCommand {
       <String>['git', 'branch', '-r'],
       workingDirectory: Cache.flutterRoot,
       mapFunction: (String line) {
+        rawOutput.add(line);
         final List<String> split = line.split('/');
         if (split.length < 2)
           return null;
@@ -74,8 +76,10 @@ class ChannelCommand extends FlutterCommand {
         return null;
       },
     );
-    if (result != 0)
-      throwToolExit('List channels failed: $result', exitCode: result);
+    if (result != 0) {
+      throwToolExit('List channels failed: $result\n${rawOutput.join('\n')}',
+          exitCode: result);
+    }
   }
 
   Future<void> _switchChannel(String branchName) {

--- a/packages/flutter_tools/test/channel_test.dart
+++ b/packages/flutter_tools/test/channel_test.dart
@@ -41,15 +41,23 @@ void main() {
       Cache.disableLocking();
     });
 
-    testUsingContext('list', () async {
+    Future<void> simpleChannelTest(List<String> args) async {
       final ChannelCommand command = ChannelCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
-      await runner.run(<String>['channel']);
+      await runner.run(args);
       expect(testLogger.errorText, hasLength(0));
       // The bots may return an empty list of channels (network hiccup?)
       // and when run locally the list of branches might be different
       // so we check for the header text rather than any specific channel name.
       expect(testLogger.statusText, contains('Flutter channels:'));
+    }
+
+    testUsingContext('list', () async {
+      await simpleChannelTest(<String>['channel']);
+    });
+
+    testUsingContext('verbose list', () async {
+      await simpleChannelTest(<String>['channel', '-v']);
     });
 
     testUsingContext('removes duplicates', () async {


### PR DESCRIPTION
## Description

This change adds output of underlying 'git branch -r' command into the error message of "flutter channel". This is an attempt to debug flaky failures on head-head-head (dart/engine/flutter) bot:

```
21:21 +668 ~4 -1: test/channel_test.dart: channel list [E]                                                                                                                                             
    Exception: List channels failed: 128
    package:flutter_tools/src/base/common.dart 24:3               throwToolExit
    package:flutter_tools/src/commands/channel.dart 78:7          ChannelCommand._listChannels
    ===== asynchronous gap ===========================
    dart:async                                                    _AsyncAwaitCompleter.completeError
    package:flutter_tools/src/commands/channel.dart               ChannelCommand._listChannels
    ===== asynchronous gap ===========================
    dart:async                                                    _asyncThenWrapperHelper
    package:flutter_tools/src/commands/channel.dart               ChannelCommand._listChannels
    package:flutter_tools/src/commands/channel.dart 38:15         ChannelCommand.runCommand
    ===== asynchronous gap ===========================
    dart:async                                                    _asyncThenWrapperHelper
    package:flutter_tools/src/runner/flutter_command.dart         FlutterCommand.verifyThenRunCommand
    package:flutter_tools/src/runner/flutter_command.dart 486:33  FlutterCommand.run.<fn>
    ===== asynchronous gap ===========================
    dart:async                                                    _asyncThenWrapperHelper
    package:flutter_tools/src/runner/flutter_command.dart         FlutterCommand.run.<fn>
    package:flutter_tools/src/base/context.dart 142:29            AppContext.run.<fn>
    ===== asynchronous gap ===========================
    dart:async                                                    _asyncThenWrapperHelper
    package:flutter_tools/src/runner/flutter_command_runner.dart  FlutterCommandRunner.runCommand.<fn>
    package:flutter_tools/src/base/context.dart 142:29            AppContext.run.<fn>
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
