### PR TITLE
Fix missing 'const' modifier for BorderRadius.circular factory

### DIFF
--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -289,7 +289,7 @@ class BorderRadius extends BorderRadiusGeometry {
   );
 
   /// Creates a border radius where all radii are [Radius.circular(radius)].
-  BorderRadius.circular(double radius) : this.all(
+  const BorderRadius.circular(double radius) : this.all(
     Radius.circular(radius),
   );
 


### PR DESCRIPTION
`BorderRadius.circular` factory is missing const modifier (unlike `.all`, `.vertical`, etc)

