### PR TITLE
switch tool tests to build runner

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -143,7 +143,7 @@ Future<void> _runSmokeTests() async {
 Future<void> _runToolTests() async {
   await _runSmokeTests();
 
-  await _pubRunTest(
+  await _buildRunnerTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     enableFlutterToolAsserts: true,
   );
@@ -304,6 +304,38 @@ Future<void> _runCoverage() async {
   }
 
   print('${bold}DONE: Coverage collection successful.$reset');
+}
+
+Future<void> _buildRunnerTest(
+  String workingDirectory, {
+    String testPath,
+   bool enableFlutterToolAsserts = false,
+  }
+) {
+  final List<String> args = <String>['run', 'build_runner', 'test', '--', '-rcompact', '-j1'];
+  if (!hasColor) {
+    args.add('--no-color');
+  }
+  if (testPath != null) {
+    args.add(testPath);
+  }
+  final Map<String, String> pubEnvironment = <String, String>{};
+  if (Directory(pubCache).existsSync()) {
+    pubEnvironment['PUB_CACHE'] = pubCache;
+  }
+  if (enableFlutterToolAsserts) {
+    // If an existing env variable exists append to it, but only if
+    // it doesn't appear to already include enable-asserts.
+    String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
+    if (!toolsArgs.contains('--enable-asserts'))
+        toolsArgs += ' --enable-asserts';
+    pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
+  }
+  return runCommand(
+    pub, args,
+    workingDirectory: workingDirectory,
+    environment: pubEnvironment,
+  );
 }
 
 Future<void> _pubRunTest(

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -145,6 +145,7 @@ Future<void> _runToolTests() async {
 
   await _buildRunnerTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
+    flutterRoot,
     enableFlutterToolAsserts: true,
   );
 
@@ -307,8 +308,9 @@ Future<void> _runCoverage() async {
 }
 
 Future<void> _buildRunnerTest(
-  String workingDirectory, {
-    String testPath,
+  String workingDirectory,
+  String flutterRoot, {
+   String testPath,
    bool enableFlutterToolAsserts = false,
   }
 ) {
@@ -319,7 +321,9 @@ Future<void> _buildRunnerTest(
   if (testPath != null) {
     args.add(testPath);
   }
-  final Map<String, String> pubEnvironment = <String, String>{};
+  final Map<String, String> pubEnvironment = <String, String>{
+    'FLUTTER_ROOT': flutterRoot,
+  };
   if (Directory(pubCache).existsSync()) {
     pubEnvironment['PUB_CACHE'] = pubCache;
   }


### PR DESCRIPTION
## Description

Switch tool tests to use build_runner. The test execution should be noticeably faster, with the trade-off of doing compilation up front. The compilation artifacts can be shared across shards though, which should allow us to increase overall test throughput. 

| shard | pub test | build_runner test
|-|-|-|
| tool_tests-linux | 30 min | 24 min |
| tool_tests-windows | 35 min | 32 min |
| tool_tests-macos | 30 min |  25 min |

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
