### PR TITLE
Make heroes fly on pushReplacement

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -619,10 +619,9 @@ class HeroController extends NavigatorObserver {
   }
 
   @override
-  void didReplace({ @required Route<dynamic> newRoute, Route<dynamic> oldRoute }) {
+  void didReplace({ Route<dynamic> newRoute, Route<dynamic> oldRoute }) {
     assert(navigator != null);
-    assert(newRoute != null);
-    if (newRoute.isCurrent) {
+    if (newRoute?.isCurrent == true) {
       // Only run hero animations if top-most route got replaced.
       _maybeStartHeroTransition(oldRoute, newRoute, HeroFlightDirection.push, false);
     }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -622,7 +622,7 @@ class HeroController extends NavigatorObserver {
   void didReplace({ Route<dynamic> newRoute, Route<dynamic> oldRoute }) {
     assert(navigator != null);
     if (newRoute?.isCurrent == true) {
-      // Only run hero animations if top-most route got replaced.
+      // Only run hero animations if the top-most route got replaced.
       _maybeStartHeroTransition(oldRoute, newRoute, HeroFlightDirection.push, false);
     }
   }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -619,6 +619,16 @@ class HeroController extends NavigatorObserver {
   }
 
   @override
+  void didReplace({ @required Route<dynamic> newRoute, Route<dynamic> oldRoute }) {
+    assert(navigator != null);
+    assert(newRoute != null);
+    if (newRoute.isCurrent) {
+      // Only run hero animations if top-most route got replaced.
+      _maybeStartHeroTransition(oldRoute, newRoute, HeroFlightDirection.push, false);
+    }
+  }
+
+  @override
   void didStartUserGesture(Route<dynamic> route, Route<dynamic> previousRoute) {
     assert(navigator != null);
     assert(route != null);


### PR DESCRIPTION
## Description

Before this change Heroes wouldn't fly when `Navigator.pushReplacement` was used because it triggered `NavigatorObserver.didReplace`, which was unimplemented by the HeroController.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28041.

## Tests

I added the following tests:

* Added a regression test for https://github.com/flutter/flutter/issues/28041.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
