### PR TITLE
Added assert to prevent complete ListTile trailing/leading horizontal expansion

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -165,8 +165,8 @@ enum ListTileControlAffinity {
 /// wraps to two lines (if it is true).
 ///
 /// The heights of the [leading] and [trailing] widgets are constrained
-/// according to the [Material spec]
-/// (https://material.io/design/components/lists.html).
+/// according to the
+/// [Material spec](https://material.io/design/components/lists.html).
 /// An exception is made for one-line ListTiles for accessibility. Please
 /// see the example below to see how to adhere to both Material spec and
 /// accessibility requirements.
@@ -221,12 +221,12 @@ enum ListTileControlAffinity {
 /// that are large enough, but it is up to the developer to ensure that
 /// their widgets follow the Material spec.
 ///
-/// The following is an example of a one-line, non-[dense] ListTile with a
+/// {@tool sample}
+///
+/// Here is an example of a one-line, non-[dense] ListTile with a
 /// tappable leading widget that adheres to accessibility requirements and
 /// the Material spec. To adjust the use case below for a one-line, [dense]
 /// ListTile, adjust the vertical padding to 8.0.
-///
-/// {@tool sample}
 ///
 /// ```dart
 /// ListTile(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -984,6 +984,14 @@ class _RenderListTile extends RenderBox {
     final double tileWidth = looseConstraints.maxWidth;
     final Size leadingSize = _layoutBox(leading, iconConstraints);
     final Size trailingSize = _layoutBox(trailing, iconConstraints);
+    assert(
+      tileWidth != leadingSize.width,
+      'Leading widget consumes entire tile width. Please use a sized widget.'
+    );
+    assert(
+      tileWidth != trailingSize.width,
+      'Trailing widget consumes entire tile width. Please use a sized widget.'
+    );
 
     final double titleStart = hasLeading
       ? math.max(_minLeadingWidth, leadingSize.width) + _horizontalTitleGap

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -171,6 +171,9 @@ enum ListTileControlAffinity {
 /// see the example below to see how to adhere to both Material spec and
 /// accessibility requirements.
 ///
+/// Note that [leading] and [trailing] widgets can expand as far as they wish
+/// horizontally, so ensure that they are properly constrained.
+///
 /// List tiles are typically used in [ListView]s, or arranged in [Column]s in
 /// [Drawer]s and [Card]s.
 ///


### PR DESCRIPTION
## Description

Added an assert statement for when `leading` or `trailing` widgets are trying to take up the entire `ListTile` width. I also tweaked the documentation a little since it was formatting incorrectly on the master API documentation.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/17666

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
