### PR TITLE
Fix hit testing PageView with viewportFraction < 1.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Marco Scannadinari <m@scannadinari.co.uk>
 Frederik Schweiger <mail@flschweiger.net>
 Martin Staadecker <machstg@gmail.com>
 Igor Katsuba <katsuba.igor@gmail.com>
+Rafał Gaweł <rafal.gawel@gmail.com>

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -522,6 +522,7 @@ class SliverGeometry extends Diagnosticable {
     double layoutExtent,
     this.maxPaintExtent = 0.0,
     this.maxScrollObstructionExtent = 0.0,
+    this.hitTestOrigin = 0.0,
     double hitTestExtent,
     bool visible,
     this.hasVisualOverflow = false,
@@ -638,8 +639,12 @@ class SliverGeometry extends Diagnosticable {
   /// actually scroll is reduced by the height of the app bar.
   final double maxScrollObstructionExtent;
 
-  /// The distance from where this sliver started painting to the bottom of
+  /// The distance from where this sliver started painting to the top of
   /// where it should accept hits.
+  final double hitTestOrigin;
+
+  /// The distance from [hitTestOrigin] to the bottom of where it should
+  /// accept hits.
   ///
   /// This must be between zero and [paintExtent]. It defaults to [paintExtent].
   final double hitTestExtent;
@@ -1166,7 +1171,7 @@ abstract class RenderSliver extends RenderObject {
   /// render object is to override its [hitTestSelf] and [hitTestChildren]
   /// methods.
   bool hitTest(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
-    if (mainAxisPosition >= 0.0 && mainAxisPosition < geometry.hitTestExtent &&
+    if (mainAxisPosition >= geometry.hitTestOrigin && mainAxisPosition < geometry.hitTestOrigin + geometry.hitTestExtent &&
         crossAxisPosition >= 0.0 && crossAxisPosition < constraints.crossAxisExtent) {
       if (hitTestChildren(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition) ||
           hitTestSelf(mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition)) {

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -243,6 +243,8 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       to: trailingScrollOffset,
     );
 
+    final double hitTestOrigin = math.max(leadingScrollOffset - scrollOffset, 0.0);
+
     final double cacheExtent = calculateCacheOffset(
       constraints,
       from: leadingScrollOffset,
@@ -255,6 +257,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     geometry = SliverGeometry(
       scrollExtent: estimatedMaxScrollOffset,
       paintExtent: paintExtent,
+      hitTestOrigin: hitTestOrigin,
       cacheExtent: cacheExtent,
       maxPaintExtent: estimatedMaxScrollOffset,
       // Conservative to avoid flickering away the clip during scroll.

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -273,9 +273,24 @@ void main() {
       ),
     ));
 
-    const Offset rightSideOfChild = Offset(400.0, 200.0);
-    await tester.tapAt(rightSideOfChild);
+    final Offset pageViewStart = tester.getTopLeft(find.byType(PageView));
+    final Offset leftBoundaryOfChild = pageViewStart.translate(150.0, 200.0);
+    final Offset rightBoundaryOfChild = pageViewStart.translate(450.0, 200.0);
+    const Offset halfPixel = Offset(0.5, 0.0);
+
+    await tester.tapAt(leftBoundaryOfChild - halfPixel);
+    expect(log, isEmpty);
+
+    await tester.tapAt(leftBoundaryOfChild);
     expect(log, equals(<String>['Tap']));
+    log.clear();
+
+    await tester.tapAt(rightBoundaryOfChild - halfPixel);
+    expect(log, equals(<String>['Tap']));
+    log.clear();
+
+    await tester.tapAt(rightBoundaryOfChild);
+    expect(log, isEmpty);
   });
 
   testWidgets('PageView in zero-size container', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -274,7 +274,7 @@ void main() {
     final Offset pageViewStart = tester.getTopLeft(find.byType(PageView));
     const Offset halfPixel = Offset(0.5, 0.0);
 
-    await tester.tapAt(pageViewStart);
+    await tester.tapAt(pageViewStart + halfPixel);
     expect(log, equals(<String>['Tap']));
     log.clear();
 
@@ -323,7 +323,7 @@ void main() {
     await tester.tapAt(leftBoundaryOfChild - halfPixel);
     expect(log, isEmpty);
 
-    await tester.tapAt(leftBoundaryOfChild);
+    await tester.tapAt(leftBoundaryOfChild + halfPixel);
     expect(log, equals(<String>['Tap']));
     log.clear();
 
@@ -331,7 +331,7 @@ void main() {
     expect(log, equals(<String>['Tap']));
     log.clear();
 
-    await tester.tapAt(rightBoundaryOfChild);
+    await tester.tapAt(rightBoundaryOfChild + halfPixel);
     expect(log, isEmpty);
   });
 

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -245,6 +245,39 @@ void main() {
     expect(previousPageCompleted, true);
   });
 
+  testWidgets('PageController with viewportFraction and only one child', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+    final PageController controller = PageController(viewportFraction: 0.5);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: SizedBox(
+          width: 600.0,
+          height: 400.0,
+          child: PageView(
+            controller: controller,
+            children: <Widget>[
+              GestureDetector(
+                onTap: () {
+                  log.add('Tap');
+                },
+                child: Container(
+                  height: 400.0,
+                  color: const Color(0xFF0000FF),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    const Offset rightSideOfChild = Offset(400.0, 200.0);
+    await tester.tapAt(rightSideOfChild);
+    expect(log, equals(<String>['Tap']));
+  });
+
   testWidgets('PageView in zero-size container', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -245,7 +245,49 @@ void main() {
     expect(previousPageCompleted, true);
   });
 
-  testWidgets('PageController with viewportFraction and only one child', (WidgetTester tester) async {
+  testWidgets('PageView with only one child', (WidgetTester tester) async {
+    final List<String> log = <String>[];
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: SizedBox(
+          width: 600.0,
+          height: 400.0,
+          child: PageView(
+            children: <Widget>[
+              GestureDetector(
+                onTap: () {
+                  log.add('Tap');
+                },
+                child: Container(
+                  height: 400.0,
+                  color: const Color(0xFF0000FF),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final Offset pageViewStart = tester.getTopLeft(find.byType(PageView));
+    const Offset halfPixel = Offset(0.5, 0.0);
+
+    await tester.tapAt(pageViewStart);
+    expect(log, equals(<String>['Tap']));
+    log.clear();
+
+    await tester.tapAt(pageViewStart + const Offset(300.0, 0.0));
+    expect(log, equals(<String>['Tap']));
+    log.clear();
+
+    await tester.tapAt(pageViewStart + const Offset(600.0, 0.0) - halfPixel);
+    expect(log, equals(<String>['Tap']));
+    log.clear();
+  });
+
+  testWidgets('PageView with viewportFraction and only one child', (WidgetTester tester) async {
     final List<String> log = <String>[];
     final PageController controller = PageController(viewportFraction: 0.5);
 


### PR DESCRIPTION
## Description

Fix hit testing for one-item PageView with viewportFraction < 1.0.

Hit testing wasn't working because wrong range was tested - let's say that we have viewportWidth=200 and viewportFraction=0.5, for those parameters hitTestExtent equals 100 and testing range is 0..100, but should be 50..150.
To fix this issue I've introduced hitTestOrigin to shift testing range. HitTestOrigin is equal to distance from paintOrigin to leading edge of the first item.

## Related Issues

https://github.com/flutter/flutter/issues/23873
https://github.com/flutter/flutter/issues/27744

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
