### PR TITLE
Cupertino localization step 6: add a GlobalCupertinoLocalizations base class with date time formatting

### DIFF
--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -375,7 +375,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         singleDigitHourFormat = intl.DateFormat('HH', locale);
         singleDigitMinuteFormat = intl.DateFormat.m(locale);
         doubleDigitMinuteFormat = intl.DateFormat('mm', locale);
-        doubleDigitMinuteFormat = intl.DateFormat.s(locale);
+        singleDigitSecondFormat = intl.DateFormat.s(locale);
       }
 
       if (intl.DateFormat.localeExists(localeName)) {

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -14,35 +14,29 @@ import 'widgets_localizations.dart';
 
 /// Implementation of localized strings for Cupertino widgets using the `intl`
 /// package for date and time formatting.
+///
+/// Further localization of strings beyond date time formatting are provided
+/// by language specific subclasses of [GlobalCupertinoLocalizations]
+///
+/// See also:
+///
+///  * [DefaultCupertinoLocalizations], which provides US English localizations
+///    for Cupertino widgets.
 abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   /// Initializes an object that defines the Cupertino widgets' localized
-  /// strings for the given `locale`.
+  /// strings for the given `localeName`.
   ///
-  /// The arguments are used for further runtime localization of data,
-  /// specifically for selecting plurals, date and time formatting, and number
-  /// formatting. They correspond to the following values:
-  ///
-  ///  1. The string that would be returned by [Intl.canonicalizedLocale] for
-  ///     the locale.
-  ///  2. The [intl.DateFormat] for [formatYear].
-  ///  3. The [intl.DateFormat] for [formatMediumDate].
-  ///  4. The [intl.DateFormat] for [formatFullDate].
-  ///  5. The [intl.DateFormat] for [formatMonthYear].
-  ///  6. The [NumberFormat] for [formatDecimal] (also used by [formatHour] and
-  ///     [formatTimeOfDay] when [timeOfDayFormat] doesn't use [HourFormat.HH]).
-  ///  7. The [NumberFormat] for [formatHour] and the hour part of
-  ///     [formatTimeOfDay] when [timeOfDayFormat] uses [HourFormat.HH], and for
-  ///     [formatMinute] and the minute part of [formatTimeOfDay].
-  ///
-  /// The [narrowWeekdays] and [firstDayOfWeekIndex] properties use the values
-  /// from the [intl.DateFormat] used by [formatFullDate].
+  /// The remaining '*Format' arguments uses the intl package to provide
+  /// [DateFormat] configurations for the `localeName`.
   const GlobalCupertinoLocalizations({
     @required String localeName,
     @required intl.DateFormat fullYearFormat,
     @required intl.DateFormat dayFormat,
     @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat datePickerHourFormat,
-    @required intl.DateFormat datePickerMinuteFormat,
+    @required intl.DateFormat singleDigitHourFormat,
+    @required intl.DateFormat singleDigitMinuteFormat,
+    @required intl.DateFormat doubleDigitMinuteFormat,
+    @required intl.DateFormat singleDigitSecondFormat,
   }) : assert(localeName != null),
        _localeName = localeName,
        assert(fullYearFormat != null),
@@ -51,17 +45,23 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
        _dayFormat = dayFormat,
        assert(mediumDateFormat != null),
        _mediumDateFormat = mediumDateFormat,
-       assert(datePickerHourFormat != null),
-       _datePickerHourFormat = datePickerHourFormat,
-       assert(datePickerMinuteFormat != null),
-       _datePickerMinuteFormat = datePickerMinuteFormat;
+       assert(singleDigitHourFormat != null),
+       _singleDigitHourFormat = singleDigitHourFormat,
+       assert(singleDigitMinuteFormat != null),
+       _singleDigitMinuteFormat = singleDigitMinuteFormat,
+       assert(doubleDigitMinuteFormat != null),
+       _doubleDigitMinuteFormat = doubleDigitMinuteFormat,
+       assert(singleDigitSecondFormat != null),
+       _singleDigitSecondFormat = singleDigitSecondFormat;
 
   final String _localeName;
   final intl.DateFormat _fullYearFormat;
   final intl.DateFormat _dayFormat;
   final intl.DateFormat _mediumDateFormat;
-  final intl.DateFormat _datePickerHourFormat;
-  final intl.DateFormat _datePickerMinuteFormat;
+  final intl.DateFormat _singleDigitHourFormat;
+  final intl.DateFormat _singleDigitMinuteFormat;
+  final intl.DateFormat _doubleDigitMinuteFormat;
+  final intl.DateFormat _singleDigitSecondFormat;
 
   @override
   String datePickerYear(int yearIndex) {
@@ -89,16 +89,23 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
 
   @override
   String datePickerHour(int hour) {
-    return _datePickerHourFormat.format(DateTime.utc(0, 0, 0, hour));
+    return _singleDigitHourFormat.format(DateTime.utc(0, 0, 0, hour));
   }
 
   @override
   String datePickerMinute(int minute) {
-    return _datePickerHourFormat.format(DateTime.utc(0, 0, 0, 0, minute));
+    return _doubleDigitMinuteFormat.format(DateTime.utc(0, 0, 0, 0, minute));
   }
 
-  /// Subclasses of this class should provide the string value for the order
-  /// from the ARB.
+  /// A string describing the [DatePickerDateOrder] enum value.
+  ///
+  /// Subclasses should provide this string value based on the ARB file for
+  /// the locale.
+  ///
+  /// See also:
+  ///
+  ///  * [datePickerDateOrder], which provides the [DatePickerDateOrder]
+  ///    enum value for [CupertinoLocalizations] based on this string value
   @protected
   String get datePickerDateOrderString;
 
@@ -122,112 +129,153 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     }
   }
 
+  /// A string describing the [DatePickerDateTimeOrder] enum value.
+  ///
+  /// Subclasses should provide this string value based on the ARB file for
+  /// the locale.
+  ///
+  /// See also:
+  ///
+  ///  * [datePickerDateTimeOrder], which provides the [DatePickerDateTimeOrder]
+  ///    enum value for [CupertinoLocalizations] based on this string value.
   @protected
   String get datePickerDateTimeOrderString;
 
   @override
   DatePickerDateTimeOrder get datePickerDateTimeOrder {
-
+    switch (datePickerDateTimeOrderString) {
+      case 'date_time_dayPeriod':
+        return DatePickerDateTimeOrder.date_time_dayPeriod;
+      case 'date_dayPeriod_time':
+        return DatePickerDateTimeOrder.date_dayPeriod_time;
+      case 'time_dayPeriod_date':
+        return DatePickerDateTimeOrder.time_dayPeriod_date;
+      case 'dayPeriod_time_date':
+        return DatePickerDateTimeOrder.dayPeriod_time_date;
+      default:
+        assert(
+          false,
+          'Failed to load DatePickerDateTimeOrder $datePickerDateTimeOrderString for locale $_localeName',
+        );
+        return null;
+    }
   }
 
-  /// The abbreviation for ante meridiem (before noon) shown in the time picker.
-  // The global version uses the translated string from the arb file.
-  String get anteMeridiemAbbreviation;
+  @override
+  String timerPickerHour(int hour) {
+    return _singleDigitHourFormat.format(DateTime.utc(0, 0, 0, hour));
+  }
 
-  /// The abbreviation for post meridiem (after noon) shown in the time picker.
-  // The global version uses the translated string from the arb file.
-  String get postMeridiemAbbreviation;
+  @override
+  String timerPickerMinute(int minute) {
+    return _singleDigitMinuteFormat.format(DateTime.utc(0, 0, 0, 0, minute));
+  }
 
