### PR TITLE
make sure we exit early if the Runner.xcodeproj file is missing

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -318,8 +318,13 @@ abstract class IOSApp extends ApplicationPackage {
     if (getCurrentHostPlatform() != HostPlatform.darwin_x64) {
       return null;
     }
-    // TODO(jonahwilliams): do more verification in this check.
     if (!project.exists) {
+      // If the project doesn't exist at all the existing hint to run flutter
+      // create is accurate.
+      return null;
+    }
+    if (!project.xcodeProject.existsSync()) {
+      printError('Expected ios/Runner.xcodeproj but this file is missing.');
       return null;
     }
     return BuildableIOSApp(project);

--- a/packages/flutter_tools/test/application_package_test.dart
+++ b/packages/flutter_tools/test/application_package_test.dart
@@ -285,6 +285,15 @@ void main() {
 
       expect(iosApp, null);
     }, overrides: overrides);
+
+    testUsingContext('returns null when there is no Runner.xcodeproj', () async {
+      fs.file('pubspec.yaml').createSync();
+      fs.file('.packages').createSync();
+      fs.file('ios/FooBar.xcodeproj').createSync(recursive: true);
+      final BuildableIOSApp iosApp = IOSApp.fromIosProject((await FlutterProject.fromDirectory(fs.currentDirectory)).ios);
+
+      expect(iosApp, null);
+    }, overrides: overrides);
   });
 }
 


### PR DESCRIPTION
## Description

If Runner.xcodeproj is missing, we can end up with a process exception instead of a clean exit.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31583
