### PR TITLE
Mark ios-deploy version 2.0.0 as bad

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -67,7 +67,7 @@ class IOSValidator extends DoctorValidator {
     try {
       final Version version = Version.parse(await iosDeployVersionText);
       return version >= Version.parse(iosDeployMinimumVersion)
-          && !iosDeployBadVersions.map((v) => Version.parse(v)).contains(version);
+          && !iosDeployBadVersions.map((String v) => Version.parse(v)).contains(version);
     } on FormatException catch (_) {
       return false;
     }

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -52,6 +52,9 @@ class IOSValidator extends DoctorValidator {
 
   String get iosDeployMinimumVersion => '1.9.4';
 
+  // ios-deploy <= v1.9.3 declares itself as v2.0.0
+  List<String> get iosDeployBadVersions => <String>['2.0.0'];
+
   Future<String> get iosDeployVersionText async => (await runAsync(<String>['ios-deploy', '--version'])).processResult.stdout.replaceAll('\n', '');
 
   bool get hasHomebrew => os.which('brew') != null;
@@ -63,7 +66,8 @@ class IOSValidator extends DoctorValidator {
       return false;
     try {
       final Version version = Version.parse(await iosDeployVersionText);
-      return version >= Version.parse(iosDeployMinimumVersion);
+      return version >= Version.parse(iosDeployMinimumVersion)
+          && !iosDeployBadVersions.map((v) => Version.parse(v)).contains(version);
     } on FormatException catch (_) {
       return false;
     }

--- a/packages/flutter_tools/test/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/ios/ios_workflow_test.dart
@@ -230,6 +230,22 @@ Show information about a connected device.
       CocoaPods: () => cocoaPods,
     });
 
+    testUsingContext('Emits partial status when ios-deploy version is a known bad version', () async {
+      when(xcode.isInstalled).thenReturn(true);
+      when(xcode.versionText)
+          .thenReturn('Xcode 8.2.1\nBuild version 8C1002\n');
+      when(xcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      when(xcode.eulaSigned).thenReturn(true);
+      when(xcode.isSimctlInstalled).thenReturn(true);
+      final IOSWorkflowTestTarget workflow = IOSWorkflowTestTarget(iosDeployVersionText: '2.0.0');
+      final ValidationResult result = await workflow.validate();
+      expect(result.type, ValidationType.partial);
+    }, overrides: <Type, Generator>{
+      IMobileDevice: () => iMobileDevice,
+      Xcode: () => xcode,
+      CocoaPods: () => cocoaPods,
+    });
+
     testUsingContext('Emits partial status when simctl is not installed', () async {
       when(xcode.isInstalled).thenReturn(true);
       when(xcode.versionText)


### PR DESCRIPTION
ios-deploy before version 1.9.4 declares itself as v2.0.0
https://github.com/ios-control/ios-deploy/commits/master/src/ios-deploy/version.h

## Description
flutter requires ios-deploy >= v1.9.4 but previous versions of ios-deploy declares itself as 2.0.0, so the problem was undetected by flutter-doctor.

ios-deploy v1.9.4 fixed the issue caused by Apple changing the UDID format in the latest generation of iPhones (XS, XS Max, XR) (https://www.theiphonewiki.com/wiki/UDID)