### PR TITLE
print system time on all mac builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,6 +163,10 @@ task:
     PUBLISHING_MATCH_CERTIFICATE_REPO: git@github.com:flutter/private_publishing_certificates.git
   osx_instance:
     image: mojave-xcode-10.1
+  # occasionally the clock on these machines is out of sync
+  # with the actual time - this should help to verify
+  print_date_script:
+    - date
   git_fetch_script:
     - git clean -xfd
     - git fetch origin
@@ -182,6 +186,10 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
     COCOAPODS_DISABLE_STATS: true
+  # occasionally the clock on these machines is out of sync
+  # with the actual time - this should help to verify
+  print_date_script:
+    - date
   install_cocoapods_script:
     - sudo gem install cocoapods
   git_fetch_script:


### PR DESCRIPTION
## Description

If the system clock is too far out of sync, we'll get JWT errors when we try to send test results up to BigQuery.  This will help to verify what time the server thinks it is on on all runs. 

/cc @fkorotkov FYI

## Related Issues

https://github.com/flutter/flutter/pull/27971#issuecomment-470786878

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
