### PR TITLE
[WIP] Compile plugins as .aars, not subprojects

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -186,26 +186,28 @@ class FlutterPlugin implements Plugin<Project> {
         File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
         Properties plugins = readPropertiesIfExist(pluginsFile)
 
-        plugins.each { name, _ ->
-            def pluginProject = project.rootProject.findProject(":$name")
-            if (pluginProject != null) {
-                project.dependencies {
-                    if (project.getConfigurations().findByName("implementation")) {
-                        implementation pluginProject
-                    } else {
-                        compile pluginProject
-                    }
-                }
-		pluginProject.afterEvaluate {
-                    pluginProject.android.buildTypes {
-                        profile {
-                            initWith debug
-                        }
-                    }
-		}
-                pluginProject.afterEvaluate this.&addFlutterJarCompileOnlyDependency
-            } else {
-                project.logger.error("Plugin project :$name not found. Please update settings.gradle.")
+        // TODO(mklim): This replacement currently requires apps to remove their
+        // `subproject {}` declarations or else break. If we're going to
+        // actually commit this we need to fix that or make this code path
+        // execute only when we detect that users have migrated their app
+        // instead.
+        plugins.each { name, path ->
+            def String artifactDir = Paths.get(path, 'android', 'build', 'outputs', 'aar').toString();
+            def Set<File> aars = project.fileTree(dir: artifactDir, include: '*.aar').getFiles();
+
+            if (aars.size() < 1) {
+                throw new GradleException("Couldn't find plugin $name .aar artifiact in $artifactDir");
+            }
+
+            def String aarPath = aars[0].getAbsolutePath();
+            if (aars.size() > 1) {
+                // TODO(mklim): Pick the AAR we actually just built, not the
+                // first one.
+                project.logger.warn("Found multiple artifacts for plugin $name. Using $aarPath.");
+            }
+
+            project.dependencies {
+                compile project.files(aarPath)
             }
         }
     }

--- a/packages/flutter_tools/gradle/plugins_init.gradle
+++ b/packages/flutter_tools/gradle/plugins_init.gradle
@@ -1,0 +1,74 @@
+import java.nio.file.Path
+import java.nio.file.Paths
+
+allprojects {
+    apply plugin: FlutterAarPlugin
+}
+
+/** Adds in a cmpileOnly dependency on flutterJar. */
+class FlutterAarPlugin implements Plugin<Project> {
+    private File flutterJar
+    private File debugFlutterJar
+    private File releaseFlutterJar
+
+    @Override
+    void apply(Project project) {
+        findFlutterJar(project)
+        project.afterEvaluate this.&addFlutterJarCompileOnlyDependency
+    }
+
+    // TODO(mklim): This logic is copied from flutter.gradle. Should probably
+    // come from the same source instead.
+    private void findFlutterJar(Project project) {
+        if (project.hasProperty('localEngineOut')) {
+            String engineOutPath = project.property('localEngineOut')
+            File engineOut = project.file(engineOutPath)
+            if (!engineOut.isDirectory()) {
+                throw new GradleException('localEngineOut must point to a local engine build')
+            }
+            flutterJar = Paths.get(engineOut.absolutePath, "flutter.jar").toFile()
+            if (!flutterJar.isFile()) {
+                throw new GradleException('Local engine build does not contain flutter.jar')
+            }
+
+            localEngine = engineOut.name
+            localEngineSrcPath = engineOut.parentFile.parent
+
+            project.dependencies {
+                compileOnly project.files(flutterJar)
+            }
+        } else {
+            Path baseEnginePath = Paths.get(project.property('flutter-root'), 'bin', 'cache', 'artifacts', 'engine')
+            String targetArch = 'arm'
+            if (project.hasProperty('target-platform') &&
+                project.property('target-platform') == 'android-arm64') {
+              targetArch = 'arm64'
+            }
+            debugFlutterJar = baseEnginePath.resolve("android-${targetArch}").resolve("flutter.jar").toFile()
+            releaseFlutterJar = baseEnginePath.resolve("android-${targetArch}-release").resolve("flutter.jar").toFile()
+            if (!debugFlutterJar.isFile()) {
+                project.exec {
+                    executable flutterExecutable.absolutePath
+                    args "--suppress-analytics"
+                    args "precache"
+                }
+                if (!debugFlutterJar.isFile()) {
+                    throw new GradleException("Unable to find flutter.jar in SDK: ${debugFlutterJar}")
+                }
+            }
+        }
+    }
+
+    private void addFlutterJarCompileOnlyDependency(Project project) {
+        if (project.state.failure) {
+            return
+        }
+        project.dependencies {
+            if (flutterJar != null) {
+                compileOnly project.files(flutterJar)
+            } else {
+                compileOnly project.files(releaseFlutterJar)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This is a very rough proof of concept. It functions on simple app cases
given manual tweaking.

It basically works by adding extra logic to `gradle.dart` before the APK
of an app is compiled.

- Gets a flat list of all transitive Flutter plugin dependencies.
- Runs an `init-script` on each one to add the local `flutter-jar` as a
  `compileOnly` dependency to it.
- Compiles each dependency as an AAR.
- Uses the plugin AARs as dependencies for compiling the APK in the
  `flutter.gradle` plugin.

There's two big blockers on this still that I'm currently aware of.

1. This requires apps to manually remove the `subprojects` declarations
   from `android/build.gradle` and the `plugins.each` loop from
   `android/settings.gradle`. It's both breaking and requiring manual
   intervention on the app side to work.
2. Transitive gradle dependencies within our Flutter plugins cause
   crashes at runtime, since the inner deps aren't being included in the
   aar. To see a failing case, use this code with a sample app requiring
   `firebase_auth`. At runtime it will crash because the firebase
   library isn't found.

## Related Issues

flutter/flutter#29328

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [ ] No, this is *not* a breaking change.

(This is a WIP. It shouldn't be merged until there's tests, it's no longer a breaking change, etc.)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
