### PR TITLE
[WIP] PoC Flutter plugins iOS integration tests Cirrus task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,14 @@ task:
       container:
         cpu: 4
         memory: 12G
-
+      - name: plugins_tests-linux
+        env:
+          SHARD: plugins_tests
+        activate_script: pub global activate flutter_plugin_tools
+        test_script:
+          - git clone https://github.com/flutter/plugins.git
+          - cd plugins
+          - ./script/incremental_build.sh test
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -257,7 +257,7 @@ docker_builder:
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  name: build-ipas+drive-examples
+  name: plugins-ios-integration-tests
   osx_instance:
     image: mojave-xcode-10.1
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -256,6 +256,28 @@ docker_builder:
   push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
 
 task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  container:
+    dockerfile: .ci/Dockerfile
+    cpu: 8
+    memory: 16G
+  setup_script:
+  - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
+  - git clone https://github.com/flutter/plugins.git
+  upgrade_script:
+  - cd plugins
+  - git pull
+  activate_script: pub global activate flutter_plugin_tools
+  matrix:
+  - name: plugins-unit-tests
+    install_script:
+    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
+    - sudo apt-get update
+    - sudo apt-get install -y --allow-unauthenticated clang-format-7
+    test_script: ./script/incremental_build.sh test
+
+task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   name: plugins-ios-integration-tests
   osx_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -254,3 +254,34 @@ docker_builder:
   build_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_build.sh"
   login_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_login.sh"
   push_script: "$CIRRUS_WORKING_DIR/dev/ci/docker_linux/docker_push.sh"
+
+task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  name: build-ipas+drive-examples
+  osx_instance:
+    image: mojave-xcode-10.1
+  env:
+    PATH: $PATH:/usr/local/bin
+    matrix:
+      PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
+    SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
+  setup_script:
+  - brew update
+  - brew install libimobiledevice
+  - brew install ideviceinstaller
+  - brew install ios-deploy
+  - pod repo update
+  - git clone https://github.com/flutter/plugins.git
+  - git fetch origin master
+  - export PATH=`pwd`/bin:`pwd`/bin/cache/dart-sdk/bin:$PATH
+  - flutter doctor
+  - pub global activate flutter_plugin_tools
+  - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-1 | xargs xcrun simctl boot
+  build_script:
+  - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
+  - cd plugins
+  - ./script/incremental_build.sh build-examples --ipa
+  - ./script/incremental_build.sh drive-examples

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,14 +89,14 @@ task:
       container:
         cpu: 4
         memory: 12G
-      - name: plugins_tests-linux
-        env:
-          SHARD: plugins_tests
-        activate_script: pub global activate flutter_plugin_tools
-        test_script:
-          - git clone https://github.com/flutter/plugins.git
-          - cd plugins
-          - ./script/incremental_build.sh test
+    - name: plugins_tests-linux
+      env:
+        SHARD: plugins_tests
+      activate_script: pub global activate flutter_plugin_tools
+      test_script:
+        - git clone https://github.com/flutter/plugins.git
+        - cd plugins
+        - ./script/incremental_build.sh test
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''


### PR DESCRIPTION
## Description

This is a PoC of enabling flutter/plugins testing on Cirrus, running on Mac and Linux builders.

Not ready for review yet, opening this PR so that I can more easily run on Cirrus.

## Related Issues

Fixes flutter/flutter#30446

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes