### PR TITLE
fix pushAndRemoveUntil not play push animation

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1852,7 +1852,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(newRoute.overlayEntries.isEmpty);
     final Route<dynamic> oldRoute = _history.isNotEmpty ? _history.last : null;
     newRoute._navigator = this;
-    newRoute.install(_currentOverlayEntry);
+    newRoute.install(null);
     _history.add(newRoute);
     newRoute.didPush().whenCompleteOrCancel(() {
       if (mounted) {


### PR DESCRIPTION
## Description

why didn't the animation play? because newRoute overlay puted below removed overlay pages. I change 
`newRoute.install(_currentOverlayEntry);` to `newRoute.install(null);` for put newRoute overlay to top
Documentation for the method `OverlayState.insertAll(Iterable<OverlayEntry> entries, { OverlayEntry above })` says:

> If `above` is non-null, the entries are inserted just above `above`. Otherwise, the entries are inserted on top.


current animation:
![not_animation_route](https://user-images.githubusercontent.com/11444783/49651475-b9682680-fa48-11e8-883c-5553cea041ac.gif)

fixed animation:
![fix](https://user-images.githubusercontent.com/11444783/53645581-98336280-3c52-11e9-8410-fe1f68fd932c.gif)
## Related Issues

fixed https://github.com/flutter/flutter/issues/25080
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.
