### PR TITLE
Allow all tests to run with --update-goldens.

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1109,7 +1109,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void initInstances() {
     super.initInstances();
-    assert(!autoUpdateGoldenFiles);
   }
 
   @override


### PR DESCRIPTION
Previously `benchmark_test.dart` would terminate `flutter test` if all tests are run with `--update-goldens`.

It is important for the Dart team to be able to run all tests this way to avoid maintaining golden files.