### PR TITLE
Handle Cupertino back gesture interrupted by Navigator push

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -274,6 +274,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     backController = _CupertinoBackGestureController<T>(
       navigator: route.navigator,
       controller: route.controller,
+      route: route,
       onEnded: () {
         backController?.dispose();
         backController = null;
@@ -579,6 +580,7 @@ class _CupertinoBackGestureController<T> {
     @required this.navigator,
     @required this.controller,
     @required this.onEnded,
+    @required this.route,
   }) : assert(navigator != null),
        assert(controller != null),
        assert(onEnded != null) {
@@ -593,6 +595,8 @@ class _CupertinoBackGestureController<T> {
   final AnimationController controller;
 
   final VoidCallback onEnded;
+
+  final PageRoute<dynamic> route;
 
   bool _animating = false;
 
@@ -652,7 +656,7 @@ class _CupertinoBackGestureController<T> {
     }
     _animating = false;
     if (status == AnimationStatus.dismissed)
-      navigator.pop<T>(); // this will cause the route to get disposed, which will dispose us
+      navigator.removeRoute(route); // this will cause the route to get disposed, which will dispose us
     onEnded(); // this will call dispose if popping the route failed to do so
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -154,7 +154,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         // We might still be an active route if a subclass is controlling the
         // the transition and hits the dismissed status. For example, the iOS
         // back gesture drives this animation to the dismissed status before
-        // removing the route.
+        // removing the route and disposing it.
         if (!isActive) {
           navigator.finalizeRoute(this);
           assert(overlayEntries.isEmpty);

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -151,11 +151,11 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
           overlayEntries.first.opaque = false;
         break;
       case AnimationStatus.dismissed:
-        // We might still be the current route if a subclass is controlling the
+        // We might still be an active route if a subclass is controlling the
         // the transition and hits the dismissed status. For example, the iOS
         // back gesture drives this animation to the dismissed status before
-        // popping the navigator.
-        if (!isCurrent) {
+        // removing the route.
+        if (!isActive) {
           navigator.finalizeRoute(this);
           assert(overlayEntries.isEmpty);
         }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -257,6 +257,7 @@ void main() {
 
   testWidgets('Back swipe dismiss interrupted by route push', (WidgetTester tester) async {
     final GlobalKey scaffoldKey = GlobalKey();
+
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.iOS),
@@ -289,10 +290,23 @@ void main() {
     expect(find.text('push'), findsNothing);
 
     TestGesture gesture = await tester.startGesture(const Offset(5, 300));
-    await gesture.moveBy(const Offset(400, 0)); // drag halfway
+    await gesture.moveBy(const Offset(400, 0));
     await gesture.up();
+    await tester.pump();
+    expect( // The 'route' route has been dragged to the right, halfway across the screen
+      tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(Scaffold))),
+      const Offset(400, 0),
+    );
+    expect( // The 'push' route is sliding in from the left.
+      tester.getTopLeft(find.ancestor(of: find.text('push'), matching: find.byType(Scaffold))).dx,
+      lessThan(0),
+    );
     await tester.pumpAndSettle();
     expect(find.text('push'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.ancestor(of: find.text('push'), matching: find.byType(Scaffold))),
+      Offset.zero,
+    );
     expect(find.text('route'), findsNothing);
 
 


### PR DESCRIPTION
Previously, if a new route was pushed before the iOS "back-swipe" dismiss animation was finished then the `_CupertinoBackGestureController` would mistakenly pop the new route when the animation actually did finish. 

Fixes https://github.com/flutter/flutter/issues/28728
Fixes https://github.com/flutter/flutter/issues/27334
