### PR TITLE
No image shader caching in default shader warm-up

### DIFF
--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -182,29 +182,7 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
       ..layout(const ui.ParagraphConstraints(width: 60.0));
     canvas.drawParagraph(paragraph, const ui.Offset(20.0, 20.0));
 
-    // Construct an image for drawImage related operations
-    const int imageWidth = 10;
-    const int imageHeight = 10;
-    final Uint8List pixels = Uint8List.fromList(List<int>.generate(
-      imageWidth * imageHeight * 4,
-          (int i) => i % 4 < 2 ? 0x00 : 0xFF,  // opaque blue
-    ));
-
-    final Completer<void> completer = Completer<void>();
-    ui.decodeImageFromPixels(pixels, imageWidth, imageHeight, ui.PixelFormat.rgba8888, (ui.Image image) {
-      // Warm up image shaders
-      canvas.translate(0.0, 80.0);
-      canvas.save();
-      final ui.Rect srcRect = ui.Rect.fromLTWH(0.0, 0.0, image.width.toDouble(), image.height.toDouble());
-      canvas.drawImage(image, const ui.Offset(20.0, 20.0), ui.Paint());
-      canvas.translate(80.0, 0.0);
-      canvas.drawImageRect(image, srcRect, ui.Rect.fromLTWH(20.0, 20.0, imageWidth * 0.6, imageWidth * 0.6), paints[0]);
-      canvas.translate(80.0, 0.0);
-      canvas.drawImageRect(image, srcRect, ui.Rect.fromLTWH(10.0, 10.0, imageWidth * 1.5, imageWidth * 1.5), paints[0]);
-      canvas.restore();
-      completer.complete();
-    });
-
-    return completer.future;
+    // No asynchronous work in the default shader warm-up yet.
+    return Future<void>.value(null);
   }
 }

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:developer';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -106,7 +105,7 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
   /// Trigger common draw operations on a canvas to warm up GPU shader
   /// compilation cache.
   @override
-  Future<void> warmUpOnCanvas(ui.Canvas canvas) {
+  Future<void> warmUpOnCanvas(ui.Canvas canvas) async {
     final ui.RRect rrect = ui.RRect.fromLTRBXY(20.0, 20.0, 60.0, 60.0, 10.0, 10.0);
     final ui.Path rrectPath = ui.Path()..addRRect(rrect);
 
@@ -181,8 +180,5 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
     final ui.Paragraph paragraph = paragraphBuilder.build()
       ..layout(const ui.ParagraphConstraints(width: 60.0));
     canvas.drawParagraph(paragraph, const ui.Offset(20.0, 20.0));
-
-    // No asynchronous work in the default shader warm-up yet.
-    return Future<void>.value(null);
   }
 }


### PR DESCRIPTION
## Description

It turns out that no matter how small the image is, too much memory will
be used. Hence remove the image shader caching and let the client
implement itself based on needs.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29172

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
