### PR TITLE
Improve RadioListTile Callback Behavior Consistency

### DIFF
--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -228,7 +228,13 @@ class RadioListTile<T> extends StatelessWidget {
           isThreeLine: isThreeLine,
           dense: dense,
           enabled: onChanged != null,
-          onTap: onChanged != null ? () { onChanged(value); } : null,
+          onTap: onChanged != null ?
+            () {
+              if (!checked) {
+                onChanged(value);
+              }
+            } :
+            null,
           selected: selected,
         ),
       ),

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -228,13 +228,7 @@ class RadioListTile<T> extends StatelessWidget {
           isThreeLine: isThreeLine,
           dense: dense,
           enabled: onChanged != null,
-          onTap: onChanged != null ?
-            () {
-              if (!checked) {
-                onChanged(value);
-              }
-            } :
-            null,
+          onTap: onChanged != null  && !checked ? () { onChanged(value); } : null,
           selected: selected,
         ),
       ),

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -37,42 +37,45 @@ void main() {
   testWidgets('RadioListTile should initialize according to groupValue', (WidgetTester tester) async {
     final List<int> values = <int>[0, 1, 2];
     int selectedValue;
-    // Input parameters are required for [RadioListTile], but they are
+    // Constructor parameters are required for [RadioListTile], but they are
     // irrelevant when searching with [find.byType].
     final Type radioListTileType = const RadioListTile<int>(
       value: 0,
       groupValue: 0,
       onChanged: null,
     ).runtimeType;
+
     List<RadioListTile<int>> generatedRadioListTiles;
-
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
-                onChanged: (int value) {
-                  setState(() { selectedValue = value; });
-                },
-                value: values[index],
-                groupValue: selectedValue,
-                title: Text(values[index].toString()),
-              ),
-            ),
-          );
-        },
-      ),
-    ));
-
-    generatedRadioListTiles = find
+    List<RadioListTile<int>> findTiles() => find
       .byType(radioListTileType)
       .evaluate()
-      .map((Element element) {
-        final RadioListTile<int> tile = element.widget;
-        return tile;
-      }).toList();
+      .map<RadioListTile<int>>((Element element) => element.widget)
+      .toList();
+
+    Widget buildFrame() {
+      return wrap(
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: ListView.builder(
+                itemCount: values.length,
+                itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                  onChanged: (int value) {
+                    setState(() { selectedValue = value; });
+                  },
+                  value: values[index],
+                  groupValue: selectedValue,
+                  title: Text(values[index].toString()),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    generatedRadioListTiles = findTiles();
 
     expect(generatedRadioListTiles[0].checked, equals(false));
     expect(generatedRadioListTiles[1].checked, equals(false));
@@ -80,33 +83,8 @@ void main() {
 
     selectedValue = 1;
 
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
-                onChanged: (int value) {
-                  setState(() { selectedValue = value; });
-                },
-                value: values[index],
-                groupValue: selectedValue,
-                title: Text(values[index].toString()),
-              ),
-            ),
-          );
-        },
-      ),
-    ));
-
-    generatedRadioListTiles = find
-      .byType(radioListTileType)
-      .evaluate()
-      .map((Element element) {
-        final RadioListTile<int> tile = element.widget;
-        return tile;
-      }).toList();
+    await tester.pumpWidget(buildFrame());
+    generatedRadioListTiles = findTiles();
 
     expect(generatedRadioListTiles[0].checked, equals(false));
     expect(generatedRadioListTiles[1].checked, equals(true));
