### PR TITLE
Fix crash on flutter update-packages

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -132,8 +132,12 @@ class UpdatePackagesCommand extends FlutterCommand {
     // package that is in the goldens repository. We need to make sure that the goldens
     // repository is cloned locally before we verify or update pubspecs.
     printStatus('Cloning goldens repository...');
-    final GoldensClient goldensClient = GoldensClient();
-    await goldensClient.prepare();
+    try {
+      final GoldensClient goldensClient = GoldensClient();
+      await goldensClient.prepare();
+    } on NonZeroExitCode catch (e) {
+      throwToolExit(e.stderr, exitCode: e.exitCode);
+    }
 
     if (isVerifyOnly) {
       bool needsUpdate = false;


### PR DESCRIPTION
When running git update-packages, if the goldens repo is dirty, the
flutter tool currently crashes and logs the failure from git pull.

This adds a check for a dirty git client and emits a friendlier error
message in the case where it's not clean, and avoid the crash by
catching the NonZeroExitCode exception and rethrowing as toolExit
instead.

Fixes: https://github.com/flutter/flutter/issues/28915