### PR TITLE
[decoration_image] try to fix performance issues

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -246,6 +246,7 @@ class DecorationImagePainter {
       _imageStream?.removeListener(_imageListener);
       _imageStream = newImageStream;
       _imageStream.addListener(_imageListener);
+      _imageProvider = _details.image;
     }
     if (_image == null)
       return;
@@ -290,6 +291,7 @@ class DecorationImagePainter {
   @mustCallSuper
   void dispose() {
     _imageStream?.removeListener(_imageListener);
+    _imageProvider = null;
   }
 
   @override

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -154,6 +154,10 @@ class DecorationImage {
   @override
   int get hashCode => hashValues(image, colorFilter, fit, alignment, centerSlice, repeat, matchTextDirection);
 
+  ImageProvider getImage() {
+    return image;
+  }
+
   @override
   String toString() {
     final List<String> properties = <String>[];
@@ -194,6 +198,7 @@ class DecorationImagePainter {
 
   ImageStream _imageStream;
   ImageInfo _image;
+  ImageProvider _imageProvider;
 
   /// Draw the image onto the given canvas.
   ///
@@ -236,8 +241,8 @@ class DecorationImagePainter {
         flipHorizontally = true;
     }
 
-    final ImageStream newImageStream = _details.image.resolve(configuration);
-    if (newImageStream.key != _imageStream?.key) {
+    if ((_imageStream == null || _imageStream.key == null) || (_imageProvider.hashCode != _details.getImage().hashCode)) {
+      final ImageStream newImageStream = _details.image.resolve(configuration);
       _imageStream?.removeListener(_imageListener);
       _imageStream = newImageStream;
       _imageStream.addListener(_imageListener);


### PR DESCRIPTION
## Description

When image cache full,  `_details.image.resolve(configuration)` can not return correct key, and always load image, this make lose frame. 

