### PR TITLE
fix transform assert

### DIFF
--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -163,7 +163,10 @@ class MatrixUtils {
   /// 0.0 before computing its bounding rect.
   static Rect inverseTransformRect(Matrix4 transform, Rect rect) {
     assert(rect != null);
-    assert(transform.determinant() != 0.0);
+    // As exposed by `unrelated_type_equality_checks`, this assert was a no-op.
+    // Fixing it introduces a bunch of runtime failures; for more context see:
+    // https://github.com/flutter/flutter/pull/31568
+    // assert(transform.determinant != 0.0);
     if (isIdentity(transform))
       return rect;
     transform = Matrix4.copy(transform)..invert();

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -163,7 +163,7 @@ class MatrixUtils {
   /// 0.0 before computing its bounding rect.
   static Rect inverseTransformRect(Matrix4 transform, Rect rect) {
     assert(rect != null);
-    assert(transform.determinant != 0.0);
+    assert(transform.determinant() != 0.0);
     if (isIdentity(transform))
       return rect;
     transform = Matrix4.copy(transform)..invert();


### PR DESCRIPTION
## Description

Fixes an assert that was bogus.

Flagged by the newly updated `unrelated_type_equality_checks` lint in this failing try:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8915275287386529616/+/steps/analyze_flutter/0/stdout

Cheers @srawlins for the fix!
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
