### PR TITLE
Allow all tests to run with --update-goldens.

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1107,11 +1107,6 @@ enum LiveTestWidgetsFlutterBindingFramePolicy {
 /// anyway.)
 class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
-  void initInstances() {
-    super.initInstances();
-  }
-
-  @override
   bool get inTest => _inTest;
   bool _inTest = false;
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1109,7 +1109,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void initInstances() {
     super.initInstances();
-    assert(!autoUpdateGoldenFiles);
   }
 
   @override

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -124,7 +124,6 @@ class TrivialComparator implements GoldenFileComparator {
 
   @override
   Future<void> update(Uri golden, Uint8List imageBytes) {
-    // [autoUpdateGoldenFiles] should never be set in a live widget binding.
     throw StateError('goldenFileComparator has not been initialized');
   }
 }


### PR DESCRIPTION
(Resurrecting #31554 because using our 3xH patch will cause other problems).

Previously benchmark_test.dart would terminate flutter test if all tests are run with --update-goldens.

It is important for the Dart team to be able to run all tests this way to avoid maintaining golden files.