### PR TITLE
Add a `flutter create --list-samples` command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -97,8 +97,8 @@ class CreateCommand extends FlutterCommand {
     );
     argParser.addOption(
       'list-samples',
-      help: 'Specifies a file to output a list of Flutter code samples that can '
-        'be created with --sample to a JSON file.',
+      help: 'Specifies a JSON output file for a listing of Flutter code samples '
+        'that can created with --sample.',
       valueHelp: 'path',
     );
     argParser.addFlag(

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -185,6 +185,7 @@ class CreateCommand extends FlutterCommand {
     return null;
   }
 
+  /// The hostname for the Flutter docs for the current channel.
   String get _snippetsHost => FlutterVersion.instance.channel == 'stable'
         ? 'docs.flutter.io'
         : 'master-docs.flutter.io';
@@ -199,10 +200,13 @@ class CreateCommand extends FlutterCommand {
     return utf8.decode(await fetchUrl(Uri.https(_snippetsHost, 'snippets/$sampleId.dart')));
   }
 
+  /// Fetches the samples index file from the Flutter docs website.
   Future<String> _fetchSamplesIndexFromServer() async {
     return utf8.decode(await fetchUrl(Uri.https(_snippetsHost, 'snippets/index.json')));
   }
 
+  /// Fetches the samples index file from the server and writes it to
+  /// [outputFilePath].
   Future<void> _writeSamplesJson(String outputFilePath) async {
     try {
       final File outputFile = fs.file(outputFilePath);


### PR DESCRIPTION
## Description

Adds an option to `flutter create` to list the available samples. This is to be used by editors to get a list of valid samples without having to fetch them from the server themselves (which would require duplicating the logic for what the URL/hostname in the editors).

Called like this:

```
$ flutter create --list-samples samples.json
```

@pq @gspencergoog 

## Related Issues

- Fixes #28896.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
