### PR TITLE
Moved the touch events expending to the flutter engine side

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -81,7 +81,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void _handlePointerDataPacket(ui.PointerDataPacket packet) {
     // We convert pointer data to logical pixels so that e.g. the touch slop can be
     // defined in a device-independent manner.
-    _pendingPointerEvents.addAll(PointerEventConverter.expand(packet.data, window.devicePixelRatio));
+    _pendingPointerEvents.addAll(PointerEventConverter.format(packet.data, window.devicePixelRatio));
     if (!locked)
       _flushPointerEventQueue();
   }

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -81,7 +81,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void _handlePointerDataPacket(ui.PointerDataPacket packet) {
     // We convert pointer data to logical pixels so that e.g. the touch slop can be
     // defined in a device-independent manner.
-    _pendingPointerEvents.addAll(PointerEventConverter.format(packet.data, window.devicePixelRatio));
+    _pendingPointerEvents.addAll(PointerEventConverter.expand(packet.data, window.devicePixelRatio));
     if (!locked)
       _flushPointerEventQueue();
   }

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -65,8 +65,7 @@ class PointerEventConverter {
     );
   }
 
-  static String _formatErrorMessage(ui.PointerChange change, String msg) => 'Invalid event \'$change\': $msg';
-
+  static String _formatErrorMessage(ui.PointerChange change, String message) => 'Invalid event \'$change\': $message';
 
   /// Format the given packet of pointer data into a framework
   /// pointer events.