-  /// The term used by the system to announce dialog alerts.
-  // The global version uses the translated string from the arb file.
-  String get alertDialogLabel;
+  @override
+  String timerPickerSecond(int second) {
+    return _singleDigitSecondFormat.format(DateTime.utc(0, 0, 0, 0, 0, second));
+  }
 
-  /// Hour that is shown in [CupertinoTimerPicker] corresponding to
-  /// the given hour value.
-  ///
-  /// Examples: timerPickerHour(1) in:
-  ///
-  ///  - US English: 1
-  ///  - Arabic: ١
-  // The global version uses date symbols data from the intl package.
-  String timerPickerHour(int hour);
+  /// Subclasses should provide the optional zero pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelZero => null;
+  /// Subclasses should provide the optional one pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelOne => null;
+  /// Subclasses should provide the optional two pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelTwo => null;
+  /// Subclasses should provide the optional few pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelFew => null;
+  /// Subclasses should provide the optional many pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelMany => null;
+  /// Subclasses should provide the required other pluralization of [timerPickerHourLabel] based on the ARB file.
+  @protected String get timePickerHourLabelOther;
 
-  /// Minute that is shown in [CupertinoTimerPicker] corresponding to
-  /// the given minute value.
-  ///
-  /// Examples: timerPickerMinute(1) in:
-  ///
-  ///  - US English: 1
-  ///  - Arabic: ١
-  // The global version uses date symbols data from the intl package.
-  String timerPickerMinute(int minute);
+  @override
+  String timerPickerHourLabel(int hour) {
+    return intl.Intl.pluralLogic(
+      hour,
+      zero: timePickerHourLabelZero,
+      one: timePickerHourLabelOne,
+      two: timePickerHourLabelTwo,
+      few: timePickerHourLabelFew,
+      many: timePickerHourLabelMany,
+      other: timePickerHourLabelOther,
+    );
+  }
 
-  /// Second that is shown in [CupertinoTimerPicker] corresponding to
-  /// the given second value.
-  ///
-  /// Examples: timerPickerSecond(1) in:
-  ///
-  ///  - US English: 1
-  ///  - Arabic: ١
-  // The global version uses date symbols data from the intl package.
-  String timerPickerSecond(int second);
+  /// Subclasses should provide the optional zero pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelZero => null;
+  /// Subclasses should provide the optional one pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelOne => null;
+  /// Subclasses should provide the optional two pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelTwo => null;
+  /// Subclasses should provide the optional few pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelFew => null;
+  /// Subclasses should provide the optional many pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelMany => null;
+  /// Subclasses should provide the required other pluralization of [timerPickerMinuteLabel] based on the ARB file.
+  @protected String get timePickerMinuteLabelOther;
 
-  /// Label that appears next to the hour picker in
-  /// [CupertinoTimerPicker] when selected hour value is `hour`.
-  /// This function will deal with pluralization based on the `hour` parameter.
-  // The global version uses the translated string from the arb file.
-  String timerPickerHourLabel(int hour);
+  @override
+  String timerPickerMinuteLabel(int minute) {
+    return intl.Intl.pluralLogic(
+      minute,
+      zero: timePickerMinuteLabelZero,
+      one: timePickerMinuteLabelOne,
+      two: timePickerMinuteLabelTwo,
+      few: timePickerMinuteLabelFew,
+      many: timePickerMinuteLabelMany,
+      other: timePickerMinuteLabelOther,
+    );
+  }
 
-  /// Label that appears next to the minute picker in
-  /// [CupertinoTimerPicker] when selected minute value is `minute`.
-  /// This function will deal with pluralization based on the `minute` parameter.
-  // The global version uses the translated string from the arb file.
-  String timerPickerMinuteLabel(int minute);
+  /// Subclasses should provide the optional zero pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelZero => null;
+  /// Subclasses should provide the optional one pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelOne => null;
+  /// Subclasses should provide the optional two pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelTwo => null;
+  /// Subclasses should provide the optional few pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelFew => null;
+  /// Subclasses should provide the optional many pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelMany => null;
+  /// Subclasses should provide the required other pluralization of [timerPickerSecondLabel] based on the ARB file.
+  @protected String get timePickerSecondLabelOther;
 
-  /// Label that appears next to the minute picker in
-  /// [CupertinoTimerPicker] when selected minute value is `second`.
-  /// This function will deal with pluralization based on the `second` parameter.
-  // The global version uses the translated string from the arb file.
-  String timerPickerSecondLabel(int second);
+  @override
+  String timerPickerSecondLabel(int second) {
+    return intl.Intl.pluralLogic(
+      second,
+      zero: timePickerSecondLabelZero,
+      one: timePickerSecondLabelOne,
+      two: timePickerSecondLabelTwo,
+      few: timePickerSecondLabelFew,
+      many: timePickerSecondLabelMany,
+      other: timePickerSecondLabelOther,
+    );
+  }
 
-  /// The term used for cutting
-  // The global version uses the translated string from the arb file.
-  String get cutButtonLabel;
-
-  /// The term used for copying
-  // The global version uses the translated string from the arb file.
-  String get copyButtonLabel;
-
-  /// The term used for pasting
-  // The global version uses the translated string from the arb file.
-  String get pasteButtonLabel;
-
-  /// The term used for selecting everything
-  // The global version uses the translated string from the arb file.
-  String get selectAllButtonLabel;
-
-  /// A [LocalizationsDelegate] that uses [GlobalMaterialLocalizations.load]
+  /// A [LocalizationsDelegate] that uses [GlobalCupertinoLocalizations.load]
   /// to create an instance of this class.
   ///
-  /// Most internationalized apps will use [GlobalMaterialLocalizations.delegates]
-  /// as the value of [MaterialApp.localizationsDelegates] to include
-  /// the localizations for both the material and widget libraries.
-  static const LocalizationsDelegate<MaterialLocalizations> delegate = _MaterialLocalizationsDelegate();
+  /// Most internationalized apps will use [GlobalCupertinoLocalizations.delegates]
+  /// as the value of [CupertinoApp.localizationsDelegates] to include
+  /// the localizations for both the cupertino and widget libraries.
+  static const LocalizationsDelegate<CupertinoLocalizations> delegate = _GlobalCupertinoLocalizationsDelegate();
 
-  /// A value for [MaterialApp.localizationsDelegates] that's typically used by
+  /// A value for [CupertinoApp.localizationsDelegates] that's typically used by
   /// internationalized apps.
   ///
   /// ## Sample code
   ///
   /// To include the localizations provided by this class and by
-  /// [GlobalWidgetsLocalizations] in a [MaterialApp],
-  /// use [GlobalMaterialLocalizations.delegates] as the value of
-  /// [MaterialApp.localizationsDelegates], and specify the locales your
-  /// app supports with [MaterialApp.supportedLocales]:
+  /// [GlobalWidgetsLocalizations] in a [CupertinoApp],
+  /// use [GlobalCupertinoLocalizations.delegates] as the value of
+  /// [CupertinoApp.localizationsDelegates], and specify the locales your
+  /// app supports with [CupertinoApp.supportedLocales]:
   ///
   /// ```dart
