### PR TITLE
TextField Validator Height Docs

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -288,6 +288,13 @@ class FormField<T> extends StatefulWidget {
   /// The returned value is exposed by the [FormFieldState.errorText] property.
   /// The [TextFormField] uses this to override the [InputDecoration.errorText]
   /// value.
+  ///
+  /// Alternating between error and normal state can cause the height of the
+  /// [TextFormField] to change if no other subtext decoration is set on the
+  /// field. To create a field whose height is fixed regardless of whether or
+  /// not an error is displayed, either wrap the  [TextFormField] in a fixed
+  /// height parent like [SizedBox], or set the [TextFormField.helperText]
+  /// parameter to a space.
   final FormFieldValidator<T> validator;
 
   /// Function that returns the widget representing this form field. It is


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/15400

When using a `TextFormField` with a `validator` function, users were sometimes surprised to see that the `TextFormField` would grow when an error appeared.

![Input without error](https://user-images.githubusercontent.com/389558/54789181-da671880-4bee-11e9-8e94-2aebddbe3e49.png)
![flutter_01](https://user-images.githubusercontent.com/389558/54789180-da671880-4bee-11e9-8980-b1dc472670b7.png)

This PR updates the documentation to include useful fixes to this problem.