### PR TITLE
Form Snippet for API Docs

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -18,8 +18,7 @@ import 'will_pop_scope.dart';
 ///
 /// {@tool snippet --template=stateful_widget_material}
 /// This example shows a [Form] with one [TextFormField] and a [RaisedButton]. A
-/// [GlobalKey] is required to identify the [Form], and it is used here to
-/// validate input.
+/// [GlobalKey] is used here to identify the [Form] and validate input.
 ///
 /// ```dart
 /// final _formKey = GlobalKey<FormState>();

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -15,6 +15,56 @@ import 'will_pop_scope.dart';
 /// descendant of this [Form]. To obtain the [FormState], you may use [Form.of]
 /// with a context whose ancestor is the [Form], or pass a [GlobalKey] to the
 /// [Form] constructor and call [GlobalKey.currentState].
+///
+/// {@tool snippet --template=stateful_widget_material}
+/// This example shows a [Form] with one [TextFormField] and a [RaisedButton]. A
+/// [GlobalKey] is required to identify the [Form], and it is used here to
+/// validate input.
+///
+/// ```dart
+/// final _formKey = GlobalKey<FormState>();
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   // Build a Form widget using the _formKey we created above
+///   return Form(
+///     key: _formKey,
+///     child: Column(
+///       crossAxisAlignment: CrossAxisAlignment.start,
+///       children: <Widget>[
+///         TextFormField(
+///         validator: (value) {
+///         if (value.isEmpty) {
+///           return 'Please enter some text';
+///             }
+///           },
+///         ),
+///         Padding(
+///           padding: const EdgeInsets.symmetric(vertical: 16.0),
+///           child: RaisedButton(
+///             onPressed: () {
+///               // Validate will return true if the form is valid, or false if
+///               // the form is invalid.
+///               if (_formKey.currentState.validate()) {
+///                 // Process data.
+///               }
+///             },
+///             child: Text('Submit'),
+///           ),
+///         ),
+///       ],
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * [GlobalKey], a key that is unique across the entire app.
+///  * [FormField], a single form field widget that maintains the current state.
+///  * [TextFormField], a convenience widget that wraps a [TextField] widget in
+///  a [FormField].
+///
 class Form extends StatefulWidget {
   /// Creates a container for form fields.
   ///

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -26,16 +26,15 @@ import 'will_pop_scope.dart';
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   // Build a Form widget using the _formKey we created above
 ///   return Form(
 ///     key: _formKey,
 ///     child: Column(
 ///       crossAxisAlignment: CrossAxisAlignment.start,
 ///       children: <Widget>[
 ///         TextFormField(
-///         validator: (value) {
-///         if (value.isEmpty) {
-///           return 'Please enter some text';
+///           validator: (value) {
+///             if (value.isEmpty) {
+///               return 'Please enter some text';
 ///             }
 ///           },
 ///         ),
@@ -60,11 +59,10 @@ import 'will_pop_scope.dart';
 /// {@end-tool}
 ///
 /// See also:
+///
 ///  * [GlobalKey], a key that is unique across the entire app.
 ///  * [FormField], a single form field widget that maintains the current state.
-///  * [TextFormField], a convenience widget that wraps a [TextField] widget in
-///  a [FormField].
-///
+///  * [TextFormField], a convenience widget that wraps a [TextField] widget in a [FormField].
 class Form extends StatefulWidget {
   /// Creates a container for form fields.
   ///


### PR DESCRIPTION
## Description

This PR adds a code snippet for the Form class in he API docs. It also adds references to 'See also...' for other relevant widgets.

## Related Issues

Ref: #21136 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
