### PR TITLE
Update DropdownButton underline to be customizable

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -599,6 +599,7 @@ class DropdownButton<T> extends StatefulWidget {
     @required this.onChanged,
     this.elevation = 8,
     this.style,
+    this.underline,
     this.iconSize = 24.0,
     this.isDense = false,
     this.isExpanded = false,
@@ -652,6 +653,11 @@ class DropdownButton<T> extends StatefulWidget {
   /// Defaults to the [TextTheme.subhead] value of the current
   /// [ThemeData.textTheme] of the current [Theme].
   final TextStyle style;
+
+  /// The border to use for the drop-down button's underline.
+  ///
+  /// Defaults to a 0.0 width border with color 0xFFBDBDBD.
+  final BorderSide underline;
 
   /// The size to use for the drop-down button's down arrow icon button.
   ///
@@ -857,8 +863,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
             bottom: bottom,
             child: Container(
               height: 1.0,
-              decoration: const BoxDecoration(
-                border: Border(bottom: BorderSide(color: Color(0xFFBDBDBD), width: 0.0))
+              decoration: BoxDecoration(
+                border: Border(bottom: widget.underline
+                    ?? const BorderSide(color: Color(0xFFBDBDBD), width: 0.0))
               ),
             ),
           ),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -28,6 +28,7 @@ Widget buildFrame({
   bool isExpanded = false,
   Widget hint,
   Widget disabledHint,
+  BorderSide underline,
   List<String> items = menuItems,
   Alignment alignment = Alignment.center,
   TextDirection textDirection = TextDirection.ltr,
@@ -43,6 +44,7 @@ Widget buildFrame({
             value: value,
             hint: hint,
             disabledHint: disabledHint,
+            underline: underline,
             onChanged: onChanged,
             isDense: isDense,
             isExpanded: isExpanded,
@@ -1079,5 +1081,19 @@ void main() {
     await tester.tap(find.text('13').last);
     await tester.pumpAndSettle();
     expect(selectedIndex, 13);
+  });
+
+  testWidgets('Underlined dropdown golden', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    Widget build() => buildFrame(buttonKey: buttonKey,
+        underline: const BorderSide(color: Color(0xFFFFAAEE), width: 4.0));
+    await tester.pumpWidget(build());
+    final Finder buttonFinder = find.byKey(buttonKey);
+    assert(tester.renderObject(buttonFinder).attached);
+    await expectLater(
+      find.ancestor(of: buttonFinder, matching: find.byType(RepaintBoundary)).first,
+      matchesGoldenFile('dropdown_test.underlined.0.png'),
+      skip: !Platform.isLinux,
+    );
   });
 }


### PR DESCRIPTION
## Description

Submitting this patch to make DropdownButton's underline customizable. Currently, it is set to a hardcoded value of `BorderSide(color: Color(0xFFBDBDBD), width: 0.0))`.

Added a `BorderSide underline` field to the `DropdownButton` class to change the color/width of this underline.

Also added a golden test for this new field but don't have a Linux box so the screenshot needs to be generated.

## Related Issues

https://github.com/flutter/flutter/issues/28861

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.