### PR TITLE
Add InkWell docs on transitions and ink splash clipping

### DIFF
--- a/analysis_benchmark.json
+++ b/analysis_benchmark.json
@@ -1,0 +1,5 @@
+{
+  "time": 4.167,
+  "issues": 0,
+  "missingDartDocs": 0
+}

--- a/analysis_benchmark.json
+++ b/analysis_benchmark.json
@@ -1,5 +1,0 @@
-{
-  "time": 4.167,
-  "issues": 0,
-  "missingDartDocs": 0
-}

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -616,6 +616,13 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// ancestor to the ink well). The [MaterialType.transparency] material
 /// kind can be used for this purpose.
 ///
+/// ### The ink splashes are clipping or animating unpleasantly!
+///
+/// If the layout changes, a LayoutChangedNotification must be dispatched at
+/// the relevant subtree. This means that Transitions should not be placed
+/// inside Material. Otherwise, in-progress ink features (e.g., ink splashes
+/// and ink highlights) won't move to account for the new layout.
+///
 /// See also:
 ///
 ///  * [GestureDetector], for listening for gestures without ink splashes.

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -649,7 +649,7 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 ///         ),
 ///       ),
 ///     ),
-///   ),
+///   );
 /// }
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -616,10 +616,10 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// ancestor to the ink well). The [MaterialType.transparency] material
 /// kind can be used for this purpose.
 ///
-/// ### The ink splashes are clipping or animating unpleasantly!
+/// ### The ink splashes are unpleasantly animating with transitioning widgets!
 ///
 /// If the layout changes, a LayoutChangedNotification must be dispatched at
-/// the relevant subtree. This means that Transitions should not be placed
+/// the relevant subtree. This means that transitions should not be placed
 /// inside Material. Otherwise, in-progress ink features (e.g., ink splashes
 /// and ink highlights) won't move to account for the new layout.
 ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -622,19 +622,45 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 ///
 /// An example of this situation is as follows:
 ///
-/// ```dart
-/// InkWell(
-///   child: new AnimatedContainer(
-///     height: someGrowingFunction(),
-///     duration: ...
-///   )
-/// )
-/// ```
+/// {@tool snippet --template=stateful_widget_scaffold}
 ///
-/// An InkWell's splashes will not change to conform to changes in the size
-/// of its underlying [Material], where the splashes are rendered. Hence, you
-/// should not create InkWells within [Material] widgets with sizes that change
-/// as they are animating.
+/// Tap the container to cause it to grow. Then, tap it again and hold before
+/// the widget reaches its maximum size to observe the clipped ink splash.
+///
+/// ```dart
+/// double sideLength = 50;
+///
+/// void updateSideLength() {
+///   setState(() {
+///     sideLength == 50
+///       ? sideLength = 100
+///       : sideLength = 50;
+///   });
+/// }
+///
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: AnimatedContainer(
+///       height: sideLength,
+///       width: sideLength,
+///       duration: Duration(seconds: 2),
+///       curve: Curves.easeIn,
+///       child: Ink(
+///         color: Colors.yellow,
+///         child: InkWell(
+///           onTap: updateSideLength,
+///         ),
+///       ),
+///     ),
+///   ),
+/// }
+/// ```
+/// {@end-tool}
+///
+/// An InkWell's splashes will not properly update to conform to changes in the
+/// size of its underlying [Material], where the splashes are rendered,
+/// mid-animation. Hence, you should avoid using InkWells within [Material]
+/// widgets that are changing size.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -630,14 +630,6 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// ```dart
 /// double sideLength = 50;
 ///
-/// void updateSideLength() {
-///   setState(() {
-///     sideLength == 50
-///       ? sideLength = 100
-///       : sideLength = 50;
-///   });
-/// }
-///
 /// Widget build(BuildContext context) {
 ///   return Center(
 ///     child: AnimatedContainer(
@@ -645,10 +637,14 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 ///       width: sideLength,
 ///       duration: Duration(seconds: 2),
 ///       curve: Curves.easeIn,
-///       child: Ink(
+///       child: Material(
 ///         color: Colors.yellow,
 ///         child: InkWell(
-///           onTap: updateSideLength,
+///           onTap: () {
+///             setState(() {
+///               sideLength == 50 ? sideLength = 100 : sideLength = 50;
+///             });
+///           },
 ///         ),
 ///       ),
 ///     ),

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -653,8 +653,8 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// ```
 /// {@end-tool}
 ///
-/// An InkWell's splashes will not properly update to conform to changes in the
-/// size of its underlying [Material], where the splashes are rendered,
+/// An InkWell's splashes will not properly update to conform to changes if the
+/// size of its underlying [Material], where the splashes are rendered, is
 /// mid-animation. Hence, you should avoid using InkWells within [Material]
 /// widgets that are changing size.
 ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -617,9 +617,10 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// kind can be used for this purpose.
 ///
 /// ### The ink splashes don't track the size of an animated container
-/// When nesting an InkWell in a widget that changes size or animates,
-/// you may notice that ink splashes may clip and result in unusually cut
-/// circles. An example of this situation is as follows:
+/// When you wrap an animating widget with an InkWell, you may notice that ink
+/// splashes may clip and result in unusually cut circles.
+///
+/// An example of this situation is as follows:
 ///
 /// ```dart
 /// InkWell(

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -616,12 +616,24 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// ancestor to the ink well). The [MaterialType.transparency] material
 /// kind can be used for this purpose.
 ///
-/// ### The ink splashes are unpleasantly animating with transitioning widgets!
+/// ### The ink splashes don't track the size of an animated container
+/// When nesting an InkWell in a widget that changes size or animates,
+/// you may notice that ink splashes may clip and result in unusually cut
+/// circles. An example of this situation is as follows:
 ///
-/// If the layout changes, a LayoutChangedNotification must be dispatched at
-/// the relevant subtree. This means that transitions should not be placed
-/// inside Material. Otherwise, in-progress ink features (e.g., ink splashes
-/// and ink highlights) won't move to account for the new layout.
+/// ```dart
+/// InkWell(
+///   child: new AnimatedContainer(
+///     height: someGrowingFunction(),
+///     duration: ...
+///   )
+/// )
+/// ```
+///
+/// An InkWell's splashes will not change to conform to changes in the size
+/// of its underlying [Material], where the splashes are rendered. Hence, you
+/// should not create InkWells within [Material] widgets with sizes that change
+/// as they are animating.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -617,8 +617,9 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// kind can be used for this purpose.
 ///
 /// ### The ink splashes don't track the size of an animated container
-/// When you wrap an animating widget with an InkWell, you may notice that ink
-/// splashes may clip and result in unusually cut circles.
+/// If the size of an InkWell's [Material] ancestor changes while the InkWell's
+/// splashes are expanding, you may notice that the splashes aren't clipped
+/// correctly. This can't be avoided.
 ///
 /// An example of this situation is as follows:
 ///
@@ -654,9 +655,9 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 /// {@end-tool}
 ///
 /// An InkWell's splashes will not properly update to conform to changes if the
-/// size of its underlying [Material], where the splashes are rendered, is
-/// mid-animation. Hence, you should avoid using InkWells within [Material]
-/// widgets that are changing size.
+/// size of its underlying [Material], where the splashes are rendered, changes
+/// during animation. You should avoid using InkWells within [Material] widgets
+/// that are changing size.
 ///
 /// See also:
 ///


### PR DESCRIPTION
## Description

Added a section to the `InkWell` documentation highlighting that widget transitions within an InkWell widget may cause clipping or unpleasant rippling effects.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/5211

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
