### PR TITLE
Add sorting to flutter version command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -35,7 +35,7 @@ class VersionCommand extends FlutterCommand {
 
   Future<List<String>> getTags() async {
     final RunResult runResult = await runCheckedAsync(
-      <String>['git', 'tag', '-l', 'v*'],
+      <String>['git', 'tag', '-l', 'v*', '--sort=creatordate'],
       workingDirectory: Cache.flutterRoot,
     );
     return runResult.toString().split('\n');

--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -35,7 +35,7 @@ class VersionCommand extends FlutterCommand {
 
   Future<List<String>> getTags() async {
     final RunResult runResult = await runCheckedAsync(
-      <String>['git', 'tag', '-l', 'v*', '--sort=creatordate'],
+      <String>['git', 'tag', '-l', 'v*', '--sort=-creatordate'],
       workingDirectory: Cache.flutterRoot,
     );
     return runResult.toString().split('\n');


### PR DESCRIPTION
Fixes #31013

## Description

This PR adds sorting to `flutter version` command
This makes `v1.4.19` appear after `v1.4.9` and not after `v1.4.1`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31013

## Tests

No tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
