### PR TITLE
Made a few grammatical changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,12 @@ presented.
 3. [Setting up your engine development environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment),
    which describes the steps you need to configure your computer to
    work on Flutter's engine. If you only want to write code for the
-   Flutter framework, you can skip this step. Flutter's engine uses
-   mainly C++, Java, and ObjectiveC.
+   Flutter framework, you can skip this step. Flutter's engine mainly
+   uses C++, Java, and Objective-C.
 
 4. [Setting up your framework development environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Framework-development-environment),
    which describes the steps you need to configure your computer to
-   work on Flutter's framework. Flutter's framework uses mainly Dart.
+   work on Flutter's framework. Flutter's framework mainly uses Dart.
 
 4. [Tree hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene),
    which covers how to land a PR, how to do code review, how to


### PR DESCRIPTION
## Description

I made a few grammatical changes. I changed ObjectiveC to Objective-C. I also reversed "uses mainly" to "mainly uses" which is more grammatically correct. Otherwise it appears to the eye that it's called "mainly Dart."

## Related Issues

This is my second commit for the same change. The first one was accepted but it wouldn't merge because I hadn't signed the CLA beforehand.

## Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x ] No, this is *not* a breaking change.