### PR TITLE
Show/hide toolbar and handles based on device kind

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -469,8 +469,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
   FocusNode _focusNode;
   FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
 
-  final DeviceKindTracker _deviceKindTracker = DeviceKindTracker();
-  PointerDeviceKind get _lastUsedDeviceKind => _deviceKindTracker.value;
+  PointerDeviceKind _lastUsedDeviceKind;
 
   // The selection overlay should only be enabled when the user is interacting
   // through a touch screen. Mouse and other devices shouldn't trigger the
@@ -818,21 +817,25 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
                 : CupertinoTheme.of(context).brightness == Brightness.light
                     ? _kDisabledBackground
                     : CupertinoColors.darkBackgroundGray,
-            child: TextSelectionGestureDetector(
-              onTapDown: _handleTapDown,
-              onForcePressStart: _handleForcePressStarted,
-              onForcePressEnd: _handleForcePressEnded,
-              onSingleTapUp: _handleSingleTapUp,
-              onSingleLongTapStart: _handleSingleLongTapStart,
-              onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
-              onSingleLongTapEnd: _handleSingleLongTapEnd,
-              onDoubleTapDown: _handleDoubleTapDown,
-              onDragSelectionStart: _handleMouseDragSelectionStart,
-              onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
-              onDragSelectionEnd: _handleMouseDragSelectionEnd,
-              behavior: HitTestBehavior.translucent,
-              deviceKindTracker: _deviceKindTracker,
-              child: _addTextDependentAttachments(paddedEditable, textStyle, placeholderStyle),
+            child: Listener(
+              onPointerDown: (PointerDownEvent event) {
+                _lastUsedDeviceKind = event.kind;
+              },
+              child: TextSelectionGestureDetector(
+                onTapDown: _handleTapDown,
+                onForcePressStart: _handleForcePressStarted,
+                onForcePressEnd: _handleForcePressEnded,
+                onSingleTapUp: _handleSingleTapUp,
+                onSingleLongTapStart: _handleSingleLongTapStart,
+                onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
+                onSingleLongTapEnd: _handleSingleLongTapEnd,
+                onDoubleTapDown: _handleDoubleTapDown,
+                onDragSelectionStart: _handleMouseDragSelectionStart,
+                onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
+                onDragSelectionEnd: _handleMouseDragSelectionEnd,
+                behavior: HitTestBehavior.translucent,
+                child: _addTextDependentAttachments(paddedEditable, textStyle, placeholderStyle),
+              ),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -469,17 +469,11 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
   FocusNode _focusNode;
   FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
 
-  PointerDeviceKind _lastUsedDeviceKind;
-
   // The selection overlay should only be shown when the user is interacting
   // through a touch screen (via either a finger or a stylus). A mouse shouldn't
   // trigger the selection overlay.
   // For backwards-compatibility, we treat a null kind the same as touch.
-  bool get _shouldShowSelectionOverlay {
-    return _lastUsedDeviceKind == null
-        || _lastUsedDeviceKind == PointerDeviceKind.touch
-        || _lastUsedDeviceKind == PointerDeviceKind.stylus;
-  }
+  bool _shouldShowSelectionOverlay = true;
 
   @override
   void initState() {
@@ -523,6 +517,16 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
 
   void _handleTapDown(TapDownDetails details) {
     _renderEditable.handleTapDown(details);
+
+    // The selection overlay should only be shown when the user is interacting
+    // through a touch screen (via either a finger or a stylus). A mouse shouldn't
+    // trigger the selection overlay.
+    // For backwards-compatibility, we treat a null kind the same as touch.
+    final PointerDeviceKind kind = details.kind;
+    _shouldShowSelectionOverlay =
+        kind == null ||
+        kind == PointerDeviceKind.touch ||
+        kind == PointerDeviceKind.stylus;
   }
 
   void _handleForcePressStarted(ForcePressDetails details) {
@@ -584,9 +588,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     if (cause == SelectionChangedCause.keyboard)
       return false;
 
-    if (cause == SelectionChangedCause.longPress)
-      return true;
-
     if (_effectiveController.text.isNotEmpty)
       return true;
 
@@ -620,7 +621,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
       _editableText?.bringIntoView(selection.base);
     }
     if (_shouldShowHandles(cause)) {
-      _editableText.showHandles();
+      _editableText?.showHandles();
     }
   }
 
@@ -744,10 +745,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     );
   }
 
-  void _updateLastUsedDeviceKind(PointerDownEvent event) {
-    _lastUsedDeviceKind = event.kind;
-  }
-
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
@@ -825,23 +822,20 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
                 : CupertinoTheme.of(context).brightness == Brightness.light
                     ? _kDisabledBackground
                     : CupertinoColors.darkBackgroundGray,
