### PR TITLE
Heroes and nested Navigators

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -111,7 +111,7 @@ Rect _globalBoundingBoxFor(BuildContext context) {
 /// B to A, route A's hero's widget is, by default, placed over where route B's
 /// hero's widget was, and then the animation goes the other way.
 ///
-/// ## Nested Navigators
+/// ### Nested Navigators
 ///
 /// If either or both routes contain nested [Navigator]s, only [Hero]s
 /// contained in the top-most routes (as defined by [Route.isCurrent] of those
@@ -202,11 +202,13 @@ class Hero extends StatefulWidget {
   /// Defaults to false and cannot be null.
   final bool transitionOnUserGestures;
 
-  // Returns a map of all of the heroes in context, indexed by hero tag.
+  // Returns a map of all of the heroes in `context` indexed by hero tag that
+  // should be considered for animation when `navigator` transitions from one
+  // PageRoute to another, .
   static Map<Object, _HeroState> _allHeroesFor(
       BuildContext context,
       bool isUserGestureTransition,
-      NavigatorState triggeringNavigator,
+      NavigatorState navigator,
   ) {
     assert(context != null);
     assert(isUserGestureTransition != null);
@@ -237,11 +239,14 @@ class Hero extends StatefulWidget {
         if (!isUserGestureTransition || heroWidget.transitionOnUserGestures) {
           final Object tag = heroWidget.tag;
           assert(tag != null);
-          if (Navigator.of(hero) == triggeringNavigator) {
+          if (Navigator.of(hero) == navigator) {
             addHero(hero, tag);
           } else {
-            // Nested navigators: only consider heros in the topmost route of
-            // the nested navigator, if it is a PageRoute.
+            // The nearest navigator to the Hero is not the Navigator that is
+            // currently transitioning from one route to another. This means,
+            // the Hero is inside a nested Navigator and should only be
+            // considered for animation, if it is part of the top-most route in
+            // that nested Navigator and if that route is also a PageRoute.
             final ModalRoute<dynamic> heroRoute = ModalRoute.of(hero);
             if (heroRoute != null && heroRoute is PageRoute && heroRoute.isCurrent) {
               addHero(hero, tag);

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -114,10 +114,10 @@ Rect _globalBoundingBoxFor(BuildContext context) {
 /// ### Nested Navigators
 ///
 /// If either or both routes contain nested [Navigator]s, only [Hero]s
-/// contained in the top-most routes (as defined by [Route.isCurrent] of those
-/// nested [Navigator]s are considered for animation. Furthermore, the top-most
-/// routes containing these [Hero]s in the nested [Navigator]s also have to be
-/// [PageRoute]s.
+/// contained in the top-most routes (as defined by [Route.isCurrent]) *of those
+/// nested [Navigator]s* are considered for animation. Just like in the
+/// non-nested case the top-most routes containing these [Hero]s in the nested
+/// [Navigator]s have to be [PageRoute]s.
 ///
 /// ## Parts of a Hero Transition
 ///
@@ -212,6 +212,7 @@ class Hero extends StatefulWidget {
   ) {
     assert(context != null);
     assert(isUserGestureTransition != null);
+    assert(navigator != null);
     final Map<Object, _HeroState> result = <Object, _HeroState>{};
 
     void addHero(StatefulElement hero, Object tag) {
@@ -219,7 +220,7 @@ class Hero extends StatefulWidget {
         if (result.containsKey(tag)) {
           throw FlutterError(
             'There are multiple heroes that share the same tag within a subtree.\n'
-            'Within each subtree for which heroes are to be animated (typically a PageRoute subtree), '
+            'Within each subtree for which heroes are to be animated (i.e. a PageRoute subtree), '
             'each Hero must have a unique non-null tag.\n'
             'In this case, multiple heroes had the following tag: $tag\n'
             'Here is the subtree for one of the offending heroes:\n'

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -204,7 +204,7 @@ class Hero extends StatefulWidget {
 
   // Returns a map of all of the heroes in `context` indexed by hero tag that
   // should be considered for animation when `navigator` transitions from one
-  // PageRoute to another, .
+  // PageRoute to another.
   static Map<Object, _HeroState> _allHeroesFor(
       BuildContext context,
       bool isUserGestureTransition,

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -243,9 +243,9 @@ class Hero extends StatefulWidget {
             addHero(hero, tag);
           } else {
             // The nearest navigator to the Hero is not the Navigator that is
-            // currently transitioning from one route to another. This means,
+            // currently transitioning from one route to another. This means
             // the Hero is inside a nested Navigator and should only be
-            // considered for animation, if it is part of the top-most route in
+            // considered for animation if it is part of the top-most route in
             // that nested Navigator and if that route is also a PageRoute.
             final ModalRoute<dynamic> heroRoute = ModalRoute.of(hero);
             if (heroRoute != null && heroRoute is PageRoute && heroRoute.isCurrent) {

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -10,6 +10,7 @@ import 'framework.dart';
 import 'navigator.dart';
 import 'overlay.dart';
 import 'pages.dart';
+import 'routes.dart';
 import 'transitions.dart';
 
 /// Signature for a function that takes two [Rect] instances and returns a
@@ -110,6 +111,14 @@ Rect _globalBoundingBoxFor(BuildContext context) {
 /// B to A, route A's hero's widget is, by default, placed over where route B's
 /// hero's widget was, and then the animation goes the other way.
 ///
+/// ## Nested Navigators
+///
+/// If either or both routes contain nested [Navigator]s, only [Hero]s
+/// contained in the top-most routes (as defined by [Route.isCurrent] of those
+/// nested [Navigator]s are considered for animation. Furthermore, the top-most
+/// routes containing these [Hero]s in the nested [Navigator]s also have to be
+/// [PageRoute]s.
+///
 /// ## Parts of a Hero Transition
 ///
 /// ![Diagrams with parts of the Hero transition.](https://flutter.github.io/assets-for-api-docs/assets/interaction/heroes.png)
@@ -194,10 +203,33 @@ class Hero extends StatefulWidget {
   final bool transitionOnUserGestures;
 
   // Returns a map of all of the heroes in context, indexed by hero tag.
-  static Map<Object, _HeroState> _allHeroesFor(BuildContext context, bool isUserGestureTransition) {
+  static Map<Object, _HeroState> _allHeroesFor(
+      BuildContext context,
+      bool isUserGestureTransition,
+      NavigatorState triggeringNavigator,
+  ) {
     assert(context != null);
     assert(isUserGestureTransition != null);
     final Map<Object, _HeroState> result = <Object, _HeroState>{};
+
+    void addHero(StatefulElement hero, Object tag) {
+      assert(() {
+        if (result.containsKey(tag)) {
+          throw FlutterError(
+            'There are multiple heroes that share the same tag within a subtree.\n'
+            'Within each subtree for which heroes are to be animated (typically a PageRoute subtree), '
+            'each Hero must have a unique non-null tag.\n'
+            'In this case, multiple heroes had the following tag: $tag\n'
+            'Here is the subtree for one of the offending heroes:\n'
+            '${hero.toStringDeep(prefixLineOne: "# ")}'
+          );
+        }
+        return true;
+      }());
+      final _HeroState heroState = hero.state;
+      result[tag] = heroState;
+    }
+
     void visitor(Element element) {
       if (element.widget is Hero) {
         final StatefulElement hero = element;
@@ -205,25 +237,21 @@ class Hero extends StatefulWidget {
         if (!isUserGestureTransition || heroWidget.transitionOnUserGestures) {
           final Object tag = heroWidget.tag;
           assert(tag != null);
-          assert(() {
-            if (result.containsKey(tag)) {
-              throw FlutterError(
-                'There are multiple heroes that share the same tag within a subtree.\n'
-                'Within each subtree for which heroes are to be animated (typically a PageRoute subtree), '
-                'each Hero must have a unique non-null tag.\n'
-                'In this case, multiple heroes had the following tag: $tag\n'
-                'Here is the subtree for one of the offending heroes:\n'
-                '${element.toStringDeep(prefixLineOne: "# ")}'
-              );
+          if (Navigator.of(hero) == triggeringNavigator) {
+            addHero(hero, tag);
+          } else {
+            // Nested navigators: only consider heros in the topmost route of
+            // the nested navigator, if it is a PageRoute.
+            final ModalRoute<dynamic> heroRoute = ModalRoute.of(hero);
+            if (heroRoute != null && heroRoute is PageRoute && heroRoute.isCurrent) {
+              addHero(hero, tag);
             }
-            return true;
-          }());
-          final _HeroState heroState = hero.state;
-          result[tag] = heroState;
+          }
         }
       }
       element.visitChildren(visitor);
     }
+
     context.visitChildElements(visitor);
     return result;
   }
@@ -652,8 +680,8 @@ class HeroController extends NavigatorObserver {
     final Rect navigatorRect = _globalBoundingBoxFor(navigator.context);
 
     // At this point the toHeroes may have been built and laid out for the first time.
-    final Map<Object, _HeroState> fromHeroes = Hero._allHeroesFor(from.subtreeContext, isUserGestureTransition);
-    final Map<Object, _HeroState> toHeroes = Hero._allHeroesFor(to.subtreeContext, isUserGestureTransition);
+    final Map<Object, _HeroState> fromHeroes = Hero._allHeroesFor(from.subtreeContext, isUserGestureTransition, navigator);
+    final Map<Object, _HeroState> toHeroes = Hero._allHeroesFor(to.subtreeContext, isUserGestureTransition, navigator);
 
     // If the `to` route was offstage, then we're implicitly restoring its
     // animation value back to what it was before it was "moved" offstage.

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1524,4 +1524,90 @@ void main() {
     expect(find.byKey(nestedRouteHeroBottom), findsNothing);
     expect(find.byKey(nestedRouteHeroBottom, skipOffstage: false), findsOneWidget);
   });
+
+  testWidgets('Can hero from route in root Navigator to route in nested Navigator', (WidgetTester tester) async {
+    const String heroTag = 'foo';
+    final GlobalKey<NavigatorState> rootNavigator = GlobalKey();
+    final GlobalKey smallContainer = GlobalKey();
+    final GlobalKey largeContainer = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: rootNavigator,
+        home: Center(
+          child: Card(
+            child: Hero(
+              tag: heroTag,
+              child: Container(
+                key: largeContainer,
+                color: Colors.red,
+                height: 200.0,
+                width: 200.0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+
+    // The initial setup.
+    expect(find.byKey(largeContainer), isOnstage);
+    expect(find.byKey(largeContainer), isInCard);
+    expect(find.byKey(smallContainer, skipOffstage: false), findsNothing);
+
+    rootNavigator.currentState.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) {
+          return Center(
+            child: Card(
+              child: Hero(
+                tag: heroTag,
+                child: Container(
+                  key: smallContainer,
+                  color: Colors.red,
+                  height: 100.0,
+                  width: 100.0,
+                ),
+              ),
+            ),
+          );
+        }
+      ),
+    );
+    await tester.pump();
+
+    // The second route exists offstage.
+    expect(find.byKey(largeContainer), isOnstage);
+    expect(find.byKey(largeContainer), isInCard);
+    expect(find.byKey(smallContainer, skipOffstage: false), isOffstage);
+    expect(find.byKey(smallContainer, skipOffstage: false), isInCard);
+
+    await tester.pump();
+
+    // The hero started flying.
+    expect(find.byKey(largeContainer), findsNothing);
+    expect(find.byKey(smallContainer), isOnstage);
+    expect(find.byKey(smallContainer), isNotInCard);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    
+    // The hero is in-flight.
+    expect(find.byKey(largeContainer), findsNothing);
+    expect(find.byKey(smallContainer), isOnstage);
+    expect(find.byKey(smallContainer), isNotInCard);
+    final Size size = tester.getSize(find.byKey(smallContainer));
+    expect(size.height, greaterThan(100));
+    expect(size.width, greaterThan(100));
+    expect(size.height, lessThan(200));
+    expect(size.width, lessThan(200));
+
+    await tester.pumpAndSettle();
+
+    // The transition has ended.
+    expect(find.byKey(largeContainer), findsNothing);
+    expect(find.byKey(smallContainer), isOnstage);
+    expect(find.byKey(smallContainer), isInCard);
+    expect(tester.getSize(find.byKey(smallContainer)), const Size(100,100));
+  });
 }

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1383,7 +1383,7 @@ void main() {
 
     await tester.pump();
 
-    // Both Heros exist and seated in their normal parents.
+    // Both Heroes exist and seated in their normal parents.
     expect(find.byKey(firstKey), isOnstage);
     expect(find.byKey(firstKey), isInCard);
     expect(find.byKey(secondKey), isOnstage);
@@ -1493,7 +1493,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    // Both heros are in the tree, one is offstage
+    // Both heroes are in the tree, one is offstage
     expect(find.byKey(nestedRouteHeroTop), findsOneWidget);
     expect(find.byKey(nestedRouteHeroBottom), findsNothing);
     expect(find.byKey(nestedRouteHeroBottom, skipOffstage: false), findsOneWidget);
@@ -1519,7 +1519,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Foo'), findsNothing);
-    // Both heros are in the tree, one is offstage
+    // Both heroes are in the tree, one is offstage
     expect(find.byKey(nestedRouteHeroTop), findsOneWidget);
     expect(find.byKey(nestedRouteHeroBottom), findsNothing);
     expect(find.byKey(nestedRouteHeroBottom, skipOffstage: false), findsOneWidget);
@@ -1591,7 +1591,7 @@ void main() {
     expect(find.byKey(smallContainer), isNotInCard);
 
     await tester.pump(const Duration(milliseconds: 100));
-    
+
     // The hero is in-flight.
     expect(find.byKey(largeContainer), findsNothing);
     expect(find.byKey(smallContainer), isOnstage);

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1383,7 +1383,7 @@ void main() {
 
     await tester.pump();
 
-    // Both Heroes exist and seated in their normal parents.
+    // Both Heroes exist and are seated in their normal parents.
     expect(find.byKey(firstKey), isOnstage);
     expect(find.byKey(firstKey), isInCard);
     expect(find.byKey(secondKey), isOnstage);
@@ -1457,8 +1457,8 @@ void main() {
     const String heroTag = 'You are my hero!';
     final GlobalKey<NavigatorState> rootNavigator = GlobalKey();
     final GlobalKey<NavigatorState> nestedNavigator = GlobalKey();
-    final GlobalKey nestedRouteHeroBottom = GlobalKey();
-    final GlobalKey nestedRouteHeroTop = GlobalKey();
+    final Key nestedRouteHeroBottom = UniqueKey();
+    final Key nestedRouteHeroTop = UniqueKey();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1528,8 +1528,8 @@ void main() {
   testWidgets('Can hero from route in root Navigator to route in nested Navigator', (WidgetTester tester) async {
     const String heroTag = 'foo';
     final GlobalKey<NavigatorState> rootNavigator = GlobalKey();
-    final GlobalKey smallContainer = GlobalKey();
-    final GlobalKey largeContainer = GlobalKey();
+    final Key smallContainer = UniqueKey();
+    final Key largeContainer = UniqueKey();
 
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

Before this change nested Navigators were causing trouble for Heroes: If the inner Navigator had two PageRoutes on its stack with a Hero tagged "superman" in each of them (because that Hero was supposed to animate between the two PageRoutes) and you were pushing a PageRoute on the outer navigator it would fail because the from route (the one with the nested Navigator) had two Heroes with the same tag. That's legal in the context of the inner Navigator, but was causing trouble for the outer Navigator (it would assert).

This PR changes which Heroes are considered for animation **for nested Navigators only**: If the source or destination route for a potential Hero transition contain nested Navigators, only the Heroes in the top-most Route (which has to be a PageRoute) of that nested Navigator are considered for animation. 

This is preserving the (existing) behavior of animating a Hero from a PageRoute in the outer Navigator to a PageRoute in the inner navigator (I'll add a test for this).

It's an alternative to the approach suggested in https://github.com/flutter/flutter/pull/28420.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28042

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
