### PR TITLE
Add support for Tooltip hover

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -43,7 +43,7 @@ class Tooltip extends StatefulWidget {
   /// By default, tooltips prefer to appear below the [child] widget when the
   /// user long presses on the widget.
   ///
-  /// All of the arguments except [child] must not be null.
+  /// All of the arguments except [child] and [decoration] must not be null.
   const Tooltip({
     Key key,
     @required this.message,
@@ -52,6 +52,7 @@ class Tooltip extends StatefulWidget {
     this.verticalOffset = 24.0,
     this.preferBelow = true,
     this.excludeFromSemantics = false,
+    this.decoration,
     this.waitDuration = _kDefaultWaitDuration,
     this.showDuration = _kDefaultShowDuration,
     this.child,
@@ -96,6 +97,12 @@ class Tooltip extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.child}
   final Widget child;
+
+  /// Specifies the decoration of the tooltip window.
+  ///
+  /// If not specified, defaults to a rounded rectangle with a border radius of
+  /// 4.0, and a color derived from the text theme.
+  final Decoration decoration;
 
   /// The amount of time that a pointer must hover over the widget before it
   /// will show a tooltip.
@@ -190,6 +197,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       message: widget.message,
       height: widget.height,
       padding: widget.padding,
+      decoration: widget.decoration,
       animation: CurvedAnimation(
         parent: _controller,
         curve: Curves.fastOutSlowIn,
@@ -236,18 +244,16 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (_entry != null) {
+    if (_entry != null)
       _removeEntry();
-    }
     _controller.dispose();
     super.dispose();
   }
 
   void _handleLongPress() {
     final bool tooltipCreated = ensureTooltipVisible();
-    if (tooltipCreated) {
+    if (tooltipCreated)
       Feedback.forLongPress(context);
-    }
   }
 
   @override
@@ -313,7 +319,9 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_TooltipPositionDelegate oldDelegate) {
-    return target != oldDelegate.target || verticalOffset != oldDelegate.verticalOffset || preferBelow != oldDelegate.preferBelow;
+    return target != oldDelegate.target
+        || verticalOffset != oldDelegate.verticalOffset
+        || preferBelow != oldDelegate.preferBelow;
   }
 }
 
@@ -323,6 +331,7 @@ class _TooltipOverlay extends StatelessWidget {
     this.message,
     this.height,
     this.padding,
+    this.decoration,
     this.animation,
     this.target,
     this.verticalOffset,
@@ -332,6 +341,7 @@ class _TooltipOverlay extends StatelessWidget {
   final String message;
   final double height;
   final EdgeInsetsGeometry padding;
+  final Decoration decoration;
   final Animation<double> animation;
   final Offset target;
   final double verticalOffset;
@@ -358,9 +368,9 @@ class _TooltipOverlay extends StatelessWidget {
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: height),
               child: Container(
-                decoration: BoxDecoration(
-                  color: darkTheme.backgroundColor,
-                  borderRadius: BorderRadius.circular(2.0),
+                decoration: decoration ?? BoxDecoration(
+                  color: darkTheme.backgroundColor.withOpacity(0.9),
+                  borderRadius: BorderRadius.circular(4.0),
                 ),
                 padding: padding,
                 child: Center(

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -132,12 +132,14 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _handleStatusChanged(AnimationStatus status) {
+    print('Animation status changed to $status');
     if (status == AnimationStatus.dismissed) {
       _hideTooltip(immediately: true);
     }
   }
 
   void _hideTooltip({bool immediately = false}) {
+    print('Hiding tooltip${immediately ? ' immediately' : ' in ${widget.showDuration}'}');
     _showTimer?.cancel();
     _showTimer = null;
     if (immediately) {
@@ -148,6 +150,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _showTooltip({bool immediately = false}) {
+    print('Showing tooltip${immediately ? ' immediately' : ' in ${widget.waitDuration}'}');
     _hideTimer?.cancel();
     _hideTimer = null;
     if (immediately) {
@@ -167,10 +170,12 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       // Stop trying to hide, if we were.
       _hideTimer?.cancel();
       _hideTimer = null;
+      print('Showing existing entry');
       _controller.forward();
       return false; // Already visible.
     }
     _createNewEntry();
+    print('Showing new entry');
     _controller.forward();
     return true;
   }
@@ -201,6 +206,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _removeEntry() {
+    print('Removing entry');
     _hideTimer?.cancel();
     _hideTimer = null;
     _entry?.remove();
@@ -219,6 +225,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   void deactivate() {
+    print('deactivating');
     if (_entry != null) {
       _hideTooltip(immediately: true);
     }
@@ -230,6 +237,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     if (_entry != null) {
       _removeEntry();
     }
+    print('disposing controller');
     _controller.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -201,6 +201,9 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       animation: CurvedAnimation(
         parent: _controller,
         curve: Curves.fastOutSlowIn,
+        // Add an interval here to make the fade out use a different (shorter)
+        // duration than the fade in. If _kFadeOutDuration is made longer than
+        // _kFadeInDuration, then the equation below will need to change.
         reverseCurve: Interval(
           0.0,
           _kFadeOutDuration.inMilliseconds / _kFadeInDuration.inMilliseconds,

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -470,7 +470,6 @@ void main() {
             child: Container(
               width: 100.0,
               height: 100.0,
-              color: Colors.green[500],
             ),
           ),
         ),
@@ -482,9 +481,24 @@ void main() {
     await gesture.moveTo(Offset.zero);
     await tester.pump();
     await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump();
+    // Wait for it to appear.
     await tester.pump(waitDuration);
-    await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tooltipText), findsOneWidget);
+
+    // Wait a looong time to make sure that it doesn't go away if the mouse is
+    // still over the widget.
+    await tester.pump(const Duration(days: 1));
+    await tester.pumpAndSettle();
+    expect(find.text(tooltipText), findsOneWidget);
+
+    await gesture.moveTo(Offset.zero);
+    await tester.pump();
+
+    // Wait for it to disappear.
+    await tester.pump(showDuration);
+    await tester.pumpAndSettle();
+    expect(find.text(tooltipText), findsNothing);
   });
 
   testWidgets('Does tooltip contribute semantics', (WidgetTester tester) async {

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
@@ -67,7 +68,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -123,7 +124,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -175,7 +176,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -229,7 +230,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     // we try to put it here but it doesn't fit:
@@ -294,7 +295,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -347,7 +348,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -402,7 +403,7 @@ void main() {
         ),
       ),
     );
-    (key.currentState as dynamic).ensureTooltipVisible(); // before using "as dynamic" in your code, see note top of file
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
     /********************* 800x600 screen
@@ -420,6 +421,82 @@ void main() {
     expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(310.0));
     expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dx, equals(790.0));
     expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(324.0));
+  });
+
+  testWidgets('Does tooltip end up with the right default size, shape, and color', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          initialEntries: <OverlayEntry>[
+            OverlayEntry(
+              builder: (BuildContext context) {
+                return Tooltip(
+                  key: key,
+                  message: tooltipText,
+                  child: Container(
+                    width: 0.0,
+                    height: 0.0,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
+    await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+    final RenderBox tip = tester.renderObject(find.text(tooltipText)).parent.parent.parent.parent;
+
+    expect(tip.size.height, equals(32.0));
+    expect(tip.size.width, equals(74.0));
+    expect(tip, paints..rrect(
+      rrect: RRect.fromRectAndRadius(tip.paintBounds, const Radius.circular(4.0)),
+      color: const Color(0xe6616161),
+    ));
+  });
+
+  testWidgets('Can tooltip decoration be customized', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    const Decoration customDecoration = ShapeDecoration(
+      shape: StadiumBorder(),
+      color: Color(0x80800000),
+    );
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          initialEntries: <OverlayEntry>[
+            OverlayEntry(
+              builder: (BuildContext context) {
+                return Tooltip(
+                  key: key,
+                  decoration: customDecoration,
+                  message: tooltipText,
+                  child: Container(
+                    width: 0.0,
+                    height: 0.0,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
+    await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+    final RenderBox tip = tester.renderObject(find.text(tooltipText)).parent.parent.parent.parent;
+
+    expect(tip.size.height, equals(32.0));
+    expect(tip.size.width, equals(74.0));
+    expect(tip, paints..path(
+      color: const Color(0x80800000),
+    ));
   });
 
   testWidgets('Tooltip stays around', (WidgetTester tester) async {
@@ -544,7 +621,7 @@ void main() {
 
     expect(semantics, hasSemantics(expected, ignoreTransform: true, ignoreRect: true));
 
-    // before using "as dynamic" in your code, see note top of file
+    // Before using "as dynamic" in your code, see note at the top of the file.
     (key.currentState as dynamic).ensureTooltipVisible(); // this triggers a rebuild of the semantics because the tree changes
 
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -457,8 +457,8 @@ void main() {
     gesture.up();
   });
 
-  testWidgets('Tooltip stays around when hovered', (WidgetTester tester) async {
-    const Duration waitDuration = Duration(milliseconds: 600);
+  testWidgets('Tooltip shows/hides when hovered', (WidgetTester tester) async {
+    const Duration waitDuration = Duration(milliseconds: 0);
     const Duration showDuration = Duration(milliseconds: 1500);
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -457,6 +457,36 @@ void main() {
     gesture.up();
   });
 
+  testWidgets('Tooltip stays around when hovered', (WidgetTester tester) async {
+    const Duration waitDuration = Duration(milliseconds: 600);
+    const Duration showDuration = Duration(milliseconds: 1500);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: Tooltip(
+            message: tooltipText,
+            showDuration: showDuration,
+            waitDuration: waitDuration,
+            child: Container(
+              width: 100.0,
+              height: 100.0,
+              color: Colors.green[500],
+            ),
+          ),
+        ),
+      )
+    );
+
+    final Finder tooltip = find.byType(Tooltip);
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(Offset.zero);
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump(waitDuration);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tooltipText), findsOneWidget);
+  });
+
   testWidgets('Does tooltip contribute semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 


### PR DESCRIPTION
## Description

Adds support for mouse pointer hovering to trigger tooltips, as well as custom timeouts for the tooltip durations, and a custom decoration. It also makes the tooltip be fully opaque when shown, and fade in over 150ms, and fade out over 75ms, and draw a 4.0 corner radius, all to conform with the [material spec](https://material.io/design/components/tooltips.html#behavior). Prior to this change, it was using a corner radius of 2.0 when shown, and faded in and out over 200ms.

## Related Issues

Fixes #22817

## Tests

I added the following tests:

 - Test to see if tooltip appears on hover
 - Test to see if tooltip remains as long as pointer is over widget
 - Test to see if tooltip disappears after being displayed for 1.5 seconds.
 - Test to see if tooltip is drawn with the right shape and color by default.
 - Test to see if tooltip honors custom decoration.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
