### PR TITLE
Added opacity to cupertino switch when disabled

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -73,7 +73,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// change state until the parent widget rebuilds the switch with the new
   /// value.
   ///
-  /// If null, the switch will be displayed as disabled with an opacity of 
+  /// If null, the switch will be displayed as disabled with an opacity of
   /// 0.5. This is opacity value appears to be accurate in comparison to the
   /// actual iOS switch.
   ///

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -73,7 +73,9 @@ class CupertinoSwitch extends StatefulWidget {
   /// change state until the parent widget rebuilds the switch with the new
   /// value.
   ///
-  /// If null, the switch will be displayed as disabled.
+  /// If null, the switch will be displayed as disabled with an opacity of 
+  /// 0.5. This is opacity value appears to be accurate in comparison to the
+  /// actual iOS switch.
   ///
   /// The callback provided to onChanged should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
@@ -132,7 +134,7 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   @override
   Widget build(BuildContext context) {
     return Opacity(
-      opacity: widget.onChanged == null ? 0.4 : 1.0,
+      opacity: widget.onChanged == null ? 0.5 : 1.0,
       child: _CupertinoSwitchRenderObjectWidget(
         value: widget.value,
         activeColor: widget.activeColor ?? CupertinoColors.activeGreen,

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -131,12 +131,15 @@ class CupertinoSwitch extends StatefulWidget {
 class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
-    return _CupertinoSwitchRenderObjectWidget(
-      value: widget.value,
-      activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
-      onChanged: widget.onChanged,
-      vsync: this,
-      dragStartBehavior: widget.dragStartBehavior,
+    return Opacity(
+      opacity: widget.onChanged == null ? 0.4 : 1.0,
+      child: _CupertinoSwitchRenderObjectWidget(
+        value: widget.value,
+        activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
+        onChanged: widget.onChanged,
+        vsync: this,
+        dragStartBehavior: widget.dragStartBehavior,
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -74,7 +74,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// value.
   ///
   /// If null, the switch will be displayed as disabled with an opacity of [kCupertinoSwitchDisabledOpacity]
-  /// 
+  ///
   /// The callback provided to onChanged should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt; for example:

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -192,7 +192,7 @@ const double _kTrackInnerEnd = _kTrackWidth - _kTrackInnerStart;
 const double _kTrackInnerLength = _kTrackInnerEnd - _kTrackInnerStart;
 const double _kSwitchWidth = 59.0;
 const double _kSwitchHeight = 39.0;
-const double _kCupertinoSwitchDisabledOpacity = 0.5; //value appears to be accurate in comparison to the actual iOS switch
+const double _kCupertinoSwitchDisabledOpacity = 0.5;//value appears to be accurate in comparison to the actual iOS switch
 
 const Color _kTrackColor = CupertinoColors.lightBackgroundGray;
 const Duration _kReactionDuration = Duration(milliseconds: 300);

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -73,10 +73,8 @@ class CupertinoSwitch extends StatefulWidget {
   /// change state until the parent widget rebuilds the switch with the new
   /// value.
   ///
-  /// If null, the switch will be displayed as disabled with an opacity of
-  /// 0.5. This is opacity value appears to be accurate in comparison to the
-  /// actual iOS switch.
-  ///
+  /// If null, the switch will be displayed as disabled with an opacity of [kCupertinoSwitchDisabledOpacity]
+  /// 
   /// The callback provided to onChanged should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt; for example:
@@ -134,7 +132,7 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   @override
   Widget build(BuildContext context) {
     return Opacity(
-      opacity: widget.onChanged == null ? 0.5 : 1.0,
+      opacity: widget.onChanged == null ? _kCupertinoSwitchDisabledOpacity : 1.0,
       child: _CupertinoSwitchRenderObjectWidget(
         value: widget.value,
         activeColor: widget.activeColor ?? CupertinoColors.activeGreen,
@@ -194,6 +192,7 @@ const double _kTrackInnerEnd = _kTrackWidth - _kTrackInnerStart;
 const double _kTrackInnerLength = _kTrackInnerEnd - _kTrackInnerStart;
 const double _kSwitchWidth = 59.0;
 const double _kSwitchHeight = 39.0;
+const double _kCupertinoSwitchDisabledOpacity = 0.5; //value appears to be accurate in comparison to the actual iOS switch
 
 const Color _kTrackColor = CupertinoColors.lightBackgroundGray;
 const Duration _kReactionDuration = Duration(milliseconds: 300);

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -73,7 +73,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// change state until the parent widget rebuilds the switch with the new
   /// value.
   ///
-  /// If null, the switch will be displayed as disabled with an opacity of [kCupertinoSwitchDisabledOpacity]
+  /// If null, the switch will be displayed as disabled, which has a reduced opacity.
   ///
   /// The callback provided to onChanged should update the state of the parent
   /// [StatefulWidget] using the [State.setState] method, so that the parent
@@ -192,7 +192,8 @@ const double _kTrackInnerEnd = _kTrackWidth - _kTrackInnerStart;
 const double _kTrackInnerLength = _kTrackInnerEnd - _kTrackInnerStart;
 const double _kSwitchWidth = 59.0;
 const double _kSwitchHeight = 39.0;
-const double _kCupertinoSwitchDisabledOpacity = 0.5;//value appears to be accurate in comparison to the actual iOS switch
+// Opacity of a disabled switch, as eye-balled from iOS Simulator on Mac.
+const double _kCupertinoSwitchDisabledOpacity = 0.5;
 
 const Color _kTrackColor = CupertinoColors.lightBackgroundGray;
 const Duration _kReactionDuration = Duration(milliseconds: 300);

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -419,7 +419,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
-          child: CupertinoSwitch(
+          child: const CupertinoSwitch(
             value: false,
             dragStartBehavior: DragStartBehavior.down,
             onChanged: null,

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -414,27 +414,39 @@ void main() {
 
     expect(value, isFalse);
   });
-  testWidgets('Switch is opaque when disabled', (WidgetTester tester) async {
-    final Key switchKey = UniqueKey();
+  testWidgets('Switch is translucent when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Center(
-              child: CupertinoSwitch(
-                key: switchKey,
-                value: false,
-                dragStartBehavior: DragStartBehavior.down,
-                onChanged: null,
-              ),
-            );
-          },
-        ),
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        )
       ),
     );
 
-    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.4);
+    expect(find.byType(Opacity), findsOneWidget);
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.5);
+  });
+  testWidgets('Switch is opaque when enabled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: (bool newValue) {},
+          ),
+        )
+      ),
+    );
+
+    expect(find.byType(Opacity), findsOneWidget);
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 1.0);
   });
 
 }

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -416,10 +416,10 @@ void main() {
   });
   testWidgets('Switch is translucent when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
-          child: const CupertinoSwitch(
+          child: CupertinoSwitch(
             value: false,
             dragStartBehavior: DragStartBehavior.down,
             onChanged: null,

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -414,5 +414,27 @@ void main() {
 
     expect(value, isFalse);
   });
+  testWidgets('Switch is opaque when disabled', (WidgetTester tester) async {
+    final Key switchKey = UniqueKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Center(
+              child: CupertinoSwitch(
+                key: switchKey,
+                value: false,
+                dragStartBehavior: DragStartBehavior.down,
+                onChanged: null,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.4);
+  });
 
 }

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -414,7 +414,7 @@ void main() {
 
     expect(value, isFalse);
   });
-  
+
   testWidgets('Switch is translucent when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -451,4 +451,66 @@ void main() {
     expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 1.0);
   });
 
