### PR TITLE
fix_emoji_crash

### DIFF
--- a/packages/flutter/lib/src/services/text_editing.dart
+++ b/packages/flutter/lib/src/services/text_editing.dart
@@ -57,12 +57,25 @@ class TextRange {
   /// The text before this range.
   String textBefore(String text) {
     assert(isNormalized);
+    if(text.isNotEmpty && start > 0 && start < text.length ){
+      final int startCodeUnit = text.codeUnitAt(start);
+      if( startCodeUnit & 0x8C00 == 0x8C00 ){
+        return text.substring(0,start -1);
+      }
+    }
+
     return text.substring(0, start);
   }
 
   /// The text after this range.
   String textAfter(String text) {
     assert(isNormalized);
+    if(text.isNotEmpty && end > 0 && end < text.length){
+      final int endCodeUnit = text.codeUnitAt(end);
+      if(endCodeUnit & 0x8C00 == 0x8C00 ){
+        return text.substring(end -1);
+      }
+    }
     return text.substring(end);
   }
 


### PR DESCRIPTION
## Description
**fix in iOS paste emoji crash**
1 **Test code** 
```
import 'package:flutter/material.dart';

class MyTextField extends StatelessWidget {
//  MediaQuery
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: TextField(
          maxLines: null,
        ),
      ),
    );
  }
}

void main() async {
  runApp(MaterialApp(
    home: MyTextField(),
  ));
}
```
2. **environment**
**device**：iOS 12 ，iPhone
**keyboard setting** ： english & emoji
![image](https://user-images.githubusercontent.com/12166990/56553419-08aa9000-65c1-11e9-9546-a10da7e25d94.png)

3. **analyze**
```
main() {
  String a='𐐷';
  print(a.codeUnits.map((v)=> v.toRadixString(16)));
  String b='宋';
  print(b.codeUnits.map((v)=> v.toRadixString(16)));
}
```
https://en.wikipedia.org/wiki/UTF-16 @dnfield one character may be two code units.
try this code,

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