@@ -75,8 +74,7 @@ class PointerEventConverter {
   /// [dart:ui.Window.devicePixelRatio]) is used to convert the incoming data
   /// from physical coordinates to logical pixels. See the discussion at
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
-  static List<PointerEvent> format(List<ui.PointerData> data, double devicePixelRatio) {
-    final List<PointerEvent> frameworkPointerData = <PointerEvent>[];
+  static Iterable<PointerEvent> expand(List<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);
@@ -93,22 +91,20 @@ class PointerEventConverter {
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} already exist.'));
             final _PointerState state = _ensureStateForPointer(datum, position);
             assert(state.lastPosition == position);
-            frameworkPointerData.add(
-                PointerAddedEvent(
-                  timeStamp: timeStamp,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  obscured: datum.obscured,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distance: datum.distance,
-                  distanceMax: datum.distanceMax,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                )
+            yield PointerAddedEvent(
+              timeStamp: timeStamp,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              obscured: datum.obscured,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
             );
             break;
           case ui.PointerChange.hover:
@@ -119,27 +115,25 @@ class PointerEventConverter {
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} is down.'));
             final Offset offset = position - state.lastPosition;
             state.lastPosition = position;
-            frameworkPointerData.add(
-                PointerHoverEvent(
-                  timeStamp: timeStamp,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  delta: offset,
-                  buttons: datum.buttons,
-                  obscured: datum.obscured,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distance: datum.distance,
-                  distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                )
+            yield PointerHoverEvent(
+              timeStamp: timeStamp,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              delta: offset,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
             );
             break;
           case ui.PointerChange.move:
@@ -150,29 +144,27 @@ class PointerEventConverter {
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} is up.'));
             final Offset offset = position - state.lastPosition;
             state.lastPosition = position;
-            frameworkPointerData.add(
-                PointerMoveEvent(
-                  timeStamp: timeStamp,
-                  pointer: state.pointer,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  delta: offset,
-                  buttons: datum.buttons,
-                  obscured: datum.obscured,
-                  pressure: datum.pressure,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                  platformData: datum.platformData,
-                )
+            yield PointerMoveEvent(
+              timeStamp: timeStamp,
+              pointer: state.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              delta: offset,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressure: datum.pressure,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
+              platformData: datum.platformData,
             );
             break;
           case ui.PointerChange.down:
@@ -185,27 +177,25 @@ class PointerEventConverter {
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} new position does not match previous position'));
             state.startNewPointer();
             state.setDown();
-            frameworkPointerData.add(
-                PointerDownEvent(
-                  timeStamp: timeStamp,
-                  pointer: state.pointer,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  buttons: datum.buttons,
-                  obscured: datum.obscured,
-                  pressure: datum.pressure,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                )
+            yield PointerDownEvent(
+              timeStamp: timeStamp,
+              pointer: state.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressure: datum.pressure,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
             );
             break;
           case ui.PointerChange.up:
@@ -217,28 +207,26 @@ class PointerEventConverter {
             assert(position == state.lastPosition,
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} new position does not match previous position'));
             state.setUp();
-            frameworkPointerData.add(
-                PointerUpEvent(
-                  timeStamp: timeStamp,
-                  pointer: state.pointer,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  buttons: datum.buttons,
-                  obscured: datum.obscured,
-                  pressure: datum.pressure,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distance: datum.distance,
-                  distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                )
+            yield PointerUpEvent(
+              timeStamp: timeStamp,
+              pointer: state.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressure: datum.pressure,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
             );
             break;
           case ui.PointerChange.cancel:
@@ -249,27 +237,25 @@ class PointerEventConverter {
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} is already up.'));
             assert(position == state.lastPosition,
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} new position does not match previous position'));
-            frameworkPointerData.add(
-                PointerCancelEvent(
-                  timeStamp: timeStamp,
-                  pointer: state.pointer,
-                  kind: kind,
-                  device: datum.device,
-                  position: position,
-                  buttons: datum.buttons,
-                  obscured: datum.obscured,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distance: datum.distance,
-                  distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                  orientation: datum.orientation,
-                  tilt: datum.tilt,
-                )
+            yield PointerCancelEvent(
+              timeStamp: timeStamp,
+              pointer: state.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
             );
             break;
           case ui.PointerChange.remove:
@@ -279,18 +265,16 @@ class PointerEventConverter {
             assert(!state.down,
               _formatErrorMessage(datum.change, 'Pointer ${datum.device} is down.'));
             _pointers.remove(datum.device);
-            frameworkPointerData.add(
-                PointerRemovedEvent(
-                  timeStamp: timeStamp,
-                  kind: kind,
-                  device: datum.device,
-                  obscured: datum.obscured,
-                  pressureMin: datum.pressureMin,
-                  pressureMax: datum.pressureMax,
-                  distanceMax: datum.distanceMax,
-                  radiusMin: radiusMin,
-                  radiusMax: radiusMax,
-                )
+            yield PointerRemovedEvent(
+              timeStamp: timeStamp,
+              kind: kind,
+              device: datum.device,
+              obscured: datum.obscured,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distanceMax: datum.distanceMax,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
             );
             break;
         }
@@ -303,14 +287,12 @@ class PointerEventConverter {
             assert(state.lastPosition == position);
             final Offset scrollDelta =
                 Offset(datum.scrollDeltaX, datum.scrollDeltaY) / devicePixelRatio;
-            frameworkPointerData.add(
-              PointerScrollEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                scrollDelta: scrollDelta,
-              )
+            yield PointerScrollEvent(
+              timeStamp: timeStamp,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              scrollDelta: scrollDelta,
             );
             break;
           case ui.PointerSignalKind.none:
@@ -322,7 +304,6 @@ class PointerEventConverter {
         }
       }
     }
-    return frameworkPointerData;
   }
 
   static double _toLogicalPixels(double physicalPixels, double devicePixelRatio) =>

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -19,22 +19,11 @@ class _PointerState {
     _pointer = _pointerCount;
   }
 
-  bool get down => _down;
-  bool _down = false;
-  void setDown() {
-    assert(!_down);
-    _down = true;
-  }
-  void setUp() {
-    assert(_down);
-    _down = false;
-  }
-
   Offset lastPosition;
 
   @override
   String toString() {
-    return '_PointerState(pointer: $pointer, down: $down, lastPosition: $lastPosition)';
+    return '_PointerState(pointer: $pointer, lastPosition: $lastPosition)';
   }
 }
 
@@ -65,14 +54,15 @@ class PointerEventConverter {
     );
   }
 
-  /// Expand the given packet of pointer data into a sequence of framework
+  /// format the given packet of pointer data into a framework
   /// pointer events.
   ///
   /// The `devicePixelRatio` argument (usually given the value from
   /// [dart:ui.Window.devicePixelRatio]) is used to convert the incoming data
   /// from physical coordinates to logical pixels. See the discussion at
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
-  static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
+  static List<PointerEvent> format(List<ui.PointerData> data, double devicePixelRatio) {
+    final List<PointerEvent> frameworkPointerData = <PointerEvent>[];
     for (ui.PointerData datum in data) {
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);
@@ -88,334 +78,31 @@ class PointerEventConverter {
             assert(!_pointers.containsKey(datum.device));
             final _PointerState state = _ensureStateForPointer(datum, position);
             assert(state.lastPosition == position);
-            yield PointerAddedEvent(
-              timeStamp: timeStamp,
-              kind: kind,
-              device: datum.device,
-              position: position,
-              obscured: datum.obscured,
-              pressureMin: datum.pressureMin,
-              pressureMax: datum.pressureMax,
-              distance: datum.distance,
-              distanceMax: datum.distanceMax,
-              radiusMin: radiusMin,
-              radiusMax: radiusMax,
-              orientation: datum.orientation,
-              tilt: datum.tilt,
-            );
-            break;
-          case ui.PointerChange.hover:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              assert(state.lastPosition == position);
-              yield PointerAddedEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            final Offset offset = position - state.lastPosition;
-            state.lastPosition = position;
-            yield PointerHoverEvent(
-              timeStamp: timeStamp,
-              kind: kind,
-              device: datum.device,
-              position: position,
-              delta: offset,
-              buttons: datum.buttons,
-              obscured: datum.obscured,
-              pressureMin: datum.pressureMin,
-              pressureMax: datum.pressureMax,
-              distance: datum.distance,
-              distanceMax: datum.distanceMax,
-              size: datum.size,
-              radiusMajor: radiusMajor,
-              radiusMinor: radiusMinor,
-              radiusMin: radiusMin,
-              radiusMax: radiusMax,
-              orientation: datum.orientation,
-              tilt: datum.tilt,
-            );
-            state.lastPosition = position;
-            break;
-          case ui.PointerChange.down:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              assert(state.lastPosition == position);
-              yield PointerAddedEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            if (state.lastPosition != position) {
-              // Not all sources of pointer packets respect the invariant that
-              // they hover the pointer to the down location before sending the
-              // down event. We restore the invariant here for our clients.
-              final Offset offset = position - state.lastPosition;
-              state.lastPosition = position;
-              yield PointerHoverEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                delta: offset,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-                synthesized: true,
-              );
-              state.lastPosition = position;
-            }
-            state.startNewPointer();
-            state.setDown();
-            yield PointerDownEvent(
-              timeStamp: timeStamp,
-              pointer: state.pointer,
-              kind: kind,
-              device: datum.device,
-              position: position,
-              buttons: datum.buttons,
-              obscured: datum.obscured,
-              pressure: datum.pressure,
-              pressureMin: datum.pressureMin,
-              pressureMax: datum.pressureMax,
-              distanceMax: datum.distanceMax,
-              size: datum.size,
-              radiusMajor: radiusMajor,
-              radiusMinor: radiusMinor,
-              radiusMin: radiusMin,
-              radiusMax: radiusMax,
-              orientation: datum.orientation,
-              tilt: datum.tilt,
-            );
-            break;
-          case ui.PointerChange.move:
-            // If the service starts supporting hover pointers, then it must also
-            // start sending us ADDED and REMOVED data points.
-            // See also: https://github.com/flutter/flutter/issues/720
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(state.down);
-            final Offset offset = position - state.lastPosition;
-            state.lastPosition = position;
-            yield PointerMoveEvent(
-              timeStamp: timeStamp,
-              pointer: state.pointer,
-              kind: kind,
-              device: datum.device,
-              position: position,
-              delta: offset,
-              buttons: datum.buttons,
-              obscured: datum.obscured,
-              pressure: datum.pressure,
-              pressureMin: datum.pressureMin,
-              pressureMax: datum.pressureMax,
-              distanceMax: datum.distanceMax,
-              size: datum.size,
-              radiusMajor: radiusMajor,
-              radiusMinor: radiusMinor,
-              radiusMin: radiusMin,
-              radiusMax: radiusMax,
-              orientation: datum.orientation,
-              tilt: datum.tilt,
-              platformData: datum.platformData,
-            );
-            break;
-          case ui.PointerChange.up:
-          case ui.PointerChange.cancel:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(state.down);
-            if (position != state.lastPosition) {
-              // Not all sources of pointer packets respect the invariant that
-              // they move the pointer to the up location before sending the up
-              // event. For example, in the iOS simulator, of you drag outside the
-              // window, you'll get a stream of pointers that violates that
-              // invariant. We restore the invariant here for our clients.
-              final Offset offset = position - state.lastPosition;
-              state.lastPosition = position;
-              yield PointerMoveEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                delta: offset,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressure: datum.pressure,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-                synthesized: true,
-              );
-              state.lastPosition = position;
-            }
-            assert(position == state.lastPosition);
-            state.setUp();
-            if (datum.change == ui.PointerChange.up) {
-              yield PointerUpEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressure: datum.pressure,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            } else {
-              yield PointerCancelEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            break;
-          case ui.PointerChange.remove:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            if (state.down) {
-              yield PointerCancelEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            _pointers.remove(datum.device);
-            yield PointerRemovedEvent(
-              timeStamp: timeStamp,
-              kind: kind,
-              device: datum.device,
-              obscured: datum.obscured,
-              pressureMin: datum.pressureMin,
-              pressureMax: datum.pressureMax,
-              distanceMax: datum.distanceMax,
-              radiusMin: radiusMin,
-              radiusMax: radiusMax,
-            );
-            break;
-        }
-      } else {
-        switch (datum.signalKind) {
-          case ui.PointerSignalKind.scroll:
-            // Devices must be added before they send scroll events.
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            if (state.lastPosition != position) {
-              // Synthesize a hover/move of the pointer to the scroll location
-              // before sending the scroll event, if necessary, so that clients
-              // don't have to worry about native ordering of hover and scroll
-              // events.
-              final Offset offset = position - state.lastPosition;
-              state.lastPosition = position;
-              if (state.down) {
-                yield PointerMoveEvent(
+            frameworkPointerData.add(
+                PointerAddedEvent(
                   timeStamp: timeStamp,
-                  pointer: state.pointer,
                   kind: kind,
                   device: datum.device,
                   position: position,
-                  delta: offset,
-                  buttons: datum.buttons,
                   obscured: datum.obscured,
                   pressureMin: datum.pressureMin,
                   pressureMax: datum.pressureMax,
+                  distance: datum.distance,
                   distanceMax: datum.distanceMax,
-                  size: datum.size,
-                  radiusMajor: radiusMajor,
-                  radiusMinor: radiusMinor,
                   radiusMin: radiusMin,
                   radiusMax: radiusMax,
                   orientation: datum.orientation,
                   tilt: datum.tilt,
-                  synthesized: true,
-                );
-              } else {
-                yield PointerHoverEvent(
+                )
+            );
+            break;
+          case ui.PointerChange.hover:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            final Offset offset = position - state.lastPosition;
+            state.lastPosition = position;
+            frameworkPointerData.add(
+                PointerHoverEvent(
                   timeStamp: timeStamp,
                   kind: kind,
                   device: datum.device,
@@ -434,29 +121,169 @@ class PointerEventConverter {
                   radiusMax: radiusMax,
                   orientation: datum.orientation,
                   tilt: datum.tilt,
-                  synthesized: true,
-                );
-              }
-            }
+                )
+            );
+            break;
+          case ui.PointerChange.move:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            final Offset offset = position - state.lastPosition;
+            state.lastPosition = position;
+            frameworkPointerData.add(
+                PointerMoveEvent(
+                  timeStamp: timeStamp,
+                  pointer: state.pointer,
+                  kind: kind,
+                  device: datum.device,
+                  position: position,
+                  delta: offset,
+                  buttons: datum.buttons,
+                  obscured: datum.obscured,
+                  pressure: datum.pressure,
+                  pressureMin: datum.pressureMin,
+                  pressureMax: datum.pressureMax,
+                  distanceMax: datum.distanceMax,
+                  size: datum.size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: datum.orientation,
+                  tilt: datum.tilt,
+                  platformData: datum.platformData,
+                )
+            );
+            break;
+          case ui.PointerChange.down:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            assert(position == state.lastPosition);
+            state.startNewPointer();
+            frameworkPointerData.add(
+                PointerDownEvent(
+                  timeStamp: timeStamp,
+                  pointer: state.pointer,
+                  kind: kind,
+                  device: datum.device,
+                  position: position,
+                  buttons: datum.buttons,
+                  obscured: datum.obscured,
+                  pressure: datum.pressure,
+                  pressureMin: datum.pressureMin,
+                  pressureMax: datum.pressureMax,
+                  distanceMax: datum.distanceMax,
+                  size: datum.size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: datum.orientation,
+                  tilt: datum.tilt,
+                )
+            );
+            break;
+          case ui.PointerChange.up:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            assert(position == state.lastPosition);
+            frameworkPointerData.add(
+                PointerUpEvent(
+                  timeStamp: timeStamp,
+                  pointer: state.pointer,
+                  kind: kind,
+                  device: datum.device,
+                  position: position,
+                  buttons: datum.buttons,
+                  obscured: datum.obscured,
+                  pressure: datum.pressure,
+                  pressureMin: datum.pressureMin,
+                  pressureMax: datum.pressureMax,
+                  distance: datum.distance,
+                  distanceMax: datum.distanceMax,
+                  size: datum.size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: datum.orientation,
+                  tilt: datum.tilt,
+                )
+            );
+            break;
+          case ui.PointerChange.cancel:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            assert(position == state.lastPosition);
+            frameworkPointerData.add(
+                PointerCancelEvent(
+                  timeStamp: timeStamp,
+                  pointer: state.pointer,
+                  kind: kind,
+                  device: datum.device,
+                  position: position,
+                  buttons: datum.buttons,
+                  obscured: datum.obscured,
+                  pressureMin: datum.pressureMin,
+                  pressureMax: datum.pressureMax,
+                  distance: datum.distance,
+                  distanceMax: datum.distanceMax,
+                  size: datum.size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: datum.orientation,
+                  tilt: datum.tilt,
+                )
+            );
+            break;
+          case ui.PointerChange.remove:
+            assert(_pointers.containsKey(datum.device));
+            _pointers.remove(datum.device);
+            frameworkPointerData.add(
+                PointerRemovedEvent(
+                  timeStamp: timeStamp,
+                  kind: kind,
+                  device: datum.device,
+                  obscured: datum.obscured,
+                  pressureMin: datum.pressureMin,
+                  pressureMax: datum.pressureMax,
+                  distanceMax: datum.distanceMax,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                )
+            );
+            break;
+        }
+      } else {
+        switch (datum.signalKind) {
+          case ui.PointerSignalKind.scroll:
+            //Devices must be added before they send scroll events.
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _ensureStateForPointer(datum, position);
+            assert(state.lastPosition == position);
             final Offset scrollDelta =
                 Offset(datum.scrollDeltaX, datum.scrollDeltaY) / devicePixelRatio;
-            yield PointerScrollEvent(
-              timeStamp: timeStamp,
-              kind: kind,
-              device: datum.device,
-              position: position,
-              scrollDelta: scrollDelta,
+            frameworkPointerData.add(
+              PointerScrollEvent(
+                timeStamp: timeStamp,
+                kind: kind,
+                device: datum.device,
+                position: position,
+                scrollDelta: scrollDelta,
+              )
             );
             break;
           case ui.PointerSignalKind.none:
             assert(false); // This branch should already have 'none' filtered out.
             break;
           case ui.PointerSignalKind.unknown:
-            // Ignore unknown signals.
+          // Ignore unknown signals.
             break;
         }
       }
     }
+    return frameworkPointerData;
   }
 
   static double _toLogicalPixels(double physicalPixels, double devicePixelRatio) =>

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -150,7 +150,7 @@ void main() {
         ]
     );
 
-    final List<PointerEvent> events = PointerEventConverter.format(
+    final List<PointerEvent> events = PointerEventConverter.expand(
         packet.data, ui.window.devicePixelRatio).toList();
 
     expect(events.length, 2);

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -24,6 +24,7 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding {
 
   static const ui.PointerDataPacket packet = ui.PointerDataPacket(
     data: <ui.PointerData>[
+      ui.PointerData(change: ui.PointerChange.add),
       ui.PointerData(change: ui.PointerChange.down),
       ui.PointerData(change: ui.PointerChange.up),
     ]

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -63,7 +63,13 @@ void main() {
     });
 
     test('receives and processes mouse hover events', () {
-      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+      const ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+            change: ui.PointerChange.add,
+            device: 0,
+        ),
+      ]);
+      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
           physicalX: 0.0 * ui.window.devicePixelRatio,
@@ -71,7 +77,7 @@ void main() {
           kind: PointerDeviceKind.mouse,
         ),
       ]);
-      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      final ui.PointerDataPacket packet3 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
           physicalX: 1.0 * ui.window.devicePixelRatio,
@@ -79,13 +85,19 @@ void main() {
           kind: PointerDeviceKind.mouse,
         ),
       ]);
-      const ui.PointerDataPacket packet3 = ui.PointerDataPacket(data: <ui.PointerData>[
+      const ui.PointerDataPacket packet4 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.remove,
           kind: PointerDeviceKind.mouse,
         ),
       ]);
-      final ui.PointerDataPacket packet4 = ui.PointerDataPacket(data: <ui.PointerData>[
+      const ui.PointerDataPacket packet5 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.add,
+          device: 0,
+        ),
+      ]);
+      final ui.PointerDataPacket packet6 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
           physicalX: 1.0 * ui.window.devicePixelRatio,
