### PR TITLE
Fix coverage shard and print summary after test run

### DIFF
--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -37,6 +37,7 @@ Stream<String> runAndGetStdout(String executable, List<String> arguments, {
   int expectedExitCode,
   String failureMessage,
   Duration timeout = _kLongTimeout,
+  Function beforeExit,
 }) async* {
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
   final String relativeWorkingDir = path.relative(workingDirectory);
@@ -70,6 +71,7 @@ Stream<String> runAndGetStdout(String executable, List<String> arguments, {
             '${bold}Relative working directory:$red $relativeWorkingDir$reset\n'
             '$redLine'
     );
+    beforeExit?.call();
     exit(1);
   }
 }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -550,7 +550,8 @@ Future<void> _runFlutterTest(String workingDirectory, {
   if (flutterTestArgs != null && flutterTestArgs.isNotEmpty)
     args.addAll(flutterTestArgs);
 
-  if (!expectFailure) {
+  final bool shouldProcessOutput = !expectFailure && !options.contains('--coverage');
+  if (shouldProcessOutput) {
     args.add('--machine');
   }
 
@@ -568,7 +569,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
     }
     args.add(script);
   }
-  if (expectFailure) {
+  if (!shouldProcessOutput) {
     return runCommand(flutter, args,
       workingDirectory: workingDirectory,
       expectNonZeroExit: true,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -463,6 +463,7 @@ String _getGitHash() {
 Future<void> _processTestOutput(Stream<String> testOutput, bq.TabledataResourceApi tableData) async {
   final FlutterCompactFormatter formatter = FlutterCompactFormatter();
   await testOutput.forEach(formatter.processRawOutput);
+  formatter.finish();
   if (tableData == null || formatter.tests.isEmpty) {
     return;
   }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -538,7 +538,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
   if (flutterTestArgs != null && flutterTestArgs.isNotEmpty)
     args.addAll(flutterTestArgs);
 
-  if (!expectFailure) {
+  if (!expectFailure && !options.contains('--coverage')) {
     args.add('--machine');
   }
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -538,7 +538,8 @@ Future<void> _runFlutterTest(String workingDirectory, {
   if (flutterTestArgs != null && flutterTestArgs.isNotEmpty)
     args.addAll(flutterTestArgs);
 
-  if (!expectFailure && !options.contains('--coverage')) {
+  final bool shouldProcessOutput = !expectFailure && !options.contains('--coverage');
+  if (shouldProcessOutput) {
     args.add('--machine');
   }
 
@@ -556,7 +557,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
     }
     args.add(script);
   }
-  if (expectFailure) {
+  if (!shouldProcessOutput) {
     return runCommand(flutter, args,
       workingDirectory: workingDirectory,
       expectNonZeroExit: true,


### PR DESCRIPTION
## Description

This fixes the coverage shard on LUCI.  --machine Should not be used with coverage.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
