### PR TITLE
cupertino add french strings

### DIFF
--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -207,8 +207,13 @@ abstract class CupertinoLocalizations {
 class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {
   const _CupertinoLocalizationsDelegate();
 
+  const Set<String> kSupportedLanguages = <String>{
+    'en', // English
+    'fr', // French
+  };
+
   @override
-  bool isSupported(Locale locale) => <String>['en', 'fr'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => kSupportedLanguages.contains(locale.languageCode);
 
   @override
   Future<CupertinoLocalizations> load(Locale locale) {

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -208,16 +208,26 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
   const _CupertinoLocalizationsDelegate();
 
   @override
-  bool isSupported(Locale locale) => locale.languageCode == 'en';
+  bool isSupported(Locale locale) => <String>['en', 'fr'].contains(locale.languageCode);
 
   @override
-  Future<CupertinoLocalizations> load(Locale locale) => DefaultCupertinoLocalizations.load(locale);
+  Future<CupertinoLocalizations> load(Locale locale) {
+    switch (locale.languageCode) {
+      case 'fr':
+        return CupertinoLocalizationsFr.load(locale);
+        return SynchronousFuture<CupertinoLocalizations>(const CupertinoLocalizationsFr());
+      case 'en':
+      default:
+        return DefaultCupertinoLocalizations.load(locale);
+        return SynchronousFuture<CupertinoLocalizations>(const DefaultCupertinoLocalizations());
+    }
+  }
 
   @override
   bool shouldReload(_CupertinoLocalizationsDelegate old) => false;
 
   @override
-  String toString() => 'DefaultCupertinoLocalizations.delegate(en_US)';
+  String toString() => 'DefaultCupertinoLocalizations.delegate()';
 }
 
 /// US English strings for the cupertino widgets.
@@ -354,11 +364,155 @@ class DefaultCupertinoLocalizations implements CupertinoLocalizations {
   /// The [locale] parameter is ignored.
   ///
   /// This method is typically used to create a [LocalizationsDelegate].
-  static Future<CupertinoLocalizations> load(Locale locale) {
-    return SynchronousFuture<CupertinoLocalizations>(const DefaultCupertinoLocalizations());
-  }
+  static Future<CupertinoLocalizations> load(Locale locale) => SynchronousFuture<CupertinoLocalizations>(const DefaultCupertinoLocalizations());
 
   /// A [LocalizationsDelegate] that uses [DefaultCupertinoLocalizations.load]
   /// to create an instance of this class.
   static const LocalizationsDelegate<CupertinoLocalizations> delegate = _CupertinoLocalizationsDelegate();
 }
+
+/// French strings for the cupertino widgets.
+class CupertinoLocalizationsFr implements CupertinoLocalizations {
+  /// Constructs an object that defines the cupertino widgets' localized strings
+  /// for French.
+  ///
+  /// [LocalizationsDelegate] implementations typically call the static [load]
+  /// function, rather than constructing this class directly.
+  const CupertinoLocalizationsFr();
+
+  static const List<String> _shortWeekdays = <String>[
+    'Lun',
+    'Mar',
+    'Mer',
+    'Jeu',
+    'Ven',
+    'Sam',
+    'Dim',
+  ];
+
+  static const List<String> _shortMonths = <String>[
+    'Jan',
+    'Févr.',
+    'Mars',
+    'Avr.',
+    'Mai',
+    'Juin',
+    'Juil.',
+    'Août',
+    'Sept.',
+    'Oct.',
+    'Nov.',
+    'Déc.',
+  ];
+
+  static const List<String> _months = <String>[
+    'Janvier',
+    'Février',
+    'Mars',
+    'Avril',
+    'Mai',
+    'Juin',
+    'Juillet',
+    'Août',
+    'Septemebre',
+    'Octobre',
+    'Novembre',
+    'Décembre',
+  ];
+
+
+
+  @override
+  String datePickerYear(int yearIndex) => yearIndex.toString();
+
+  @override
+  String datePickerMonth(int monthIndex) => _months[monthIndex - 1];
+
+  @override
+  String datePickerDayOfMonth(int dayIndex) => dayIndex.toString();
+
+  @override
+  String datePickerHour(int hour) => hour.toString();
+
+  @override
+  String datePickerHourSemanticsLabel(int hour)  {
+    if (hour == 1)
+      return '1 heure';
+    return hour.toString() + ' heures';
+  }
+
+  @override
+  String datePickerMinute(int minute) => minute.toString().padLeft(2, '0');
+
+  @override
+  String datePickerMinuteSemanticsLabel(int minute) {
+    if (minute == 1)
+      return '1 minute';
+    return minute.toString() + ' minutes';
+  }
+
+  @override
+  String datePickerMediumDate(DateTime date) {
+    return '${_shortWeekdays[date.weekday - DateTime.monday]} '
+        '${_shortMonths[date.month - DateTime.january]} '
+        '${date.day.toString().padRight(2)}';
+  }
+
+  @override
+  DatePickerDateOrder get datePickerDateOrder => DatePickerDateOrder.mdy;
+
+  @override
+  DatePickerDateTimeOrder get datePickerDateTimeOrder => DatePickerDateTimeOrder.date_time_dayPeriod;
+
+  @override
+  String get anteMeridiemAbbreviation => 'AM';
+
+  @override
+  String get postMeridiemAbbreviation => 'PM';
+
+  @override
+  String get alertDialogLabel => 'Alerte';
+
+  @override
+  String timerPickerHour(int hour) => hour.toString();
+
+  @override
+  String timerPickerMinute(int minute) => minute.toString();
+
+  @override
+  String timerPickerSecond(int second) => second.toString();
+
+  @override
+  String timerPickerHourLabel(int hour) => hour == 1 ? 'heure' : 'heures';
+
+  @override
+  String timerPickerMinuteLabel(int minute) => 'min';
+
+  @override
+  String timerPickerSecondLabel(int second) => 'sec';
+
+  @override
+  String get cutButtonLabel => 'Couper';
+
+  @override
+  String get copyButtonLabel => 'Copier';
+
+  @override
+  String get pasteButtonLabel => 'Coller';
+
+  @override
+  String get selectAllButtonLabel => 'Sélectionner tout';
+
+  /// Creates an object that provides French resource values for the
+  /// cupertino library widgets.
+  ///
+  /// The [locale] parameter is ignored.
+  ///
+  /// This method is typically used to create a [LocalizationsDelegate].
+  static Future<CupertinoLocalizations> load(Locale locale) => SynchronousFuture<CupertinoLocalizations>(const CupertinoLocalizationsFr());
+
+  /// A [LocalizationsDelegate] that uses [DefaultCupertinoLocalizations.load]
+  /// to create an instance of this class.
+  static const LocalizationsDelegate<CupertinoLocalizations> delegate = _CupertinoLocalizationsDelegate();
+}
+

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -207,7 +207,7 @@ abstract class CupertinoLocalizations {
 class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {
   const _CupertinoLocalizationsDelegate();
 
-  const Set<String> kSupportedLanguages = <String>{
+  static const Set<String> kSupportedLanguages = <String>{
     'en', // English
     'fr', // French
   };

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -215,11 +215,9 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
     switch (locale.languageCode) {
       case 'fr':
         return CupertinoLocalizationsFr.load(locale);
-        return SynchronousFuture<CupertinoLocalizations>(const CupertinoLocalizationsFr());
       case 'en':
       default:
         return DefaultCupertinoLocalizations.load(locale);
-        return SynchronousFuture<CupertinoLocalizations>(const DefaultCupertinoLocalizations());
     }
   }
 


### PR DESCRIPTION
## Description

Addition of French strings for CupertinoLocalization

## Related Issues

#13452 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
