### PR TITLE
Improve ThemeData.accentColor connection to secondary color

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -480,7 +480,13 @@ class ThemeData extends Diagnosticable {
   final Color canvasColor;
 
   /// The foreground color for widgets (knobs, text, overscroll edge effect, etc).
-  /// It is also known as the secondary color.
+  ///
+  /// Accent color can also known as the secondary color.
+  ///
+  /// The theme's [colorScheme] property contains [ColorScheme.secondary], as
+  /// well as a color that contrasts well with the secondary color called
+  /// [ColorScheme.onSecondary]. These may be more convenient alternatives, as
+  /// they already follow the baseline Material color schemes.
   final Color accentColor;
 
   /// The brightness of the [accentColor]. Used to determine the color of text

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -481,12 +481,12 @@ class ThemeData extends Diagnosticable {
 
   /// The foreground color for widgets (knobs, text, overscroll edge effect, etc).
   ///
-  /// Accent color can also known as the secondary color.
+  /// Accent color is also known as the secondary color.
   ///
   /// The theme's [colorScheme] property contains [ColorScheme.secondary], as
   /// well as a color that contrasts well with the secondary color called
-  /// [ColorScheme.onSecondary]. These may be more convenient alternatives, as
-  /// they already follow the baseline Material color schemes.
+  /// [ColorScheme.onSecondary]. It might be simpler to just configure an app's
+  /// visuals in terms of the theme's [colorScheme].
   final Color accentColor;
 
   /// The brightness of the [accentColor]. Used to determine the color of text

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -480,6 +480,7 @@ class ThemeData extends Diagnosticable {
   final Color canvasColor;
 
   /// The foreground color for widgets (knobs, text, overscroll edge effect, etc).
+  /// It is also known as the secondary color.
   final Color accentColor;
 
   /// The brightness of the [accentColor]. Used to determine the color of text

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -349,9 +349,7 @@ class TextStyle extends Diagnosticable {
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
   ///
-  /// The Material specifications has a concept of a secondary text color.
-  /// This color is specified in [ThemeData] as the [ThemeData.accentColor]
-  /// field.
+  /// In [ThemeData], secondary color is referenced as [ThemeData.accentColor].
   final Color color;
 
   /// The color to use as the background for the text.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -348,6 +348,10 @@ class TextStyle extends Diagnosticable {
   /// In [merge], [apply], and [lerp], conflicts between [color] and [foreground]
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
+  ///
+  /// The Material specifications has a concept of a secondary text color.
+  /// This color is specified in [ThemeData] as the [ThemeData.accentColor]
+  /// field.
   final Color color;
 
   /// The color to use as the background for the text.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -349,7 +349,8 @@ class TextStyle extends Diagnosticable {
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
   ///
-  /// In [ThemeData], secondary color is referenced as [ThemeData.accentColor].
+  /// In [ThemeData], secondary color is referenced as
+  /// [ThemeData.colorScheme.secondary].
   final Color color;
 
   /// The color to use as the background for the text.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -348,9 +348,6 @@ class TextStyle extends Diagnosticable {
   /// In [merge], [apply], and [lerp], conflicts between [color] and [foreground]
   /// specification are resolved in [foreground]'s favor - i.e. if [foreground] is
   /// specified in one place, it will dominate [color] in another.
-  ///
-  /// In [ThemeData], secondary color is referenced as
-  /// [ThemeData.colorScheme.secondary].
   final Color color;
 
   /// The color to use as the background for the text.


### PR DESCRIPTION
## Description

Added some documentation to highlight that `ThemeData.accentColor` is synonymous with secondary color.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/3856

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
