### PR TITLE
Let `sliver.dart` `_createErrorWidget` work with other Widgets

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1291,8 +1291,8 @@ class KeepAlive extends ParentDataWidget<SliverWithKeepAliveWidget> {
   }
 }
 
-// Return an ErrorWidget for the given Exception
-ErrorWidget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
+// Return a Widget for the given Exception
+Widget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
   final FlutterErrorDetails details = FlutterErrorDetails(
     exception: exception,
     stack: stackTrace,

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -198,6 +198,7 @@ void main() {
 
   testWidgets('Can override ErrorWidget.build', (WidgetTester tester) async {
     const Text errorText = Text('error');
+    final ErrorWidgetBuilder oldBuilder = ErrorWidget.builder;
     ErrorWidget.builder = (FlutterErrorDetails details) => errorText;
     final SliverChildBuilderDelegate builderThrowsDelegate = SliverChildBuilderDelegate(
       (_, __) => throw 'builder',
@@ -207,5 +208,6 @@ void main() {
     );
     expect(builderThrowsDelegate.build(null, 0), errorText);
     expect(tester.takeException(), 'builder');
+    ErrorWidget.builder = oldBuilder;
   });
 }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -195,4 +195,17 @@ void main() {
     expect(find.text('B'), findsNothing);
     expect(find.text('BOTTOM'), findsOneWidget);
   });
+
+  testWidgets('Can override ErrorWidget.build', (WidgetTester tester) async {
+    const Text errorText = Text('error');
+    ErrorWidget.builder = (FlutterErrorDetails details) => errorText;
+    final SliverChildBuilderDelegate builderThrowsDelegate = SliverChildBuilderDelegate(
+      (_, __) => throw 'builder',
+      addAutomaticKeepAlives: false,
+      addRepaintBoundaries: false,
+      addSemanticIndexes: false,
+    );
+    expect(builderThrowsDelegate.build(null, 0), errorText);
+    expect(tester.takeException(), 'builder');
+  });
 }


### PR DESCRIPTION
## Description

The `_createErrorWidget` method in `widgets/sliver.dart` doesn't properly handle the case where someone overrides `FlutteError.builder` to not return an `ErrorWidget`.  

This just adds a test to the change suggested in #30431 

## Tests

Adds a test that exercises `_createErrorWidget` with a non `ErrorWidget`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
