### PR TITLE
Fix showMenu's PopupMenu offset given initialValue 

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -539,7 +539,7 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
     if (selectedItemOffset == null) {
       y = position.top;
     } else {
-      y = position.top + (size.height - position.top - position.bottom) / 2.0 - selectedItemOffset;
+      y = position.top - selectedItemOffset;
     }
 
     // Find the ideal horizontal position.
@@ -663,13 +663,17 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 
 /// Show a popup menu that contains the `items` at `position`.
 ///
-/// If `initialValue` is specified then the first item with a matching value
-/// will be highlighted and the value of `position` gives the rectangle whose
-/// vertical center will be aligned with the vertical center of the highlighted
-/// item (when possible).
+/// If `initialValue` is specified, the first item in `items` with a matching
+/// value will be highlighted. Also, the vertical center of the `position` rectangle
+/// will be aligned with the vertical center of the highlighted item (when possible).
 ///
-/// If `initialValue` is not specified then the top of the menu will be aligned
-/// with the top of the `position` rectangle.
+/// The vertical center of the highlighted item is determined by iterating over the
+/// `items` to find the first whose [PopupMenuEntry.represents] method returns true
+/// for `initialValue`, and then summing the values of [PopupMenuEntry.height] for
+/// all preceding items to half the current item's height.
+///
+/// If `initialValue` is not specified, then the top of the popup menu will be
+/// aligned with the top of the `position` rectangle.
 ///
 /// In both cases, the menu position will be adjusted if necessary to fit on the
 /// screen.
@@ -681,12 +685,6 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 /// edges of the `position` are equidistant from the opposite edge of the
 /// screen, then the ambient [Directionality] is used as a tie-breaker,
 /// preferring to grow in the reading direction.
-///
-/// The positioning of the `initialValue` at the `position` is implemented by
-/// iterating over the `items` to find the first whose
-/// [PopupMenuEntry.represents] method returns true for `initialValue`, and then
-/// summing the values of [PopupMenuEntry.height] for all the preceding widgets
-/// in the list.
 ///
 /// The `elevation` argument specifies the z-coordinate at which to place the
 /// menu. The elevation defaults to 8, the appropriate elevation for popup


### PR DESCRIPTION
## Description

Currently, the calculation for the offset for `showMenu` given an `initialValue` results in incorrect behavior. This fix resolves the problem. Documentation has been reworded to improve clarity of behavior.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29505

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
