### PR TITLE
Removes unnecessary "new" in documentation

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/README.md
+++ b/packages/flutter_localizations/lib/src/l10n/README.md
@@ -41,8 +41,8 @@ class. For example:
 
 ```dart
 Widget build(BuildContext context) {
-  return new FlatButton(
-    child: new Text(
+  return FlatButton(
+    child: Text(
       MaterialLocalizations.of(context).cancelButtonLabel,
     ),
   );


### PR DESCRIPTION
## Description
This PR removes unnecessary `new` from the documentation example while calling constructors, as `new` is optional.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.
