### PR TITLE
Error message for setting shaderWarmUp too late

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -53,7 +53,20 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// See also:
   ///
   ///  * [ShaderWarmUp], the interface of how this warm up works.
-  static ShaderWarmUp shaderWarmUp = const DefaultShaderWarmUp();
+  static ShaderWarmUp get shaderWarmUp => _shaderWarmUp;
+  static void set shaderWarmUp(ShaderWarmUp value) {
+    assert(_instance == null,
+        'PaintingBinding.shaderWarmUp should only be set before the '
+        'PaintingBinding singleton instance is initialized.\n\n'
+        'Set it after init would not affect how shaders are warmed up.\n\n'
+        'To fix this, try to change PaintingBinding.shaderWarmUp before:\n'
+        ' 1. runApp\n'
+        ' 2. WidgetsFlutterBinding.ensureInitialized\n'
+        ' 3. enableFlutterDriverExtension\n'
+    );
+    _shaderWarmUp = value;
+  }
+  static ShaderWarmUp _shaderWarmUp = const DefaultShaderWarmUp();
 
   /// The singleton that implements the Flutter framework's image cache.
   ///

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -54,11 +54,11 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   ///
   ///  * [ShaderWarmUp], the interface of how this warm up works.
   static ShaderWarmUp get shaderWarmUp => _shaderWarmUp;
-  static void set shaderWarmUp(ShaderWarmUp value) {
+  static set shaderWarmUp(ShaderWarmUp value) {
     assert(_instance == null,
         'PaintingBinding.shaderWarmUp should only be set before the '
         'PaintingBinding singleton instance is initialized.\n\n'
-        'Set it after init would not affect how shaders are warmed up.\n\n'
+        'Setting it after init would not affect how shaders are warmed up.\n\n'
         'To fix this, try to change PaintingBinding.shaderWarmUp before:\n'
         ' 1. runApp\n'
         ' 2. WidgetsFlutterBinding.ensureInitialized\n'


### PR DESCRIPTION
## Description

Developers may get confused by setting `PaintingBinding.shaderWarmUp` in
the wrong place. The added assert and error message help avoid that.

## Related Issues

#813

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
