### PR TITLE
(WIP) Re-enable app-jit snapshots

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -127,7 +127,7 @@ function upgrade_flutter () {
 
     retry_upgrade
 
-    "$DART" $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
+    "$DART" $FLUTTER_TOOL_ARGS --snapshot-kind=app-jit --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
     echo "$revision" > "$STAMP_PATH"
   fi
   # The exit here is duplicitous since the function is run in a subshell,

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -153,9 +153,9 @@ GOTO :after_subroutine
     POPD
 
     IF "%FLUTTER_TOOL_ARGS%" == "" (
-      "%dart%" --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.packages" "%script_path%"
+      "%dart%" --snapshot="%snapshot_path%" --snapshot-kind=app-jit --packages="%flutter_tools_dir%\.packages" "%script_path%"
     ) else (
-      "%dart%" "%FLUTTER_TOOL_ARGS%" --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.packages" "%script_path%"
+      "%dart%" "%FLUTTER_TOOL_ARGS%" --snapshot="%snapshot_path%" --snapshot-kind=app-jit --packages="%flutter_tools_dir%\.packages" "%script_path%"
     )
     IF "%ERRORLEVEL%" NEQ "0" (
       ECHO Error: Unable to create dart snapshot for flutter tool.


### PR DESCRIPTION
## Description

These were disabled due to crashes while upgrading. Testing the upgrade process to see if it can be fixed, since this shaves off a reasonable amount of test time.