### PR TITLE
Add ability to control RefreshProgressIndicator's distance from edges.

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -123,6 +123,12 @@ class RefreshIndicator extends StatefulWidget {
 
   /// The distance of [RefreshProgressIndicator] from the edge of the screen.
   ///
+  /// Depending whether the indicator is showing on the top or bottom edges of
+  /// screen, the value of this variable controls how far from the edges will
+  /// the progress indicator start to appear. This may come in handy if, for
+  /// example, the UI contains a top [Widget] which covers the edge where the
+  /// progress indicator would otherwise appear.
+  ///
   /// By default, the edge distance is set to 0.
   final double edgeDistance;
 

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -84,7 +84,7 @@ enum _RefreshIndicatorMode {
 class RefreshIndicator extends StatefulWidget {
   /// Creates a refresh indicator.
   ///
-  /// The [onRefresh], [child], [edgeDistance], and [notificationPredicate] arguments must be
+  /// The [onRefresh], [child], and [notificationPredicate] arguments must be
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
   ///
@@ -104,7 +104,6 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsLabel,
     this.semanticsValue,
   }) : assert(child != null),
-       assert(edgeDistance != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
        super(key: key);

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -84,7 +84,7 @@ enum _RefreshIndicatorMode {
 class RefreshIndicator extends StatefulWidget {
   /// Creates a refresh indicator.
   ///
-  /// The [onRefresh], [child], and [notificationPredicate] arguments must be
+  /// The [onRefresh], [child], [edgeDistance], and [notificationPredicate] arguments must be
   /// non-null. The default
   /// [displacement] is 40.0 logical pixels.
   ///
@@ -96,6 +96,7 @@ class RefreshIndicator extends StatefulWidget {
     Key key,
     @required this.child,
     this.displacement = 40.0,
+    this.edgeDistance = 0.0,
     @required this.onRefresh,
     this.color,
     this.backgroundColor,
@@ -103,6 +104,7 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsLabel,
     this.semanticsValue,
   }) : assert(child != null),
+       assert(edgeDistance != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
        super(key: key);
@@ -119,6 +121,11 @@ class RefreshIndicator extends StatefulWidget {
   /// indicator will settle. During the drag that exposes the refresh indicator,
   /// its actual displacement may significantly exceed this value.
   final double displacement;
+
+  /// The distance of [RefreshProgressIndicator] from the edge of the screen.
+  ///
+  /// By default, the edge distance is set to 0.
+  final double edgeDistance;
 
   /// A function that's called when the user has dragged the refresh indicator
   /// far enough to demonstrate that they want the app to refresh. The returned
@@ -433,8 +440,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       children: <Widget>[
         child,
         Positioned(
-          top: _isIndicatorAtTop ? 0.0 : null,
-          bottom: !_isIndicatorAtTop ? 0.0 : null,
+          top: _isIndicatorAtTop ? widget.edgeDistance : null,
+          bottom: !_isIndicatorAtTop ? widget.edgeDistance : null,
           left: 0.0,
           right: 0.0,
           child: SizeTransition(


### PR DESCRIPTION
## Description

This PR allows the user to set the distance of `RefreshProgressIndicator` from the screen edges.

Current behavior: the embedded `RefreshProgressIndicator` used internally by `RefreshIndicator` is always placed at the very top/bottom of the screen.

New behavior: the user is able to set an `edgeDistance` property which controls how far the `RefreshProgressIndicator` is from the top/bottom edges of the screen. To be backward-compatible, the default value of `edgeDistance` is 0.

## Use case

Let's have a `ListView` and a top-positioned `AppBar` as children in a `Stack`. Naturally, you need to give the `ListView` some padding on top in order for the top items not to be covered by the `AppBar`. So that means that when pulling to refresh, the `RefreshProgressIndicator` should start to appear where the app bar ends, and not from the top of the screen.

## Related Issues

No issues involved.

## Tests

I have not added any tests!

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
