### PR TITLE
Fix #28887: change URL from flutter.io to flutter.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Flutter is Google’s mobile app SDK for crafting high-quality native interfaces
 
 ### Documentation
 
-**Main site: [flutter.io][]**
-* [Install](https://flutter.io/get-started/install/)
-* [Get started](https://flutter.io/get-started/)
-* [API documentation](https://docs.flutter.io/)
+**Main site: [flutter.dev][]**
+* [Install](https://flutter.dev/get-started/install/)
+* [Get started](https://flutter.dev/get-started/)
+* [API documentation](https://docs.flutter.dev/)
 * [Changelog](https://github.com/flutter/flutter/wiki/Changelog)
 * [How to contribute](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
 
@@ -47,7 +47,7 @@ smooth natural scrolling, and platform awareness.
 [<img src="https://github.com/flutter/website/blob/master/src/images/homepage/screenshot-3.png" width="270" height="480" alt="Contact app design" align="left">](https://github.com/flutter/flutter/blob/master/examples/flutter_gallery/lib/demo/contacts_demo.dart)
 [<img src="https://github.com/flutter/website/blob/master/src/images/homepage/ios-friendlychat.png" width="270" height="480" alt="iOS chat app design">](https://codelabs.developers.google.com/codelabs/flutter/)
 
-Browse the <a href="https://flutter.io/widgets/">widget catalog</a>.
+Browse the <a href="https://flutter.dev/widgets/">widget catalog</a>.
 
 ## Modern, reactive framework
 
@@ -89,9 +89,9 @@ class CounterState extends State<Counter> {
 }
 ```
 
-Browse the <a href="https://flutter.io/widgets/">widget catalog</a>
+Browse the <a href="https://flutter.dev/widgets/">widget catalog</a>
 and learn more about the
-<a href="https://flutter.io/widgets-intro/">functional-reactive framework</a>.
+<a href="https://flutter.dev/widgets-intro/">functional-reactive framework</a>.
 
 ## Access native features and SDKs
 
@@ -118,8 +118,8 @@ Future<void> getBatteryLevel() async {
 }
 ```
 
-Learn how to use <a href="https://flutter.io/using-packages/">packages</a> or
-write <a href="https://flutter.io/platform-channels/">platform channels</a>
+Learn how to use <a href="https://flutter.dev/using-packages/">packages</a> or
+write <a href="https://flutter.dev/platform-channels/">platform channels</a>
 to access native code, APIs, and SDKs.
 
 ## Unified app development
@@ -133,7 +133,7 @@ you can use Flutter for your views and leverage much of your
 existing Java/Kotlin/ObjC/Swift investment.
 
 Learn more about what makes Flutter special in the
-<a href="https://flutter.io/technical-overview/">technical overview</a>.
+<a href="https://flutter.dev/technical-overview/">technical overview</a>.
 
 # More resources
 
@@ -146,7 +146,7 @@ To join the team working on Flutter, see our [contributor guide](CONTRIBUTING.md
 
 [Build Status - Cirrus]: https://api.cirrus-ci.com/github/flutter/flutter.svg
 [Build status]: https://cirrus-ci.com/github/flutter/flutter/master
-[flutter.io]: https://flutter.io
+[flutter.dev]: https://flutter.dev
 [Flutter logo]: https://github.com/dart-lang/site-shared/blob/master/src/_assets/image/flutter/icon/64.png?raw=1
 [Gitter Channel]: https://badges.gitter.im/flutter/flutter.svg
 [Gitter badge]: https://gitter.im/flutter/flutter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
## Description

Since Flutter's new home URL is changed from flutter.io to flutter.dev, hence README should be updated to reflect the new URL.

## Related Issues

No issue created, yet. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
