### PR TITLE
Added font bold when isDefaultAction is true in CupertinoDialogAction

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1046,12 +1046,13 @@ class CupertinoDialogAction extends StatelessWidget {
 
   /// Set to true if button is the default choice in the dialog.
   ///
-  /// Default buttons are bold.
+  /// Default buttons are bold. Defaults to false and cannot be null.
   final bool isDefaultAction;
 
   /// Whether this action destroys an object.
   ///
-  /// For example, an action that deletes an email is destructive.
+  /// For example, an action that deletes an email is destructive. Defaults to 
+  /// false and cannot be null
   final bool isDestructiveAction;
 
   /// [TextStyle] to apply to any text that appears in this button.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1046,13 +1046,16 @@ class CupertinoDialogAction extends StatelessWidget {
 
   /// Set to true if button is the default choice in the dialog.
   ///
-  /// Default buttons are bold. Defaults to false and cannot be null.
+  /// Default buttons are bold.
+  ///
+  /// This parameters defaults to false and cannot be null.
   final bool isDefaultAction;
 
   /// Whether this action destroys an object.
   ///
-  /// For example, an action that deletes an email is destructive. Defaults to
-  /// false and cannot be null.
+  /// For example, an action that deletes an email is destructive.
+  ///
+  /// Defaults to false and cannot be null.
   final bool isDestructiveAction;
 
   /// [TextStyle] to apply to any text that appears in this button.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1051,8 +1051,8 @@ class CupertinoDialogAction extends StatelessWidget {
 
   /// Whether this action destroys an object.
   ///
-  /// false and cannot be null
   /// For example, an action that deletes an email is destructive. Defaults to
+  /// false and cannot be null.
   final bool isDestructiveAction;
 
   /// [TextStyle] to apply to any text that appears in this button.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1051,8 +1051,8 @@ class CupertinoDialogAction extends StatelessWidget {
 
   /// Whether this action destroys an object.
   ///
-  /// For example, an action that deletes an email is destructive. Defaults to 
   /// false and cannot be null
+  /// For example, an action that deletes an email is destructive. Defaults to
   final bool isDestructiveAction;
 
   /// [TextStyle] to apply to any text that appears in this button.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1036,9 +1036,7 @@ class CupertinoDialogAction extends StatelessWidget {
     @required this.child,
   }) : assert(child != null),
        assert(isDefaultAction != null),
-       assert(isDestructiveAction != null),
-       assert(!(isDefaultAction && isDestructiveAction),
-          "Action can't be default and destructive at the same time");
+       assert(isDestructiveAction != null);
 
   /// The callback that is called when the button is tapped or otherwise
   /// activated.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1034,7 +1034,8 @@ class CupertinoDialogAction extends StatelessWidget {
     this.isDestructiveAction = false,
     this.textStyle,
     @required this.child,
-  }) : assert(child != null);
+  }) : assert(child != null),
+       assert(isDefaultAction != null || isDestructiveAction != null);
 
   /// The callback that is called when the button is tapped or otherwise
   /// activated.

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1035,7 +1035,8 @@ class CupertinoDialogAction extends StatelessWidget {
     this.textStyle,
     @required this.child,
   }) : assert(child != null),
-       assert(isDefaultAction != null || isDestructiveAction != null),
+       assert(isDefaultAction != null),
+       assert(isDestructiveAction != null),
        assert(!(isDefaultAction && isDestructiveAction),
           "Action can't be default and destructive at the same time");
 

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1140,6 +1140,10 @@ class CupertinoDialogAction extends StatelessWidget {
     TextStyle style = _kCupertinoDialogActionStyle;
     style = style.merge(textStyle);
 
+    if (isDefaultAction) {
+      style = style.copyWith(fontWeight: FontWeight.bold);
+    }
+
     if (isDestructiveAction) {
       style = style.copyWith(color: CupertinoColors.destructiveRed);
     }

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1143,7 +1143,7 @@ class CupertinoDialogAction extends StatelessWidget {
     style = style.merge(textStyle);
 
     if (isDefaultAction) {
-      style = style.copyWith(fontWeight: FontWeight.bold);
+      style = style.copyWith(fontWeight: FontWeight.w600);
     }
 
     if (isDestructiveAction) {

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1035,7 +1035,9 @@ class CupertinoDialogAction extends StatelessWidget {
     this.textStyle,
     @required this.child,
   }) : assert(child != null),
-       assert(isDefaultAction != null || isDestructiveAction != null);
+       assert(isDefaultAction != null || isDestructiveAction != null),
+       assert(!(isDefaultAction && isDestructiveAction),
+          "Action can't be default and destructive at the same time");
 
   /// The callback that is called when the button is tapped or otherwise
   /// activated.

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -166,6 +166,17 @@ void main() {
     expect(widget.style.color.opacity, lessThanOrEqualTo(128 / 255));
   });
 
+  testWidgets('Dialog enabled action style', (WidgetTester tester) async {
+    await tester.pumpWidget(boilerplate(CupertinoDialogAction(
+      child: const Text('Ok'),
+      onPressed: () {},
+    )));
+
+    final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
+
+    expect(widget.style.color.opacity, equals(1.0));
+  });
+
   testWidgets('Message is scrollable, has correct padding with large text sizes', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -52,7 +52,7 @@ void main() {
     expect(find.text('Delete'), findsNothing);
   });
 
-  testWidgets('Dialog destructive action styles', (WidgetTester tester) async {
+  testWidgets('Dialog destructive action style', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
       isDestructiveAction: true,
       child: Text('Ok'),
@@ -60,8 +60,7 @@ void main() {
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.color.red, greaterThan(widget.style.color.blue));
-    expect(widget.style.color.alpha, lessThan(255));
+    expect(widget.style.color.withAlpha(255), CupertinoColors.destructiveRed);
   });
 
   testWidgets('Has semantic annotations', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -132,7 +132,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Dialog default action styles', (WidgetTester tester) async {
+  testWidgets('Dialog default action style', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
       isDefaultAction: true,
       child: Text('Ok'),
@@ -140,7 +140,7 @@ void main() {
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.fontWeight, equals(FontWeight.w400));
+    expect(widget.style.fontWeight, equals(FontWeight.bold));
   });
 
   testWidgets('Dialog destructive action style', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -142,15 +142,19 @@ void main() {
     expect(widget.style.fontWeight, equals(FontWeight.w600));
   });
 
-  testWidgets('Dialog destructive action style', (WidgetTester tester) async {
+  testWidgets('Dialog default and destructive action styles', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
+      isDefaultAction: true,
       isDestructiveAction: true,
       child: Text('Ok'),
     )));
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.color.withOpacity(1), equals(CupertinoColors.destructiveRed));
+    expect(widget.style.color.withAlpha(255), CupertinoColors.destructiveRed);
+    expect(widget.style.fontWeight, equals(FontWeight.w600));
+  });
+
   });
 
   testWidgets('Message is scrollable, has correct padding with large text sizes', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -143,17 +143,15 @@ void main() {
     expect(widget.style.fontWeight, equals(FontWeight.w400));
   });
 
