### PR TITLE
make literals const for @immutable constructors

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -965,9 +965,9 @@ class _DialPainter extends CustomPainter {
             textDirection: textDirection,
             onTap: label.onTap,
           ),
-          tags: <SemanticsTag>{
+          tags: const <SemanticsTag>{
             // Used by tests to find this node.
-            const SemanticsTag('dial-label'),
+            SemanticsTag('dial-label'),
           },
         );
         nodes.add(node);

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -241,7 +241,7 @@ void main() {
                 child: ABCModel( // The "inner" model
                   a: 100 + _a,
                   b: 100 + _b,
-                  aspects: <String>{'a'},
+                  aspects: const <String>{'a'},
                   child: Center(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Description

Fix up constructor calls to ensure literals are `const`.  See failed try here:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8918609300278128304/+/steps/analyze_flutter/0/stdout

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
