### PR TITLE
2d transforms UX improvements

### DIFF
--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -35,7 +35,7 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
     // The scene is drawn by a CustomPaint, but user interaction is handled by
     // the GestureTransformable parent widget.
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(title: const Text('2D Tranformations')),
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           // Draw the scene as big as is available, but allow the user to

--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -25,26 +25,9 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
     hexagonRadius: _kHexagonRadius,
     hexagonMargin: _kHexagonMargin,
   );
-  bool _seenInstructionDialog = false;
 
   @override
   Widget build (BuildContext context) {
-    if (!_seenInstructionDialog) {
-      Future<void>.delayed(const Duration(seconds: 1), () {
-        if (_seenInstructionDialog) {
-          return;
-        }
-        setState(() {
-          _seenInstructionDialog = true;
-        });
-
-        showDialog<Column>(
-          context: context,
-          builder: (BuildContext context) => instructionDialog,
-        );
-      });
-    }
-
     final BoardPainter painter = BoardPainter(
       board: _board,
     );
@@ -52,7 +35,21 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
     // The scene is drawn by a CustomPaint, but user interaction is handled by
     // the GestureTransformable parent widget.
     return Scaffold(
-      appBar: AppBar(title: const Text('2D Tranformations')),
+      appBar: AppBar(
+        title: const Text('2D Tranformations'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.help),
+            tooltip: 'Help',
+            onPressed: () {
+              showDialog<Column>(
+                context: context,
+                builder: (BuildContext context) => instructionDialog,
+              );
+            },
+          ),
+        ],
+      ),
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           // Draw the scene as big as is available, but allow the user to

--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -25,9 +25,26 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
     hexagonRadius: _kHexagonRadius,
     hexagonMargin: _kHexagonMargin,
   );
+  bool _seenInstructionDialog = false;
 
   @override
   Widget build (BuildContext context) {
+    if (!_seenInstructionDialog) {
+      Future<void>.delayed(Duration.zero, () {
+        if (_seenInstructionDialog) {
+          return;
+        }
+        setState(() {
+          _seenInstructionDialog = true;
+        });
+
+        showDialog<Column>(
+          context: context,
+          builder: (BuildContext context) => instructionDialog,
+        );
+      });
+    }
+
     final BoardPainter painter = BoardPainter(
       board: _board,
     );
@@ -68,6 +85,31 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
         },
       ),
       floatingActionButton: _board.selected == null ? resetButton : editButton,
+    );
+  }
+
+  Widget get instructionDialog {
+    return AlertDialog(
+      title: const Text('2D Transformations'),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: const <Widget>[
+          Text('Tap to edit hex tiles, and use gestures to move around the scene:\n'),
+          Text('- Drag to pan.'),
+          Text('- Pinch to zoom.'),
+          Text('- Rotate with two fingers.'),
+          Text('\nYou can always press the home button to return to the starting orientation!'),
+        ],
+      ),
+      actions: <Widget>[
+        FlatButton(
+          child: const Text('OK'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
     );
   }
 

--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -30,7 +30,7 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
   @override
   Widget build (BuildContext context) {
     if (!_seenInstructionDialog) {
-      Future<void>.delayed(Duration.zero, () {
+      Future<void>.delayed(Duration(seconds: 1), () {
         if (_seenInstructionDialog) {
           return;
         }

--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -30,7 +30,7 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
   @override
   Widget build (BuildContext context) {
     if (!_seenInstructionDialog) {
-      Future<void>.delayed(Duration(seconds: 1), () {
+      Future<void>.delayed(const Duration(seconds: 1), () {
         if (_seenInstructionDialog) {
           return;
         }


### PR DESCRIPTION
This just makes the 2D Transformations demo in the Flutter Gallery a bit more user friendly.  I added a title in the app bar and a first-time dialog with a description.

<img width="284" alt="Screen Shot 2019-04-11 at 12 38 58 PM" src="https://user-images.githubusercontent.com/389558/55991803-f8f58800-5c5f-11e9-8252-236519ee4daa.png">