@@ -116,7 +94,7 @@ void main() {
   testWidgets('RadioListTile control tests', (WidgetTester tester) async {
     final List<int> values = <int>[0, 1, 2];
     int selectedValue;
-    // Input parameters are required for [Radio], but they are irrelevant
+    // Constructor parameters are required for [Radio], but they are irrelevant
     // when searching with [find.byType].
     final Type radioType = const Radio<int>(
       value: 0,
@@ -125,28 +103,31 @@ void main() {
     ).runtimeType;
     final List<dynamic> log = <dynamic>[];
 
-    // Tests for tapping between [Radio] and [ListTile]
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
-                onChanged: (int value) {
-                  log.add(value);
-                  setState(() { selectedValue = value; });
-                },
-                value: values[index],
-                groupValue: selectedValue,
-                title: Text(values[index].toString()),
+    Widget buildFrame() {
+      return wrap(
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: ListView.builder(
+                itemCount: values.length,
+                itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                  onChanged: (int value) {
+                    log.add(value);
+                    setState(() { selectedValue = value; });
+                  },
+                  value: values[index],
+                  groupValue: selectedValue,
+                  title: Text(values[index].toString()),
+                ),
               ),
-            ),
-          );
-        },
-      ),
-    ));
+            );
+          },
+        ),
+      );
+    }
 
+    // Tests for tapping between [Radio] and [ListTile]
+    await tester.pumpWidget(buildFrame());
     await tester.tap(find.text('1'));
     log.add('-');
     await tester.tap(find.byType(radioType).at(2));
@@ -158,27 +139,7 @@ void main() {
     selectedValue = null;
 
     // Tests for tapping across [Radio]s exclusively
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
-                onChanged: (int value) {
-                  log.add(value);
-                  setState(() { selectedValue = value; });
-                },
-                value: values[index],
-                groupValue: selectedValue,
-                title: Text(values[index].toString()),
-              ),
-            ),
-          );
-        },
-      ),
-    ));
-
+    await tester.pumpWidget(buildFrame());
     await tester.tap(find.byType(radioType).at(1));
     log.add('-');
     await tester.tap(find.byType(radioType).at(2));
@@ -188,27 +149,7 @@ void main() {
     selectedValue = null;
 
     // Tests for tapping across [ListTile]s exclusively
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
-                onChanged: (int value) {
-                  log.add(value);
-                  setState(() { selectedValue = value; });
-                },
-                value: values[index],
-                groupValue: selectedValue,
-                title: Text(values[index].toString()),
-              ),
-            ),
-          );
-        },
-      ),
-    ));
-
+    await tester.pumpWidget(buildFrame());
     await tester.tap(find.text('1'));
     log.add('-');
     await tester.tap(find.text('2'));