-  /// new MaterialApp(
-  ///   localizationsDelegates: GlobalMaterialLocalizations.delegates,
+  /// new CupertinoApp(
+  ///   localizationsDelegates: GlobalCupertinoLocalizations.delegates,
   ///   supportedLocales: [
   ///     const Locale('en', 'US'), // English
   ///     const Locale('he', 'IL'), // Hebrew
@@ -236,7 +284,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   /// )
   /// ```
   static const List<LocalizationsDelegate<dynamic>> delegates = <LocalizationsDelegate<dynamic>>[
-    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
   ];
 }
@@ -245,13 +293,13 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
   const _GlobalCupertinoLocalizationsDelegate();
 
   @override
-  bool isSupported(Locale locale) => kSupportedLanguages.contains(locale.languageCode);
+  bool isSupported(Locale locale) => false; // TODO(xster): implement.
 
   static final Map<Locale, Future<CupertinoLocalizations>> _loadedTranslations = <Locale, Future<CupertinoLocalizations>>{};
 
   @override
   Future<CupertinoLocalizations> load(Locale locale) {
-    assert(isSupported(locale));
+    assert(isSupported(locale)); // TODO(xster): implement.
     return _loadedTranslations.putIfAbsent(locale, () {
       util.loadDateIntlDataIfNotLoaded();
 
@@ -262,15 +310,20 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
       intl.DateFormat mediumDateFormat;
       // We don't want any additional decoration here. The am/pm is handled in
       // the date picker. We just want an hour number localized.
-      intl.DateFormat datePickerHourFormat;
-      intl.DateFormat datePickerMinuteFormat;
+      intl.DateFormat singleDigitHourFormat;
+      intl.DateFormat singleDigitMinuteFormat;
+      intl.DateFormat doubleDigitMinuteFormat;
+      intl.DateFormat singleDigitSecondFormat;
 
       void loadFormats(String locale) {
         fullYearFormat = intl.DateFormat.y(locale);
         dayFormat = intl.DateFormat.d(locale);
         mediumDateFormat = intl.DateFormat.MMMEd(locale);
-        datePickerHourFormat = intl.DateFormat('HH', locale);
-        datePickerHourFormat = intl.DateFormat('mm', locale);
+        // TODO(xster): fix when https://github.com/dart-lang/intl/issues/207 is resolved.
+        singleDigitHourFormat = intl.DateFormat('HH', locale);
+        singleDigitMinuteFormat = intl.DateFormat.m(locale);
+        doubleDigitMinuteFormat = intl.DateFormat('mm', locale);
+        doubleDigitMinuteFormat = intl.DateFormat.s(locale);
       }
 
       if (intl.DateFormat.localeExists(localeName)) {
@@ -281,36 +334,34 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         loadFormats(null);
       }
 
-      intl.NumberFormat decimalFormat;
-      intl.NumberFormat twoDigitZeroPaddedFormat;
-      if (intl.NumberFormat.localeExists(localeName)) {
-        decimalFormat = intl.NumberFormat.decimalPattern(localeName);
-        twoDigitZeroPaddedFormat = intl.NumberFormat('00', localeName);
-      } else if (intl.NumberFormat.localeExists(locale.languageCode)) {
-        decimalFormat = intl.NumberFormat.decimalPattern(locale.languageCode);
-        twoDigitZeroPaddedFormat = intl.NumberFormat('00', locale.languageCode);
-      } else {
-        decimalFormat = intl.NumberFormat.decimalPattern();
-        twoDigitZeroPaddedFormat = intl.NumberFormat('00');
-      }
-
       assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
-      return SynchronousFuture<CupertinoLocalizations>(getMaterialTranslation(
-        locale,
+      return SynchronousFuture<CupertinoLocalizations>(_getCupertinoTranslation(
+        localeName,
         fullYearFormat,
+        dayFormat,
         mediumDateFormat,
-        longDateFormat,
-        yearMonthFormat,
-        decimalFormat,
-        twoDigitZeroPaddedFormat,
+        singleDigitHourFormat,
+        singleDigitMinuteFormat,
+        doubleDigitMinuteFormat,
+        singleDigitSecondFormat,
       ));
     });
   }
 
   @override
   bool shouldReload(_GlobalCupertinoLocalizationsDelegate old) => false;
+}
 
-  @override
-  String toString() => 'GlobalMaterialLocalizations.delegate(${kSupportedLanguages.length} locales)';
+CupertinoLocalizations _getCupertinoTranslation(
+  String localeName,
+  intl.DateFormat fullYearFormat,
+  intl.DateFormat dayFormat,
+  intl.DateFormat mediumDateFormat,
+  intl.DateFormat singleDigitHourFormat,
+  intl.DateFormat singleDigitMinuteFormat,
+  intl.DateFormat doubleDigitMinuteFormat,
+  intl.DateFormat singleDigitSecondFormat,
+) {
+  return null; // TODO(xster): implement in generated subclass.
 }

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -369,7 +369,11 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
       util.loadDateIntlDataIfNotLoaded();
 
       final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
-      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
+      assert(
+        locale.toString() == localeName,
+        'Flutter does not support the non-standard locale form $locale (which '
+        'might be $localeName',
+      );
 
       intl.DateFormat fullYearFormat;
       intl.DateFormat dayFormat;

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -97,6 +97,58 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     return _doubleDigitMinuteFormat.format(DateTime.utc(0, 0, 0, 0, minute));
   }
 
+  /// Subclasses should provide the optional zero pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelZero => null;
+  /// Subclasses should provide the optional one pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelOne => null;
+  /// Subclasses should provide the optional two pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelTwo => null;
+  /// Subclasses should provide the optional few pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelFew => null;
+  /// Subclasses should provide the optional many pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelMany => null;
+  /// Subclasses should provide the required other pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
+  @protected String get datePickerHourSemanticsLabelOther;
+
+  @override
+  String datePickerHourSemanticsLabel(int hour) {
+    return intl.Intl.pluralLogic(
+      hour,
+      zero: datePickerHourSemanticsLabelZero,
+      one: datePickerHourSemanticsLabelOne,
+      two: datePickerHourSemanticsLabelTwo,
+      few: datePickerHourSemanticsLabelFew,
+      many: datePickerHourSemanticsLabelMany,
+      other: datePickerHourSemanticsLabelOther,
+    );
+  }
+
+  /// Subclasses should provide the optional zero pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelZero => null;
+  /// Subclasses should provide the optional one pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelOne => null;
+  /// Subclasses should provide the optional two pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelTwo => null;
+  /// Subclasses should provide the optional few pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelFew => null;
+  /// Subclasses should provide the optional many pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelMany => null;
+  /// Subclasses should provide the required other pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
+  @protected String get datePickerMinuteSemanticsLabelOther;
+
+  @override
+  String datePickerMinuteSemanticsLabel(int minute) {
+    return intl.Intl.pluralLogic(
+      minute,
+      zero: datePickerMinuteSemanticsLabelZero,
+      one: datePickerMinuteSemanticsLabelOne,
+      two: datePickerMinuteSemanticsLabelTwo,
+      few: datePickerMinuteSemanticsLabelFew,
+      many: datePickerMinuteSemanticsLabelMany,
+      other: datePickerMinuteSemanticsLabelOther,
+    );
+  }
+
   /// A string describing the [DatePickerDateOrder] enum value.
   ///
   /// Subclasses should provide this string value based on the ARB file for
