### PR TITLE
Text Style Persists for Text-only Heroes in Flight 

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -12,6 +12,7 @@ import 'overlay.dart';
 import 'pages.dart';
 import 'routes.dart';
 import 'transitions.dart';
+import 'package:flutter/material.dart';
 
 /// Signature for a function that takes two [Rect] instances and returns a
 /// [RectTween] that transitions between them.
@@ -754,6 +755,9 @@ class HeroController extends NavigatorObserver {
     BuildContext toHeroContext,
   ) {
     final Hero toHero = toHeroContext.widget;
-    return toHero.child;
+    return DefaultTextStyle(
+      child: toHero.child,
+      style: DefaultTextStyle.of(toHeroContext).style,
+    );
   };
 }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-
+import 'package:flutter/material.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'framework.dart';
@@ -12,7 +12,7 @@ import 'overlay.dart';
 import 'pages.dart';
 import 'routes.dart';
 import 'transitions.dart';
-import 'package:flutter/material.dart';
+
 
 /// Signature for a function that takes two [Rect] instances and returns a
 /// [RectTween] that transitions between them.

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1811,7 +1811,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          textTheme: TextTheme(
+          textTheme: const TextTheme(
             body1: TextStyle(color: Colors.blue),
           ),
         ),


### PR DESCRIPTION
## Description

This PR addresses the issue of Text-only Hero widgets breaking from style in flight. The default `HeroFlightShuttleBuilder` for the Hero widget uses the destination widget as a model for the shuttle. As such, this PR wraps the shuttle in a `DefaultTextStyle` using the context of the destination widget so that the intended Test styling is not lost in flight.

## Related Issues

- Fixes #30647 
- Fixes #20845 
- Fixes #12463

## Tests

I added the following tests:
- Check that a given `TextStyle` persists through `Hero` flight
- Check that the `DefaultTextStyle` of underlined red text does not replace the `Text` `Hero` in flight.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
