### PR TITLE
Add sample to forEachTween

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -16,9 +16,14 @@ import 'ticker_provider.dart';
 import 'transitions.dart';
 
 // Examples can assume:
-// Color myCurrentTargetColor;
-// class _Noop {}
-// class MyWidget = ImplicitlyAnimatedWidget with _Noop;
+// class MyWidget extends ImplicitlyAnimatedWidget {
+//   MyWidget() : super(duration: const Duration(seconds: 1));
+//
+//   final Color targetColor = Color.black;
+//
+//   @override
+//   HeadlineState createState() => MyWidgetState();
+// }
 
 /// An interpolation between two [BoxConstraints].
 ///
@@ -381,7 +386,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   ///   void forEachTween(TweenVisitor<dynamic> visitor) {
   ///     _colorTween = visitor(
   ///       _colorTween,
-  ///       myCurrentTargetColor,
+  ///       widget.targetColor,
   ///       (value) => ColorTween(begin: value),
   ///     );
   ///   }

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -371,7 +371,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// ```dart
   /// class MyWidgetState extends AnimatedWidgetBaseState<MyWidget> {
   ///   ColorTween _colorTween;
-  /// 
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     return Text(

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -367,6 +367,11 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// properties. Dependent properties should not be updated within
   /// [forEachTween].
   ///
+  /// ### Sample code
+  ///
+  /// A sample code implementing an `ImplicitlyAnimatedWidgetState` that
+  /// animates between colors whenever `widget.targetColor` changes.
+  ///
   /// {@tool sample}
   /// ```dart
   /// class MyWidgetState extends AnimatedWidgetBaseState<MyWidget> {
@@ -376,17 +381,26 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   ///   Widget build(BuildContext context) {
   ///     return Text(
   ///       'Hello World',
+  ///       // Computes the value of the text color at any given time.
   ///       style: TextStyle(color: _colorTween.evaluate(animation)),
   ///     );
   ///   }
   ///
   ///   @override
   ///   void forEachTween(TweenVisitor<dynamic> visitor) {
+  ///     // Update the tween using the provided visitor function.
   ///     _colorTween = visitor(
+  ///       // The latest tween value. Can be `null`.
   ///       _colorTween,
+  ///       // The color value toward which we are animating.
   ///       widget.targetColor,
+  ///       // A function that takes a color value and returns a tween
+  ///       // beginning at that value.
   ///       (value) => ColorTween(begin: value),
   ///     );
+  ///
+  ///     // We could have more tweens than one by using the visitor
+  ///     // multiple times.
   ///   }
   /// }
   /// ```

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -18,9 +18,7 @@ import 'transitions.dart';
 // Examples can assume:
 // class MyWidget extends ImplicitlyAnimatedWidget {
 //   MyWidget() : super(duration: const Duration(seconds: 1));
-//
 //   final Color targetColor = Color.black;
-//
 //   @override
 //   HeadlineState createState() => MyWidgetState();
 // }

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -368,6 +368,11 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// [forEachTween].
   ///
   /// {@tool sample}
+  ///
+  /// Sample code implementing an implicitly animated widget's `State`.
+  /// The widget animates between colors whenever `widget.targetColor`
+  /// changes.
+  ///
   /// ```dart
   /// class MyWidgetState extends AnimatedWidgetBaseState<MyWidget> {
   ///   ColorTween _colorTween;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -15,6 +15,9 @@ import 'text.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
+// Examples can assume:
+// Color myCurrentTargetColor;
+
 /// An interpolation between two [BoxConstraints].
 ///
 /// This class specializes the interpolation of [Tween<BoxConstraints>] to use
@@ -358,6 +361,31 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// [forEachTween] should override [didUpdateTweens] to update those
   /// properties. Dependent properties should not be updated within
   /// [forEachTween].
+  ///
+  /// {@tool sample}
+  /// ```dart
+  /// class MyWidgetState extends AnimatedWidgetBaseState<MyWidget> {
+  ///   ColorTween _colorTween;
+  /// 
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return Text(
+  ///       'Hello World',
+  ///       style: TextStyle(color: _colorTween.evaluate(animation)),
+  ///     );
+  ///   }
+  ///
+  ///   @override
+  ///   void forEachTween(TweenVisitor<dynamic> visitor) {
+  ///     _colorTween = visitor(
+  ///       _colorTween,
+  ///       myCurrentTargetColor,
+  ///       (value) => ColorTween(begin: value),
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
   @protected
   void forEachTween(TweenVisitor<dynamic> visitor);
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -17,7 +17,8 @@ import 'transitions.dart';
 
 // Examples can assume:
 // Color myCurrentTargetColor;
-// class MyWidget = ImplicitlyAnimatedWidget;
+// class _Noop {}
+// class MyWidget = ImplicitlyAnimatedWidget with _Noop;
 
 /// An interpolation between two [BoxConstraints].
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -17,6 +17,7 @@ import 'transitions.dart';
 
 // Examples can assume:
 // Color myCurrentTargetColor;
+// class MyWidget = ImplicitlyAnimatedWidget;
 
 /// An interpolation between two [BoxConstraints].
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -367,11 +367,6 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// properties. Dependent properties should not be updated within
   /// [forEachTween].
   ///
-  /// ### Sample code
-  ///
-  /// A sample code implementing an `ImplicitlyAnimatedWidgetState` that
-  /// animates between colors whenever `widget.targetColor` changes.
-  ///
   /// {@tool sample}
   /// ```dart
   /// class MyWidgetState extends AnimatedWidgetBaseState<MyWidget> {

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -18,9 +18,9 @@ import 'transitions.dart';
 // Examples can assume:
 // class MyWidget extends ImplicitlyAnimatedWidget {
 //   MyWidget() : super(duration: const Duration(seconds: 1));
-//   final Color targetColor = Color.black;
+//   final Color targetColor = Colors.black;
 //   @override
-//   HeadlineState createState() => MyWidgetState();
+//   MyWidgetState createState() => MyWidgetState();
 // }
 
 /// An interpolation between two [BoxConstraints].


### PR DESCRIPTION
The current documentation for `AnimatedWidgetBaseState.forEachTween` is exhaustive but a little hard to grok. An example will be useful.

## Description

*This adds a short sample to the method.

## Related Issues

* Sorry, I did not create an issue for this. Feel free to push back.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
