### PR TITLE
Fix issue with account drawer header arrow rotating when setState is called

### DIFF
--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -118,8 +118,7 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
       return;
     }
 
-    if (_animation.status == AnimationStatus.dismissed ||
-        _animation.status == AnimationStatus.reverse) {
+    if (widget.isOpen) {
       _controller.forward();
     } else {
       _controller.reverse();

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -113,6 +113,11 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
   @override
   void didUpdateWidget (_AccountDetails oldWidget) {
     super.didUpdateWidget(oldWidget);
+    // If the state of the arrow did not change, there is no need to trigger the animation
+    if (oldWidget.isOpen == widget.isOpen) {
+      return;
+    }
+
     if (_animation.status == AnimationStatus.dismissed ||
         _animation.status == AnimationStatus.reverse) {
       _controller.forward();

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -149,6 +149,8 @@ void main() {
             testSetState = setState;
             return UserAccountsDrawerHeader(
               onDetailsPressed: () { },
+              accountName: const Text('name'),
+              accountEmail: const Text('email'),
             );
           },
         ),

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
 
-const Key gestureKey = Key('Gesture');
 const Key avatarA = Key('A');
 const Key avatarC = Key('C');
 const Key avatarD = Key('D');
@@ -34,8 +33,8 @@ Future<void> pumpTestWidget(
           child: Center(
             child: UserAccountsDrawerHeader(
               onDetailsPressed: withOnDetailsPressedHandler ? () { } : null,
-              currentAccountPicture: ExcludeSemantics(
-                child: const CircleAvatar(
+              currentAccountPicture: const ExcludeSemantics(
+                child: CircleAvatar(
                   key: avatarA,
                   child: Text('A'),
                 ),


### PR DESCRIPTION
## Description

The UserAccountsDrawerHeader had a bug with the arrow rotating whenever setState was called on its parent. This change makes sure that we check that the state actually changed before allowing the animation to trigger.

## Related Issues

Fixes #25801 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