@@ -177,80 +229,80 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelZero => null;
+  @protected String get timerPickerHourLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelOne => null;
+  @protected String get timerPickerHourLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelTwo => null;
+  @protected String get timerPickerHourLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelFew => null;
+  @protected String get timerPickerHourLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelMany => null;
+  @protected String get timerPickerHourLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timePickerHourLabelOther;
+  @protected String get timerPickerHourLabelOther;
 
   @override
   String timerPickerHourLabel(int hour) {
     return intl.Intl.pluralLogic(
       hour,
-      zero: timePickerHourLabelZero,
-      one: timePickerHourLabelOne,
-      two: timePickerHourLabelTwo,
-      few: timePickerHourLabelFew,
-      many: timePickerHourLabelMany,
-      other: timePickerHourLabelOther,
+      zero: timerPickerHourLabelZero,
+      one: timerPickerHourLabelOne,
+      two: timerPickerHourLabelTwo,
+      few: timerPickerHourLabelFew,
+      many: timerPickerHourLabelMany,
+      other: timerPickerHourLabelOther,
     );
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelZero => null;
+  @protected String get timerPickerMinuteLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelOne => null;
+  @protected String get timerPickerMinuteLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelTwo => null;
+  @protected String get timerPickerMinuteLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelFew => null;
+  @protected String get timerPickerMinuteLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelMany => null;
+  @protected String get timerPickerMinuteLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timePickerMinuteLabelOther;
+  @protected String get timerPickerMinuteLabelOther;
 
   @override
   String timerPickerMinuteLabel(int minute) {
     return intl.Intl.pluralLogic(
       minute,
-      zero: timePickerMinuteLabelZero,
-      one: timePickerMinuteLabelOne,
-      two: timePickerMinuteLabelTwo,
-      few: timePickerMinuteLabelFew,
-      many: timePickerMinuteLabelMany,
-      other: timePickerMinuteLabelOther,
+      zero: timerPickerMinuteLabelZero,
+      one: timerPickerMinuteLabelOne,
+      two: timerPickerMinuteLabelTwo,
+      few: timerPickerMinuteLabelFew,
+      many: timerPickerMinuteLabelMany,
+      other: timerPickerMinuteLabelOther,
     );
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelZero => null;
+  @protected String get timerPickerSecondLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelOne => null;
+  @protected String get timerPickerSecondLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelTwo => null;
+  @protected String get timerPickerSecondLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelFew => null;
+  @protected String get timerPickerSecondLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelMany => null;
+  @protected String get timerPickerSecondLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timePickerSecondLabelOther;
+  @protected String get timerPickerSecondLabelOther;
 
   @override
   String timerPickerSecondLabel(int second) {
     return intl.Intl.pluralLogic(
       second,
-      zero: timePickerSecondLabelZero,
-      one: timePickerSecondLabelOne,
-      two: timePickerSecondLabelTwo,
-      few: timePickerSecondLabelFew,
-      many: timePickerSecondLabelMany,
-      other: timePickerSecondLabelOther,
+      zero: timerPickerSecondLabelZero,
+      one: timerPickerSecondLabelOne,
+      two: timerPickerSecondLabelTwo,
+      few: timerPickerSecondLabelFew,
+      many: timerPickerSecondLabelMany,
+      other: timerPickerSecondLabelOther,
     );
   }
 

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -39,7 +39,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   const GlobalCupertinoLocalizations({
     @required String localeName,
     @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat dayFormat,
     @required intl.DateFormat longDateFormat,
     @required intl.DateFormat yearMonthFormat,
     @required intl.NumberFormat decimalFormat,
@@ -48,269 +48,152 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
        _localeName = localeName,
        assert(fullYearFormat != null),
        _fullYearFormat = fullYearFormat,
-       assert(mediumDateFormat != null),
-       _mediumDateFormat = mediumDateFormat,
-       assert(longDateFormat != null),
-       _longDateFormat = longDateFormat,
-       assert(yearMonthFormat != null),
-       _yearMonthFormat = yearMonthFormat,
-       assert(decimalFormat != null),
-       _decimalFormat = decimalFormat,
-       assert(twoDigitZeroPaddedFormat != null),
-       _twoDigitZeroPaddedFormat = twoDigitZeroPaddedFormat;
+       assert(dayFormat != null),
+       _dayFormat = dayFormat;
 
   final String _localeName;
   final intl.DateFormat _fullYearFormat;
-  final intl.DateFormat _mediumDateFormat;
-  final intl.DateFormat _longDateFormat;
-  final intl.DateFormat _yearMonthFormat;
-  final intl.NumberFormat _decimalFormat;
-  final intl.NumberFormat _twoDigitZeroPaddedFormat;
-
-
-  /// The "zero" form of [selectedRowCountTitle].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleMany], the "many" form
-  ///  * [selectedRowCountTitleOther], the "other" form
-  @protected
-  String get selectedRowCountTitleZero => null;
-
-  /// The "one" form of [selectedRowCountTitle].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleMany], the "many" form
-  ///  * [selectedRowCountTitleOther], the "other" form
-  @protected
-  String get selectedRowCountTitleOne => null;
-
-  /// The "two" form of [selectedRowCountTitle].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleMany], the "many" form
-  ///  * [selectedRowCountTitleOther], the "other" form
-  @protected
-  String get selectedRowCountTitleTwo => null;
-
-  /// The "few" form of [selectedRowCountTitle].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleMany], the "many" form
-  ///  * [selectedRowCountTitleOther], the "other" form
-  @protected
-  String get selectedRowCountTitleFew => null;
-
-  /// The "many" form of [selectedRowCountTitle].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleOther], the "other" form
-  @protected
-  String get selectedRowCountTitleMany => null;
-
-  /// The "other" form of [selectedRowCountTitle].
-  ///
-  /// This form is required.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [selectedRowCountTitleZero], the "zero" form
-  ///  * [selectedRowCountTitleOne], the "one" form
-  ///  * [selectedRowCountTitleTwo], the "two" form
-  ///  * [selectedRowCountTitleFew], the "few" form
-  ///  * [selectedRowCountTitleMany], the "many" form
-  @protected
-  String get selectedRowCountTitleOther;
+  final intl.DateFormat _dayFormat;
 
   @override
-  String selectedRowCountTitle(int selectedRowCount) {
-    return intl.Intl.pluralLogic(
-      selectedRowCount,
-      zero: selectedRowCountTitleZero,
-      one: selectedRowCountTitleOne,
-      two: selectedRowCountTitleTwo,
-      few: selectedRowCountTitleFew,
-      many: selectedRowCountTitleMany,
-      other: selectedRowCountTitleOther,
-      locale: _localeName,
-    ).replaceFirst(r'$selectedRowCount', formatDecimal(selectedRowCount));
-  }
-
-  /// The format to use for [timeOfDayFormat].
-  @protected
-  TimeOfDayFormat get timeOfDayFormatRaw;
-
-  /// The [TimeOfDayFormat] corresponding to one of the following supported
-  /// patterns:
-  ///
-  ///  * `HH:mm`
-  ///  * `HH.mm`
-  ///  * `HH 'h' mm`
-  ///  * `HH:mm น.`
-  ///  * `H:mm`
-  ///  * `h:mm a`
-  ///  * `a h:mm`
-  ///  * `ah:mm`
-  ///
-  /// See also:
-  ///
-  ///  * <http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US>, which shows
-  ///    the short time pattern used in the `en_US` locale.
-  @override
-  TimeOfDayFormat timeOfDayFormat({ bool alwaysUse24HourFormat = false }) {
-    assert(alwaysUse24HourFormat != null);
-    if (alwaysUse24HourFormat)
-      return _get24HourVersionOf(timeOfDayFormatRaw);
-    return timeOfDayFormatRaw;
-  }
-
-  /// The "zero" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is required.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountZero;
-
-  /// The "one" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountOne => null;
-
-  /// The "two" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountTwo => null;
-
-  /// The "many" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountMany => null;
-
-  /// The "few" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is optional.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountFew => null;
-
-  /// The "other" form of [remainingTextFieldCharacterCount].
-  ///
-  /// This form is required.
-  ///
-  /// See also:
-  ///
-  ///  * [Intl.plural], to which this form is passed.
-  ///  * [remainingTextFieldCharacterCountZero], the "zero" form
-  ///  * [remainingTextFieldCharacterCountOne], the "one" form
-  ///  * [remainingTextFieldCharacterCountTwo], the "two" form
-  ///  * [remainingTextFieldCharacterCountFew], the "few" form
-  ///  * [remainingTextFieldCharacterCountMany], the "many" form
-  ///  * [remainingTextFieldCharacterCountOther], the "other" form
-  @protected
-  String get remainingTextFieldCharacterCountOther;
-
-  @override
-  String remainingTextFieldCharacterCount(int remainingCount) {
-    return intl.Intl.pluralLogic(
-      remainingCount,
-      zero: remainingTextFieldCharacterCountZero,
-      one: remainingTextFieldCharacterCountOne,
-      two: remainingTextFieldCharacterCountTwo,
-      many: remainingTextFieldCharacterCountMany,
-      few: remainingTextFieldCharacterCountFew,
-      other: remainingTextFieldCharacterCountOther,
-      locale: _localeName,
-    ).replaceFirst(r'$remainingCount', formatDecimal(remainingCount));
+  String datePickerYear(int yearIndex) {
+    return _fullYearFormat.format(DateTime.utc(yearIndex));
   }
 
   @override
-  ScriptCategory get scriptCategory;
+  String datePickerMonth(int monthIndex) {
+    // It doesn't actually have anything to do with _fullYearFormat. It's just
+    // taking advantage of the fact that _fullYearFormat loaded the needed
+    // locale's symbols.
+    return _fullYearFormat.dateSymbols.MONTHS[monthIndex];
+  }
+
+  @override
+  String datePickerDayOfMonth(int dayIndex) {
+
+  }
+
+  /// The medium-width date format that is shown in [CupertinoDatePicker]
+  /// spinner. Abbreviates month and days of week.
+  ///
+  /// Examples:
+  ///
+  /// - US English: Wed Sep 27
+  /// - Russian: ср сент. 27
+  // The global version is based on intl package's DateFormat.MMMEd.
+  String datePickerMediumDate(DateTime date);
+
+  /// Hour that is shown in [CupertinoDatePicker] spinner corresponding
+  /// to the given hour value.
+  ///
+  /// Examples: datePickerHour(1) in:
+  ///
+  ///  - US English: 1
+  ///  - Arabic: ٠١
+  // The global version uses date symbols data from the intl package.
+  String datePickerHour(int hour);
+
+  /// Semantics label for the given hour value in [CupertinoDatePicker].
+  // The global version uses the translated string from the arb file.
+  String datePickerHourSemanticsLabel(int hour);
+
+  /// Minute that is shown in [CupertinoDatePicker] spinner corresponding
+  /// to the given minute value.
+  ///
+  /// Examples: datePickerMinute(1) in:
+  ///
+  ///  - US English: 01
+  ///  - Arabic: ٠١
+  // The global version uses date symbols data from the intl package.
+  String datePickerMinute(int minute);
+
+  /// Semantics label for the given minute value in [CupertinoDatePicker].
+  // The global version uses the translated string from the arb file.
+  String datePickerMinuteSemanticsLabel(int minute);
+
+  /// The order of the date elements that will be shown in [CupertinoDatePicker].
+  // The global version uses the translated string from the arb file.
+  DatePickerDateOrder get datePickerDateOrder;
+
+  /// The order of the time elements that will be shown in [CupertinoDatePicker].
+  // The global version uses the translated string from the arb file.
+  DatePickerDateTimeOrder get datePickerDateTimeOrder;
+
+  /// The abbreviation for ante meridiem (before noon) shown in the time picker.
+  // The global version uses the translated string from the arb file.
+  String get anteMeridiemAbbreviation;
+
+  /// The abbreviation for post meridiem (after noon) shown in the time picker.
+  // The global version uses the translated string from the arb file.
+  String get postMeridiemAbbreviation;
+
+  /// The term used by the system to announce dialog alerts.
+  // The global version uses the translated string from the arb file.
+  String get alertDialogLabel;
+
+  /// Hour that is shown in [CupertinoTimerPicker] corresponding to
+  /// the given hour value.
+  ///
+  /// Examples: timerPickerHour(1) in:
+  ///
+  ///  - US English: 1
+  ///  - Arabic: ١
+  // The global version uses date symbols data from the intl package.
+  String timerPickerHour(int hour);
+
+  /// Minute that is shown in [CupertinoTimerPicker] corresponding to
+  /// the given minute value.
+  ///
+  /// Examples: timerPickerMinute(1) in:
+  ///
+  ///  - US English: 1
+  ///  - Arabic: ١
+  // The global version uses date symbols data from the intl package.
+  String timerPickerMinute(int minute);
+
+  /// Second that is shown in [CupertinoTimerPicker] corresponding to
+  /// the given second value.
+  ///
+  /// Examples: timerPickerSecond(1) in:
+  ///
+  ///  - US English: 1
+  ///  - Arabic: ١
+  // The global version uses date symbols data from the intl package.
+  String timerPickerSecond(int second);
+
+  /// Label that appears next to the hour picker in
+  /// [CupertinoTimerPicker] when selected hour value is `hour`.
+  /// This function will deal with pluralization based on the `hour` parameter.
+  // The global version uses the translated string from the arb file.
+  String timerPickerHourLabel(int hour);
+
+  /// Label that appears next to the minute picker in
+  /// [CupertinoTimerPicker] when selected minute value is `minute`.
+  /// This function will deal with pluralization based on the `minute` parameter.
+  // The global version uses the translated string from the arb file.
+  String timerPickerMinuteLabel(int minute);
+
+  /// Label that appears next to the minute picker in
+  /// [CupertinoTimerPicker] when selected minute value is `second`.
+  /// This function will deal with pluralization based on the `second` parameter.
+  // The global version uses the translated string from the arb file.
+  String timerPickerSecondLabel(int second);
+
+  /// The term used for cutting
+  // The global version uses the translated string from the arb file.
+  String get cutButtonLabel;
+
+  /// The term used for copying
+  // The global version uses the translated string from the arb file.
+  String get copyButtonLabel;
+
+  /// The term used for pasting
+  // The global version uses the translated string from the arb file.
+  String get pasteButtonLabel;
+
+  /// The term used for selecting everything
+  // The global version uses the translated string from the arb file.
+  String get selectAllButtonLabel;
 
   /// A [LocalizationsDelegate] that uses [GlobalMaterialLocalizations.load]
   /// to create an instance of this class.
@@ -345,23 +228,6 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     GlobalMaterialLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
   ];
-}
-
-/// Finds the [TimeOfDayFormat] to use instead of the `original` when the
-/// `original` uses 12-hour format and [MediaQueryData.alwaysUse24HourFormat]
-/// is true.
-TimeOfDayFormat _get24HourVersionOf(TimeOfDayFormat original) {
-  switch (original) {
-    case TimeOfDayFormat.HH_colon_mm:
-    case TimeOfDayFormat.HH_dot_mm:
-    case TimeOfDayFormat.frenchCanadian:
-    case TimeOfDayFormat.H_colon_mm:
-      return original;
-    case TimeOfDayFormat.h_colon_mm_space_a:
-    case TimeOfDayFormat.a_space_h_colon_mm:
-      return TimeOfDayFormat.HH_colon_mm;
-  }
-  return TimeOfDayFormat.HH_colon_mm;
 }
 
 class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -181,7 +181,9 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       default:
         assert(
           false,
-          'Failed to load DatePickerDateOrder $datePickerDateOrderString for locale $_localeName',
+          'Failed to load DatePickerDateOrder $datePickerDateOrderString for '
+          'locale $_localeName.\nNon conforming string for ${_localeName}\'s '
+          '.arb file',
         );
         return null;
     }
@@ -213,7 +215,9 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       default:
         assert(
           false,
-          'Failed to load DatePickerDateTimeOrder $datePickerDateTimeOrderString for locale $_localeName',
+          'Failed to load DatePickerDateTimeOrder $datePickerDateTimeOrderString '
+          'for locale $_localeName.\nNon conforming string for ${_localeName}\'s '
+          '.arb file',
         );
         return null;
     }
@@ -365,6 +369,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
       util.loadDateIntlDataIfNotLoaded();
 
       final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
       intl.DateFormat fullYearFormat;
       intl.DateFormat dayFormat;
@@ -396,8 +401,6 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
       } else {
         loadFormats(null);
       }
