### PR TITLE
Let docker image install fastlane too for Linux

### DIFF
--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -100,6 +100,10 @@ ENV LANG en_US.UTF-8
 
 # Install coveralls and Firebase
 # This is why we need ruby installed.
-RUN gem install coveralls
-RUN gem install bundler
+# Skip all the documentation (-N) since it's just on CI.
+RUN gem install coveralls -N
+RUN gem install bundler -N
+# Install fastlane which is used on Linux to build and deploy Android
+# builds to the Play Store.
+RUN gem install fastlane -N
 


### PR DESCRIPTION
## Description

I broke Play Store deploy on Linux since it uses our own images rather than Cirrus's