-  testWidgets('Default and destructive style', (WidgetTester tester) async {
+  testWidgets('Dialog destructive action style', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
-      isDefaultAction: true,
       isDestructiveAction: true,
       child: Text('Ok'),
     )));
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.fontWeight, equals(FontWeight.w400));
-    expect(widget.style.color.red, greaterThan(widget.style.color.blue));
+    expect(widget.style.color.withOpacity(1), equals(CupertinoColors.destructiveRed));
   });
 
   testWidgets('Message is scrollable, has correct padding with large text sizes', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -155,6 +155,15 @@ void main() {
     expect(widget.style.fontWeight, equals(FontWeight.w600));
   });
 
+  testWidgets('Dialog disabled action style', (WidgetTester tester) async {
+    await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
+      child: Text('Ok'),
+    )));
+
+    final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
+
+    expect(widget.style.color.opacity, greaterThanOrEqualTo(127 / 255));
+    expect(widget.style.color.opacity, lessThanOrEqualTo(128 / 255));
   });
 
   testWidgets('Message is scrollable, has correct padding with large text sizes', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -139,7 +139,7 @@ void main() {
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.fontWeight, equals(FontWeight.bold));
+    expect(widget.style.fontWeight, equals(FontWeight.w600));
   });
 
   testWidgets('Dialog destructive action style', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

From the `isDefaultAction` doc in the `CupertinoDialogAction` class.

https://github.com/flutter/flutter/blob/eaf058d81d868b8570ef75dba8bcbfd0c0149080/packages/flutter/lib/src/cupertino/dialog.dart#L1045-L1048

But actually changing this parameter doesn't cause any effect.

### Example

By launching this app

```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: MyHomePage(),
    );
  }
}

class MyHomePage extends StatefulWidget {
  MyHomePage({Key key}) : super(key: key);

  @override
  _MyHomePageState createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      child: Center(
        child: CupertinoButton(
          child: Text('Alert'),
          onPressed: () {
            showDialog<void>(
                context: context,
                builder: (BuildContext context) {
                  return CupertinoAlertDialog(
                    title: Text('Title'),
                    content: Text('Content'),
                    actions: <Widget>[
                      CupertinoDialogAction(
                        child: Text('Cancel'),
                        onPressed: () => Navigator.of(context).pop(),
                      ),
                      CupertinoDialogAction(
                        child: Text('Ok'),
                        onPressed: () => Navigator.of(context).pop(),
                        isDefaultAction: true,
                      ),
                    ],
                  );
                });
          },
        ),
      ),
    );
  }
}
```

you will get

<img width="492" alt="Screenshot 2019-04-19 at 15 17 39" src="https://user-images.githubusercontent.com/6663880/56426439-9ed87080-62b8-11e9-92c0-227028a071f3.png">

where the "ok" button is not bold.

### Solution

The change seem to solve the problem.

<img width="492" alt="Screenshot 2019-04-19 at 15 27 09" src="https://user-images.githubusercontent.com/6663880/56426541-f676dc00-62b8-11e9-8657-7642ec6fcfe8.png">

Also `isDefaultAction` variable was never used in the code.

## Related Issues

No related issues found.

## Tests

Only performed visual test on the application (see screenshots above).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
