### PR TITLE
Use identical instead of '==' in a constant expression.

### DIFF
--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -53,7 +53,7 @@ class FlutterLogoDecoration extends Decoration {
        assert(textColor != null),
        assert(style != null),
        assert(margin != null),
-       _position = style == FlutterLogoStyle.markOnly ? 0.0 : style == FlutterLogoStyle.horizontal ? 1.0 : -1.0, // ignore: CONST_EVAL_TYPE_BOOL_NUM_STRING
+       _position = identical(style, FlutterLogoStyle.markOnly) ? 0.0 : identical(style, FlutterLogoStyle.horizontal) ? 1.0 : -1.0,
        // (see https://github.com/dart-lang/sdk/issues/26980 for details about that ignore statement)
        _opacity = 1.0;
 

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -8,19 +8,19 @@ import 'package:flutter/painting.dart';
 void main() {
   // Here and below, see: https://github.com/dart-lang/sdk/issues/26980
   const FlutterLogoDecoration start = FlutterLogoDecoration(
-    lightColor: const Color(0xFF000000),
-    darkColor: const Color(0xFFFFFFFF),
-    textColor: const Color(0xFFD4F144),
+    lightColor: Color(0xFF000000),
+    darkColor: Color(0xFFFFFFFF),
+    textColor: Color(0xFFD4F144),
     style: FlutterLogoStyle.stacked,
-    margin: const EdgeInsets.all(10.0),
+    margin: EdgeInsets.all(10.0),
   );
 
   const FlutterLogoDecoration end = FlutterLogoDecoration(
-    lightColor: const Color(0xFFFFFFFF),
-    darkColor: const Color(0xFF000000),
-    textColor: const Color(0xFF81D4FA),
+    lightColor: Color(0xFFFFFFFF),
+    darkColor: Color(0xFF000000),
+    textColor: Color(0xFF81D4FA),
     style: FlutterLogoStyle.stacked,
-    margin: const EdgeInsets.all(10.0),
+    margin: EdgeInsets.all(10.0),
   );
 
   test('FlutterLogoDecoration lerp from null to null is null', () {

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/painting.dart';
 
 void main() {
   // Here and below, see: https://github.com/dart-lang/sdk/issues/26980
-  final FlutterLogoDecoration start = FlutterLogoDecoration(
+  const FlutterLogoDecoration start = FlutterLogoDecoration(
     lightColor: const Color(0xFF000000),
     darkColor: const Color(0xFFFFFFFF),
     textColor: const Color(0xFFD4F144),
@@ -15,7 +15,7 @@ void main() {
     margin: const EdgeInsets.all(10.0),
   );
 
-  final FlutterLogoDecoration end = FlutterLogoDecoration(
+  const FlutterLogoDecoration end = FlutterLogoDecoration(
     lightColor: const Color(0xFFFFFFFF),
     darkColor: const Color(0xFF000000),
     textColor: const Color(0xFF81D4FA),


### PR DESCRIPTION
## Description

use identical instead of '==' in the constant expression involving enum values as the Dart language spec allows only operands of type 'bool', 'num', 'String' or 'null' in such an expression

## Related Issues
https://github.com/dart-lang/sdk/issues/26980
https://github.com/dart-lang/sdk/issues/36564
https://github.com/dart-lang/sdk/issues/36511
https://github.com/dart-lang/sdk/issues/36528

