### PR TITLE
added friendlier error for invalid AndroidManifest.xml

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -166,15 +166,16 @@ class AndroidApk extends ApplicationPackage {
     try {
       document = xml.parse(manifestString);
     } on xml.XmlParserException catch (exception) {
-      printError('AndroidManifest.xml is not a valid XML document.');
       String manifestLocation;
       if (androidProject.isUsingGradle) {
         manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'app', 'src', 'main', );
       } else {
         manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'AndroidManifest.xml');
       }
-
-      printError('Please check $manifestLocation for errors');
+      printError(
+        '''AndroidManifest.xml is not a valid XML document.
+        Please check $manifestLocation for errors.'''
+      );
       throwToolExit('XML Parser error message: ${exception.toString()}', exitCode: 1);
     }
 

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -161,7 +161,13 @@ class AndroidApk extends ApplicationPackage {
       return null;
 
     final String manifestString = manifest.readAsStringSync();
-    final xml.XmlDocument document = xml.parse(manifestString);
+    xml.XmlDocument document;
+    try {
+      document = xml.parse(manifestString);
+    } on Exception {
+      printError('AndroidManifest.xml is not a valid XML document.');
+      return null;
+    }
 
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');
     if (manifests.isEmpty)

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -10,6 +10,7 @@ import 'package:xml/xml.dart' as xml;
 
 import 'android/android_sdk.dart';
 import 'android/gradle.dart';
+import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/os.dart' show os;
@@ -167,7 +168,7 @@ class AndroidApk extends ApplicationPackage {
     } on xml.XmlParserException catch (exception) {
       String manifestLocation;
       if (androidProject.isUsingGradle) {
-        manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'app', 'src', 'main', );
+        manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'app', 'src', 'main', 'AndroidManifest.xml');
       } else {
         manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'AndroidManifest.xml');
       }

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -11,7 +11,6 @@ import 'package:xml/xml.dart' as xml;
 import 'android/android_sdk.dart';
 import 'android/gradle.dart';
 import 'base/context.dart';
-import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/os.dart' show os;
 import 'base/process.dart';

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -11,6 +11,7 @@ import 'package:xml/xml.dart' as xml;
 import 'android/android_sdk.dart';
 import 'android/gradle.dart';
 import 'base/context.dart';
+import 'base/common.dart';
 import 'base/file_system.dart';
 import 'base/os.dart' show os;
 import 'base/process.dart';
@@ -164,9 +165,15 @@ class AndroidApk extends ApplicationPackage {
     xml.XmlDocument document;
     try {
       document = xml.parse(manifestString);
-    } on Exception {
+    } on xml.XmlParserException catch (exception) {
       printError('AndroidManifest.xml is not a valid XML document.');
-      return null;
+      if (androidProject.isUsingGradle) {
+        printError('Please check ${androidProject.hostAppGradleRoot}/app/src/main/AndroidManifest.xml for errors');
+      } else {
+        printError('Please check ${androidProject.hostAppGradleRoot}/AndroidManifest.xml for errors');
+      }
+
+      throwToolExit(exception.toString(), exitCode: 1);
     }
 
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -174,7 +174,7 @@ class AndroidApk extends ApplicationPackage {
       }
       printError('AndroidManifest.xml is not a valid XML document.');
       printError('Please check $manifestLocation for errors.');
-      throwToolExit('XML Parser error message: ${exception.toString()}', exitCode: 1);
+      throwToolExit('XML Parser error message: ${exception.toString()}');
     }
 
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -167,13 +167,15 @@ class AndroidApk extends ApplicationPackage {
       document = xml.parse(manifestString);
     } on xml.XmlParserException catch (exception) {
       printError('AndroidManifest.xml is not a valid XML document.');
+      String manifestLocation;
       if (androidProject.isUsingGradle) {
-        printError('Please check ${androidProject.hostAppGradleRoot}/app/src/main/AndroidManifest.xml for errors');
+        manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'app', 'src', 'main', );
       } else {
-        printError('Please check ${androidProject.hostAppGradleRoot}/AndroidManifest.xml for errors');
+        manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'AndroidManifest.xml');
       }
 
-      throwToolExit(exception.toString(), exitCode: 1);
+      printError('Please check $manifestLocation for errors');
+      throwToolExit('XML Parser error message: ${exception.toString()}', exitCode: 1);
     }
 
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -172,10 +172,8 @@ class AndroidApk extends ApplicationPackage {
       } else {
         manifestLocation = fs.path.join(androidProject.hostAppGradleRoot.path, 'AndroidManifest.xml');
       }
-      printError(
-        '''AndroidManifest.xml is not a valid XML document.
-        Please check $manifestLocation for errors.'''
-      );
+      printError('AndroidManifest.xml is not a valid XML document.');
+      printError('Please check $manifestLocation for errors.');
       throwToolExit('XML Parser error message: ${exception.toString()}', exitCode: 1);
     }
 


### PR DESCRIPTION
## Description

Added a friendlier error message to help users identify if their AndroidManifest.xml is corrupted.

<img width="969" alt="Screen Shot 2019-03-19 at 8 47 22 AM" src="https://user-images.githubusercontent.com/27032613/54620761-e0f56480-4a23-11e9-9345-e80a2e0c90d2.png">

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28708

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