-
-      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
       return SynchronousFuture<CupertinoLocalizations>(_getCupertinoTranslation(
         localeName,

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -115,7 +115,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       case 'dmy':
         return DatePickerDateOrder.dmy;
       case 'mdy':
-        return DatePickerDateOrder.dmy;
+        return DatePickerDateOrder.mdy;
       case 'ymd':
         return DatePickerDateOrder.ymd;
       case 'ydm':

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -1,72 +1,22 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
 import 'package:intl/date_symbols.dart' as intl;
 
-import 'l10n/generated_material_localizations.dart';
 import 'utils/date_localizations.dart' as util;
 import 'widgets_localizations.dart';
 
-/// Implementation of localized strings for the material widgets using the
-/// `intl` package for date and time formatting.
-///
-/// ## Supported languages
-///
-/// This class supports locales with the following [Locale.languageCode]s:
-///
-/// {@macro flutter.localizations.languages}
-///
-/// This list is available programatically via [kSupportedLanguages].
-///
-/// ## Sample code
-///
-/// To include the localizations provided by this class in a [MaterialApp],
-/// add [GlobalMaterialLocalizations.delegates] to
-/// [MaterialApp.localizationsDelegates], and specify the locales your
-/// app supports with [MaterialApp.supportedLocales]:
-///
-/// ```dart
-/// new MaterialApp(
-///   localizationsDelegates: GlobalMaterialLocalizations.delegates,
-///   supportedLocales: [
-///     const Locale('en', 'US'), // American English
-///     const Locale('he', 'IL'), // Israeli Hebrew
-///     // ...
-///   ],
-///   // ...
-/// )
-/// ```
-///
-/// ## Overriding translations
-///
-/// To create a translation that's similar to an existing language's translation
-/// but has slightly different strings, subclass the relevant translation
-/// directly and then create a [LocalizationsDelegate<MaterialLocalizations>]
-/// subclass to define how to load it.
-///
-/// Avoid subclassing an unrelated language (for example, subclassing
-/// [MaterialLocalizationEn] and then passing a non-English `localeName` to the
-/// constructor). Doing so will cause confusion for locale-specific behaviors;
-/// in particular, translations that use the `localeName` for determining how to
-/// pluralize will end up doing invalid things. Subclassing an existing
-/// language's translations is only suitable for making small changes to the
-/// existing strings. For providing a new language entirely, implement
-/// [MaterialLocalizations] directly.
-///
-/// See also:
-///
-///  * The Flutter Internationalization Tutorial,
-///    <https://flutter.dev/tutorials/internationalization/>.
-///  * [DefaultMaterialLocalizations], which only provides US English translations.
-abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
-  /// Initializes an object that defines the material widgets' localized strings
-  /// for the given `locale`.
+/// Implementation of localized strings for Cupertino widgets using the `intl`
+/// package for date and time formatting.
+abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
+  /// Initializes an object that defines the Cupertino widgets' localized
+  /// strings for the given `locale`.
   ///
   /// The arguments are used for further runtime localization of data,
   /// specifically for selecting plurals, date and time formatting, and number
@@ -86,7 +36,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///
   /// The [narrowWeekdays] and [firstDayOfWeekIndex] properties use the values
   /// from the [intl.DateFormat] used by [formatFullDate].
-  const GlobalMaterialLocalizations({
+  const GlobalCupertinoLocalizations({
     @required String localeName,
     @required intl.DateFormat fullYearFormat,
     @required intl.DateFormat mediumDateFormat,
@@ -117,144 +67,6 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   final intl.NumberFormat _decimalFormat;
   final intl.NumberFormat _twoDigitZeroPaddedFormat;
 
-  @override
-  String formatHour(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat = false }) {
-    switch (hourFormat(of: timeOfDayFormat(alwaysUse24HourFormat: alwaysUse24HourFormat))) {
-      case HourFormat.HH:
-        return _twoDigitZeroPaddedFormat.format(timeOfDay.hour);
-      case HourFormat.H:
-        return formatDecimal(timeOfDay.hour);
-      case HourFormat.h:
-        final int hour = timeOfDay.hourOfPeriod;
-        return formatDecimal(hour == 0 ? 12 : hour);
-    }
-    return null;
-  }
-
-  @override
-  String formatMinute(TimeOfDay timeOfDay) {
-    return _twoDigitZeroPaddedFormat.format(timeOfDay.minute);
-  }
-
-  @override
-  String formatYear(DateTime date) {
-    return _fullYearFormat.format(date);
-  }
-
-  @override
-  String formatMediumDate(DateTime date) {
-    return _mediumDateFormat.format(date);
-  }
-
-  @override
-  String formatFullDate(DateTime date) {
-    return _longDateFormat.format(date);
-  }
-
-  @override
-  String formatMonthYear(DateTime date) {
-    return _yearMonthFormat.format(date);
-  }
-
-  @override
-  List<String> get narrowWeekdays {
-    return _longDateFormat.dateSymbols.NARROWWEEKDAYS;
-  }
-
-  @override
-  int get firstDayOfWeekIndex => (_longDateFormat.dateSymbols.FIRSTDAYOFWEEK + 1) % 7;
-
-  @override
-  String formatDecimal(int number) {
-    return _decimalFormat.format(number);
-  }
-
-  @override
-  String formatTimeOfDay(TimeOfDay timeOfDay, { bool alwaysUse24HourFormat = false }) {
-    // Not using intl.DateFormat for two reasons:
-    //
-    // - DateFormat supports more formats than our material time picker does,
-    //   and we want to be consistent across time picker format and the string
-    //   formatting of the time of day.
-    // - DateFormat operates on DateTime, which is sensitive to time eras and
-    //   time zones, while here we want to format hour and minute within one day
-    //   no matter what date the day falls on.
-    final String hour = formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat);
-    final String minute = formatMinute(timeOfDay);
-    switch (timeOfDayFormat(alwaysUse24HourFormat: alwaysUse24HourFormat)) {
-      case TimeOfDayFormat.h_colon_mm_space_a:
-        return '$hour:$minute ${_formatDayPeriod(timeOfDay)}';
-      case TimeOfDayFormat.H_colon_mm:
-      case TimeOfDayFormat.HH_colon_mm:
-        return '$hour:$minute';
-      case TimeOfDayFormat.HH_dot_mm:
-        return '$hour.$minute';
-      case TimeOfDayFormat.a_space_h_colon_mm:
-        return '${_formatDayPeriod(timeOfDay)} $hour:$minute';
-      case TimeOfDayFormat.frenchCanadian:
-        return '$hour h $minute';
-    }
-    return null;
-  }
-
-  String _formatDayPeriod(TimeOfDay timeOfDay) {
-    switch (timeOfDay.period) {
-      case DayPeriod.am:
-        return anteMeridiemAbbreviation;
-      case DayPeriod.pm:
-        return postMeridiemAbbreviation;
-    }
-    return null;
-  }
-
-  /// The raw version of [aboutListTileTitle], with `$applicationName` verbatim
-  /// in the string.
-  @protected
-  String get aboutListTileTitleRaw;
-
-  @override
-  String aboutListTileTitle(String applicationName) {
-    final String text = aboutListTileTitleRaw;
-    return text.replaceFirst(r'$applicationName', applicationName);
-  }
-
-  /// The raw version of [pageRowsInfoTitle], with `$firstRow`, `$lastRow`' and
-  /// `$rowCount` verbatim in the string, for the case where the value is
-  /// approximate.
-  @protected
-  String get pageRowsInfoTitleApproximateRaw;
-
-  /// The raw version of [pageRowsInfoTitle], with `$firstRow`, `$lastRow`' and
-  /// `$rowCount` verbatim in the string, for the case where the value is
-  /// precise.
-  @protected
-  String get pageRowsInfoTitleRaw;
-
-  @override
-  String pageRowsInfoTitle(int firstRow, int lastRow, int rowCount, bool rowCountIsApproximate) {
-    String text = rowCountIsApproximate ? pageRowsInfoTitleApproximateRaw : null;
-    text ??= pageRowsInfoTitleRaw;
-    assert(text != null, 'A $_localeName localization was not found for pageRowsInfoTitle or pageRowsInfoTitleApproximate');
-    return text
-      .replaceFirst(r'$firstRow', formatDecimal(firstRow))
-      .replaceFirst(r'$lastRow', formatDecimal(lastRow))
-      .replaceFirst(r'$rowCount', formatDecimal(rowCount));
-  }
-
-  /// The raw version of [tabLabel], with `$tabIndex` and `$tabCount` verbatim
-  /// in the string.
-  @protected
-  String get tabLabelRaw;
-
-  @override
-  String tabLabel({ int tabIndex, int tabCount }) {
-    assert(tabIndex >= 1);
-    assert(tabCount >= 1);
-    final String template = tabLabelRaw;
-    return template
-      .replaceFirst(r'$tabIndex', formatDecimal(tabIndex))
-      .replaceFirst(r'$tabCount', formatDecimal(tabCount));
-  }
 
   /// The "zero" form of [selectedRowCountTitle].
   ///
@@ -552,16 +364,16 @@ TimeOfDayFormat _get24HourVersionOf(TimeOfDayFormat original) {
   return TimeOfDayFormat.HH_colon_mm;
 }
 
-class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
-  const _MaterialLocalizationsDelegate();
+class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {
+  const _GlobalCupertinoLocalizationsDelegate();
 
   @override
   bool isSupported(Locale locale) => kSupportedLanguages.contains(locale.languageCode);
 
-  static final Map<Locale, Future<MaterialLocalizations>> _loadedTranslations = <Locale, Future<MaterialLocalizations>>{};
+  static final Map<Locale, Future<CupertinoLocalizations>> _loadedTranslations = <Locale, Future<CupertinoLocalizations>>{};
 
   @override
-  Future<MaterialLocalizations> load(Locale locale) {
+  Future<CupertinoLocalizations> load(Locale locale) {
     assert(isSupported(locale));
     return _loadedTranslations.putIfAbsent(locale, () {
       util.loadDateIntlDataIfNotLoaded();
@@ -604,7 +416,7 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
 
       assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
-      return SynchronousFuture<MaterialLocalizations>(getMaterialTranslation(
+      return SynchronousFuture<CupertinoLocalizations>(getMaterialTranslation(
         locale,
         fullYearFormat,
         mediumDateFormat,
@@ -617,7 +429,7 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
   }
 
   @override
-  bool shouldReload(_MaterialLocalizationsDelegate old) => false;
+  bool shouldReload(_GlobalCupertinoLocalizationsDelegate old) => false;
 
   @override
   String toString() => 'GlobalMaterialLocalizations.delegate(${kSupportedLanguages.length} locales)';

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -182,7 +182,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
         assert(
           false,
           'Failed to load DatePickerDateOrder $datePickerDateOrderString for '
-          'locale $_localeName.\nNon conforming string for ${_localeName}\'s '
+          'locale $_localeName.\nNon conforming string for $_localeName\'s '
           '.arb file',
         );
         return null;
@@ -216,7 +216,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
         assert(
           false,
           'Failed to load DatePickerDateTimeOrder $datePickerDateTimeOrderString '
-          'for locale $_localeName.\nNon conforming string for ${_localeName}\'s '
+          'for locale $_localeName.\nNon conforming string for $_localeName\'s '
           '.arb file',
         );
         return null;

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -37,6 +37,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     @required intl.DateFormat singleDigitMinuteFormat,
     @required intl.DateFormat doubleDigitMinuteFormat,
     @required intl.DateFormat singleDigitSecondFormat,
+    @required intl.NumberFormat decimalFormat,
   }) : assert(localeName != null),
        _localeName = localeName,
        assert(fullYearFormat != null),
@@ -52,7 +53,9 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
        assert(doubleDigitMinuteFormat != null),
        _doubleDigitMinuteFormat = doubleDigitMinuteFormat,
        assert(singleDigitSecondFormat != null),
-       _singleDigitSecondFormat = singleDigitSecondFormat;
+       _singleDigitSecondFormat = singleDigitSecondFormat,
+       assert(decimalFormat != null),
+       _decimalFormat =decimalFormat;
 
   final String _localeName;
   final intl.DateFormat _fullYearFormat;
@@ -62,6 +65,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   final intl.DateFormat _singleDigitMinuteFormat;
   final intl.DateFormat _doubleDigitMinuteFormat;
   final intl.DateFormat _singleDigitSecondFormat;
+  final intl.NumberFormat _decimalFormat;
 
   @override
   String datePickerYear(int yearIndex) {
@@ -120,7 +124,8 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: datePickerHourSemanticsLabelFew,
       many: datePickerHourSemanticsLabelMany,
       other: datePickerHourSemanticsLabelOther,
-    ).replaceFirst(r'$hour', hour);
+      locale: _localeName,
+    ).replaceFirst(r'$hour', _decimalFormat.format(hour));
   }
 
   /// Subclasses should provide the optional zero pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
@@ -146,7 +151,8 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: datePickerMinuteSemanticsLabelFew,
       many: datePickerMinuteSemanticsLabelMany,
       other: datePickerMinuteSemanticsLabelOther,
-    ).replaceFirst(r'$minute', minute);
+      locale: _localeName,
+    ).replaceFirst(r'$minute', _decimalFormat.format(minute));
   }
 
   /// A string describing the [DatePickerDateOrder] enum value.
@@ -251,7 +257,8 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerHourLabelFew,
       many: timerPickerHourLabelMany,
       other: timerPickerHourLabelOther,
-    ).replaceFirst(r'$hour', hour);
+      locale: _localeName,
+    ).replaceFirst(r'$hour', _decimalFormat.format(hour));
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerMinuteLabel] based on the ARB file.
@@ -277,7 +284,8 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerMinuteLabelFew,
       many: timerPickerMinuteLabelMany,
       other: timerPickerMinuteLabelOther,
-    ).replaceFirst(r'$minute', minute);
+      locale: _localeName,
+    ).replaceFirst(r'$minute', _decimalFormat.format(minute));
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerSecondLabel] based on the ARB file.
@@ -303,7 +311,8 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerSecondLabelFew,
       many: timerPickerSecondLabelMany,
       other: timerPickerSecondLabelOther,
