### PR TITLE
Disable all Dart fingerprinters

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -196,10 +196,11 @@ class AOTSnapshotter {
       },
       depfilePaths: <String>[],
     );
-    if (await fingerprinter.doesFingerprintMatch()) {
-      printTrace('Skipping AOT snapshot build. Fingerprint match.');
-      return 0;
-    }
+    // TODO(jonahwilliams): re-enable once this can be proved correct.
+    // if (await fingerprinter.doesFingerprintMatch()) {
+    //   printTrace('Skipping AOT snapshot build. Fingerprint match.');
+    //   return 0;
+    // }
 
     final SnapshotType snapshotType = SnapshotType(platform, buildMode);
     final int genSnapshotExitCode = await _timedStep('gen_snapshot', () => genSnapshot.run(
@@ -467,10 +468,11 @@ class JITSnapshotter {
       },
       depfilePaths: <String>[],
     );
-    if (await fingerprinter.doesFingerprintMatch()) {
-      printTrace('Skipping JIT snapshot build. Fingerprint match.');
-      return 0;
-    }
+    // TODO(jonahwilliams): re-enable once this can be proved correct.
+    // if (await fingerprinter.doesFingerprintMatch()) {
+    //   printTrace('Skipping JIT snapshot build. Fingerprint match.');
+    //   return 0;
+    // }
 
     final SnapshotType snapshotType = SnapshotType(platform, buildMode);
     final int genSnapshotExitCode = await genSnapshot.run(

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -384,11 +384,12 @@ Future<XcodeBuildResult> buildXcodeProject({
       ],
       properties: <String, String>{},
     );
+    // TODO(jonahwilliams): re-enable once this can be proved correct.
     final bool didPodInstall = await cocoaPods.processPods(
       iosProject: project.ios,
       iosEngineDir: flutterFrameworkDir(buildInfo.mode),
       isSwift: project.ios.isSwift,
-      dependenciesChanged: !await fingerprinter.doesFingerprintMatch(),
+      dependenciesChanged: true,
     );
     if (didPodInstall)
       await fingerprinter.writeFingerprint();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -384,12 +384,12 @@ Future<XcodeBuildResult> buildXcodeProject({
       ],
       properties: <String, String>{},
     );
-    // TODO(jonahwilliams): re-enable once this can be proved correct.
+
     final bool didPodInstall = await cocoaPods.processPods(
       iosProject: project.ios,
       iosEngineDir: flutterFrameworkDir(buildInfo.mode),
       isSwift: project.ios.isSwift,
-      dependenciesChanged: true,
+      dependenciesChanged: !await fingerprinter.doesFingerprintMatch(),
     );
     if (didPodInstall)
       await fingerprinter.writeFingerprint();


### PR DESCRIPTION
## Description

There are units tests which cover the behavior of the Fingerprinter given the underlying axiom that the provided values completely describe the build in question. In practice, this assumption is false, as can be seen from the issues linked below.

Until such a time as we can prove them correct, and keep them correct via substantial integration testing, they should stay disabled.

## Related Issues

https://github.com/flutter/flutter/issues/16604
https://github.com/flutter/flutter/issues/27720
