### PR TITLE
Fix gitignore template to exclude build folder and pubspec.lock

### DIFF
--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -25,7 +25,8 @@
 .packages
 .pub-cache/
 .pub/
-/build/
+**/build/
+pubspec.lock
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
Currently, after running `flutter create`, then `flutter packages get` and `flutter run`, your Git status will include your build directory and your pubspec.lock, neither of which should be tracked by Git.  This change fixes that.