### PR TITLE
Add run capability for macOS target

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -50,9 +50,9 @@ class ApplicationPackageFactory {
       case TargetPlatform.tester:
         return FlutterTesterApp.fromCurrentDirectory();
       case TargetPlatform.darwin_x64:
-        return applicationBinary != null
-          ? MacOSApp.fromPrebuiltApp(applicationBinary)
-          : null;
+        return applicationBinary == null
+          ? MacOSApp.fromMacOSProject((await FlutterProject.current()).macos)
+          : MacOSApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.web:
         return WebApplicationPackage(await FlutterProject.current());
       case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -5,13 +5,10 @@
 import 'dart:async';
 
 import '../base/common.dart';
-import '../base/io.dart';
 import '../base/platform.dart';
-import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../convert.dart';
-import '../globals.dart';
+import '../macos/build_macos.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
 import 'build.dart';
@@ -62,23 +59,7 @@ class BuildMacosCommand extends BuildSubCommand {
     if (!flutterProject.macos.existsSync()) {
       throwToolExit('No macOS desktop project configured.');
     }
-    final Process process = await processManager.start(<String>[
-      flutterProject.macos.buildScript.path,
-      Cache.flutterRoot,
-      buildInfo.isDebug ? 'debug' : 'release',
-    ], runInShell: true);
-    process.stderr
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen(printError);
-    process.stdout
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen(printStatus);
-    final int result = await process.exitCode;
-    if (result != 0) {
-      throwToolExit('Build process failed');
-    }
+    await buildMacOS(flutterProject, buildInfo);
     return null;
   }
 }

--- a/packages/flutter_tools/lib/src/desktop.dart
+++ b/packages/flutter_tools/lib/src/desktop.dart
@@ -6,9 +6,9 @@ import 'base/platform.dart';
 import 'version.dart';
 
 // Only launch or display desktop embedding devices if
-// `FLUTTER_DESKTOP_EMBEDDING` environment variable is set to true.
+// `ENABLE_FLUTTER_DESKTOP` environment variable is set to true.
 bool get flutterDesktopEnabled {
-  _flutterDesktopEnabled ??= platform.environment['FLUTTER_DESKTOP_EMBEDDING']?.toLowerCase() == 'true';
+  _flutterDesktopEnabled ??= platform.environment['ENABLE_FLUTTER_DESKTOP']?.toLowerCase() == 'true';
   return _flutterDesktopEnabled && !FlutterVersion.instance.isStable;
 }
 bool _flutterDesktopEnabled;

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../ios/plist_utils.dart' as plist;

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -83,6 +83,8 @@ abstract class MacOSApp extends ApplicationPackage {
   @override
   String get displayName => id;
 
+  String applicationBundle(BuildMode buildMode);
+
   String executable(BuildMode buildMode);
 }
 
@@ -105,6 +107,9 @@ class PrebuiltMacOSApp extends MacOSApp {
   String get name => bundleName;
 
   @override
+  String applicationBundle(BuildMode buildMode) => bundleDir.path;
+
+  @override
   String executable(BuildMode buildMode) => _executable;
 }
 
@@ -115,6 +120,16 @@ class BuildableMacOSApp extends MacOSApp {
 
   @override
   String get name => 'macOS';
+
+  @override
+  String applicationBundle(BuildMode buildMode) {
+    final ProcessResult result = processManager.runSync(<String>[
+      project.nameScript.path,
+      buildMode == BuildMode.debug ? 'debug' : 'release'
+    ], runInShell: true);
+    final String directory = result.stdout.toString().trim();
+    return directory;
+  }
 
   @override
   String executable(BuildMode buildMode) {

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -34,7 +34,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     .transform(const LineSplitter())
     .listen(printTrace);
   } finally {
-    status.toString();
+    status.cancel();
   }
   final int result = await process.exitCode;
   if (result != 0) {

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -1,0 +1,33 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/common.dart';
+import '../base/io.dart';
+import '../base/process_manager.dart';
+import '../build_info.dart';
+import '../cache.dart';
+import '../convert.dart';
+import '../globals.dart';
+import '../project.dart';
+
+/// Builds the macOS project through the project shell script.
+Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) async {
+  final Process process = await processManager.start(<String>[
+    flutterProject.macos.buildScript.path,
+    Cache.flutterRoot,
+    buildInfo.isDebug ? 'debug' : 'release',
+  ], runInShell: true);
+  process.stderr
+    .transform(utf8.decoder)
+    .transform(const LineSplitter())
+    .listen(printError);
+  process.stdout
+    .transform(utf8.decoder)
+    .transform(const LineSplitter())
+    .listen(printStatus);
+  final int result = await process.exitCode;
+  if (result != 0) {
+    throwToolExit('Build process failed');
+  }
+}

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -20,7 +20,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     buildInfo.isDebug ? 'debug' : 'release',
   ], runInShell: true);
   final Status status = logger.startProgress(
-    'building macOS application...',
+    'Building macOS application...',
     timeout: null,
   );
   int result;

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -24,19 +24,20 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     'building macOS application...',
     timeout: null,
   );
