### PR TITLE
Document that Hero needs to be present on destination page's zero frame

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -77,10 +77,12 @@ Rect _globalBoundingBoxFor(BuildContext context) {
 /// same tag, a hero animation is triggered.
 ///
 /// If a [Hero] is already in flight when navigation occurs, its
-/// flight animation will be redirected to its new destination.
-
-/// The widget shown in-flight during the transition is, by default, the
+/// flight animation will be redirected to its new destination. The
+/// widget shown in-flight during the transition is, by default, the
 /// destination route's [Hero]'s child.
+///
+/// For a Hero animation to trigger, the Hero has to exist on the very first
+/// frame of the new page's animation.
 ///
 /// Routes must not contain more than one [Hero] for each [tag].
 ///


### PR DESCRIPTION
## Description

Adds a line letting users know that they need to have the Hero present on the very first frame of the destination route for the animation to trigger.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/15586

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
