### PR TITLE
add assert if length of TabController and number of tabs do not match

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -944,6 +944,11 @@ class _TabBarState extends State<TabBar> {
 
   @override
   Widget build(BuildContext context) {
+    final int tabControllerLength = widget.controller.length;
+    final int numTabs = widget.tabs.length;
+
+    assert(tabControllerLength == numTabs,
+      'TabController length ($tabControllerLength) and number of tabs ($numTabs) should be equal');
     assert(debugCheckHasMaterialLocalizations(context));
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     if (_controller.length == 0) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -778,6 +778,17 @@ class _TabBarState extends State<TabBar> {
       }
       return true;
     }());
+
+    assert(() {
+      if (newController.length != widget.tabs.length) {
+        throw FlutterError(
+          'Controller\'s length property (${newController.length}) does not match the \n'
+          'number of tab elements (${widget.tabs.length}) present in TabBar\'s tabs property.'
+        );
+      }
+      return true;
+    }());
+
     if (newController == _controller)
       return;
 
@@ -944,11 +955,6 @@ class _TabBarState extends State<TabBar> {
 
   @override
   Widget build(BuildContext context) {
-    final int tabControllerLength = widget.controller.length;
-    final int numTabs = widget.tabs.length;
-
-    assert(tabControllerLength == numTabs,
-      'TabController length ($tabControllerLength) and number of tabs ($numTabs) should be equal');
     assert(debugCheckHasMaterialLocalizations(context));
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     if (_controller.length == 0) {
@@ -1125,6 +1131,17 @@ class _TabBarViewState extends State<TabBarView> {
       }
       return true;
     }());
+
+    assert(() {
+      if (newController.length != widget.children.length) {
+        throw FlutterError(
+          'Controller\'s length property (${newController.length}) does not match the \n'
+          'number of elements (${widget.children.length}) present in TabBarView\'s children property.'
+        );
+      }
+      return true;
+    }());
+
     if (newController == _controller)
       return;
 


### PR DESCRIPTION
## Description

Initially, an exception would be thrown on certain gestures when there is a mismatch in TabController length and the number of TabBar tabs. This change introduces an assert that throws an exception when:
1) The TabController length and the number of TabBar tabs do not match
2) The TabController length and the number of TabBarView children elements do not match

## Related Issues

Fixes https://github.com/flutter/flutter/issues/16292

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
