### PR TITLE
ValueNotifier changed to use identical() rather than operator==

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -260,7 +260,7 @@ class ValueNotifier<T> extends ChangeNotifier implements ValueListenable<T> {
   T get value => _value;
   T _value;
   set value(T newValue) {
-    if (_value == newValue)
+    if (identical(_value, newValue))
       return;
     _value = newValue;
     notifyListeners();

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -31,6 +31,13 @@ class B extends A with ChangeNotifier {
   }
 }
 
+// A simple int container with overridden == operator that compares contents.
+class IntContainer {
+  int x;
+  bool operator ==(o) => o is IntContainer && o.x == x;
+  IntContainer(this.x);
+};
+
 void main() {
   testWidgets('ChangeNotifier', (WidgetTester tester) async {
     final List<String> log = <String>[];
@@ -225,6 +232,23 @@ void main() {
 
     notifier.value = 3.0;
     expect(log, isEmpty);
+  });
+
+  test('ValueNotifier ignores overridden operator==', () {
+    // ValueNotifier should notify if the contained value is changed to a
+    // different instance, even if the == operator between the two instances
+    // returns true. They are distinct and the difference might be important.
+    final c = IntContainer(5);
+    final ValueNotifier<IntContainer> notifier = ValueNotifier<IntContainer>(c);
+    final List<int> log = <int>[];
+    final VoidCallback listener = () { log.add(notifier.value.x); };
+    notifier.addListener(listener);
+    // Set value to the same instance it already contains.
+    notifier.value = c;
+    expect(log, isEmpty);
+    // Set value to same content but a different instance.
+    notifier.value = IntContainer(5);
+    expect(log, equals(<int>[ 5 ]));
   });
 
   test('Listenable.merge toString', () {


### PR DESCRIPTION
## Description

Changed ValueNotifier to use identical() rather than operator== to determine whether to notify listeners of a change.

## Related Issues

#29922

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA]. (Google Corporate CLA.)
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Uncertain - this *may* break something if someone relies on the surprising behavior. I'm inclined to doubt that anyone relies on the surprising behavior.
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
