### PR TITLE
Fix for post submit on cirrus

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -422,7 +422,7 @@ String _getCiProviderName() {
 int _getPrNumber() {
   switch(_getCiProvider()) {
     case CiProviders.cirrus:
-      return int.tryParse(Platform.environment['CIRRUS_PR']);
+      return int.tryParse(Platform.environment['CIRRUS_PR'] ?? -1);
     case CiProviders.luci:
       return -1; // LUCI doesn't know about this.
   }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -422,7 +422,9 @@ String _getCiProviderName() {
 int _getPrNumber() {
   switch(_getCiProvider()) {
     case CiProviders.cirrus:
-      return int.tryParse(Platform.environment['CIRRUS_PR'] ?? -1);
+      return Platform.environment['CIRRUS_PR'] == null
+          ? -1
+          : int.tryParse(Platform.environment['CIRRUS_PR']);
     case CiProviders.luci:
       return -1; // LUCI doesn't know about this.
   }


### PR DESCRIPTION
## Description

Cirrus doesn't set this env var on post submits.  `int.tryParse` blows up if it's passed null.

This will have to be landed on red.
`
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
