### PR TITLE
Update to ListView Sample Code in API Docs

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -604,15 +604,73 @@ abstract class BoxScrollView extends ScrollView {
 /// padding. To avoid this behavior, override with a zero [padding] property.
 ///
 /// {@tool sample}
-///
-/// An infinite list of children:
+/// This example uses the default constructor for [ListView] which takes an
+/// explicit [List<Widget] of children. This [ListView]'s children are made up
+/// of [Container]s with [Text].
 ///
 /// ```dart
-/// ListView.builder(
+/// ListView(
 ///   padding: EdgeInsets.all(8.0),
-///   itemExtent: 20.0,
-///   itemBuilder: (BuildContext context, int index) {
-///     return Text('entry $index');
+///   children: <Widget>[
+///     Container(
+///       height: 50,
+///       color: Colors.amber[600],
+///       child: Center( child: Text('Entry A')),
+///     ),
+///     Container(
+///       height: 50,
+///       color: Colors.amber[500],
+///       child: Center(child: Text('Entry B')),
+///     ),
+///     Container(
+///       height: 50,
+///       color: Colors.amber[100],
+///       child: Center(child: Text('Entry C')),
+///     ),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+/// {@tool sample}
+/// This example mirrors the previous one, creating the same list using
+/// [ListView.builder].
+///
+/// ```dart
+/// final List entries = ['A', 'B', 'C'];
+/// final colorCodes = [600, 500, 100];
+///
+/// ListView.builder(
+///   itemCount: entries.length,
+///   itemBuilder: (context, index) {
+///     return Container(
+///       height: 50,
+///       color: Colors.amber[colorCodes[index]],
+///       child: Center(child: Text('Entry ${entries[index]}')),
+///     );
+///   }
+/// )
+/// ```
+/// {@end-tool}
+/// {@tool sample}
+/// This example continues to build from our the previous ones, creating a
+/// similar list using [ListView.separated]. Here, a [Divider] is used as a
+/// separator.
+///
+/// ```dart
+/// final List entries = ['A', 'B', 'C'];
+/// final colorCodes = [600, 500, 100];
+///
+/// ListView.separated(
+///   itemCount: entries.length,
+///   itemBuilder: (context, index) {
+///     return Container(
+///       height: 50,
+///       color: Colors.amber[colorCodes[index]],
+///       child: Center(child: Text('Entry ${entries[index]}')),
+///     );
+///   },
+///   separatorBuilder: (context, position) {
+///     return Divider();
 ///   },
 /// )
 /// ```

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -637,8 +637,8 @@ abstract class BoxScrollView extends ScrollView {
 /// are built lazily and can be infinite in number.
 ///
 /// ```dart
-/// const List entries = ['A', 'B', 'C'];
-/// const colorCodes = [600, 500, 100];
+/// final List entries = ['A', 'B', 'C'];
+/// final colorCodes = [600, 500, 100];
 ///
 /// ListView.builder(
 ///   padding: const EdgeInsets.all(8.0),
@@ -659,8 +659,8 @@ abstract class BoxScrollView extends ScrollView {
 /// separator.
 ///
 /// ```dart
-/// const List entries = ['A', 'B', 'C'];
-/// const colorCodes = [600, 500, 100];
+/// final List entries = ['A', 'B', 'C'];
+/// final colorCodes = [600, 500, 100];
 ///
 /// ListView.separated(
 ///   padding: const EdgeInsets.all(8.0),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -648,7 +648,7 @@ abstract class BoxScrollView extends ScrollView {
 ///       child: Center(child: Text('Entry ${entries[index]}')),
 ///     );
 ///   }
-/// )
+/// );
 /// ```
 /// {@end-tool}
 /// {@tool sample}
@@ -672,7 +672,7 @@ abstract class BoxScrollView extends ScrollView {
 ///   separatorBuilder: (context, position) {
 ///     return Divider();
 ///   },
-/// )
+/// );
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -615,17 +615,17 @@ abstract class BoxScrollView extends ScrollView {
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[600],
-///       child: const Center(child: const Text('Entry A')),
+///       child: const Center(child: Text('Entry A')),
 ///     ),
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[500],
-///       child: const Center(child: const Text('Entry B')),
+///       child: const Center(child: Text('Entry B')),
 ///     ),
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[100],
-///       child: const Center(child: const Text('Entry C')),
+///       child: const Center(child: Text('Entry C')),
 ///     ),
 ///   ],
 /// )
@@ -637,8 +637,8 @@ abstract class BoxScrollView extends ScrollView {
 /// are built lazily and can be infinite in number.
 ///
 /// ```dart
-/// static const List entries = ['A', 'B', 'C'];
-/// static const colorCodes = [600, 500, 100];
+/// const List entries = ['A', 'B', 'C'];
+/// const colorCodes = [600, 500, 100];
 ///
 /// ListView.builder(
 ///   padding: const EdgeInsets.all(8.0),
@@ -659,8 +659,8 @@ abstract class BoxScrollView extends ScrollView {
 /// separator.
 ///
 /// ```dart
-/// static const List entries = ['A', 'B', 'C'];
-/// static const colorCodes = [600, 500, 100];
+/// const List entries = ['A', 'B', 'C'];
+/// const colorCodes = [600, 500, 100];
 ///
 /// ListView.separated(
 ///   padding: const EdgeInsets.all(8.0),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -632,8 +632,9 @@ abstract class BoxScrollView extends ScrollView {
 /// ```
 /// {@end-tool}
 /// {@tool sample}
-/// This example mirrors the previous one, creating the same list using
-/// [ListView.builder].
+/// This example mirrors the previous one, creating the same list using the
+/// [ListView.builder] constructor. Using the [IndexedWidgetBuilder], children
+/// are built lazily and can be infinite in number.
 ///
 /// ```dart
 /// static const List entries = ['A', 'B', 'C'];

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -637,8 +637,8 @@ abstract class BoxScrollView extends ScrollView {
 /// are built lazily and can be infinite in number.
 ///
 /// ```dart
-/// final List entries = ['A', 'B', 'C'];
-/// final colorCodes = [600, 500, 100];
+/// final List<String> entries = <String>['A', 'B', 'C'];
+/// final List<int> colorCodes = <int>[600, 500, 100];
 ///
 /// ListView.builder(
 ///   padding: const EdgeInsets.all(8.0),
@@ -659,8 +659,8 @@ abstract class BoxScrollView extends ScrollView {
 /// separator.
 ///
 /// ```dart
-/// final List entries = ['A', 'B', 'C'];
-/// final colorCodes = [600, 500, 100];
+/// final List<String> entries = <String>['A', 'B', 'C'];
+/// final List<int> colorCodes = <int>[600, 500, 100];
 ///
 /// ListView.separated(
 ///   padding: const EdgeInsets.all(8.0),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -605,27 +605,27 @@ abstract class BoxScrollView extends ScrollView {
 ///
 /// {@tool sample}
 /// This example uses the default constructor for [ListView] which takes an
-/// explicit [List<Widget] of children. This [ListView]'s children are made up
+/// explicit [List<Widget>] of children. This [ListView]'s children are made up
 /// of [Container]s with [Text].
 ///
 /// ```dart
 /// ListView(
-///   padding: EdgeInsets.all(8.0),
+///   padding: const EdgeInsets.all(8.0),
 ///   children: <Widget>[
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[600],
-///       child: Center( child: Text('Entry A')),
+///       child: const Center(child: const Text('Entry A')),
 ///     ),
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[500],
-///       child: Center(child: Text('Entry B')),
+///       child: const Center(child: const Text('Entry B')),
 ///     ),
 ///     Container(
 ///       height: 50,
 ///       color: Colors.amber[100],
-///       child: Center(child: Text('Entry C')),
+///       child: const Center(child: const Text('Entry C')),
 ///     ),
 ///   ],
 /// )
@@ -636,12 +636,13 @@ abstract class BoxScrollView extends ScrollView {
 /// [ListView.builder].
 ///
 /// ```dart
-/// final List entries = ['A', 'B', 'C'];
-/// final colorCodes = [600, 500, 100];
+/// static const List entries = ['A', 'B', 'C'];
+/// static const colorCodes = [600, 500, 100];
 ///
 /// ListView.builder(
+///   padding: const EdgeInsets.all(8.0),
 ///   itemCount: entries.length,
-///   itemBuilder: (context, index) {
+///   itemBuilder: (BuildContext context, int index) {
 ///     return Container(
 ///       height: 50,
 ///       color: Colors.amber[colorCodes[index]],
@@ -657,21 +658,20 @@ abstract class BoxScrollView extends ScrollView {
 /// separator.
 ///
 /// ```dart
-/// final List entries = ['A', 'B', 'C'];
-/// final colorCodes = [600, 500, 100];
+/// static const List entries = ['A', 'B', 'C'];
+/// static const colorCodes = [600, 500, 100];
 ///
 /// ListView.separated(
+///   padding: const EdgeInsets.all(8.0),
 ///   itemCount: entries.length,
-///   itemBuilder: (context, index) {
+///   itemBuilder: (BuildContext context, int index) {
 ///     return Container(
 ///       height: 50,
 ///       color: Colors.amber[colorCodes[index]],
 ///       child: Center(child: Text('Entry ${entries[index]}')),
 ///     );
 ///   },
-///   separatorBuilder: (context, position) {
-///     return Divider();
-///   },
+///   separatorBuilder: (BuildContext context, int index) => const Divider(),
 /// );
 /// ```
 /// {@end-tool}


### PR DESCRIPTION
## Description

Update to the List View Sample snippets for the API Docs, these samples utilize different constructors. They also are set to match WIP diagrams based upon final approval of the sample code. 

## Related Issues

Part of multiple efforts to improve API Docs.
- #21136 
- #13637 
- #27225
- #27386
- ...


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
