### PR TITLE
[WIP] Update fuchsia artifacts and roll fuchsia SDK version

### DIFF
--- a/bin/internal/fuchsia.version
+++ b/bin/internal/fuchsia.version
@@ -1,2 +1,1 @@
 PUvAttXXcL26gsJ2oBG9nlUlWpHndlXkwewleWHTO88C
-

--- a/bin/internal/fuchsia.version
+++ b/bin/internal/fuchsia.version
@@ -1,1 +1,2 @@
-Ow5Xdviq7OwKr7XNuf-Bw0nBMeAr849mFn7gc_RUpzUC
+PUvAttXXcL26gsJ2oBG9nlUlWpHndlXkwewleWHTO88C
+

--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -11,10 +11,11 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
-import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 
 final ArgParser parser = ArgParser()
@@ -105,13 +106,15 @@ Future<void> main(List<String> args) async {
     muteCommandLogging: false,
     verboseHelp: false,
     overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig, devFinder: devFinder),
+      FuchsiaWorkflow: () => const _FuchsiaWorkflow(),
       Artifacts: () => OverrideArtifacts(
         parent: CachedArtifacts(),
         frontendServer: frontendServer,
         engineDartBinary: dartSdk,
         platformKernelDill: platformKernelDill,
         flutterPatchedSdk: flutterPatchedSdk,
+        devFinder: devFinder,
+        fuchsiaSshConfig: sshConfig,
       ),
     },
   );
@@ -146,4 +149,20 @@ class _FuchsiaAttachCommand extends AttachCommand {
     Cache.flutterRoot = '$originalWorkingDirectory/third_party/dart-pkg/git/flutter';
     return super.runCommand();
   }
