### PR TITLE
Part 2: Refactor Navigator's imperative API

### DIFF
--- a/examples/flutter_gallery/lib/demo/video_demo.dart
+++ b/examples/flutter_gallery/lib/demo/video_demo.dart
@@ -60,7 +60,7 @@ class VideoCard extends StatelessWidget {
 
     void pushFullScreenWidget() {
       final TransitionRoute<void> route = PageRouteBuilder<void>(
-        settings: RouteSettings(name: title, isInitialRoute: false),
+        settings: RouteSettings(name: title),
         pageBuilder: fullScreenRoutePageBuilder,
       );
 

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:developer' as developer;
 import 'dart:io' show exit;
-// Before adding any more dart:ui imports, pleaes read the README.
+// Before adding any more dart:ui imports, please read the README.
 import 'dart:ui' as ui show saveCompilationTrace, Window, window;
 
 import 'package:meta/meta.dart';

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -275,7 +275,8 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   AnimationController _animationController;
 
   @override
-  AnimationController createAnimationController() {
+  AnimationController createAnimationController({ bool isInitialRoute = false }) {
+    assert(!isInitialRoute);
     assert(_animationController == null);
     _animationController = BottomSheet.createAnimationController(navigator.overlay);
     return _animationController;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -25,8 +25,17 @@ import 'ticker_provider.dart';
 
 /// Creates a route for the given route settings.
 ///
-/// Used by [Navigator.onGenerateRoute] and [Navigator.onUnknownRoute].
+/// Used by [Navigator.onGenerateRoute].
+///
+/// See also:
+///
+///  * [Navigator], which is where all the [Route]s end up.
 typedef RouteFactory = Route<dynamic> Function(RouteSettings settings);
+
+/// Creates a series of one or more routes.
+///
+/// Used by [Navigator.onGenerateInitialRoutes].
+typedef RouteListFactory = List<Route<dynamic>> Function(NavigatorState navigator, String initialRoute);
 
 /// Signature for the [Navigator.popUntil] predicate argument.
 typedef RoutePredicate = bool Function(Route<dynamic> route);
@@ -71,11 +80,15 @@ enum RoutePopDisposition {
 /// visual affordances, which they place in the navigators [Overlay] using one
 /// or more [OverlayEntry] objects.
 ///
-/// See [Navigator] for more explanation of how to use a Route
-/// with navigation, including code examples.
+/// See [Navigator] for more explanation of how to use a [Route] with
+/// navigation, including code examples.
 ///
-/// See [MaterialPageRoute] for a route that replaces the
-/// entire screen with a platform-adaptive transition.
+/// See [MaterialPageRoute] for a route that replaces the entire screen with a
+/// platform-adaptive transition.
+///
+/// The type argument `T` is the route's return type, as used by
+/// [currentResult], [popped], and [didPop]. The type `void` may be used if the
+/// route does not return a value.
 abstract class Route<T> {
   /// Initialize the [Route].
   ///
@@ -92,23 +105,30 @@ abstract class Route<T> {
   /// See [RouteSettings] for details.
   final RouteSettings settings;
 
-  /// The overlay entries for this route.
+  /// The entries this route has placed in the overlay.
+  ///
+  /// These are typically populated by [install], added to the [Overlay] by the
+  /// [Navigator], and then removed by [dispose].
+  ///
+  /// There must be at least one entry in this list after [install] has been
+  /// invoked.
+  ///
+  /// The [Navigator] will take care of keeping the entries together if the
+  /// route is moved in the history.
   List<OverlayEntry> get overlayEntries => const <OverlayEntry>[];
 
   /// Called when the route is inserted into the navigator.
   ///
-  /// Use this to populate [overlayEntries] and add them to the overlay
-  /// (accessible as [Navigator.overlay]). (The reason the [Route] is
-  /// responsible for doing this, rather than the [Navigator], is that the
-  /// [Route] will be responsible for _removing_ the entries and this way it's
-  /// symmetric.)
+  /// Use this to populate [overlayEntries]. The [Navigator] will then add them
+  /// to the [Overlay]. It's the responsibility of the [dispose] method on this
+  /// [Route] object to remove them by calling [OverlayEntry.remove].
   ///
-  /// The `insertionPoint` argument will be null if this is the first route
-  /// inserted. Otherwise, it indicates the overlay entry to place immediately
-  /// below the first overlay for this route.
+  /// The `isInitialRoute` argument indicates whether this route is part of the
+  /// first batch of routes being pushed onto the [Navigator]. Typically this
+  /// is used to skip any entrance transition during startup.
   @protected
   @mustCallSuper
-  void install(OverlayEntry insertionPoint) { }
+  void install({ bool isInitialRoute = false}) { }
 
   /// Called after [install] when the route is pushed onto the navigator.
   ///
@@ -127,12 +147,24 @@ abstract class Route<T> {
   @mustCallSuper
   void didReplace(Route<dynamic> oldRoute) { }
 
-  /// Returns false if this route wants to veto a [Navigator.pop]. This method is
-  /// called by [Navigator.maybePop].
+  /// Returns whether calling [Navigator.maybePop] when this [Route] is current
+  /// ([isCurrent]) should do anything.
   ///
-  /// By default, routes veto a pop if they're the first route in the history
-  /// (i.e., if [isFirst]). This behavior prevents the user from popping the
-  /// first route off the history and being stranded at a blank screen.
+  /// [Navigator.maybePop] is usually used instead of [pop] to handle the system
+  /// back button.
+  ///
+  /// By default, if a [Route] is the first route in the history (i.e., if
+  /// [isFirst]), it reports that pops should be bubbled
+  /// ([RoutePopDisposition.bubble]). This behavior prevents the user from
+  /// popping the first route off the history and being stranded at a blank
+  /// screen; instead, the larger scope is popped (e.g. the application quits,
+  /// so that the user returns to the previous application).
+  ///
+  /// In other cases, the default behaviour is to accept the pop
+  /// ([RoutePopDisposition.pop]).
+  ///
+  /// The third possible value is [RoutePopDisposition.doNotPop], which causes
+  /// the pop request to be ignored entirely.
   ///
   /// See also:
   ///
@@ -149,17 +181,22 @@ abstract class Route<T> {
 
   /// When this route is popped (see [Navigator.pop]) if the result isn't
   /// specified or if it's null, this value will be used instead.
+  ///
+  /// This fallback is implemented by [didComplete]. This value is used if the
+  /// argument to that method is null.
   T get currentResult => null;
 
   /// A future that completes when this route is popped off the navigator.
   ///
-  /// The future completes with the value given to [Navigator.pop], if any.
+  /// The future completes with the value given to [Navigator.pop], if any, or
+  /// else the value of [currentResult]. See [didComplete] for more discussion
+  /// on this topic.
   Future<T> get popped => _popCompleter.future;
   final Completer<T> _popCompleter = Completer<T>();
 
   /// A request was made to pop this route. If the route can handle it
   /// internally (e.g. because it has its own stack of internal state) then
-  /// return false, otherwise return true (by return the value of calling
+  /// return false, otherwise return true (by returning the value of calling
   /// `super.didPop`). Returning false will prevent the default behavior of
   /// [NavigatorState.pop].
   ///
@@ -169,6 +206,13 @@ abstract class Route<T> {
   /// call [dispose] on the route. This sequence lets the route perform an
   /// exit animation (or some other visual effect) after being popped but prior
   /// to being disposed.
+  ///
+  /// This method should call [didComplete] to resolve the [popped] future (and
+  /// this is all that the default implementation does); routes should not wait
+  /// for their exit animation to complete before doing so.
+  ///
+  /// See [popped], [didComplete], and [currentResult] for a discussion of the
+  /// `result` argument.
   @protected
   @mustCallSuper
   bool didPop(T result) {
@@ -178,34 +222,56 @@ abstract class Route<T> {
 
   /// The route was popped or is otherwise being removed somewhat gracefully.
   ///
-  /// This is called by [didPop] and in response to [Navigator.pushReplacement].
+  /// This is called by [didPop] and in response to
+  /// [NavigatorState.pushReplacement]. If [didPop] was not called, then the
+  /// [Navigator.finalizeRoute] method must be called immediately, and no exit
+  /// animation will run.
   ///
-  /// The [popped] future is completed by this method.
+  /// The [popped] future is completed by this method. The `result` argument
+  /// specifies the value that this future is completed with, unless it is null,
+  /// in which case [currentResult] is used instead.
+  ///
+  /// This should be called before the pop animation, if any, takes place,
+  /// though in some cases the animation may be driven by the user before the
+  /// route is committed to being popped; this can in particular happen with the
+  /// iOS-style back gesture. See [Navigator.didStartUserGesture].
   @protected
   @mustCallSuper
   void didComplete(T result) {
-    _popCompleter.complete(result);
+    _popCompleter.complete(result ?? currentResult);
   }
 
   /// The given route, which was above this one, has been popped off the
   /// navigator.
+  ///
+  /// This route is now the current route ([isCurrent] is now true), and there
+  /// is no next route.
   @protected
   @mustCallSuper
   void didPopNext(Route<dynamic> nextRoute) { }
 
-  /// This route's next route has changed to the given new route. This is called
-  /// on a route whenever the next route changes for any reason, so long as it
-  /// is in the history, including when a route is first added to a [Navigator]
-  /// (e.g. by [Navigator.push]), except for cases when [didPopNext] would be
-  /// called. `nextRoute` will be null if there's no next route.
+  /// This route's next route has changed to the given new route.
+  ///
+  /// This is called on a route whenever the next route changes for any reason,
+  /// so long as it is in the history, including when a route is first added to
+  /// a [Navigator] (e.g. by [Navigator.push]), except for cases when
+  /// [didPopNext] would be called.
+  ///
+  /// The `nextRoute` argument will be null if there's no new next route (i.e.
+  /// if [isCurrent] is true).
   @protected
   @mustCallSuper
   void didChangeNext(Route<dynamic> nextRoute) { }
 
-  /// This route's previous route has changed to the given new route. This is
-  /// called on a route whenever the previous route changes for any reason, so
-  /// long as it is in the history. `previousRoute` will be null if there's no
-  /// previous route.
+  /// This route's previous route has changed to the given new route.
+  ///
+  /// This is called on a route whenever the previous route changes for any
+  /// reason, so long as it is in the history, except for immediately after the
+  /// route itself has been pushed (in which case [didPush] or [didReplace] will
+  /// be called instead).
+  ///
+  /// The `previousRoute` argument will be null if there's no previous route
+  /// (i.e. if [isFirst] is true).
   @protected
   @mustCallSuper
   void didChangePrevious(Route<dynamic> previousRoute) { }
@@ -242,9 +308,17 @@ abstract class Route<T> {
   @mustCallSuper
   void changedExternalState() { }
 
-  /// The route should remove its overlays and free any other resources.
+  /// Discards any resources used by the object.
   ///
-  /// This route is no longer referenced by the navigator.
+  /// After this is called, the object is not in a usable state and should be
+  /// discarded.
+  ///
+  /// This method should only be called by the object's owner; typically the
+  /// [Navigator] owns a route and so will call this method when the route is
+  /// removed, after which the route is no longer referenced by the navigator.
+  ///
+  /// When this method is called, the route should remove its overlays and free
+  /// any other resources.
   @mustCallSuper
   @protected
   void dispose() {
@@ -255,7 +329,15 @@ abstract class Route<T> {
   ///
   /// If this is true, then [isActive] is also true.
   bool get isCurrent {
-    return _navigator != null && _navigator._history.last == this;
+    if (_navigator == null)
+      return false;
+    final _RouteEntry currentRouteEntry = _navigator._history.lastWhere(
+      _RouteEntry.isPresentPredicate,
+      orElse: () => null,
+    );
+    if (currentRouteEntry == null)
+      return false;
+    return currentRouteEntry.route == this;
   }
 
   /// Whether this route is the bottom-most route on the navigator.
@@ -266,7 +348,15 @@ abstract class Route<T> {
   /// If [isFirst] and [isCurrent] are both true then this is the only route on
   /// the navigator (and [isActive] will also be true).
   bool get isFirst {
-    return _navigator != null && _navigator._history.first == this;
+    if (_navigator == null)
+      return false;
+    final _RouteEntry currentRouteEntry = _navigator._history.firstWhere(
+      _RouteEntry.isPresentPredicate,
+      orElse: () => null,
+    );
+    if (currentRouteEntry == null)
+      return false;
+    return currentRouteEntry.route == this;
   }
 
   /// Whether this route is on the navigator.
@@ -279,7 +369,9 @@ abstract class Route<T> {
   /// rendered. It is even possible for the route to be active but for the stateful
   /// widgets within the route to not be instantiated. See [ModalRoute.maintainState].
   bool get isActive {
-    return _navigator != null && _navigator._history.contains(this);
+    if (_navigator == null)
+      return false;
+    return _navigator._history.firstWhere(_RouteEntry.isRoutePredicate(this)).isPresent;
   }
 }
 
@@ -289,7 +381,6 @@ class RouteSettings {
   /// Creates data used to construct routes.
   const RouteSettings({
     this.name,
-    this.isInitialRoute = false,
     this.arguments,
   });
 
@@ -297,12 +388,10 @@ class RouteSettings {
   /// replaced with the new values.
   RouteSettings copyWith({
     String name,
-    bool isInitialRoute,
     Object arguments,
   }) {
     return RouteSettings(
       name: name ?? this.name,
-      isInitialRoute: isInitialRoute ?? this.isInitialRoute,
       arguments: arguments ?? this.arguments,
     );
   }
@@ -311,11 +400,6 @@ class RouteSettings {
   ///
   /// If null, the route is anonymous.
   final String name;
-
-  /// Whether this route is the very first route being pushed onto this [Navigator].
-  ///
-  /// The initial route typically skips any entrance transition to speed startup.
-  final bool isInitialRoute;
 
   /// The arguments passed to this route.
   ///
@@ -358,17 +442,10 @@ class NavigatorObserver {
   /// The [Navigator] replaced `oldRoute` with `newRoute`.
   void didReplace({ Route<dynamic> newRoute, Route<dynamic> oldRoute }) { }
 
-  /// The [Navigator]'s route `route` is being moved by a user gesture.
+  /// The [Navigator]'s routes are being moved by a user gesture.
   ///
-  /// For example, this is called when an iOS back gesture starts.
-  ///
-  /// Paired with a call to [didStopUserGesture] when the route is no longer
-  /// being manipulated via user gesture.
-  ///
-  /// If present, the route immediately below `route` is `previousRoute`.
-  /// Though the gesture may not necessarily conclude at `previousRoute` if
-  /// the gesture is canceled. In that case, [didStopUserGesture] is still
-  /// called but a follow-up [didPop] is not.
+  /// For example, this is called when an iOS back gesture starts, and is used
+  /// to disabled hero animations during such interactions.
   void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute) { }
 
   /// User gesture is no longer controlling the [Navigator].
@@ -386,7 +463,7 @@ class NavigatorObserver {
 /// around in the overlay. Similarly, the navigator can be used to show a dialog
 /// by positioning the dialog widget above the current page.
 ///
-/// ## Using the Navigator
+/// ## Using the Navigator API
 ///
 /// Mobile apps typically reveal their contents via full-screen elements
 /// called "screens" or "pages". In Flutter these elements are called
@@ -396,9 +473,10 @@ class NavigatorObserver {
 ///
 /// ### Displaying a full-screen route
 ///
-/// Although you can create a navigator directly, it's most common to use
-/// the navigator created by a [WidgetsApp] or a [MaterialApp] widget. You
-/// can refer to that navigator with [Navigator.of].
+/// Although you can create a navigator directly, it's most common to use the
+/// navigator created by the [Router] which itself is created and configured by
+/// a [WidgetsApp] or a [MaterialApp] widget. You can refer to that navigator
+/// with [Navigator.of].
 ///
 /// A [MaterialApp] is the simplest way to set things up. The [MaterialApp]'s
 /// home becomes the route at the bottom of the [Navigator]'s stack. It is what
@@ -571,12 +649,12 @@ class NavigatorObserver {
 ///
 /// ### Nesting Navigators
 ///
-/// An app can use more than one Navigator. Nesting one Navigator below
-/// another Navigator can be used to create an "inner journey" such as tabbed
+/// An app can use more than one [Navigator]. Nesting one [Navigator] below
+/// another [Navigator] can be used to create an "inner journey" such as tabbed
 /// navigation, user registration, store checkout, or other independent journeys
 /// that represent a subsection of your overall application.
 ///
-/// #### Real World Example
+/// #### Example
 ///
 /// It is standard practice for iOS apps to use tabbed navigation where each
 /// tab maintains its own navigation history. Therefore, each tab has its own
@@ -589,10 +667,9 @@ class NavigatorObserver {
 /// tab's [Navigator]s are actually nested [Navigator]s sitting below a single
 /// root [Navigator].
 ///
-/// The nested [Navigator]s for tabbed navigation sit in [WidgetApp] and
-/// [CupertinoTabView], so you don't need to worry about nested [Navigator]s
-/// in this situation, but it's a real world example where nested [Navigator]s
-/// are used.
+/// In practice, the nested [Navigator]s for tabbed navigation sit in the
+/// [WidgetApp] and [CupertinoTabView] widgets, and so do not need to be
+/// explicitly created or managed.
 ///
 /// {@tool snippet --template=freeform}
 /// The following example demonstrates how a nested [Navigator] can be used to
@@ -734,29 +811,23 @@ class NavigatorObserver {
 /// a desired location in the widget subtree.
 class Navigator extends StatefulWidget {
   /// Creates a widget that maintains a stack-based history of child widgets.
-  ///
-  /// The [onGenerateRoute] argument must not be null.
   const Navigator({
     Key key,
     this.initialRoute,
-    @required this.onGenerateRoute,
+    this.onGenerateInitialRoutes = Navigator.defaultGenerateInitialRoutes,
+    this.onGenerateRoute,
     this.onUnknownRoute,
     this.observers = const <NavigatorObserver>[],
-  }) : assert(onGenerateRoute != null),
+  }) : assert(onGenerateInitialRoutes != null),
+       assert(observers != null),
        super(key: key);
 
   /// The name of the first route to show.
   ///
-  /// By default, this defers to [dart:ui.Window.defaultRouteName].
+  /// Defaults to [Navigator.defaultRouteName].
   ///
-  /// If this string contains any `/` characters, then the string is split on
-  /// those characters and substrings from the start of the string up to each
-  /// such character are, in turn, used as routes to push.
-  ///
-  /// For example, if the route `/stocks/HOOLI` was used as the [initialRoute],
-  /// then the [Navigator] would push the following routes on startup: `/`,
-  /// `/stocks`, `/stocks/HOOLI`. This enables deep linking while allowing the
-  /// application to maintain a predictable route history.
+  /// The value is interpreted according to [onGenerateInitialRoutes], which
+  /// defaults to [defaultGenerateInitialRoutes].
   final String initialRoute;
 
   /// Called to generate a route for a given [RouteSettings].
@@ -775,13 +846,23 @@ class Navigator extends StatefulWidget {
   /// A list of observers for this navigator.
   final List<NavigatorObserver> observers;
 
-  /// The default name for the [initialRoute].
+  /// The name for the default route of the application.
   ///
   /// See also:
   ///
   ///  * [dart:ui.Window.defaultRouteName], which reflects the route that the
   ///    application was started with.
   static const String defaultRouteName = '/';
+
+  /// Called when the widget is created to generate the initial list of [Route]
+  /// objects, if [initialRoute] is not null.
+  ///
+  /// Defaults to [defaultGenerateInitialRoutes].
+  ///
+  /// The [NavigatorState] and [initialRoute] will be passed to the callback.
+  /// The callback must return a list of [Route] objects with which the history
+  /// will be primed.
+  final RouteListFactory onGenerateInitialRoutes;
 
   /// Push a named route onto the navigator that most tightly encloses the given
   /// context.
@@ -802,6 +883,8 @@ class Navigator extends StatefulWidget {
   /// when the pushed route is popped off the navigator.
   ///
   /// The `T` type argument is the type of the return value of the route.
+  ///
+  /// To use [pushNamed], an [onGenerateRoute] callback must be provided,
   /// {@endtemplate}
   ///
   /// {@template flutter.widgets.navigator.pushNamed.arguments}
@@ -908,6 +991,9 @@ class Navigator extends StatefulWidget {
   ///
   /// The `T` type argument is the type of the return value of the new route,
   /// and `TO` is the type of the return value of the old route.
+  ///
+  /// To use [pushReplacementNamed], an [onGenerateRoute] callback must be
+  /// provided.
   /// {@endtemplate}
   ///
   /// {@macro flutter.widgets.navigator.pushNamed.arguments}
@@ -936,14 +1022,9 @@ class Navigator extends StatefulWidget {
   /// given context and push a named route in its place.
   ///
   /// {@template flutter.widgets.navigator.popAndPushNamed}
-  /// If non-null, `result` will be used as the result of the route that is
-  /// popped; the future that had been returned from pushing the popped route
-  /// will complete with `result`. Routes such as dialogs or popup menus
-  /// typically use this mechanism to return the value selected by the user to
-  /// the widget that created their route. The type of `result`, if provided,
-  /// must match the type argument of the class of the popped route (`TO`).
+  /// The popping of the previous route is handled as per [pop].
   ///
-  /// The route name will be passed to the navigator's [onGenerateRoute]
+  /// The new route's name will be passed to the navigator's [onGenerateRoute]
   /// callback. The returned route will be pushed into the navigator.
   ///
   /// The new route, the old route, and the route below the old route (if any)
@@ -963,6 +1044,9 @@ class Navigator extends StatefulWidget {
   ///
   /// The `T` type argument is the type of the return value of the new route,
   /// and `TO` is the return value type of the old route.
+  ///
+  /// To use [popAndPushNamed], an [onGenerateRoute] callback must be provided.
+  ///
   /// {@endtemplate}
   ///
   /// {@macro flutter.widgets.navigator.pushNamed.arguments}
@@ -1024,6 +1108,9 @@ class Navigator extends StatefulWidget {
   /// when the pushed route is popped off the navigator.
   ///
   /// The `T` type argument is the type of the return value of the new route.
+  ///
+  /// To use [pushNamedAndRemoveUntil], an [onGenerateRoute] callback must be
+  /// provided.
   /// {@endtemplate}
   ///
   /// {@macro flutter.widgets.navigator.pushNamed.arguments}
@@ -1269,15 +1356,28 @@ class Navigator extends StatefulWidget {
     return navigator != null && navigator.canPop();
   }
 
-  /// Returns the value of the current route's [Route.willPop] method for the
-  /// navigator that most tightly encloses the given context.
+  /// Consults the current route's [Route.willPop] method, and acts accordingly,
+  /// potentially popping the route as a result; returns whether the pop request
+  /// should be considered handled.
   ///
   /// {@template flutter.widgets.navigator.maybePop}
-  /// This method is typically called before a user-initiated [pop]. For example
-  /// on Android it's called by the binding for the system's back button.
+  /// If [Route.willPop] returns [RoutePopDisposition.pop], then the [pop]
+  /// method is called, and this method returns true, indicating that it handled
+  /// the pop request.
+  ///
+  /// If [Route.willPop] returns [RoutePopDisposition.doNotPop], then this
+  /// method returns true, but does not do anything beyond that.
+  ///
+  /// If [Route.willPop] returns [RoutePopDisposition.bubble], then this method
+  /// returns false, and the caller is responsible for sending the request to
+  /// the containing scope (e.g. by closing the application).
+  ///
+  /// This method is typically called for a user-initiated [pop]. For example on
+  /// Android it's called by the binding for the system's back button.
   ///
   /// The `T` type argument is the type of the return value of the current
-  /// route.
+  /// route. (Typically this isn't known; consider specifying `dynamic` or
+  /// `Null`.)
   /// {@endtemplate}
   ///
   /// See also:
@@ -1296,8 +1396,8 @@ class Navigator extends StatefulWidget {
   ///
   /// {@template flutter.widgets.navigator.pop}
   /// The current route's [Route.didPop] method is called first. If that method
-  /// returns false, then this method returns true but nothing else is changed
-  /// (the route is expected to have popped some internal state; see e.g.
+  /// returns false, then the route remains in the [Navigator]'s history (the
+  /// route is expected to have popped some internal state; see e.g.
   /// [LocalHistoryRoute]). Otherwise, the rest of this description applies.
   ///
   /// If non-null, `result` will be used as the result of the route that is
@@ -1314,8 +1414,8 @@ class Navigator extends StatefulWidget {
   ///
   /// The `T` type argument is the type of the return value of the popped route.
   ///
-  /// Returns true if a route was popped (including if [Route.didPop] returned
-  /// false); returns false if there are no further previous routes.
+  /// The type of `result`, if provided, must match the type argument of the
+  /// class of the popped route (`T`).
   /// {@endtemplate}
   ///
   /// {@tool sample}
@@ -1337,8 +1437,8 @@ class Navigator extends StatefulWidget {
   /// }
   /// ```
   @optionalTypeArgs
-  static bool pop<T extends Object>(BuildContext context, [ T result ]) {
-    return Navigator.of(context).pop<T>(result);
+  static void pop<T extends Object>(BuildContext context, [ T result ]) {
+    Navigator.of(context).pop<T>(result);
   }
 
   /// Calls [pop] repeatedly on the navigator that most tightly encloses the
@@ -1457,20 +1557,296 @@ class Navigator extends StatefulWidget {
     return navigator;
   }
 
+  /// Turn a route name into a set of [Route] objects.
+  ///
+  /// This is the default value of [onGenerateInitialRoutes], which is used if
+  /// [initialRoute] is not null.
+  ///
+  /// If this string contains any `/` characters, then the string is split on
+  /// those characters and substrings from the start of the string up to each
+  /// such character are, in turn, used as routes to push.
+  ///
+  /// For example, if the route `/stocks/HOOLI` was used as the [initialRoute],
+  /// then the [Navigator] would push the following routes on startup: `/`,
+  /// `/stocks`, `/stocks/HOOLI`. This enables deep linking while allowing the
+  /// application to maintain a predictable route history.
+  static List<Route<dynamic>> defaultGenerateInitialRoutes(NavigatorState navigator, String initialRouteName) {
+    final List<Route<dynamic>> result = <Route<dynamic>>[];
+    if (initialRouteName.startsWith('/') && initialRouteName.length > 1) {
+      initialRouteName = initialRouteName.substring(1); // strip leading '/'
+      assert(Navigator.defaultRouteName == '/');
+      List<String> debugRouteNames;
+      assert(() {
+        debugRouteNames = <String>[ Navigator.defaultRouteName ];
+        return true;
+      }());
+      result.add(navigator._routeNamed<dynamic>(Navigator.defaultRouteName, arguments: null, allowNull: true));
+      final List<String> routeParts = initialRouteName.split('/');
+      if (initialRouteName.isNotEmpty) {
+        String routeName = '';
+        for (String part in routeParts) {
+          routeName += '/$part';
+          assert(() {
+            debugRouteNames.add(routeName);
+            return true;
+          }());
+          result.add(navigator._routeNamed<dynamic>(routeName, arguments: null, allowNull: true));
+        }
+      }
+      if (result.contains(null)) {
+        assert(() {
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception:
+                'Could not navigate to initial route.\n'
+                'The requested route name was: "/$initialRouteName"\n'
+                'The following routes were therefore attempted:\n'
+                ' * ${debugRouteNames.join("\n * ")}\n'
+                'This resulted in the following objects:\n'
+                ' * ${result.join("\n * ")}\n'
+                'One or more of those objects was null, and therefore the initial route specified will be '
+                'ignored and "${Navigator.defaultRouteName}" will be used instead.'
+            ),
+          );
+          return true;
+        }());
+        result.clear();
+      }
+    } else if (initialRouteName != Navigator.defaultRouteName) {
+      // If initialRouteName wasn't '/', then we try to get it with allowNull:true, so that if that fails,
+      // we fall back to '/' (without allowNull:true, see below).
+      result.add(navigator._routeNamed<dynamic>(initialRouteName, arguments: null, allowNull: true));
+    }
+    if (result.isEmpty)
+      result.add(navigator._routeNamed<dynamic>(Navigator.defaultRouteName, arguments: null));
+    return result;
+  }
+
   @override
   NavigatorState createState() => NavigatorState();
 }
 
+// The _RouteLifecycle state machine (only goes down):
+//
+//                    [creation of a _RouteEntry]
+//                   /  |             |       |
+//                  /   |             |       |
+//                 /    |             |       |
+//                /     |             |       |
+//               /      |             |       |
+//      pushReplace   push*      initial*   replace*
+//               \       |       /            |
+//                \       \     /            /
+//                +-----pushing#            /
+//                          \              /
+//                           \            /
+//                           idle--------+
+//                           /  \
+//                          /    \
+//                        pop*  remove*
+//                        /        \
+//                       /       removing#
+//                     popping#       |
+//                      |             |
+//                   [finalizeRoute]  |
+//                              \     |
+//                              dispose*
+//                                 |
+//                                 |
+//                              disposed
+//                                 |
+//                                 |
+//                  [_RouteEntry garbage collected]
+//                          (terminal state)
+//
+// * These states are transient; as soon as _flushHistoryUpdates is run the
+//   route entry will exit that state.
+// # These states await futures or other events, then transition automatically.
+enum _RouteLifecycle {
+  // routes that are present:
+  push, // we'll want to run install, didPush, etc; a route added via push() and friends
+  pushReplace, // we'll want to run install, didPush, etc; a route added via pushReplace() and friends
+  replace, // we'll want to run install, didReplace, etc; a route added via replace() and friends
+  initial, // we'll want to run install; a route created by onGenerateInitialRoutes or by the initial widget.pages
+  pushing, // we're waiting for the future from didPush to complete
+  idle, // route is being harmless
+  // routes that are not present:
+  pop, // we'll want to call didPop
+  popping, // we're waiting for the route to call finalizeRoute to switch to dispose
+  remove, // we'll want to run didReplace/didRemove etc
+  removing, // we are waiting for subsequent routes to be done animating, then will switch to dispose
+  dispose, // we will dispose the route momentarily
+  disposed, // we have disposed the route
+}
+
+typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
+
+class _RouteEntry {
+  _RouteEntry(
+    this.route, {
+      @required _RouteLifecycle initialState,
+    }) : assert(route != null),
+         assert(initialState != null),
+         assert(
+           initialState == _RouteLifecycle.initial ||
+           initialState == _RouteLifecycle.push ||
+           initialState == _RouteLifecycle.pushReplace ||
+           initialState == _RouteLifecycle.replace
+         ),
+         currentState = initialState; // ignore: prefer_initializing_formals
+
+  final Route<dynamic> route;
+
+  _RouteLifecycle currentState;
+  Route<dynamic> lastAnnouncedNextRoute; // last argument to Route.didChangeNext
+  Route<dynamic> lastAnnouncedPreviousRoute; // last argument to Route.didChangePrevious
+  Route<dynamic> lastAnnouncedPoppedNextRoute; // last argument to Route.didPopNext
+
+  void handleAddition({ @required NavigatorState navigator, @required bool isNewFirst, @required Route<dynamic> previous, @required Route<dynamic> previousPresent }) {
+    assert(currentState == _RouteLifecycle.initial || currentState == _RouteLifecycle.push || currentState == _RouteLifecycle.pushReplace || currentState == _RouteLifecycle.replace);
+    assert(navigator != null);
+    assert(navigator._debugLocked);
+    assert(route._navigator == null);
+    final _RouteLifecycle previousState = currentState;
+    route._navigator = navigator;
+    route.install(isInitialRoute: currentState == _RouteLifecycle.initial);
+    assert(route.overlayEntries.isNotEmpty);
+    if (currentState == _RouteLifecycle.initial || currentState == _RouteLifecycle.push || currentState == _RouteLifecycle.pushReplace) {
+      currentState = _RouteLifecycle.pushing;
+      route.didPush().whenCompleteOrCancel(() {
+        if (currentState == _RouteLifecycle.pushing) {
+          currentState = _RouteLifecycle.idle;
+          assert(!navigator._debugLocked);
+          assert(() { navigator._debugLocked = true; return true; }());
+          navigator._flushHistoryUpdates();
+          assert(() { navigator._debugLocked = false; return true; }());
+        }
+      });
+    } else {
+      assert(currentState == _RouteLifecycle.replace);
+      if (currentState == _RouteLifecycle.replace)
+        route.didReplace(previous);
+      currentState = _RouteLifecycle.idle;
+    }
+    if (isNewFirst) {
+      route.didChangeNext(null);
+    }
+    if (previousState == _RouteLifecycle.replace || previousState == _RouteLifecycle.pushReplace) {
+      for (NavigatorObserver observer in navigator.widget.observers)
+        observer.didReplace(newRoute: route, oldRoute: previous);
+    } else {
+      assert(previousState == _RouteLifecycle.initial || previousState == _RouteLifecycle.push);
+      for (NavigatorObserver observer in navigator.widget.observers)
+        observer.didPush(route, previousPresent);
+    }
+  }
+
+  void handleDidPopNext(Route<dynamic> poppedRoute) {
+    route.didPopNext(poppedRoute);
+    lastAnnouncedPoppedNextRoute = poppedRoute;
+  }
+
+  void handlePop({ @required NavigatorState navigator, @required Route<dynamic> previousPresent }) {
+    assert(navigator != null);
+    assert(navigator._debugLocked);
+    assert(route._navigator == navigator);
+    currentState = _RouteLifecycle.popping;
+    for (NavigatorObserver observer in navigator.widget.observers)
+      observer.didPop(route, previousPresent);
+  }
+
+  void handleRemoval({ @required NavigatorState navigator, @required Route<dynamic> previousPresent }) {
+    assert(navigator != null);
+    assert(navigator._debugLocked);
+    assert(route._navigator == navigator);
+    currentState = _RouteLifecycle.removing;
+    if (_reportRemovalToObserver) {
+      for (NavigatorObserver observer in navigator.widget.observers)
+        observer.didRemove(route, previousPresent);
+    }
+  }
+
+  bool doingPop = false;
+
+  void pop<T>(T result) {
+    assert(isPresent);
+    doingPop = true;
+    if (route.didPop(result) && doingPop) {
+      currentState = _RouteLifecycle.pop;
+    }
+    doingPop = false;
+  }
+
+  bool _reportRemovalToObserver = true;
+
+  // Route is removed without being completed.
+  void remove({ bool isReplaced = false }) {
+    if (currentState.index >= _RouteLifecycle.remove.index)
+      return;
+    assert(isPresent);
+    _reportRemovalToObserver = !isReplaced;
+    currentState = _RouteLifecycle.remove;
+  }
+
+  // Route completes with `result` and is removed.
+  void complete<T>(T result, { bool isReplaced = false }) {
+    if (currentState.index >= _RouteLifecycle.remove.index)
+      return;
+    assert(isPresent);
+    _reportRemovalToObserver = !isReplaced;
+    route.didComplete(result);
+    assert(route._popCompleter.isCompleted); // implies didComplete was called
+    currentState = _RouteLifecycle.remove;
+  }
+
+  void finalize() {
+    assert(currentState.index < _RouteLifecycle.dispose.index);
+    currentState = _RouteLifecycle.dispose;
+  }
+
+  void dispose() {
+    assert(currentState.index < _RouteLifecycle.disposed.index);
+    route.dispose();
+    currentState = _RouteLifecycle.disposed;
+  }
+
+  bool get isPresent => currentState.index <= _RouteLifecycle.idle.index;
+
+  bool shouldAnnounceChangeToNext(Route<dynamic> nextRoute) {
+    assert(nextRoute != lastAnnouncedNextRoute);
+    // Do not announce if `next` changes from a just popped route to null. We
+    // already announced this change by calling didPopNext.
+    return !(
+      nextRoute == null &&
+      lastAnnouncedPoppedNextRoute != null &&
+      lastAnnouncedPoppedNextRoute == lastAnnouncedNextRoute
+    );
+  }
+
+  static final _RouteEntryPredicate isPresentPredicate = (_RouteEntry entry) => entry.isPresent;
+
+  static _RouteEntryPredicate isRoutePredicate(Route<dynamic> route) {
+    return (_RouteEntry entry) => entry.route == route;
+  }
+}
+
 /// The state for a [Navigator] widget.
 class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
-  final GlobalKey<OverlayState> _overlayKey = GlobalKey<OverlayState>();
-  final List<Route<dynamic>> _history = <Route<dynamic>>[];
-  final Set<Route<dynamic>> _poppedRoutes = <Route<dynamic>>{};
+  final List<_RouteEntry> _history = <_RouteEntry>[];
+
+  bool _debugLocked = false; // used to prevent re-entrant calls to push, pop, and friends
 
   /// The [FocusScopeNode] for the [FocusScope] that encloses the routes.
   final FocusScopeNode focusScopeNode = FocusScopeNode();
 
-  final List<OverlayEntry> _initialOverlayEntries = <OverlayEntry>[];
+  /// The overlay this navigator uses for its visual presentation.
+  OverlayState get overlay => _overlayKey.currentState;
+  final GlobalKey<OverlayState> _overlayKey = GlobalKey<OverlayState>();
+
+  Iterable<OverlayEntry> get _allRouteOverlayEntries sync* {
+    for (_RouteEntry entry in _history)
+      yield* entry.route.overlayEntries;
+  }
 
   @override
   void initState() {
@@ -1479,70 +1855,36 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       assert(observer.navigator == null);
       observer._navigator = this;
     }
-    String initialRouteName = widget.initialRoute ?? Navigator.defaultRouteName;
-    if (initialRouteName.startsWith('/') && initialRouteName.length > 1) {
-      initialRouteName = initialRouteName.substring(1); // strip leading '/'
-      assert(Navigator.defaultRouteName == '/');
-      final List<String> plannedInitialRouteNames = <String>[
-        Navigator.defaultRouteName,
-      ];
-      final List<Route<dynamic>> plannedInitialRoutes = <Route<dynamic>>[
-        _routeNamed<dynamic>(Navigator.defaultRouteName, allowNull: true, arguments: null),
-      ];
-      final List<String> routeParts = initialRouteName.split('/');
-      if (initialRouteName.isNotEmpty) {
-        String routeName = '';
-        for (String part in routeParts) {
-          routeName += '/$part';
-          plannedInitialRouteNames.add(routeName);
-          plannedInitialRoutes.add(_routeNamed<dynamic>(routeName, allowNull: true, arguments: null));
-        }
-      }
-      if (plannedInitialRoutes.contains(null)) {
-        assert(() {
-          FlutterError.reportError(
-            FlutterErrorDetails(
-              exception:
-                'Could not navigate to initial route.\n'
-                'The requested route name was: "/$initialRouteName"\n'
-                'The following routes were therefore attempted:\n'
-                ' * ${plannedInitialRouteNames.join("\n * ")}\n'
-                'This resulted in the following objects:\n'
-                ' * ${plannedInitialRoutes.join("\n * ")}\n'
-                'One or more of those objects was null, and therefore the initial route specified will be '
-                'ignored and "${Navigator.defaultRouteName}" will be used instead.'
-            ),
-          );
-          return true;
-        }());
-        push(_routeNamed<Object>(Navigator.defaultRouteName, arguments: null));
-      } else {
-        plannedInitialRoutes.forEach(push);
-      }
-    } else {
-      Route<Object> route;
-      if (initialRouteName != Navigator.defaultRouteName)
-        route = _routeNamed<Object>(initialRouteName, allowNull: true, arguments: null);
-      route ??= _routeNamed<Object>(Navigator.defaultRouteName, arguments: null);
-      push(route);
-    }
-    for (Route<dynamic> route in _history)
-      _initialOverlayEntries.addAll(route.overlayEntries);
+    // TODO(goderbauer): don't use defaultRouteName if pages are provided
+    _history.addAll(
+      widget.onGenerateInitialRoutes(this, widget.initialRoute ?? Navigator.defaultRouteName)
+        .map((Route<dynamic> route) => _RouteEntry(
+          route,
+          initialState: _RouteLifecycle.initial,
+        ),
+      ),
+    );
+    assert(!_debugLocked);
+    assert(() { _debugLocked = true; return true; }());
+    _flushHistoryUpdates();
+    assert(() { _debugLocked = false; return true; }());
   }
 
   @override
   void didUpdateWidget(Navigator oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.observers != widget.observers) {
-      for (NavigatorObserver observer in oldWidget.observers)
+      for (NavigatorObserver observer in oldWidget.observers) {
+        assert(observer.navigator == this);
         observer._navigator = null;
+      }
       for (NavigatorObserver observer in widget.observers) {
         assert(observer.navigator == null);
         observer._navigator = this;
       }
     }
-    for (Route<dynamic> route in _history)
-      route.changedExternalState();
+    for (_RouteEntry entry in _history)
+      entry.route.changedExternalState();
   }
 
   @override
@@ -1551,35 +1893,168 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(() { _debugLocked = true; return true; }());
     for (NavigatorObserver observer in widget.observers)
       observer._navigator = null;
-    final List<Route<dynamic>> doomed = _poppedRoutes.toList()..addAll(_history);
-    for (Route<dynamic> route in doomed)
-      route.dispose();
-    _poppedRoutes.clear();
-    _history.clear();
     focusScopeNode.detach();
+    for (_RouteEntry entry in _history)
+      entry.dispose();
     super.dispose();
-    assert(() { _debugLocked = false; return true; }());
+    // don't unlock, so that the object becomes unusable
   }
 
-  /// The overlay this navigator uses for its visual presentation.
-  OverlayState get overlay => _overlayKey.currentState;
-
-  OverlayEntry get _currentOverlayEntry {
-    for (Route<dynamic> route in _history.reversed) {
-      if (route.overlayEntries.isNotEmpty)
-        return route.overlayEntries.last;
+  void _flushHistoryUpdates() {
+    assert(_debugLocked);
+    // Clean up the list, sending updates to the routes that changed. Notably,
+    // we don't send the didChangePrevious/didChangeNext updates to those that
+    // did not change at this point, because we're not yet sure exactly what the
+    // routes will be at the end of the day (some might get disposed).
+    int index = _history.length - 1;
+    _RouteEntry next;
+    _RouteEntry entry = _history[index];
+    _RouteEntry previous = index > 0 ? _history[index - 1] : null;
+    bool canRemove = false;
+    Route<dynamic> poppedRoute; // The route that should trigger didPopNext on the top active route.
+    bool seenTopActiveRoute = false; // Whether we've seen the route that would get didPopNext.
+    final List<_RouteEntry> toBeDisposed = <_RouteEntry>[];
+    while (index >= 0) {
+      switch (entry.currentState) {
+        case _RouteLifecycle.initial:
+        case _RouteLifecycle.push:
+        case _RouteLifecycle.pushReplace:
+        case _RouteLifecycle.replace:
+          entry.handleAddition(
+            navigator: this,
+            previous: previous?.route,
+            previousPresent: _getPresentRouteBefore(index - 1)?.route,
+            isNewFirst: next == null,
+          );
+          assert(entry.currentState != _RouteLifecycle.initial);
+          assert(entry.currentState != _RouteLifecycle.push);
+          assert(entry.currentState != _RouteLifecycle.pushReplace);
+          assert(entry.currentState != _RouteLifecycle.replace);
+          if (entry.currentState == _RouteLifecycle.idle) {
+            continue;
+          }
+          break;
+        case _RouteLifecycle.pushing: // Will exit this state when animation completes.
+          if (!seenTopActiveRoute && poppedRoute != null)
+            entry.handleDidPopNext(poppedRoute);
+          seenTopActiveRoute = true;
+          break;
+        case _RouteLifecycle.idle:
+          if (!seenTopActiveRoute && poppedRoute != null)
+            entry.handleDidPopNext(poppedRoute);
+          seenTopActiveRoute = true;
+          // This route is idle, so we are allowed to remove subsequent (earlier)
+          // routes that are waiting to be removed silently:
+          canRemove = true;
+          break;
+        case _RouteLifecycle.pop:
+          if (!seenTopActiveRoute) {
+            if (poppedRoute != null)
+              entry.handleDidPopNext(poppedRoute);
+            poppedRoute = entry.route;
+          }
+          entry.handlePop(
+            navigator: this,
+            previousPresent: _getPresentRouteBefore(index)?.route,
+          );
+          assert(entry.currentState == _RouteLifecycle.popping);
+          break;
+        case _RouteLifecycle.popping:
+          // Will exit this state when animation completes.
+          break;
+        case _RouteLifecycle.remove:
+          if (!seenTopActiveRoute) {
+            if (poppedRoute != null)
+              entry.route.didPopNext(poppedRoute);
+            poppedRoute = null;
+          }
+          entry.handleRemoval(
+            navigator: this,
+            previousPresent: _getPresentRouteBefore(index)?.route,
+          );
+          assert(entry.currentState == _RouteLifecycle.removing);
+          continue;
+        case _RouteLifecycle.removing:
+          if (!canRemove && next != null) {
+            // We aren't allowed to remove this route yet.
+            break;
+          }
+          entry.currentState = _RouteLifecycle.dispose;
+          continue;
+        case _RouteLifecycle.dispose:
+          // Delay disposal until didChangeNext/didChangePrevious have been sent.
+          toBeDisposed.add(_history.removeAt(index));
+          entry = next;
+          break;
+        case _RouteLifecycle.disposed:
+          assert(false);
+          break;
+      }
+      index -= 1;
+      next = entry;
+      entry = previous;
+      previous = index > 0 ? _history[index - 1] : null;
     }
-    return null;
+    // Now that the list is clean, send the didChangeNext/didChangePrevious
+    // notifications.
+    index = _getPresentIndexBefore(_history.length - 1);
+    entry = null;
+    previous = _history[index];
+    while (index >= 0) {
+      next = entry;
+      entry = previous;
+      index = _getPresentIndexBefore(index - 1);
+      previous = index >= 0 ? _history[index] : null;
+      if (next?.route != entry.lastAnnouncedNextRoute) {
+        if (entry.shouldAnnounceChangeToNext(next?.route)) {
+          entry.route.didChangeNext(next?.route);
+        }
+        entry.lastAnnouncedNextRoute = next?.route;
+      }
+      if (previous?.route != entry.lastAnnouncedPreviousRoute) {
+        entry.route.didChangePrevious(previous?.route);
+        entry.lastAnnouncedPreviousRoute = previous?.route;
+      }
+    }
+    // Lastly, dispose all marked entries.
+    for (_RouteEntry entry in toBeDisposed) {
+      entry.dispose();
+    }
+    overlay?.rearrange(_allRouteOverlayEntries);
   }
 
-  bool _debugLocked = false; // used to prevent re-entrant calls to push, pop, and friends
+  int _getPresentIndexBefore(int index) {
+    while(index > -1 && !_history[index].isPresent) {
+      index--;
+    }
+    return index;
+  }
+
+  _RouteEntry _getPresentRouteBefore(int index) {
+    index = _getPresentIndexBefore(index);
+    return index >= 0 ? _history[index] : null;
+  }
 
   Route<T> _routeNamed<T>(String name, { @required Object arguments, bool allowNull = false }) {
     assert(!_debugLocked);
     assert(name != null);
+    if (allowNull && widget.onGenerateRoute == null)
+      return null;
+    assert(() {
+      if (widget.onGenerateRoute == null) {
+        throw FlutterError(
+          'Navigator.onGenerateRoute was null, but the route named "$name" was referenced.\n'
+          'To use the Navigator API with named routes (pushNamed, pushReplacementNamed, or '
+          'pushNamedAndRemoveUntil), the Navigator must be provided with an '
+          'onGenerateRoute handler.\n'
+          'The Navigator was:\n'
+          '  $this'
+        );
+      }
+      return true;
+    }());
     final RouteSettings settings = RouteSettings(
       name: name,
-      isInitialRoute: _history.isEmpty,
       arguments: arguments,
     );
     Route<T> route = widget.onGenerateRoute(settings);
@@ -1587,9 +2062,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       assert(() {
         if (widget.onUnknownRoute == null) {
           throw FlutterError(
-            'If a Navigator has no onUnknownRoute, then its onGenerateRoute must never return null.\n'
-            'When trying to build the route "$name", onGenerateRoute returned null, but there was no '
-            'onUnknownRoute callback specified.\n'
+            'Navigator.onGenerateRoute returned null when requested to build route "$name".\n'
+            'The onGenerateRoute callback must never return null, unless an onUnknownRoute '
+            'callback is provided as well.\n'
             'The Navigator was:\n'
             '  $this'
           );
@@ -1600,9 +2075,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       assert(() {
         if (route == null) {
           throw FlutterError(
-            'A Navigator\'s onUnknownRoute returned null.\n'
-            'When trying to build the route "$name", both onGenerateRoute and onUnknownRoute returned '
-            'null. The onUnknownRoute callback should never return null.\n'
+            'Navigator.onUnknownRoute returned null when requested to build route "$name".\n'
+            'The onUnknownRoute callback must never return null.\n'
             'The Navigator was:\n'
             '  $this'
           );
@@ -1610,6 +2084,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
         return true;
       }());
     }
+    assert(route != null || allowNull);
     return route;
   }
 
@@ -1737,18 +2212,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(() { _debugLocked = true; return true; }());
     assert(route != null);
     assert(route._navigator == null);
-    final Route<dynamic> oldRoute = _history.isNotEmpty ? _history.last : null;
-    route._navigator = this;
-    route.install(_currentOverlayEntry);
-    _history.add(route);
-    route.didPush();
-    route.didChangeNext(null);
-    if (oldRoute != null) {
-      oldRoute.didChangeNext(route);
-      route.didChangePrevious(oldRoute);
-    }
-    for (NavigatorObserver observer in widget.observers)
-      observer.didPush(route, oldRoute);
+    _history.add(_RouteEntry(route, initialState: _RouteLifecycle.push));
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
     _afterNavigation();
     return route.popped;
@@ -1787,33 +2252,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   Future<T> pushReplacement<T extends Object, TO extends Object>(Route<T> newRoute, { TO result }) {
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; }());
-    final Route<dynamic> oldRoute = _history.last;
-    assert(oldRoute != null && oldRoute._navigator == this);
-    assert(oldRoute.overlayEntries.isNotEmpty);
+    assert(newRoute != null);
     assert(newRoute._navigator == null);
-    assert(newRoute.overlayEntries.isEmpty);
-    final int index = _history.length - 1;
-    assert(index >= 0);
-    assert(_history.indexOf(oldRoute) == index);
-    newRoute._navigator = this;
-    newRoute.install(_currentOverlayEntry);
-    _history[index] = newRoute;
-    newRoute.didPush().whenCompleteOrCancel(() {
-      // The old route's exit is not animated. We're assuming that the
-      // new route completely obscures the old one.
-      if (mounted) {
-        oldRoute
-          ..didComplete(result ?? oldRoute.currentResult)
-          ..dispose();
-      }
-    });
-    newRoute.didChangeNext(null);
-    if (index > 0) {
-      _history[index - 1].didChangeNext(newRoute);
-      newRoute.didChangePrevious(_history[index - 1]);
-    }
-    for (NavigatorObserver observer in widget.observers)
-      observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    assert(_history.isNotEmpty);
+    assert(_history.any(_RouteEntry.isPresentPredicate), 'Navigator has no active routes to replace.');
+    _history.lastWhere(_RouteEntry.isPresentPredicate).complete(result, isReplaced: true);
+    _history.add(_RouteEntry(newRoute, initialState: _RouteLifecycle.pushReplace));
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
     _afterNavigation();
     return newRoute.popped;
@@ -1841,33 +2286,18 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   Future<T> pushAndRemoveUntil<T extends Object>(Route<T> newRoute, RoutePredicate predicate) {
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; }());
-    final List<Route<dynamic>> removedRoutes = <Route<dynamic>>[];
-    while (_history.isNotEmpty && !predicate(_history.last)) {
-      final Route<dynamic> removedRoute = _history.removeLast();
-      assert(removedRoute != null && removedRoute._navigator == this);
-      assert(removedRoute.overlayEntries.isNotEmpty);
-      removedRoutes.add(removedRoute);
-    }
+    assert(newRoute != null);
     assert(newRoute._navigator == null);
-    assert(newRoute.overlayEntries.isEmpty);
-    final Route<dynamic> oldRoute = _history.isNotEmpty ? _history.last : null;
-    newRoute._navigator = this;
-    newRoute.install(_currentOverlayEntry);
-    _history.add(newRoute);
-    newRoute.didPush().whenCompleteOrCancel(() {
-      if (mounted) {
-        for (Route<dynamic> route in removedRoutes)
-          route.dispose();
-      }
-    });
-    newRoute.didChangeNext(null);
-    if (oldRoute != null)
-      oldRoute.didChangeNext(newRoute);
-    for (NavigatorObserver observer in widget.observers) {
-      observer.didPush(newRoute, oldRoute);
-      for (Route<dynamic> removedRoute in removedRoutes)
-        observer.didRemove(removedRoute, oldRoute);
+    assert(predicate != null);
+    int index = _history.length - 1;
+    _history.add(_RouteEntry(newRoute, initialState: _RouteLifecycle.push));
+    while (index >= 0) {
+      final _RouteEntry entry = _history[index];
+      if (entry.isPresent && !predicate(entry.route))
+        _history[index].remove();
+      index -= 1;
     }
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
     _afterNavigation();
     return newRoute.popped;
@@ -1884,36 +2314,21 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   @optionalTypeArgs
   void replace<T extends Object>({ @required Route<dynamic> oldRoute, @required Route<T> newRoute }) {
     assert(!_debugLocked);
-    assert(oldRoute != null);
-    assert(newRoute != null);
-    if (oldRoute == newRoute)
-      return;
     assert(() { _debugLocked = true; return true; }());
+    assert(oldRoute != null);
     assert(oldRoute._navigator == this);
+    assert(newRoute != null);
     assert(newRoute._navigator == null);
-    assert(oldRoute.overlayEntries.isNotEmpty);
-    assert(newRoute.overlayEntries.isEmpty);
-    assert(!overlay.debugIsVisible(oldRoute.overlayEntries.last));
-    final int index = _history.indexOf(oldRoute);
-    assert(index >= 0);
-    newRoute._navigator = this;
-    newRoute.install(oldRoute.overlayEntries.last);
-    _history[index] = newRoute;
-    newRoute.didReplace(oldRoute);
-    if (index + 1 < _history.length) {
-      newRoute.didChangeNext(_history[index + 1]);
-      _history[index + 1].didChangePrevious(newRoute);
-    } else {
-      newRoute.didChangeNext(null);
-    }
-    if (index > 0) {
-      _history[index - 1].didChangeNext(newRoute);
-      newRoute.didChangePrevious(_history[index - 1]);
-    }
-    for (NavigatorObserver observer in widget.observers)
-      observer.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    oldRoute.dispose();
+    final int index = _history.indexWhere(_RouteEntry.isRoutePredicate(oldRoute));
+    assert(index >= 0, 'This Navigator does not contain the specified oldRoute.');
+    assert(_history[index].isPresent, 'The specified oldRoute has already been removed from the Navigator.');
+    final bool wasCurrent = oldRoute.isCurrent;
+    _history.insert(index + 1, _RouteEntry(newRoute, initialState: _RouteLifecycle.replace));
+    _history[index].remove(isReplaced: true);
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
+    if (wasCurrent)
+      _afterNavigation();
   }
 
   /// Replaces a route on the navigator with a new route. The route to be
@@ -1926,11 +2341,27 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   ///  * [replace], which is the same but identifies the route to be removed
   ///    directly.
   @optionalTypeArgs
-  void replaceRouteBelow<T extends Object>({ @required Route<dynamic> anchorRoute, Route<T> newRoute }) {
+  void replaceRouteBelow<T extends Object>({ @required Route<dynamic> anchorRoute, @required Route<T> newRoute }) {
+    assert(!_debugLocked);
+    assert(() { _debugLocked = true; return true; }());
     assert(anchorRoute != null);
     assert(anchorRoute._navigator == this);
-    assert(_history.indexOf(anchorRoute) > 0);
-    replace<T>(oldRoute: _history[_history.indexOf(anchorRoute) - 1], newRoute: newRoute);
+    assert(newRoute != null);
+    assert(newRoute._navigator == null);
+    final int anchorIndex = _history.indexWhere(_RouteEntry.isRoutePredicate(anchorRoute));
+    assert(anchorIndex >= 0, 'This Navigator does not contain the specified anchorRoute.');
+    assert(_history[anchorIndex].isPresent, 'The specified anchorRoute has already been removed from the Navigator.');
+    int index = anchorIndex - 1;
+    while (index >= 0) {
+      if (_history[index].isPresent)
+        break;
+      index -= 1;
+    }
+    assert(index >= 0, 'There are no routes below the specified anchorRoute.');
+    _history.insert(index + 1, _RouteEntry(newRoute, initialState: _RouteLifecycle.replace));
+    _history[index].remove(isReplaced: true);
+    _flushHistoryUpdates();
+    assert(() { _debugLocked = false; return true; }());
   }
 
   /// Whether the navigator can be popped.
@@ -1942,12 +2373,19 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   ///  * [Route.isFirst], which returns true for routes for which [canPop]
   ///    returns false.
   bool canPop() {
-    assert(_history.isNotEmpty);
-    return _history.length > 1 || _history[0].willHandlePopInternally;
+    final Iterator<_RouteEntry> iterator = _history.where(_RouteEntry.isPresentPredicate).iterator;
+    if (!iterator.moveNext())
+      return false; // we have no active routes, so we can't pop
+    if (iterator.current.route.willHandlePopInternally)
+      return true; // the first route can handle pops itself, so we can pop
+    if (!iterator.moveNext())
+      return false; // there's only one route, so we can't pop
+    return true; // there's at least two routes, so we can pop
   }
 
-  /// Returns the value of the current route's [Route.willPop] method for the
-  /// navigator.
+  /// Consults the current route's [Route.willPop] method, and acts accordingly,
+  /// potentially popping the route as a result; returns whether the pop request
+  /// should be considered handled.
   ///
   /// {@macro flutter.widgets.navigator.maybePop}
   ///
@@ -1957,17 +2395,28 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   ///    to veto a [pop] initiated by the app's back button.
   ///  * [ModalRoute], which provides a `scopedWillPopCallback` that can be used
   ///    to define the route's `willPop` method.
-  @optionalTypeArgs
   Future<bool> maybePop<T extends Object>([ T result ]) async {
-    final Route<T> route = _history.last;
-    assert(route._navigator == this);
-    final RoutePopDisposition disposition = await route.willPop();
-    if (disposition != RoutePopDisposition.bubble && mounted) {
-      if (disposition == RoutePopDisposition.pop)
+    final _RouteEntry lastEntry = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
+    if (lastEntry == null)
+      return false;
+    assert(lastEntry.route._navigator == this);
+    final RoutePopDisposition disposition = await lastEntry.route.willPop(); // this is asynchronous
+    assert(disposition != null);
+    if (!mounted)
+      return true; // forget about this pop, we were disposed in the meantime
+    final _RouteEntry newLastEntry = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
+    if (lastEntry != newLastEntry)
+      return true; // forget about this pop, something happened to our history in the meantime
+    switch (disposition) {
+      case RoutePopDisposition.bubble:
+        return false;
+      case RoutePopDisposition.pop:
         pop(result);
-      return true;
+        return true;
+      case RoutePopDisposition.doNotPop:
+        return true;
     }
-    return false;
+    return null;
   }
 
   /// Pop the top-most route off the navigator.
@@ -1995,35 +2444,19 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// ```
   /// {@end-tool}
   @optionalTypeArgs
-  bool pop<T extends Object>([ T result ]) {
+  void pop<T extends Object>([ T result ]) {
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; }());
-    final Route<dynamic> route = _history.last;
-    assert(route._navigator == this);
-    bool debugPredictedWouldPop;
-    assert(() { debugPredictedWouldPop = !route.willHandlePopInternally; return true; }());
-    if (route.didPop(result ?? route.currentResult)) {
-      assert(debugPredictedWouldPop);
-      if (_history.length > 1) {
-        _history.removeLast();
-        // If route._navigator is null, the route called finalizeRoute from
-        // didPop, which means the route has already been disposed and doesn't
-        // need to be added to _poppedRoutes for later disposal.
-        if (route._navigator != null)
-          _poppedRoutes.add(route);
-        _history.last.didPopNext(route);
-        for (NavigatorObserver observer in widget.observers)
-          observer.didPop(route, _history.last);
-      } else {
-        assert(() { _debugLocked = false; return true; }());
-        return false;
-      }
-    } else {
-      assert(!debugPredictedWouldPop);
+    final _RouteEntry entry = _history.lastWhere(_RouteEntry.isPresentPredicate);
+    entry.pop<T>(result);
+    if (entry.currentState == _RouteLifecycle.pop) {
+      // Flush the history if the route actually wants to be popped (the pop
+      // wasn't handled internally).
+      _flushHistoryUpdates();
+      assert(entry.route._popCompleter.isCompleted);
     }
     assert(() { _debugLocked = false; return true; }());
     _afterNavigation();
-    return true;
   }
 
   /// Calls [pop] repeatedly until the predicate returns true.
@@ -2041,30 +2474,27 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// ```
   /// {@end-tool}
   void popUntil(RoutePredicate predicate) {
-    while (!predicate(_history.last))
+    while (!predicate(_history.lastWhere(_RouteEntry.isPresentPredicate).route)) {
       pop();
+    }
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.
   ///
   /// {@macro flutter.widgets.navigator.removeRoute}
   void removeRoute(Route<dynamic> route) {
-    assert(route != null);
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; }());
+    assert(route != null);
     assert(route._navigator == this);
-    final int index = _history.indexOf(route);
-    assert(index != -1);
-    final Route<dynamic> previousRoute = index > 0 ? _history[index - 1] : null;
-    final Route<dynamic> nextRoute = (index + 1 < _history.length) ? _history[index + 1] : null;
-    _history.removeAt(index);
-    previousRoute?.didChangeNext(nextRoute);
-    nextRoute?.didChangePrevious(previousRoute);
-    for (NavigatorObserver observer in widget.observers)
-      observer.didRemove(route, previousRoute);
-    route.dispose();
+    final bool wasCurrent = route.isCurrent;
+    final _RouteEntry entry = _history.firstWhere(_RouteEntry.isRoutePredicate(route), orElse: () => null);
+    assert(entry != null);
+    entry.remove();
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
-    _afterNavigation();
+    if (wasCurrent)
+      _afterNavigation();
   }
 
   /// Immediately remove a route from the navigator, and [Route.dispose] it. The
@@ -2074,20 +2504,20 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   void removeRouteBelow(Route<dynamic> anchorRoute) {
     assert(!_debugLocked);
     assert(() { _debugLocked = true; return true; }());
+    assert(anchorRoute != null);
     assert(anchorRoute._navigator == this);
-    final int index = _history.indexOf(anchorRoute) - 1;
-    assert(index >= 0);
-    final Route<dynamic> targetRoute = _history[index];
-    assert(targetRoute._navigator == this);
-    assert(targetRoute.overlayEntries.isEmpty || !overlay.debugIsVisible(targetRoute.overlayEntries.last));
-    _history.removeAt(index);
-    final Route<dynamic> nextRoute = index < _history.length ? _history[index] : null;
-    final Route<dynamic> previousRoute = index > 0 ? _history[index - 1] : null;
-    if (previousRoute != null)
-      previousRoute.didChangeNext(nextRoute);
-    if (nextRoute != null)
-      nextRoute.didChangePrevious(previousRoute);
-    targetRoute.dispose();
+    final int anchorIndex = _history.indexWhere(_RouteEntry.isRoutePredicate(anchorRoute));
+    assert(anchorIndex >= 0, 'This Navigator does not contain the specified anchorRoute.');
+    assert(_history[anchorIndex].isPresent, 'The specified anchorRoute has already been removed from the Navigator.');
+    int index = anchorIndex - 1;
+    while (index >= 0) {
+      if (_history[index].isPresent)
+        break;
+      index -= 1;
+    }
+    assert(index >= 0, 'There are no routes below the specified anchorRoute.');
+    _history[index].remove();
+    _flushHistoryUpdates();
     assert(() { _debugLocked = false; return true; }());
   }
 
@@ -2103,8 +2533,23 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// This function may be called directly from [Route.didPop] if [Route.didPop]
   /// will return true.
   void finalizeRoute(Route<dynamic> route) {
-    _poppedRoutes.remove(route);
-    route.dispose();
+    // FinalizeRoute may have been called while we were already locked as a
+    // responds to route.didPop(). Make sure to leave in the state we were in
+    // before the call.
+    bool wasDebugLocked;
+    assert(() { wasDebugLocked = _debugLocked; _debugLocked = true; return true; }());
+    assert(_history.where(_RouteEntry.isRoutePredicate(route)).length == 1);
+    final _RouteEntry entry =  _history.firstWhere(_RouteEntry.isRoutePredicate(route));
+    if (entry.doingPop) {
+      // We were called synchronously from Route.didPop(), but didn't process
+      // the pop yet. Let's do that now before finalizing.
+      entry.currentState = _RouteLifecycle.pop;
+      _flushHistoryUpdates();
+    }
+    assert(entry.currentState != _RouteLifecycle.pop);
+    entry.finalize();
+    _flushHistoryUpdates();
+    assert(() { _debugLocked = wasDebugLocked; return true; }());
   }
 
   /// Whether a route is currently being manipulated by the user, e.g.
@@ -2120,13 +2565,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   void didStartUserGesture() {
     _userGesturesInProgress += 1;
     if (_userGesturesInProgress == 1) {
-      final Route<dynamic> route = _history.last;
-      final Route<dynamic> previousRoute = !route.willHandlePopInternally && _history.length > 1
-          ? _history[_history.length - 2]
-          : null;
-      // Don't operate the _history list since the gesture may be cancelled.
-      // In case of a back swipe, the gesture controller will call .pop() itself.
-
+      final int routeIndex = _getPresentIndexBefore(_history.length - 1);
+      assert(routeIndex != null);
+      final Route<dynamic> route = _history[routeIndex].route;
+      Route<dynamic> previousRoute;
+      if (!route.willHandlePopInternally && routeIndex > 0) {
+        previousRoute = _getPresentRouteBefore(routeIndex - 1).route;
+      }
       for (NavigatorObserver observer in widget.observers)
         observer.didStartUserGesture(route, previousRoute);
     }
@@ -2186,7 +2631,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           autofocus: true,
           child: Overlay(
             key: _overlayKey,
-            initialEntries: _initialOverlayEntries,
+            initialEntries: overlay == null ?  _allRouteOverlayEntries.toList(growable: false) : const <OverlayEntry>[],
           ),
         ),
       ),

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -371,7 +371,10 @@ abstract class Route<T> {
   bool get isActive {
     if (_navigator == null)
       return false;
-    return _navigator._history.firstWhere(_RouteEntry.isRoutePredicate(this)).isPresent;
+    return _navigator._history.firstWhere(
+      _RouteEntry.isRoutePredicate(this),
+      orElse: () => null,
+    )?.isPresent == true;
   }
 }
 
@@ -1898,6 +1901,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       entry.dispose();
     super.dispose();
     // don't unlock, so that the object becomes unusable
+    assert(_debugLocked);
   }
 
   void _flushHistoryUpdates() {
@@ -2416,6 +2420,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       case RoutePopDisposition.doNotPop:
         return true;
     }
+    assert(false, 'unreachable');
     return null;
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2420,7 +2420,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       case RoutePopDisposition.doNotPop:
         return true;
     }
-    assert(false, 'unreachable');
     return null;
   }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -86,8 +86,8 @@ class OverlayEntry {
     if (_opaque == value)
       return;
     _opaque = value;
-    assert(_overlay != null);
-    _overlay._didChangeEntryOpacity();
+    if (_overlay != null)
+      _overlay._didChangeEntryOpacity();
   }
 
   /// Whether this entry must be included in the tree even if there is a fully

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -34,14 +34,6 @@ abstract class PageRoute<T> extends ModalRoute<T> {
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) => previousRoute is PageRoute;
-
-  @override
-  AnimationController createAnimationController() {
-    final AnimationController controller = super.createAnimationController();
-    if (settings.isInitialRoute)
-      controller.value = 1.0;
-    return controller;
-  }
 }
 
 Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -239,10 +239,11 @@ void main() {
       )
     );
 
-    expect(find.text('route "/"'), findsOneWidget);
+    expect(find.text('route "/"', skipOffstage: false), findsOneWidget);
+    expect(find.text('route "/"'), findsNothing);
     expect(find.text('route "/a"'), findsOneWidget);
-    expect(find.text('route "/a/b"'), findsNothing);
-    expect(find.text('route "/b"'), findsNothing);
+    expect(find.text('route "/a/b"', skipOffstage: false), findsNothing);
+    expect(find.text('route "/b"', skipOffstage: false), findsNothing);
   });
 
   testWidgets('Return value from pop is correct', (WidgetTester tester) async {
@@ -299,10 +300,12 @@ void main() {
         routes: routes,
       )
     );
-    expect(find.text('route "/"'), findsOneWidget);
-    expect(find.text('route "/a"'), findsOneWidget);
+    expect(find.text('route "/"'), findsNothing);
+    expect(find.text('route "/"', skipOffstage: false), findsOneWidget);
+    expect(find.text('route "/a"'), findsNothing);
+    expect(find.text('route "/a"', skipOffstage: false), findsOneWidget);
     expect(find.text('route "/a/b"'), findsOneWidget);
-    expect(find.text('route "/b"'), findsNothing);
+    expect(find.text('route "/b"', skipOffstage: false), findsNothing);
   });
 
   testWidgets('Initial route with missing step', (WidgetTester tester) async {
@@ -341,9 +344,10 @@ void main() {
         routes: routes,
       )
     );
-    expect(find.text('route "/"'), findsOneWidget);
+    expect(find.text('route "/"'), findsNothing);
+    expect(find.text('route "/"', skipOffstage: false), findsOneWidget);
     expect(find.text('route "/a"'), findsOneWidget);
-    expect(find.text('route "/b"'), findsNothing);
+    expect(find.text('route "/b"', skipOffstage: false), findsNothing);
 
     // changing initialRoute has no effect
     await tester.pumpWidget(
@@ -352,15 +356,17 @@ void main() {
         routes: routes,
       )
     );
-    expect(find.text('route "/"'), findsOneWidget);
+    expect(find.text('route "/"'), findsNothing);
+    expect(find.text('route "/"', skipOffstage: false), findsOneWidget);
     expect(find.text('route "/a"'), findsOneWidget);
-    expect(find.text('route "/b"'), findsNothing);
+    expect(find.text('route "/b"', skipOffstage: false), findsNothing);
 
     // removing it has no effect
     await tester.pumpWidget(MaterialApp(routes: routes));
-    expect(find.text('route "/"'), findsOneWidget);
+    expect(find.text('route "/"'), findsNothing);
+    expect(find.text('route "/"', skipOffstage: false), findsOneWidget);
     expect(find.text('route "/a"'), findsOneWidget);
-    expect(find.text('route "/b"'), findsNothing);
+    expect(find.text('route "/b"', skipOffstage: false), findsNothing);
   });
 
   testWidgets('onGenerateRoute / onUnknownRoute', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1448,7 +1448,7 @@ void main() {
       routes: routes,
       initialRoute: '/two',
     ));
-    expect(find.text('two'), findsOneWidget);
+    expect(find.text('three'), findsOneWidget);
   });
 
   testWidgets('Can push/pop on outer Navigator if nested Navigator contains Heroes', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -27,16 +27,15 @@ class TestRoute extends Route<String> with LocalHistoryRoute<String> {
   }
 
   @override
-  void install(OverlayEntry insertionPoint) {
+  void install({ bool isInitialRoute = false }) {
     log('install');
     final OverlayEntry entry = OverlayEntry(
       builder: (BuildContext context) => Container(),
       opaque: true,
     );
     _entries.add(entry);
-    navigator.overlay?.insert(entry, above: insertionPoint);
     routes.add(this);
-    super.install(insertionPoint);
+    super.install(isInitialRoute: isInitialRoute);
   }
 
   @override
@@ -109,10 +108,6 @@ void main() {
     expect(settings, hasOneLineDescription);
     final RouteSettings settings2 = settings.copyWith(name: 'B');
     expect(settings2.name, 'B');
-    expect(settings2.isInitialRoute, false);
-    final RouteSettings settings3 = settings2.copyWith(isInitialRoute: true);
-    expect(settings3.name, 'B');
-    expect(settings3.isInitialRoute, true);
   });
 
   testWidgets('Route settings arguments', (WidgetTester tester) async {
@@ -132,7 +127,7 @@ void main() {
     expect(settings4.arguments, isNot(same(arguments)));
   });
 
-  testWidgets('Route management - push, replace, pop', (WidgetTester tester) async {
+  testWidgets('Route management - push, replace, pop sequence', (WidgetTester tester) async {
     final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
     await tester.pumpWidget(
       Directionality(
@@ -159,7 +154,7 @@ void main() {
       tester,
       host,
       () { host.push(second = TestRoute('second')); },
-      <String>[
+      <String>[ // stack is: initial, second
         'second: install',
         'second: didPush',
         'second: didChangeNext null',
@@ -170,7 +165,7 @@ void main() {
       tester,
       host,
       () { host.push(TestRoute('third')); },
-      <String>[
+      <String>[ // stack is: initial, second, third
         'third: install',
         'third: didPush',
         'third: didChangeNext null',
@@ -181,7 +176,7 @@ void main() {
       tester,
       host,
       () { host.replace(oldRoute: second, newRoute: TestRoute('two')); },
-      <String>[
+      <String>[ // stack is: initial, two, third
         'two: install',
         'two: didReplace second',
         'two: didChangeNext third',
@@ -193,20 +188,20 @@ void main() {
       tester,
       host,
       () { host.pop('hello'); },
-      <String>[
+      <String>[ // stack is: initial, two
         'third: didPop hello',
-        'third: dispose',
         'two: didPopNext third',
+        'third: dispose',
       ],
     );
     await runNavigatorTest(
       tester,
       host,
       () { host.pop('good bye'); },
-      <String>[
+      <String>[ // stack is: initial
         'two: didPop good bye',
-        'two: dispose',
         'initial: didPopNext two',
+        'two: dispose',
       ],
     );
     await tester.pumpWidget(Container());
@@ -274,8 +269,8 @@ void main() {
       () { host.pop('good bye'); },
       <String>[
         'third: didPop good bye',
-        'third: dispose',
         'second: didPopNext third',
+        'third: dispose',
       ],
     );
     await runNavigatorTest(
@@ -316,8 +311,8 @@ void main() {
       () { host.pop('the end'); },
       <String>[
         'four: didPop the end',
-        'four: dispose',
         'second: didPopNext four',
+        'four: dispose',
       ],
     );
     await tester.pumpWidget(Container());
@@ -391,8 +386,8 @@ void main() {
       () { host.popUntil((Route<dynamic> route) => route == routeB); },
       <String>[
         'C: didPop null',
-        'C: dispose',
         'b: didPopNext C',
+        'C: dispose',
       ],
     );
     await tester.pumpWidget(Container());


### PR DESCRIPTION
This is a four part change:
1. https://github.com/flutter/flutter/pull/28747: Improves the Overlay API
2. (This change): refactors the Navigator's imperative API in preparation for part 3
3. (coming soon): Adds `Page`s to the Navigator
4. (coming soon): Adds a new `Router` widget

## Description

This change prepares the `Navigator` for the upcoming introduction of `Page`s, that can be used to declaratively set the content of the Navigator's history. This change moves the Navigator's imperative API (`push`, `pop`, `remove`, and friends) over to a model that will continue to work in that new world.

It also introduces a new callback `onGenerateInitialRoutes` on the Navigator, which can be used to change how the Navigator generates the initial Routes based on the `initialRoute` property.

The PR also contains clarifications to existing documentation and fixes some bugs:

* Routes generated from `initialRoute` will now correctly be marked as offstage when they are covered by an opaque route.
* Fixes https://github.com/flutter/flutter/issues/25080
* Fixes https://github.com/flutter/flutter/issues/16602
* Fixes https://github.com/flutter/flutter/issues/4172

## Related Issues

See above.

## Tests

I added the following tests:

* Ensure that `onGenerateInitialRoutes` is used correctly
* Ensure that routes pushed as part of `initialRoute` processing are marked offstage when covered by opaque routes
* Regression test for https://github.com/flutter/flutter/issues/25080.
* Regression tests for https://github.com/flutter/flutter/issues/16602.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]):

* `Route.install` is no longer responsible for adding entries to the Navigator's overlay. The Navigator is responsible for this now. Therefore, `Route.install` will no longer be provided with a `overlayInsertionPoint`. Instead, it will get a boolean indicating if the route is an initial route, which the route may use to disable any entrance animations.
* For the same reasons outlined above, `TransitionRoute.createAnimationController` now takes a bool indicating if the Route is an initial route.
* `RouteSettings` no longer has an `initialRoute` property.
* `Navigator.pop` no longer returns a boolean, it's a void function now.
* A route is always disposed *after* all notifications concerning the route are sent to neighboring routes. Previously, sometimes the route would get disposed before these notifications have been sent.

A request for comment on those suggested breaking changes will be send out before this PR is considered for submission and after I've determined that part 3 of this endeavor doesn't require further breaking changes.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
