### PR TITLE
Resolve ReorderableListView ScrollController conflict

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -256,7 +256,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
   @override
   void didChangeDependencies() {
-    _scrollController = PrimaryScrollController.of(context) ?? ScrollController();
+    _scrollController = ScrollController();
     super.didChangeDependencies();
   }
 


### PR DESCRIPTION
## Description
An error : `ScrollController attached to multiple scroll views` occurred when ReorderableListView exists with other scroll views