### PR TITLE
prevent stream notifications from interfering with reload

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -51,9 +51,6 @@ TaskFunction createHotModeTest() {
               .listen((String line) async {
             if (line.contains('\] Reloaded ')) {
               if (hotReloadCount == 0) {
-                // Ensure that notifications triggered after the previous hot
-                // reload have finished.
-                await Future<void>.delayed(const Duration(seconds: 2));
                 // Update the file and reload again.
                 final File appDartSource = file(path.join(
                     _editedFlutterGalleryDir.path, 'lib/gallery/app.dart',

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -48,9 +48,12 @@ TaskFunction createHotModeTest() {
           process.stdout
               .transform<String>(utf8.decoder)
               .transform<String>(const LineSplitter())
-              .listen((String line) {
+              .listen((String line) async {
             if (line.contains('\] Reloaded ')) {
               if (hotReloadCount == 0) {
+                // Ensure that notifications triggered after the previous hot
+                // reload have finished.
+                await Future<void>.delayed(const Duration(seconds: 2));
                 // Update the file and reload again.
                 final File appDartSource = file(path.join(
                     _editedFlutterGalleryDir.path, 'lib/gallery/app.dart',

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -48,7 +48,7 @@ TaskFunction createHotModeTest() {
           process.stdout
               .transform<String>(utf8.decoder)
               .transform<String>(const LineSplitter())
-              .listen((String line) async {
+              .listen((String line) {
             if (line.contains('\] Reloaded ')) {
               if (hotReloadCount == 0) {
                 // Update the file and reload again.

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -216,6 +216,7 @@ class HotRunner extends ResidentRunner {
       // Measure time to perform a hot restart.
       printStatus('Benchmarking hot restart');
       await restart(fullRestart: true);
+      await Future<void>.delayed(const Duration(seconds: 2));
       printStatus('Benchmarking hot reload');
       // Measure time to perform a hot reload.
       await restart(fullRestart: false);

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -474,7 +474,7 @@ class HotRunner extends ResidentRunner {
           isolateNotifications.add(
             view.owner.vm.vmService.onIsolateEvent.then((Stream<ServiceEvent> serviceEvents) async {
               await for (ServiceEvent serviceEvent in serviceEvents) {
-                if (serviceEvent.owner.name.contains('_spawn') == true && serviceEvent.kind == ServiceEvent.kIsolateExit) {
+                if (serviceEvent.owner.name.contains('_spawn') && serviceEvent.kind == ServiceEvent.kIsolateExit) {
                   return;
                 }
               }


### PR DESCRIPTION
## Description

The performance regression on the latest hot reload benchmark is fairly unexpected and not reproducible locally. From inspecting the logs, it appears that a number of notifications from the hot restart are arriving after the hot reload is started. The isolate may not be immediately ready for the hot reload, and the previous reload time covered this up.

```
2019-03-15T18:13:07.027490: stdout: [   +5 ms] Refreshing active FlutterViews before reloading.
2019-03-15T18:13:07.027658: stdout: [        ] Sending to VM service: _flutter.listViews({})
2019-03-15T18:13:07.033230: stdout: [   +5 ms] Result: {type: FlutterViewList, views: [{type: FlutterView, id: _flutterView/0x9a47bf0c, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart$main-60789868, number: 60789868}}]}
2019-03-15T18:13:07.050290: stdout: [  +17 ms] Syncing files to device Moto G 4...
2019-03-15T18:13:07.050432: stdout: [        ] Scanning asset files
2019-03-15T18:13:07.069979: stdout: [  +19 ms] Compiling dart to kernel with 0 updated files
2019-03-15T18:13:07.085620: stdout: [  +15 ms] Updating files
2019-03-15T18:13:07.097876: stdout: [  +12 ms] DevFS: Sync finished
2019-03-15T18:13:07.098021: stdout: [        ] Syncing files to device Moto G 4... (completed in 47ms)
stdout: [        ] Synced 0.0MB.
2019-03-15T18:13:07.099996: stdout: [   +1 ms] Sending to VM service: _reloadSources({pause: false, rootLibUri: file:///data/user/0/io.flutter.demo.gallery/cache/edited_flutter_galleryNMQZGR/edited_flutter_gallery/lib/main.dart.incremental.dill, packagesUri: file:///data/user/0/io.flutter.demo.gallery/cache/edited_flutter_galleryNMQZGR/edited_flutter_gallery/.packages, isolateId: isolates/60789868})
2019-03-15T18:13:07.109883: stdout: [   +9 ms] Result: {type: ReloadReport, success: true, details: {finalLibraryCount: 578, receivedLibraryCount: 0, receivedLibrariesBytes: 128, receivedClassesCount: 0, receivedProceduresCount: 0, savedLibraryCount: 578, loadedLibraryCount: 0}}
2019-03-15T18:13:07.112344: stdout: [   +2 ms] reloaded 0 of 578 libraries
2019-03-15T18:13:07.112565: stdout: [        ] Sending reload events to Moto G 4
stdout: [        ] Sending reload event to "main.dart$main-60789868"
2019-03-15T18:13:07.112731: stdout: [        ] Sending to VM service: getIsolate({isolateId: isolates/60789868})
2019-03-15T18:13:07.167692: stdout: [  +54 ms] Result: {type: Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868, _originNumber: 60789868, startTime: 1552698786942, _heaps: {new: {type: HeapSpace, name: new, vmName: Scavenger, collections: 0, avgCollectionPeriodMil...
2019-03-15T18:13:07.176823: stdout: [   +9 ms] Sending to VM service: _flutter.listViews({})
2019-03-15T18:13:07.183087: stdout: [   +6 ms] Result: {type: FlutterViewList, views: [{type: FlutterView, id: _flutterView/0x9a47bf0c, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart$main-60789868, number: 60789868}}]}
2019-03-15T18:13:07.183240: stdout: [        ] Evicting dirty assets
2019-03-15T18:13:07.184102: stdout: [        ] Reassembling application
2019-03-15T18:13:07.185624: stdout: [   +1 ms] Sending to VM service: ext.flutter.reassemble({isolateId: isolates/60789868})
2019-03-15T18:13:07.197493: stderr: [  +10 ms] Error -32601 received from application: Method not found
2019-03-15T18:13:07.197644: stdout: [        ] {request: {method: ext.flutter.reassemble, params: {isolateId: isolates/60789868}}}
2019-03-15T18:13:07.197738: stdout: [        ] Sending to VM service: ext.ui.window.scheduleFrame({isolateId: isolates/60789868})
2019-03-15T18:13:07.255593: stdout: [  +57 ms] Notification from VM: {streamId: Isolate, event: {type: Event, kind: ServiceExtensionAdded, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868}, timestamp: 1552698787731, extensionRPC: ext.flutter.reassemble}}
2019-03-15T18:13:07.258106: stdout: [   +2 ms] Notification from VM: {streamId: Isolate, event: {type: Event, kind: ServiceExtensionAdded, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868}, timestamp: 1552698787731, extensionRPC: ext.flutter.exit}}
2019-03-15T18:13:07.258474: stdout: [        ] Notification from VM: {streamId: Isolate, event: {type: Event, kind: ServiceExtensionAdded, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868}, timestamp: 1552698787732, extensionRPC: ext.flutter.saveCompilationTrace}}
2019-03-15T18:13:07.259766: stdout: [   +1 ms] Notification from VM: {streamId: Isolate, event: {type: Event, kind: ServiceExtensionAdded, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868}, timestamp: 1552698787732, extensionRPC: ext.flutter.platformOverride}}
2019-03-15T18:13:07.262017: stdout: [   +2 ms] Notification from VM: {streamId: Isolate, event: {type: Event, kind: ServiceExtensionAdded, isolate: {type: @Isolate, fixedId: true, id: isolates/60789868, name: main.dart:main(), number: 60789868}, timestamp: 1552698787734, extensionRPC: ext.flutter.evict}}
```

## Related Issues

https://github.com/flutter/flutter/issues/29468

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
