### PR TITLE
Correctly synthesise event buttons

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -40,6 +40,22 @@ class _PointerState {
   }
 }
 
+// Add `kPrimaryButton` to [buttons] when a pointer of certain devices is down.
+//
+// TODO(tongmu): This patch is supposed to be done by embedders. Patching it
+// in framework is a workaround before [PointerEventConverter] is moved to embedders.
+// https://github.com/flutter/flutter/issues/30454
+int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
+  switch (kind) {
+  case PointerDeviceKind.touch:
+  case PointerDeviceKind.stylus:
+  case PointerDeviceKind.invertedStylus:
+    return buttons | kPrimaryButton;
+  default:
+    return buttons;
+  }
+}
+
 /// Converts from engine pointer data to framework pointer events.
 ///
 /// This takes [PointerDataPacket] objects, as received from the engine via
@@ -207,8 +223,7 @@ class PointerEventConverter {
               kind: kind,
               device: datum.device,
               position: position,
-              // TODO(tongmu): Move button patching to embedder, https://github.com/flutter/flutter/issues/30454
-              buttons: datum.buttons | kPrimaryButton,
+              buttons: _synthesiseDownButtons(datum.buttons, kind),
               obscured: datum.obscured,
               pressure: datum.pressure,
               pressureMin: datum.pressureMin,
@@ -237,8 +252,7 @@ class PointerEventConverter {
               device: datum.device,
               position: position,
               delta: state.deltaTo(position),
-              // TODO(tongmu): Move button patching to embedder, https://github.com/flutter/flutter/issues/30454
-              buttons: datum.buttons | kPrimaryButton,
+              buttons: _synthesiseDownButtons(datum.buttons, kind),
               obscured: datum.obscured,
               pressure: datum.pressure,
               pressureMin: datum.pressureMin,
@@ -273,8 +287,7 @@ class PointerEventConverter {
                 device: datum.device,
                 position: position,
                 delta: state.deltaTo(position),
-                // TODO(tongmu): Move button patching to embedder, https://github.com/flutter/flutter/issues/30454
-                buttons: datum.buttons | kPrimaryButton,
+                buttons: _synthesiseDownButtons(datum.buttons, kind),
                 obscured: datum.obscured,
                 pressure: datum.pressure,
                 pressureMin: datum.pressureMin,
@@ -421,8 +434,7 @@ class PointerEventConverter {
                   device: datum.device,
                   position: position,
                   delta: state.deltaTo(position),
-                  // TODO(tongmu): Move button patching to embedder, https://github.com/flutter/flutter/issues/30454
-                  buttons: datum.buttons | kPrimaryButton,
+                  buttons: _synthesiseDownButtons(datum.buttons, kind),
                   obscured: datum.obscured,
                   pressure: datum.pressure,
                   pressureMin: datum.pressureMin,

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -47,12 +47,12 @@ class _PointerState {
 // https://github.com/flutter/flutter/issues/30454
 int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
   switch (kind) {
-  case PointerDeviceKind.touch:
-  case PointerDeviceKind.stylus:
-  case PointerDeviceKind.invertedStylus:
-    return buttons | kPrimaryButton;
-  default:
-    return buttons;
+    case PointerDeviceKind.touch:
+    case PointerDeviceKind.stylus:
+    case PointerDeviceKind.invertedStylus:
+      return buttons | kPrimaryButton;
+    default:
+      return buttons;
   }
 }
 

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -47,7 +47,6 @@ void main() {
     ui.window.onPointerDataPacket(packet);
     expect(events.length, 2);
     expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[0].buttons, equals(1));
     expect(events[1].runtimeType, equals(PointerUpEvent));
   });
 
@@ -66,9 +65,7 @@ void main() {
     ui.window.onPointerDataPacket(packet);
     expect(events.length, 3);
     expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[0].buttons, equals(1));
     expect(events[1].runtimeType, equals(PointerMoveEvent));
-    expect(events[1].buttons, equals(1));
     expect(events[2].runtimeType, equals(PointerUpEvent));
   });
 
@@ -122,9 +119,7 @@ void main() {
     ui.window.onPointerDataPacket(packet);
     expect(events.length, 3);
     expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[0].buttons, equals(1));
     expect(events[1].runtimeType, equals(PointerMoveEvent));
-    expect(events[1].buttons, equals(1));
     expect(events[1].delta, equals(const Offset(9.0, 12.0)));
     expect(events[2].runtimeType, equals(PointerUpEvent));
   });
@@ -143,7 +138,6 @@ void main() {
     ui.window.onPointerDataPacket(packet);
     expect(events.length, 2);
     expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[0].buttons, equals(1));
     expect(events[1].runtimeType, equals(PointerCancelEvent));
   });
 
@@ -165,7 +159,6 @@ void main() {
     ui.window.onPointerDataPacket(packet);
     expect(events.length, 2);
     expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[0].buttons, equals(1));
     expect(events[1].runtimeType, equals(PointerCancelEvent));
   });
 
