### PR TITLE
Issues/31511

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -13,6 +13,7 @@ import '../bundle.dart';
 import '../cache.dart';
 import '../codegen.dart';
 import '../dart/pub.dart';
+import '../devfs.dart';
 import '../globals.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
@@ -239,7 +240,30 @@ class TestCommand extends FastFlutterCommand {
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
     }
-    await writeBundle(fs.directory(fs.path.join('build', 'unit_test_assets')), assetBundle.entries);
+    if (_needRebuild(assetBundle.entries)) {
+      await writeBundle(fs.directory(fs.path.join('build', 'unit_test_assets')),
+          assetBundle.entries);
+    }
+  }
+  bool _needRebuild(Map<String, DevFSContent> entries) {
+    final File manifest = fs.file(fs.path.join('build', 'unit_test_assets', 'AssetManifest.json'));
+    if (!manifest.existsSync()) {
+      return true;
+    }
+    final DateTime lastModified = manifest.lastModifiedSync();
+    final File pub = fs.file('pubspec.yaml');
+    if (pub.lastModifiedSync().isAfter(lastModified)) {
+      return true;
+    }
+
+    for (DevFSFileContent entry in entries.values.whereType<DevFSFileContent>()) {
+      // Calling isModified to access file stats first in order for isModifiedAfter
+      // to work.
+      if (entry.isModified && entry.isModifiedAfter(lastModified)) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Description

This pr changed the asset build behavior, it will first gather all the assets, check if any assets has new modify time. if there is, it will rebuild it. otherwise, skip.

## Related Issues
https://github.com/flutter/flutter/issues/31511

## Tests

TBD

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
