### PR TITLE
Watch wildcard directories in addition to asset bundle

### DIFF
--- a/packages/flutter_tools/test/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_test.dart
@@ -70,6 +70,11 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(manifestPath: 'pubspec.yaml');
+      // Expected assets:
+      //  - asset manifest
+      //  - font manifest
+      //  - license file
+      //  - assets/foo/bar.txt
       expect(bundle.entries.length, 4);
       expect(bundle.needsBuild(manifestPath: 'pubspec.yaml'), false);
 
@@ -81,6 +86,12 @@ flutter:
 
       expect(bundle.needsBuild(manifestPath: 'pubspec.yaml'), true);
       await bundle.build(manifestPath: 'pubspec.yaml');
+      // Expected assets:
+      //  - asset manifest
+      //  - font manifest
+      //  - license file
+      //  - assets/foo/bar.txt
+      //  - assets/foo/fizz.txt
       expect(bundle.entries.length, 5);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,

--- a/packages/flutter_tools/test/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/asset_bundle_test.dart
@@ -59,7 +59,7 @@ void main() {
 
     testUsingContext('wildcard directories are updated when filesystem changes', () async {
       fs.file('.packages').createSync();
-      fs.file('assets/foo/bar.txt').createSync(recursive: true);
+      fs.file(fs.path.join('assets', 'foo', 'bar.txt')).createSync(recursive: true);
       fs.file('pubspec.yaml')
         ..createSync()
         ..writeAsStringSync(r'''
@@ -75,9 +75,9 @@ flutter:
 
       // Adding a file should update the stat of the directory, but instead
       // we need to fully recreate it.
-      fs.directory('assets/foo').deleteSync(recursive: true);
-      fs.file('assets/foo/fizz.txt').createSync(recursive: true);
-      fs.file('assets/foo/bar.txt').createSync();
+      fs.directory(fs.path.join('assets', 'foo')).deleteSync(recursive: true);
+      fs.file(fs.path.join('assets', 'foo', 'fizz.txt')).createSync(recursive: true);
+      fs.file(fs.path.join('assets', 'foo', 'bar.txt')).createSync();
 
       expect(bundle.needsBuild(manifestPath: 'pubspec.yaml'), true);
       await bundle.build(manifestPath: 'pubspec.yaml');


### PR DESCRIPTION
## Description

Currently we only update assets when we detect either a change to an existing asset or an update to the asset manifest. Due to the existence of wildcard assets `foo/` (all files directly under foo), it is possible for a user to add a new asset which isn't detected through either of these previous approaches.

To fix this, we can track each wildcard directory in addition to the asset manifest, and mark the bundle as needing to be updated when the directory stat has occurred after the last build time. This allows adding a new asset to a wildcard directory and hot reloading it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/18896

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
