### PR TITLE
Fix the warning test by checking stderr

### DIFF
--- a/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
+++ b/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
@@ -8,14 +8,16 @@ import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
-Future<String> _runWithMode(String mode, String deviceId) {
-  return evalFlutter('drive', options: <String>[
+Future<String> _runWithMode(String mode, String deviceId) async {
+  final StringBuffer stderr = StringBuffer();
+  await evalFlutter('drive', stderr: stderr, options: <String>[
     mode,
     '-t',
     'test_driver/scroll_perf.dart',
     '-d',
     deviceId,
   ]);
+  return stderr.toString();
 }
 
 Future<TaskResult> run() async {

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -303,6 +303,7 @@ Future<String> eval(
   Map<String, String> environment,
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   String workingDirectory,
+  StringBuffer stderr, // if not null, the stderr will be written here
 }) async {
   final Process process = await startProcess(executable, arguments, environment: environment, workingDirectory: workingDirectory);
 
@@ -321,6 +322,7 @@ Future<String> eval(
       .transform<String>(const LineSplitter())
       .listen((String line) {
         print('stderr: $line');
+        stderr?.writeln(line);
       }, onDone: () { stderrDone.complete(); });
 
   await Future.wait<void>(<Future<void>>[stdoutDone.future, stderrDone.future]);
@@ -347,10 +349,11 @@ Future<String> evalFlutter(String command, {
   List<String> options = const <String>[],
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String> environment,
+  StringBuffer stderr, // if not null, the stderr will be written here.
 }) {
   final List<String> args = <String>[command]..addAll(options);
   return eval(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
-      canFail: canFail, environment: environment);
+      canFail: canFail, environment: environment, stderr: stderr);
 }
 
 String get dartBin =>


### PR DESCRIPTION
## Description

Previously, I used the Android emulator for testing and everything
seemed to work fine with stdout (if I remember correctly). But our
devicelab uses real Android devices and the warnings are routed to
stderr. Hence change stdout to stderr in the test.

## Related Issues

#30625

## Tests

drive_perf_debug_warning devicelab test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
