### PR TITLE
Change -c to --enable-asserts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,7 +118,7 @@ task:
     - bin\flutter.bat update-packages
     - git fetch origin master
   test_all_script:
-    - bin\cache\dart-sdk\bin\dart.exe -c dev\bots\test.dart
+    - bin\cache\dart-sdk\bin\dart.exe --enable-asserts dev\bots\test.dart
   matrix:
     - name: tests-windows
       env:


### PR DESCRIPTION
Unblock the engine roll that includes the Dart roll that removes `-c`.

See, e.g., https://github.com/flutter/flutter/pull/29956