### PR TITLE
Use fs.identical to compare paths when finding the engine source path

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -411,7 +411,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
       try {
         Uri engineUri = PackageMap(PackageMap.globalPackagesPath).map[kFlutterEnginePackageName];
         // Skip if sky_engine is the self-contained one.
-        if (fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'pkg', kFlutterEnginePackageName, 'lib') + fs.path.separator == engineUri?.path) {
+        if (engineUri != null && fs.identicalSync(fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'pkg', kFlutterEnginePackageName, 'lib'), engineUri.path)) {
           engineUri = null;
         }
         // If sky_engine is specified and the engineSourcePath not set, try to determine the engineSourcePath by sky_engine setting.

--- a/packages/flutter_tools/test/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/runner/flutter_command_runner_test.dart
@@ -74,6 +74,11 @@ void main() {
         fs.directory('$_kArbitraryEngineRoot/src/out/host_debug').createSync(recursive: true);
         fs.file(_kDotPackages).writeAsStringSync('sky_engine:file://$_kArbitraryEngineRoot/src/out/ios_debug/gen/dart-pkg/sky_engine/lib/');
         await runner.run(<String>['dummy', '--local-engine=ios_debug']);
+
+        // Verify that this also works if the sky_engine path is a symlink to the engine root.
+        fs.link('/symlink').createSync('$_kArbitraryEngineRoot');
+        fs.file(_kDotPackages).writeAsStringSync('sky_engine:file:///symlink/src/out/ios_debug/gen/dart-pkg/sky_engine/lib/');
+        await runner.run(<String>['dummy', '--local-engine=ios_debug']);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         Platform: () => platform,


### PR DESCRIPTION
This will handle paths with symlinks that resolve to the same location.