### PR TITLE
Revert "Error message for setting shaderWarmUp too late (#30145)"

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -53,20 +53,7 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// See also:
   ///
   ///  * [ShaderWarmUp], the interface of how this warm up works.
-  static ShaderWarmUp get shaderWarmUp => _shaderWarmUp;
-  static set shaderWarmUp(ShaderWarmUp value) {
-    assert(_instance == null,
-        'PaintingBinding.shaderWarmUp should only be set before the '
-        'PaintingBinding singleton instance is initialized.\n\n'
-        'Setting it after init would not affect how shaders are warmed up.\n\n'
-        'To fix this, try to change PaintingBinding.shaderWarmUp before:\n'
-        ' 1. runApp\n'
-        ' 2. WidgetsFlutterBinding.ensureInitialized\n'
-        ' 3. enableFlutterDriverExtension\n'
-    );
-    _shaderWarmUp = value;
-  }
-  static ShaderWarmUp _shaderWarmUp = const DefaultShaderWarmUp();
+  static ShaderWarmUp shaderWarmUp = const DefaultShaderWarmUp();
 
   /// The singleton that implements the Flutter framework's image cache.
   ///


### PR DESCRIPTION
This reverts commit ffbb335e35ae7416be98b72779baae6c9bd25b3b.

Reason for revert: flutter driver tests may have bugs in getting first frame. Revert this until we figure out what happened.
