### PR TITLE
Fix typo in flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -370,14 +370,14 @@ class AndroidSdk {
   }
 
   static bool validSdkDirectory(String dir) {
-    return sdkDirectoryHasLicneses(dir) || sdkDirectoryHasPlatformTools(dir);
+    return sdkDirectoryHasLicenses(dir) || sdkDirectoryHasPlatformTools(dir);
   }
 
   static bool sdkDirectoryHasPlatformTools(String dir) {
     return fs.isDirectorySync(fs.path.join(dir, 'platform-tools'));
   }
 
-  static bool sdkDirectoryHasLicneses(String dir) {
+  static bool sdkDirectoryHasLicenses(String dir) {
     return fs.isDirectorySync(fs.path.join(dir, 'licenses'));
   }
 


### PR DESCRIPTION
Just a small typo fix in the code, s/Licneses/Licenses/