### PR TITLE
re-enable dart2js test

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -191,22 +191,21 @@ Future<void> _runBuildTests() async {
     await _flutterBuildApk(path);
     await _flutterBuildIpa(path);
   }
-  // TODO(jonahwilliams): re-enable when engine rolls.
-  //await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'));
+  await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'));
 
   print('${bold}DONE: All build tests successful.$reset');
 }
 
-// Future<void> _flutterBuildDart2js(String relativePathToApplication) async {
-//   print('Running Dart2JS build tests...');
-//   await runCommand(flutter,
-//     <String>['build', 'web', '-v'],
-//     workingDirectory: path.join(flutterRoot, relativePathToApplication),
-//     expectNonZeroExit: false,
-//     timeout: _kShortTimeout,
-//   );
-//   print('Done.');
-// }
+Future<void> _flutterBuildDart2js(String relativePathToApplication) async {
+  print('Running Dart2JS build tests...');
+  await runCommand(flutter,
+    <String>['build', 'web', '-v'],
+    workingDirectory: path.join(flutterRoot, relativePathToApplication),
+    expectNonZeroExit: false,
+    timeout: _kShortTimeout,
+  );
+  print('Done.');
+}
 
 Future<void> _flutterBuildAot(String relativePathToApplication) async {
   print('Running AOT build tests...');

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -73,9 +73,9 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
     case Artifact.engineDartBinary:
       return 'dart';
     case Artifact.dart2jsSnapshot:
-      return 'flutter_dart2js.dart.snapshot';
+      return 'dart2js.dart.snapshot';
     case Artifact.kernelWorkerSnapshot:
-      return 'flutter_kernel_worker.dart.snapshot';
+      return 'kernel_worker.dart.snapshot';
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../base/common.dart';
 import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart';
@@ -33,6 +34,9 @@ class BuildWebCommand extends BuildSubCommand {
     final Status status = logger.startProgress('Compiling $target to JavaScript...', timeout: null);
     final int result = await webCompiler.compile(target: target);
     status.stop();
-    return FlutterCommandResult(result == 0 ? ExitStatus.success : ExitStatus.fail);
+    if (result != 0) {
+      throwToolExit('JavaScript compilation failed.');
+    }
+    return null;
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -8,7 +8,7 @@ import '../base/common.dart';
 import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart';
-import '../runner/flutter_command.dart' show ExitStatus, FlutterCommandResult;
+import '../runner/flutter_command.dart' show FlutterCommandResult;
 import '../web/compile.dart';
 import 'build.dart';
 


### PR DESCRIPTION
## Description

Re-enable compilation to JavaScript test now that we are on the full SDK

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
