### PR TITLE
Fix hover annotation removal

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -124,7 +124,7 @@ class MouseTracker {
     for (int deviceId in trackedAnnotation.activeDevices) {
       annotation.onExit(PointerExitEvent.fromMouseEvent(_lastMouseEvent[deviceId]));
     }
-    _trackedAnnotations.remove(annotation);
+    _trackedAnnotations.remove(trackedAnnotation);
   }
 
   void _scheduleMousePositionCheck() {


### PR DESCRIPTION
This fixes a bug in hover that was introduced when we switched to allowing exit events to be created by any event (in #28602).

Fixes #30744