-            child: Listener(
-              onPointerDown: _updateLastUsedDeviceKind,
-              child: TextSelectionGestureDetector(
-                onTapDown: _handleTapDown,
-                onForcePressStart: _handleForcePressStarted,
-                onForcePressEnd: _handleForcePressEnded,
-                onSingleTapUp: _handleSingleTapUp,
-                onSingleLongTapStart: _handleSingleLongTapStart,
-                onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
-                onSingleLongTapEnd: _handleSingleLongTapEnd,
-                onDoubleTapDown: _handleDoubleTapDown,
-                onDragSelectionStart: _handleMouseDragSelectionStart,
-                onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
-                onDragSelectionEnd: _handleMouseDragSelectionEnd,
-                behavior: HitTestBehavior.translucent,
-                child: _addTextDependentAttachments(paddedEditable, textStyle, placeholderStyle),
-              ),
+            child: TextSelectionGestureDetector(
+              onTapDown: _handleTapDown,
+              onForcePressStart: _handleForcePressStarted,
+              onForcePressEnd: _handleForcePressEnded,
+              onSingleTapUp: _handleSingleTapUp,
+              onSingleLongTapStart: _handleSingleLongTapStart,
+              onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
+              onSingleLongTapEnd: _handleSingleLongTapEnd,
+              onDoubleTapDown: _handleDoubleTapDown,
+              onDragSelectionStart: _handleMouseDragSelectionStart,
+              onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
+              onDragSelectionEnd: _handleMouseDragSelectionEnd,
+              behavior: HitTestBehavior.translucent,
+              child: _addTextDependentAttachments(paddedEditable, textStyle, placeholderStyle),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -473,7 +473,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
   // through a touch screen (via either a finger or a stylus). A mouse shouldn't
   // trigger the selection overlay.
   // For backwards-compatibility, we treat a null kind the same as touch.
-  bool _shouldShowSelectionOverlay = true;
+  bool _shouldShowSelectionToolbar = true;
 
   @override
   void initState() {
@@ -523,7 +523,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     // trigger the selection overlay.
     // For backwards-compatibility, we treat a null kind the same as touch.
     final PointerDeviceKind kind = details.kind;
-    _shouldShowSelectionOverlay =
+    _shouldShowSelectionToolbar =
         kind == null ||
         kind == PointerDeviceKind.touch ||
         kind == PointerDeviceKind.stylus;
@@ -541,7 +541,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
       from: details.globalPosition,
       cause: SelectionChangedCause.forcePress,
     );
-    if (_shouldShowSelectionOverlay)
+    if (_shouldShowSelectionToolbar)
       _editableText.showToolbar();
   }
 
@@ -565,20 +565,20 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
   }
 
   void _handleSingleLongTapEnd(LongPressEndDetails details) {
-    if (_shouldShowSelectionOverlay)
+    if (_shouldShowSelectionToolbar)
       _editableText.showToolbar();
   }
 
   void _handleDoubleTapDown(TapDownDetails details) {
     _renderEditable.selectWord(cause: SelectionChangedCause.tap);
-    if (_shouldShowSelectionOverlay)
+    if (_shouldShowSelectionToolbar)
       _editableText.showToolbar();
   }
 
-  bool _shouldShowHandles(SelectionChangedCause cause) {
+  bool _shouldShowSelectionHandles(SelectionChangedCause cause) {
     // When the text field is activated by something that doesn't trigger the
     // selection overlay, we shouldn't show the handles either.
-    if (!_shouldShowSelectionOverlay)
+    if (!_shouldShowSelectionToolbar)
       return false;
 
     // On iOS, we don't show handles when the selection is collapsed.
@@ -620,7 +620,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     if (cause == SelectionChangedCause.longPress) {
       _editableText?.bringIntoView(selection.base);
     }
-    if (_shouldShowHandles(cause)) {
+    if (_shouldShowSelectionHandles(cause)) {
       _editableText?.showHandles();
     }
   }

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -397,7 +397,12 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
       longTapDelay: longTapDelay,
     );
     if (onTapDown != null)
-      invokeCallback<void>('onTapDown', () => onTapDown(event.pointer, TapDownDetails(globalPosition: event.position)));
+      invokeCallback<void>('onTapDown', () {
+        onTapDown(event.pointer, TapDownDetails(
+          globalPosition: event.position,
+          kind: event.kind,
+        ));
+      });
   }
 
   @override
