### PR TITLE
Make sure initial build populates file cache

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -946,12 +946,12 @@ abstract class ResidentRunner {
     if (device.package.packagesFile == null || !device.package.packagesFile.existsSync()) {
       return true;
     }
-    // why is this sometimes an APK.
-    if (!device.package.packagesFile.path.contains('.packages')) {
+    // Leave pubspec null to check all dependencies.
+    final File actualPackagesFile = fs.file(PackageMap.globalPackagesPath);
+    if (!actualPackagesFile.existsSync()) {
       return true;
     }
-    // Leave pubspec null to check all dependencies.
-    final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(device.package.packagesFile.path, null);
+    final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(actualPackagesFile.path, null);
     projectFileInvalidator.findInvalidated();
     final int lastBuildTime = device.package.packagesFile.statSync().modified.millisecondsSinceEpoch;
     for (int updateTime in projectFileInvalidator.updateTime.values) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -345,7 +345,7 @@ class FlutterDevice {
     startEchoingDeviceLog();
 
     // Start the application.
-    final bool hasDirtyDependencies = hotRunner.hasDirtyDependencies(this);
+    final bool hasDirtyDependencies = await hotRunner.hasDirtyDependencies(this);
     final Future<LaunchResult> futureResult = device.startApp(
       package,
       mainPath: hotRunner.mainPath,
@@ -409,7 +409,7 @@ class FlutterDevice {
 
     startEchoingDeviceLog();
 
-    final bool hasDirtyDependencies = coldRunner.hasDirtyDependencies(this);
+    final bool hasDirtyDependencies = await coldRunner.hasDirtyDependencies(this);
     final LaunchResult result = await device.startApp(
       package,
       mainPath: coldRunner.mainPath,
@@ -942,16 +942,16 @@ abstract class ResidentRunner {
     return exitCode;
   }
 
-  bool hasDirtyDependencies(FlutterDevice device) {
+  Future<bool> hasDirtyDependencies(FlutterDevice device) async {
     if (device.package.packagesFile == null || !device.package.packagesFile.existsSync()) {
       return true;
     }
-    // Leave pubspec null to check all dependencies.
     final File actualPackagesFile = fs.file(PackageMap.globalPackagesPath);
     if (!actualPackagesFile.existsSync()) {
       return true;
     }
-    final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(actualPackagesFile.path, null);
+    final FlutterProject flutterProject = await FlutterProject.current();
+    final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(actualPackagesFile.path, flutterProject);
     projectFileInvalidator.findInvalidated();
     final int lastBuildTime = device.package.packagesFile.statSync().modified.millisecondsSinceEpoch;
     for (int updateTime in projectFileInvalidator.updateTime.values) {


### PR DESCRIPTION
## Description

It turns out that the file called packagesFile is more of a packaging file like an APK, use the global packageMap to pre-populate the file cache. Currently this work is being counted as part of the first reload, which is throwing off the windows benchmarks.

## Related Issues

https://github.com/flutter/flutter/issues/29468

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
