### PR TITLE
Unbounded TextField width error

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -834,6 +834,11 @@ class _RenderDecoration extends RenderBox {
   // This method applies layout to all of the renderers except the container.
   // For convenience, the container is laid out in performLayout().
   _RenderDecorationLayout _layout(BoxConstraints layoutConstraints) {
+    assert(
+      layoutConstraints.maxWidth < double.infinity,
+      'A text input cannot have an unbounded width. If you want it to take up the leftover space inside its parent, try wrapping it in a Flexible.',
+    );
+
     // Margin on each side of subtext (counter and helperError)
     final Map<RenderBox, double> boxToBaseline = <RenderBox, double>{};
     final BoxConstraints boxConstraints = layoutConstraints.loosen();

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -836,7 +836,13 @@ class _RenderDecoration extends RenderBox {
   _RenderDecorationLayout _layout(BoxConstraints layoutConstraints) {
     assert(
       layoutConstraints.maxWidth < double.infinity,
-      'A text input cannot have an unbounded width. If you want it to take up the leftover space inside its parent, try wrapping it in a Flexible.',
+      'An InputDecorator, which is typically created by a TextField, cannot '
+      'have an unbounded width.\n'
+      'This happens when the parent widget does not provide a finite width '
+      'constraint. For example, if the InputDecorator is contained by a Row, '
+      'then its width must be constrained. An Expanded widget or a SizedBox '
+      'can be used to constrain the width of the InputDecorator or the '
+      'TextField that contains it.',
     );
 
     // Margin on each side of subtext (counter and helperError)

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -8,8 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 
 import 'debug.dart';
 import 'framework.dart';
@@ -3684,12 +3682,6 @@ class Flex extends MultiChildRenderObjectWidget {
        assert(crossAxisAlignment != null),
        assert(verticalDirection != null),
        assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null),
-       assert(
-         !children.any((Widget widget) =>
-           direction == Axis.horizontal && (widget is TextField || widget is CupertinoTextField)
-         ),
-         'TextField cannot have an unbounded width. If you want it to take up the leftover space inside its parent, try wrapping it in a Flexible.',
-       ),
        super(key: key, children: children);
 
   /// The direction to use as the main axis.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 import 'debug.dart';
 import 'framework.dart';
@@ -3682,6 +3684,12 @@ class Flex extends MultiChildRenderObjectWidget {
        assert(crossAxisAlignment != null),
        assert(verticalDirection != null),
        assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null),
+       assert(
+         !children.any((Widget widget) =>
+           direction == Axis.horizontal && (widget is TextField || widget is CupertinoTextField)
+         ),
+         'TextField cannot have an unbounded width. If you want it to take up the leftover space inside its parent, try wrapping it in a Flexible.',
+       ),
        super(key: key, children: children);
 
   /// The direction to use as the main axis.


### PR DESCRIPTION
Closes: https://github.com/flutter/flutter/issues/9780

This improves the error message shown when a TextField ends up with an unbounded width.