@@ -432,7 +437,15 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
   void _dispatchLongTap(int pointer, Offset lastPosition) {
     assert(_gestureMap.containsKey(pointer));
     if (onLongTapDown != null)
-      invokeCallback<void>('onLongTapDown', () => onLongTapDown(pointer, TapDownDetails(globalPosition: lastPosition)));
+      invokeCallback<void>('onLongTapDown', () {
+        onLongTapDown(
+          pointer,
+          TapDownDetails(
+            globalPosition: lastPosition,
+            kind: getKindForPointer(pointer),
+          ),
+        );
+      });
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -64,7 +64,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// by providing the optional [kind] argument. If [kind] is null,
   /// the recognizer will accept pointer events from all device kinds.
   /// {@endtemplate}
-  GestureRecognizer({ this.debugOwner, PointerDeviceKind kind }) : _kind = kind;
+  GestureRecognizer({ this.debugOwner, PointerDeviceKind kind }) : _filterByKind = kind;
 
   /// The recognizer's owner.
   ///
@@ -74,7 +74,11 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
 
   /// The kind of device that's allowed to be recognized. If null, events from
   /// all device kinds will be tracked and recognized.
-  final PointerDeviceKind _kind;
+  final PointerDeviceKind _filterByKind;
+
+  /// Holds a mapping between pointer IDs and the kind of devices they are
+  /// coming from.
+  final Map<int, PointerDeviceKind> _pointerToKind = <int, PointerDeviceKind>{};
 
   /// Registers a new pointer that might be relevant to this gesture
   /// detector.
@@ -92,6 +96,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// This method is called for each and all pointers being added. In
   /// most cases, you want to override [addAllowedPointer] instead.
   void addPointer(PointerDownEvent event) {
+    _pointerToKind[event.pointer] = event.kind;
     if (isPointerAllowed(event)) {
       addAllowedPointer(event);
     } else {
@@ -123,7 +128,17 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   bool isPointerAllowed(PointerDownEvent event) {
     // Currently, it only checks for device kind. But in the future we could check
     // for other things e.g. mouse button.
-    return _kind == null || _kind == event.kind;
+    return _filterByKind == null || _filterByKind == event.kind;
+  }
+
+  /// For a given pointer ID, returns the device kind associated with it.
+  ///
+  /// The pointer ID is expected to be a valid one i.e. an event was received
+  /// with that pointer ID.
+  @protected
+  PointerDeviceKind getKindForPointer(int pointer) {
+    assert(_pointerToKind.containsKey(pointer));
+    return _pointerToKind[pointer];
   }
 
   /// Releases any resources used by the object.
@@ -411,7 +426,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
       primaryPointer = event.pointer;
       initialPosition = event.position;
       if (deadline != null)
-        _timer = Timer(deadline, didExceedDeadline);
+        _timer = Timer(deadline, () => didExceedDeadlineWithEvent(event));
     }
   }
 
@@ -444,10 +459,21 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
 
   /// Override to be notified when [deadline] is exceeded.
   ///
-  /// You must override this method if you supply a [deadline].
+  /// You must override this method or [didExceedDeadlineWithEvent] if you
+  /// supply a [deadline].
   @protected
   void didExceedDeadline() {
     assert(deadline == null);
+  }
+
+  /// Same as [didExceedDeadline] but receives the [event] that initiated the
+  /// gesture.
+  ///
+  /// You must override this method or [didExceedDeadline] if you supply a
+  /// [deadline].
+  @protected
+  void didExceedDeadlineWithEvent(PointerDownEvent event) {
+    didExceedDeadline();
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -64,7 +64,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// by providing the optional [kind] argument. If [kind] is null,
   /// the recognizer will accept pointer events from all device kinds.
   /// {@endtemplate}
-  GestureRecognizer({ this.debugOwner, PointerDeviceKind kind }) : _filterByKind = kind;
+  GestureRecognizer({ this.debugOwner, PointerDeviceKind kind }) : _kindFilter = kind;
 
   /// The recognizer's owner.
   ///
@@ -74,7 +74,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
 
   /// The kind of device that's allowed to be recognized. If null, events from
   /// all device kinds will be tracked and recognized.
-  final PointerDeviceKind _filterByKind;
+  final PointerDeviceKind _kindFilter;
 
   /// Holds a mapping between pointer IDs and the kind of devices they are
   /// coming from.
@@ -128,7 +128,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   bool isPointerAllowed(PointerDownEvent event) {
     // Currently, it only checks for device kind. But in the future we could check
     // for other things e.g. mouse button.
-    return _filterByKind == null || _filterByKind == event.kind;
+    return _kindFilter == null || _kindFilter == event.kind;
   }
 
   /// For a given pointer ID, returns the device kind associated with it.

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -19,11 +19,16 @@ class TapDownDetails {
   /// Creates details for a [GestureTapDownCallback].
   ///
   /// The [globalPosition] argument must not be null.
-  TapDownDetails({ this.globalPosition = Offset.zero })
-    : assert(globalPosition != null);
+  TapDownDetails({
+    this.globalPosition = Offset.zero,
+    this.kind,
+  }) : assert(globalPosition != null);
 
   /// The global position at which the pointer contacted the screen.
   final Offset globalPosition;
+
+  /// The kind of the device that initiated the event.
+  final PointerDeviceKind kind;
 }
 
 /// Signature for when a pointer that might cause a tap has contacted the
@@ -198,15 +203,15 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
   }
 
   @override
-  void didExceedDeadline() {
-    _checkDown();
+  void didExceedDeadlineWithEvent(PointerDownEvent event) {
+    _checkDown(event.pointer);
   }
 
   @override
   void acceptGesture(int pointer) {
     super.acceptGesture(pointer);
     if (pointer == primaryPointer) {
-      _checkDown();
+      _checkDown(pointer);
       _wonArenaForPrimaryPointer = true;
       _checkUp();
     }
@@ -224,10 +229,15 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
     }
   }
 
-  void _checkDown() {
+  void _checkDown(int pointer) {
     if (!_sentTapDown) {
       if (onTapDown != null)
-        invokeCallback<void>('onTapDown', () { onTapDown(TapDownDetails(globalPosition: initialPosition)); });
+        invokeCallback<void>('onTapDown', () {
+          onTapDown(TapDownDetails(
+            globalPosition: initialPosition,
+            kind: getKindForPointer(pointer),
+          ));
+        });
       _sentTapDown = true;
     }
   }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -513,7 +513,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     && widget.decoration != null
     && widget.decoration.counterText == null;
 
-  bool _shouldShowSelectionOverlay = true;
+  bool _shouldShowSelectionToolbar = true;
 
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -613,10 +613,10 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     _editableText?.requestKeyboard();
   }
 
-  bool _shouldShowHandles(SelectionChangedCause cause) {
+  bool _shouldShowSelectionHandles(SelectionChangedCause cause) {
     // When the text field is activated by something that doesn't trigger the
     // selection overlay, we shouldn't show the handles either.
-    if (!_shouldShowSelectionOverlay)
+    if (!_shouldShowSelectionToolbar)
       return false;
 
     if (cause == SelectionChangedCause.keyboard)
@@ -645,7 +645,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         // Do nothing.
     }
 
-    if (_shouldShowHandles(cause)) {
+    if (_shouldShowSelectionHandles(cause)) {
       _editableText?.showHandles();
     }
   }
@@ -702,7 +702,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     // trigger the selection overlay.
     // For backwards-compatibility, we treat a null kind the same as touch.
     final PointerDeviceKind kind = details.kind;
-    _shouldShowSelectionOverlay =
+    _shouldShowSelectionToolbar =
         kind == null ||
         kind == PointerDeviceKind.touch ||
         kind == PointerDeviceKind.stylus;
@@ -714,7 +714,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         from: details.globalPosition,
         cause: SelectionChangedCause.forcePress,
       );
-      if (_shouldShowSelectionOverlay)
+      if (_shouldShowSelectionToolbar)
         _editableTextKey.currentState.showToolbar();
     }
   }
