### PR TITLE
Fix CupertinoTabView tree re-shape on view inset change

### DIFF
--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -194,14 +194,12 @@ class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> {
       tabNumber: widget.tabBar.items.length,
       tabBuilder: widget.tabBuilder,
     );
+    EdgeInsets contentPadding = EdgeInsets.zero;
 
     if (widget.resizeToAvoidBottomInset) {
       // Remove the view inset and add it back as a padding in the inner content.
       newMediaQuery = newMediaQuery.removeViewInsets(removeBottom: true);
-      content = Padding(
-        padding: EdgeInsets.only(bottom: existingMediaQuery.viewInsets.bottom),
-        child: content,
-      );
+      contentPadding = EdgeInsets.only(bottom: existingMediaQuery.viewInsets.bottom);
     }
 
     if (widget.tabBar != null &&
@@ -219,10 +217,7 @@ class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> {
       // translucent, let main content draw behind the tab bar but hint the
       // obstructed area.
       if (widget.tabBar.opaque(context)) {
-        content = Padding(
-          padding: EdgeInsets.only(bottom: bottomPadding),
-          child: content,
-        );
+        contentPadding = EdgeInsets.only(bottom: bottomPadding);
       } else {
         newMediaQuery = newMediaQuery.copyWith(
           padding: newMediaQuery.padding.copyWith(
@@ -234,7 +229,10 @@ class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> {
 
     content = MediaQuery(
       data: newMediaQuery,
-      child: content,
+      child: Padding(
+        padding: contentPadding,
+        child: content,
+      ),
     );
 
     // The main content being at the bottom is added to the stack first.

--- a/packages/flutter/test/cupertino/README.md
+++ b/packages/flutter/test/cupertino/README.md
@@ -3,5 +3,8 @@
 Avoid importing the Material 'package:flutter/material.dart' in these tests as
 we're trying to test the Cupertino package in standalone scenarios.
 
-Some tests may be replicated in the Material tests when Material reuses
+The 'material' subdirectory contains tests for cross-interactions of Material
+Cupertino widgets in hybridized apps.
+
+Some tests may also be replicated in the Material tests when Material reuses
 Cupertino components on iOS such as page transitions and text editing.

--- a/packages/flutter/test/cupertino/material/README.md
+++ b/packages/flutter/test/cupertino/material/README.md
@@ -1,0 +1,4 @@
+# Tests for the Cupertino+Material mixed usages
+
+In this package, we test for interactions between Material and Cupertino
+widgets.

--- a/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
@@ -187,7 +187,7 @@ void main() {
             child: CupertinoTabScaffold(
               tabBar: _buildTabBar(),
               tabBuilder: (BuildContext context, int index) {
-                return TextField();
+                return const TextField();
               },
             ),
           ),
@@ -209,7 +209,7 @@ void main() {
             child: CupertinoTabScaffold(
               tabBar: _buildTabBar(),
               tabBuilder: (BuildContext context, int index) {
-                return TextField();
+                return const TextField();
               },
             ),
           ),

--- a/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
@@ -1,0 +1,241 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../painting/mocks_for_image_cache.dart';
+
+List<int> selectedTabs;
+
+void main() {
+  setUp(() {
+    selectedTabs = <int>[];
+  });
+
+  testWidgets('Last tab gets focus', (WidgetTester tester) async {
+    // 2 nodes for 2 tabs
+    final List<FocusNode> focusNodes = <FocusNode>[FocusNode(), FocusNode()];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CupertinoTabScaffold(
+            tabBar: _buildTabBar(),
+            tabBuilder: (BuildContext context, int index) {
+              return TextField(
+                focusNode: focusNodes[index],
+                autofocus: true,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(focusNodes[0].hasFocus, isTrue);
+
+    await tester.tap(find.text('Tab 2'));
+    await tester.pump();
+
+    expect(focusNodes[0].hasFocus, isFalse);
+    expect(focusNodes[1].hasFocus, isTrue);
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump();
+
+    expect(focusNodes[0].hasFocus, isTrue);
+    expect(focusNodes[1].hasFocus, isFalse);
+  });
+
+  testWidgets('Do not affect focus order in the route', (WidgetTester tester) async {
+    final List<FocusNode> focusNodes = <FocusNode>[
+      FocusNode(), FocusNode(), FocusNode(), FocusNode(),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CupertinoTabScaffold(
+            tabBar: _buildTabBar(),
+            tabBuilder: (BuildContext context, int index) {
+              return Column(
+                children: <Widget>[
+                  TextField(
+                    focusNode: focusNodes[index * 2],
+                    decoration: const InputDecoration(
+                      hintText: 'TextField 1',
+                    ),
+                  ),
+                  TextField(
+                    focusNode: focusNodes[index * 2 + 1],
+                    decoration: const InputDecoration(
+                      hintText: 'TextField 2',
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      focusNodes.any((FocusNode node) => node.hasFocus),
+      isFalse,
+    );
+
+    await tester.tap(find.widgetWithText(TextField, 'TextField 2'));
+
+    expect(
+      focusNodes.indexOf(focusNodes.singleWhere((FocusNode node) => node.hasFocus)),
+      1,
+    );
+
+    await tester.tap(find.text('Tab 2'));
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(TextField, 'TextField 1'));
+
+    expect(
+      focusNodes.indexOf(focusNodes.singleWhere((FocusNode node) => node.hasFocus)),
+      2,
+    );
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump();
+
+    // Upon going back to tab 1, the item it tab 1 that previously had the focus
+    // (TextField 2) gets it back.
+    expect(
+      focusNodes.indexOf(focusNodes.singleWhere((FocusNode node) => node.hasFocus)),
+      1,
+    );
+  });
+
+  testWidgets('Tab bar respects themes', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoTabScaffold(
+          tabBar: _buildTabBar(),
+          tabBuilder: (BuildContext context, int index) {
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+
+    BoxDecoration tabDecoration = tester.widget<DecoratedBox>(find.descendant(
+      of: find.byType(CupertinoTabBar),
+      matching: find.byType(DecoratedBox),
+    )).decoration;
+
+    expect(tabDecoration.color, const Color(0xCCF8F8F8));
+
+    await tester.tap(find.text('Tab 2'));
+    await tester.pump();
+
+    // Pump again but with dark theme.
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(
+          brightness: Brightness.dark,
+          primaryColor: CupertinoColors.destructiveRed,
+        ),
+        home: CupertinoTabScaffold(
+          tabBar: _buildTabBar(),
+          tabBuilder: (BuildContext context, int index) {
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+
+    tabDecoration = tester.widget<DecoratedBox>(find.descendant(
+      of: find.byType(CupertinoTabBar),
+      matching: find.byType(DecoratedBox),
+    )).decoration;
+
+    expect(tabDecoration.color, const Color(0xB7212121));
+
+    final RichText tab1 = tester.widget(find.descendant(
+      of: find.text('Tab 1'),
+      matching: find.byType(RichText),
+    ));
+    // Tab 2 should still be selected after changing theme.
+    expect(tab1.text.style.color, CupertinoColors.inactiveGray);
+    final RichText tab2 = tester.widget(find.descendant(
+      of: find.text('Tab 2'),
+      matching: find.byType(RichText),
+    ));
+    expect(tab2.text.style.color, CupertinoColors.destructiveRed);
+  });
+
+  testWidgets('Does not lose state when focusing on text input', (WidgetTester tester) async {
+    // Regression testing for https://github.com/flutter/flutter/issues/28457.
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          viewInsets:  EdgeInsets.only(bottom: 0),
+        ),
+        child: MaterialApp(
+          home: Material(
+            child: CupertinoTabScaffold(
+              tabBar: _buildTabBar(),
+              tabBuilder: (BuildContext context, int index) {
+                return TextField();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final EditableTextState editableState = tester.state<EditableTextState>(find.byType(EditableText));
+
+    await tester.enterText(find.byType(TextField), "don't lose me");
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          viewInsets:  EdgeInsets.only(bottom: 100),
+        ),
+        child: MaterialApp(
+          home: Material(
+            child: CupertinoTabScaffold(
+              tabBar: _buildTabBar(),
+              tabBuilder: (BuildContext context, int index) {
+                return TextField();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The exact same state instance is still there.
+    expect(tester.state<EditableTextState>(find.byType(EditableText)), editableState);
+    expect(find.text("don't lose me"), findsOneWidget);
+  });
+}
+
+CupertinoTabBar _buildTabBar({ int selectedTab = 0 }) {
+  return CupertinoTabBar(
+    items: const <BottomNavigationBarItem>[
+      BottomNavigationBarItem(
+        icon: ImageIcon(TestImageProvider(24, 24)),
+        title: Text('Tab 1'),
+      ),
+      BottomNavigationBarItem(
+        icon: ImageIcon(TestImageProvider(24, 24)),
+        title: Text('Tab 2'),
+      ),
+    ],
+    currentIndex: selectedTab,
+    onTap: (int newTab) => selectedTabs.add(newTab),
+  );
+}

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -475,7 +475,7 @@ void main() {
           home: CupertinoTabScaffold(
             tabBar: _buildTabBar(),
             tabBuilder: (BuildContext context, int index) {
-              return CupertinoTextField();
+              return const CupertinoTextField();
             },
           ),
         ),
@@ -495,7 +495,7 @@ void main() {
           home: CupertinoTabScaffold(
             tabBar: _buildTabBar(),
             tabBuilder: (BuildContext context, int index) {
-              return CupertinoTextField();
+              return const CupertinoTextField();
             },
           ),
         ),


### PR DESCRIPTION
## Description

A tree reshape (inserting a Padding widget in between the tab scaffold and the content) causes all inner states to be lost when the view inset change (such as when bringing up the keyboard). 

## Related Issues

#28457

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
