### PR TITLE
rectMoreOrLess equals, prep for 64bit rects

### DIFF
--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -326,7 +326,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), Rect.fromLTWH(16.0, 28.0, 56.0, 56.0));
+    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
   });
 
   testWidgets('End-top floating action button location RTL', (WidgetTester tester) async {
@@ -342,7 +342,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), Rect.fromLTWH(16.0, 28.0, 56.0, 56.0));
+    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
   });
 
   testWidgets('Start-top floating action button location RTL', (WidgetTester tester) async {
@@ -358,7 +358,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0));
+    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
   });
 
   testWidgets('End-top floating action button location LTR', (WidgetTester tester) async {
@@ -371,7 +371,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0));
+    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
   });
 }
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -762,13 +762,13 @@ void main() {
 
     expect(tester.getRect(find.byKey(appBar)), Rect.fromLTRB(0.0, 0.0, 800.0, 43.0));
     expect(tester.getRect(find.byKey(body)), Rect.fromLTRB(0.0, 43.0, 800.0, 348.0));
-    expect(tester.getRect(find.byKey(floatingActionButton)), Rect.fromLTRB(36.0, 255.0, 113.0, 332.0));
+    expect(tester.getRect(find.byKey(floatingActionButton)), rectMoreOrLessEquals(Rect.fromLTRB(36.0, 255.0, 113.0, 332.0)));
     expect(tester.getRect(find.byKey(persistentFooterButton)), Rect.fromLTRB(28.0, 357.0, 128.0, 447.0)); // Note: has 8px each top/bottom padding.
     expect(tester.getRect(find.byKey(drawer)), Rect.fromLTRB(596.0, 0.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(bottomNavigationBar)), Rect.fromLTRB(0.0, 515.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(insideAppBar)), Rect.fromLTRB(20.0, 30.0, 750.0, 43.0));
     expect(tester.getRect(find.byKey(insideBody)), Rect.fromLTRB(20.0, 43.0, 750.0, 348.0));
-    expect(tester.getRect(find.byKey(insideFloatingActionButton)), Rect.fromLTRB(36.0, 255.0, 113.0, 332.0));
+    expect(tester.getRect(find.byKey(insideFloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTRB(36.0, 255.0, 113.0, 332.0)));
     expect(tester.getRect(find.byKey(insidePersistentFooterButton)), Rect.fromLTRB(28.0, 357.0, 128.0, 447.0));
     expect(tester.getRect(find.byKey(insideDrawer)), Rect.fromLTRB(596.0, 30.0, 750.0, 540.0));
     expect(tester.getRect(find.byKey(insideBottomNavigationBar)), Rect.fromLTRB(20.0, 515.0, 750.0, 540.0));
@@ -857,12 +857,12 @@ void main() {
 
     expect(tester.getRect(find.byKey(appBar)), Rect.fromLTRB(0.0, 0.0, 800.0, 43.0));
     expect(tester.getRect(find.byKey(body)), Rect.fromLTRB(0.0, 43.0, 800.0, 400.0));
-    expect(tester.getRect(find.byKey(floatingActionButton)), Rect.fromLTRB(36.0, 307.0, 113.0, 384.0));
+    expect(tester.getRect(find.byKey(floatingActionButton)), rectMoreOrLessEquals(Rect.fromLTRB(36.0, 307.0, 113.0, 384.0)));
     expect(tester.getRect(find.byKey(persistentFooterButton)), Rect.fromLTRB(28.0, 442.0, 128.0, 532.0)); // Note: has 8px each top/bottom padding.
     expect(tester.getRect(find.byKey(drawer)), Rect.fromLTRB(596.0, 0.0, 800.0, 600.0));
     expect(tester.getRect(find.byKey(insideAppBar)), Rect.fromLTRB(20.0, 30.0, 750.0, 43.0));
     expect(tester.getRect(find.byKey(insideBody)), Rect.fromLTRB(20.0, 43.0, 750.0, 400.0));
-    expect(tester.getRect(find.byKey(insideFloatingActionButton)), Rect.fromLTRB(36.0, 307.0, 113.0, 384.0));
+    expect(tester.getRect(find.byKey(insideFloatingActionButton)), rectMoreOrLessEquals(Rect.fromLTRB(36.0, 307.0, 113.0, 384.0)));
     expect(tester.getRect(find.byKey(insidePersistentFooterButton)), Rect.fromLTRB(28.0, 442.0, 128.0, 532.0));
     expect(tester.getRect(find.byKey(insideDrawer)), Rect.fromLTRB(596.0, 30.0, 750.0, 540.0));
   });

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -251,11 +251,8 @@ void main() {
 
     for (int i = 0; i < 8; i += 1) {
       final double angle = start + i.toDouble() * math.pi / 4.0;
-      // Round these to the first decimal place so that a `Rect` that supports
-      // full 64 bit precision won't cause strange failures here when this is
-      // passed through to a SizedBox.
-      final double dx = (math.cos(angle) * 50.0).roundToDouble() / 10.0;
-      final double dy = (math.sin(angle) * 50.0).roundToDouble() / 10.0;
+      final double dx = math.cos(angle) * 5.0;
+      final double dy = math.sin(angle) * 5.0;
 
       final Map<String, Rect> children = <String, Rect>{
         'A': const Offset(10.0, 10.0) & tenByTen,

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -251,6 +251,9 @@ void main() {
 
     for (int i = 0; i < 8; i += 1) {
       final double angle = start + i.toDouble() * math.pi / 4.0;
+      // Round these to the first decimal place so that a `Rect` that supports
+      // full 64 bit precision won't cause strange failures here when this is
+      // passed through to a SizedBox.
       final double dx = (math.cos(angle) * 50.0).roundToDouble() / 10.0;
       final double dy = (math.sin(angle) * 50.0).roundToDouble() / 10.0;
 

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -251,8 +251,8 @@ void main() {
 
     for (int i = 0; i < 8; i += 1) {
       final double angle = start + i.toDouble() * math.pi / 4.0;
-      final double dx = math.cos(angle) * 5.0;
-      final double dy = math.sin(angle) * 5.0;
+      final double dx = (math.cos(angle) * 50.0).roundToDouble() / 10.0;
+      final double dy = (math.sin(angle) * 50.0).roundToDouble() / 10.0;
 
       final Map<String, Rect> children = <String, Rect>{
         'A': const Offset(10.0, 10.0) & tenByTen,

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -222,6 +222,21 @@ Matcher moreOrLessEquals(double value, { double epsilon = 1e-10 }) {
   return _MoreOrLessEquals(value, epsilon);
 }
 
+/// Asserts that two [Rect]s are equal, within some tolerated error.
+///
+/// Two values are considered equal if the difference between them is within
+/// 1e-10 of the larger one. This is an arbitrary value which can be adjusted
+/// using the `epsilon` argument. This matcher is intended to compare floating
+/// point numbers that are the result of different sequences of operations, such
+/// that they may have accumulated slightly different errors.
+///
+/// See also:
+///
+///  * [moreOrLessEquals], which is for [double]s.
+Matcher rectMoreOrLessEquals(Rect value, { double epsilon = 1e-10 }) {
+  return _RectMoreOrLessEquals(value, epsilon);
+}
+
 /// Asserts that two [String]s are equal after normalizing likely hash codes.
 ///
 /// A `#` followed by 5 hexadecimal digits is assumed to be a short hash code
@@ -1078,6 +1093,31 @@ class _MoreOrLessEquals extends Matcher {
       return true;
     final double test = object;
     return (test - value).abs() <= epsilon;
+  }
+
+  @override
+  Description describe(Description description) => description.add('$value (±$epsilon)');
+}
+
+class _RectMoreOrLessEquals extends Matcher {
+  const _RectMoreOrLessEquals(this.value, this.epsilon);
+
+  final Rect value;
+  final double epsilon;
+
+  @override
+  bool matches(Object object, Map<dynamic, dynamic> matchState) {
+    if (object is! Rect) {
+      return false;
+    }
+    if (object == value) {
+      return true;
+    }
+    final Rect rect = object;
+    return (rect.left    - value.left).abs() <= epsilon &&
+           (rect.top     - value.top).abs() <= epsilon &&
+           (rect.right   - value.right).abs() <= epsilon &&
+           (rect.bottom  - value.bottom).abs() <= epsilon;
   }
 
   @override

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -233,8 +233,10 @@ Matcher moreOrLessEquals(double value, { double epsilon = 1e-10 }) {
 /// See also:
 ///
 ///  * [moreOrLessEquals], which is for [double]s.
+///  * [within], which offers a generic version of this functionality that can
+///    be used to match [Rect]s as well as other types.
 Matcher rectMoreOrLessEquals(Rect value, { double epsilon = 1e-10 }) {
-  return _RectMoreOrLessEquals(value, epsilon);
+  return _IsWithinDistance<Rect>(_rectDistance, value, epsilon);
 }
 
 /// Asserts that two [String]s are equal after normalizing likely hash codes.
@@ -1019,6 +1021,8 @@ double _sizeDistance(Size a, Size b) {
 ///
 ///  * [moreOrLessEquals], which is similar to this function, but specializes in
 ///    [double]s and has an optional `epsilon` parameter.
+///  * [rectMoreOrLessEquals], which is similar to this function, but
+///    specializes in [Rect]s and has an optional `epsilon` parameter.
 ///  * [closeTo], which specializes in numbers only.
 Matcher within<T>({
   @required num distance,
@@ -1093,31 +1097,6 @@ class _MoreOrLessEquals extends Matcher {
       return true;
     final double test = object;
     return (test - value).abs() <= epsilon;
-  }
-
-  @override
-  Description describe(Description description) => description.add('$value (±$epsilon)');
-}
-
-class _RectMoreOrLessEquals extends Matcher {
-  const _RectMoreOrLessEquals(this.value, this.epsilon);
-
-  final Rect value;
-  final double epsilon;
-
-  @override
-  bool matches(Object object, Map<dynamic, dynamic> matchState) {
-    if (object is! Rect) {
-      return false;
-    }
-    if (object == value) {
-      return true;
-    }
-    final Rect rect = object;
-    return (rect.left   - value.left).abs() <= epsilon &&
-           (rect.top    - value.top).abs() <= epsilon &&
-           (rect.right  - value.right).abs() <= epsilon &&
-           (rect.bottom - value.bottom).abs() <= epsilon;
   }
 
   @override

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1114,10 +1114,10 @@ class _RectMoreOrLessEquals extends Matcher {
       return true;
     }
     final Rect rect = object;
-    return (rect.left    - value.left).abs() <= epsilon &&
-           (rect.top     - value.top).abs() <= epsilon &&
-           (rect.right   - value.right).abs() <= epsilon &&
-           (rect.bottom  - value.bottom).abs() <= epsilon;
+    return (rect.left   - value.left).abs() <= epsilon &&
+           (rect.top    - value.top).abs() <= epsilon &&
+           (rect.right  - value.right).abs() <= epsilon &&
+           (rect.bottom - value.bottom).abs() <= epsilon;
   }
 
   @override

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -185,6 +185,23 @@ void main() {
     expect(-11.0, moreOrLessEquals(11.0, epsilon: 100.0));
   });
 
+  test('rectMoreOrLessEquals', () {
+    expect(
+      Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
+      rectMoreOrLessEquals(Rect.fromLTRB(1e-11, 0.0, 10.0, 10.0000000001)),
+    );
+
+    expect(
+      Rect.fromLTRB(11.0, 11.0, 20.0, 20.0),
+      isNot(rectMoreOrLessEquals(Rect.fromLTRB(-11.0, -11.0, 20.0, 20.0), epsilon: 1.0)),
+    );
+
+    expect(
+      Rect.fromLTRB(11.0, 11.0, 20.0, 20.0),
+      rectMoreOrLessEquals(Rect.fromLTRB(-11.0, -11.0, 20.0, 20.0), epsilon: 100.0),
+    );
+  });
+
   test('within', () {
     expect(0.0, within<double>(distance: 0.1, from: 0.05));
     expect(0.0, isNot(within<double>(distance: 0.1, from: 0.2)));


### PR DESCRIPTION
## Description

https://github.com/flutter/engine/pull/8524 had to be reverted because the increased precision fixed some issues, but caused our tests to fail for others.

In paritcular, FloatingActionButton animations involve a transform that gets very slightly translated. After going through various matrix multiplications, there's a slight loss of precision now that's captured by a double backed `Rect`.  That's resolved with a new matcher called `rectMoreOrLessEquals`, which works like `moreOrLessEquals`.

The semantics change is because the rect also has more precision, and when that extra precision is pumped through to `SizedBox` it causes a failure.  I'm hoping @yjbanov or @goderbauer can validate that this is safe - it seems so to me but I may be missing a bug in the semantics traversal algorithm.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/30920
Allows us to reland flutter/engine#8524 (or something similar to it).

## Tests

I added the following tests:

New tests for `rectMoreOrLessEquals`.
Updated tests in preparation for increased precision in `Rect`s.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