@@ -782,14 +782,15 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   }
 
   void _handleSingleLongTapEnd(LongPressEndDetails details) {
-    if (_shouldShowSelectionOverlay)
+    print('long tap end');
+    if (_shouldShowSelectionToolbar)
       _editableTextKey.currentState.showToolbar();
   }
 
   void _handleDoubleTapDown(TapDownDetails details) {
     if (widget.selectionEnabled) {
       _renderEditable.selectWord(cause: SelectionChangedCause.doubleTap);
-      if (_shouldShowSelectionOverlay)
+      if (_shouldShowSelectionToolbar)
         _editableTextKey.currentState.showToolbar();
     }
   }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -513,8 +513,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     && widget.decoration != null
     && widget.decoration.counterText == null;
 
-  final DeviceKindTracker _deviceKindTracker = DeviceKindTracker();
-  PointerDeviceKind get _lastUsedDeviceKind => _deviceKindTracker.value;
+  PointerDeviceKind _lastUsedDeviceKind;
 
   // The selection overlay should only be enabled when the user is interacting
   // through a touch screen. Mouse and other devices shouldn't trigger the
@@ -977,20 +976,24 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       },
       child: IgnorePointer(
         ignoring: !(widget.enabled ?? widget.decoration?.enabled ?? true),
-        child: TextSelectionGestureDetector(
-          onTapDown: _handleTapDown,
-          onForcePressStart: forcePressEnabled ? _handleForcePressStarted : null,
-          onSingleTapUp: _handleSingleTapUp,
-          onSingleTapCancel: _handleSingleTapCancel,
-          onSingleLongTapStart: _handleSingleLongTapStart,
-          onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
-          onSingleLongTapEnd: _handleSingleLongTapEnd,
-          onDoubleTapDown: _handleDoubleTapDown,
-          onDragSelectionStart: _handleMouseDragSelectionStart,
-          onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
-          behavior: HitTestBehavior.translucent,
-          deviceKindTracker: _deviceKindTracker,
-          child: child,
+        child: Listener(
+          onPointerDown: (PointerDownEvent event) {
+            _lastUsedDeviceKind = event.kind;
+          },
+          child: TextSelectionGestureDetector(
+            onTapDown: _handleTapDown,
+            onForcePressStart: forcePressEnabled ? _handleForcePressStarted : null,
+            onSingleTapUp: _handleSingleTapUp,
+            onSingleTapCancel: _handleSingleTapCancel,
+            onSingleLongTapStart: _handleSingleLongTapStart,
+            onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
+            onSingleLongTapEnd: _handleSingleLongTapEnd,
+            onDoubleTapDown: _handleDoubleTapDown,
+            onDragSelectionStart: _handleMouseDragSelectionStart,
+            onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
+            behavior: HitTestBehavior.translucent,
+            child: child,
+          ),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -634,6 +634,10 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause cause) {
     // iOS cursor doesn't move via a selection handle. The scroll happens
     // directly from new text selection changes.
+    if (_shouldShowSelectionHandles(cause)) {
+      _editableText?.showHandles();
+    }
+
     switch (Theme.of(context).platform) {
       case TargetPlatform.iOS:
         if (cause == SelectionChangedCause.longPress) {
@@ -643,10 +647,6 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         // Do nothing.
-    }
-
-    if (_shouldShowSelectionHandles(cause)) {
-      _editableText?.showHandles();
     }
   }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -513,17 +513,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     && widget.decoration != null
     && widget.decoration.counterText == null;
 
-  PointerDeviceKind _lastUsedDeviceKind;
-
-  // The selection overlay should only be shown when the user is interacting
-  // through a touch screen (via either a finger or a stylus). A mouse shouldn't
-  // trigger the selection overlay.
-  // For backwards-compatibility, we treat a null kind the same as touch.
-  bool get _shouldShowSelectionOverlay {
-    return _lastUsedDeviceKind == null
-        || _lastUsedDeviceKind == PointerDeviceKind.touch
-        || _lastUsedDeviceKind == PointerDeviceKind.stylus;
-  }
+  bool _shouldShowSelectionOverlay = true;
 
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -706,6 +696,16 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   void _handleTapDown(TapDownDetails details) {
     _renderEditable.handleTapDown(details);
     _startSplash(details.globalPosition);
+
+    // The selection overlay should only be shown when the user is interacting
+    // through a touch screen (via either a finger or a stylus). A mouse shouldn't
+    // trigger the selection overlay.
+    // For backwards-compatibility, we treat a null kind the same as touch.
+    final PointerDeviceKind kind = details.kind;
+    _shouldShowSelectionOverlay =
+        kind == null ||
+        kind == PointerDeviceKind.touch ||
+        kind == PointerDeviceKind.stylus;
   }
 
   void _handleForcePressStarted(ForcePressDetails details) {
@@ -811,10 +811,6 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       to: updateDetails.globalPosition,
       cause: SelectionChangedCause.drag,
     );
-  }
-
-  void _updateLastUsedDeviceKind(PointerDownEvent event) {
-    _lastUsedDeviceKind = event.kind;
   }
 
   void _startSplash(Offset globalPosition) {
@@ -978,22 +974,19 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       },
       child: IgnorePointer(
         ignoring: !(widget.enabled ?? widget.decoration?.enabled ?? true),
-        child: Listener(
-          onPointerDown: _updateLastUsedDeviceKind,
-          child: TextSelectionGestureDetector(
-            onTapDown: _handleTapDown,
-            onForcePressStart: forcePressEnabled ? _handleForcePressStarted : null,
-            onSingleTapUp: _handleSingleTapUp,
-            onSingleTapCancel: _handleSingleTapCancel,
-            onSingleLongTapStart: _handleSingleLongTapStart,
-            onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
-            onSingleLongTapEnd: _handleSingleLongTapEnd,
-            onDoubleTapDown: _handleDoubleTapDown,
-            onDragSelectionStart: _handleMouseDragSelectionStart,
-            onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
-            behavior: HitTestBehavior.translucent,
-            child: child,
-          ),
+        child: TextSelectionGestureDetector(
+          onTapDown: _handleTapDown,
+          onForcePressStart: forcePressEnabled ? _handleForcePressStarted : null,
+          onSingleTapUp: _handleSingleTapUp,
+          onSingleTapCancel: _handleSingleTapCancel,
+          onSingleLongTapStart: _handleSingleLongTapStart,
+          onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
+          onSingleLongTapEnd: _handleSingleLongTapEnd,
+          onDoubleTapDown: _handleDoubleTapDown,
+          onDragSelectionStart: _handleMouseDragSelectionStart,
+          onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
+          behavior: HitTestBehavior.translucent,
+          child: child,
         ),
       ),
     );

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1239,6 +1239,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   Duration get cursorBlinkInterval => _kCursorBlinkHalfPeriod;
 
   /// The current status of the text selection handles.
+  @visibleForTesting
   TextSelectionOverlay get selectionOverlay => _selectionOverlay;
 
   int _obscureShowCharTicksPending = 0;
@@ -1378,15 +1379,25 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     return true;
   }
 
+  @override
+  void hideToolbar() {
+    _selectionOverlay?.hide();
+  }
+
+  /// Toggles the visibility of the toolbar.
+  void toggleToolbar() {
+    assert(_selectionOverlay != null);
+    if (_selectionOverlay.toolbarIsVisible) {
+      hideToolbar();
+    } else {
+      showToolbar();
+    }
+  }
+
   /// Shows the handles at the location of the current selection.
   void showHandles() {
     assert(_selectionOverlay != null);
     _selectionOverlay.showHandles();
-  }
-
-  @override
-  void hideToolbar() {
-    _selectionOverlay?.hide();
   }
 
   VoidCallback _semanticsOnCopy(TextSelectionControls controls) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -290,6 +290,7 @@ class EditableText extends StatefulWidget {
     this.onEditingComplete,
     this.onSubmitted,
     this.onSelectionChanged,
+    this.onSelectionHandleTapped,
     List<TextInputFormatter> inputFormatters,
     this.rendererIgnoresPointer = false,
     this.cursorWidth = 2.0,
@@ -644,6 +645,9 @@ class EditableText extends StatefulWidget {
   /// Called when the user changes the selection of text (including the cursor
   /// location).
   final SelectionChangedCallback onSelectionChanged;
+
+  /// {@macro flutter.widgets.textSelection.onSelectionHandleTapped}
+  final VoidCallback onSelectionHandleTapped;
 
   /// {@template flutter.widgets.editableText.inputFormatters}
   /// Optional input validation and formatting overrides.
@@ -1135,10 +1139,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         selectionControls: widget.selectionControls,
         selectionDelegate: this,
         dragStartBehavior: widget.dragStartBehavior,
+        onSelectionHandleTapped: widget.onSelectionHandleTapped,
       );
-      final bool longPress = cause == SelectionChangedCause.longPress;
-      if (cause != SelectionChangedCause.keyboard && (_value.text.isNotEmpty || longPress))
-        _selectionOverlay.showHandles();
+
       if (widget.onSelectionChanged != null)
         widget.onSelectionChanged(selection, cause);
     }
@@ -1236,7 +1239,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   Duration get cursorBlinkInterval => _kCursorBlinkHalfPeriod;
 
   /// The current status of the text selection handles.
-  @visibleForTesting
   TextSelectionOverlay get selectionOverlay => _selectionOverlay;
 
   int _obscureShowCharTicksPending = 0;
@@ -1374,6 +1376,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
     _selectionOverlay.showToolbar();
     return true;
+  }
+
+  /// Shows the handles at the location of the current selection.
+  void showHandles() {
+    assert(_selectionOverlay != null);
+    _selectionOverlay.showHandles();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -580,6 +580,12 @@ class GestureDetector extends StatelessWidget {
   }
 }
 
