### PR TITLE
Fix MouseTracker annotation leak

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -124,7 +124,7 @@ class MouseTracker {
     for (int deviceId in trackedAnnotation.activeDevices) {
       annotation.onExit(PointerExitEvent.fromHoverEvent(_lastMouseEvent[deviceId]));
     }
-    _trackedAnnotations.remove(trackedAnnotation);
+    _trackedAnnotations.remove(annotation);
   }
 
   void _scheduleMousePositionCheck() {
@@ -169,6 +169,12 @@ class MouseTracker {
         'Unable to find annotation $annotation in tracked annotations. '
         'Check that attachAnnotation has been called for all annotated layers.');
     return trackedAnnotation;
+  }
+
+  /// Checks if the given [MouseTrackerAnnotation] is attached to this
+  /// [MouseTracker].
+  bool isAnnotationAttached(MouseTrackerAnnotation annotation) {
+    return _trackedAnnotations[annotation] != null;
   }
 
   /// Tells interested objects that a mouse has entered, exited, or moved, given

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -173,6 +173,10 @@ class MouseTracker {
 
   /// Checks if the given [MouseTrackerAnnotation] is attached to this
   /// [MouseTracker].
+  ///
+  /// This function is only public to allow for proper testing of the
+  /// MouseTracker. Do not call in other contexts.
+  @visibleForTesting
   bool isAnnotationAttached(MouseTrackerAnnotation annotation) {
     return _trackedAnnotations[annotation] != null;
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2582,6 +2582,13 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
   // Object used for annotation of the layer used for hover hit detection.
   MouseTrackerAnnotation _hoverAnnotation;
 
+  /// Object used for annotation of the layer used for hover hit detection.
+  ///
+  /// This is only public to allow for testing of Listener widgets. Do not call
+  /// in other contexts.
+  @visibleForTesting
+  MouseTrackerAnnotation get hoverAnnotation => _hoverAnnotation;
+
   void _updateAnnotations() {
     if (_hoverAnnotation != null && attached) {
       RendererBinding.instance.mouseTracker.detachAnnotation(_hoverAnnotation);

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -112,7 +112,7 @@ void main() {
           onPointerExit: (PointerExitEvent details) => exit = details,
         ),
       ));
-      final RenderPointerListener renderListener = listenerKey.currentContext.findRenderObject();
+      final RenderPointerListener renderListener = tester.renderObject(find.byType(Listener));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -129,7 +129,7 @@ void main() {
       ));
       expect(exit, isNotNull);
       expect(exit.position, equals(const Offset(400.0, 300.0)));
-      expect(WidgetsBinding.instance.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
     });
   });
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
@@ -98,8 +99,10 @@ void main() {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
+      final GlobalKey listenerKey = GlobalKey();
       await tester.pumpWidget(Center(
         child: Listener(
+          key: listenerKey,
           child: Container(
             width: 100.0,
             height: 100.0,
@@ -109,6 +112,7 @@ void main() {
           onPointerExit: (PointerExitEvent details) => exit = details,
         ),
       ));
+      final RenderPointerListener renderListener = listenerKey.currentContext.findRenderObject();
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -125,6 +129,7 @@ void main() {
       ));
       expect(exit, isNotNull);
       expect(exit.position, equals(const Offset(400.0, 300.0)));
+      expect(WidgetsBinding.instance.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
     });
   });
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -99,10 +99,8 @@ void main() {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
-      final GlobalKey listenerKey = GlobalKey();
       await tester.pumpWidget(Center(
         child: Listener(
-          key: listenerKey,
           child: Container(
             width: 100.0,
             height: 100.0,


### PR DESCRIPTION
## Description

MouseTracker had a bug where `Map.remove` was being called with a value instead of a key, causing widgets and their state to leak (if it used a Listener).

Changed the existing pointer listener test to check if the annotation has been removed from the MouseTracker.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
