### PR TITLE
Allow profile widget builds in profile mode

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -305,14 +305,16 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
     }
 
     // Expose the ability to send Widget rebuilds as [Timeline] events.
-    registerBoolServiceExtension(
-      name: 'profileWidgetBuilds',
-      getter: () async => debugProfileBuildsEnabled,
-      setter: (bool value) async {
-        if (debugProfileBuildsEnabled != value)
-          debugProfileBuildsEnabled = value;
-      },
-    );
+    if (!kReleaseMode) {
+      registerBoolServiceExtension(
+        name: 'profileWidgetBuilds',
+        getter: () async => debugProfileBuildsEnabled,
+        setter: (bool value) async {
+          if (debugProfileBuildsEnabled != value)
+            debugProfileBuildsEnabled = value;
+        },
+      );
+    }
 
     assert(() {
       registerBoolServiceExtension(

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -304,6 +304,16 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
       );
     }
 
+    // Expose the ability to send Widget rebuilds as [Timeline] events.
+    registerBoolServiceExtension(
+      name: 'profileWidgetBuilds',
+      getter: () async => debugProfileBuildsEnabled,
+      setter: (bool value) async {
+        if (debugProfileBuildsEnabled != value)
+          debugProfileBuildsEnabled = value;
+      },
+    );
+
     assert(() {
       registerBoolServiceExtension(
         name: 'debugAllowBanner',
@@ -313,16 +323,6 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
             return Future<void>.value();
           WidgetsApp.debugAllowBannerOverride = value;
           return _forceRebuild();
-        },
-      );
-
-      // Expose the ability to send Widget rebuilds as [Timeline] events.
-      registerBoolServiceExtension(
-        name: 'profileWidgetBuilds',
-        getter: () async => debugProfileBuildsEnabled,
-        setter: (bool value) async {
-          if (debugProfileBuildsEnabled != value)
-            debugProfileBuildsEnabled = value;
         },
       );
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -302,10 +302,8 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
           };
         },
       );
-    }
 
-    // Expose the ability to send Widget rebuilds as [Timeline] events.
-    if (!kReleaseMode) {
+      // Expose the ability to send Widget rebuilds as [Timeline] events.
       registerBoolServiceExtension(
         name: 'profileWidgetBuilds',
         getter: () async => debugProfileBuildsEnabled,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3730,11 +3730,8 @@ abstract class ComponentElement extends Element {
   /// [rebuild] when the element needs updating.
   @override
   void performRebuild() {
-    assert(() {
-      if (debugProfileBuildsEnabled)
-        Timeline.startSync('${widget.runtimeType}',  arguments: timelineWhitelistArguments);
-      return true;
-    }());
+    if (debugProfileBuildsEnabled)
+      Timeline.startSync('${widget.runtimeType}',  arguments: timelineWhitelistArguments);
 
     assert(_debugSetAllowIgnoredCallsToMarkNeedsBuild(true));
     Widget built;
@@ -3757,11 +3754,8 @@ abstract class ComponentElement extends Element {
       _child = updateChild(null, built, slot);
     }
 
-    assert(() {
-      if (debugProfileBuildsEnabled)
-        Timeline.finishSync();
-      return true;
-    }());
+    if (debugProfileBuildsEnabled)
+      Timeline.finishSync();
   }
 
   /// Subclasses should override this function to actually call the appropriate

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3730,7 +3730,7 @@ abstract class ComponentElement extends Element {
   /// [rebuild] when the element needs updating.
   @override
   void performRebuild() {
-    if (debugProfileBuildsEnabled)
+    if (!kReleaseMode && debugProfileBuildsEnabled)
       Timeline.startSync('${widget.runtimeType}',  arguments: timelineWhitelistArguments);
 
     assert(_debugSetAllowIgnoredCallsToMarkNeedsBuild(true));
@@ -3754,7 +3754,7 @@ abstract class ComponentElement extends Element {
       _child = updateChild(null, built, slot);
     }
 
-    if (debugProfileBuildsEnabled)
+    if (!kReleaseMode && debugProfileBuildsEnabled)
       Timeline.finishSync();
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -884,7 +884,7 @@ abstract class ResidentRunner {
       }
       return true;
     } else if (character == 'a') {
-      if (supportsServiceProtocol && isRunningDebug) {
+      if (supportsServiceProtocol && (isRunningDebug || isRunningProfile)) {
         await _debugToggleProfileWidgetBuilds();
       }
     } else if (lower == 'o') {
@@ -993,12 +993,14 @@ abstract class ResidentRunner {
         printStatus('To toggle the widget inspector (WidgetsApp.showWidgetInspectorOverride), press "i".');
         printStatus('To toggle the display of construction lines (debugPaintSizeEnabled), press "p".');
         printStatus('To simulate different operating systems, (defaultTargetPlatform), press "o".');
-        printStatus('To enable timeline events for all widget build methods, (debugProfileWidgetBuilds), press "a"');
         printStatus('To toggle the elevation checker, press "z".');
       } else {
         printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "U" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
+      if (isRunningProfile || isRunningDebug) {
+        printStatus('To enable timeline events for all widget build methods, (debugProfileWidgetBuilds), press "a"');
+      }
     }
     if (flutterDevices.any((FlutterDevice d) => d.device.supportsScreenshot)) {
       printStatus('To save a screenshot to flutter.png, press "s".');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -884,7 +884,7 @@ abstract class ResidentRunner {
       }
       return true;
     } else if (character == 'a') {
-      if (supportsServiceProtocol && (isRunningDebug || isRunningProfile)) {
+      if (supportsServiceProtocol) {
         await _debugToggleProfileWidgetBuilds();
       }
     } else if (lower == 'o') {
@@ -998,9 +998,7 @@ abstract class ResidentRunner {
         printStatus('To dump the accessibility tree (debugDumpSemantics), press "S" (for traversal order) or "U" (for inverse hit test order).');
       }
       printStatus('To display the performance overlay (WidgetsApp.showPerformanceOverlay), press "P".');
-      if (isRunningProfile || isRunningDebug) {
-        printStatus('To enable timeline events for all widget build methods, (debugProfileWidgetBuilds), press "a"');
-      }
+      printStatus('To enable timeline events for all widget build methods, (debugProfileWidgetBuilds), press "a"');
     }
     if (flutterDevices.any((FlutterDevice d) => d.device.supportsScreenshot)) {
       printStatus('To save a screenshot to flutter.png, press "s".');


### PR DESCRIPTION
## Description

Previously, such function is only available in the debug mode. But the
performance information is very noisy in debug mode with JIT. I feel
that such function is as important and useful as the performance overlay
and the `--trace-skia` option for the GPU thread.  So we should give it
the same ability to run in both profile and debug mode.

I've tested it using flutter_gallery in the profile mode. There's no
observable difference in the performance overlay between toggling widget
build profiling.

## Related Issues

https://github.com/flutter/flutter/issues/30984

## Tests

I haven't found any test for the keyboard command of `ResidentRunner`. I'd love to add a test for it if someone could teach me how to write one.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
