### PR TITLE
CupertinoTimerPicker should use the text scale factor controlled by its localizations.

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1100,7 +1100,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
   Widget _buildLabel(String text) {
     return Text(
       text,
-      textScaleFactor: 0.9,
+      textScaleFactor: localizations.scaleFactor,
       style: const TextStyle(fontWeight: FontWeight.w600),
     );
   }

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -214,6 +214,16 @@ abstract class CupertinoLocalizations {
   // The global version uses the translated string from the arb file.
   String get selectAllButtonLabel;
 
+  /// The scaling factor of the language with which the font size is
+  /// going to be calculated. The scaling factor of `0.8` is based on the
+  /// English language.
+  ///
+  /// Example:
+  ///
+  ///  - English word: `hours`, scale factor: `0.9`
+  ///  - French word: `heures`, scale factor: `1.0`
+  double get scaleFactor;
+
   /// The `CupertinoLocalizations` from the closest [Localizations] instance
   /// that encloses the given context.
   ///
@@ -377,6 +387,9 @@ class DefaultCupertinoLocalizations implements CupertinoLocalizations {
 
   @override
   String get selectAllButtonLabel => 'Select All';
+
+  @override
+  double get scaleFactor => 0.9;
 
   /// Creates an object that provides US English resource values for the
   /// cupertino library widgets.


### PR DESCRIPTION
## Description

The `textScaleFactor` in `CupertinoTimerPicker` is fixed to 0.8, but this is problematic when other languages are used. For example the French word for 'hours', 'heures, is longer than the English one. In this situation the language provider should specify the appropriate `scaleFactor` in the implementation of `CupertinoLocalizations`. 

## Related Issues

Fixes #29825

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