+/// Keeps track of the last [PointerDeviceKind] that initiated a gesture.
+class DeviceKindTracker extends ValueNotifier<PointerDeviceKind> {
+  /// Creates an instance of [DeviceKindTracker].
+  DeviceKindTracker() : super(null);
+}
+
 /// A widget that detects gestures described by the given gesture
 /// factories.
 ///
@@ -632,6 +638,7 @@ class RawGestureDetector extends StatefulWidget {
     this.gestures = const <Type, GestureRecognizerFactory>{},
     this.behavior,
     this.excludeFromSemantics = false,
+    this.deviceKindTracker,
   }) : assert(gestures != null),
        assert(excludeFromSemantics != null),
        super(key: key);
@@ -662,6 +669,11 @@ class RawGestureDetector extends StatefulWidget {
   /// tree directly and so having a gesture to show it would result in
   /// duplication of information.
   final bool excludeFromSemantics;
+
+  /// {@template flutter.widgets.gestureDetector.deviceKindTracker}
+  /// Keeps track of the last device kind used to initiate a gesture.
+  /// {@endtemplate}
+  final DeviceKindTracker deviceKindTracker;
 
   @override
   RawGestureDetectorState createState() => RawGestureDetectorState();
@@ -775,6 +787,9 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
 
   void _handlePointerDown(PointerDownEvent event) {
     assert(_recognizers != null);
+    if (widget.deviceKindTracker != null) {
+      widget.deviceKindTracker.value = event.kind;
+    }
     for (GestureRecognizer recognizer in _recognizers.values)
       recognizer.addPointer(event);
   }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -580,12 +580,6 @@ class GestureDetector extends StatelessWidget {
   }
 }
 