+}
+
+class _FuchsiaWorkflow implements FuchsiaWorkflow {
+  const _FuchsiaWorkflow();
+
+  @override
+  bool get appliesToHostPlatform => platform.isLinux || platform.isMacOS;
+
+  @override
+  bool get canListDevices => true;
+
+  @override
+  bool get canLaunchDevices => true;
+
+  @override
+  bool get canListEmulators => false;
 }

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -29,6 +29,8 @@ enum Artifact {
   dart2jsSnapshot,
   kernelWorkerSnapshot,
   flutterWebSdk,
+  devFinder,
+  fuchsiaSshConfig,
 }
 
 String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMode mode ]) {
@@ -80,6 +82,11 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'dart2js.dart.snapshot';
     case Artifact.kernelWorkerSnapshot:
       return 'kernel_worker.dart.snapshot';
+    case Artifact.devFinder:
+      return 'dev_finder';
+    case Artifact.fuchsiaSshConfig:
+      assert(false, 'This artifact is not currently supported');
+      return null;
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;
@@ -212,6 +219,9 @@ class CachedArtifacts extends Artifacts {
         return fs.path.join(dartSdkPath, 'bin', 'snapshots', _artifactToFileName(artifact));
       case Artifact.kernelWorkerSnapshot:
         return fs.path.join(dartSdkPath, 'bin', 'snapshots', _artifactToFileName(artifact));
+      case Artifact.devFinder:
+         final String fuchsiaArtifactsPath = cache.getArtifactDirectory('fuchsia').path;
+         return fs.path.join(fuchsiaArtifactsPath, 'tools', _artifactToFileName(artifact));
       default:
         assert(false, 'Artifact $artifact not available for platform $platform.');
         return null;
@@ -298,6 +308,10 @@ class LocalEngineArtifacts extends Artifacts {
         return fs.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', _artifactToFileName(artifact));
       case Artifact.kernelWorkerSnapshot:
         return fs.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', _artifactToFileName(artifact));
+      case Artifact.devFinder:
+      case Artifact.fuchsiaSshConfig:
+        assert(false, 'Fuchsia artifacts are not supported in local engine builds');
+        return null;
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;
@@ -353,6 +367,8 @@ class OverrideArtifacts implements Artifacts {
     this.engineDartBinary,
     this.platformKernelDill,
     this.flutterPatchedSdk,
+    this.devFinder,
+    this.fuchsiaSshConfig,
   }) : assert(parent != null);
 
   final Artifacts parent;
@@ -360,6 +376,8 @@ class OverrideArtifacts implements Artifacts {
   final File engineDartBinary;
   final File platformKernelDill;
   final File flutterPatchedSdk;
+  final File devFinder;
+  final File fuchsiaSshConfig;
 
   @override
   String getArtifactPath(Artifact artifact, { TargetPlatform platform, BuildMode mode }) {
@@ -374,6 +392,12 @@ class OverrideArtifacts implements Artifacts {
     }
     if (artifact == Artifact.flutterPatchedSdkPath && flutterPatchedSdk != null) {
       return flutterPatchedSdk.path;
+    }
+    if (artifact == Artifact.devFinder && devFinder != null) {
+      return devFinder.path;
+    }
+    if (artifact == Artifact.fuchsiaSshConfig && fuchsiaSshConfig != null) {
+      return fuchsiaSshConfig.path;
     }
     return parent.getArtifactPath(artifact, platform: platform, mode: mode);
   }

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -72,7 +72,7 @@ Future<T> runInContext<T>(
       DoctorValidatorsProvider: () => DoctorValidatorsProvider.defaultInstance,
       EmulatorManager: () => EmulatorManager(),
       FuchsiaSdk: () => FuchsiaSdk(),
-      FuchsiaArtifacts: () => FuchsiaArtifacts(),
+      // FuchsiaArtifacts: () => FuchsiaArtifacts(),
       FuchsiaWorkflow: () => FuchsiaWorkflow(),
       Flags: () => const EmptyFlags(),
       FlutterVersion: () => FlutterVersion(const SystemClock()),

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../application_package.dart';
+import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -257,8 +258,9 @@ class FuchsiaDevice extends Device {
 
   /// Run `command` on the Fuchsia device shell.
   Future<String> shell(String command) async {
+    final String sshConfigPath = artifacts.getArtifactPath(Artifact.fuchsiaSshConfig);
     final RunResult result = await runAsync(<String>[
-      'ssh', '-F', fuchsiaArtifacts.sshConfig.absolute.path, id, command]);
+      'ssh', '-F', sshConfigPath, id, command]);
     if (result.exitCode != 0) {
       throwToolExit('Command failed: $command\nstdout: ${result.stdout}\nstderr: ${result.stderr}');
       return null;
@@ -402,8 +404,9 @@ class _FuchsiaPortForwarder extends DevicePortForwarder {
     hostPort ??= await _findPort();
     // Note: the provided command works around a bug in -N, see US-515
     // for more explanation.
+    final String sshConfigPath = artifacts.getArtifactPath(Artifact.fuchsiaSshConfig);
     final List<String> command = <String>[
-      'ssh', '-6', '-F', fuchsiaArtifacts.sshConfig.absolute.path, '-nNT', '-vvv', '-f',
+      'ssh', '-6', '-F', sshConfigPath, '-nNT', '-vvv', '-f',
       '-L', '$hostPort:$_ipv4Loopback:$devicePort', device.id, 'true',
     ];
     final Process process = await processManager.start(command);
@@ -426,8 +429,9 @@ class _FuchsiaPortForwarder extends DevicePortForwarder {
     _forwardedPorts.remove(forwardedPort);
     final Process process = _processes.remove(forwardedPort.hostPort);
     process?.kill();
+    final String sshConfigPath = artifacts.getArtifactPath(Artifact.fuchsiaSshConfig);
     final List<String> command = <String>[
-        'ssh', '-F', fuchsiaArtifacts.sshConfig.absolute.path, '-O', 'cancel', '-vvv',
+        'ssh', '-F', sshConfigPath, '-O', 'cancel', '-vvv',
         '-L', '${forwardedPort.hostPort}:$_ipv4Loopback:${forwardedPort.devicePort}', device.id];
     final ProcessResult result = await processManager.run(command);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -4,11 +4,10 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/platform.dart';
-
 import '../artifacts.dart';
 import '../base/context.dart';
 import '../base/io.dart';
+import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
 import '../convert.dart';

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -4,8 +4,10 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/platform.dart';
+
+import '../artifacts.dart';
 import '../base/context.dart';
-import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
@@ -14,9 +16,6 @@ import '../globals.dart';
 
 /// The [FuchsiaSdk] instance.
 FuchsiaSdk get fuchsiaSdk => context[FuchsiaSdk];
-
-/// The [FuchsiaArtifacts] instance.
-FuchsiaArtifacts get fuchsiaArtifacts => context[FuchsiaArtifacts];
 
 /// The Fuchsia SDK shell commands.
 ///
@@ -30,9 +29,14 @@ class FuchsiaSdk {
   ///    > 192.168.42.56 paper-pulp-bush-angel
   Future<String> listDevices() async {
     try {
-      final String path = fuchsiaArtifacts.devFinder.absolute.path;
-      final RunResult process = await runAsync(<String>[path, 'list', '-full']);
-      return process.stdout.trim();
+      if (platform.isLinux) {
+        final String path = artifacts.getArtifactPath(Artifact.devFinder);
+        final RunResult process = await runAsync(<String>[path, 'list', '-full']);
+        return process.stdout.trim();
+      } else {
+        printError('Fuchsia device discovery is only supported on Linux');
+        return '';
+      }
     } catch (exception) {
       printTrace('$exception');
     }
@@ -62,18 +66,4 @@ class FuchsiaSdk {
     }
     return null;
   }
-}
-
-/// Fuchsia-specific artifacts used to interact with a device.
-class FuchsiaArtifacts {
-  /// Creates a new [FuchsiaArtifacts].
-  FuchsiaArtifacts({this.sshConfig, this.devFinder});
-
-  /// The location of the SSH configuration file used to interact with a
-  /// Fuchsia device.
-  final File sshConfig;
-
-  /// The location of the dev finder tool used to locate connected
-  /// Fuchsia devices.
-  final File devFinder;
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
@@ -5,28 +5,27 @@
 import '../base/context.dart';
 import '../base/platform.dart';
 import '../doctor.dart';
-import 'fuchsia_sdk.dart';
+import '../globals.dart';
 
 /// The [FuchsiaWorkflow] instance.
 FuchsiaWorkflow get fuchsiaWorkflow => context[FuchsiaWorkflow];
 
 /// The Fuchsia-specific implementation of a [Workflow].
 ///
-/// This workflow assumes development within the fuchsia source tree,
-/// including a working fx command-line tool in the user's PATH.
+/// This currently only supports Linux externally.
 class FuchsiaWorkflow implements Workflow {
 
   @override
-  bool get appliesToHostPlatform => platform.isLinux || platform.isMacOS;
+  bool get appliesToHostPlatform => platform.isLinux;
 
   @override
   bool get canListDevices {
-    return fuchsiaArtifacts.devFinder != null;
+    return cache.getArtifactDirectory('fuchsia').existsSync();
   }
 
   @override
   bool get canLaunchDevices {
-    return fuchsiaArtifacts.devFinder != null && fuchsiaArtifacts.sshConfig != null;
+    return cache.getArtifactDirectory('fuchsia').existsSync();
   }
 
   @override

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -5,7 +5,9 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -16,7 +18,6 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_device.dart';
-import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -94,8 +95,9 @@ void main() {
       expect(toolExit.message, contains('No Dart Observatories found. Are you running a debug build?'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => emptyStdoutProcessManager,
-      FuchsiaArtifacts: () => FuchsiaArtifacts(
-        sshConfig: mockFile,
+      Artifacts: () => OverrideArtifacts(
+        parent: artifacts,
+        fuchsiaSshConfig: mockFile,
         devFinder: mockFile,
       ),
     });


### PR DESCRIPTION
## Description

Rolls the internal Fuchsia core sdk version, since the last image disappeared - we probably need to download it from CIPD in the engine and re-upload.

Makes devFinder and sshConfig artifacts and removes the fuchsia special casing for those. Overrides are provided to the fuchsia_attach script to keep it working as normal.

TBD: how do we create the ssh config in the external workflow
TODO: wire up mac connection artifacts.

## Related Issues

https://github.com/flutter/flutter/issues/31143

## Tests

I added the following tests:

Updated existing tests which used the fuchsia artifacts.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