-    ).replaceFirst(r'$second', second);
+      locale: _localeName,
+    ).replaceFirst(r'$second', _decimalFormat.format(second));
   }
 
   /// A [LocalizationsDelegate] that uses [GlobalCupertinoLocalizations.load]
@@ -366,6 +375,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
       intl.DateFormat singleDigitMinuteFormat;
       intl.DateFormat doubleDigitMinuteFormat;
       intl.DateFormat singleDigitSecondFormat;
+      intl.NumberFormat decimalFormat;
 
       void loadFormats(String locale) {
         fullYearFormat = intl.DateFormat.y(locale);
@@ -376,6 +386,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         singleDigitMinuteFormat = intl.DateFormat.m(locale);
         doubleDigitMinuteFormat = intl.DateFormat('mm', locale);
         singleDigitSecondFormat = intl.DateFormat.s(locale);
+        decimalFormat = intl.NumberFormat(locale);
       }
 
       if (intl.DateFormat.localeExists(localeName)) {
@@ -397,6 +408,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         singleDigitMinuteFormat,
         doubleDigitMinuteFormat,
         singleDigitSecondFormat,
+        decimalFormat,
       ));
     });
   }
@@ -414,6 +426,7 @@ CupertinoLocalizations _getCupertinoTranslation(
   intl.DateFormat singleDigitMinuteFormat,
   intl.DateFormat doubleDigitMinuteFormat,
   intl.DateFormat singleDigitSecondFormat,
+  intl.NumberFormat decimalFormat,
 ) {
   return null; // TODO(xster): implement in generated subclass.
 }

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -120,7 +120,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: datePickerHourSemanticsLabelFew,
       many: datePickerHourSemanticsLabelMany,
       other: datePickerHourSemanticsLabelOther,
