### PR TITLE
fix issue 30526: rounding error

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -65,7 +65,15 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
   /// order, without gaps, starting from layout offset zero.
   @protected
   int getMinChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
-    return itemExtent > 0.0 ? math.max(0, scrollOffset ~/ itemExtent) : 0;
+    if (itemExtent > 0.0) {
+      final double actual = scrollOffset / itemExtent;
+      final int round = actual.round();
+      if ((actual - round).abs() < precisionErrorTolerance) {
+        return round;
+      }
+      return actual.floor();
+    }
+    return 0;
   }
 
   /// The maximum child index that is visible at the given scroll offset.
@@ -224,7 +232,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     final double leadingScrollOffset = indexToLayoutOffset(itemExtent, firstIndex);
     final double trailingScrollOffset = indexToLayoutOffset(itemExtent, lastIndex + 1);
 
-    assert(firstIndex == 0 || childScrollOffset(firstChild) <= scrollOffset);
+    assert(firstIndex == 0 || childScrollOffset(firstChild) - scrollOffset <= precisionErrorTolerance);
     assert(debugAssertChildListIsNonEmptyAndContiguous());
     assert(indexOf(firstChild) == firstIndex);
     assert(targetLastIndex == null || lastIndex <= targetLastIndex);

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -1,0 +1,106 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import '../flutter_test_alternative.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test('RenderSliverFixedExtentList layout test - rounding error', () {
+    final List<RenderBox> children = <RenderBox>[
+      RenderSizedBox(const Size(400.0, 100.0)),
+      RenderSizedBox(const Size(400.0, 100.0)),
+      RenderSizedBox(const Size(400.0, 100.0))
+    ];
+    final TestRenderSliverBoxChildManager childManager = TestRenderSliverBoxChildManager(
+      children: children,
+    );
+    final RenderViewport root = RenderViewport(
+      axisDirection: AxisDirection.down,
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      cacheExtent: 0,
+      children: <RenderSliver>[
+        childManager.createRenderSliverFillViewport(),
+      ],
+    );
+    layout(root);
+    expect(children[0].attached, true);
+    expect(children[1].attached, false);
+
+    root.offset = ViewportOffset.fixed(600);
+    pumpFrame();
+    expect(children[0].attached, false);
+    expect(children[1].attached, true);
+
+    // Simulate double precision error.
+    root.offset = ViewportOffset.fixed(1199.999999999998);
+    pumpFrame();
+    expect(children[1].attached, false);
+    expect(children[2].attached, true);
+  });
+}
+
+class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
+  TestRenderSliverBoxChildManager({
+    this.children,
+  });
+
+  RenderSliverMultiBoxAdaptor _renderObject;
+  List<RenderBox> children;
+
+  RenderSliverFillViewport createRenderSliverFillViewport() {
+    assert(_renderObject == null);
+    _renderObject = RenderSliverFillViewport(
+      childManager: this,
+    );
+    return _renderObject;
+  }
+
+  int _currentlyUpdatingChildIndex;
+
+  @override
+  void createChild(int index, { @required RenderBox after }) {
+    if (index < 0 || index >= children.length)
+      return;
+    try {
+      _currentlyUpdatingChildIndex = index;
+      _renderObject.insert(children[index], after: after);
+    } finally {
+      _currentlyUpdatingChildIndex = null;
+    }
+  }
+
+  @override
+  void removeChild(RenderBox child) {
+    _renderObject.remove(child);
+  }
+
+  @override
+  double estimateMaxScrollOffset(
+      SliverConstraints constraints, {
+        int firstIndex,
+        int lastIndex,
+        double leadingScrollOffset,
+        double trailingScrollOffset,
+      }) {
+    assert(lastIndex >= firstIndex);
+    return children.length * (trailingScrollOffset - leadingScrollOffset) / (lastIndex - firstIndex + 1);
+  }
+
+  @override
+  int get childCount => children.length;
+
+  @override
+  void didAdoptChild(RenderBox child) {
+    assert(_currentlyUpdatingChildIndex != null);
+    final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
+    childParentData.index = _currentlyUpdatingChildIndex;
+  }
+
+  @override
+  void setDidUnderflow(bool value) { }
+}


### PR DESCRIPTION
## Description

This pr only fixes the rounding error outline in the issue

## Related Issues

https://github.com/flutter/flutter/issues/30526

## Tests

I added the following tests:

https://github.com/chunhtai/flutter/blob/fb7ab807481d90a19f359831f2d14584de1945b3/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart#L12

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
