### PR TITLE
Replace flutter.io with flutter.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/ACTIVATION.md
+++ b/.github/ISSUE_TEMPLATE/ACTIVATION.md
@@ -10,13 +10,13 @@ about: You have run into problems while downloading or installing Flutter, or th
 
      If you are looking for support, please check out our documentation
      or consider asking a question on Stack Overflow:
-      * https://flutter.io/
+      * https://flutter.dev/
       * https://docs.flutter.io/
       * https://stackoverflow.com/questions/tagged/flutter?sort=frequent
 
      If you have found a bug or if our documentation doesn't have an answer
      to what you're looking for, then fill our the template below. Please read
-     our guide to filing a bug first:  https://flutter.io/bug-reports/
+     our guide to filing a bug first:  https://flutter.dev/bug-reports/
 -->
 
 ## Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -9,13 +9,13 @@ about: You are writing an application with Flutter but the application is crashi
 
      If you are looking for support, please check out our documentation
      or consider asking a question on Stack Overflow:
-      * https://flutter.io/
+      * https://flutter.dev/
       * https://docs.flutter.io/
       * https://stackoverflow.com/questions/tagged/flutter?sort=frequent
 
      If you have found a bug or if our documentation doesn't have an answer
      to what you're looking for, then fill our the template below. Please read
-     our guide to filing a bug first:  https://flutter.io/bug-reports/
+     our guide to filing a bug first:  https://flutter.dev/bug-reports/
 -->
 
 ## Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT.md
@@ -8,7 +8,7 @@ about: You have a question for how to achieve a particular effect, or you need h
 <!-- Thank you for using Flutter!
 
      Please check out our documentation first:
