### PR TITLE
Fixed Table flex column layout error #30437

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -958,8 +958,8 @@ class RenderTable extends RenderBox {
                 deficit -= widths[x] - minWidths[x];
                 widths[x] = minWidths[x];
               } else {
-                deficit -= availableDelta;
-                widths[x] -= availableDelta;
+                deficit -= delta;
+                widths[x] -= delta;
                 newAvailableColumns += 1;
               }
             }

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -47,6 +47,20 @@ void main() {
     expect(table.size, equals(const Size(0.0, 0.0)));
   });
 
+  test('Table control test: constrained flex columns', () {
+    final RenderTable table = RenderTable(textDirection: TextDirection.ltr);
+    final List<RenderBox> children =
+    List<RenderBox>.generate(6, (_) => RenderPositionedBox());
+
+    table.setFlatChildren(6, children);
+    layout(table, constraints: const BoxConstraints.tightFor(width: 100.0));
+
+    const double expectedWidth = 100.0 / 6;
+    for (RenderBox child in children) {
+      expect(child.size.width, moreOrLessEquals(expectedWidth));
+    }
+  });
+
   test('Table test: combinations', () {
     RenderTable table;
     layout(RenderPositionedBox(child: table = RenderTable(

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -49,8 +49,7 @@ void main() {
 
   test('Table control test: constrained flex columns', () {
     final RenderTable table = RenderTable(textDirection: TextDirection.ltr);
-    final List<RenderBox> children =
-        List<RenderBox>.generate(6, (_) => RenderPositionedBox());
+    final List<RenderBox> children = List<RenderBox>.generate(6, (_) => RenderPositionedBox());
 
     table.setFlatChildren(6, children);
     layout(table, constraints: const BoxConstraints.tightFor(width: 100.0));

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -50,7 +50,7 @@ void main() {
   test('Table control test: constrained flex columns', () {
     final RenderTable table = RenderTable(textDirection: TextDirection.ltr);
     final List<RenderBox> children =
-    List<RenderBox>.generate(6, (_) => RenderPositionedBox());
+        List<RenderBox>.generate(6, (_) => RenderPositionedBox());
 
     table.setFlatChildren(6, children);
     layout(table, constraints: const BoxConstraints.tightFor(width: 100.0));


### PR DESCRIPTION
This PR is to fix issue #30437 

RenderTable._computeColumnWidths() had a logic error that caused flex columns to be collapsed to their minimum widths in certain situations dependent on the layout width constraint and the number of flex columns.

The problem was in a loop at the end of RenderTable._computeColumnWidths. After the flex columns are grown to fill the width constraint and if the table size is now greater than the constraint, this loop is supposed to evenly remove a portion of the deficit from each flex column to bring the table width into the constraint. Instead it removes all of flex space in each column and in the example code reduces every column to zero width.

The error is in the last if/else statement:

```
              if (availableDelta <= delta) {
                // shrank to minimum
                deficit -= widths[x] - minWidths[x];
                widths[x] = minWidths[x];
              } else {
                deficit -= availableDelta;
                widths[x] -= availableDelta;
                newAvailableColumns += 1;
              }
```

The delta variable was calculated to be the even portion of the deficit that is to be subtracted from each column:

```
final double delta = deficit / availableColumns;
```

The if/else statement is supposed to remove the availableDelta from a column width if availableDelta is less than delta, otherwise it should be subtracting delta from the columnWidth.

Instead, if availableDelta is greater than delta, it's removing all of availableDelta from the column width, which collapses it to its minimum width. The else statements should have been subtracting delta, not availableDelta.

## Tests
A test was added to verify that a table with a constrained width evenly distributes its width between its columns. Prior to the fix, this test would fail and would result in zero width columns.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

r