### PR TITLE
Fix MaterialApp's _navigatorObserver when only builder used

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -419,7 +419,7 @@ class _MaterialAppState extends State<MaterialApp> {
       _navigatorObservers = List<NavigatorObserver>.from(widget.navigatorObservers)
         ..add(_heroController);
     } else {
-      _navigatorObservers = null;
+      _navigatorObservers = const <NavigatorObserver>[];
     }
   }
 

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -596,4 +596,14 @@ void main() {
     expect(themeBeforeBrightnessChange.brightness, Brightness.light);
     expect(themeAfterBrightnessChange.brightness, Brightness.dark);
   });
+
+  testWidgets('MaterialApp with builder and no route information works.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget child) {
+          return const SizedBox();
+        },
+      ),
+    );
+  });
 }

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -381,6 +381,17 @@ void main() {
     expect(log, <String>['onGenerateRoute /', 'onUnknownRoute /']);
   });
 
+  testWidgets('MaterialApp with builder and no route information works.', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/18904
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget child) {
+          return const SizedBox();
+        },
+      ),
+    );
+  });
+
   testWidgets('Can get text scale from media query', (WidgetTester tester) async {
     double textScaleFactor;
     await tester.pumpWidget(MaterialApp(
@@ -595,15 +606,5 @@ void main() {
 
     expect(themeBeforeBrightnessChange.brightness, Brightness.light);
     expect(themeAfterBrightnessChange.brightness, Brightness.dark);
-  });
-
-  testWidgets('MaterialApp with builder and no route information works.', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        builder: (BuildContext context, Widget child) {
-          return const SizedBox();
-        },
-      ),
-    );
   });
 }


### PR DESCRIPTION
## Description

Sets _navigatorObserver to [] rather than null so that WidgetApp's assertion no longer fails.

## Related Issues

Fixes #18904

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.
