### PR TITLE
Let CupertinoTextField's clear button also call onChanged

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -638,15 +638,14 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
         } else if (_showClearButton(text)) {
           rowChildren.add(
             GestureDetector(
-              onTap: widget.enabled ?? true
-                  ? () {
-                // special handle onChanged for ClearButton.
-                final bool textChanged = _effectiveController.text != '';
+              onTap: widget.enabled ?? true ? () {
+                // Special handle onChanged for ClearButton
+                // Also call onChanged when the clear button is tapped.
+                final String oldText = _effectiveController.text;
                 _effectiveController.clear();
-                if (widget.onChanged != null && textChanged)
-                  widget.onChanged(_effectiveController.text);
-              }
-                  : null,
+                if (widget.onChanged != null && oldText.isNotEmpty)
+                  widget.onChanged(oldText);
+              } : null,
               child: const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 6.0),
                 child: Icon(

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -641,10 +641,10 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
               onTap: widget.enabled ?? true ? () {
                 // Special handle onChanged for ClearButton
                 // Also call onChanged when the clear button is tapped.
-                final String oldText = _effectiveController.text;
+                final bool textChanged = _effectiveController.text.isNotEmpty;
                 _effectiveController.clear();
-                if (widget.onChanged != null && oldText.isNotEmpty)
-                  widget.onChanged(oldText);
+                if (widget.onChanged != null && textChanged)
+                  widget.onChanged(_effectiveController.text);
               } : null,
               child: const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 6.0),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -639,7 +639,13 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
           rowChildren.add(
             GestureDetector(
               onTap: widget.enabled ?? true
-                  ? () => _effectiveController.clear()
+                  ? () {
+                // special handle onChanged for ClearButton.
+                final bool textChanged = _effectiveController.text != '';
+                _effectiveController.clear();
+                if (widget.onChanged != null && textChanged)
+                  widget.onChanged(_effectiveController.text);
+              }
                   : null,
               child: const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 6.0),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -762,10 +762,11 @@ void main() {
                     child: CupertinoTextField(
                       controller: controller,
                       placeholder: 'placeholder',
-                      onChanged: (String newValue) =>
-                          setState(() {
-                            value = newValue;
-                          }),
+                      onChanged: (String newValue) {
+                        setState(() {
+                          value = newValue;
+                        });
+                      },
                       clearButtonMode: OverlayVisibilityMode.always,
                     ),
                   );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -750,41 +750,32 @@ void main() {
   );
 
   testWidgets(
-    'clear button tapped alse call onChanged when text not empty',
+    'tapping clear button also calls onChanged when text not empty',
         (WidgetTester tester) async {
-      String value = '';
+      String value = 'text entry';
       final TextEditingController controller = TextEditingController();
       await tester.pumpWidget(
         CupertinoApp(
-            home: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return Center(
-                    child: CupertinoTextField(
-                      controller: controller,
-                      placeholder: 'placeholder',
-                      onChanged: (String newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                      clearButtonMode: OverlayVisibilityMode.always,
-                    ),
-                  );
-                })
+          home: Center(
+            child: CupertinoTextField(
+              controller: controller,
+              placeholder: 'placeholder',
+              onChanged: (String newValue) => value = newValue,
+              clearButtonMode: OverlayVisibilityMode.always,
+            ),
+          ),
         ),
       );
 
-      expect(value, isEmpty);
-      controller.text = 'text entry';
+      controller.text = value;
       await tester.pump();
 
       await tester.tap(find.byIcon(CupertinoIcons.clear_thick_circled));
       await tester.pump();
 
-      expect(controller.text, '');
+      expect(controller.text, isEmpty);
       expect(find.text('text entry'), findsNothing);
-      expect(value, 'text entry');
-      expect(find.byIcon(CupertinoIcons.clear_thick_circled), findsOneWidget);
+      expect(value, isEmpty);
     },
   );
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -774,7 +774,6 @@ void main() {
       );
 
       expect(value, isEmpty);
-
       controller.text = 'text entry';
       await tester.pump();
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -762,7 +762,7 @@ void main() {
                     child: CupertinoTextField(
                       controller: controller,
                       placeholder: 'placeholder',
-                      onChanged: (newValue) =>
+                      onChanged: (String newValue) =>
                           setState(() {
                             value = newValue;
                           }),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -750,6 +750,45 @@ void main() {
   );
 
   testWidgets(
+    'clear button tapped alse call onChanged when text not empty',
+        (WidgetTester tester) async {
+      String value = '';
+      final TextEditingController controller = TextEditingController();
+      await tester.pumpWidget(
+        CupertinoApp(
+            home: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Center(
+                    child: CupertinoTextField(
+                      controller: controller,
+                      placeholder: 'placeholder',
+                      onChanged: (newValue) =>
+                          setState(() {
+                            value = newValue;
+                          }),
+                      clearButtonMode: OverlayVisibilityMode.always,
+                    ),
+                  );
+                })
+        ),
+      );
+
+      expect(value, isEmpty);
+
+      controller.text = 'text entry';
+      await tester.pump();
+
+      await tester.tap(find.byIcon(CupertinoIcons.clear_thick_circled));
+      await tester.pump();
+
+      expect(controller.text, '');
+      expect(find.text('text entry'), findsNothing);
+      expect(value, 'text entry');
+      expect(find.byIcon(CupertinoIcons.clear_thick_circled), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'clear button yields precedence to suffix',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController();


### PR DESCRIPTION
## Description

*CupertinoTextField does not call onChanged when its clear button is tapped.*

## Related Issues

*#29345.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