+  testWidgets('Switch turns translucent after becoming disabled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: (bool newValue) {},
+          ),
+        )
+      ),
+    );
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        )
+      ),
+    );
+
+    expect(find.byType(Opacity), findsOneWidget);
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.5);    
+  });
+
+    testWidgets('Switch turns opaque after becoming enabled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        )
+      ),
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: (bool newValue) {},
+          ),
+        )
+      ),
+    );
+
+    expect(find.byType(Opacity), findsOneWidget);
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 1.0);    
+  });
+
 }

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -479,7 +479,7 @@ void main() {
     );
 
     expect(find.byType(Opacity), findsOneWidget);
-    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.5);    
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.5);
   });
 
     testWidgets('Switch turns opaque after becoming enabled', (WidgetTester tester) async {
@@ -510,7 +510,7 @@ void main() {
     );
 
     expect(find.byType(Opacity), findsOneWidget);
-    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 1.0);    
+    expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 1.0);
   });
 
 }

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -414,6 +414,7 @@ void main() {
 
     expect(value, isFalse);
   });
+  
   testWidgets('Switch is translucent when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
@@ -431,6 +432,7 @@ void main() {
     expect(find.byType(Opacity), findsOneWidget);
     expect(tester.widget<Opacity>(find.byType(Opacity).first).opacity, 0.5);
   });
+
   testWidgets('Switch is opaque when enabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(


### PR DESCRIPTION
## Description

Wrapped the widget in an opacity, if onChange is null the opacity is 0.4 otherwise it is 1.0

## Related Issues

https://github.com/flutter/flutter/issues/29164

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes