### PR TITLE
Fix dartdoc

### DIFF
--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -112,7 +112,7 @@ class SawTooth extends Curve {
 }
 
 /// A curve that is 0.0 until [begin], then curved (according to [curve] from
-/// 0.0 to 1.0 at [end], then 1.0.
+/// 0.0 to 1.0) at [end], then 1.0.
 ///
 /// An [Interval] can be used to delay an animation. For example, a six second
 /// animation that uses an [Interval] with its [begin] set to 0.5 and its [end]


### PR DESCRIPTION

added ')'

is this right position? I'm not good at English.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
