### PR TITLE
Allow adb stdout to contain the port number without failing

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -885,12 +885,12 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
         process.throwException('adb did not report forwarded port');
       hostPort = int.tryParse(process.stdout) ?? (throw 'adb returned invalid port number:\n${process.stdout}');
     } else {
-      // dantup: stdout may be empty, or the port we asked it to forward
+      // dantup: stdout may be empty or the port we asked it to forward,
       // depending on some factors I do not understand. On MacOS it's always
-      // empty for Flutter, yet at the terminal it returns the port number
-      // if it forwarded, and nothing if it was already being forwarded. On CrOS
-      // it returns the port number even to Flutter, which results in a failure
-      // even though everything worked fine.
+      // empty for Flutter, yet at the terminal it prints the port number
+      // only if it forwarded (nothing if it was already being forwarded).
+      // On CrOS it prints the port number even for Flutter, which results in a
+      // failure unless we allow the hostPort in the output here.
       if (process.stdout.isNotEmpty && process.stdout.trim() != '$hostPort')
         process.throwException('adb returned error:\n${process.stdout}');
     }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -885,7 +885,13 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
         process.throwException('adb did not report forwarded port');
       hostPort = int.tryParse(process.stdout) ?? (throw 'adb returned invalid port number:\n${process.stdout}');
     } else {
-      if (process.stdout.isNotEmpty)
+      // dantup: stdout may be empty, or the port we asked it to forward
+      // depending on some factors I do not understand. On MacOS it's always
+      // empty for Flutter, yet at the terminal it returns the port number
+      // if it forwarded, and nothing if it was already being forwarded. On CrOS
+      // it returns the port number even to Flutter, which results in a failure
+      // even though everything worked fine.
+      if (process.stdout.isNotEmpty && process.stdout.trim() != '$hostPort')
         process.throwException('adb returned error:\n${process.stdout}');
     }
 

--- a/packages/flutter_tools/test/android/android_device_test.dart
+++ b/packages/flutter_tools/test/android/android_device_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -195,6 +196,48 @@ flutter:
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+  });
+
+  group('portForwarder', () {
+    final ProcessManager mockProcessManager = MockProcessManager();
+    final AndroidDevice device = AndroidDevice('1234');
+    final DevicePortForwarder forwarder = device.portForwarder;
+
+    testUsingContext('returns the generated host port from stdout', () async {
+      when(mockProcessManager.run(argThat(contains('forward'))))
+      .thenAnswer((_) async => ProcessResult(0, 0, '456', ''));
+
+      expect(await forwarder.forward(123), equals(456));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('returns the supplied host port when stdout is empty', () async {
+      when(mockProcessManager.run(argThat(contains('forward'))))
+      .thenAnswer((_) async => ProcessResult(0, 0, '', ''));
+
+      expect(await forwarder.forward(123, hostPort: 456), equals(456));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('returns the supplied host port when stdout is the host port', () async {
+      when(mockProcessManager.run(argThat(contains('forward'))))
+      .thenAnswer((_) async => ProcessResult(0, 0, '456', ''));
+
+      expect(await forwarder.forward(123, hostPort: 456), equals(456));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('throws an error when stdout is not blank nor the host port', () async {
+      when(mockProcessManager.run(argThat(contains('forward'))))
+      .thenAnswer((_) async => ProcessResult(0, 0, '123456', ''));
+
+      expect(forwarder.forward(123, hostPort: 456), throwsA(isInstanceOf<ProcessException>()));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
   });
 }
 


### PR DESCRIPTION
While testing on CrOS I found some strange behaviour. When running Flutter with `--observatory-port xxxx` it fails like this:

```
$ flutter run --observatory-port 9006

// ...
Built build/app/outputs/apk/debug/app-debug.apk.
Error waiting for a debug connection: ProcessException: adb returned error:
9006

 Command: /home/danny/Apps/Android/platform-tools/adb -s 100.115.92.2:5555 forward tcp:9006 tcp:33803
Error launching application on Google Pixelbook.
```

The reason it fails, is that our code assumes that when we call `adb forward` that `stdout` is empty *if we supplied a port* but that it contains the port number *if we used port=0*. On ChromeOS, the port is written to `stdout` even when we specify it.

It seems strange that this behaves differently on CrOS, so I did some testing. And it got stranger. If I run `adb forward` from the terminal *on macOS* I see the same behaviour as CrOS - it prints the port out. However, it only does it the first time (not if it's already forwarded). I can pick any random ports and then run the forward command 10 times, and it's consistent - port printed the first time, but never after:

<img width="1021" alt="Screenshot 2019-04-23 at 4 40 25 pm" src="https://user-images.githubusercontent.com/1078012/56597649-cc8c2500-65ea-11e9-8c4a-5fcc5fd79bc8.png">

It seems like there may be some logic to this, but what I cannot explain is why when Flutter runs `adb forward` on macOS it *never* sees the stdout with the port number. I added logging and it never gets a port number:

```
[  +10 ms]       command: /Users/dantup/Library/Android/sdk/platform-tools/adb -s ZY2224Z9N9 forward tcp:8080 tcp:44201
                 exitCode: 0
                 stdout: 
                 stderr: 

[        ] stdout was empty!
```

Yet running the exact same command (with a new port number, since that one was now forwarded) I *do* see the port number:

```
$ /Users/dantup/Library/Android/sdk/platform-tools/adb -s ZY2224Z9N9 forward tcp:8085 tcp:43000
8085
```

So, this change tolerates this, by allowing stdout to be exactly the port number. It will no longer throw. This seems like a sensible change, even though I'm sad I can't figure out why macOS isn't crashing all over the place too.

FWIW, in my testing the ADB versions on both machines are:

```
Android Debug Bridge version 1.0.40
Version 28.0.2-5303910
Installed as /Users/dantup/Library/Android/sdk/platform-tools/adb
```