### PR TITLE
Avoid the overhead of instantiating a generator in paintImage

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -438,22 +438,25 @@ void paintImage({
     final Rect sourceRect = alignment.inscribe(
       sourceSize, Offset.zero & inputSize,
     );
-    for (Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
-      canvas.drawImageRect(image, sourceRect, tileRect, paint);
+    if (repeat == ImageRepeat.noRepeat) {
+      canvas.drawImageRect(image, sourceRect, destinationRect, paint);
+    } else {
+      for (Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
+        canvas.drawImageRect(image, sourceRect, tileRect, paint);
+    }
   } else {
-    for (Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
-      canvas.drawImageNine(image, centerSlice, tileRect, paint);
+    if (repeat == ImageRepeat.noRepeat) {
+      canvas.drawImageNine(image, centerSlice, destinationRect, paint);
+    } else {
+      for (Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
+        canvas.drawImageNine(image, centerSlice, tileRect, paint);
+    }
   }
   if (needSave)
     canvas.restore();
 }
 
 Iterable<Rect> _generateImageTileRects(Rect outputRect, Rect fundamentalRect, ImageRepeat repeat) sync* {
-  if (repeat == ImageRepeat.noRepeat) {
-    yield fundamentalRect;
-    return;
-  }
-
   int startX = 0;
   int startY = 0;
   int stopX = 0;


### PR DESCRIPTION
This function is called frequently with non-repeating images during many
animations