### PR TITLE
MaterialButton shape should override ButtonTheme shape

### DIFF
--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -223,6 +223,9 @@ class MaterialButton extends StatelessWidget {
   /// The button's highlight and splash are clipped to this shape. If the
   /// button has an elevation, then its drop shadow is defined by this
   /// shape as well.
+  ///
+  /// Defaults to the value from the current [ButtonTheme],
+  /// [ButtonThemeData.shape].
   final ShapeBorder shape;
 
   /// {@macro flutter.widgets.Clip}
@@ -271,7 +274,7 @@ class MaterialButton extends StatelessWidget {
         minWidth: minWidth,
         minHeight: height,
       ),
-      shape: buttonTheme.shape,
+      shape: buttonTheme.getShape(this),
       clipBehavior: clipBehavior ?? Clip.none,
       animationDuration: buttonTheme.getAnimationDuration(this),
       child: child,

--- a/packages/flutter/test/material/buttons_test.dart
+++ b/packages/flutter/test/material/buttons_test.dart
@@ -625,4 +625,24 @@ void main() {
         paintsExactlyCountTimes(#clipPath, 0),
     );
   });
+
+  testWidgets('MaterialButton shape overrides ButtonTheme shape', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/29146
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MaterialButton(
+          onPressed: () { },
+          shape: const StadiumBorder(),
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder rawButtonMaterial = find.descendant(
+      of: find.byType(MaterialButton),
+      matching: find.byType(Material),
+    );
+    expect(tester.widget<Material>(rawButtonMaterial).shape, const StadiumBorder());
+  });
 }


### PR DESCRIPTION
This fix was originally contributed by @HeavenOSK in https://github.com/flutter/flutter/pull/29090.

Fixes https://github.com/flutter/flutter/issues/29146

MaterialButton now uses its shape parameter if it's non null.