-    );
+    ).replaceFirst(r'$hour', hour);
   }
 
   /// Subclasses should provide the optional zero pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
@@ -146,7 +146,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: datePickerMinuteSemanticsLabelFew,
       many: datePickerMinuteSemanticsLabelMany,
       other: datePickerMinuteSemanticsLabelOther,
-    );
+    ).replaceFirst(r'$minute', minute);
   }
 
   /// A string describing the [DatePickerDateOrder] enum value.
@@ -251,7 +251,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerHourLabelFew,
       many: timerPickerHourLabelMany,
       other: timerPickerHourLabelOther,
-    );
+    ).replaceFirst(r'$hour', hour);
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerMinuteLabel] based on the ARB file.
@@ -277,7 +277,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerMinuteLabelFew,
       many: timerPickerMinuteLabelMany,
       other: timerPickerMinuteLabelOther,
-    );
+    ).replaceFirst(r'$minute', minute);
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerSecondLabel] based on the ARB file.
@@ -303,7 +303,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       few: timerPickerSecondLabelFew,
       many: timerPickerSecondLabelMany,
       other: timerPickerSecondLabelOther,
-    );
+    ).replaceFirst(r'$second', second);
   }
 
   /// A [LocalizationsDelegate] that uses [GlobalCupertinoLocalizations.load]

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -567,7 +567,11 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
       util.loadDateIntlDataIfNotLoaded();
 
       final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
