### PR TITLE
Avoid flickering while dragging to select text

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1,6 +1,7 @@
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -180,12 +181,14 @@ class CupertinoTextField extends StatefulWidget {
     this.cursorColor,
     this.keyboardAppearance,
     this.scrollPadding = const EdgeInsets.all(20.0),
+    this.dragStartBehavior = DragStartBehavior.start,
   }) : assert(textAlign != null),
        assert(autofocus != null),
        assert(obscureText != null),
        assert(autocorrect != null),
        assert(maxLengthEnforced != null),
        assert(scrollPadding != null),
+       assert(dragStartBehavior != null),
        assert(maxLines == null || maxLines > 0),
        assert(minLines == null || minLines > 0),
        assert(
@@ -403,6 +406,9 @@ class CupertinoTextField extends StatefulWidget {
 
   /// {@macro flutter.widgets.editableText.scrollPadding}
   final EdgeInsets scrollPadding;
+
+  /// {@macro flutter.widgets.scrollable.dragStartBehavior}
+  final DragStartBehavior dragStartBehavior;
 
   @override
   _CupertinoTextFieldState createState() => _CupertinoTextFieldState();
@@ -703,6 +709,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
           backgroundCursorColor: CupertinoColors.inactiveGray,
           scrollPadding: widget.scrollPadding,
           keyboardAppearance: keyboardAppearance,
+          dragStartBehavior: widget.dragStartBehavior,
         ),
       ),
     );

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1385,15 +1385,15 @@ class RenderEditable extends RenderBox {
         extentOffset = math.max(fromPosition.offset, toPosition.offset);
       }
 
-      onSelectionChanged(
-        TextSelection(
-          baseOffset: baseOffset,
-          extentOffset: extentOffset,
-          affinity: fromPosition.affinity,
-        ),
-        this,
-        cause,
+      final TextSelection newSelection = TextSelection(
+        baseOffset: baseOffset,
+        extentOffset: extentOffset,
+        affinity: fromPosition.affinity,
       );
+      // Call [onSelectionChanged] only when the selection actually changed.
+      if (newSelection != _selection) {
+        onSelectionChanged(newSelection, this, cause);
+      }
     }
   }
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -367,4 +367,59 @@ void main() {
     expect(currentSelection.baseOffset, 1);
     expect(currentSelection.extentOffset, 3);
   });
+
+  test('selection does not flicker as user is dragging', () {
+    int selectionChangedCount = 0;
+    TextSelection updatedSelection;
+    final TextSelectionDelegate delegate = FakeEditableTextState();
+    const TextSpan text = TextSpan(
+      text: 'abc def ghi',
+      style: TextStyle(
+        height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+      ),
+    );
+
+    final RenderEditable editable1 = RenderEditable(
+      textSelectionDelegate: delegate,
+      textDirection: TextDirection.ltr,
+      offset: ViewportOffset.zero(),
+      selection: const TextSelection(baseOffset: 3, extentOffset: 4),
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+        selectionChangedCount++;
+        updatedSelection = selection;
+      },
+      text: text,
+    );
+
+    layout(editable1);
+
+    // Shouldn't cause a selection change.
+    editable1.selectPositionAt(from: const Offset(30, 2), to: const Offset(42, 2), cause: SelectionChangedCause.drag);
+    pumpFrame();
+
+    expect(updatedSelection, isNull);
+    expect(selectionChangedCount, 0);
+
+    final RenderEditable editable2 = RenderEditable(
+      textSelectionDelegate: delegate,
+      textDirection: TextDirection.ltr,
+      offset: ViewportOffset.zero(),
+      selection: const TextSelection(baseOffset: 3, extentOffset: 4),
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+        selectionChangedCount++;
+        updatedSelection = selection;
+      },
+      text: text,
+    );
+
+    layout(editable2);
+
+    // Now this should cause a selection change.
+    editable2.selectPositionAt(from: const Offset(30, 2), to: const Offset(48, 2), cause: SelectionChangedCause.drag);
+    pumpFrame();
+
+    expect(updatedSelection.baseOffset, 3);
+    expect(updatedSelection.extentOffset, 5);
+    expect(selectionChangedCount, 1);
+  });
 }


### PR DESCRIPTION
When dragging to select text, we continuously call `onSelectionChanged` which causes the selection box and handles to be repainted. This causes unnecessary flickering to happen.

The solution in this PR is to avoid calling `onSelectionChanged` if the new selection is the same as the existing one.

*Another unrelated change is the addition of tests addressing @xster comment in https://github.com/flutter/flutter/pull/29395. As part of that, I found out that the existing `drag handles ...` test was not `expect`ing the right thing.*

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
