### PR TITLE
Add check that xcode project configuration is not missing

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -319,12 +319,16 @@ abstract class IOSApp extends ApplicationPackage {
       return null;
     }
     if (!project.exists) {
-      // If the project doesn't exist at all the existing hint to run flutter
+      // If the project doesn't exist at all the current hint to run flutter
       // create is accurate.
       return null;
     }
     if (!project.xcodeProject.existsSync()) {
       printError('Expected ios/Runner.xcodeproj but this file is missing.');
+      return null;
+    }
+    if (!project.xcodeProjectInfoFile.existsSync()) {
+      printError('Expected ios/Runner.xcodeproj/project.pbxproj but this file is missing.');
       return null;
     }
     return BuildableIOSApp(project);

--- a/packages/flutter_tools/test/application_package_test.dart
+++ b/packages/flutter_tools/test/application_package_test.dart
@@ -294,6 +294,15 @@ void main() {
 
       expect(iosApp, null);
     }, overrides: overrides);
+
+    testUsingContext('returns null when there is no Runner.xcodeproj/project.pbxproj', () async {
+      fs.file('pubspec.yaml').createSync();
+      fs.file('.packages').createSync();
+      fs.file('ios/Runner.xcodeproj').createSync(recursive: true);
+      final BuildableIOSApp iosApp = IOSApp.fromIosProject((await FlutterProject.fromDirectory(fs.currentDirectory)).ios);
+
+      expect(iosApp, null);
+    }, overrides: overrides);
   });
 }
 


### PR DESCRIPTION
## Description

If this file is missing we'll get a process exception instead of a failure message from Xcode.

Fixes https://github.com/flutter/flutter/issues/28231