-      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
+      assert(
+        locale.toString() == localeName,
+        'Flutter does not support the non-standard locale form $locale (which '
+        'might be $localeName',
+      );
 
       intl.DateFormat fullYearFormat;
       intl.DateFormat mediumDateFormat;

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -567,6 +567,7 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
       util.loadDateIntlDataIfNotLoaded();
 
       final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
       intl.DateFormat fullYearFormat;
       intl.DateFormat mediumDateFormat;
@@ -601,8 +602,6 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
         decimalFormat = intl.NumberFormat.decimalPattern();
         twoDigitZeroPaddedFormat = intl.NumberFormat('00');
       }
-
-      assert(locale.toString() == localeName, 'comparing "$locale" to "$localeName"');
 
       return SynchronousFuture<MaterialLocalizations>(getMaterialTranslation(
         locale,

--- a/packages/flutter_localizations/lib/src/utils/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/utils/date_localizations.dart
@@ -1,3 +1,7 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:intl/date_symbols.dart' as intl;
 import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
 import '../l10n/generated_date_localizations.dart' as date_localizations;

--- a/packages/flutter_localizations/lib/src/utils/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/utils/date_localizations.dart
@@ -1,0 +1,45 @@
+import 'package:intl/date_symbols.dart' as intl;
+import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
+import '../l10n/generated_date_localizations.dart' as date_localizations;
+
+/// Tracks if date i18n data has been loaded.
+bool _dateIntlDataInitialized = false;
+
+/// Loads i18n data for dates if it hasn't be loaded yet.
+///
+/// Only the first invocation of this function has the effect of loading the
+/// data. Subsequent invocations have no effect.
+void loadDateIntlDataIfNotLoaded() {
+  if (!_dateIntlDataInitialized) {
+    // TODO(garyq): Add support for scriptCodes. Do not strip scriptCode from string.
+
+    // Keep track of initialzed locales, or will fail on attempted double init.
+    // This can only happen if a locale with a stripped scriptCode has already
+    // been initialzed. This should be removed when scriptCode stripping is removed.
+    final Set<String> initializedLocales = <String>{};
+    date_localizations.dateSymbols.forEach((String locale, dynamic data) {
+      // Strip scriptCode from the locale, as we do not distinguish between scripts
+      // for dates.
+      final List<String> codes = locale.split('_');
+      String countryCode;
+      if (codes.length == 2) {
+        countryCode = codes[1].length < 4 ? codes[1] : null;
+      } else if (codes.length == 3) {
+        countryCode = codes[1].length < codes[2].length ? codes[1] : codes[2];
+      }
+      locale = codes[0] + (countryCode != null ? '_' + countryCode : '');
+      if (initializedLocales.contains(locale))
+        return;
+      initializedLocales.add(locale);
+      // Perform initialization.
+      assert(date_localizations.datePatterns.containsKey(locale));
+      final intl.DateSymbols symbols = intl.DateSymbols.deserializeFromMap(data);
+      date_symbol_data_custom.initializeDateFormattingCustom(
+        locale: locale,
+        symbols: symbols,
+        patterns: date_localizations.datePatterns[locale],
+      );
+    });
+    _dateIntlDataInitialized = true;
+  }
+}


### PR DESCRIPTION
## Description

Let there be a date time localizing subclass as a foundation for ARB based subclasses. 

Diffbase https://github.com/xster/flutter/compare/localization-3...xster:localization-4

## Related Issues

#13452

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes