### PR TITLE
Warn on uncomitted changes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -67,6 +67,17 @@ class UpgradeCommandRunner {
         );
       }
     }
+    // If there are uncomitted changes we might be on the right commit but
+    // we should still warn.
+    if (!force && await hasUncomittedChanges()) {
+      throwToolExit(
+        'Your flutter checkout has local changes that would be erased by '
+        'upgrading. If you want to keep these changes, it is recommended that '
+        'you stash them via "git stash" or else commit the changes to a local '
+        'branch. If it is okay to remove local changes, then re-run this '
+        'command with --force.'
+      );
+    }
     await resetChanges(gitTagVersion);
     await upgradeChannel(flutterVersion);
     await attemptFastForward();
@@ -74,6 +85,18 @@ class UpgradeCommandRunner {
     await updatePackages(flutterVersion);
     await runDoctor();
     return null;
+  }
+
+  Future<bool> hasUncomittedChanges() async {
+    try {
+      final RunResult result = await runCheckedAsync(<String>[
+        'git', 'status', '-s'
+      ], workingDirectory: Cache.flutterRoot);
+      return result.stdout.trim().isNotEmpty;
+    } catch (e) {
+      throwToolExit('git status failed: $e');
+    }
+    return false;
   }
 
   /// Check if there is an upstream repository configured.


### PR DESCRIPTION
## Description

In case the user has modified by not commited anything to the local branch.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

## Tests

I added the following tests:

- throws tool exit with uncommited change
- does not throw tool exit with uncommited changes and force

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
