### PR TITLE
DatePicker header overflow fix

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -45,7 +45,6 @@ enum DatePickerMode {
   year,
 }
 
-const double _kDatePickerHeaderPortraitHeight = 100.0;
 const double _kDatePickerHeaderLandscapeWidth = 168.0;
 
 const Duration _kMonthScrollDuration = Duration(milliseconds: 200);
@@ -114,12 +113,10 @@ class _DatePickerHeader extends StatelessWidget {
     }
 
     double width;
-    double height;
     EdgeInsets padding;
     MainAxisAlignment mainAxisAlignment;
     switch (orientation) {
       case Orientation.portrait:
-        height = _kDatePickerHeaderPortraitHeight;
         padding = const EdgeInsets.symmetric(horizontal: 16.0);
         mainAxisAlignment = MainAxisAlignment.center;
         break;
@@ -158,7 +155,6 @@ class _DatePickerHeader extends StatelessWidget {
 
     return Container(
       width: width,
-      height: height,
       padding: padding,
       color: backgroundColor,
       child: Column(


### PR DESCRIPTION


## Description

In this PR I removed constant, hardcoded DatePicker header height. Leaving Container with no specified height enables it to wrap its content and prevent clipping/overflowing.

How it looked:
<img width="299" alt="Screenshot 2019-04-19 at 23 32 21" src="https://user-images.githubusercontent.com/16081839/56445188-38754180-62fc-11e9-9a05-036b4a053b1c.png">

How it looks now:
<img width="293" alt="Screenshot 2019-04-19 at 23 34 06" src="https://user-images.githubusercontent.com/16081839/56445197-41fea980-62fc-11e9-9ccd-d2fe78bb381a.png">


## Related Issues

#29736
#28778
#29681