### PR TITLE
Ensure that assumed formatting of properties file is correct

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -221,6 +221,8 @@ class AndroidNdk {
         final List<String> parts = line.split(' = ');
         if (parts.length == 2) {
           properties[parts[0]] = parts[1];
+        } else {
+          printError('Malformed line in ndk source.properties: "$line".');
         }
       }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -216,10 +216,13 @@ class AndroidNdk {
           .split('\n')
           .map<String>((String line) => line.trim())
           .where((String line) => line.isNotEmpty);
-      final Map<String, String> properties = Map<String, String>.fromIterable(
-          propertiesFileLines.map<List<String>>((String line) => line.split(' = ')),
-          key: (dynamic split) => split[0],
-          value: (dynamic split) => split[1]);
+      final Map<String, String> properties = <String, String>{};
+      for (String line in propertiesFileLines) {
+        final List<String> parts = line.split(' = ');
+        if (parts.length == 2) {
+          properties[parts[0]] = parts[1];
+        }
+      }
 
       if (!properties.containsKey('Pkg.Revision')) {
         throw AndroidNdkSearchError('Can not establish ndk-bundle version: $propertiesFile does not contain Pkg.Revision');


### PR DESCRIPTION
## Description

We've seen several user reports of an exception in this method. Currently we assume that the format is exactly `key = value`, but it is possible this has changed or users files are corrupted. Add a defensive check to ensure we return a reasonable error if we don't find the desired property instead of crashing.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29486

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