+  int result;
   try {
-  process.stderr
-    .transform(utf8.decoder)
-    .transform(const LineSplitter())
-    .listen(printError);
-  process.stdout
-    .transform(utf8.decoder)
-    .transform(const LineSplitter())
-    .listen(printTrace);
+    process.stderr
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(printError);
+    process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(printTrace);
+    result = await process.exitCode;
   } finally {
     status.cancel();
   }
-  final int result = await process.exitCode;
   if (result != 0) {
     throwToolExit('Build process failed');
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/logger.dart';
+
 import '../base/common.dart';
 import '../base/io.dart';
 import '../base/process_manager.dart';
@@ -18,6 +20,11 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     Cache.flutterRoot,
     buildInfo.isDebug ? 'debug' : 'release',
   ], runInShell: true);
+  final Status status = logger.startProgress(
+    'building macOS application...',
+    timeout: null,
+  );
+  try {
   process.stderr
     .transform(utf8.decoder)
     .transform(const LineSplitter())
@@ -25,7 +32,10 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
   process.stdout
     .transform(utf8.decoder)
     .transform(const LineSplitter())
-    .listen(printStatus);
+    .listen(printTrace);
+  } finally {
+    status.toString();
+  }
   final int result = await process.exitCode;
   if (result != 0) {
     throwToolExit('Build process failed');

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -17,7 +17,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
   final Process process = await processManager.start(<String>[
     flutterProject.macos.buildScript.path,
     Cache.flutterRoot,
-    buildInfo.isDebug ? 'debug' : 'release',
+    buildInfo?.isDebug == true ? 'debug' : 'release',
   ], runInShell: true);
   final Status status = logger.startProgress(
     'Building macOS application...',

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/logger.dart';
-
 import '../base/common.dart';
 import '../base/io.dart';
+import '../base/logger.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../cache.dart';

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -79,7 +79,7 @@ class MacOSDevice extends Device {
     final Process process = await processManager.start(<String>[
       package.executable(debuggingOptions.buildInfo.mode)
     ]);
-    if (debuggingOptions.buildInfo.isRelease) {
+    if (debuggingOptions.buildInfo?.isRelease == true) {
       return LaunchResult.succeeded();
     }
     final MacOSLogReader logReader = MacOSLogReader(package, process);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -8,11 +8,14 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
+import '../cache.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../globals.dart';
 import '../macos/application_package.dart';
+import '../project.dart';
 import '../protocol_discovery.dart';
+import 'build_macos.dart';
 import 'macos_workflow.dart';
 
 /// A device that represents a desktop MacOS target.
@@ -66,12 +69,16 @@ class MacOSDevice extends Device {
     bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
-    if (!prebuiltApplication) {
-      return LaunchResult.failed();
-    }
     // Stop any running applications with the same executable.
     await stopApp(package);
-    final Process process = await processManager.start(<String>[package.executable]);
+    if (!prebuiltApplication) {
+      Cache.releaseLockEarly();
+      await buildMacOS(await FlutterProject.current(), debuggingOptions.buildInfo);
+    }
+    final Process process = await processManager.start(<String>[package.executable(debuggingOptions.buildInfo.mode)]);
+    if (debuggingOptions.buildInfo.isRelease) {
+      return LaunchResult.succeeded();
+    }
     final MacOSLogReader logReader = MacOSLogReader(package, process);
     final ProtocolDiscovery observatoryDiscovery = ProtocolDiscovery.observatory(logReader);
     try {
@@ -91,6 +98,8 @@ class MacOSDevice extends Device {
   Future<bool> stopApp(covariant MacOSApp app) async {
     final RegExp whitespace = RegExp(r'\s+');
     bool succeeded = true;
+    // assume debug for now.
+    final String executable = app.executable(BuildMode.debug);
     try {
       final ProcessResult result = await processManager.run(<String>[
         'ps', 'aux',
@@ -100,7 +109,7 @@ class MacOSDevice extends Device {
       }
       final List<String> lines = result.stdout.split('\n');
       for (String line in lines) {
-        if (!line.contains(app.executable)) {
+        if (!line.contains(executable)) {
           continue;
         }
         final List<String> values = line.split(whitespace);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -88,7 +88,7 @@ class MacOSDevice extends Device {
       final Uri observatoryUri = await observatoryDiscovery.uri;
       // Bring app to foreground.
       await processManager.run(<String>[
-        'open', package.applicationBundle(debuggingOptions.buildInfo.mode),
+        'open', package.applicationBundle(debuggingOptions?.buildInfo?.mode),
       ]);
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } catch (error) {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -75,7 +75,9 @@ class MacOSDevice extends Device {
       Cache.releaseLockEarly();
       await buildMacOS(await FlutterProject.current(), debuggingOptions.buildInfo);
     }
-    final Process process = await processManager.start(<String>[package.executable(debuggingOptions.buildInfo.mode)]);
+    final Process process = await processManager.start(<String>[
+      package.executable(debuggingOptions.buildInfo.mode)
+    ]);
     if (debuggingOptions.buildInfo.isRelease) {
       return LaunchResult.succeeded();
     }
@@ -83,6 +85,10 @@ class MacOSDevice extends Device {
     final ProtocolDiscovery observatoryDiscovery = ProtocolDiscovery.observatory(logReader);
     try {
       final Uri observatoryUri = await observatoryDiscovery.uri;
+      // Bring app to foreground.
+      await processManager.run(<String>[
+        'open', package.applicationBundle(debuggingOptions.buildInfo.mode),
+      ], runInShell: true);
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } catch (error) {
       printError('Error waiting for a debug connection: $error');

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -79,7 +79,7 @@ class MacOSDevice extends Device {
     final Process process = await processManager.start(<String>[
       package.executable(debuggingOptions?.buildInfo?.mode)
     ]);
-    if (debuggingOptions.buildInfo?.isRelease == true) {
+    if (debuggingOptions?.buildInfo?.isRelease == true) {
       return LaunchResult.succeeded();
     }
     final MacOSLogReader logReader = MacOSLogReader(package, process);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -77,7 +77,7 @@ class MacOSDevice extends Device {
     // Make sure to call stop app after we've built.
     await stopApp(package);
     final Process process = await processManager.start(<String>[
-      package.executable(debuggingOptions.buildInfo.mode)
+      package.executable(debuggingOptions?.buildInfo?.mode)
     ]);
     if (debuggingOptions.buildInfo?.isRelease == true) {
       return LaunchResult.succeeded();

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -89,7 +89,7 @@ class MacOSDevice extends Device {
       // Bring app to foreground.
       await processManager.run(<String>[
         'open', package.applicationBundle(debuggingOptions.buildInfo.mode),
-      ], runInShell: true);
+      ]);
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } catch (error) {
       printError('Error waiting for a debug connection: $error');

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -70,11 +70,12 @@ class MacOSDevice extends Device {
     bool ipv6 = false,
   }) async {
     // Stop any running applications with the same executable.
-    await stopApp(package);
     if (!prebuiltApplication) {
       Cache.releaseLockEarly();
       await buildMacOS(await FlutterProject.current(), debuggingOptions.buildInfo);
     }
+    // Make sure to call stop app after we've built.
+    await stopApp(package);
     final Process process = await processManager.start(<String>[
       package.executable(debuggingOptions.buildInfo.mode)
     ]);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -72,7 +72,7 @@ class MacOSDevice extends Device {
     // Stop any running applications with the same executable.
     if (!prebuiltApplication) {
       Cache.releaseLockEarly();
-      await buildMacOS(await FlutterProject.current(), debuggingOptions.buildInfo);
+      await buildMacOS(await FlutterProject.current(), debuggingOptions?.buildInfo);
     }
     // Make sure to call stop app after we've built.
     await stopApp(package);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -538,6 +538,9 @@ class MacOSProject {
 
   // Note: The build script file exists as a temporary shim.
   File get buildScript => project.directory.childDirectory('macos').childFile('build.sh');
+
+  // Note: The name script file exists as a temporary shim.
+  File get nameScript => project.directory.childDirectory('macos').childFile('name_output.sh');
 }
 
 /// The Windows sub project
@@ -550,6 +553,9 @@ class WindowsProject {
 
   // Note: The build script file exists as a temporary shim.
   File get buildScript => project.directory.childDirectory('windows').childFile('build.bat');
+
+  // Note: The name script file exists as a temporary shim.
+  File get nameScript => project.directory.childDirectory('windows').childFile('name_output.sh');
 }
 
 /// The Linux sub project.
@@ -562,4 +568,7 @@ class LinuxProject {
 
   // Note: The build script file exists as a temporary shim.
   File get buildScript => project.directory.childDirectory('linux').childFile('build.sh');
+
+  // Note: The name script file exists as a temporary shim.
+  File get nameScript => project.directory.childDirectory('linux').childFile('name_output.sh');
 }

--- a/packages/flutter_tools/test/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands/build_linux_test.dart
@@ -44,6 +44,7 @@ void main() {
     ), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     Platform: () => linuxPlatform,
+    FileSystem: () => memoryFilesystem,
   });
 
   testUsingContext('Linux build fails on non-linux platform', () async {

--- a/packages/flutter_tools/test/linux/linux_workflow_test.dart
+++ b/packages/flutter_tools/test/linux/linux_workflow_test.dart
@@ -13,7 +13,7 @@ void main() {
   group(LinuxWorkflow, () {
     final MockPlatform linux = MockPlatform();
     final MockPlatform linuxWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
+      ..environment['ENABLE_FLUTTER_DESKTOP'] = 'true';
     final MockPlatform notLinux = MockPlatform();
     when(linux.isLinux).thenReturn(true);
     when(linuxWithFde.isLinux).thenReturn(true);

--- a/packages/flutter_tools/test/linux/linux_workflow_test.dart
+++ b/packages/flutter_tools/test/linux/linux_workflow_test.dart
@@ -13,7 +13,7 @@ void main() {
   group(LinuxWorkflow, () {
     final MockPlatform linux = MockPlatform();
     final MockPlatform linuxWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_EMBEDDING'] = 'true';
+      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
     final MockPlatform notLinux = MockPlatform();
     when(linux.isLinux).thenReturn(true);
     when(linuxWithFde.isLinux).thenReturn(true);

--- a/packages/flutter_tools/test/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/macos/macos_device_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     testUsingContext('defaults', () async {
       final MockMacOSApp mockMacOSApp = MockMacOSApp();
-      when(mockMacOSApp.executable).thenReturn('foo');
+      when(mockMacOSApp.executable(any)).thenReturn('foo');
       expect(await device.targetPlatform, TargetPlatform.darwin_x64);
       expect(device.name, 'macOS');
       expect(await device.installApp(mockMacOSApp), true);
@@ -49,7 +49,7 @@ void main() {
 tester    17193   0.0  0.2  4791128  37820   ??  S     2:27PM   0:00.09 /Applications/foo
 ''';
       final MockMacOSApp mockMacOSApp = MockMacOSApp();
-      when(mockMacOSApp.executable).thenReturn('/Applications/foo');
+      when(mockMacOSApp.executable(any)).thenReturn('/Applications/foo');
       when(mockProcessManager.run(<String>['ps', 'aux'])).thenAnswer((Invocation invocation) async {
         return ProcessResult(1, 0, psOut, '');
       });
@@ -68,7 +68,7 @@ tester    17193   0.0  0.2  4791128  37820   ??  S     2:27PM   0:00.09 /Applica
       final MockProcessManager mockProcessManager = MockProcessManager();
       final MockFile mockFile = MockFile();
       final MockProcess mockProcess = MockProcess();
-      when(macOSApp.executable).thenReturn('test');
+      when(macOSApp.executable(any)).thenReturn('test');
       when(mockFileSystem.file('test')).thenReturn(mockFile);
       when(mockFile.existsSync()).thenReturn(true);
       when(mockProcessManager.start(<String>['test'])).thenAnswer((Invocation invocation) async {

--- a/packages/flutter_tools/test/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/macos/macos_device_test.dart
@@ -83,11 +83,6 @@ tester    17193   0.0  0.2  4791128  37820   ??  S     2:27PM   0:00.09 /Applica
         ]);
       });
 
-      test('fails without a prebuilt application', () async {
-        final LaunchResult result = await device.startApp(macOSApp, prebuiltApplication: false);
-        expect(result.started, false);
-      });
-
       testUsingContext('Can run from prebuilt application', () async {
         final LaunchResult result = await device.startApp(macOSApp, prebuiltApplication: true);
         expect(result.started, true);

--- a/packages/flutter_tools/test/macos/macos_workflow_test.dart
+++ b/packages/flutter_tools/test/macos/macos_workflow_test.dart
@@ -16,7 +16,7 @@ void main() {
   group(MacOSWorkflow, () {
     final MockPlatform mac = MockPlatform();
     final MockPlatform macWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
+      ..environment['ENABLE_FLUTTER_DESKTOP'] = 'true';
     final MockPlatform notMac = MockPlatform();
     when(mac.isMacOS).thenReturn(true);
     when(macWithFde.isMacOS).thenReturn(true);

--- a/packages/flutter_tools/test/macos/macos_workflow_test.dart
+++ b/packages/flutter_tools/test/macos/macos_workflow_test.dart
@@ -16,7 +16,7 @@ void main() {
   group(MacOSWorkflow, () {
     final MockPlatform mac = MockPlatform();
     final MockPlatform macWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_EMBEDDING'] = 'true';
+      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
     final MockPlatform notMac = MockPlatform();
     when(mac.isMacOS).thenReturn(true);
     when(macWithFde.isMacOS).thenReturn(true);

--- a/packages/flutter_tools/test/windows/windows_workflow_test.dart
+++ b/packages/flutter_tools/test/windows/windows_workflow_test.dart
@@ -14,7 +14,7 @@ void main() {
   group(WindowsWorkflow, () {
     final MockPlatform windows = MockPlatform();
     final MockPlatform windowsWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
+      ..environment['ENABLE_FLUTTER_DESKTOP'] = 'true';
     final MockPlatform notWindows = MockPlatform();
     when(windows.isWindows).thenReturn(true);
     when(windowsWithFde.isWindows).thenReturn(true);

--- a/packages/flutter_tools/test/windows/windows_workflow_test.dart
+++ b/packages/flutter_tools/test/windows/windows_workflow_test.dart
@@ -14,7 +14,7 @@ void main() {
   group(WindowsWorkflow, () {
     final MockPlatform windows = MockPlatform();
     final MockPlatform windowsWithFde = MockPlatform()
-      ..environment['FLUTTER_DESKTOP_EMBEDDING'] = 'true';
+      ..environment['FLUTTER_DESKTOP_ENABLED'] = 'true';
     final MockPlatform notWindows = MockPlatform();
     when(windows.isWindows).thenReturn(true);
     when(windowsWithFde.isWindows).thenReturn(true);


### PR DESCRIPTION
## Description

For `flutter run` on a macos target, invoke the build script if not running from a prebuilt application. Update the application package to call the name script, and otherwise proceed with the run as normal

## Related Issues

https://github.com/flutter/flutter/issues/30707

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
