### PR TITLE
Forward missing pub commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -15,6 +15,14 @@ class PackagesCommand extends FlutterCommand {
     addSubcommand(PackagesGetCommand('get', false));
     addSubcommand(PackagesGetCommand('upgrade', true));
     addSubcommand(PackagesTestCommand());
+    addSubcommand(PackagesForwardCommand('downgrade', 'Downgrade packages in a Flutter project', requiresPubspec: true));
+    addSubcommand(PackagesForwardCommand('publish', 'Publish the current package to pub.dartlang.org', requiresPubspec: true));
+    addSubcommand(PackagesForwardCommand('deps', 'Print package dependencies', requiresPubspec: true));
+    addSubcommand(PackagesForwardCommand('run', 'Run an executable from a package', requiresPubspec: true));
+    addSubcommand(PackagesForwardCommand('cache', 'Work with the Pub system cache'));
+    addSubcommand(PackagesForwardCommand('version', 'Print Pub version'));
+    addSubcommand(PackagesForwardCommand('uploader', 'Manage uploaders for a package on pub.dartlang.org'));
+    addSubcommand(PackagesForwardCommand('global', 'Work with Pub global packages'));
     addSubcommand(PackagesPassthroughCommand());
   }
 
@@ -122,6 +130,36 @@ class PackagesTestCommand extends FlutterCommand {
     await pub(<String>['run', 'test']..addAll(argResults.rest), context: PubContext.runTest, retry: false);
     return null;
   }
+}
+
+class PackagesForwardCommand extends FlutterCommand {
+  PackagesForwardCommand(this._commandName, this._description, {bool requiresPubspec = false}) {
+    if (requiresPubspec) 
+    requiresPubspecYaml();
+  }
+  final String _commandName;
+  final String _description;
+
+  @override
+  String get name => _commandName;
+
+  @override
+  String get description {
+    return '$_description.\n'
+           'This runs the "pub" tool in a Flutter context.';
+  }
+
+  @override
+  String get invocation {
+    return '${runner.executableName} packages $_commandName [<arguments...>]';
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    await pub(<String>[_commandName]..addAll(argResults.rest), context: PubContext.pubForward, retry: false);
+    return null;
+  }
+
 }
 
 class PackagesPassthroughCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -134,8 +134,9 @@ class PackagesTestCommand extends FlutterCommand {
 
 class PackagesForwardCommand extends FlutterCommand {
   PackagesForwardCommand(this._commandName, this._description, {bool requiresPubspec = false}) {
-    if (requiresPubspec) 
-    requiresPubspecYaml();
+    if (requiresPubspec) {
+      requiresPubspecYaml();
+    }
   }
   final String _commandName;
   final String _description;

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -41,6 +41,7 @@ class PubContext {
   static final PubContext interactive = PubContext._(<String>['interactive']);
   static final PubContext pubGet = PubContext._(<String>['get']);
   static final PubContext pubUpgrade = PubContext._(<String>['upgrade']);
+  static final PubContext pubForward = PubContext._(<String>['forward']);
   static final PubContext runTest = PubContext._(<String>['run_test']);
 
   static final PubContext flutterTests = PubContext._(<String>['flutter_tests']);

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -335,68 +335,80 @@ void main() {
     testUsingContext('publish', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'publish']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
+      expect(commands, hasLength(3));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'publish');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
     testUsingContext('deps', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'deps']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
+      expect(commands, hasLength(3));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'deps');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'deps');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
     testUsingContext('cache', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'cache']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
+      expect(commands, hasLength(3));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'cache');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'cache');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
     testUsingContext('version', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'version']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
+      expect(commands, hasLength(3));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'version');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'version');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
     testUsingContext('uploader', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'uploader']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
+      expect(commands, hasLength(3));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'uploader');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'uploader');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
     testUsingContext('global', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'global', 'list']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(3));
+      expect(commands, hasLength(4));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'global');
-      expect(commands[2], 'list');
+      expect(commands[1], '--trace');
+      expect(commands[2], 'global');
+      expect(commands[3], 'list');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
     });
   });
 }

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -309,20 +309,9 @@ void main() {
     });
 
     testUsingContext('pub publish', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-    });
-
-    testUsingContext('publish', () async {
       final PromptingProcess process = PromptingProcess();
       mockProcessManager.processFactory = (List<String> commands) => process;
-      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'publish']);
+      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
       final Future<void> runPrompt = process.showPrompt('Proceed (y/n)? ', <String>['hello', 'world']);
       final Future<void> simulateUserInput = Future<void>(() {
         mockStdio.simulateStdin('y');
@@ -338,6 +327,17 @@ void main() {
       expect(stdout.sublist(0, 2), contains('y\n'));
       expect(stdout[2], 'hello\n');
       expect(stdout[3], 'world\n');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('publish', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'publish']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'publish');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,

--- a/packages/flutter_tools/test/commands/packages_test.dart
+++ b/packages/flutter_tools/test/commands/packages_test.dart
@@ -308,10 +308,21 @@ void main() {
       Stdio: () => mockStdio,
     });
 
+    testUsingContext('pub publish', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'publish');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
     testUsingContext('publish', () async {
       final PromptingProcess process = PromptingProcess();
       mockProcessManager.processFactory = (List<String> commands) => process;
-      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
+      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'publish']);
       final Future<void> runPrompt = process.showPrompt('Proceed (y/n)? ', <String>['hello', 'world']);
       final Future<void> simulateUserInput = Future<void>(() {
         mockStdio.simulateStdin('y');
@@ -327,6 +338,62 @@ void main() {
       expect(stdout.sublist(0, 2), contains('y\n'));
       expect(stdout[2], 'hello\n');
       expect(stdout[3], 'world\n');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('deps', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'deps']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'deps');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('cache', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'cache']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'cache');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('version', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'version']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'version');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('uploader', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'uploader']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'uploader');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+    });
+
+    testUsingContext('global', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'global', 'list']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(3));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'global');
+      expect(commands[2], 'list');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,


### PR DESCRIPTION
## Description

Currently `flutter` supports just two pub subcommands:

1. `flutter packages get` -> `pub get`
1. `flutter packages upgrade` -> `pub upgrade`

This adds forwards for the following missing pub commands:

1. `flutter packages downgrade` -> `pub downgrade`, the opposite of upgrade
1. `flutter packages publish` -> `pub publish` to support publishing a plugin
1. `flutter packages deps` -> `pub deps` to show package dependencies
1. `flutter packages run` -> `pub run` to support running executables, e.g. for package:intl
1. `flutter packages cache` -> `pub cache` to manage the pub cache contents
1. `flutter packages version` -> `pub version` to see the pub version
1. `flutter packages uploader` -> `pub uploader` to manage [package uploaders](https://www.dartlang.org/tools/pub/cmd/pub-uploader)
1. `flutter packages global` -> `pub global`: pub global commands

## Related Issues

Fixes https://github.com/flutter/flutter/issues/27911
Fixes https://github.com/flutter/flutter/issues/9301
Fixes https://github.com/flutter/flutter/issues/13360
Fixes https://github.com/flutter/flutter/issues/21898
Fixes https://github.com/flutter/flutter/issues/28292