-/// Keeps track of the last [PointerDeviceKind] that initiated a gesture.
-class DeviceKindTracker extends ValueNotifier<PointerDeviceKind> {
-  /// Creates an instance of [DeviceKindTracker].
-  DeviceKindTracker() : super(null);
-}
-
 /// A widget that detects gestures described by the given gesture
 /// factories.
 ///
@@ -638,7 +632,6 @@ class RawGestureDetector extends StatefulWidget {
     this.gestures = const <Type, GestureRecognizerFactory>{},
     this.behavior,
     this.excludeFromSemantics = false,
-    this.deviceKindTracker,
   }) : assert(gestures != null),
        assert(excludeFromSemantics != null),
        super(key: key);
@@ -669,11 +662,6 @@ class RawGestureDetector extends StatefulWidget {
   /// tree directly and so having a gesture to show it would result in
   /// duplication of information.
   final bool excludeFromSemantics;
-
-  /// {@template flutter.widgets.gestureDetector.deviceKindTracker}
-  /// Keeps track of the last device kind used to initiate a gesture.
-  /// {@endtemplate}
-  final DeviceKindTracker deviceKindTracker;
 
   @override
   RawGestureDetectorState createState() => RawGestureDetectorState();
@@ -787,9 +775,6 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
 
   void _handlePointerDown(PointerDownEvent event) {
     assert(_recognizers != null);
-    if (widget.deviceKindTracker != null) {
-      widget.deviceKindTracker.value = event.kind;
-    }
     for (GestureRecognizer recognizer in _recognizers.values)
       recognizer.addPointer(event);
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -319,6 +319,9 @@ class TextSelectionOverlay {
 
   /// {@template flutter.widgets.textSelection.onSelectionHandleTapped}
   /// A callback that's invoked when a selection handle is tapped.
+  ///
+  /// Both regular taps and long presses invoke this callback, but a drag
+  /// gesture won't.
   /// {@endtemplate}
   final VoidCallback onSelectionHandleTapped;
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -402,7 +402,7 @@ class TextSelectionOverlay {
   /// Whether the toolbar is currently visible.
   bool get toolbarIsVisible => _toolbar != null;
 
-  /// Hides the overlay.
+  /// Hides the entire overlay including the toolbar and the handles.
   void hide() {
     if (_handles != null) {
       _handles[0].remove();
@@ -414,7 +414,9 @@ class TextSelectionOverlay {
     }
   }
 
-  /// Hides the toolbar.
+  /// Hides the toolbar part of the overlay.
+  ///
+  /// To hide the whole overlay, see [hide].
   void hideToolbar() {
     assert(_toolbar != null);
     _toolbarController.stop();

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -263,6 +263,7 @@ class TextSelectionOverlay {
     this.selectionControls,
     this.selectionDelegate,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.onSelectionHandleTapped,
   }) : assert(value != null),
        assert(context != null),
        _value = value {
@@ -315,6 +316,11 @@ class TextSelectionOverlay {
   ///
   ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
   final DragStartBehavior dragStartBehavior;
+
+  /// {@template flutter.widgets.textSelection.onSelectionHandleTapped}
+  /// A callback that's invoked when a selection handle is tapped.
+  /// {@endtemplate}
+  final VoidCallback onSelectionHandleTapped;
 
   /// Controls the fade-in and fade-out animations for the toolbar and handles.
   static const Duration fadeDuration = Duration(milliseconds: 150);
@@ -400,10 +406,17 @@ class TextSelectionOverlay {
       _handles[1].remove();
       _handles = null;
     }
-    _toolbar?.remove();
-    _toolbar = null;
+    if (_toolbar != null) {
+      hideToolbar();
+    }
+  }
 
+  /// Hides the toolbar.
+  void hideToolbar() {
+    assert(_toolbar != null);
     _toolbarController.stop();
+    _toolbar.remove();
+    _toolbar = null;
   }
 
   /// Final cleanup.
@@ -418,7 +431,7 @@ class TextSelectionOverlay {
       return Container(); // hide the second handle when collapsed
     return _TextSelectionHandleOverlay(
       onSelectionHandleChanged: (TextSelection newSelection) { _handleSelectionHandleChanged(newSelection, position); },
-      onSelectionHandleTapped: _handleSelectionHandleTapped,
+      onSelectionHandleTapped: onSelectionHandleTapped,
       layerLink: layerLink,
       renderObject: renderObject,
       selection: _selection,
@@ -475,17 +488,6 @@ class TextSelectionOverlay {
     }
     selectionDelegate.textEditingValue = _value.copyWith(selection: newSelection, composing: TextRange.empty);
     selectionDelegate.bringIntoView(textPosition);
-  }
-
-  void _handleSelectionHandleTapped() {
-    if (_value.selection.isCollapsed) {
-      if (_toolbar != null) {
-        _toolbar?.remove();
-        _toolbar = null;
-      } else {
-        showToolbar();
-      }
-    }
   }
 }
 
@@ -602,7 +604,8 @@ class _TextSelectionHandleOverlayState
   }
 
   void _handleTap() {
-    widget.onSelectionHandleTapped();
+    if (widget.onSelectionHandleTapped != null)
+      widget.onSelectionHandleTapped();
   }
 
   @override
@@ -713,6 +716,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
     this.behavior,
+    this.deviceKindTracker,
     @required this.child,
   }) : assert(child != null),
        super(key: key);
@@ -773,6 +777,9 @@ class TextSelectionGestureDetector extends StatefulWidget {
   ///
   /// This defaults to [HitTestBehavior.deferToChild].
   final HitTestBehavior behavior;
+
+  /// {@macro flutter.widgets.gestureDetector.deviceKindTracker}
+  final DeviceKindTracker deviceKindTracker;
 
   /// Child below this widget.
   final Widget child;
@@ -994,6 +1001,7 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
       gestures: gestures,
       excludeFromSemantics: true,
       behavior: widget.behavior,
+      deviceKindTracker: widget.deviceKindTracker,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -716,7 +716,6 @@ class TextSelectionGestureDetector extends StatefulWidget {
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
     this.behavior,
-    this.deviceKindTracker,
     @required this.child,
   }) : assert(child != null),
        super(key: key);
@@ -777,9 +776,6 @@ class TextSelectionGestureDetector extends StatefulWidget {
   ///
   /// This defaults to [HitTestBehavior.deferToChild].
   final HitTestBehavior behavior;
-
-  /// {@macro flutter.widgets.gestureDetector.deviceKindTracker}
-  final DeviceKindTracker deviceKindTracker;
 
   /// Child below this widget.
   final Widget child;
@@ -1001,7 +997,6 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
       gestures: gestures,
       excludeFromSemantics: true,
       behavior: widget.behavior,
-      deviceKindTracker: widget.deviceKindTracker,
       child: widget.child,
     );
   }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2042,6 +2042,8 @@ void main() {
     // Long press to trigger the text field.
     await tester.longPress(find.byType(CupertinoTextField));
     await tester.pump();
+    // A long press in Cupertino should position the cursor without any selection.
+    expect(controller.selection.isCollapsed, isTrue);
 
     final EditableTextState editableText = tester.state(find.byType(EditableText));
     expect(editableText.selectionOverlay.handlesAreVisible, isFalse);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2004,6 +2004,193 @@ void main() {
     expect(controller.selection.extentOffset, 9);
   });
 
+  testWidgets('Tap does not show handles nor toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Tap to trigger the text field.
+    await tester.tap(find.byType(CupertinoTextField));
+    await tester.pump();
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+  });
+
+  testWidgets('Long press shows toolbar but not handles', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Long press to trigger the text field.
+    await tester.longPress(find.byType(CupertinoTextField));
+    await tester.pump();
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+  });
+
+  testWidgets(
+    'Double tap shows handles and toolbar if selection is not collapsed',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(controller: controller),
+          ),
+        ),
+      );
+
+      final Offset hPos = textOffsetToPosition(tester, 9); // Position of 'h'.
+
+      // Double tap on 'h' to select 'ghi'.
+      await tester.tapAt(hPos);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(hPos);
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    },
+  );
+
+  testWidgets(
+    'Double tap shows toolbar but not handles if selection is collapsed',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(controller: controller),
+          ),
+        ),
+      );
+
+      final Offset textEndPos = textOffsetToPosition(tester, 11); // Position at the end of text.
+
+      // Double tap to place the cursor at the end.
+      await tester.tapAt(textEndPos);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(textEndPos);
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    },
+  );
+
+  testWidgets(
+    'Mouse long press does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Long press to trigger the text field.
+      final Offset textFieldPos = tester.getCenter(find.byType(CupertinoTextField));
+      final TestGesture gesture = await tester.startGesture(
+        textFieldPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await gesture.up();
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    },
+  );
+
+  testWidgets(
+    'Mouse double tap does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(controller: controller),
+          ),
+        ),
+      );
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+
+      // Double tap at the end of text.
+      final Offset textEndPos = textOffsetToPosition(tester, 11); // Position at the end of text.
+      TestGesture gesture = await tester.startGesture(
+        textEndPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textEndPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+
+      final Offset hPos = textOffsetToPosition(tester, 9); // Position of 'h'.
+
+      // Double tap on 'h' to select 'ghi'.
+      gesture = await tester.startGesture(
+        hPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(hPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+    },
+  );
+
   testWidgets(
     'text field respects theme',
     (WidgetTester tester) async {

--- a/packages/flutter/test/gestures/debug_test.dart
+++ b/packages/flutter/test/gestures/debug_test.dart
@@ -151,7 +151,7 @@ void main() {
     expect(tap.toString(), equalsIgnoringHashCodes('TapGestureRecognizer#00000(state: ready)'));
     const PointerEvent event = PointerDownEvent(pointer: 1, position: Offset(10.0, 10.0));
     tap.addPointer(event);
-    tap.didExceedDeadline();
+    tap.didExceedDeadlineWithEvent(event);
     expect(tap.toString(), equalsIgnoringHashCodes('TapGestureRecognizer#00000(state: possible, sent tap down)'));
   });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5899,11 +5899,13 @@ void main() {
       ),
     );
 
-    final RenderEditable renderEditable =
-      tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
+    final EditableTextState state =
+      tester.state<EditableTextState>(find.byType(EditableText));
+    final RenderEditable renderEditable = state.renderEditable;
 
     await tester.tapAt(const Offset(20, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pumpAndSettle();
 
     final List<Widget> transitions =

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5905,7 +5905,6 @@ void main() {
 
     await tester.tapAt(const Offset(20, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
-    state.showHandles();
     await tester.pumpAndSettle();
 
     final List<Widget> transitions =

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5951,4 +5951,281 @@ void main() {
 
     debugDefaultTargetPlatformOverride = null;
   });
+
+  testWidgets('Tap shows handles but not toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Tap to trigger the text field.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+  });
+
+  testWidgets(
+    'Tap in empty text field does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Tap to trigger the text field.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+    },
+  );
+
+  testWidgets('Long press shows handles and toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Long press to trigger the text field.
+    await tester.longPress(find.byType(TextField));
+    await tester.pump();
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+  });
+
+  testWidgets(
+    'Long press in empty text field shows handles and toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Tap to trigger the text field.
+      await tester.longPress(find.byType(TextField));
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    },
+  );
+
+  testWidgets('Double tap shows handles and toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Double tap to trigger the text field.
+    await tester.tap(find.byType(TextField));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+  });
+
+  testWidgets(
+    'Double tap in empty text field shows toolbar but not handles',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Double tap to trigger the text field.
+      await tester.tap(find.byType(TextField));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    },
+  );
+
+  testWidgets(
+    'Mouse tap does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Long press to trigger the text field.
+      final Offset textFieldPos = tester.getCenter(find.byType(TextField));
+      final TestGesture gesture = await tester.startGesture(
+        textFieldPos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    },
+  );
+
+  testWidgets(
+    'Mouse long press does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Long press to trigger the text field.
+      final Offset textFieldPos = tester.getCenter(find.byType(TextField));
+      final TestGesture gesture = await tester.startGesture(
+        textFieldPos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await gesture.up();
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    },
+  );
+
+  testWidgets(
+    'Mouse double tap does not show handles nor toolbar',
+        (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'abc def ghi',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(controller: controller),
+          ),
+        ),
+      );
+
+      // Double tap to trigger the text field.
+      final Offset textFieldPos = tester.getCenter(find.byType(TextField));
+      final TestGesture gesture = await tester.startGesture(
+        textFieldPos,
+        pointer: 7,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textFieldPos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      final EditableTextState editableText = tester.state(find.byType(EditableText));
+      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    },
+  );
+
+  testWidgets('Tapping selection handles toggles the toolbar', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'abc def ghi',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(controller: controller),
+        ),
+      ),
+    );
+
+    // Tap to position the cursor and show the selection handles.
+    final Offset ePos = textOffsetToPosition(tester, 5); // Index of 'e'.
+    await tester.tapAt(ePos, pointer: 7);
+
+    final EditableTextState editableText = tester.state(find.byType(EditableText));
+    expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 1);
+
+    // Tap the handle to show the toolbar.
+    final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
+    await tester.tapAt(handlePos, pointer: 7);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+
+    // Tap the handle again to hide the toolbar.
+    await tester.tapAt(handlePos, pointer: 7);
+    expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+  });
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -898,51 +898,6 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('changing selection with keyboard does not show handles', (WidgetTester tester) async {
-    const String value1 = 'Hello World';
-
-    controller.text = value1;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: EditableText(
-          backgroundCursorColor: Colors.grey,
-          controller: controller,
-          selectionControls: materialTextSelectionControls,
-          focusNode: focusNode,
-          style: textStyle,
-          cursorColor: cursorColor,
-        ),
-      ),
-    );
-
-    // Simulate selection change via tap to show handles.
-    final RenderEditable render = tester.allRenderObjects
-        .firstWhere((RenderObject o) => o.runtimeType == RenderEditable);
-    render.onSelectionChanged(const TextSelection.collapsed(offset: 4), render,
-        SelectionChangedCause.tap);
-
-    await tester.pumpAndSettle();
-    final EditableTextState textState = tester.state(find.byType(EditableText));
-
-    expect(textState.selectionOverlay.handlesAreVisible, isTrue);
-    expect(
-      textState.selectionOverlay.selectionDelegate.textEditingValue.selection,
-      const TextSelection.collapsed(offset: 4),
-    );
-
-    // Simulate selection change via keyboard and expect handles to disappear.
-    render.onSelectionChanged(const TextSelection.collapsed(offset: 10), render,
-        SelectionChangedCause.keyboard);
-    await tester.pumpAndSettle();
-
-    expect(textState.selectionOverlay.handlesAreVisible, isFalse);
-    expect(
-      textState.selectionOverlay.selectionDelegate.textEditingValue.selection,
-      const TextSelection.collapsed(offset: 10),
-    );
-  });
-
   testWidgets('exposes correct cursor movement semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
@@ -2034,6 +1989,7 @@ void main() {
     // Select the first word. Both handles should be visible.
     await tester.tapAt(const Offset(20, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pump();
     await verifyVisibility(HandlePositionInViewport.leftEdge, true, HandlePositionInViewport.within, true);
 
@@ -2239,6 +2195,7 @@ void main() {
     // Now that the second word has been dragged fully into view, select it.
     await tester.tapAt(const Offset(80, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pump();
     await verifyVisibility(HandlePositionInViewport.within, true, HandlePositionInViewport.within, true);
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2011,6 +2011,7 @@ void main() {
     // Now that the second word has been dragged fully into view, select it.
     await tester.tapAt(const Offset(80, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pump();
     await verifyVisibility(HandlePositionInViewport.within, true, HandlePositionInViewport.within, true);
 
@@ -2055,6 +2056,7 @@ void main() {
     // Select the first word. Both handles should be visible.
     await tester.tapAt(const Offset(20, 10));
     state.renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pump();
     final List<Positioned> positioned =
       find.byType(Positioned).evaluate().map((Element e) => e.widget).cast<Positioned>().toList();
@@ -2174,6 +2176,7 @@ void main() {
     // Select the first word. Both handles should be visible.
     await tester.tapAt(const Offset(20, 10));
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    state.showHandles();
     await tester.pump();
     await verifyVisibility(HandlePositionInViewport.leftEdge, true, HandlePositionInViewport.within, true);
 


### PR DESCRIPTION
## Description

When the user is interacting with a text field through a mouse, we don't want to show the toolbar nor the selection handles. They should only be shown when the user is interacting through a touch screen.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [ ] No, this is *not* a breaking change.

Fixes https://github.com/flutter/flutter/issues/31629

## TODO
- [x] Implement for material text field.
  - [x] Write tests.
- [x] Implement for cupertino text field.
  - [x] Write tests.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