@@ -93,7 +105,13 @@ void main() {
           kind: PointerDeviceKind.mouse,
         ),
       ]);
-      final ui.PointerDataPacket packet5 = ui.PointerDataPacket(data: <ui.PointerData>[
+      const ui.PointerDataPacket packet7 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.add,
+          device: 1,
+        ),
+      ]);
+      final ui.PointerDataPacket packet8 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
           physicalX: 1.0 * ui.window.devicePixelRatio,
@@ -102,9 +120,23 @@ void main() {
           device: 1,
         ),
       ]);
+      const ui.PointerDataPacket packet9 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.remove,
+          kind: PointerDeviceKind.mouse,
+          device: 1
+        ),
+      ]);
+      const ui.PointerDataPacket packet10 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.remove,
+          kind: PointerDeviceKind.mouse,
+        ),
+      ]);
       tracker.attachAnnotation(annotation);
       isInHitRegion = true;
       ui.window.onPointerDataPacket(packet1);
+      ui.window.onPointerDataPacket(packet2);
       tracker.collectMousePositions();
       expect(enter.length, equals(1), reason: 'enter contains $enter');
       expect(enter.first.position, equals(const Offset(0.0, 0.0)));
@@ -117,7 +149,7 @@ void main() {
       expect(move.first.runtimeType, equals(PointerHoverEvent));
       clear();
 
-      ui.window.onPointerDataPacket(packet2);
+      ui.window.onPointerDataPacket(packet3);
       tracker.collectMousePositions();
       expect(enter.length, equals(0), reason: 'enter contains $enter');
       expect(exit.length, equals(0), reason: 'exit contains $exit');
@@ -127,7 +159,7 @@ void main() {
       expect(move.first.runtimeType, equals(PointerHoverEvent));
       clear();
 
-      ui.window.onPointerDataPacket(packet3);
+      ui.window.onPointerDataPacket(packet4);
       tracker.collectMousePositions();
       expect(enter.length, equals(0), reason: 'enter contains $enter');
       expect(move.length, equals(0), reason: 'move contains $move');
@@ -137,7 +169,8 @@ void main() {
       expect(exit.first.runtimeType, equals(PointerExitEvent));
 
       clear();
-      ui.window.onPointerDataPacket(packet4);
+      ui.window.onPointerDataPacket(packet5);
+      ui.window.onPointerDataPacket(packet6);
       tracker.collectMousePositions();
       expect(enter.length, equals(1), reason: 'enter contains $enter');
       expect(enter.first.position, equals(const Offset(1.0, 201.0)));
@@ -151,7 +184,8 @@ void main() {
 
       // add in a second mouse simultaneously.
       clear();
-      ui.window.onPointerDataPacket(packet5);
+      ui.window.onPointerDataPacket(packet7);
+      ui.window.onPointerDataPacket(packet8);
       tracker.collectMousePositions();
       expect(enter.length, equals(1), reason: 'enter contains $enter');
       expect(enter.first.position, equals(const Offset(1.0, 301.0)));
@@ -165,8 +199,22 @@ void main() {
       expect(move.last.position, equals(const Offset(1.0, 301.0)));
       expect(move.last.device, equals(1));
       expect(move.last.runtimeType, equals(PointerHoverEvent));
+
+      clear();
+      ui.window.onPointerDataPacket(packet9);
+      ui.window.onPointerDataPacket(packet10);
+      clear();
     });
     test('detects exit when annotated layer no longer hit', () {
+      const ui.PointerDataPacket addPointer0 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(change: ui.PointerChange.add),
+      ]);
+      const ui.PointerDataPacket removePointer0 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(
+          change: ui.PointerChange.remove,
+          kind: PointerDeviceKind.mouse,
+        ),
+      ]);
       final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
@@ -191,7 +239,7 @@ void main() {
       ]);
       isInHitRegion = true;
       tracker.attachAnnotation(annotation);
