### PR TITLE
Remove need for build/name scripts on Linux desktop

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -392,6 +392,11 @@ String getWebBuildDirectory() {
   return fs.path.join(getBuildDirectory(), 'web');
 }
 
+/// Returns the linux build output directory.
+String getLinuxBuildDirectory() {
+  return fs.path.join(getBuildDirectory(), 'linux');
+}
+
 /// Returns directory used by incremental compiler (IKG - incremental kernel
 /// generator) to store cached intermediate state.
 String getIncrementalCompilerByteStoreDirectory() {

--- a/packages/flutter_tools/lib/src/linux/application_package.dart
+++ b/packages/flutter_tools/lib/src/linux/application_package.dart
@@ -5,12 +5,10 @@
 import 'package:meta/meta.dart';
 
 import '../application_package.dart';
-import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
-import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../project.dart';
+import 'makefile.dart';
 
 abstract class LinuxApp extends ApplicationPackage {
   LinuxApp({@required String projectBundleId}) : super(id: projectBundleId);
@@ -59,14 +57,12 @@ class BuildableLinuxApp extends LinuxApp {
 
   @override
   String executable(BuildMode buildMode) {
-    final ProcessResult result = processManager.runSync(<String>[
-      project.nameScript.path,
-      buildMode == BuildMode.debug ? 'debug' : 'release',
-    ]);
-    if (result.exitCode != 0) {
-      throwToolExit('Failed to find Linux project name');
+    final String binaryName = makefileExecutableName(project);
+    if (buildMode == BuildMode.debug) {
+      return fs.path.join(getLinuxBuildDirectory(), 'debug', binaryName);
+    } else {
+      return fs.path.join(getLinuxBuildDirectory(), 'release', binaryName);
     }
-    return result.stdout.toString().trim();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -12,13 +12,22 @@ import '../convert.dart';
 import '../globals.dart';
 import '../project.dart';
 
-/// Builds the Linux project through the project shell script.
+/// Builds the Linux project through the Makefile.
 Future<void> buildLinux(LinuxProject linuxProject, BuildInfo buildInfo) async {
+  /// Cache flutter root in linux directory.
+  linuxProject.editableHostAppDirectory.childFile('.generated_flutter_root')
+    ..createSync(recursive: true)
+    ..writeAsStringSync(Cache.flutterRoot);
+
+  final String buildFlag = buildInfo?.isDebug == true ? 'debug' : 'release';
+  final String bundleFlags = buildInfo?.trackWidgetCreation == true ? '--track-widget-creation' : '';
   final Process process = await processManager.start(<String>[
-    linuxProject.buildScript.path,
-    Cache.flutterRoot,
-    buildInfo?.isDebug == true ? 'debug' : 'release',
-    buildInfo?.trackWidgetCreation == true ? 'track-widget-creation' : 'no-track-widget-creation',
+    'make',
+    '-C',
+    linuxProject.editableHostAppDirectory.path,
+    'BUILD=$buildFlag',
+    'FLUTTER_ROOT=${Cache.flutterRoot}',
+    'FLUTTER_BUNDLE_FLAGS=$bundleFlags',
   ], runInShell: true);
   final Status status = logger.startProgress(
     'Building Linux application...',

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -71,6 +71,7 @@ class LinuxDevice extends Device {
     bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
+    _lastBuiltMode = debuggingOptions.buildInfo.mode;
     if (!prebuiltApplication) {
       await buildLinux((await FlutterProject.current()).linux, debuggingOptions.buildInfo);
     }
@@ -97,7 +98,7 @@ class LinuxDevice extends Device {
   @override
   Future<bool> stopApp(covariant LinuxApp app) async {
     // Assume debug for now.
-    return killProcess(app.executable(BuildMode.debug));
+    return killProcess(app.executable(_lastBuiltMode));
   }
 
   @override
@@ -107,6 +108,9 @@ class LinuxDevice extends Device {
   // to uninstall the application.
   @override
   Future<bool> uninstallApp(ApplicationPackage app) async => true;
+
+  // Track the last built mode from startApp.
+  BuildMode _lastBuiltMode;
 }
 
 class LinuxDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -97,7 +97,6 @@ class LinuxDevice extends Device {
 
   @override
   Future<bool> stopApp(covariant LinuxApp app) async {
-    // Assume debug for now.
     return killProcess(app.executable(_lastBuiltMode));
   }
 

--- a/packages/flutter_tools/lib/src/linux/makefile.dart
+++ b/packages/flutter_tools/lib/src/linux/makefile.dart
@@ -1,0 +1,20 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../project.dart';
+
+// The setting that controls the executable name in the linux makefile.
+const String _kBinaryName = 'BINARY_NAME=';
+
+/// Extracts the `BINARY_NAME` from a linux project Makefile.
+///
+/// Returns `null` if it cannot be found.
+String makefileExecutableName(LinuxProject project) {
+  for (String line in project.makeFile.readAsLinesSync()) {
+    if (line.startsWith(_kBinaryName)) {
+      return line.split(_kBinaryName).last.trim();
+    }
+  }
+  return null;
+}

--- a/packages/flutter_tools/lib/src/linux/makefile.dart
+++ b/packages/flutter_tools/lib/src/linux/makefile.dart
@@ -5,15 +5,15 @@
 import '../project.dart';
 
 // The setting that controls the executable name in the linux makefile.
-const String _kBinaryName = 'BINARY_NAME=';
+const String _kBinaryNameVariable = 'BINARY_NAME=';
 
 /// Extracts the `BINARY_NAME` from a linux project Makefile.
 ///
 /// Returns `null` if it cannot be found.
 String makefileExecutableName(LinuxProject project) {
   for (String line in project.makeFile.readAsLinesSync()) {
-    if (line.startsWith(_kBinaryName)) {
-      return line.split(_kBinaryName).last.trim();
+    if (line.startsWith(_kBinaryNameVariable)) {
+      return line.split(_kBinaryNameVariable).last.trim();
     }
   }
   return null;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -588,6 +588,6 @@ class LinuxProject {
 
   bool existsSync() => editableHostAppDirectory.existsSync();
 
-  /// The linux project makefile.
+  /// The Linux project makefile.
   File get makeFile => editableHostAppDirectory.childFile('Makefile');
 }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -584,11 +584,10 @@ class LinuxProject {
 
   final FlutterProject project;
 
-  bool existsSync() => project.directory.childDirectory('linux').existsSync();
+  Directory get editableHostAppDirectory => project.directory.childDirectory('linux');
 
-  // Note: The build script file exists as a temporary shim.
-  File get buildScript => project.directory.childDirectory('linux').childFile('build.sh');
+  bool existsSync() => editableHostAppDirectory.existsSync();
 
-  // Note: The name script file exists as a temporary shim.
-  File get nameScript => project.directory.childDirectory('linux').childFile('name_output.sh');
+  /// The linux project makefile.
+  File get makeFile => editableHostAppDirectory.childFile('Makefile');
 }


### PR DESCRIPTION
Teaches flutter tool to make, and to find the binary name for the flutter desktop target.

https://github.com/flutter/flutter/issues/30707
https://github.com/flutter/flutter/issues/30706