### PR TITLE
 Fix issue 23527: Exception: RenderViewport exceeded its maximum numb…

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -686,7 +686,8 @@ class SliverGeometry extends Diagnosticable {
   ///  * [RenderViewport.cacheExtent] for a description of a viewport's cache area.
   final double cacheExtent;
 
-  static const double _epsilon = 1e-10;
+  /// The epsilon of tolerable double precision error.
+  static const double precisionErrorTolerance = 1e-10;
 
   /// Asserts that this geometry is internally consistent.
   ///
@@ -719,8 +720,8 @@ class SliverGeometry extends Diagnosticable {
       }
       verify(maxPaintExtent != null, 'The "maxPaintExtent" is null.');
       // If the paintExtent is slightly more than the maxPaintExtent, but the difference is still less
-      // than epsilon, we will not throw the assert below.
-      if (paintExtent - maxPaintExtent > _epsilon) {
+      // than precisionErrorTolerance, we will not throw the assert below.
+      if (paintExtent - maxPaintExtent > precisionErrorTolerance) {
         verify(false,
           'The "maxPaintExtent" is less than the "paintExtent".\n' +
           _debugCompareFloats('maxPaintExtent', maxPaintExtent, 'paintExtent', paintExtent) +

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -119,7 +119,8 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       }
 
       final double firstChildScrollOffset = earliestScrollOffset - paintExtentOf(firstChild);
-      if (firstChildScrollOffset < 0.0) {
+      // firstChildScrollOffset may contain double precision error
+      if (firstChildScrollOffset < -SliverGeometry.precisionErrorTolerance) {
         // The first child doesn't fit within the viewport (underflow) and
         // there may be additional children above it. Find the real first child
         // and then correct the scroll position so that there's room for all and


### PR DESCRIPTION
…er of layout cycles

## Description

this is caused by double precision error. If we have certain height of widget in sliver list, the way we calculate layout offset of children will introduce some double precision error. Later when we scroll all the way to top, we will try to correct the error by shifting the scroll offset even if it is so tiny and does not really need to be corrected (~2e-14).

Most of the time it is correctable, but some times it fail to do so due to precision error in double operation

for example iphone 6s
corrected_scrollofset = scrolloffset + correction
if scrolloffset = 258.8489087697789 and correction = 0.00000000000002842170943040401
Then the scrolloffset does not change after correction due to precision error.
258.8489087697789 + 0.00000000000002842170943040401 = 258.8489087697789
Thus, it stuck on an infinite update loop.

## Related Issues

https://github.com/flutter/flutter/issues/23527

## Tests

I added the following tests:

https://github.com/chunhtai/flutter/blob/465ade89e57a6d8fffc34094d327bcbb99ee8f7c/packages/flutter/test/rendering/slivers_block_test.dart#L298

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
