### PR TITLE
Fix DartDoc for UniqueKey

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -36,28 +36,6 @@ export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpR
 // abstract class FrogJar extends RenderObjectWidget { }
 // abstract class FrogJarParentData extends ParentData { Size size; }
 
-// DOCUMENTATION TEMPLATES FOR THE WIDGET LIBRARY
-
-/// {@template flutter.widgets.child}
-/// This widget can only have one child. To lay out multiple children, let this
-/// widget's child be a widget such as [Row], [Column], or [Stack], which have a
-/// `children` property, and then provide the children to that widget.
-/// {@endtemplate}
-
-/// {@template flutter.widgets.subscriptions}
-/// If a [State]'s [build] method depends on an object that can itself
-/// change state, for example a [ChangeNotifier] or [Stream], or some
-/// other object to which one can subscribe to receive notifications, then
-/// be sure to subscribe and unsubscribe properly in [initState],
-/// [didUpdateWidget], and [dispose]:
-///
-///  * In [initState], subscribe to the object.
-///  * In [didUpdateWidget] unsubscribe from the old object and subscribe
-///    to the new one if the updated widget configuration requires
-///    replacing the object.
-///  * In [dispose], unsubscribe from the object.
-/// {@endtemplate}
-
 // KEYS
 
 /// A key that is only equal to itself.
@@ -993,7 +971,19 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   /// location at which this object was inserted into the tree (i.e., [context])
   /// or on the widget used to configure this object (i.e., [widget]).
   ///
-  /// {@macro flutter.widgets.subscriptions}
+  /// {@template flutter.widgets.subscriptions}
+  /// If a [State]'s [build] method depends on an object that can itself
+  /// change state, for example a [ChangeNotifier] or [Stream], or some
+  /// other object to which one can subscribe to receive notifications, then
+  /// be sure to subscribe and unsubscribe properly in [initState],
+  /// [didUpdateWidget], and [dispose]:
+  ///
+  ///  * In [initState], subscribe to the object.
+  ///  * In [didUpdateWidget] unsubscribe from the old object and subscribe
+  ///    to the new one if the updated widget configuration requires
+  ///    replacing the object.
+  ///  * In [dispose], unsubscribe from the object.
+  /// {@endtemplate}
   ///
   /// You cannot use [BuildContext.inheritFromWidgetOfExactType] from this
   /// method. However, [didChangeDependencies] will be called immediately
@@ -1344,7 +1334,11 @@ abstract class ProxyWidget extends Widget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@template flutter.widgets.child}
+  /// This widget can only have one child. To lay out multiple children, let this
+  /// widget's child be a widget such as [Row], [Column], or [Stack], which have a
+  /// `children` property, and then provide the children to that widget.
+  /// {@endtemplate}
   final Widget child;
 }
 


### PR DESCRIPTION
## Description

The generated documentation for DartDoc is broken: https://master-docs.flutter.io/flutter/widgets/UniqueKey-class.html It includes doc templates, which it is not supposed to include. This PR moves the template to the first location that uses the template, which is the pattern we use everywhere else in the code base.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28965.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
