### PR TITLE
Add timeout/retry logic to xcodebuild -list call

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -311,7 +311,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     modern: false,
   );
 
-  final XcodeProjectInfo projectInfo = xcodeProjectInterpreter.getInfo(app.project.hostAppRoot.path);
+  final XcodeProjectInfo projectInfo = await xcodeProjectInterpreter.getInfo(app.project.hostAppRoot.path);
   if (!projectInfo.targets.contains('Runner')) {
     printError('The Xcode project does not define target "Runner" which is needed by Flutter tooling.');
     printError('Open Xcode to fix the problem:');

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -167,18 +167,23 @@ class XcodeProjectInterpreter {
     // See: https://github.com/flutter/flutter/issues/28415
     String out;
     for (int i = 0; i < 5; i++) {
-      final RunResult result = await runCheckedAsync(
-        <String>[_executable, '-list'],
-        workingDirectory: projectPath,
-      ).timeout(const Duration(seconds: 10));
-      if (result.exitCode == 0) {
-        out = result.stdout;
-        break;
+      try {
+        final RunResult result = await runCheckedAsync(
+          <String>[_executable, '-list'],
+          workingDirectory: projectPath,
+        ).timeout(const Duration(seconds: 10));
+        if (result.exitCode == 0) {
+          out = result.stdout;
+          break;
+        }
+      } on TimeoutException {
+        continue;
       }
     }
-    // assume we timed out or failed.
+    // Assume we timed out or failed.
     if (out == null) {
-      throwToolExit('xcodebuild -list timed out');
+      throwToolExit(
+        'xcodebuild -list timed out. Please see flutter/issues/28415 for more context.');
     }
     return XcodeProjectInfo.fromXcodeBuildOutput(out);
   }

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -172,7 +172,7 @@ class XcodeProjectInterpreter {
           <String>[_executable, '-list'],
           workingDirectory: projectPath,
         ).timeout(const Duration(seconds: 10));
-        // Its okay for this call to fail - it will if the project is
+        // It's okay for this call to fail - it will if the project is
         // misconfigured. We just don't want it to timeout or hang.
         out = result.toString();
         break;

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -172,10 +172,10 @@ class XcodeProjectInterpreter {
           <String>[_executable, '-list'],
           workingDirectory: projectPath,
         ).timeout(const Duration(seconds: 10));
-        if (result.exitCode == 0) {
-          out = result.stdout;
-          break;
-        }
+        // Its okay for this call to fail - it will if the project is
+        // misconfigured. We just don't want it to timeout or hang.
+        out = result.toString();
+        break;
       } on TimeoutException {
         continue;
       }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -294,7 +294,7 @@ class MockXcodeProjectInterpreter implements XcodeProjectInterpreter {
   }
 
   @override
-  XcodeProjectInfo getInfo(String projectPath) {
+  Future<XcodeProjectInfo> getInfo(String projectPath) async {
     return XcodeProjectInfo(
       <String>['Runner'],
       <String>['Debug', 'Release'],


### PR DESCRIPTION
## Description

Many users are reporting flakiness (20% failure) in flutter builds on iOS that are caused when the call to xcodebuild -list times out. Until we understand the root cause of how this happens, we can smooth this over with some retry logic.

## Related Issues

https://github.com/flutter/flutter/issues/28415

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
