### PR TITLE
Cause `flutter analyze` to fail if the analysis server experienced an error.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -67,6 +67,9 @@ class AnalyzeContinuously extends AnalyzeBase {
     if (exitCode != 0)
       throwToolExit(message, exitCode: exitCode);
     printStatus(message);
+
+    if (server.didServerErrorOccur)
+      throwToolExit('Server error(s) occurred.');
   }
 
   void _handleAnalysisStatus(AnalysisServer server, bool isAnalyzing) {

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -155,6 +155,10 @@ class AnalyzeOnce extends AnalyzeBase {
       }
     }
 
+    if (server.didServerErrorOccur) {
+      throwToolExit('Server error(s) occurred. (ran in ${seconds}s)');
+    }
+
     if (argResults['congratulate']) {
       if (undocumentedMembers > 0) {
         printStatus('No issues found! (ran in ${seconds}s; $dartdocMessage)');

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -27,6 +27,7 @@ class AnalysisServer {
       StreamController<bool>.broadcast();
   final StreamController<FileAnalysisErrors> _errorsController =
       StreamController<FileAnalysisErrors>.broadcast();
+  bool _didServerErrorOccur = false;
 
   int _id = 0;
 
@@ -61,6 +62,7 @@ class AnalysisServer {
         <String, dynamic>{'included': directories, 'excluded': <String>[]});
   }
 
+  bool get didServerErrorOccur => _didServerErrorOccur;
   Stream<bool> get onAnalyzing => _analyzingController.stream;
   Stream<FileAnalysisErrors> get onErrors => _errorsController.stream;
 
@@ -120,6 +122,7 @@ class AnalysisServer {
     if (error['stackTrace'] != null) {
       printError(error['stackTrace']);
     }
+    _didServerErrorOccur = true;
   }
 
   void _handleAnalysisIssues(Map<String, dynamic> issueInfo) {


### PR DESCRIPTION
Substantially reduces the danger that a bug in the analysis server
might prevent errors from being detected by `flutter analyze`.

## Description

This PR changes the existing behavior of `flutter analyze` so that if an internal analysis server occurs, `flutter analyze` will exit with a nonzero exit code.  The previous behavior was to exit with a zero exit code, indicating success.  The motivation for the change is to make sure that if the Dart team accidentally makes changes to the analyzer that would break the ability to analyze Flutter, we will be alerted to the problem by a failure of the Dart team's `flutter-analyze` bot.  (Without this change, the `flutter-analyze` bot will only fail if a change to the analyzer causes errors to be reported; it won't detect changes that cause an internal analysis server error).

## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
  - Unfortunately this is not feasible since there is no reliable way to cause the analyzer to produce an internal error without manually changing it to throw an exception.  (If there were, it would be a bug in the analyzer, and fixing it would break the test).  However, I have manually tested the new behavior.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
