### PR TITLE
fix crash resulted from no flavor in mergeAssets task

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -413,8 +413,18 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 } catch (Exception e) {
                 }
+                String currentFlavor = ""
+                try {
+                    String tmpCurrentFlavor = project.rootProject.ext.currentFlavor
+                    if (tmpCurrentFlavor != null) {
+                        currentFlavor = tmpCurrentFlavor
+                    }
+                } catch (Exception e) {
+                }
+                String buildVariant = "${currentFlavor.capitalize()}${variant.name.capitalize()}"
+
                 // Only include configurations that exist in parent project.
-                Task mergeAssets = project.tasks.findByPath(":${mainModuleName}:merge${variant.name.capitalize()}Assets")
+                Task mergeAssets = project.tasks.findByPath(":${mainModuleName}:merge${buildVariant}Assets")
                 if (mergeAssets) {
                     mergeAssets.dependsOn(copyFlutterAssetsTask)
                 }

--- a/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
@@ -24,6 +24,10 @@ gradle.getGradle().projectsLoaded { g ->
         if (_mainModuleName != null && !_mainModuleName.empty) {
             p.ext.mainModuleName = _mainModuleName
         }
+        _currentFlavor = binding.variables['currentFlavor']
+        if (_currentFlavor != null && !_currentFlavor.empty) {
+            p.ext.currentFlavor = _currentFlavor
+        }
     }
     g.rootProject.afterEvaluate { p ->
         p.subprojects { sp ->


### PR DESCRIPTION
## Description

In [packages/flutter_tools/gradle/flutter.gradle](https://github.com/flutter/flutter/blob/edd4c6207adb9ab243cf8376b111cb56232c4cdb/packages/flutter_tools/gradle/flutter.gradle#L417), if the Android existing app has flavors, we don't append the current flavor to find the correct mergeAssets task path.

Changes in this PR allows the developer to pass the current flavor of the app.
```gradle
include ':app'
setBinding(new Binding([gradle: this, currentFlavor: 'demo']))
evaluate(new File(                                                     
        settingsDir.parentFile,                                              
        'my_flutter/.android/include_flutter.groovy'                         
))
```

Besides,
wiki: https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps
should be updated after merging this PR.


## Related Issues
This should fix https://github.com/flutter/flutter/issues/29646


## Breaking Change
this is *not* a breaking change.

## Similar PR
The idea of this PR is similar to this https://github.com/flutter/flutter/pull/27154 but here we pass the current flavor.


