### PR TITLE
Speed up CI via mojave-flutter image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -191,6 +191,28 @@ task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/flutter sdk"
     COCOAPODS_DISABLE_STATS: true
+  matrix:
+    - name: tests-macos
+      env:
+        GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
+        SHARD: tests
+    - name: tool_tests-macos
+      env:
+        GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
+        SHARD: tool_tests
+    - name: $SHARD-macos
+      env:
+        matrix:
+          - SHARD: integration_tests
+          - SHARD: build_tests
+            COCOAPODS_DISABLE_STATS: true
+            FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/bin/cache/artifacts/engine/ios/"
+      osx_instance:
+        image: mojave-flutter
+      remove_preinstalled_fluuter_script: rm -rf $FLUTTER_HOME
+    - name: add2app-macos
+      env:
+        SHARD: add2app_test
   # occasionally the clock on these machines is out of sync
   # with the actual time - this should help to verify
   print_date_script:
@@ -213,42 +235,6 @@ task:
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter update-packages
-  matrix:
-    - name: tests-macos
-      env:
-        GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
-        SHARD: tests
-    - name: tool_tests-macos
-      env:
-        GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
-        SHARD: tool_tests
-    - name: $SHARD-macos
-      env:
-        matrix:
-          - SHARD: integration_tests
-          - SHARD: build_tests
-            COCOAPODS_DISABLE_STATS: true
-            FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/bin/cache/artifacts/engine/ios/"
-        ANDROID_SDK_TOOLS_URL: https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip
-        ANDROID_SDK_ROOT: $HOME/Android
-        ANDROID_HOME: $HOME/Android
-        OPEN_JDK_URL: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz
-        OPEN_JDK_REVISION: jdk8u202-b08
-        JAVA_HOME: $HOME/Java/$OPEN_JDK_REVISION/Contents/Home
-        PATH: "$PATH:$JAVA_HOME/bin:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/tools/bin:$ANDROID_SDK_ROOT/platform-tools"
-      # TODO(dnfield): If the OSX image starts including this, we can remove it. https://github.com/cirruslabs/osx-images/issues/3
-      open_jdk_cache:
-        folder: $HOME/Java
-        fingerprint_script: echo $OPEN_JDK_URL; cat dev/bots/download_open_jdk.sh
-        populate_script: dev/bots/download_open_jdk.sh
-      # TODO(dnfield): If the OSX image starts including this, we can remove it. https://github.com/cirruslabs/osx-images/issues/3
-      android_sdk_cache:
-        folder: $ANDROID_SDK_ROOT
-        fingerprint_script: echo $ANDROID_SDK_TOOLS_URL; cat dev/bots/download_android_sdk.sh
-        populate_script: dev/bots/download_android_sdk.sh
-    - name: add2app-macos
-      env:
-        SHARD: add2app_test
   test_all_script: |
     ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/test.dart


### PR DESCRIPTION
## Description

I've noticed that installing and caching of JDK and Android SDK is taking too long. Sometimes up to 40 minutes. This change uses `mojave-flutter` image which already has them both pre-installed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
