### PR TITLE
Make expansion panel optionally toggle its state by tapping its header.

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -6,6 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'expand_icon.dart';
+import 'ink_well.dart';
 import 'mergeable_material.dart';
 import 'theme.dart';
 
@@ -71,9 +72,11 @@ class ExpansionPanel {
     @required this.headerBuilder,
     @required this.body,
     this.isExpanded = false,
+    this.canTapOnHeader = false,
   }) : assert(headerBuilder != null),
        assert(body != null),
-       assert(isExpanded != null);
+       assert(isExpanded != null),
+       assert(canTapOnHeader != null);
 
   /// The widget builder that builds the expansion panels' header.
   final ExpansionPanelHeaderBuilder headerBuilder;
@@ -87,6 +90,11 @@ class ExpansionPanel {
   ///
   /// Defaults to false.
   final bool isExpanded;
+
+  /// Whether tapping on the panel's header will expand/collapse it.
+  ///
+  /// Defaults to false.
+  final bool canTapOnHeader;
 
 }
 
@@ -109,8 +117,13 @@ class ExpansionPanelRadio extends ExpansionPanel {
     @required this.value,
     @required ExpansionPanelHeaderBuilder headerBuilder,
     @required Widget body,
+    bool canTapOnHeader = false,
   }) : assert(value != null),
-       super(body: body, headerBuilder: headerBuilder);
+      super(
+        body: body,
+        headerBuilder: headerBuilder,
+        canTapOnHeader: canTapOnHeader,
+      );
 
   /// The value that uniquely identifies a radio panel so that the currently
   /// selected radio panel can be identified.
@@ -406,6 +419,10 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         items.add(MaterialGap(key: _SaltedKey<BuildContext, int>(context, index * 2 - 1)));
 
       final ExpansionPanel child = widget.children[index];
+      final Widget headerWidget = child.headerBuilder(
+        context,
+        _isChildExpanded(index),
+      );
       final Row header = Row(
         children: <Widget>[
           Expanded(
@@ -415,10 +432,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
               margin: _isChildExpanded(index) ? kExpandedEdgeInsets : EdgeInsets.zero,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: _kPanelHeaderCollapsedHeight),
-                child: child.headerBuilder(
-                  context,
-                  _isChildExpanded(index),
-                ),
+                child: headerWidget,
               ),
             ),
           ),
@@ -427,7 +441,9 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
             child: ExpandIcon(
               isExpanded: _isChildExpanded(index),
               padding: const EdgeInsets.all(16.0),
-              onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+              onPressed: !child.canTapOnHeader
+                ? (bool isExpanded) => _handlePressed(isExpanded, index)
+                : null,
             ),
           ),
         ],
@@ -438,7 +454,14 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           key: _SaltedKey<BuildContext, int>(context, index * 2),
           child: Column(
             children: <Widget>[
-              MergeSemantics(child: header),
+              MergeSemantics(
+                child: child.canTapOnHeader
+                  ? InkWell(
+                  onTap: () => _handlePressed(_isChildExpanded(index), index),
+                  child: header,
+                )
+                  : header,
+              ),
               AnimatedCrossFade(
                 firstChild: Container(height: 0.0),
                 secondChild: child.body,


### PR DESCRIPTION
## Description

`ExpansionPanel`s can toggle their expand/collapse state only by tapping on the `ExpandIcon`. This change introduces an optional parameter to the `ExpansionPanel` that can make it toggle its state by tapping anywhere in its header widget.

## Related Issues

Fixes #5845

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
