### PR TITLE
guard new formatter behind env var

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -22,6 +22,9 @@ final String pub = path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', Pla
 final String pubCache = path.join(flutterRoot, '.pub-cache');
 final List<String> flutterTestArgs = <String>[];
 
+
+final bool useFlutterTestFormatter = Platform.environment['FLUTTER_TEST_FORMATTER'] == 'true';
+
 const Map<String, ShardRunner> _kShards = <String, ShardRunner>{
   'tests': _runTests,
   'tool_tests': _runToolTests,
@@ -146,6 +149,9 @@ Future<void> _runSmokeTests() async {
 }
 
 Future<bq.BigqueryApi> _getBigqueryApi() async {
+  if (!useFlutterTestFormatter) {
+    return null;
+  }
   // TODO(dnfield): How will we do this on LUCI?
   final String privateKey = Platform.environment['GCLOUD_SERVICE_ACCOUNT_KEY'];
   // If we're on Cirrus and a non-collaborator is doing this, we can't get the key.
@@ -153,7 +159,7 @@ Future<bq.BigqueryApi> _getBigqueryApi() async {
     return null;
   }
   try {
-    final auth.ServiceAccountCredentials accountCredentials = auth.ServiceAccountCredentials( //.fromJson(credentials);
+    final auth.ServiceAccountCredentials accountCredentials = auth.ServiceAccountCredentials(
       'flutter-ci-test-reporter@flutter-infra.iam.gserviceaccount.com',
       auth.ClientId.serviceAccount('114390419920880060881.apps.googleusercontent.com'),
       '-----BEGIN PRIVATE KEY-----\n$privateKey\n-----END PRIVATE KEY-----\n',
@@ -366,15 +372,24 @@ Future<void> _buildRunnerTest(
     pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
   }
 
-  final FlutterCompactFormatter formatter = FlutterCompactFormatter();
-  final Stream<String> testOutput = runAndGetStdout(
-    pub,
-    args,
-    workingDirectory: workingDirectory,
-    environment: pubEnvironment,
-    beforeExit: formatter.finish
-  );
-  await _processTestOutput(formatter, testOutput, tableData);
+  if (useFlutterTestFormatter) {
+    final FlutterCompactFormatter formatter = FlutterCompactFormatter();
+    final Stream<String> testOutput = runAndGetStdout(
+      pub,
+      args,
+      workingDirectory: workingDirectory,
+      environment: pubEnvironment,
+      beforeExit: formatter.finish
+    );
+    await _processTestOutput(formatter, testOutput, tableData);
+  } else {
+    await runCommand(
+      pub,
+      args,
+      workingDirectory:workingDirectory,
+      environment:pubEnvironment,
+    );
+  }
 }
 
 Future<void> _pubRunTest(
@@ -383,7 +398,7 @@ Future<void> _pubRunTest(
   bool enableFlutterToolAsserts = false,
   bq.TabledataResourceApi tableData,
 }) async {
-  final List<String> args = <String>['run', 'test', '-rjson', '-j1'];
+  final List<String> args = <String>['run', 'test', useFlutterTestFormatter ? '-rjson' : '-rcompact', '-j1'];
   if (!hasColor)
     args.add('--no-color');
   if (testPath != null)
@@ -400,14 +415,22 @@ Future<void> _pubRunTest(
         toolsArgs += ' --enable-asserts';
     pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
   }
-  final FlutterCompactFormatter formatter = FlutterCompactFormatter();
-  final Stream<String> testOutput = runAndGetStdout(
-    pub,
-    args,
-    workingDirectory: workingDirectory,
-    beforeExit: formatter.finish,
-  );
-  await _processTestOutput(formatter, testOutput, tableData);
+  if (useFlutterTestFormatter) {
+    final FlutterCompactFormatter formatter = FlutterCompactFormatter();
+    final Stream<String> testOutput = runAndGetStdout(
+      pub,
+      args,
+      workingDirectory: workingDirectory,
+      beforeExit: formatter.finish,
+    );
+    await _processTestOutput(formatter, testOutput, tableData);
+  } else {
+    await runCommand(
+      pub,
+      args,
+      workingDirectory:workingDirectory,
+    );
+  }
 }
 
 enum CiProviders {
@@ -563,7 +586,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
   if (flutterTestArgs != null && flutterTestArgs.isNotEmpty)
     args.addAll(flutterTestArgs);
 
-  final bool shouldProcessOutput = !expectFailure && !options.contains('--coverage');
+  final bool shouldProcessOutput = useFlutterTestFormatter && !expectFailure && !options.contains('--coverage');
   if (shouldProcessOutput) {
     args.add('--machine');
   }
@@ -591,14 +614,27 @@ Future<void> _runFlutterTest(String workingDirectory, {
       timeout: timeout,
     );
   }
+
+  if (useFlutterTestFormatter) {
   final FlutterCompactFormatter formatter = FlutterCompactFormatter();
-  final Stream<String> testOutput = runAndGetStdout(flutter, args,
+  final Stream<String> testOutput = runAndGetStdout(
+    flutter,
+    args,
     workingDirectory: workingDirectory,
     expectNonZeroExit: expectFailure,
     timeout: timeout,
     beforeExit: formatter.finish,
   );
   await _processTestOutput(formatter, testOutput, tableData);
+  } else {
+    await runCommand(
+      flutter,
+      args,
+      workingDirectory: workingDirectory,
+      expectNonZeroExit: expectFailure,
+      timeout: timeout,
+    );
+  }
 }
 
 Future<void> _verifyVersion(String filename) async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -350,7 +350,7 @@ Future<void> _buildRunnerTest(
   bool enableFlutterToolAsserts = false,
   bq.TabledataResourceApi tableData,
 }) async {
-  final List<String> args = <String>['run', 'build_runner', 'test', '--', '-rcompact', '-j1'];
+  final List<String> args = <String>['run', 'build_runner', 'test', '--', useFlutterTestFormatter ? '-rjson' : '-rcompact', '-j1'];
   if (!hasColor) {
     args.add('--no-color');
   }


### PR DESCRIPTION
The new formatter isn't quite working in some scenarios.  Til I can get it straightened out it'll be disabled behind the env var `FLUTTER_TEST_FORMATTER`, which has to be set to the string `true` to re-enable it.