### PR TITLE
Trackpad mode crash fix

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -914,6 +914,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void updateFloatingCursor(RawFloatingCursorPoint point) {
     switch(point.state){
       case FloatingCursorDragState.Start:
+        if (_floatingCursorResetController.isAnimating) {
+          _floatingCursorResetController.stop();
+          _onFloatingCursorResetTick();
+        }
         final TextPosition currentTextPosition = TextPosition(offset: renderEditable.selection.baseOffset);
         _startCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
         renderEditable.setFloatingCursor(point.state, _startCaretRect.center - _floatingCursorOffset, currentTextPosition);


### PR DESCRIPTION
Fixes a crash reported by the Adwords team.

On iOS, it's possible to use the keyboard in "trackpad mode" by 3D touching the keyboard and dragging your finger around.  3D touching again without picking up your finger will start a selection, and dragging will edit it.

![trackpad_mode](https://user-images.githubusercontent.com/389558/55520722-67b85d00-5632-11e9-8e33-68f7c93b1d8e.gif)


Flutter supports trackpad mode, but currently, trying to do selection as well causes a crash.  This PR fixes the crash, but selection in trackpad mode still doesn't work.  Did we ever support this, or is it something that we should build?

This is what happens when the user attempts to select in trackpad mode now after this fix:

![trackpad_mode_flutter](https://user-images.githubusercontent.com/389558/55520731-6dae3e00-5632-11e9-8d91-05a038540000.gif)

