### PR TITLE
Add flutter attach documentation

### DIFF
--- a/packages/flutter_tools/doc/attach.md
+++ b/packages/flutter_tools/doc/attach.md
@@ -7,13 +7,13 @@ without `flutter run`.
 
 With an application already running, a HotRunner can be attached to it
 with:
-```shell
+```
 $ flutter attach --debug-port 12345
 ```
 
 Alternatively, the attach command can start listening and scan for new
 programs that become active:
-```bash
+```
 $ flutter attach
 ```
 As soon as a new observatory is detected the command attaches to it and

--- a/packages/flutter_tools/doc/attach.md
+++ b/packages/flutter_tools/doc/attach.md
@@ -15,18 +15,13 @@ explicitly provided to attach via the command-line, e.g. `$ flutter attach
 1. If the app is already running and the platform is iOS, attach can use mDNS
 to lookup the observatory port via the application ID, with just `$ flutter
 attach`
-1. If the platform is Fuchsia and the app is not yet running, the module name
-must be provided, e.g. `$ flutter attach --module=mod_name`. Attach will then
-listen and wait for the mod to start
+1. If the platform is Fuchsia the module name must be provided, e.g. `$
+flutter attach --module=mod_name`. This can be called either before or after
+the application is started, attach will poll the device if it cannot
+immediately discover the port
 1. On other platforms (i.e. Android), if the app is not yet running attach
 will listen and wait for the app to be (manually) started with the default
 command: `$ flutter attach`
-
-## To-do
-
-Implmenting mDNS discovery for Android would be more reliable and simple for
-the user. Moving the implementations to the individual device classes would
-simplify the `AttachCommand` code.
 
 ## Source
 

--- a/packages/flutter_tools/doc/attach.md
+++ b/packages/flutter_tools/doc/attach.md
@@ -3,21 +3,31 @@
 ## Overview
 
 A Flutter-command that attaches to applications that have been launched
-without `flutter run`.
+without `flutter run` and provides a HotRunner (enabling hot reload/restart).
 
-With an application already running, a HotRunner can be attached to it
-with:
-```
-$ flutter attach --debug-port 12345
-```
+## Usage
 
-Alternatively, the attach command can start listening and scan for new
-programs that become active:
-```
-$ flutter attach
-```
-As soon as a new observatory is detected the command attaches to it and
-enables hot reloading.
+There are four ways for the attach command to discover a running app:
 
-To attach to a flutter mod running on a fuchsia device, `--module` must
-also be provided.
+1. If the app is already running and the observatory port is known, it can be
+explicitly provided to attach via the command-line, e.g. `$ flutter attach
+--debug-port 12345`
+1. If the app is already running and the platform is iOS, attach can use mDNS
+to lookup the observatory port via the application ID, with just `$ flutter
+attach`
+1. If the platform is Fuchsia and the app is not yet running, the module name
+must be provided, e.g. `$ flutter attach --module=mod_name`. Attach will then
+listen and wait for the mod to start
+1. On other platforms (i.e. Android), if the app is not yet running attach
+will listen and wait for the app to be (manually) started with the default
+command: `$ flutter attach`
+
+## To-do
+
+Implmenting mDNS discovery for Android would be more reliable and simple for
+the user. Moving the implementations to the individual device classes would
+simplify the `AttachCommand` code.
+
+## Source
+
+See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/commands/attach.dart) for the attach command.

--- a/packages/flutter_tools/doc/attach.md
+++ b/packages/flutter_tools/doc/attach.md
@@ -1,0 +1,23 @@
+# Flutter Attach
+
+## Overview
+
+A Flutter-command that attaches to applications that have been launched
+without `flutter run`.
+
+With an application already running, a HotRunner can be attached to it
+with:
+```shell
+$ flutter attach --debug-port 12345
+```
+
+Alternatively, the attach command can start listening and scan for new
+programs that become active:
+```bash
+$ flutter attach
+```
+As soon as a new observatory is detected the command attaches to it and
+enables hot reloading.
+
+To attach to a flutter mod running on a fuchsia device, `--module` must
+also be provided.

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -57,10 +57,6 @@ class AttachCommand extends FlutterCommand {
       ..addOption(
         'debug-port',
         help: 'Device port where the observatory is listening.',
-      )..addFlag('listen',
-        negatable: false,
-        help: 'Wait and listen for the app to start on a device (this is '
-              'enabled by default if you do not provide a debug port).'
       )..addOption(
         'app-id',
         help: 'The package name (Android) or bundle identifier (iOS) for the application. '
@@ -93,7 +89,7 @@ class AttachCommand extends FlutterCommand {
   final String name = 'attach';
 
   @override
-  final String description = 'Attach to a running application.'; // TODO
+  final String description = 'Attach to a running application.';
 
   int get debugPort {
     if (argResults['debug-port'] == null)

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -89,7 +89,7 @@ class AttachCommand extends FlutterCommand {
   final String name = 'attach';
 
   @override
-  final String description = 'Attach to a running application.';
+  final String description = 'Attach to a running application.'; // TODO(fujino): YOLO
 
   int get debugPort {
     if (argResults['debug-port'] == null)

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -57,6 +57,10 @@ class AttachCommand extends FlutterCommand {
       ..addOption(
         'debug-port',
         help: 'Device port where the observatory is listening.',
+      )..addFlag('listen',
+        negatable: false,
+        help: 'Wait and listen for the app to start on a device (this is '
+              'enabled by default if you do not provide a debug port).'
       )..addOption(
         'app-id',
         help: 'The package name (Android) or bundle identifier (iOS) for the application. '
@@ -89,7 +93,7 @@ class AttachCommand extends FlutterCommand {
   final String name = 'attach';
 
   @override
-  final String description = 'Attach to a running application.'; // TODO(fujino): YOLO
+  final String description = 'Attach to a running application.'; // TODO
 
   int get debugPort {
     if (argResults['debug-port'] == null)


### PR DESCRIPTION
## Description

The issue below highlights the fact that our `flutter attach` command is not well documented. This PR adds a markdown document which describes the functionality of the command. I intend to link to this markdown document from the wiki once the PR lands in master.

## Related Issues

[`flutter help attach` should provide better instructions #30826](https://github.com/flutter/flutter/issues/30826)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.