@@ -218,7 +159,7 @@ void main() {
   testWidgets('Selected RadioListTile should not trigger onChanged', (WidgetTester tester) async {
     final List<int> values = <int>[0, 1, 2];
     int selectedValue;
-    // Input parameters are required for [Radio], but they are irrelevant
+    // Constructor parameters are required for [Radio], but they are irrelevant
     // when searching with [find.byType].
     final Type radioType = const Radio<int>(
       value: 0,
@@ -227,14 +168,14 @@ void main() {
     ).runtimeType;
     final List<dynamic> log = <dynamic>[];
 
-    await tester.pumpWidget(wrap(
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return Scaffold(
-            body: ListView.builder(
-              itemCount: values.length,
-              itemBuilder: (BuildContext context, int index) {
-                return RadioListTile<int>(
+    Widget buildFrame() {
+      return wrap(
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: ListView.builder(
+                itemCount: values.length,
+                itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
                   onChanged: (int value) {
                     log.add(value);
                     setState(() { selectedValue = value; });
@@ -242,13 +183,15 @@ void main() {
                   value: values[index],
                   groupValue: selectedValue,
                   title: Text(values[index].toString()),
-                );
-              }
-            ),
-          );
-        },
-      ),
-    ));
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
 
     await tester.tap(find.text('0'));
     await tester.pump();

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -34,20 +34,232 @@ void main() {
     expect(log, equals(<dynamic>[false, '-', false]));
   });
 
-  testWidgets('RadioListTile control test', (WidgetTester tester) async {
-    final List<dynamic> log = <dynamic>[];
+  testWidgets('RadioListTile should initialize according to groupValue', (WidgetTester tester) async {
+    final List<int> values = <int>[0, 1, 2];
+    int selectedValue;
+    // Input parameters are required for [RadioListTile], but they are
+    // irrelevant when searching with [find.byType].
+    final Type radioListTileType = const RadioListTile<int>(
+      value: 0,
+      groupValue: 0,
+      onChanged: null,
+    ).runtimeType;
+    List<RadioListTile<int>> generatedRadioListTiles;
+
     await tester.pumpWidget(wrap(
-      child: RadioListTile<bool>(
-        value: true,
-        groupValue: false,
-        onChanged: (bool value) { log.add(value); },
-        title: const Text('Hello'),
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                onChanged: (int value) {
+                  setState(() { selectedValue = value; });
+                },
+                value: values[index],
+                groupValue: selectedValue,
+                title: Text(values[index].toString()),
+              ),
+            ),
+          );
+        },
       ),
     ));
-    await tester.tap(find.text('Hello'));
+
+    generatedRadioListTiles = find
+      .byType(radioListTileType)
+      .evaluate()
+      .map((Element element) {
+        final RadioListTile<int> tile = element.widget;
+        return tile;
+      }).toList();
+
+    expect(generatedRadioListTiles[0].checked, equals(false));
+    expect(generatedRadioListTiles[1].checked, equals(false));
+    expect(generatedRadioListTiles[2].checked, equals(false));
+
+    selectedValue = 1;
+
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                onChanged: (int value) {
+                  setState(() { selectedValue = value; });
+                },
+                value: values[index],
+                groupValue: selectedValue,
+                title: Text(values[index].toString()),
+              ),
+            ),
+          );
+        },
+      ),
+    ));
+
+    generatedRadioListTiles = find
+      .byType(radioListTileType)
+      .evaluate()
+      .map((Element element) {
+        final RadioListTile<int> tile = element.widget;
+        return tile;
+      }).toList();
+
+    expect(generatedRadioListTiles[0].checked, equals(false));
+    expect(generatedRadioListTiles[1].checked, equals(true));
+    expect(generatedRadioListTiles[2].checked, equals(false));
+  });
+
+  testWidgets('RadioListTile control tests', (WidgetTester tester) async {
+    final List<int> values = <int>[0, 1, 2];
+    int selectedValue;
+    // Input parameters are required for [Radio], but they are irrelevant
+    // when searching with [find.byType].
+    final Type radioType = const Radio<int>(
+      value: 0,
+      groupValue: 0,
+      onChanged: null,
+    ).runtimeType;
+    final List<dynamic> log = <dynamic>[];
+
+    // Tests for tapping between [Radio] and [ListTile]
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                onChanged: (int value) {
+                  log.add(value);
+                  setState(() { selectedValue = value; });
+                },
+                value: values[index],
+                groupValue: selectedValue,
+                title: Text(values[index].toString()),
+              ),
+            ),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.text('1'));
     log.add('-');
