### PR TITLE
Remove unwanted gap between navigation bar and safe area's child

### DIFF
--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -34,7 +34,8 @@ class CupertinoPageScaffold extends StatelessWidget {
   /// If translucent, the main content may slide behind it.
   /// Otherwise, the main content's top margin will be offset by its height.
   ///
-  /// The scaffold assumes the navigation bar will consume the [MediaQuery] top padding.
+  /// The scaffold assumes the navigation bar will account for the [MediaQuery] top padding,
+  /// also consume it if the navigation bar is opaque.
   // TODO(xster): document its page transition animation when ready
   final ObstructingPreferredSizeWidget navigationBar;
 
@@ -93,6 +94,7 @@ class CupertinoPageScaffold extends StatelessWidget {
       if (fullObstruction) {
         paddedContent = MediaQuery(
           data: existingMediaQuery.copyWith(
+            // If the navigation bar is opaque, the top media query padding is fully consumed by the navigation bar.
             padding: existingMediaQuery.padding.copyWith(
               top: 0,
             ),

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -93,11 +93,10 @@ class CupertinoPageScaffold extends StatelessWidget {
       // obstructed area.
       if (fullObstruction) {
         paddedContent = MediaQuery(
-          data: existingMediaQuery.copyWith(
-            // If the navigation bar is opaque, the top media query padding is fully consumed by the navigation bar.
-            padding: existingMediaQuery.padding.copyWith(
-              top: 0,
-            ),
+          data: existingMediaQuery
+          // If the navigation bar is opaque, the top media query padding is fully consumed by the navigation bar.
+          .removePadding(removeTop: true)
+          .copyWith(
             viewInsets: newViewInsets,
           ),
           child: Padding(

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -99,7 +99,7 @@ class CupertinoPageScaffold extends StatelessWidget {
             viewInsets: newViewInsets,
           ),
           child: Padding(
-            padding: EdgeInsets.only(top:topPadding, bottom: bottomPadding),
+            padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
             child: child,
           ),
         );

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -93,10 +93,13 @@ class CupertinoPageScaffold extends StatelessWidget {
       if (fullObstruction) {
         paddedContent = MediaQuery(
           data: existingMediaQuery.copyWith(
+            padding: existingMediaQuery.padding.copyWith(
+              top: 0,
+            ),
             viewInsets: newViewInsets,
           ),
           child: Padding(
-            padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
+            padding: EdgeInsets.only(top:topPadding, bottom: bottomPadding),
             child: child,
           ),
         );

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -25,7 +25,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(Center)), const Offset(0.0, 0.0));
   });
 
-  testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {
+testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -36,20 +36,38 @@ void main() {
             middle: Text('Opaque'),
             backgroundColor: Color(0xFFF8F8F8),
           ),
-          child: Builder(builder: (BuildContext context) {
-            childContext = context;
-            return Container();
-          })
+          child: Builder(
+            builder: (BuildContext context) {
+              childContext = context;
+              return Container();
+            },
+          ),
         ),
       ),
     ));
 
-    // If the navigation bar is opaque, the content should not draw behind it.
     expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0 - 100.0);
-    // The shouldn't see a media query top padding because it was consumed by
-    // the scaffold.
     expect(MediaQuery.of(childContext).padding.top, 0);
+  });
 
+  testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
+        child: CupertinoPageScaffold(
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Opaque'),
+            backgroundColor: Color(0xFFF8F8F8),
+          ),
+          child: Container(),
+        ),
+      ),
+    ));
+
+    expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0 - 100.0);
+
+    BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -30,7 +30,7 @@ testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(
-        data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
+        data: const MediaQueryData(viewInsets: EdgeInsets.only(top: 20)),
         child: CupertinoPageScaffold(
           navigationBar: const CupertinoNavigationBar(
             middle: Text('Opaque'),
@@ -46,8 +46,8 @@ testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
       ),
     ));
 
-    expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0 - 100.0);
     expect(MediaQuery.of(childContext).padding.top, 0);
+    expect(tester.getRect(find.byType(Container)), Rect.fromLTRB(0, 44, 800, 600));
   });
 
   testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -26,6 +26,7 @@ void main() {
   });
 
   testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {
+    BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(
@@ -35,14 +36,20 @@ void main() {
             middle: Text('Opaque'),
             backgroundColor: Color(0xFFF8F8F8),
           ),
-          child: Container(),
+          child: Builder(builder: (BuildContext context) {
+            childContext = context;
+            return Container();
+          })
         ),
       ),
     ));
 
+    // If the navigation bar is opaque, the content should not draw behind it.
     expect(tester.getSize(find.byType(Container)).height, 600.0 - 44.0 - 100.0);
+    // The shouldn't see a media query top padding because it was consumed by
+    // the scaffold.
+    expect(MediaQuery.of(childContext).padding.top, 0);
 
-    BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -47,7 +47,7 @@ testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     ));
 
     expect(MediaQuery.of(childContext).padding.top, 0);
-    // The top of the [Container] is 44 px from the top of the screen because 
+    // The top of the [Container] is 44 px from the top of the screen because
     // it's pushed down by the opaque navigation bar whose height is 44 px,
     // and the 20 px [MediaQuery] top padding is fully absorbed by the navigation bar.
     expect(tester.getRect(find.byType(Container)), Rect.fromLTRB(0, 44, 800, 600));

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -47,6 +47,9 @@ testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     ));
 
     expect(MediaQuery.of(childContext).padding.top, 0);
+    // The top of the [Container] is 44 px from the top of the screen because 
+    // it's pushed down by the opaque navigation bar whose height is 44 px,
+    // and the 20 px [MediaQuery] top padding is fully absorbed by the navigation bar.
     expect(tester.getRect(find.byType(Container)), Rect.fromLTRB(0, 44, 800, 600));
   });
 


### PR DESCRIPTION
## Description

Remove the additional top padding from `CupertinoPageScaffold`'s `MediaQuery` when the navigation bar is opaque (as the padding was already consumed by the navigation bar).

## Related Issues

#29136

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
