### PR TITLE
Make CupertinoNavigationBarBackButton correctly return an assert error

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1231,7 +1231,7 @@ class CupertinoNavigationBarBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ModalRoute<dynamic> currentRoute = ModalRoute.of(context);
     assert(
-      currentRoute.canPop,
+      currentRoute?.canPop == true,
       'CupertinoNavigationBarBackButton should only be used in routes that can be popped',
     );
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -896,8 +896,8 @@ void main() {
 
   testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
       await tester.pumpWidget(
-        CupertinoApp(
-          home: const CupertinoNavigationBarBackButton(),
+        const CupertinoApp(
+          home: CupertinoNavigationBarBackButton(),
         ),
       );
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -884,14 +884,26 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('Back button shows an error when manually added outside a route', (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoNavigationBarBackButton()
     );
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(exception.toString(), contains('can be popped'));
+    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+  });
+
+  testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: const CupertinoNavigationBarBackButton(),
+        ),
+      );
+
+      final dynamic exception = tester.takeException();
+      expect(exception, isAssertionError);
+      expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 }
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -883,6 +883,16 @@ void main() {
     );
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
   });
+
+  testWidgets('Back button shows an error when manually added outside a route', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoNavigationBarBackButton()
+    );
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isAssertionError);
+    expect(exception.toString(), contains('can be popped'));
+  });
 }
 
 class _ExpectStyles extends StatelessWidget {


### PR DESCRIPTION
## Description

Fixes an the error that failed to show correctly in https://stackoverflow.com/questions/55486698/in-cupertinonavigationbar-how-do-i-show-a-button-besides-back-button-in-leading

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes