### PR TITLE
userGestureInProgress always be true when using CupertinoPageRoute.

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -493,6 +493,7 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
     assert(mounted);
     assert(_backGestureController == null);
     _backGestureController = widget.onStartPopGesture();
+    _backGestureController.dragStart();
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -579,9 +579,7 @@ class _CupertinoBackGestureController<T> {
     @required this.route,
     @required this.controller,
     @required this.onEnded,
-  }) : assert(route != null), assert(controller != null), assert(onEnded != null) {
-    route.navigator.didStartUserGesture();
-  }
+  }) : assert(route != null), assert(controller != null), assert(onEnded != null);
 
   final PageRoute<T> route;
   final AnimationController controller;
@@ -593,6 +591,10 @@ class _CupertinoBackGestureController<T> {
   /// drag should be 0.0 to 1.0.
   void dragUpdate(double delta) {
     controller.value -= delta;
+  }
+
+  void dragStart() {
+    route.navigator.didStartUserGesture();
   }
 
   /// The drag gesture has ended with a horizontal motion of
@@ -636,9 +638,9 @@ class _CupertinoBackGestureController<T> {
     } else {
       // Animate calls could return inline if already at the target destination
       // value.
-      return _handleStatusChanged(controller.status);
+      _handleStatusChanged(controller.status);
     }
-
+    route.navigator?.didStopUserGesture();
   }
 
   void _handleStatusChanged(AnimationStatus status) {
@@ -654,7 +656,6 @@ class _CupertinoBackGestureController<T> {
   void dispose() {
     if (_animating)
       controller.removeStatusListener(_handleStatusChanged);
-    route.navigator?.didStopUserGesture();
   }
 }
 


### PR DESCRIPTION
## Description

```navigator.userGestureInProgress``` always be the true when using CupertinoPageRoute.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.
