### PR TITLE
check if project exists before regenerating platform specific tooling

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -443,7 +443,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         offline: argResults['offline'],
       );
       final FlutterProject project = await FlutterProject.fromDirectory(directory);
-      await project.ensureReadyForPlatformSpecificTooling();
+      await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
     }
     return generatedCount;
   }
@@ -510,7 +510,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
 
     if (argResults['pub']) {
       await pubGet(context: PubContext.create, directory: directory.path, offline: argResults['offline']);
-      await project.ensureReadyForPlatformSpecificTooling();
+      await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
     }
 
     gradle.updateLocalProperties(project: project, requireAndroidSdk: false);

--- a/packages/flutter_tools/lib/src/commands/inject_plugins.dart
+++ b/packages/flutter_tools/lib/src/commands/inject_plugins.dart
@@ -29,8 +29,8 @@ class InjectPluginsCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final FlutterProject project = await FlutterProject.current();
-    refreshPluginsList(project);
-    await injectPlugins(project);
+    refreshPluginsList(project, checkProjects: true);
+    await injectPlugins(project, checkProjects: true);
     final bool result = hasPlugins(project);
     if (result) {
       printStatus('GeneratedPluginRegistrants successfully written.');

--- a/packages/flutter_tools/lib/src/commands/make_host_app_editable.dart
+++ b/packages/flutter_tools/lib/src/commands/make_host_app_editable.dart
@@ -43,7 +43,7 @@ class MakeHostAppEditableCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await _project.ensureReadyForPlatformSpecificTooling();
+    await _project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
 
     final bool isAndroidRequested = argResults['android'];
     final bool isIOSRequested = argResults['ios'];

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -94,13 +94,13 @@ class PackagesGetCommand extends FlutterCommand {
 
     await _runPubGet(target);
     final FlutterProject rootProject = await FlutterProject.fromPath(target);
-    await rootProject.ensureReadyForPlatformSpecificTooling();
+    await rootProject.ensureReadyForPlatformSpecificTooling(checkProjects: true);
 
     // Get/upgrade packages in example app as well
     if (rootProject.hasExampleApp) {
       final FlutterProject exampleProject = rootProject.example;
       await _runPubGet(exampleProject.directory.path);
-      await exampleProject.ensureReadyForPlatformSpecificTooling();
+      await exampleProject.ensureReadyForPlatformSpecificTooling(checkProjects: true);
     }
 
     return null;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -286,8 +286,9 @@ Future<void> _writeIOSPluginRegistrant(FlutterProject project, List<Plugin> plug
 void refreshPluginsList(FlutterProject project) {
   final List<Plugin> plugins = findPlugins(project);
   final bool changed = _writeFlutterPluginsList(project, plugins);
-  if (changed)
+  if (changed && project.ios.existsSync()) {
     cocoaPods.invalidatePodInstallOutput(project.ios);
+  }
 }
 
 /// Injects plugins found in `pubspec.yaml` into the platform-specific projects.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -158,21 +158,21 @@ class FlutterProject {
 
   /// Generates project files necessary to make Gradle builds work on Android
   /// and CocoaPods+Xcode work on iOS, for app and module projects only.
-  Future<void> ensureReadyForPlatformSpecificTooling() async {
+  Future<void> ensureReadyForPlatformSpecificTooling({bool checkProjects = false}) async {
     if (!directory.existsSync() || hasExampleApp) {
       return;
     }
     refreshPluginsList(this);
-    if (android.existsSync()) {
+    if ((android.existsSync() && checkProjects) || !checkProjects) {
       await android.ensureReadyForPlatformSpecificTooling();
     }
-    if (ios.existsSync()) {
+    if ((ios.existsSync() && checkProjects) || !checkProjects) {
       await ios.ensureReadyForPlatformSpecificTooling();
     }
     if (flutterWebEnabled) {
       await web.ensureReadyForPlatformSpecificTooling();
     }
-    await injectPlugins(this);
+    await injectPlugins(this, checkProjects: checkProjects);
   }
 
   /// Return the set of builders used by this package.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -388,7 +388,7 @@ class AndroidProject {
     return _ephemeralDirectory;
   }
 
-  bool existsSync() => _flutterLibGradleRoot.existsSync();
+  bool existsSync() => _flutterLibGradleRoot.existsSync() || isModule;
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -159,8 +159,9 @@ class FlutterProject {
   /// Generates project files necessary to make Gradle builds work on Android
   /// and CocoaPods+Xcode work on iOS, for app and module projects only.
   Future<void> ensureReadyForPlatformSpecificTooling() async {
-    if (!directory.existsSync() || hasExampleApp)
+    if (!directory.existsSync() || hasExampleApp) {
       return;
+    }
     refreshPluginsList(this);
     if (android.existsSync()) {
       await android.ensureReadyForPlatformSpecificTooling();

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -162,8 +162,12 @@ class FlutterProject {
     if (!directory.existsSync() || hasExampleApp)
       return;
     refreshPluginsList(this);
-    await android.ensureReadyForPlatformSpecificTooling();
-    await ios.ensureReadyForPlatformSpecificTooling();
+    if (android.existsSync()) {
+      await android.ensureReadyForPlatformSpecificTooling();
+    }
+    if (ios.existsSync()) {
+      await ios.ensureReadyForPlatformSpecificTooling();
+    }
     if (flutterWebEnabled) {
       await web.ensureReadyForPlatformSpecificTooling();
     }
@@ -202,6 +206,8 @@ class IosProject {
 
   Directory get _ephemeralDirectory => parent.directory.childDirectory('.ios');
   Directory get _editableDirectory => parent.directory.childDirectory('ios');
+
+  bool existsSync() => hostAppRoot.existsSync();
 
   /// This parent folder of `Runner.xcodeproj`.
   Directory get hostAppRoot {
@@ -381,6 +387,8 @@ class AndroidProject {
     return _ephemeralDirectory;
   }
 
+  bool existsSync() => _flutterLibGradleRoot.existsSync();
+
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
   /// a Flutter module with an editable host app.
@@ -485,6 +493,8 @@ class WebProject {
   WebProject._(this.parent);
 
   final FlutterProject parent;
+
+  bool existsSync() => parent.directory.childDirectory('web').existsSync();
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {
     /// Generate index.html in build/web. Eventually we could support

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -208,7 +208,7 @@ class IosProject {
   Directory get _ephemeralDirectory => parent.directory.childDirectory('.ios');
   Directory get _editableDirectory => parent.directory.childDirectory('ios');
 
-  bool existsSync() => hostAppRoot.existsSync();
+  bool existsSync() => parent.isModule || _editableDirectory.existsSync();
 
   /// This parent folder of `Runner.xcodeproj`.
   Directory get hostAppRoot {
@@ -388,7 +388,7 @@ class AndroidProject {
     return _ephemeralDirectory;
   }
 
-  bool existsSync() => _flutterLibGradleRoot.existsSync() || isModule;
+  bool existsSync() => parent.isModule || _flutterLibGradleRoot.existsSync();
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -546,7 +546,7 @@ abstract class FlutterCommand extends Command<void> {
     if (shouldRunPub) {
       await pubGet(context: PubContext.getVerifyContext(name));
       final FlutterProject project = await FlutterProject.current();
-      await project.ensureReadyForPlatformSpecificTooling();
+      await project.ensureReadyForPlatformSpecificTooling(checkProjects: true);
     }
 
     setupApplicationPackages();


### PR DESCRIPTION
## Description
Currently we always regenerate platform specific android and ios folders when doing plugin injection, regardless of whether the app has an android or ios project. We should change that logic so that regeneration only applies if the app is a module or if there is a preexisting folder.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31341
Fixes https://github.com/flutter/flutter/issues/20110
