### PR TITLE
Allow search page widget search field hint text and keyboard text input action to be customizable

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -89,6 +89,23 @@ Future<T> showSearch<T>({
 /// for another [showSearch] call.
 abstract class SearchDelegate<T> {
 
+  /// The type of action button to use for the keyboard.
+  ///
+  /// Defaults to the default value specified in [TextField].
+  TextInputType keyboardType;
+
+  /// The hint text to be displayed in the search bar, prompting the user to
+  /// enter an input.
+  ///
+  /// Defaults to null.
+  String hintText;
+
+  /// The text input action configuring the soft keyboard to a particular action
+  /// button.
+  ///
+  /// Defaults to [TextInputAction.search].
+  TextInputAction textInputAction = TextInputAction.search;
+
   /// Suggestions shown in the body of the search page while the user types a
   /// query into the search field.
   ///
@@ -417,7 +434,8 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = widget.delegate.appBarTheme(context);
-    final String searchFieldLabel = MaterialLocalizations.of(context).searchFieldLabel;
+    final String searchFieldLabel = widget.delegate.hintText ??
+      MaterialLocalizations.of(context).searchFieldLabel;
     Widget body;
     switch(widget.delegate._currentBody) {
       case _SearchBody.suggestions:
@@ -459,7 +477,8 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             controller: widget.delegate._queryTextController,
             focusNode: focusNode,
             style: theme.textTheme.title,
-            textInputAction: TextInputAction.search,
+            textInputAction: widget.delegate.textInputAction,
+            keyboardType: widget.delegate.keyboardType,
             onSubmitted: (String _) {
               widget.delegate.showResults(context);
             },

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -465,7 +465,7 @@ void main() {
     expect(selectedResults, <String>['Result Foo']);
   });
 
-  testWidgets('keyboard show search button', (WidgetTester tester) async {
+  testWidgets('keyboard shows search button by default', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -477,6 +477,20 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.search.toString());
+  });
+
+  testWidgets('keyboard shows corresponding button when text input action is set', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = _TestSearchDelegate(textInputAction: TextInputAction.done);
+
+    await tester.pumpWidget(TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    await tester.showKeyboard(find.byType(TextField));
+
+    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.done.toString());
   });
 
   group('contributes semantics', () {
@@ -639,7 +653,12 @@ class _TestSearchDelegate extends SearchDelegate<String> {
     this.suggestions = 'Suggestions',
     this.result = 'Result',
     this.actions = const <Widget>[],
-  });
+    TextInputAction textInputAction,
+  }) {
+    if (textInputAction != null) {
+      this.textInputAction = textInputAction;
+    }
+  }
 
   final String suggestions;
   final String result;


### PR DESCRIPTION
## Description

Currently, the search page widget's hint text and keyboard text input action are hardcoded to the material localization of 'Search' and the search text input action, respectively. This prevents further customization where search functionality is desired, but the nuance of the action isn't exactly "searching" (e.g. adding a location via Google Maps Places API autocomplete).

Added a `getHintText` function (that takes in a `BuildContext`) and a `textInputAction` field to `SearchDelegate`. These default to the previous hardcoded attributes that were present in `SearchPage`.

These changes are purely aesthetic changes; no additional functionality is provided.
All tests still pass.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
