### PR TITLE
Move spinner `_defaultSlowWarning` message to a new line

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -598,7 +598,7 @@ class AnsiSpinner extends Status {
 
   final String _backspaceChar = '\b';
   final String _clearChar = ' ';
-  
+
   bool timedOut = false;
 
   int ticks = 0;

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -598,6 +598,8 @@ class AnsiSpinner extends Status {
 
   final String _backspaceChar = '\b';
   final String _clearChar = ' ';
+  
+  bool timedOut = false;
 
   int ticks = 0;
   Timer timer;
@@ -639,15 +641,19 @@ class AnsiSpinner extends Status {
     assert(timer.isActive);
     stdout.write(_backspace);
     ticks += 1;
-    stdout.write('${_clearChar * spinnerIndent}$_currentAnimationFrame');
     if (seemsSlow) {
+      if (!timedOut) {
+        timedOut = true;
+        stdout.write('\n');
+      }
       if (slowWarningCallback != null) {
-        _slowWarning = ' ' + slowWarningCallback();
+        _slowWarning = slowWarningCallback();
       } else {
-        _slowWarning = ' ' + _defaultSlowWarning;
+        _slowWarning = _defaultSlowWarning;
       }
       stdout.write(_slowWarning);
     }
+    stdout.write('${_clearChar * spinnerIndent}$_currentAnimationFrame');
   }
 
   @override

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -644,7 +644,7 @@ class AnsiSpinner extends Status {
     if (seemsSlow) {
       if (!timedOut) {
         timedOut = true;
-        stdout.write('\n');
+        stdout.write('$_clear\n');
       }
       if (slowWarningCallback != null) {
         _slowWarning = slowWarningCallback();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -538,7 +538,8 @@ class HotRunner extends ResidentRunner {
       }
       final Status status = logger.startProgress(
         'Performing hot restart...',
-        timeout: kFastOperation,
+        //timeout: kFastOperation,
+        timeout: const Duration(milliseconds: 375),
         progressId: 'hot.restart',
       );
       try {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -538,8 +538,7 @@ class HotRunner extends ResidentRunner {
       }
       final Status status = logger.startProgress(
         'Performing hot restart...',
-        //timeout: kFastOperation,
-        timeout: const Duration(milliseconds: 375),
+        timeout: kFastOperation,
         progressId: 'hot.restart',
       );
       try {

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -95,6 +95,47 @@ void main() {
     }
 
     for (String testOs in testPlatforms) {
+      testUsingContext('dawg - $testOs', () async {
+        final AnsiStatus ansiStatus = _createAnsiStatus();
+        FakeAsync().run((FakeAsync time) {
+          ansiStatus.start();
+          mockStopwatch.elapsed = const Duration(seconds: 4);
+          doWhileAsync(time, () => ansiStatus.ticks < 40); // 4 seconds
+          ansiStatus.stop();
+          final String out = outputStdout().join('\n');
+          int newlineCount = 0;
+          for (String char in out.split('')) {
+            if (char == '\n') {
+              newlineCount++;
+            }
+          }
+          print('There were $newlineCount newline characters for OS $testOs');
+        });
+      }, overrides: <Type, Generator>{
+        Logger: () => StdoutLogger(),
+        Platform: () => FakePlatform(operatingSystem: testOs),
+        Stdio: () => mockStdio,
+        Stopwatch: () => mockStopwatch,
+      });
+      testUsingContext('yolo - $testOs', () async {
+        FakeAsync().run((FakeAsync time) {
+          final Logger logger = context[Logger];
+          final Status status = logger.startProgress(
+              'hello world',
+              timeout: const Duration(days: 2),
+              progressIndicatorPadding: 10,
+          );
+          logger.printStatus('yolo dawg');
+          status.stop();
+          final String str = outputStdout().join('\n');
+          print(str);
+        });
+      }, overrides: <Type, Generator>{
+        Logger: () => StdoutLogger(),
+        Platform: () => FakePlatform(operatingSystem: testOs),
+        Stdio: () => mockStdio,
+      });
+
       testUsingContext('AnsiSpinner works for $testOs', () async {
         bool done = false;
         FakeAsync().run((FakeAsync time) {

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -110,6 +110,7 @@ void main() {
             }
           }
           print('There were $newlineCount newline characters for OS $testOs');
+          expect(newlineCount, 2);
         });
       }, overrides: <Type, Generator>{
         Logger: () => StdoutLogger(),
@@ -128,7 +129,7 @@ void main() {
           logger.printStatus('yolo dawg');
           status.stop();
           final String str = outputStdout().join('\n');
-          print(str);
+          //print(str);
         });
       }, overrides: <Type, Generator>{
         Logger: () => StdoutLogger(),

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -344,7 +344,7 @@ void main() {
         Platform: () => FakePlatform(operatingSystem: testOs),
         Stdio: () => mockStdio,
         Stopwatch: () => mockStopwatch,
-      }); 
+      });
     }
   });
   group('Output format', () {

--- a/packages/flutter_tools/test/base/logger_test.dart
+++ b/packages/flutter_tools/test/base/logger_test.dart
@@ -148,8 +148,8 @@ void main() {
           await tenMillisecondsLater;
           doWhileAsync(time, () => ansiSpinner.ticks < 30); // three seconds
           expect(ansiSpinner.seemsSlow, isTrue);
-          final List<String> outputList = outputStdout();
-          expect(outputList[1], contains('This is taking an unexpectedly long time.'));
+          // Check the 2nd line to verify there's a newline before the warning
+          expect(outputStdout()[1], contains('This is taking an unexpectedly long time.'));
           ansiSpinner.stop();
           expect(outputStdout().join('\n'), isNot(contains('(!)')));
           done = true;
@@ -345,26 +345,6 @@ void main() {
         Stdio: () => mockStdio,
         Stopwatch: () => mockStopwatch,
       }); 
-
-      testUsingContext('A ansiStatus logs a newline before the slow warning', () async {
-        final AnsiStatus ansiStatus = _createAnsiStatus();
-        FakeAsync().run((FakeAsync time) {
-          ansiStatus.start();
-          // Wait 3 seconds, longer than kFastOperation
-          mockStopwatch.elapsed = const Duration(seconds: 3);
-          doWhileAsync(time, () => ansiStatus.ticks < 30);
-          ansiStatus.stop();
-          final List<String> out = outputStdout();
-          expect(out[0], isNot(contains('This is taking an unexpectedly long time.')));
-          expect(out[1], contains('This is taking an unexpectedly long time.'));
-          expect(out.length, 3);
-        });
-      }, overrides: <Type, Generator>{
-        Logger: () => StdoutLogger(),
-        Platform: () => FakePlatform(operatingSystem: testOs),
-        Stdio: () => mockStdio,
-        Stopwatch: () => mockStopwatch,
-      });
     }
   });
   group('Output format', () {


### PR DESCRIPTION
## Description

In an `AnsiSpinner` (which `StdoutLogger` instantiates if terminal supports ANSI), there is a `_defaultSlowWarning` which shows after the `timeout` duration. The below issue points out that this warning message prints after the spinner, which makes the message difficult to read. This fix clears the spinner animation, and breaks to a newline before printing the warning message the first time. On successive iterations, the spinner is animated after the message.

### Old

![old-hot-restart](https://user-images.githubusercontent.com/7856010/55118215-d7ff3580-50aa-11e9-808d-2e83be47bdf9.png)

### New

![hot-restart-screenshot](https://user-images.githubusercontent.com/7856010/55117475-34ad2100-50a8-11e9-8ac5-127cc66e22fc.png)

## Related Issues

Resolves [Flutter CLi Error on hot reload and hot restart #29598](https://github.com/flutter/flutter/issues/29598).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.