### PR TITLE
fix precedence issue

### DIFF
--- a/examples/flutter_gallery/lib/gallery/options.dart
+++ b/examples/flutter_gallery/lib/gallery/options.dart
@@ -391,9 +391,9 @@ class GalleryOptionsPage extends StatelessWidget {
   List<Widget> _enabledDiagnosticItems() {
     // Boolean showFoo options with a value of null: don't display
     // the showFoo option at all.
-    if (null == options.showOffscreenLayersCheckerboard
-             ?? options.showRasterCacheImagesCheckerboard
-             ?? options.showPerformanceOverlay)
+    if (options.showOffscreenLayersCheckerboard == null &&
+        options.showRasterCacheImagesCheckerboard == null &&
+        options.showPerformanceOverlay == null)
       return const <Widget>[];
 
     final List<Widget> items = <Widget>[


### PR DESCRIPTION
As mentioned in https://github.com/flutter/flutter/pull/30138/files#r270581755 

> `==` is done before `??`. So the code was the same as `(null == options.showOffscreenLayersCheckerboard) ?? options.showRasterCacheImagesCheckerboard ?? options.showPerformanceOverlay`.

This is not what was expected according to comment.
