### PR TITLE
Simplify logic of TapGestureRecognizer

### DIFF
--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -172,6 +172,9 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void handlePrimaryPointer(PointerEvent event) {
     if (event is PointerUpEvent) {
       _finalPosition = event.position;
+      if (_wonArenaForPrimaryPointer) {
+        resolve(GestureDisposition.accepted);
+      }
       _checkUp();
     } else if (event is PointerCancelEvent) {
       if (_sentTapDown && onTapCancel != null) {
@@ -231,15 +234,6 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
 
   void _checkUp() {
     if (_wonArenaForPrimaryPointer && _finalPosition != null) {
-      resolve(GestureDisposition.accepted);
-      if (!_wonArenaForPrimaryPointer || _finalPosition == null) {
-        // It is possible that resolve has just recursively called _checkUp
-        // (see https://github.com/flutter/flutter/issues/12470).
-        // In that case _wonArenaForPrimaryPointer will be false (as _checkUp
-        // calls _reset) and we return here to avoid double invocation of the
-        // tap callbacks.
-        return;
-      }
       if (onTapUp != null)
         invokeCallback<void>('onTapUp', () { onTapUp(TapUpDetails(globalPosition: _finalPosition)); });
       if (onTap != null)

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -174,8 +174,8 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
       _finalPosition = event.position;
       if (_wonArenaForPrimaryPointer) {
         resolve(GestureDisposition.accepted);
+        _checkUp();
       }
-      _checkUp();
     } else if (event is PointerCancelEvent) {
       if (_sentTapDown && onTapCancel != null) {
         invokeCallback<void>('onTapCancel', onTapCancel);
@@ -233,7 +233,7 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
   }
 
   void _checkUp() {
-    if (_wonArenaForPrimaryPointer && _finalPosition != null) {
+    if (_finalPosition != null) {
       if (onTapUp != null)
         invokeCallback<void>('onTapUp', () { onTapUp(TapUpDetails(globalPosition: _finalPosition)); });
       if (onTap != null)


### PR DESCRIPTION
## Description
Currently, `_checkUp` calls `resolve(accept)` while `resolve(accept)` might also call `_checkUp`, which makes logic much harder to understand as well as causing a bug.

This PR refactors the logic and makes the calling dependency unidirectional.

## Related Issues

N/A

## Tests

No tests are added or changed. This PR does not change behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
