### PR TITLE
Fix return type of _createErrorWidget in sliver.dart

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1287,8 +1287,8 @@ class KeepAlive extends ParentDataWidget<SliverWithKeepAliveWidget> {
   }
 }
 
-// Return an ErrorWidget for the given Exception
-ErrorWidget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
+// Return an Widget for the given Exception
+Widget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
   final FlutterErrorDetails details = FlutterErrorDetails(
     exception: exception,
     stack: stackTrace,


### PR DESCRIPTION
## Description

Avoid to throw 'not a subtype of type' exception when use custom error widget and sliver. 

## Related Issues

No issues involved.

## Tests

I have not added any tests!

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
 