### PR TITLE
add --force flag to precache

### DIFF
--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -57,7 +57,7 @@ class PrecacheCommand extends FlutterCommand {
         requiredArtifacts.add(artifact);
       }
     }
-    final bool forceUpdate = argResult['force'];
+    final bool forceUpdate = argResults['force'];
     if (forceUpdate || !cache.isUpToDate()) {
       await cache.updateAll(requiredArtifacts);
     } else {

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -57,10 +57,11 @@ class PrecacheCommand extends FlutterCommand {
         requiredArtifacts.add(artifact);
       }
     }
-    if (cache.isUpToDate() && !argResults['force']) {
-      printStatus('Already up-to-date.');
-    } else {
+    final bool forceUpdate = argResult['force'];
+    if (forceUpdate || !cache.isUpToDate()) {
       await cache.updateAll(requiredArtifacts);
+    } else {
+      printStatus('Already up-to-date.');
     }
     return null;
   }

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -13,6 +13,8 @@ class PrecacheCommand extends FlutterCommand {
   PrecacheCommand() {
     argParser.addFlag('all-platforms', abbr: 'a', negatable: false,
         help: 'Precache artifacts for all platforms.');
+    argParser.addFlag('force', abbr: 'f', negatable: false,
+        help: 'Force downloading of artifacts.');
     argParser.addFlag('android', negatable: true, defaultsTo: true,
         help: 'Precache artifacts for Android development');
     argParser.addFlag('ios', negatable: true, defaultsTo: true,
@@ -55,7 +57,7 @@ class PrecacheCommand extends FlutterCommand {
         requiredArtifacts.add(artifact);
       }
     }
-    if (cache.isUpToDate()) {
+    if (cache.isUpToDate() && !argResults['force']) {
       printStatus('Already up-to-date.');
     } else {
       await cache.updateAll(requiredArtifacts);

--- a/packages/flutter_tools/test/commands/precache_test.dart
+++ b/packages/flutter_tools/test/commands/precache_test.dart
@@ -63,6 +63,23 @@ void main() {
       Cache: () => cache,
       FlutterVersion: () => flutterVersion,
     });
+
+    testUsingContext('Downloads artifacts when --force is provided', () async {
+      when(cache.isUpToDate()).thenReturn(true);
+      // Release lock between test cases.
+      Cache.releaseLockEarly();
+      final PrecacheCommand command = PrecacheCommand();
+      applyMocksToCommand(command);
+      await createTestCommandRunner(command).run(const <String>['precache', '--force']);
+      expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+       DevelopmentArtifact.universal,
+       DevelopmentArtifact.iOS,
+       DevelopmentArtifact.android,
+     }));
+    }, overrides: <Type, Generator>{
+      Cache: () => cache,
+      FlutterVersion: () => flutterVersion,
+    });
   });
 }
 


### PR DESCRIPTION
## Description

This allows users to force re-downloading of artifacts (due to corruption, or tools code errors) without needing to rm -rf bin/cache.

## Related Issues

None

## Tests

I added the following tests:
 - Downloads artifacts when --force is provided

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
