### PR TITLE
Time picker touch targets

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -49,7 +49,7 @@ const double _kTimePickerHeightLandscapeCollapsed = 304.0;
 ///
 /// Normally there's only one horizontal sibling, and it may appear on the left
 /// or right depending on the current [TextDirection].
-const double _kPeriodGap = 8.0;
+const double _kPeriodGap = 4.0;
 
 /// The vertical gap between pieces when laid out vertically (in portrait mode).
 const double _kVerticalGap = 8.0;
@@ -253,10 +253,16 @@ class _DayPeriodControl extends StatelessWidget {
             onTap: () {
               _setAm(context);
             },
-            child: Text(materialLocalizations.anteMeridiemAbbreviation, style: amStyle),
+            child: Padding(
+              padding: const EdgeInsets.only(
+                  left: 4.0, right: 4.0, top: 4.0, bottom: 2.0),
+              child: Text(
+                materialLocalizations.anteMeridiemAbbreviation,
+                style: amStyle,
+              ),
+            ),
           ),
         ),
-        const SizedBox(width: 0.0, height: 4.0), // Vertical spacer
         GestureDetector(
           excludeFromSemantics: true,
           onTap: Feedback.wrapForTap(() {
@@ -268,7 +274,14 @@ class _DayPeriodControl extends StatelessWidget {
             onTap: () {
               _setPm(context);
             },
-            child: Text(materialLocalizations.postMeridiemAbbreviation, style: pmStyle),
+            child: Padding(
+              padding: const EdgeInsets.only(
+                  left: 4.0, right: 4.0, bottom: 4.0, top: 2.0),
+              child: Text(
+                materialLocalizations.postMeridiemAbbreviation,
+                style: pmStyle,
+              ),
+            ),
           ),
         ),
       ],

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -340,6 +340,7 @@ class _HourControl extends StatelessWidget {
     );
 
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: Feedback.wrapForTap(() => fragmentContext.onModeChange(_TimePickerMode.hour), context),
       child: Semantics(
         hint: localizations.timePickerHourModeAnnouncement,
@@ -353,8 +354,36 @@ class _HourControl extends StatelessWidget {
         onDecrease: () {
           fragmentContext.onTimeChange(previousHour);
         },
-          child: Text(formattedHour, style: hourStyle),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            SizedBox(
+              width: hourStyle.fontSize * 0.6,
+              child: Text(
+                formattedHour.length == 2
+                // First digit
+                    ? formattedHour.substring(0, 1)
+                // Empty if formattedHour is only one digit
+                    : '',
+                style: hourStyle,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            SizedBox(
+              width: hourStyle.fontSize * 0.6,
+              child: Text(
+                formattedHour.length == 2
+                // Second digit
+                    ? formattedHour.substring(1, 2)
+                // First digit if formattedHour is only one digit
+                    : formattedHour.substring(0, 1),
+                style: hourStyle,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
         ),
+      ),
     );
   }
 }
@@ -404,6 +433,7 @@ class _MinuteControl extends StatelessWidget {
     final String formattedPreviousMinute = localizations.formatMinute(previousMinute);
 
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: Feedback.wrapForTap(() => fragmentContext.onModeChange(_TimePickerMode.minute), context),
       child: Semantics(
         excludeSemantics: true,
@@ -417,8 +447,26 @@ class _MinuteControl extends StatelessWidget {
         onDecrease: () {
           fragmentContext.onTimeChange(previousMinute);
         },
-          child: Text(formattedMinute, style: minuteStyle),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            SizedBox(
+              width: minuteStyle.fontSize * 0.6,
+              child: Text(
+                formattedMinute.substring(0, 1), // First digit
+                style: minuteStyle,
+              ),
+            ),
+            SizedBox(
+              width: minuteStyle.fontSize * 0.6,
+              child: Text(
+                formattedMinute.substring(1, 2), // Second digit
+                style: minuteStyle,
+              ),
+            ),
+          ],
         ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Description

Increased touch targets of AM/PM selector.
Splitted digits of hour and minutes and set a fixed width, so the AM/PM selector stays put when changing the minutes and the hour touch target is always the same width.

## Related Issues

Fixes #18130 

## Tests

The `can increment and decrement minutes` test in `time_picker_test.dart` still needs to be fixed, but I need some feedback on how to do this properly, since the text is now splitted over two `Text` widgets.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
