### PR TITLE
Add `const Border.uniformSide()`

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -317,7 +317,7 @@ class Border extends BoxBorder {
   /// Creates a border whose sides are all the same.
   ///
   /// The `side` argument must not be null.
-  const Border.uniformSide(BorderSide side)
+  const Border.uniform(BorderSide side)
       : assert(side != null),
         top = side,
         right = side,
@@ -333,7 +333,7 @@ class Border extends BoxBorder {
     BorderStyle style = BorderStyle.solid,
   }) {
     final BorderSide side = BorderSide(color: color, width: width, style: style);
-    return Border.uniformSide(side);
+    return Border.uniform(side);
   }
 
   /// Creates a [Border] that represents the addition of the two given

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -314,6 +314,16 @@ class Border extends BoxBorder {
        assert(bottom != null),
        assert(left != null);
 
+  /// Creates a border whose sides are all the same.
+  ///
+  /// The `side` argument must not be null.
+  const Border.uniformSide(BorderSide side)
+      : assert(side != null),
+        top = side,
+        right = side,
+        bottom = side,
+        left = side;
+
   /// A uniform border with all sides the same color and width.
   ///
   /// The sides default to black solid borders, one logical pixel wide.
@@ -323,7 +333,7 @@ class Border extends BoxBorder {
     BorderStyle style = BorderStyle.solid,
   }) {
     final BorderSide side = BorderSide(color: color, width: width, style: style);
-    return Border(top: side, right: side, bottom: side, left: side);
+    return Border.uniformSide(side);
   }
 
   /// Creates a [Border] that represents the addition of the two given

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -13,6 +13,16 @@ void main() {
     expect(() => Border(bottom: nonconst(null)), throwsAssertionError);
   });
 
+  test('Border.uniformSide constructor', () {
+    expect(() => Border.uniformSide(null), throwsAssertionError);
+    const BorderSide side = BorderSide();
+    const Border border = Border.uniformSide(side);
+    expect(border.left, same(side));
+    expect(border.top, same(side));
+    expect(border.right, same(side));
+    expect(border.bottom, same(side));
+  });
+
   test('Border.merge', () {
     const BorderSide magenta3 = BorderSide(color: Color(0xFFFF00FF), width: 3.0);
     const BorderSide magenta6 = BorderSide(color: Color(0xFFFF00FF), width: 6.0);

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -13,10 +13,10 @@ void main() {
     expect(() => Border(bottom: nonconst(null)), throwsAssertionError);
   });
 
-  test('Border.uniformSide constructor', () {
-    expect(() => Border.uniformSide(null), throwsAssertionError);
+  test('Border.uniform constructor', () {
+    expect(() => Border.uniform(null), throwsAssertionError);
     const BorderSide side = BorderSide();
-    const Border border = Border.uniformSide(side);
+    const Border border = Border.uniform(side);
     expect(border.left, same(side));
     expect(border.top, same(side));
     expect(border.right, same(side));


### PR DESCRIPTION
## Description

`Border.all()` is a factory constructor and thus not const
constructable. This change adds a `const Border.uniformSide()`
constructor and makes `Border.all()` delegate to it. This allows
callers to more likely be able to make their widget tree const
constructable.

## Tests

I added the following tests:

* A simple test of the new constructor.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.