### PR TITLE
Enable platform views for Flutter Gallery on iOS.

### DIFF
--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -41,6 +41,8 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## Description

This results in running Flutter Gallery with one less thread (platform
and gpu threads are the the same).

This is very likely to cause a regression in the iOS Gallery benchmarks.
I'm mainly interested in landing this to see how much the benchmarks
regress, and it's likely that we will revert it shortly after landing.

@Hixie @chinmaygarde @cbracken what do you think about landing this? (if the benchmark regression is bad I'll revert)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [N/A] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.