### PR TITLE
Add support for text selection via mouse to Cupertino text fields

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -533,6 +533,28 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     _editableTextKey.currentState.showToolbar();
   }
 
+  void _handleDragSelectionStart(DragStartDetails details) {
+    _renderEditable.selectPositionAt(
+      from: details.globalPosition,
+      cause: SelectionChangedCause.drag,
+    );
+  }
+
+  void _handleDragSelectionUpdate(
+      DragStartDetails startDetails,
+      DragUpdateDetails updateDetails,
+  ) {
+    _renderEditable.selectPositionAt(
+      from: startDetails.globalPosition,
+      to: updateDetails.globalPosition,
+      cause: SelectionChangedCause.drag,
+    );
+  }
+
+  void _handleDragSelectionEnd(DragEndDetails details) {
+    _requestKeyboard();
+  }
+
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause cause) {
     if (cause == SelectionChangedCause.longPress) {
       _editableTextKey.currentState?.bringIntoView(selection.base);
@@ -741,6 +763,9 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
               onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
               onSingleLongTapEnd: _handleSingleLongTapEnd,
               onDoubleTapDown: _handleDoubleTapDown,
+              onDragSelectionStart: _handleDragSelectionStart,
+              onDragSelectionUpdate: _handleDragSelectionUpdate,
+              onDragSelectionEnd: _handleDragSelectionEnd,
               behavior: HitTestBehavior.translucent,
               child: _addTextDependentAttachments(paddedEditable, textStyle),
             ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -533,14 +533,14 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     _editableTextKey.currentState.showToolbar();
   }
 
-  void _handleDragSelectionStart(DragStartDetails details) {
+  void _handleMouseDragSelectionStart(DragStartDetails details) {
     _renderEditable.selectPositionAt(
       from: details.globalPosition,
       cause: SelectionChangedCause.drag,
     );
   }
 
-  void _handleDragSelectionUpdate(
+  void _handleMouseDragSelectionUpdate(
       DragStartDetails startDetails,
       DragUpdateDetails updateDetails,
   ) {
@@ -551,7 +551,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     );
   }
 
-  void _handleDragSelectionEnd(DragEndDetails details) {
+  void _handleMouseDragSelectionEnd(DragEndDetails details) {
     _requestKeyboard();
   }
 
@@ -763,9 +763,9 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
               onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
               onSingleLongTapEnd: _handleSingleLongTapEnd,
               onDoubleTapDown: _handleDoubleTapDown,
-              onDragSelectionStart: _handleDragSelectionStart,
-              onDragSelectionUpdate: _handleDragSelectionUpdate,
-              onDragSelectionEnd: _handleDragSelectionEnd,
+              onDragSelectionStart: _handleMouseDragSelectionStart,
+              onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
+              onDragSelectionEnd: _handleMouseDragSelectionEnd,
               behavior: HitTestBehavior.translucent,
               child: _addTextDependentAttachments(paddedEditable, textStyle),
             ),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -743,7 +743,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     }
   }
 
-  void _handleDragSelectionStart(DragStartDetails details) {
+  void _handleMouseDragSelectionStart(DragStartDetails details) {
     _renderEditable.selectPositionAt(
       from: details.globalPosition,
       cause: SelectionChangedCause.drag,
@@ -751,7 +751,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     _startSplash(details.globalPosition);
   }
 
-  void _handleDragSelectionUpdate(
+  void _handleMouseDragSelectionUpdate(
       DragStartDetails startDetails,
       DragUpdateDetails updateDetails,
   ) {
@@ -930,8 +930,8 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
           onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
           onSingleLongTapEnd: _handleSingleLongTapEnd,
           onDoubleTapDown: _handleDoubleTapDown,
-          onDragSelectionStart: _handleDragSelectionStart,
-          onDragSelectionUpdate: _handleDragSelectionUpdate,
+          onDragSelectionStart: _handleMouseDragSelectionStart,
+          onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
           behavior: HitTestBehavior.translucent,
           child: child,
         ),


### PR DESCRIPTION
## Description

Text selection by mouse was implemented for Material text fields in https://github.com/flutter/flutter/pull/28290. This PR is to do the same thing for Cupertino text fields.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
