### PR TITLE
Add more doc pointing to the EditableText's rudimentary nature around gesture handling

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -237,13 +237,13 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
 ///
 /// ## Gesture Events Handling
 ///
-/// This widget will provide rudimentary, platform-agnostic gesture event
-/// handling for user actions such as tapping, long pressing and scrolling when
+/// This widget provides rudimentary, platform-agnostic gesture handling for
+/// user actions such as tapping, long-pressing and scrolling when
 /// [rendererIgnoresPointer] is false (false by default). To tightly conform
-/// to the platform behavior with respect to gesture events in text fields, use
+/// to the platform behavior with respect to input gestures in text fields, use
 /// [TextField] or [CupertinoTextField]. For custom selection behavior, call
-/// APIs such as [RenderEditable.selectPosition], [RenderEditable.selectWord]
-/// etc programmatically.
+/// methods such as [RenderEditable.selectPosition],
+/// [RenderEditable.selectWord], etc. programmatically.
 ///
 /// See also:
 ///
@@ -490,13 +490,12 @@ class EditableText extends StatefulWidget {
   /// Optional delegate for building the text selection handles and toolbar.
   ///
   /// The [EditableText] widget used on its own will not trigger the display
-  /// of the selection toolbar by itself. The toolbar can be shown by
-  /// programmatically calling [EditableTextState.showToolbar] in response
-  /// to an appropriate user event.
+  /// of the selection toolbar by itself. The toolbar is shown by calling
+  /// [EditableTextState.showToolbar] in response to an appropriate user event.
   ///
   /// See also:
   ///
-  ///  * [CupertinoTextField], which wraps a [EditableText] and which shows the
+  ///  * [CupertinoTextField], which wraps an [EditableText] and which shows the
   ///    selection toolbar upon user events that are appropriate on the iOS
   ///    platform.
   ///  * [TextField], a Material Design themed wrapper of [EditableText], which

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -235,6 +235,16 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
 /// is a full-featured, material-design text input field with placeholder text,
 /// labels, and [Form] integration.
 ///
+/// ## Gesture Events Handling
+///
+/// This widget will provide rudimentary, platform-agnostic gesture event
+/// handling for user actions such as tapping, long pressing and scrolling when
+/// [rendererIgnoresPointer] is false (false by default). To tightly conform
+/// to the platform behavior with respect to gesture events in text fields, use
+/// [TextField] or [CupertinoTextField]. For custom selection behavior, call
+/// APIs such as [RenderEditable.selectPosition], [RenderEditable.selectWord]
+/// etc programmatically.
+///
 /// See also:
 ///
 ///  * [TextField], which is a full-featured, material-design text input field
@@ -478,6 +488,20 @@ class EditableText extends StatefulWidget {
   final Color selectionColor;
 
   /// Optional delegate for building the text selection handles and toolbar.
+  ///
+  /// The [EditableText] widget used on its own will not trigger the display
+  /// of the selection toolbar by itself. The toolbar can be shown by
+  /// programmatically calling [EditableTextState.showToolbar] in response
+  /// to an appropriate user event.
+  ///
+  /// See also:
+  ///
+  ///  * [CupertinoTextField], which wraps a [EditableText] and which shows the
+  ///    selection toolbar upon user events that are appropriate on the iOS
+  ///    platform.
+  ///  * [TextField], a Material Design themed wrapper of [EditableText], which
+  ///    shows the selection toolbar upon appropriate user events based on the
+  ///    user's platform set in [ThemeData.platform].
   final TextSelectionControls selectionControls;
 
   /// {@template flutter.widgets.editableText.keyboardType}


### PR DESCRIPTION
## Description

Add more docs for people using EditableText directly

## Related Issues

#28819

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
