### PR TITLE
Add confirmDismiss example to flutter_gallery

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -270,7 +270,7 @@ class _LeaveBehindListItem extends StatelessWidget {
       ),
     );
   }
-  
+
   Future<bool> _showConfirmationDialog(BuildContext context, String action) {
     return showDialog<bool>(
       context: context,

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -14,7 +14,7 @@ enum LeaveBehindDemoAction {
   horizontalSwipe,
   leftSwipe,
   rightSwipe,
-  confirmDismiss
+  confirmDismiss,
 }
 
 class LeaveBehindItem implements Comparable<LeaveBehindItem> {
@@ -227,23 +227,15 @@ class _LeaveBehindListItem extends StatelessWidget {
           else
             _handleDelete();
         },
-        confirmDismiss: (DismissDirection dismissDirection) async {
+        confirmDismiss: !confirmDismiss ? null : (DismissDirection dismissDirection) async {
           switch(dismissDirection) {
             case DismissDirection.endToStart:
-              if(confirmDismiss) {
-                if (await _showConfirmationDialog(context, 'archive'))
-                  _handleArchive();
-              } else {
+              if (await _showConfirmationDialog(context, 'archive'))
                 _handleArchive();
-              }
               break;
             case DismissDirection.startToEnd:
-              if(confirmDismiss) {
-                if (await _showConfirmationDialog(context, 'delete'))
-                  _handleDelete();
-              } else {
+              if (await _showConfirmationDialog(context, 'delete'))
                 _handleDelete();
-              }
               break;
             case DismissDirection.horizontal:
             case DismissDirection.vertical:

--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -13,7 +13,8 @@ enum LeaveBehindDemoAction {
   reset,
   horizontalSwipe,
   leftSwipe,
-  rightSwipe
+  rightSwipe,
+  confirmDismiss
 }
 
 class LeaveBehindItem implements Comparable<LeaveBehindItem> {
@@ -43,6 +44,7 @@ class LeaveBehindDemo extends StatefulWidget {
 class LeaveBehindDemoState extends State<LeaveBehindDemo> {
   static final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   DismissDirection _dismissDirection = DismissDirection.horizontal;
+  bool _confirmDismiss = true;
   List<LeaveBehindItem> leaveBehindItems;
 
   void initListItems() {
@@ -76,6 +78,9 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
           break;
         case LeaveBehindDemoAction.rightSwipe:
           _dismissDirection = DismissDirection.startToEnd;
+          break;
+        case LeaveBehindDemoAction.confirmDismiss:
+          _confirmDismiss = !_confirmDismiss;
           break;
       }
     });
@@ -128,6 +133,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
       body = ListView(
         children: leaveBehindItems.map<Widget>((LeaveBehindItem item) {
           return _LeaveBehindListItem(
+            confirmDismiss: _confirmDismiss,
             item: item,
             onArchive: _handleArchive,
             onDelete: _handleDelete,
@@ -166,6 +172,11 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
                 checked: _dismissDirection == DismissDirection.startToEnd,
                 child: const Text('Only swipe right'),
               ),
+              CheckedPopupMenuItem<LeaveBehindDemoAction>(
+                value: LeaveBehindDemoAction.confirmDismiss,
+                checked: _confirmDismiss,
+                child: const Text('Confirm dismiss'),
+              ),
             ],
           ),
         ],
@@ -182,12 +193,14 @@ class _LeaveBehindListItem extends StatelessWidget {
     @required this.onArchive,
     @required this.onDelete,
     @required this.dismissDirection,
+    @required this.confirmDismiss,
   }) : super(key: key);
 
   final LeaveBehindItem item;
   final DismissDirection dismissDirection;
   final void Function(LeaveBehindItem) onArchive;
   final void Function(LeaveBehindItem) onDelete;
+  final bool confirmDismiss;
 
   void _handleArchive() {
     onArchive(item);
@@ -214,6 +227,31 @@ class _LeaveBehindListItem extends StatelessWidget {
           else
             _handleDelete();
         },
+        confirmDismiss: (DismissDirection dismissDirection) async {
+          switch(dismissDirection) {
+            case DismissDirection.endToStart:
+              if(confirmDismiss) {
+                if (await _showConfirmationDialog(context, 'archive'))
+                  _handleArchive();
+              } else {
+                _handleArchive();
+              }
+              break;
+            case DismissDirection.startToEnd:
+              if(confirmDismiss) {
+                if (await _showConfirmationDialog(context, 'delete'))
+                  _handleDelete();
+              } else {
+                _handleDelete();
+              }
+              break;
+            case DismissDirection.horizontal:
+            case DismissDirection.vertical:
+            case DismissDirection.up:
+            case DismissDirection.down:
+              assert(false);
+          }
+        },
         background: Container(
           color: theme.primaryColor,
           child: const ListTile(
@@ -238,6 +276,32 @@ class _LeaveBehindListItem extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+  
+  Future<bool> _showConfirmationDialog(BuildContext context, String action) {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Do you want to $action this item?'),
+          actions: <Widget>[
+            FlatButton(
+              child: const Text('Yes'),
+              onPressed: () {
+                Navigator.pop(context, true); // showDialog() returns true
+              },
+            ),
+            FlatButton(
+              child: const Text('No'),
+              onPressed: () {
+                Navigator.pop(context, false); // showDialog() returns false
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Description

I added an example to show how to use the confirmDismiss property of Dismissible.

## Related Issues

#29318

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.