### PR TITLE
Set Max Height for ListTile trailing and leading widgets

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1059,8 +1059,8 @@ class _RenderListTile extends RenderBox {
       case TextDirection.rtl: {
         if (hasLeading)
           _positionBox(leading, Offset(tileWidth - leadingSize.width, leadingY));
-          final double titleX = hasTrailing ? trailingSize.width + _horizontalTitleGap : 0.0;
-          _positionBox(title, Offset(titleX, titleY));
+        final double titleX = hasTrailing ? trailingSize.width + _horizontalTitleGap : 0.0;
+        _positionBox(title, Offset(titleX, titleY));
         if (hasSubtitle)
           _positionBox(subtitle, Offset(titleX, subtitleY));
         if (hasTrailing)
@@ -1070,7 +1070,7 @@ class _RenderListTile extends RenderBox {
       case TextDirection.ltr: {
         if (hasLeading)
           _positionBox(leading, Offset(0.0, leadingY));
-          _positionBox(title, Offset(titleStart, titleY));
+        _positionBox(title, Offset(titleStart, titleY));
         if (hasSubtitle)
           _positionBox(subtitle, Offset(titleStart, subtitleY));
         if (hasTrailing)

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -880,11 +880,9 @@ class _RenderListTile extends RenderBox {
   }
 
   double get _maxIconHeight {
-    final bool hasSubtitle = subtitle != null;
-    final bool isOneLine = !isThreeLine && !hasSubtitle;
-
-    if (isOneLine)
-      return isDense ? 32.0 : 40.0;
+    // One-line trailing and leading widget sizing does not follow
+    // Material specifications, but this sizing required to adhere
+    // to accessibility requirements for smallest tappable widget.
     return isDense ? 48.0 : 56.0;
   }
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -438,6 +438,11 @@ class ListTile extends StatelessWidget {
         data: iconThemeData,
         child: leading,
       );
+
+      leadingIcon = Container(
+        constraints: BoxConstraints(maxHeight: 56),
+        child: leadingIcon,
+      );
     }
 
     final TextStyle titleStyle = _titleTextStyle(theme, tileTheme);
@@ -463,6 +468,11 @@ class ListTile extends StatelessWidget {
       trailingIcon = IconTheme.merge(
         data: iconThemeData,
         child: trailing,
+      );
+
+      trailingIcon = Container(
+        constraints: BoxConstraints(maxHeight: 56),
+        child: trailingIcon,
       );
     }
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -438,11 +438,6 @@ class ListTile extends StatelessWidget {
         data: iconThemeData,
         child: leading,
       );
-
-      leadingIcon = Container(
-        constraints: BoxConstraints(maxHeight: 56),
-        child: leadingIcon,
-      );
     }
 
     final TextStyle titleStyle = _titleTextStyle(theme, tileTheme);
@@ -468,11 +463,6 @@ class ListTile extends StatelessWidget {
       trailingIcon = IconTheme.merge(
         data: iconThemeData,
         child: trailing,
-      );
-
-      trailingIcon = Container(
-        constraints: BoxConstraints(maxHeight: 56),
-        child: trailingIcon,
       );
     }
 
@@ -889,6 +879,15 @@ class _RenderListTile extends RenderBox {
     return isDense ? 76.0 : 88.0;
   }
 
+  double get _maxIconHeight {
+    final bool hasSubtitle = subtitle != null;
+    final bool isOneLine = !isThreeLine && !hasSubtitle;
+
+    if (isOneLine)
+      return isDense ? 32.0 : 40.0;
+    return isDense ? 48.0 : 56.0;
+  }
+
   @override
   double computeMinIntrinsicHeight(double width) {
     return math.max(
@@ -934,11 +933,16 @@ class _RenderListTile extends RenderBox {
     final bool hasTrailing = trailing != null;
     final bool isTwoLine = !isThreeLine && hasSubtitle;
     final bool isOneLine = !isThreeLine && !hasSubtitle;
+
+    final BoxConstraints maxIconHeightConstraint = BoxConstraints(
+      maxHeight: _maxIconHeight,
+    );
     final BoxConstraints looseConstraints = constraints.loosen();
+    final BoxConstraints iconConstraints = looseConstraints.enforce(maxIconHeightConstraint);
 
     final double tileWidth = looseConstraints.maxWidth;
-    final Size leadingSize = _layoutBox(leading, looseConstraints);
-    final Size trailingSize = _layoutBox(trailing, looseConstraints);
+    final Size leadingSize = _layoutBox(leading, iconConstraints);
+    final Size trailingSize = _layoutBox(trailing, iconConstraints);
 
     final double titleStart = hasLeading
       ? math.max(_minLeadingWidth, leadingSize.width) + _horizontalTitleGap
@@ -1018,8 +1022,8 @@ class _RenderListTile extends RenderBox {
       case TextDirection.rtl: {
         if (hasLeading)
           _positionBox(leading, Offset(tileWidth - leadingSize.width, leadingY));
-        final double titleX = hasTrailing ? trailingSize.width + _horizontalTitleGap : 0.0;
-        _positionBox(title, Offset(titleX, titleY));
+          final double titleX = hasTrailing ? trailingSize.width + _horizontalTitleGap : 0.0;
+          _positionBox(title, Offset(titleX, titleY));
         if (hasSubtitle)
           _positionBox(subtitle, Offset(titleX, subtitleY));
         if (hasTrailing)
@@ -1029,7 +1033,7 @@ class _RenderListTile extends RenderBox {
       case TextDirection.ltr: {
         if (hasLeading)
           _positionBox(leading, Offset(0.0, leadingY));
-        _positionBox(title, Offset(titleStart, titleY));
+          _positionBox(title, Offset(titleStart, titleY));
         if (hasSubtitle)
           _positionBox(subtitle, Offset(titleStart, subtitleY));
         if (hasTrailing)

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -164,8 +164,9 @@ enum ListTileControlAffinity {
 /// and to ensure that [subtitle] doesn't wrap (if [isThreeLine] is false) or
 /// wraps to two lines (if it is true).
 ///
-/// Leading and trailing widgets will be constrained in height according to
-/// the [Material spec](https://material.io/design/components/lists.html).
+/// The heights of the [leading] and [trailing] widgets are constrained
+/// according to the [Material spec]
+/// (https://material.io/design/components/lists.html).
 /// An exception is made for one-line ListTiles for accessibility. Please
 /// see the example below to see how to adhere to both Material spec and
 /// accessibility requirements.
@@ -205,17 +206,21 @@ enum ListTileControlAffinity {
 /// ```
 /// {@end-tool}
 ///
-/// For accessibility purposes, tappable leading and trailing widgets have to
-/// be at least 48x48px in size. However, to adhere with Material spec,
-/// trailing/leading widgets in one-line ListTiles should visually be at
-/// most 32px (dense: true) or 40px (dense: false) in height, which may
+/// To be accessible, tappable [leading] and [trailing] widgets have to
+/// be at least 48x48 in size. However, to adhere to the Material spec,
+/// [trailing] and [leading] widgets in one-line ListTiles should visually be
+/// at most 32 (dense: true) or 40 (dense: false) in height, which may
 /// conflict with the accessibility requirement.
 ///
-/// For this reason, ListTile is implemented such that the height of leading
-/// and trailing widgets will be constrained by the actual height of the
-/// ListTile. The following is an example of a one-line, non-dense ListTile
-/// with a tappable leading widget that adheres to accessibility requirements
-/// and the Material spec.
+/// For this reason, a one-line ListTile allows the height of [leading]
+/// and [trailing] widgets to be constrained by the height of the ListTile.
+/// This allows for the creation of tappable [leading] and [trailing] widgets
+/// that are large enough, but it is up to the developer to ensure that
+/// their widgets follow the Material spec.
+///
+/// The following is an example of a one-line, non-dense ListTile with a
+/// tappable leading widget that adheres to accessibility requirements and
+/// the Material spec.
 ///
 /// {@tool sample}
 ///
@@ -231,7 +236,7 @@ enum ListTileControlAffinity {
 ///       width: 48,
 ///       height: 48,
 ///       child: Padding(
-///         // creates an avatar that visually adheres to Material
+///         // creates a 32x32 avatar per the Material spec
 ///         padding: EdgeInsets.all(8.0),
 ///         child: CircleAvatar(),
 ///       ),
@@ -969,9 +974,11 @@ class _RenderListTile extends RenderBox {
     final bool isOneLine = !isThreeLine && !hasSubtitle;
 
     final BoxConstraints maxIconHeightConstraint = BoxConstraints(
-      // One-line trailing and leading widget sizing does not follow
-      // Material specifications, but this sizing required to adhere
+      // One-line trailing and leading widget heights do not follow
+      // Material specifications, but this sizing is required to adhere
       // to accessibility requirements for smallest tappable widget.
+      // Two- and three-line trailing widget heights are constrained
+      // properly according to the Material spec.
       maxHeight: isDense ? 48.0 : 56.0,
     );
     final BoxConstraints looseConstraints = constraints.loosen();

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -225,7 +225,7 @@ enum ListTileControlAffinity {
 ///   leading: GestureDetector(
 ///     // allows background to be tappable
 ///     behavior: HitTestBehavior.translucent,
-///     onTap: () {...},
+///     onTap: () {},
 ///     child: Container(
 ///       // 48x48 box that is tappable
 ///       width: 48,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -209,7 +209,7 @@ enum ListTileControlAffinity {
 /// To be accessible, tappable [leading] and [trailing] widgets have to
 /// be at least 48x48 in size. However, to adhere to the Material spec,
 /// [trailing] and [leading] widgets in one-line ListTiles should visually be
-/// at most 32 (dense: true) or 40 (dense: false) in height, which may
+/// at most 32 ([dense]: true) or 40 ([dense]: false) in height, which may
 /// conflict with the accessibility requirement.
 ///
 /// For this reason, a one-line ListTile allows the height of [leading]
@@ -218,31 +218,28 @@ enum ListTileControlAffinity {
 /// that are large enough, but it is up to the developer to ensure that
 /// their widgets follow the Material spec.
 ///
-/// The following is an example of a one-line, non-dense ListTile with a
+/// The following is an example of a one-line, non-[dense] ListTile with a
 /// tappable leading widget that adheres to accessibility requirements and
-/// the Material spec.
+/// the Material spec. To adjust the use case below for a one-line, [dense]
+/// ListTile, adjust the vertical padding to 8.0.
 ///
 /// {@tool sample}
 ///
 /// ```dart
 /// ListTile(
-///   dense: true,
 ///   leading: GestureDetector(
-///     // allows background to be tappable
 ///     behavior: HitTestBehavior.translucent,
 ///     onTap: () {},
 ///     child: Container(
-///       // 48x48 box that is tappable
 ///       width: 48,
 ///       height: 48,
-///       child: Padding(
-///         // creates a 32x32 avatar per the Material spec
-///         padding: EdgeInsets.all(8.0),
-///         child: CircleAvatar(),
-///       ),
+///       padding: EdgeInsets.symmetric(vertical: 4.0),
+///       alignment: Alignment.center,
+///       child: CircleAvatar(),
 ///     ),
 ///   ),
 ///   title: Text('title'),
+///   dense: false,
 /// ),
 /// ```
 /// {@end-tool}

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -587,10 +587,10 @@ void main() {
     );
     //                                                                    LEFT                  TOP          WIDTH  HEIGHT
     expect(tester.getRect(find.byType(ListTile).at(0)),     Rect.fromLTWH(                0.0,          0.0, 800.0, 177.0));
-    expect(tester.getRect(find.byType(CircleAvatar).at(0)), Rect.fromLTWH(               16.0,         16.0,  40.0,  40.0));
+    expect(tester.getRect(find.byType(CircleAvatar).at(0)), Rect.fromLTWH(               16.0,         16.0,  40.0,  32.0));
     expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 24.0 - 16.0,         16.0,  24.0,  24.0));
     expect(tester.getRect(find.byType(ListTile).at(1)),     Rect.fromLTWH(                0.0,        177.0, 800.0,  48.0));
-    expect(tester.getRect(find.byType(CircleAvatar).at(1)), Rect.fromLTWH(               16.0, 177.0 +  4.0,  40.0,  40.0));
+    expect(tester.getRect(find.byType(CircleAvatar).at(1)), Rect.fromLTWH(               16.0, 177.0 +  8.0,  40.0,  32.0));
     expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 24.0 - 16.0, 177.0 + 12.0,  24.0,  24.0));
 
     // NON-DENSE "ONE"-LINE
@@ -784,5 +784,337 @@ void main() {
     expect(tester.getRect(find.byType(ListTile).at(1)),     Rect.fromLTWH(                0.0, 216.0       , 800.0,  56.0));
     expect(tester.getRect(find.byType(Placeholder).at(2)),  Rect.fromLTWH(               16.0, 216.0 + 16.0,  24.0,  12.0));
     expect(tester.getRect(find.byType(Placeholder).at(3)),  Rect.fromLTWH(800.0 - 24.0 - 16.0, 216.0 + 16.0,  24.0,  24.0));
+  });
+
+  testWidgets('ListTile leading icon height does not exceed ListTile height', (WidgetTester tester) async {
+    const SizedBox oversizedWidget = SizedBox(height: 80.0, width:24.0, child: Placeholder());
+
+    // Dense One line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                dense: true,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 32.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 48.0 + 8.0, 24.0, 32.0));
+
+    // Non-dense One line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                dense: false,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 40.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 56.0 + 8.0, 24.0, 40.0));
+
+    // Dense Two line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                dense: true,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 64.0 + 8.0, 24.0, 48.0));
+
+    // Non-dense Two line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                dense: false,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 72.0 + 8.0, 24.0, 56.0));
+
+    // Dense Three line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                isThreeLine:  true,
+                dense: true,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                isThreeLine:  true,
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 76.0 + 16.0, 24.0, 48.0));
+
+    // Non-dense Three line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                isThreeLine:  true,
+                dense: false,
+              ),
+              ListTile(
+                leading: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                isThreeLine:  true,
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 88.0 + 16.0, 24.0, 56.0));
+  });
+
+  testWidgets('ListTile trailing icon height does not exceed ListTile height', (WidgetTester tester) async {
+    const SizedBox oversizedWidget = SizedBox(height: 80.0, width:24.0, child: Placeholder());
+
+    // Dense One line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                dense: true,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 32.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 48.0 + 8.0, 24.0, 32.0));
+
+    // Non-dense One line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                dense: false,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 40.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 56.0 + 8.0, 24.0, 40.0));
+
+    // Dense Two line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                dense: true,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 64.0 + 8.0, 24.0, 48.0));
+
+    // Non-dense Two line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                dense: false,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 72.0 + 8.0, 24.0, 56.0));
+
+    // Dense Three line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                isThreeLine:  true,
+                dense: true,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                isThreeLine:  true,
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 76.0 + 16.0, 24.0, 48.0));
+
+    // Non-dense Three line
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: const <Widget>[
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('A'),
+                subtitle: Text('A'),
+                isThreeLine:  true,
+                dense: false,
+              ),
+              ListTile(
+                trailing: oversizedWidget,
+                title: Text('B'),
+                subtitle: Text('B'),
+                isThreeLine:  true,
+                dense: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 88.0 + 16.0, 24.0, 56.0));
   });
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -811,8 +811,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 0.0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 48.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,  0.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 48.0, 24.0, 48.0));
 
     // Non-dense One line
     await tester.pumpWidget(
@@ -836,8 +836,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 0.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 56.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,  0.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 56.0, 24.0, 56.0));
 
     // Dense Two line
     await tester.pumpWidget(
@@ -863,8 +863,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 64.0 + 8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,        8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 64.0 + 8.0, 24.0, 48.0));
 
     // Non-dense Two line
     await tester.pumpWidget(
@@ -890,8 +890,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 72.0 + 8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,        8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 72.0 + 8.0, 24.0, 56.0));
 
     // Dense Three line
     await tester.pumpWidget(
@@ -919,8 +919,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 16.0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 76.0 + 16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,        16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 76.0 + 16.0, 24.0, 48.0));
 
     // Non-dense Three line
     await tester.pumpWidget(
@@ -948,12 +948,12 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 16.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 88.0 + 16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(16.0,        16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(16.0, 88.0 + 16.0, 24.0, 56.0));
   });
 
   testWidgets('ListTile trailing icon height does not exceed ListTile height', (WidgetTester tester) async {
-    const SizedBox oversizedWidget = SizedBox(height: 80.0, width:24.0, child: Placeholder());
+    const SizedBox oversizedWidget = SizedBox(height: 80.0, width: 24.0, child: Placeholder());
 
     // Dense One line
     await tester.pumpWidget(
@@ -977,8 +977,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 48.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,    0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 48.0, 24.0, 48.0));
 
     // Non-dense One line
     await tester.pumpWidget(
@@ -1002,8 +1002,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 0.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 56.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,  0.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 56.0, 24.0, 56.0));
 
     // Dense Two line
     await tester.pumpWidget(
@@ -1029,8 +1029,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 64.0 + 8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,        8.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 64.0 + 8.0, 24.0, 48.0));
 
     // Non-dense Two line
     await tester.pumpWidget(
@@ -1056,8 +1056,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 72.0 + 8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,        8.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 72.0 + 8.0, 24.0, 56.0));
 
     // Dense Three line
     await tester.pumpWidget(
@@ -1085,8 +1085,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 16.0, 24.0, 48.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 76.0 + 16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,        16.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 76.0 + 16.0, 24.0, 48.0));
 
     // Non-dense Three line
     await tester.pumpWidget(
@@ -1114,7 +1114,7 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 16.0, 24.0, 56.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 88.0 + 16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 16.0 - 24.0,        16.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 16.0 - 24.0, 88.0 + 16.0, 24.0, 56.0));
   });
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -787,6 +787,7 @@ void main() {
   });
 
   testWidgets('ListTile leading icon height does not exceed ListTile height', (WidgetTester tester) async {
+    // regression test for https://github.com/flutter/flutter/issues/28765
     const SizedBox oversizedWidget = SizedBox(height: 80.0, width: 24.0, child: Placeholder());
 
     // Dense One line
@@ -953,6 +954,7 @@ void main() {
   });
 
   testWidgets('ListTile trailing icon height does not exceed ListTile height', (WidgetTester tester) async {
+    // regression test for https://github.com/flutter/flutter/issues/28765
     const SizedBox oversizedWidget = SizedBox(height: 80.0, width: 24.0, child: Placeholder());
 
     // Dense One line

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -587,10 +587,10 @@ void main() {
     );
     //                                                                    LEFT                  TOP          WIDTH  HEIGHT
     expect(tester.getRect(find.byType(ListTile).at(0)),     Rect.fromLTWH(                0.0,          0.0, 800.0, 177.0));
-    expect(tester.getRect(find.byType(CircleAvatar).at(0)), Rect.fromLTWH(               16.0,         16.0,  40.0,  32.0));
+    expect(tester.getRect(find.byType(CircleAvatar).at(0)), Rect.fromLTWH(               16.0,         16.0,  40.0,  40.0));
     expect(tester.getRect(find.byType(Placeholder).at(0)),  Rect.fromLTWH(800.0 - 24.0 - 16.0,         16.0,  24.0,  24.0));
     expect(tester.getRect(find.byType(ListTile).at(1)),     Rect.fromLTWH(                0.0,        177.0, 800.0,  48.0));
-    expect(tester.getRect(find.byType(CircleAvatar).at(1)), Rect.fromLTWH(               16.0, 177.0 +  8.0,  40.0,  32.0));
+    expect(tester.getRect(find.byType(CircleAvatar).at(1)), Rect.fromLTWH(               16.0, 177.0 +  4.0,  40.0,  40.0));
     expect(tester.getRect(find.byType(Placeholder).at(1)),  Rect.fromLTWH(800.0 - 24.0 - 16.0, 177.0 + 12.0,  24.0,  24.0));
 
     // NON-DENSE "ONE"-LINE
@@ -787,7 +787,7 @@ void main() {
   });
 
   testWidgets('ListTile leading icon height does not exceed ListTile height', (WidgetTester tester) async {
-    const SizedBox oversizedWidget = SizedBox(height: 80.0, width:24.0, child: Placeholder());
+    const SizedBox oversizedWidget = SizedBox(height: 80.0, width: 24.0, child: Placeholder());
 
     // Dense One line
     await tester.pumpWidget(
@@ -811,8 +811,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 32.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 48.0 + 8.0, 24.0, 32.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 0.0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 48.0, 24.0, 48.0));
 
     // Non-dense One line
     await tester.pumpWidget(
@@ -836,8 +836,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 8.0, 24.0, 40.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 56.0 + 8.0, 24.0, 40.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(16.0, 0.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(16.0, 56.0, 24.0, 56.0));
 
     // Dense Two line
     await tester.pumpWidget(
@@ -977,8 +977,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 32.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 48.0 + 8.0, 24.0, 32.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 0, 24.0, 48.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 48.0, 24.0, 48.0));
 
     // Non-dense One line
     await tester.pumpWidget(
@@ -1002,8 +1002,8 @@ void main() {
       ),
     );
 
-    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 8.0, 24.0, 40.0));
-    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 56.0 + 8.0, 24.0, 40.0));
+    expect(tester.getRect(find.byType(Placeholder).at(0)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 0.0, 24.0, 56.0));
+    expect(tester.getRect(find.byType(Placeholder).at(1)), Rect.fromLTWH(800.0 - 16.0 - 24.0, 56.0, 24.0, 56.0));
 
     // Dense Two line
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

Updates ListTile to have a maximum height for leading and trailing icons, preventing them from stretching longer than the height of the ListTile widget. Widget height constraints follow the [material spec](https://material.io/design/components/lists.html#anatomy). ~This involves updating a previous test, as the test allowed the CircleAvatar widget to grow to a height larger than allowed by the Material spec. In particular, it's for when ListTile has `dense` set to `true` and subtitle set to `null`~

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28765

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
