### PR TITLE
Add opacity to Cupertino switch when disabled

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -131,12 +131,15 @@ class CupertinoSwitch extends StatefulWidget {
 class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
-    return _CupertinoSwitchRenderObjectWidget(
-      value: widget.value,
-      activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
-      onChanged: widget.onChanged,
-      vsync: this,
-      dragStartBehavior: widget.dragStartBehavior,
+    return Opacity(
+      opacity: widget.onChanged == null ? 0.4 : 1.0,
+      child: _CupertinoSwitchRenderObjectWidget(
+        value: widget.value,
+        activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
+        onChanged: widget.onChanged,
+        vsync: this,
+        dragStartBehavior: widget.dragStartBehavior,
+      ),
     );
   }
 }


### PR DESCRIPTION
Related to #29164. Wrapped the widget in an opacity, if onChange is null the opacity is 0.4 otherwise it is 1.0

## Description

Wrapped the widget in an opacity, if onChange is null the opacity is 0.4 otherwise it is 1.0

## Related Issues

[Cupertino] Disabled Switches do not change opacity #29164 - https://github.com/flutter/flutter/issues/29164 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes