### PR TITLE
Improve Radio Documentation with Example

### DIFF
--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -29,9 +29,9 @@ const double _kInnerRadius = 4.5;
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}
 ///
-/// Here is an example of [Radio] widgets wrapped in [ListTile]s.
+/// Here is an example of Radio widgets wrapped in ListTiles.
 ///
-/// ```dart preaamble
+/// ```dart preamble
 /// enum SingingCharacter { lafayette, jefferson }
 /// ```
 ///
@@ -63,6 +63,7 @@ const double _kInnerRadius = 4.5;
 ///   );
 /// }
 /// ```
+/// {@end-tool}
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -21,11 +21,48 @@ const double _kInnerRadius = 4.5;
 /// be selected. The values are of type `T`, the type parameter of the [Radio]
 /// class. Enums are commonly used for this purpose.
 ///
-/// The radio button itself does not maintain any state. Instead, when the state
-/// of the radio button changes, the widget calls the [onChanged] callback.
-/// Most widget that use a radio button will listen for the [onChanged]
-/// callback and rebuild the radio button with a new [groupValue] to update the
-/// visual appearance of the radio button.
+/// The radio button itself does not maintain any state. Instead, selecting the
+/// radio invokes the [onChanged] callback, passing [value] as a parameter. If
+/// [groupValue] and [value] match, this radio will be selected. Most widgets
+/// will listen to [onChanged] with setState to update the radio's visual
+/// appearance.
+///
+/// {@tool snippet --template=stateful_widget_scaffold}
+///
+/// Here is an example of [Radio] widgets wrapped in [ListTile]s.
+///
+/// ```dart preaamble
+/// enum SingingCharacter { lafayette, jefferson }
+/// ```
+///
+/// ```dart
+/// SingingCharacter _character = SingingCharacter.lafayette;
+///
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: Column(
+///       children: <Widget>[
+///         ListTile(
+///           title: const Text('Lafayette'),
+///           leading: Radio(
+///             value: SingingCharacter.lafayette,
+///             groupValue: _character,
+///             onChanged: (SingingCharacter value) { setState(() { _character = value; }); },
+///           ),
+///         ),
+///         ListTile(
+///           title: const Text('Thomas Jefferson'),
+///           leading: Radio(
+///             value: SingingCharacter.jefferson,
+///             groupValue: _character,
+///             onChanged: (SingingCharacter value) { setState(() { _character = value; }); },
+///           ),
+///         ),
+///       ],
+///     ),
+///   );
+/// }
+/// ```
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
@@ -62,7 +99,7 @@ class Radio<T> extends StatefulWidget {
   /// The value represented by this radio button.
   final T value;
 
-  /// The currently selected value for this group of radio buttons.
+  /// The currently selected value for a group of radio buttons.
   ///
   /// This radio button is considered selected if its [value] matches the
   /// [groupValue].

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -47,7 +47,9 @@ const double _kInnerRadius = 4.5;
 ///           leading: Radio(
 ///             value: SingingCharacter.lafayette,
 ///             groupValue: _character,
-///             onChanged: (SingingCharacter value) { setState(() { _character = value; }); },
+///             onChanged: (SingingCharacter value) {
+///               setState(() { _character = value; });
+///             },
 ///           ),
 ///         ),
 ///         ListTile(
@@ -55,7 +57,9 @@ const double _kInnerRadius = 4.5;
 ///           leading: Radio(
 ///             value: SingingCharacter.jefferson,
 ///             groupValue: _character,
-///             onChanged: (SingingCharacter value) { setState(() { _character = value; }); },
+///             onChanged: (SingingCharacter value) {
+///               setState(() { _character = value; });
+///             },
 ///           ),
 ///         ),
 ///       ],

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -24,8 +24,8 @@ const double _kInnerRadius = 4.5;
 /// The radio button itself does not maintain any state. Instead, selecting the
 /// radio invokes the [onChanged] callback, passing [value] as a parameter. If
 /// [groupValue] and [value] match, this radio will be selected. Most widgets
-/// will listen to [onChanged] with setState to update the radio's visual
-/// appearance.
+/// will respond to [onChanged] by calling [State.setState] to update the
+/// radio button's [groupValue].
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}
 ///

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -29,7 +29,18 @@ const double _kInnerRadius = 4.5;
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}
 ///
-/// Here is an example of Radio widgets wrapped in ListTiles.
+/// Here is an example of Radio widgets wrapped in ListTiles, which is similar
+/// to what you could get with the RadioListTile widget.
+///
+/// The currently selected character is passed into `groupValue`, which is
+/// maintained by the example's `State`. In this case, the first `Radio`
+/// will start off selected because `_character` is initialized to
+/// `SingingCharacter.lafayette`.
+///
+/// If the second radio button is pressed, the example's state is updated
+/// with `setState`, updating `_character` to `SingingCharacter.jefferson`.
+/// This causes the buttons to rebuild with the updated `groupValue`, and
+/// therefore the selection of the second button.
 ///
 /// ```dart preamble
 /// enum SingingCharacter { lafayette, jefferson }


### PR DESCRIPTION
## Description

Improve documentation for `Radio` and provided an example.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/27215

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