-    await tester.tap(find.byType(const Radio<bool>(value: false, groupValue: false, onChanged: null).runtimeType));
-    expect(log, equals(<dynamic>[true, '-', true]));
+    await tester.tap(find.byType(radioType).at(2));
+    expect(log, equals(<dynamic>[1, '-', 2]));
+    log.add('-');
+    await tester.tap(find.text('1'));
+
+    log.clear();
+    selectedValue = null;
+
+    // Tests for tapping across [Radio]s exclusively
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                onChanged: (int value) {
+                  log.add(value);
+                  setState(() { selectedValue = value; });
+                },
+                value: values[index],
+                groupValue: selectedValue,
+                title: Text(values[index].toString()),
+              ),
+            ),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.byType(radioType).at(1));
+    log.add('-');
+    await tester.tap(find.byType(radioType).at(2));
+    expect(log, equals(<dynamic>[1, '-', 2]));
+
+    log.clear();
+    selectedValue = null;
+
+    // Tests for tapping across [ListTile]s exclusively
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) => RadioListTile<int>(
+                onChanged: (int value) {
+                  log.add(value);
+                  setState(() { selectedValue = value; });
+                },
+                value: values[index],
+                groupValue: selectedValue,
+                title: Text(values[index].toString()),
+              ),
+            ),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.text('1'));
+    log.add('-');
+    await tester.tap(find.text('2'));
+    expect(log, equals(<dynamic>[1, '-', 2]));
+  });
+
+  testWidgets('Selected RadioListTile should not trigger onChanged', (WidgetTester tester) async {
+    final List<int> values = <int>[0, 1, 2];
+    int selectedValue;
+    // Input parameters are required for [Radio], but they are irrelevant
+    // when searching with [find.byType].
+    final Type radioType = const Radio<int>(
+      value: 0,
+      groupValue: 0,
+      onChanged: null,
+    ).runtimeType;
+    final List<dynamic> log = <dynamic>[];
+
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: ListView.builder(
+              itemCount: values.length,
+              itemBuilder: (BuildContext context, int index) {
+                return RadioListTile<int>(
+                  onChanged: (int value) {
+                    log.add(value);
+                    setState(() { selectedValue = value; });
+                  },
+                  value: values[index],
+                  groupValue: selectedValue,
+                  title: Text(values[index].toString()),
+                );
+              }
+            ),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.text('0'));
+    await tester.pump();
+    expect(log, equals(<int>[0]));
+
+    await tester.tap(find.text('0'));
+    expect(log, equals(<int>[0]));
+
+    await tester.tap(find.byType(radioType).at(0));
+    await tester.pump();
+    expect(log, equals(<int>[0]));
   });
 
   testWidgets('SwitchListTile control test', (WidgetTester tester) async {

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -158,7 +158,6 @@ void main() {
 
   testWidgets('Selected RadioListTile should not trigger onChanged', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/30311
-
     final List<int> values = <int>[0, 1, 2];
     int selectedValue;
     // Constructor parameters are required for [Radio], but they are irrelevant
@@ -194,7 +193,6 @@ void main() {
     }
 
     await tester.pumpWidget(buildFrame());
-
     await tester.tap(find.text('0'));
     await tester.pump();
     expect(log, equals(<int>[0]));

--- a/packages/flutter/test/material/control_list_tile_test.dart
+++ b/packages/flutter/test/material/control_list_tile_test.dart
@@ -157,6 +157,8 @@ void main() {
   });
 
   testWidgets('Selected RadioListTile should not trigger onChanged', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/30311
+
     final List<int> values = <int>[0, 1, 2];
     int selectedValue;
     // Constructor parameters are required for [Radio], but they are irrelevant


### PR DESCRIPTION
## Description

Currently, when a RadioListTile is selected, you cannot deselect the radio button by tapping on the Radio widget, but you can if you tap on the ListTile widget. This is inconsistent with the behavior of the Radio widget itself, as well as the intended behavior of radio buttons in general, since they should not be allowed to deselect. 

I also took the opportunity to add general tests for the RadioListTile widget since there was only one basic test for controls on one tile.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/30311

## Tests

I added the following tests:
- Tests for default initialized groupValue (when it's `null` and when it's initialized with an existing value)
- Tests for different selection patterns, ie, tapping solely the Radio widget, tapping solely the ListTile widget, and a mix of tapping between both widgets
- Test to ensure that tapping on a selected RadioListTile's ListTile widget does not trigger the `onChanged` callback.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). 

*[Breaking Change] Disable `onChanged` callback for checked RadioListTile*
Alters the behavior on tapping the tile of a RadioListTile, which may cause breakage for intended callback invocations when tapping on a selected RadioListTile.

- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
