### PR TITLE
Support local engine and asset sync for macOS

### DIFF
--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -40,6 +40,37 @@ if [[ -n "$TRACK_WIDGET_CREATION" ]]; then
   track_widget_creation_flag="--track-widget-creation"
 fi
 
+# Copy the framework and handle local engine builds.
+derived_dir="${SOURCE_ROOT}/../build/macos/Build/Products/flutter_framework"
+framework_path="${FLUTTER_ROOT}/bin/cache/artifacts/engine/darwin-x64"
+flutter_framework="${framework_path}/FlutterMacOS.framework"
+
+if [[ -n "$FLUTTER_ENGINE" ]]; then
+  flutter_engine_flag="--local-engine-src-path=${FLUTTER_ENGINE}"
+fi
+
+if [[ -n "$LOCAL_ENGINE" ]]; then
+  if [[ $(echo "$LOCAL_ENGINE" | tr "[:upper:]" "[:lower:]") != *"$build_mode"* ]]; then
+    EchoError "========================================================================"
+    EchoError "ERROR: Requested build with Flutter local engine at '${LOCAL_ENGINE}'"
+    EchoError "This engine is not compatible with FLUTTER_BUILD_MODE: '${build_mode}'."
+    EchoError "You can fix this by updating the LOCAL_ENGINE environment variable, or"
+    EchoError "by running:"
+    EchoError "  flutter build macos --local-engine=host_${build_mode}"
+    EchoError "or"
+    EchoError "  flutter build macos --local-engine=host_${build_mode}_unopt"
+    EchoError "========================================================================"
+    exit -1
+  fi
+  local_engine_flag="--local-engine=${LOCAL_ENGINE}"
+  flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/FlutterMacOS.framework"
+fi
+
+RunCommand mkdir -p -- "$derived_dir"
+RunCommand rm -rf -- "${derived_dir}/FlutterMacOS.framework"
+RunCommand cp -r -- "${flutter_framework}" "${derived_dir}"
+RunCommand find "${derived_dir}/FlutterMacOS.framework" -type f -exec chmod a-w "{}" \;
+
 # Set the build mode
 build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"
 
@@ -49,4 +80,6 @@ RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics               \
     --target-platform=darwin-x64                                            \
     --target="${target_path}"                                               \
     --${build_mode}                                                         \
-    ${track_widget_creation_flag}
+    ${track_widget_creation_flag}                                           \
+    ${flutter_engine_flag}                                                  \
+    ${local_engine_flag}

--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -68,7 +68,7 @@ fi
 
 RunCommand mkdir -p -- "$derived_dir"
 RunCommand rm -rf -- "${derived_dir}/${framework_name}"
-RunCommand cp -R -- "${flutter_framework}" "${derived_dir}"
+RunCommand cp -Rp -- "${flutter_framework}" "${derived_dir}"
 
 # Set the build mode
 build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"

--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -5,7 +5,6 @@
 
 # TODO(jonahwilliams): refactor this and xcode_backend.sh into one script
 # once macOS supports the same configuration as iOS.
-
 RunCommand() {
   if [[ -n "$VERBOSE_SCRIPT_LOGGING" ]]; then
     echo "♦ $*"
@@ -41,9 +40,10 @@ if [[ -n "$TRACK_WIDGET_CREATION" ]]; then
 fi
 
 # Copy the framework and handle local engine builds.
+framework_name = "FlutterMacOS.framework"
 derived_dir="${SOURCE_ROOT}/../build/macos/Build/Products/flutter_framework"
 framework_path="${FLUTTER_ROOT}/bin/cache/artifacts/engine/darwin-x64"
-flutter_framework="${framework_path}/FlutterMacOS.framework"
+flutter_framework="${framework_path}/${framework_name}"
 
 if [[ -n "$FLUTTER_ENGINE" ]]; then
   flutter_engine_flag="--local-engine-src-path=${FLUTTER_ENGINE}"
@@ -63,13 +63,12 @@ if [[ -n "$LOCAL_ENGINE" ]]; then
     exit -1
   fi
   local_engine_flag="--local-engine=${LOCAL_ENGINE}"
-  flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/FlutterMacOS.framework"
+  flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/${framework_name}"
 fi
 
 RunCommand mkdir -p -- "$derived_dir"
-RunCommand rm -rf -- "${derived_dir}/FlutterMacOS.framework"
-RunCommand cp -r -- "${flutter_framework}" "${derived_dir}"
-RunCommand find "${derived_dir}/FlutterMacOS.framework" -type f -exec chmod a-w "{}" \;
+RunCommand rm -rf -- "${derived_dir}/${framework_name}"
+RunCommand cp -R -- "${flutter_framework}" "${derived_dir}"
 
 # Set the build mode
 build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"


### PR DESCRIPTION
## Description

Move the framework copy step and corresponding local engine configuration into the macos_backend script. This supports local engine development as well.

Corresponding FDE change: https://github.com/google/flutter-desktop-embedding/pull/353

## Related Issues

https://github.com/flutter/flutter/issues/31367
