### PR TITLE
update CupertinoSwitch documentation

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -54,8 +54,8 @@ import 'thumb_painter.dart';
 class CupertinoSwitch extends StatefulWidget {
   /// Creates an iOS-style switch.
   ///
-  /// [value] must not be null
-  /// [dragStartBehavior] must not be null.
+  /// The [value] parameter must not be null.
+  /// The [dragStartBehavior] parameter defaults to [DragStartBehavior.start] and must not be null.
   const CupertinoSwitch({
     Key key,
     @required this.value,
@@ -67,6 +67,8 @@ class CupertinoSwitch extends StatefulWidget {
        super(key: key);
 
   /// Whether this switch is on or off.
+  /// 
+  /// Must not be null.
   final bool value;
 
   /// Called when the user toggles with switch on or off.

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -54,6 +54,7 @@ import 'thumb_painter.dart';
 class CupertinoSwitch extends StatefulWidget {
   /// Creates an iOS-style switch.
   ///
+  /// [value] must not be null
   /// [dragStartBehavior] must not be null.
   const CupertinoSwitch({
     Key key,
@@ -61,7 +62,8 @@ class CupertinoSwitch extends StatefulWidget {
     @required this.onChanged,
     this.activeColor,
     this.dragStartBehavior = DragStartBehavior.start,
-  }) : assert(dragStartBehavior != null),
+  }) : assert(value != null),
+       assert(dragStartBehavior != null),
        super(key: key);
 
   /// Whether this switch is on or off.

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -67,7 +67,7 @@ class CupertinoSwitch extends StatefulWidget {
        super(key: key);
 
   /// Whether this switch is on or off.
-  /// 
+  ///
   /// Must not be null.
   final bool value;
 


### PR DESCRIPTION
## Description

Documented `CupertinoSwitch.value` that it can't be `null` and added an assertion `value != null` in the constructor.

## Related Issues

#12948

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
