### PR TITLE
CupertinoDatePicker initialDateTime accounts for minuteInterval 

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -540,7 +540,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
 
   Widget _buildMinutePicker(double offAxisFraction, TransitionBuilder itemPositioningBuilder) {
     return CupertinoPicker(
-      scrollController: FixedExtentScrollController(initialItem: selectedMinute),
+      scrollController: FixedExtentScrollController(initialItem: selectedMinute ~/ widget.minuteInterval),
       offAxisFraction: offAxisFraction,
       itemExtent: _kItemExtent,
       useMagnifier: _kUseMagnifier,

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -264,6 +264,30 @@ void main() {
       expect(picker.initialDateTime, isNotNull);
     });
 
+    testWidgets('initial date honors minuteInterval', (WidgetTester tester) async {
+        DateTime newDateTime;
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: SizedBox(
+              width: 400,
+              height: 400,
+              child: CupertinoDatePicker(
+                onDateTimeChanged: (DateTime d) => newDateTime = d,
+                initialDateTime: DateTime(2018, 10, 10, 10, 3),
+                minuteInterval: 3,
+              )
+            )
+          )
+        );
+
+        // 03 -> 06
+        await tester.drag(find.text('03'), _kRowOffset);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(newDateTime.minute, 6);
+    });
+
     testWidgets('changing initialDateTime after first build does not do anything', (WidgetTester tester) async {
       DateTime selectedDateTime;
       await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -280,10 +280,11 @@ void main() {
           )
         );
 
-        // 03 -> 06
+        // Drag the minute picker to the next slot (03 -> 06).
+        // The `initialDateTime` and the `minuteInterval` values are specifically choosen
+        // so that `find.text` finds exactly one widget.
         await tester.drag(find.text('03'), _kRowOffset);
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
 
         expect(newDateTime.minute, 6);
     });


### PR DESCRIPTION
## Description

initialDateTime should account for minuteInterval 

## Related Issues

fixes #28730

## Tests

I added the following tests:

- initial date honors minuteInterval

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
