### PR TITLE
Handles custom build types when adding Flutter jar dependencies to a Flutter Gradle Plugin

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -196,42 +196,57 @@ class FlutterPlugin implements Plugin<Project> {
                         compile pluginProject
                     }
                 }
-		pluginProject.afterEvaluate {
-                    pluginProject.android.buildTypes {
+                pluginProject.afterEvaluate {
+                    pluginProject.android.buildTypes { buildTypes ->
                         profile {
                             initWith debug
                         }
+
+                        buildTypes.each {
+                            this.addFlutterJarCompileOnlyDependency(pluginProject, it)
+                        }
                     }
-		}
-                pluginProject.afterEvaluate this.&addFlutterJarCompileOnlyDependency
+                }
             } else {
                 project.logger.error("Plugin project :$name not found. Please update settings.gradle.")
             }
         }
     }
 
-    private void addFlutterJarCompileOnlyDependency(Project project) {
+    /**
+     * Adds suitable flutter.jar api dependencies to the specified buildType.
+     *
+     * Note: The BuildType DSL type is not public, and is therefore omitted from the signature.
+     */
+    private void addFlutterJarCompileOnlyDependency(Project project, buildType) {
         if (project.state.failure) {
             return
         }
+
         project.dependencies {
-            if (flutterJar != null) {
-                if (project.getConfigurations().findByName("compileOnly")) {
-                    compileOnly project.files(flutterJar)
-                } else {
-                    provided project.files(flutterJar)
-                }
+            String configuration;
+            if (project.getConfigurations().any { it.name.endsWith("CompileOnly") }) {
+                configuration = buildType.name + "CompileOnly";
             } else {
-                if (project.getConfigurations().findByName("debugCompileOnly")) {
-                    debugCompileOnly project.files(debugFlutterJar)
-                    profileCompileOnly project.files(profileFlutterJar)
-                    releaseCompileOnly project.files(releaseFlutterJar)
-                } else {
-                    debugProvided project.files(debugFlutterJar)
-                    profileProvided project.files(profileFlutterJar)
-                    releaseProvided project.files(releaseFlutterJar)
-                }
+                configuration = buildType.name + "Provided";
             }
+            add(configuration, project.files {
+                String buildMode = buildModeFor(buildType)
+
+                if (buildMode == "profile") {
+                    profileFlutterJar
+                } else if (buildMode == "dynamicProfile") {
+                    dynamicProfileFlutterJar
+                } else if (buildMode == "dynamicRelease") {
+                    dynamicReleaseFlutterJar
+                } else {
+                    if (buildType.debuggable) {
+                        debugFlutterJar
+                    } else {
+                        releaseFlutterJar
+                    }
+                }
+            })
         }
     }
 
@@ -250,16 +265,18 @@ class FlutterPlugin implements Plugin<Project> {
             }
             add(configuration, project.files {
                 String buildMode = buildModeFor(buildType)
-                if (buildMode == "debug") {
-                    [flutterX86JarTask, debugFlutterJar]
-                } else if (buildMode == "profile") {
+                if (buildMode == "profile") {
                     profileFlutterJar
                 } else if (buildMode == "dynamicProfile") {
                     dynamicProfileFlutterJar
                 } else if (buildMode == "dynamicRelease") {
                     dynamicReleaseFlutterJar
                 } else {
-                    releaseFlutterJar
+                    if (buildType.debuggable) {
+                        [flutterX86JarTask, debugFlutterJar]
+                    } else {
+                        releaseFlutterJar
+                    }
                 }
             })
         }


### PR DESCRIPTION
Flutter Gradle Plugin

## Description

A project with a custom build type would fail to build if it used plugins.

The custom build types propagate down to the plugin projects, but the plugin projects were only adding the Flutter jar to a fixed set of build types.

The Flutter jar is now added to all build types.

## Related Issues

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