-      * https://flutter.io/
+      * https://flutter.dev/
       * https://docs.flutter.io/
 
      If you can't find the answer there, please consider asking a question on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ our trust and demonstrated a commitment to Flutter.
 This document focuses on what is needed to contribute by writing code
 and submitting pull requests for the Flutter framework. For
 information on contributing in other ways, see [the community page
-on flutter.io](https://flutter.io/community).
+on flutter.dev](https://flutter.dev/community).
 
 Developing for Flutter
 ----------------------
@@ -50,17 +50,17 @@ presented.
    which describes the steps you need to configure your computer to
    work on Flutter's framework. Flutter's framework uses mainly Dart.
 
-4. [Tree hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene),
+5. [Tree hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene),
    which covers how to land a PR, how to do code review, how to
    handle breaking changes, how to handle regressions, and how to
    handle post-commit test failures.
 
-3. [Issue hygiene](https://github.com/flutter/flutter/wiki/Issue-hygiene),
+6. [Issue hygiene](https://github.com/flutter/flutter/wiki/Issue-hygiene),
    which covers our processes around triaging bugs, escalating high
    priority bugs, assigning bugs, and our GitHub labels and
    milestones.
 
-5. [Our style guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo),
+7. [Our style guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo),
    which includes advice for designing APIs for Flutter, and how to
    format code in the framework.
 

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -28,7 +28,7 @@ $psMajorVersionRequired = 5
 $psMajorVersionLocal = $PSVersionTable.PSVersion.Major
 if ($psMajorVersionLocal -lt $psMajorVersionRequired) {
     Write-Host "Flutter requires PowerShell $psMajorVersionRequired.0 or newer."
-    Write-Host "See https://flutter.io/docs/get-started/install/windows for more."
+    Write-Host "See https://flutter.dev/docs/get-started/install/windows for more."
     return
 }
 

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -74,7 +74,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     echo
     echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
     echo "If you're located in China, please see this page:"
-    echo "  https://flutter.io/community/china"
+    echo "  https://flutter.dev/community/china"
     echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -1,4 +1,4 @@
-# Flutter (https://flutter.io) Developement Environment for Linux
+# Flutter (https://flutter.dev) Developement Environment for Linux
 # ===============================================================
 #
 # This environment passes all Linux Flutter Doctor checks and is sufficient

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -274,7 +274,7 @@ class CompileTest {
         await flutter('build', options: options);
         watch.stop();
         final String appPath =  '$cwd/build/ios/Release-iphoneos/Runner.app/';
-        // IPAs are created manually, https://flutter.io/ios-release/
+        // IPAs are created manually, https://flutter.dev/ios-release/
         await exec('tar', <String>['-zcf', 'build/app.ipa', appPath]);
         releaseSizeInBytes = await file('$cwd/build/app.ipa').length();
         if (reportPackageContentSizes)

--- a/dev/docs/dashing.json
+++ b/dev/docs/dashing.json
@@ -3,7 +3,7 @@
   "package": "flutter",
   "author": {
     "name": "The Flutter Team",
-    "link": "https://flutter.io"
+    "link": "https://flutter.dev"
   },
   "index": "index.html",
   "icon32x32": "flutter/static-assets/favicon.png",

--- a/dev/integration_tests/ios_add2app/Pods/Local Podspecs/Flutter.podspec.json
+++ b/dev/integration_tests/ios_add2app/Pods/Local Podspecs/Flutter.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "summary": "High-performance, high-fidelity mobile apps.",
   "description": "Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.",
-  "homepage": "https://flutter.io",
+  "homepage": "https://flutter.dev",
   "license": {
     "type": "MIT"
   },

--- a/dev/integration_tests/ios_add2app/Pods/Local Podspecs/FlutterPluginRegistrant.podspec.json
+++ b/dev/integration_tests/ios_add2app/Pods/Local Podspecs/FlutterPluginRegistrant.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "summary": "Registers plugins with your flutter app",
   "description": "Depends on all your plugins, and provides a function to register them.",
-  "homepage": "https://flutter.io",
+  "homepage": "https://flutter.dev",
   "license": {
     "type": "BSD"
   },

--- a/dev/integration_tests/ios_add2app/flutterapp/README.md
+++ b/dev/integration_tests/ios_add2app/flutterapp/README.md
@@ -5,4 +5,4 @@ A new flutter module project.
 ## Getting Started
 
 For help getting started with Flutter, view our online
-[documentation](https://flutter.io/).
+[documentation](https://flutter.dev/).

--- a/dev/integration_tests/ios_add2app/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app/flutterapp/pubspec.yaml
@@ -63,10 +63,10 @@ flutter:
   #  - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
+  # https://flutter.dev/assets-and-images/#resolution-aware.
 
   # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
+  # https://flutter.dev/assets-and-images/#from-packages
 
   # To add Flutter specific custom fonts to your application, add a fonts
   # section here, in this "flutter" section. Each entry in this list should
@@ -86,7 +86,7 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.io/custom-fonts/#from-packages
+  # see https://flutter.dev/custom-fonts/#from-packages
 
   # This section identifies your Flutter project as a module meant for
   # embedding in a native host app.  These identifiers should _not_ ordinarily

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -49,7 +49,7 @@ Future<void> main(List<String> arguments) async {
   // Create the pubspec.yaml file.
   final StringBuffer buf = StringBuffer();
   buf.writeln('name: Flutter');
-  buf.writeln('homepage: https://flutter.io');
+  buf.writeln('homepage: https://flutter.dev');
   buf.writeln('version: $version');
   buf.writeln('dependencies:');
   for (String package in findPackageNames()) {
@@ -389,8 +389,8 @@ void changePackageToSdkInTitlebar() {
   final File indexFile = File('$kPublishRoot/index.html');
   String indexContents = indexFile.readAsStringSync();
   indexContents = indexContents.replaceFirst(
-    '<li><a href="https://flutter.io">Flutter package</a></li>',
-    '<li><a href="https://flutter.io">Flutter SDK</a></li>',
+    '<li><a href="https://flutter.dev">Flutter package</a></li>',
+    '<li><a href="https://flutter.dev">Flutter SDK</a></li>',
   );
 
   indexFile.writeAsStringSync(indexContents);

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vitool
 description: A tool for generating Dart vector animation code from SVG sequences.
 version: 0.0.1
-homepage: https://flutter.io
+homepage: https://flutter.dev
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@ Flutter Examples
 
 This directory contains several examples of using Flutter. To run an example,
 use `flutter run` inside that example's directory. See the [getting started
-guide](https://flutter.io/getting-started/) to install the `flutter` tool.
+guide](https://flutter.dev/getting-started/) to install the `flutter` tool.
 
 For additional samples, see the
 [`flutter/samples`](https://github.com/flutter/samples) repo.
@@ -23,7 +23,7 @@ Available examples include:
 
 - **Platform Channel** The [platform channel app](platform_channel) demonstrates
   how to connect a Flutter app to platform-specific APIs. For documentation, see
-  <https://flutter.io/platform-channels/>.
+  <https://flutter.dev/platform-channels/>.
 
 - **Platform Channel Swift** The [platform channel swift
   app](platform_channel_swift) is the same as [platform

--- a/examples/flutter_gallery/README.md
+++ b/examples/flutter_gallery/README.md
@@ -11,7 +11,7 @@ and install it onto your device.
 ### Prerequisites
 
 If you are new to Flutter, please first follow
-the [Flutter Setup](https://flutter.io/setup/) guide.
+the [Flutter Setup](https://flutter.dev/setup/) guide.
 
 ### Building and installing the Flutter app
 

--- a/examples/flutter_gallery/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/examples/flutter_gallery/android/fastlane/metadata/android/en-US/full_description.txt
@@ -6,4 +6,4 @@ Flutter is Google’s multi-platform mobile app SDK for crafting beautiful nativ
 
 This app is open source. Check out the code to see how this app is built: https://github.com/flutter/flutter/tree/master/examples/flutter_gallery
 
-Visit https://flutter.io to learn more.
+Visit https://flutter.dev to learn more.

--- a/examples/flutter_gallery/lib/gallery/about.dart
+++ b/examples/flutter_gallery/lib/gallery/about.dart
@@ -59,7 +59,7 @@ void showGalleryAboutDialog(BuildContext context) {
               ),
               _LinkTextSpan(
                 style: linkStyle,
-                url: 'https://flutter.io',
+                url: 'https://flutter.dev',
               ),
               TextSpan(
                 style: aboutTextStyle,

--- a/examples/flutter_view/README.md
+++ b/examples/flutter_view/README.md
@@ -6,7 +6,7 @@ Android, the Android and Flutter components are built with Android Studio or
 gradle.
 
 You can read more about
-[accessing platform and third-party services in Flutter](https://flutter.io/platform-services/).
+[accessing platform and third-party services in Flutter](https://flutter.dev/platform-services/).
 
 ## iOS
 

--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -53,7 +53,7 @@ void attachWidgetTreeToRenderTree(RenderProxyBox container) {
                     RaisedButton(
                       child: Row(
                         children: <Widget>[
-                          Image.network('https://flutter.io/images/favicon.png'),
+                          Image.network('https://flutter.dev/images/favicon.png'),
                           const Text('PRESS ME'),
                         ],
                       ),

--- a/examples/platform_channel/README.md
+++ b/examples/platform_channel/README.md
@@ -3,7 +3,7 @@
 This project demonstrates how to connect a Flutter app to platform specific services.
 
 You can read more about
-[accessing platform and third-party services in Flutter](https://flutter.io/platform-channels/).
+[accessing platform and third-party services in Flutter](https://flutter.dev/platform-channels/).
 
 ## iOS
 You can use the commands `flutter build` and `flutter run` from the app's root

--- a/examples/platform_channel_swift/README.md
+++ b/examples/platform_channel_swift/README.md
@@ -5,7 +5,7 @@ specific services on iOS using Swift. The equivalent version of this
 project in Objective C is found in examples/platform_channel.
 
 You can read more about
-[accessing platform and third-party services in Flutter](https://flutter.io/platform-channels/).
+[accessing platform and third-party services in Flutter](https://flutter.dev/platform-channels/).
 
 ## iOS
 You can use the commands `flutter build` and `flutter run` from the app's root

--- a/examples/stocks/README.md
+++ b/examples/stocks/README.md
@@ -10,7 +10,7 @@ and install it onto your device.
 ### Prerequisites
 
 If you are new to Flutter, please first follow
-the [Flutter Setup](https://flutter.io/setup/) guide.
+the [Flutter Setup](https://flutter.dev/setup/) guide.
 
 ### Building and installing the stocks demo app
 
@@ -26,7 +26,7 @@ This app has been internationalized (just enough to show how it's
 done). It's an example of how one can do so with the
 [Dart intl package](https://pub.dartlang.org/packages/intl).
 
-The [Flutter Internationalization Tutorial](https://flutter.io/tutorials/internationalization/)
+The [Flutter Internationalization Tutorial](https://flutter.dev/tutorials/internationalization/)
 covers Flutter app internationalization in general.
 
 See [regenerate.md](lib/i18n/regenerate.md) for an explanation

--- a/flutter_console.bat
+++ b/flutter_console.bat
@@ -25,10 +25,10 @@ echo  Run "flutter create <app_name>" to create a new Flutter project.
 echo.
 echo  Run "flutter help" to see all available commands.
 echo.
-echo  Want to use an IDE to interact with Flutter? https://flutter.io/ide-setup/
+echo  Want to use an IDE to interact with Flutter? https://flutter.dev/ide-setup/
 echo.
 echo  Want to run the "flutter" command from any Command Prompt or PowerShell window?
-echo  Add Flutter to your PATH: https://flutter.io/setup-windows/#update-your-path
+echo  Add Flutter to your PATH: https://flutter.dev/setup-windows/#update-your-path
 echo.
 echo  ================================================================================
 

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -5,5 +5,5 @@ Flutter is a new way to build high-performance, cross-platform mobile apps.
 Flutter is optimized for today's — and tomorrow's — mobile devices. We are
 focused on low-latency input and high frame rates on Android and iOS.
 
-See the [getting started guide](https://flutter.io/getting-started/) for
+See the [getting started guide](https://flutter.dev/getting-started/) for
 information about using Flutter.

--- a/packages/flutter/lib/animation.dart
+++ b/packages/flutter/lib/animation.dart
@@ -6,7 +6,7 @@
 ///
 /// To use, import `package:flutter/animation.dart`.
 ///
-/// See [flutter.io/animations](https://flutter.io/animations/) for an overview.
+/// See [flutter.dev/animations](https://flutter.dev/animations/) for an overview.
 ///
 /// This library depends only on core Dart libraries and the `physics.dart` library.
 library animation;

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -10,7 +10,7 @@
 ///
 /// See also:
 ///
-///  * [flutter.io/widgets](https://flutter.io/widgets/)
+///  * [flutter.dev/widgets](https://flutter.dev/widgets/)
 ///    for a catalog of commonly-used Flutter widgets.
 ///  * [material.io/design](https://material.io/design/)
 ///    for an introduction to Material Design.

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -175,7 +175,7 @@ class CupertinoApp extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * <https://flutter.io/debugging/#performanceoverlay>
+  ///  * <https://flutter.dev/debugging/#performanceoverlay>
   final bool showPerformanceOverlay;
 
   /// Turns on checkerboarding of raster cache images.

--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -94,7 +94,7 @@ class _GestureArena {
 
 /// The first member to accept or the last member to not reject wins.
 ///
-/// See <https://flutter.io/gestures/#gesture-disambiguation> for more
+/// See <https://flutter.dev/gestures/#gesture-disambiguation> for more
 /// information about the role this class plays in the gesture system.
 ///
 /// To debug problems with gestures, consider using

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,7 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// first detected.
   ///
   /// For more information about the gesture arena:
-  /// https://flutter.io/docs/development/ui/advanced/gestures#gesture-disambiguation
+  /// https://flutter.dev/docs/development/ui/advanced/gestures#gesture-disambiguation
   ///
   /// By default, the drag start behavior is [DragStartBehavior.start].
   ///

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -71,7 +71,7 @@ const TextStyle _errorTextStyle = TextStyle(
 ///  * [MaterialPageRoute], which defines an app page that transitions in a material-specific way.
 ///  * [WidgetsApp], which defines the basic app elements but does not depend on the material library.
 ///  * The Flutter Internationalization Tutorial,
-///    <https://flutter.io/tutorials/internationalization/>.
+///    <https://flutter.dev/tutorials/internationalization/>.
 class MaterialApp extends StatefulWidget {
   /// Creates a MaterialApp.
   ///
@@ -300,7 +300,7 @@ class MaterialApp extends StatefulWidget {
   ///  * [GlobalMaterialLocalizations], a [localizationsDelegates] value
   ///    which provides material localizations for many languages.
   ///  * The Flutter Internationalization Tutorial,
-  ///    <https://flutter.io/tutorials/internationalization/>.
+  ///    <https://flutter.dev/tutorials/internationalization/>.
   final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
 
   /// {@macro flutter.widgets.widgetsApp.localeListResolutionCallback}
@@ -324,14 +324,14 @@ class MaterialApp extends StatefulWidget {
   ///  * [GlobalMaterialLocalizations], a [localizationsDelegates] value
   ///    which provides material localizations for many languages.
   ///  * The Flutter Internationalization Tutorial,
-  ///    <https://flutter.io/tutorials/internationalization/>.
+  ///    <https://flutter.dev/tutorials/internationalization/>.
   final Iterable<Locale> supportedLocales;
 
   /// Turns on a performance overlay.
   ///
   /// See also:
   ///
-  ///  * <https://flutter.io/debugging/#performanceoverlay>
+  ///  * <https://flutter.dev/debugging/#performanceoverlay>
   final bool showPerformanceOverlay;
 
   /// Turns on checkerboarding of raster cache images.

--- a/packages/flutter/lib/src/material/flutter_logo.dart
+++ b/packages/flutter/lib/src/material/flutter_logo.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 
 /// The Flutter logo, in widget form. This widget respects the [IconTheme].
-/// For guidelines on using the Flutter logo, visit https://flutter.io/brand.
+/// For guidelines on using the Flutter logo, visit https://flutter.dev/brand.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1756,7 +1756,7 @@ abstract class RenderBox extends RenderObject {
           '  $constraints\n'
           'The exact size it was given was:\n'
           '  $_size\n'
-          'See https://flutter.io/layout/ for more information.'
+          'See https://flutter.dev/layout/ for more information.'
         );
       }
       // verify that the size is within the constraints

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -683,7 +683,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
               information.write('  ');
               information.writeln(node.toStringShallow(joiner: '\n  '));
             }
-            information.writeln('See also: https://flutter.io/layout/');
+            information.writeln('See also: https://flutter.dev/layout/');
             addendum = information.toString();
           } else {
             return true;
@@ -704,7 +704,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
             '  $debugCreator\n'
             '$addendum'
             'If this message did not help you determine the problem, consider using debugDumpRenderTree():\n'
-            '  https://flutter.io/debugging/#rendering-layer\n'
+            '  https://flutter.dev/debugging/#rendering-layer\n'
             '  http://docs.flutter.io/flutter/rendering/debugDumpRenderTree.html\n'
             'If none of the above helps enough to fix this problem, please don\'t hesitate to file a bug:\n'
             '  https://github.com/flutter/flutter/issues/new?template=BUG.md'

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -27,7 +27,7 @@ import 'platform_messages.dart';
 /// The logical identity of the channel is given by its name. Identically named
 /// channels will interfere with each other's communication.
 ///
-/// See: <https://flutter.io/platform-channels/>
+/// See: <https://flutter.dev/platform-channels/>
 class BasicMessageChannel<T> {
   /// Creates a [BasicMessageChannel] with the specified [name] and [codec].
   ///
@@ -105,7 +105,7 @@ class BasicMessageChannel<T> {
 /// The logical identity of the channel is given by its name. Identically named
 /// channels will interfere with each other's communication.
 ///
-/// See: <https://flutter.io/platform-channels/>
+/// See: <https://flutter.dev/platform-channels/>
 class MethodChannel {
   /// Creates a [MethodChannel] with the specified [name].
   ///
@@ -148,7 +148,7 @@ class MethodChannel {
   /// {@tool sample}
   ///
   /// The code might be packaged up as a musical plugin, see
-  /// <https://flutter.io/developing-packages/>:
+  /// <https://flutter.dev/developing-packages/>:
   ///
   /// ```dart
   /// class Music {
@@ -441,7 +441,7 @@ class OptionalMethodChannel extends MethodChannel {
 /// The logical identity of the channel is given by its name. Identically named
 /// channels will interfere with each other's communication.
 ///
-/// See: <https://flutter.io/platform-channels/>
+/// See: <https://flutter.dev/platform-channels/>
 class EventChannel {
   /// Creates an [EventChannel] with the specified [name].
   ///

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -23,7 +23,7 @@ typedef _MessageHandler = Future<ByteData> Function(ByteData message);
 ///  * [MethodChannel], which provides platform communication using asynchronous
 ///    method calls.
 ///  * [EventChannel], which provides platform communication using event streams.
-///  * <https://flutter.io/platform-channels/>
+///  * <https://flutter.dev/platform-channels/>
 class BinaryMessages {
   BinaryMessages._();
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -625,7 +625,7 @@ class WidgetsApp extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * <https://flutter.io/debugging/#performanceoverlay>
+  ///  * <https://flutter.dev/debugging/#performanceoverlay>
   final bool showPerformanceOverlay;
 
   /// Checkerboards raster cache images.
@@ -1068,7 +1068,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
         );
       }
       message.writeln(
-        'See https://flutter.io/tutorials/internationalization/ for more\n'
+        'See https://flutter.dev/tutorials/internationalization/ for more\n'
         'information about configuring an app\'s locale, supportedLocales,\n'
         'and localizationsDelegates parameters.'
       );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1321,7 +1321,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
 ///
 ///  * [Transform], which applies an arbitrary transform to its child widget at
 ///    paint time.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class FittedBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that scales and positions its child within itself according to [fit].
   ///
@@ -1395,7 +1395,7 @@ class FittedBox extends SingleChildRenderObjectWidget {
 ///    paint time.
 ///  * [new Transform.translate], which applies an absolute offset translation
 ///    transformation instead of an offset scaled to the child.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class FractionalTranslation extends SingleChildRenderObjectWidget {
   /// Creates a widget that translates its child's painting.
   ///
@@ -1457,7 +1457,7 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
 ///  * [Transform], which is a paint effect that allows you to apply an
 ///    arbitrary transform to a child.
 ///  * [new Transform.rotate], which applies a rotation paint effect.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class RotatedBox extends SingleChildRenderObjectWidget {
   /// A widget that rotates its child.
   ///
@@ -1524,7 +1524,7 @@ class RotatedBox extends SingleChildRenderObjectWidget {
 /// See also:
 ///
 ///  * [EdgeInsets], the class that is used to describe the padding dimensions.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Padding extends SingleChildRenderObjectWidget {
   /// Creates a widget that insets its child.
   ///
@@ -1686,7 +1686,7 @@ class Padding extends SingleChildRenderObjectWidget {
 ///    set to [Alignment.center].
 ///  * [FractionallySizedBox], which sizes its child based on a fraction of its
 ///    own size and positions the child according to an [Alignment] value.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Align extends SingleChildRenderObjectWidget {
   /// Creates an alignment widget.
   ///
@@ -1776,7 +1776,7 @@ class Align extends SingleChildRenderObjectWidget {
 ///  * [Column], a widget that displays its children in a vertical array.
 ///  * [Container], a convenience widget that combines common painting,
 ///    positioning, and sizing widgets.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Center extends Align {
   /// Creates a widget that centers its child.
   const Center({ Key key, double widthFactor, double heightFactor, Widget child })
@@ -1956,7 +1956,7 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
 ///    constraints while also sizing its child to match a given aspect ratio.
 ///  * [FittedBox], which sizes and positions its child widget to fit the parent
 ///    according to a given [BoxFit] discipline.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class SizedBox extends SingleChildRenderObjectWidget {
   /// Creates a fixed size box. The [width] and [height] parameters can be null
   /// to indicate that the size of the box should not be constrained in
@@ -2064,7 +2064,7 @@ class SizedBox extends SingleChildRenderObjectWidget {
 ///    own size and positions the child according to an [Alignment] value.
 ///  * [AspectRatio], a widget that attempts to fit within the parent's
 ///    constraints while also sizing its child to match a given aspect ratio.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class ConstrainedBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that imposes additional constraints on its child.
   ///
@@ -2192,7 +2192,7 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
 ///  * [OverflowBox], a widget that imposes different constraints on its child
 ///    than it gets from its parent, possibly allowing the child to overflow the
 ///    parent.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class FractionallySizedBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that sizes its child to a fraction of the total available space.
   ///
@@ -2297,7 +2297,7 @@ class FractionallySizedBox extends SingleChildRenderObjectWidget {
 ///    when the incoming constraints are unbounded.
 ///  * [SizedBox], which lets you specify tight constraints by explicitly
 ///    specifying the height or width.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class LimitedBox extends SingleChildRenderObjectWidget {
   /// Creates a box that limits its size only when it's unconstrained.
   ///
@@ -2357,7 +2357,7 @@ class LimitedBox extends SingleChildRenderObjectWidget {
 ///  * [UnconstrainedBox], a container that tries to let its child draw without
 ///    constraints.
 ///  * [SizedBox], a box with a specified size.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class OverflowBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that lets its child overflow itself.
   const OverflowBox({
@@ -2452,7 +2452,7 @@ class OverflowBox extends SingleChildRenderObjectWidget {
 ///    child.
 ///  * [UnconstrainedBox], a container that tries to let its child draw without
 ///    constraints.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class SizedOverflowBox extends SingleChildRenderObjectWidget {
   /// Creates a widget of a given size that lets its child overflow.
   ///
@@ -2531,7 +2531,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///  * [Visibility], which can hide a child more efficiently (albeit less
 ///    subtly).
 ///  * [TickerMode], which can be used to disable animations in a subtree.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Offstage extends SingleChildRenderObjectWidget {
   /// Creates a widget that visually hides its child.
   const Offstage({ Key key, this.offstage = true, Widget child })
@@ -2613,7 +2613,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 ///    child.
 ///  * [UnconstrainedBox], a container that tries to let its child draw without
 ///    constraints.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class AspectRatio extends SingleChildRenderObjectWidget {
   /// Creates a widget with a specific aspect ratio.
   ///
@@ -2664,7 +2664,7 @@ class AspectRatio extends SingleChildRenderObjectWidget {
 ///
 /// See also:
 ///
-///  * [The catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * [The catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class IntrinsicWidth extends SingleChildRenderObjectWidget {
   /// Creates a widget that sizes its child to the child's intrinsic width.
   ///
@@ -2723,7 +2723,7 @@ class IntrinsicWidth extends SingleChildRenderObjectWidget {
 ///
 /// See also:
 ///
-///  * [The catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * [The catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class IntrinsicHeight extends SingleChildRenderObjectWidget {
   /// Creates a widget that sizes its child to the child's intrinsic height.
   ///
@@ -2748,7 +2748,7 @@ class IntrinsicHeight extends SingleChildRenderObjectWidget {
 ///  * [Align], a widget that aligns its child within itself and optionally
 ///    sizes itself based on the child's size.
 ///  * [Center], a widget that centers its child within itself.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Baseline extends SingleChildRenderObjectWidget {
   /// Creates a widget that positions its child according to the child's baseline.
   ///
@@ -3080,7 +3080,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 ///    children.
 ///  * [Flow], which provides paint-time control of its children using transform
 ///    matrices.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Stack extends MultiChildRenderObjectWidget {
   /// Creates a stack layout widget.
   ///
@@ -3175,7 +3175,7 @@ class Stack extends MultiChildRenderObjectWidget {
 /// See also:
 ///
 ///  * [Stack], for more details about stacks.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class IndexedStack extends Stack {
   /// Creates a [Stack] widget that paints a single child.
   ///
@@ -3651,7 +3651,7 @@ class PositionedDirectional extends StatelessWidget {
 ///  * [Flexible], to indicate children that should share the remaining room.
 ///  * [Spacer], a widget that takes up space proportional to it's flex value.
 ///    that may be sized smaller (leaving some remaining room unused).
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Flex extends MultiChildRenderObjectWidget {
   /// Creates a flex layout.
   ///
@@ -3989,7 +3989,7 @@ class Flex extends MultiChildRenderObjectWidget {
 ///  * [Flexible], to indicate children that should share the remaining room but
 ///    that may by sized smaller (leaving some remaining room unused).
 ///  * [Spacer], a widget that takes up space proportional to it's flex value.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Row extends Flex {
   /// Creates a horizontal array of children.
   ///
@@ -4187,7 +4187,7 @@ class Row extends Flex {
 ///  * [SingleChildScrollView], whose documentation discusses some ways to
 ///    use a [Column] inside a scrolling container.
 ///  * [Spacer], a widget that takes up space proportional to it's flex value.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Column extends Flex {
   /// Creates a vertical array of children.
   ///
@@ -4239,7 +4239,7 @@ class Column extends Flex {
 ///
 ///  * [Expanded], which forces the child to expand to fill the available space.
 ///  * [Spacer], a widget that takes up space proportional to it's flex value.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Flexible extends ParentDataWidget<Flex> {
   /// Creates a widget that controls how a child of a [Row], [Column], or [Flex]
   /// flexes.
@@ -4392,7 +4392,7 @@ class Flexible extends ParentDataWidget<Flex> {
 ///
 ///  * [Flexible], which does not force the child to fill the available space.
 ///  * [Spacer], a widget that takes up space proportional to it's flex value.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Expanded extends Flexible {
   /// Creates a widget that expands a child of a [Row], [Column], or [Flex]
   /// expand to fill the available space in the main axis.
@@ -4454,7 +4454,7 @@ class Expanded extends Flexible {
 ///
 ///  * [Row], which places children in one line, and gives control over their
 ///    alignment and spacing.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Wrap extends MultiChildRenderObjectWidget {
   /// Creates a wrap layout.
   ///
@@ -4685,7 +4685,7 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///    a single child.
 ///  * [CustomMultiChildLayout], which uses a delegate to position multiple
 ///    children.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Flow extends MultiChildRenderObjectWidget {
   /// Creates a flow layout.
   ///

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -240,7 +240,7 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
 ///  * [Border], which has a sample which uses [Container] heavily.
 ///  * [Ink], which paints a [Decoration] on a [Material], allowing
 ///    [InkResponse] and [InkWell] splashes to paint over them.
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class Container extends StatelessWidget {
   /// Creates a widget that combines common painting, positioning, and sizing widgets.
   ///

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -119,7 +119,7 @@ class GestureRecognizerFactoryWithHandlers<T extends GestureRecognizer> extends 
 /// them to the callbacks. To ignore accessibility events, set
 /// [excludeFromSemantics] to true.
 ///
-/// See <http://flutter.io/gestures/> for additional information.
+/// See <http://flutter.dev/gestures/> for additional information.
 ///
 /// Material design applications typically react to touches with ink splash
 /// effects. The [InkWell] class implements this effect and can be used in place

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -386,7 +386,7 @@ class Image extends StatefulWidget {
   ///    omitted.
   ///  * [ExactAssetImage], which is used to implement the behavior when the
   ///    scale is present.
-  ///  * <https://flutter.io/assets-and-images/>, an introduction to assets in
+  ///  * <https://flutter.dev/assets-and-images/>, an introduction to assets in
   ///    Flutter.
   Image.asset(
     String name, {

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -462,7 +462,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 ///  * [AnimatedPadding], which is a subset of this widget that only
 ///    supports animating the [padding].
-///  * The [catalog of layout widgets](https://flutter.io/widgets/layout/).
+///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -8,7 +8,7 @@
 ///
 /// See also:
 ///
-///  * [flutter.io/widgets](https://flutter.io/widgets/)
+///  * [flutter.dev/widgets](https://flutter.dev/widgets/)
 ///    for a catalog of commonly-used Flutter widgets.
 library widgets;
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
-homepage: http://flutter.io
+homepage: http://flutter.dev
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_driver
 description: Integration and performance test API for Flutter applications
-homepage: http://flutter.io
+homepage: http://flutter.dev
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:

--- a/packages/flutter_localizations/lib/src/l10n/README.md
+++ b/packages/flutter_localizations/lib/src/l10n/README.md
@@ -7,7 +7,7 @@ linked with the rest of flutter_localizations package.
 
 If you're looking for information about internationalizing Flutter
 apps in general, see the
-[Internationalizing Flutter Apps](https://flutter.io/tutorials/internationalization/) tutorial.
+[Internationalizing Flutter Apps](https://flutter.dev/tutorials/internationalization/) tutorial.
 
 
 ### Translations for one locale: .arb files
@@ -189,7 +189,7 @@ If you have feedback about the translations please
 
 ### See Also
 
-The [Internationalizing Flutter Apps](https://flutter.io/tutorials/internationalization/)
+The [Internationalizing Flutter Apps](https://flutter.dev/tutorials/internationalization/)
 tutorial describes how to use the internationalization APIs in an
 ordinary Flutter app.
 

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -63,7 +63,7 @@ import 'widgets_localizations.dart';
 /// See also:
 ///
 ///  * The Flutter Internationalization Tutorial,
-///    <https://flutter.io/tutorials/internationalization/>.
+///    <https://flutter.dev/tutorials/internationalization/>.
 ///  * [DefaultMaterialLocalizations], which only provides US English translations.
 abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   /// Initializes an object that defines the material widgets' localized strings

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -33,7 +33,7 @@ class UserMessages {
   String intellijStatusInfo(String version) => 'version $version';
   String get intellijPluginInfo =>
       'For information about installing plugins, see\n'
-      'https://flutter.io/intellij-setup/#installing-the-plugins';
+      'https://flutter.dev/intellij-setup/#installing-the-plugins';
   String intellijMinimumVersion(String minVersion) =>
       'This install is older than the minimum recommended version of $minVersion.';
   String intellijLocation(String installPath) => 'IntelliJ at $installPath';
@@ -65,7 +65,7 @@ class UserMessages {
       'Unable to locate Android SDK.\n'
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
-      '(or visit https://flutter.io/setup/#android-setup for detailed instructions).\n'
+      '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).\n'
       'If the Android SDK has been installed to a custom location, set $envKey to that location.\n'
       'You may also want to add it to your PATH environment variable.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
@@ -73,7 +73,7 @@ class UserMessages {
       'Platform $platform, build-tools $tools';
   String get androidSdkInstallHelp =>
       'Try re-installing or updating your Android SDK,\n'
-      'visit https://flutter.io/setup/#android-setup for detailed instructions.';
+      'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
   String get androidMissingNdk => 'Android NDK location not configured (optional; useful for native profiling support)';
   String androidNdkLocation(String directory) => 'Android NDK at $directory';
   // Also occurs in AndroidLicenseValidator
@@ -92,7 +92,7 @@ class UserMessages {
       'Android license status unknown.\n'
       'Try re-installing or updating your Android SDK Manager.\n'
       'See https://developer.android.com/studio/#downloads or visit '
-      'https://flutter.io/setup/#android-setup for detailed instructions.';
+      'https://flutter.dev/setup/#android-setup for detailed instructions.';
   String androidSdkManagerOutdated(String managerPath) =>
       'A newer version of the Android SDK is required. To update, run:\n'
       '$managerPath --update\n';
@@ -101,12 +101,12 @@ class UserMessages {
   String androidMissingSdkManager(String sdkManagerPath) =>
       'Android sdkmanager tool not found ($sdkManagerPath).\n'
       'Try re-installing or updating your Android SDK,\n'
-      'visit https://flutter.io/setup/#android-setup for detailed instructions.';
+      'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
   String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
       'To update using sdkmanager, run:\n'
       '  "$managerPath" "platforms;android-$sdkMinVersion" "build-tools;$buildToolsMinVersion"\n'
-      'or visit https://flutter.io/setup/#android-setup for detailed instructions.';
+      'or visit https://flutter.dev/setup/#android-setup for detailed instructions.';
 
   // Messages used in AndroidStudioValidator
   String androidStudioVersion(String version) => 'version $version';
@@ -124,7 +124,7 @@ class UserMessages {
       'but Android Studio not found at this location.';
   String get androidStudioInstallation =>
       'Android Studio not found; download from https://developer.android.com/studio/index.html\n'
-      '(or visit https://flutter.io/setup/#android-setup for detailed instructions).';
+      '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).';
 
   // Messages used in IOSValidator
   String iOSXcodeLocation(String location) => 'Xcode at $location';

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -259,7 +259,7 @@ class Cache {
         printError(
           'Failed to retrieve Flutter tool dependencies: ${e.message}.\n'
           'If you\'re in China, please see this page: '
-          'https://flutter.io/community/china',
+          'https://flutter.dev/community/china',
           emphasis: true,
         );
       }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -407,7 +407,7 @@ Your $application code is in $relativeAppMain.
 Your plugin code is in $relativePluginMain.
 
 Host platform code is in the "android" and "ios" directories under $relativePluginPath.
-To edit platform code in an IDE see https://flutter.io/developing-packages/#edit-plugin-package.
+To edit platform code in an IDE see https://flutter.dev/developing-packages/#edit-plugin-package.
 ''');
         }
       } else {

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -34,7 +34,7 @@ class DevicesCommand extends FlutterCommand {
         'No devices detected.\n\n'
         "Run 'flutter emulators' to list and start any available device emulators.\n\n"
         'Or, if you expected your device to be detected, please run "flutter doctor" to diagnose '
-        'potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');
+        'potential issues, or visit https://flutter.dev/setup/ for troubleshooting tips.');
       final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
       if (diagnostics.isNotEmpty) {
         printStatus('');

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -135,7 +135,7 @@ class EmulatorsCommand extends FlutterCommand {
     if (showRunInstruction || showCreateInstruction) {
       printStatus('');
     }
-    // TODO(dantup): Update this link to flutter.io if/when we have a better page.
+    // TODO(dantup): Update this link to flutter.dev if/when we have a better page.
     // That page can then link out to these places if required.
     printStatus('You can find more information on managing emulators at the links below:\n'
         '  https://developer.android.com/studio/run/managing-avds\n'

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -215,7 +215,7 @@ class RunCommand extends RunCommandBase {
       printStatus("Run 'flutter emulators' to list and start any available device emulators.");
       printStatus('');
       printStatus('If you expected your device to be detected, please run "flutter doctor" to diagnose');
-      printStatus('potential issues, or visit https://flutter.io/setup/ for troubleshooting tips.');
+      printStatus('potential issues, or visit https://flutter.dev/setup/ for troubleshooting tips.');
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -23,7 +23,7 @@ import 'xcodeproj.dart';
 const String noCocoaPodsConsequence = '''
   CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
   Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
-  For more info, see https://flutter.io/platform-plugins''';
+  For more info, see https://flutter.dev/platform-plugins''';
 
 const String unknownCocoaPodsConsequence = '''
   Flutter is unable to determine the installed CocoaPods's version.

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -46,7 +46,7 @@ It's also possible that a previously installed app with the same Bundle\u0020
 Identifier was signed with a different certificate.
 
 For more information, please visit:
-  https://flutter.io/setup/#deploy-to-ios-devices
+  https://flutter.dev/setup/#deploy-to-ios-devices
 
 Or run on an iOS simulator without code signing
 ════════════════════════════════════════════════════════════════════════════════''';
@@ -60,7 +60,7 @@ Provisioning Profile. Please ensure that a Development Team is selected by:
 $fixWithDevelopmentTeamInstruction
 
 For more information, please visit:
-  https://flutter.io/setup/#deploy-to-ios-devices
+  https://flutter.dev/setup/#deploy-to-ios-devices
 
 Or run on an iOS simulator without code signing
 ════════════════════════════════════════════════════════════════════════════════''';

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -221,7 +221,7 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Depends on all your plugins, and provides a function to register them.
                        DESC
-  s.homepage         = 'https://flutter.io'
+  s.homepage         = 'https://flutter.dev'
   s.license          = { :type => 'BSD' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.ios.deployment_target = '8.0'

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -148,7 +148,7 @@ class Usage {
     printStatus('');
     printStatus('''
   ╔════════════════════════════════════════════════════════════════════════════╗
-  ║                 Welcome to Flutter! - https://flutter.io                   ║
+  ║                 Welcome to Flutter! - https://flutter.dev                  ║
   ║                                                                            ║
   ║ The Flutter tool anonymously reports feature usage statistics and crash    ║
   ║ reports to Google in order to help Google contribute improvements to       ║

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tools
 description: Tools for building Flutter applications
-homepage: https://flutter.io
+homepage: https://flutter.dev
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:

--- a/packages/flutter_tools/templates/app/README.md.tmpl
+++ b/packages/flutter_tools/templates/app/README.md.tmpl
@@ -8,9 +8,9 @@ This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://flutter.io/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.io/docs/cookbook)
+- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
 
 For help getting started with Flutter, view our 
-[online documentation](https://flutter.io/docs), which offers tutorials, 
+[online documentation](https://flutter.dev/docs), which offers tutorials, 
 samples, guidance on mobile development, and a full API reference.

--- a/packages/flutter_tools/templates/app/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/app/lib/main.dart.tmpl
@@ -15,7 +15,7 @@ void main() => runApp(MyApp());
 {{#withDriverTest}}
 void main() {
   // Enable integration testing with the Flutter Driver extension.
-  // See https://flutter.io/testing/ for more info.
+  // See https://flutter.dev/testing/ for more info.
   enableFlutterDriverExtension();
   runApp(MyApp());
 }

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -60,10 +60,10 @@ flutter:
   #  - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
+  # https://flutter.dev/assets-and-images/#resolution-aware.
 
   # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
+  # https://flutter.dev/assets-and-images/#from-packages
 
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
@@ -83,4 +83,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.io/custom-fonts/#from-packages
+  # see https://flutter.dev/custom-fonts/#from-packages

--- a/packages/flutter_tools/templates/module/common/README.md.tmpl
+++ b/packages/flutter_tools/templates/module/common/README.md.tmpl
@@ -5,4 +5,4 @@
 ## Getting Started
 
 For help getting started with Flutter, view our online
-[documentation](https://flutter.io/).
+[documentation](https://flutter.dev/).

--- a/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
@@ -15,7 +15,7 @@ void main() => runApp(MyApp());
 {{#withDriverTest}}
 void main() {
   // Enable integration testing with the Flutter Driver extension.
-  // See https://flutter.io/testing/ for more info.
+  // See https://flutter.dev/testing/ for more info.
   enableFlutterDriverExtension();
   runApp(MyApp());
 }

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -52,10 +52,10 @@ flutter:
   #  - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
+  # https://flutter.dev/assets-and-images/#resolution-aware.
 
   # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
+  # https://flutter.dev/assets-and-images/#from-packages
 
   # To add Flutter specific custom fonts to your application, add a fonts
   # section here, in this "flutter" section. Each entry in this list should
@@ -75,7 +75,7 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.io/custom-fonts/#from-packages
+  # see https://flutter.dev/custom-fonts/#from-packages
 
 
   # This section identifies your Flutter project as a module meant for

--- a/packages/flutter_tools/templates/package/README.md.tmpl
+++ b/packages/flutter_tools/templates/package/README.md.tmpl
@@ -5,10 +5,10 @@
 ## Getting Started
 
 This project is a starting point for a Dart
-[package](https://flutter.io/developing-packages/),
+[package](https://flutter.dev/developing-packages/),
 a library module containing code that can be shared easily across
 multiple Flutter or Dart projects.
 
 For help getting started with Flutter, view our 
-[online documentation](https://flutter.io/docs), which offers tutorials, 
+[online documentation](https://flutter.dev/docs), which offers tutorials, 
 samples, guidance on mobile development, and a full API reference.

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -31,10 +31,10 @@ flutter:
   #  - images/a_dot_ham.jpeg
   #
   # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
+  # https://flutter.dev/assets-and-images/#from-packages
   #
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
+  # https://flutter.dev/assets-and-images/#resolution-aware.
 
   # To add custom fonts to your package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
@@ -54,4 +54,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages
+  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/flutter_tools/templates/plugin/README.md.tmpl
+++ b/packages/flutter_tools/templates/plugin/README.md.tmpl
@@ -5,10 +5,10 @@
 ## Getting Started
 
 This project is a starting point for a Flutter
-[plug-in package](https://flutter.io/developing-packages/),
+[plug-in package](https://flutter.dev/developing-packages/),
 a specialized package that includes platform-specific implementation code for
 Android and/or iOS.
 
 For help getting started with Flutter, view our 
-[online documentation](https://flutter.io/docs), which offers tutorials, 
+[online documentation](https://flutter.dev/docs), which offers tutorials, 
 samples, guidance on mobile development, and a full API reference.

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -34,10 +34,10 @@ flutter:
   #  - images/a_dot_ham.jpeg
   #
   # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
+  # https://flutter.dev/assets-and-images/#from-packages
   #
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
+  # https://flutter.dev/assets-and-images/#resolution-aware.
 
   # To add custom fonts to your plugin package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
@@ -57,4 +57,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages
+  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/flutter_tools/test/cache_test.dart
+++ b/packages/flutter_tools/test/cache_test.dart
@@ -128,16 +128,16 @@ void main() {
         verifyNever(artifact2.update(<DevelopmentArtifact>{}));
         expect(
           testLogger.errorText,
-          contains('https://flutter.io/community/china'),
+          contains('https://flutter.dev/community/china'),
         );
       }
     });
   });
 
   testUsingContext('flattenNameSubdirs', () {
-    expect(flattenNameSubdirs(Uri.parse('http://flutter.io/foo/bar')), 'flutter.io/foo/bar');
+    expect(flattenNameSubdirs(Uri.parse('http://flutter.dev/foo/bar')), 'flutter.dev/foo/bar');
     expect(flattenNameSubdirs(Uri.parse('http://docs.flutter.io/foo/bar')), 'docs.flutter.io/foo/bar');
-    expect(flattenNameSubdirs(Uri.parse('https://www.flutter.io')), 'www.flutter.io');
+    expect(flattenNameSubdirs(Uri.parse('https://www.flutter.dev')), 'www.flutter.dev');
   }, overrides: <Type, Generator>{
     FileSystem: () => MockFileSystem(),
   });

--- a/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
+++ b/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
@@ -16,7 +16,7 @@ import 'package:fuchsia_remote_debug_protocol/logging.dart';
 ///
 /// Make sure to set up your application (you can change the name from
 /// 'todo_list') follows the setup for testing with the flutter driver:
-/// https://flutter.io/testing/#adding-the-flutter_driver-dependency
+/// https://flutter.dev/testing/#adding-the-flutter_driver-dependency
 ///
 /// Example usage:
 ///

--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fuchsia_remote_debug_protocol
 description: Provides an API to test/debug Flutter applications on remote Fuchsia devices and emulators.
-homepage: http://flutter.io
+homepage: http://flutter.dev
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:


### PR DESCRIPTION
## Description

We've moved our canonical domain from flutter.io to [flutter.dev](https://flutter.dev). While we won't be removing flutter.io any time soon, we want new developers to recognize flutter.dev as our site. 

This PR is focused on replacing URLs for the primary site. It does not replace references to docs.flutter.io, since that site migration is still underway. 

I've tested a representative subset of these changes by hand to validate that the new URLs work. I've also visually reviewed every change to make sure that there's no unexpected side-effects (e.g. spacing problems with command-line tools). 