### PR TITLE
Mark cubic_bezier_perf__timeline_summary nonflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -159,7 +159,6 @@ tasks:
       Measures the runtime performance of cubic bezier animations on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-    flaky: true
 
   flavors_test:
     description: >


### PR DESCRIPTION
The devicelab test cubic_bezier_perf__timeline_summary has been running for weeks without any flakyness.