### PR TITLE
add printError messages and tool exit to android device

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -385,7 +385,7 @@ class AndroidDevice extends Device {
     }
     // There was a failure parsing the android project information.
     if (package == null) {
-      throwToolExit('Error in AndroidManifest.');
+      throwToolExit('');
     }
 
     printTrace("Stopping app '${package.name}' on $name.");

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -383,6 +383,10 @@ class AndroidDevice extends Device {
       // activity name from the .apk.
       package = await AndroidApk.fromAndroidProject(project.android);
     }
+    // There was a failure parsing the android project information.
+    if (package == null) {
+      throwToolExit('Error in AndroidManifest.');
+    }
 
     printTrace("Stopping app '${package.name}' on $name.");
     await stopApp(package);

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -385,7 +385,7 @@ class AndroidDevice extends Device {
     }
     // There was a failure parsing the android project information.
     if (package == null) {
-      throwToolExit('');
+      throwToolExit('Problem building Android application: see above error(s).');
     }
 
     printTrace("Stopping app '${package.name}' on $name.");

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -166,8 +166,11 @@ class AndroidApk extends ApplicationPackage {
 
     final File manifest = androidProject.appManifestFile;
 
-    if (!manifest.existsSync())
+    if (!manifest.existsSync()) {
+      printError('AndroidManifest.xml could not be found.');
+      printError('Please check ${manifest?.path ?? '??'} for errors.');
       return null;
+    }
 
     final String manifestString = manifest.readAsStringSync();
     xml.XmlDocument document;
@@ -186,8 +189,11 @@ class AndroidApk extends ApplicationPackage {
     }
 
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');
-    if (manifests.isEmpty)
+    if (manifests.isEmpty) {
+      printError('AndroidManifest.xml has no manifest element.');
+      printError('Please check ${manifest?.path ?? 'AndroidManifest.xml'} for errors.');
       return null;
+    }
     final String packageId = manifests.first.getAttribute('package');
 
     String launchActivity;
@@ -220,8 +226,11 @@ class AndroidApk extends ApplicationPackage {
       }
     }
 
-    if (packageId == null || launchActivity == null)
+    if (packageId == null || launchActivity == null) {
+      printError('package identifier or launch activity not found.');
+      printError('Please check ${manifest?.path ?? 'AndroidManifest.xml'} for errors.');
       return null;
+    }
 
     return AndroidApk(
       id: packageId,

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -168,7 +168,7 @@ class AndroidApk extends ApplicationPackage {
 
     if (!manifest.existsSync()) {
       printError('AndroidManifest.xml could not be found.');
-      printError('Please check ${manifest?.path ?? '??'} for errors.');
+      printError('Please check ${manifest.path} for errors.');
       return null;
     }
 
@@ -191,7 +191,7 @@ class AndroidApk extends ApplicationPackage {
     final Iterable<xml.XmlElement> manifests = document.findElements('manifest');
     if (manifests.isEmpty) {
       printError('AndroidManifest.xml has no manifest element.');
-      printError('Please check ${manifest?.path ?? 'AndroidManifest.xml'} for errors.');
+      printError('Please check ${manifest.path} for errors.');
       return null;
     }
     final String packageId = manifests.first.getAttribute('package');
@@ -228,7 +228,7 @@ class AndroidApk extends ApplicationPackage {
 
     if (packageId == null || launchActivity == null) {
       printError('package identifier or launch activity not found.');
-      printError('Please check ${manifest?.path ?? 'AndroidManifest.xml'} for errors.');
+      printError('Please check ${manifest.path} for errors.');
       return null;
     }
 


### PR DESCRIPTION
## Description

The ApplicationPackage logic could return null for certain invalid manifests, which would cause an NPE. instead, we should log errors and exit the tool gracefully.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28806