@@ -207,7 +200,6 @@ void main() {
     expect(events[1].runtimeType, equals(PointerHoverEvent));
     expect(events[1].delta, equals(const Offset(5.0, 7.0)));
     expect(events[2].runtimeType, equals(PointerDownEvent));
-    expect(events[2].buttons, equals(1));
     expect(events[3].runtimeType, equals(PointerCancelEvent));
     expect(events[4].runtimeType, equals(PointerHoverEvent));
     expect(events[5].runtimeType, equals(PointerRemovedEvent));
@@ -254,10 +246,109 @@ void main() {
     expect(events[2].runtimeType, equals(PointerScrollEvent));
     expect(events[3].runtimeType, equals(PointerHoverEvent));
     expect(events[4].runtimeType, equals(PointerDownEvent));
-    expect(events[4].buttons, equals(1));
     expect(events[5].runtimeType, equals(PointerMoveEvent));
-    expect(events[5].buttons, equals(1));
     expect(events[5].delta, equals(unexpectedOffset));
     expect(events[6].runtimeType, equals(PointerScrollEvent));
+  });
+
+  test('Should synthesise kPrimaryButton for touch', () {
+    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    const PointerDeviceKind kind = PointerDeviceKind.touch;
+    final ui.PointerDataPacket packet = ui.PointerDataPacket(
+      data: <ui.PointerData>[
+        ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ui.PointerData(change: ui.PointerChange.down, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ui.PointerData(change: ui.PointerChange.move, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
+      ]
+    );
+
+    final List<PointerEvent> events = PointerEventConverter.expand(
+      packet.data, ui.window.devicePixelRatio).toList();
+
+    expect(events.length, 5);
+    expect(events[0].runtimeType, equals(PointerAddedEvent));
+    expect(events[0].buttons, equals(0));
+    expect(events[1].runtimeType, equals(PointerHoverEvent));
+    expect(events[1].buttons, equals(0));
+    expect(events[2].runtimeType, equals(PointerDownEvent));
+    expect(events[2].buttons, equals(kPrimaryButton));
+    expect(events[3].runtimeType, equals(PointerMoveEvent));
+    expect(events[3].buttons, equals(kPrimaryButton));
+    expect(events[4].runtimeType, equals(PointerUpEvent));
+    expect(events[4].buttons, equals(0));
+
+    PointerEventConverter.clearPointers();
+  });
+
+  test('Should synthesise kPrimaryButton for stylus', () {
+    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    for (PointerDeviceKind kind in <PointerDeviceKind>[
+      PointerDeviceKind.stylus,
+      PointerDeviceKind.invertedStylus,
+    ]) {
+
+      final ui.PointerDataPacket packet = ui.PointerDataPacket(
+        data: <ui.PointerData>[
+          ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.down, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.move, buttons: kSecondaryStylusButton, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ]
+      );
+
+      final List<PointerEvent> events = PointerEventConverter.expand(
+        packet.data, ui.window.devicePixelRatio).toList();
+
+      expect(events.length, 5);
+      expect(events[0].runtimeType, equals(PointerAddedEvent));
+      expect(events[0].buttons, equals(0));
+      expect(events[1].runtimeType, equals(PointerHoverEvent));
+      expect(events[1].buttons, equals(0));
+      expect(events[2].runtimeType, equals(PointerDownEvent));
+      expect(events[2].buttons, equals(kPrimaryButton));
+      expect(events[3].runtimeType, equals(PointerMoveEvent));
+      expect(events[3].buttons, equals(kPrimaryButton | kSecondaryStylusButton));
+      expect(events[4].runtimeType, equals(PointerUpEvent));
+      expect(events[4].buttons, equals(0));
+
+      PointerEventConverter.clearPointers();
+    }
+  });
+
+  test('Should not synthesise kPrimaryButton for certain devices', () {
+    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    for (PointerDeviceKind kind in <PointerDeviceKind>[
+      PointerDeviceKind.mouse,
+    ]) {
+      final ui.PointerDataPacket packet = ui.PointerDataPacket(
+        data: <ui.PointerData>[
+          ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.down, kind: kind, buttons: kMiddleMouseButton, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.move, kind: kind, buttons: kMiddleMouseButton | kSecondaryMouseButton, physicalX: location.dx, physicalY: location.dy),
+          ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
+        ]
+      );
+
+      final List<PointerEvent> events = PointerEventConverter.expand(
+        packet.data, ui.window.devicePixelRatio).toList();
+
+      expect(events.length, 5);
+      expect(events[0].runtimeType, equals(PointerAddedEvent));
+      expect(events[0].buttons, equals(0));
+      expect(events[1].runtimeType, equals(PointerHoverEvent));
+      expect(events[1].buttons, equals(0));
+      expect(events[2].runtimeType, equals(PointerDownEvent));
+      expect(events[2].buttons, equals(kMiddleMouseButton));
+      expect(events[3].runtimeType, equals(PointerMoveEvent));
+      expect(events[3].buttons, equals(kMiddleMouseButton | kSecondaryMouseButton));
+      expect(events[4].runtimeType, equals(PointerUpEvent));
+      expect(events[4].buttons, equals(0));
+
+      PointerEventConverter.clearPointers();
+    }
   });
 }


### PR DESCRIPTION
## Description

#30457 introduces a bug where all mouse buttons will have 0x01 incorrectly set, specifically when buttons other than left are pressed. (See https://github.com/flutter/flutter/pull/30457/files#r272393824)

This PR correctly synthesises buttons based on device.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/30532

## Tests

I added the following tests:
- Should synthesise kPrimaryButton for touch
- Should synthesise kPrimaryButton for stylus
- Should not synthesise kPrimaryButton for mouse

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