-
+      ui.window.onPointerDataPacket(addPointer0);
       ui.window.onPointerDataPacket(packet1);
       tracker.collectMousePositions();
       expect(enter.length, equals(1), reason: 'enter contains $enter');
@@ -215,8 +263,14 @@ void main() {
       expect(exit.first.position, const Offset(1.0, 201.0));
       expect(exit.first.device, equals(0));
       expect(exit.first.runtimeType, equals(PointerExitEvent));
+      clear();
+      ui.window.onPointerDataPacket(removePointer0);
+      clear();
     });
     test('detects exit when mouse goes away', () {
+      const ui.PointerDataPacket addPointer0 = ui.PointerDataPacket(data: <ui.PointerData>[
+        ui.PointerData(change: ui.PointerChange.add),
+      ]);
       final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.hover,
@@ -231,7 +285,7 @@ void main() {
           kind: PointerDeviceKind.mouse,
         ),
       ]);
-      const ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      const ui.PointerDataPacket removePointer0 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(
           change: ui.PointerChange.remove,
           kind: PointerDeviceKind.mouse,
@@ -239,9 +293,10 @@ void main() {
       ]);
       isInHitRegion = true;
       tracker.attachAnnotation(annotation);
+      ui.window.onPointerDataPacket(addPointer0);
       ui.window.onPointerDataPacket(packet1);
       tracker.collectMousePositions();
-      ui.window.onPointerDataPacket(packet2);
+      ui.window.onPointerDataPacket(removePointer0);
       tracker.collectMousePositions();
       expect(enter.length, equals(1), reason: 'enter contains $enter');
       expect(enter.first.position, equals(const Offset(1.0, 101.0)));


### PR DESCRIPTION
## Description

This decision came up when we try to deal with https://github.com/flutter/flutter/issues/20517
We decide the logic that normalize the touch events should reside in flutter/engine instead of flutter/flutter.
Engine should have platform specific code to ensure the clean touch events sent to flutter/flutter.


## Related Issues

https://github.com/flutter/flutter/issues/20517

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
