### PR TITLE
Allow applying a local Gradle file when deploying as a module.

### DIFF
--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
@@ -1,7 +1,9 @@
 // Generated file. Do not edit.
 
+def localDirectory = buildscript.sourceFile.parentFile.parentFile
+
 def localProperties = new Properties()
-def localPropertiesFile = new File(buildscript.sourceFile.parentFile.parentFile, 'local.properties')
+def localPropertiesFile = new File(localDirectory, 'local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
@@ -36,6 +38,11 @@ android {
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+}
+
+def localAndroidFile = new File(localDirectory.parentFile, 'flutter-android.gradle')
+if (localAndroidFile.exists()) {
+    apply from: localAndroidFile
 }
 
 flutter {


### PR DESCRIPTION
## Description

This enables adding additional required configurations (f.ex: flavors) to ensure smooth operation of the Android module.

## Related Issues

As an example, native apps having non-standard flavors were failing to run without adding the same flavors in Flutter's Gradle file.

## Tests

No tests were added!

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

No breaking changes.

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
