### PR TITLE
Issue #30249 - increase OutlineInputBorder TextField label padding

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1240,10 +1240,10 @@ class _RenderDecoration extends RenderBox {
       final Offset labelOffset = _boxParentData(label).offset;
       final double labelHeight = label.size.height;
       final double t = decoration.floatingLabelProgress;
-      // The center of the outline border label ends up a little below the
+      // The bottom of the outline border label ends up a little below the
       // center of the top border line.
       final bool isOutlineBorder = decoration.border != null && decoration.border.isOutline;
-      final double floatingY = isOutlineBorder ? -labelHeight * 0.25 : contentPadding.top;
+      final double floatingY = isOutlineBorder ? -labelHeight * 0.42 : contentPadding.top;
       final double scale = lerpDouble(1.0, 0.75, t);
       double dx;
       switch (textDirection) {


### PR DESCRIPTION
## Description

Increased y padding for outline border textfield label, because it was too low compared to textfield from material design guide (as described in ticket).

How it looked before:
<img width="324" alt="Screenshot 2019-04-19 at 20 56 08" src="https://user-images.githubusercontent.com/16081839/56440716-88e3a380-62ea-11e9-91dc-7133f0b495ef.png">

How it looks now:
<img width="326" alt="Screenshot 2019-04-19 at 21 05 55" src="https://user-images.githubusercontent.com/16081839/56440720-90a34800-62ea-11e9-97b3-48da29eb93eb.png">

## Related Issues

#30249 TextField label with OutlineInputBorder doesn't match Material design guidelines.
