### PR TITLE
make shellcheck (linter) changes to bin/flutter bash script

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -41,11 +41,11 @@ function _rmlock () {
 
 function retry_upgrade {
   local total_tries="10"
-  local remaining_tries=$(($total_tries - 1))
-  while [[ "$remaining_tries" > 0 ]]; do
+  local remaining_tries=$((total_tries - 1))
+  while [[ "$remaining_tries" -gt 0 ]]; do
     (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY") && break
     echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
-    remaining_tries=$(($remaining_tries - 1))
+    remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
@@ -102,6 +102,12 @@ function upgrade_flutter () {
   fi
 
   local revision="$(cd "$FLUTTER_ROOT"; git rev-parse HEAD)"
+
+  # Invalidate cache if:
+  #  * SNAPSHOT_PATH is not a file, or
+  #  * STAMP_PATH is not a file with nonzero size, or
+  #  * Contents of STAMP_PATH is not our local git HEAD revision, or
+  #  * pubspec.yaml last modified after pubspec.lock
   if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$STAMP_PATH" || "$(cat "$STAMP_PATH")" != "$revision" || "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
     rm -f "$FLUTTER_ROOT/version"
     touch "$FLUTTER_ROOT/bin/cache/.dartignore"


### PR DESCRIPTION
## Description

A few minor linter changes. These lines were not failing, but rather correctly operating...for the wrong reasons. See below for Shellcheck documentation for the changes.

## References

[SC2071: > is for string comparisons. Use -gt instead.](https://github.com/koalaman/shellcheck/wiki/SC2071)
[SC2004: $/${} is unnecessary on arithmetic variables](https://github.com/koalaman/shellcheck/wiki/SC2004)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.