### PR TITLE
Add more asserts to check matrix validity

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1166,7 +1166,8 @@ class TransformLayer extends OffsetLayer {
   /// The [transform] and [offset] properties must be non-null before the
   /// compositing phase of the pipeline.
   TransformLayer({ Matrix4 transform, Offset offset = Offset.zero })
-    : _transform = transform,
+    : assert(transform.storage.every((double value) => value.isFinite)),
+      _transform = transform,
       super(offset: offset);
 
   /// The matrix to apply.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2258,7 +2258,7 @@ class RenderFittedBox extends RenderProxyBox {
     _transform = null;
   }
 
-  double _div_handle_zero(double a, double b) {
+  double _divHandleZero(double a, double b) {
     return a == 0 ? 0 : a / b;
   }
 
@@ -2273,8 +2273,8 @@ class RenderFittedBox extends RenderProxyBox {
       _resolve();
       final Size childSize = child.size;
       final FittedSizes sizes = applyBoxFit(_fit, childSize, size);
-      final double scaleX = _div_handle_zero(sizes.destination.width, sizes.source.width);
-      final double scaleY = _div_handle_zero(sizes.destination.height, sizes.source.height);
+      final double scaleX = _divHandleZero(sizes.destination.width, sizes.source.width);
+      final double scaleY = _divHandleZero(sizes.destination.height, sizes.source.height);
       final Rect sourceRect = _resolvedAlignment.inscribe(sizes.source, Offset.zero & childSize);
       final Rect destinationRect = _resolvedAlignment.inscribe(sizes.destination, Offset.zero & size);
       _hasVisualOverflow = sourceRect.width < childSize.width || sourceRect.height < childSize.height;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2258,10 +2258,6 @@ class RenderFittedBox extends RenderProxyBox {
     _transform = null;
   }
 
-  double _divHandleZero(double a, double b) {
-    return a == 0 ? 0 : a / b;
-  }
-
   void _updatePaintData() {
     if (_transform != null)
       return;
@@ -2273,8 +2269,8 @@ class RenderFittedBox extends RenderProxyBox {
       _resolve();
       final Size childSize = child.size;
       final FittedSizes sizes = applyBoxFit(_fit, childSize, size);
-      final double scaleX = _divHandleZero(sizes.destination.width, sizes.source.width);
-      final double scaleY = _divHandleZero(sizes.destination.height, sizes.source.height);
+      final double scaleX = sizes.destination.width / sizes.source.width;
+      final double scaleY = sizes.destination.height / sizes.source.height;
       final Rect sourceRect = _resolvedAlignment.inscribe(sizes.source, Offset.zero & childSize);
       final Rect destinationRect = _resolvedAlignment.inscribe(sizes.destination, Offset.zero & size);
       _hasVisualOverflow = sourceRect.width < childSize.width || sourceRect.height < childSize.height;
@@ -2296,7 +2292,7 @@ class RenderFittedBox extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (size.isEmpty)
+    if (size.isEmpty || child.size.isEmpty)
       return;
     _updatePaintData();
     if (child != null) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2274,9 +2274,11 @@ class RenderFittedBox extends RenderProxyBox {
       final Rect sourceRect = _resolvedAlignment.inscribe(sizes.source, Offset.zero & childSize);
       final Rect destinationRect = _resolvedAlignment.inscribe(sizes.destination, Offset.zero & size);
       _hasVisualOverflow = sourceRect.width < childSize.width || sourceRect.height < childSize.height;
+      assert(scaleX.isFinite && scaleY.isFinite);
       _transform = Matrix4.translationValues(destinationRect.left, destinationRect.top, 0.0)
         ..scale(scaleX, scaleY, 1.0)
         ..translate(-sourceRect.left, -sourceRect.top);
+      assert(_transform.storage.every((double value) => value.isFinite));
     }
   }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2258,6 +2258,10 @@ class RenderFittedBox extends RenderProxyBox {
     _transform = null;
   }
 
+  double _div_handle_zero(double a, double b) {
+    return a == 0 ? 0 : a / b;
+  }
+
   void _updatePaintData() {
     if (_transform != null)
       return;
@@ -2269,8 +2273,8 @@ class RenderFittedBox extends RenderProxyBox {
       _resolve();
       final Size childSize = child.size;
       final FittedSizes sizes = applyBoxFit(_fit, childSize, size);
-      final double scaleX = sizes.destination.width / sizes.source.width;
-      final double scaleY = sizes.destination.height / sizes.source.height;
+      final double scaleX = _div_handle_zero(sizes.destination.width, sizes.source.width);
+      final double scaleY = _div_handle_zero(sizes.destination.height, sizes.source.height);
       final Rect sourceRect = _resolvedAlignment.inscribe(sizes.source, Offset.zero & childSize);
       final Rect destinationRect = _resolvedAlignment.inscribe(sizes.destination, Offset.zero & size);
       _hasVisualOverflow = sourceRect.width < childSize.width || sourceRect.height < childSize.height;

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -15,11 +15,12 @@ import '../flutter_test_alternative.dart';
 import 'rendering_tester.dart';
 
 void main() {
-  test('RenderFittedBox paint', () {
+  test('RenderFittedBox does not paint with empty sizes', () {
     bool painted;
-    RenderFittedBox makeFittedBox() {
+    RenderFittedBox makeFittedBox(Size size) {
       return RenderFittedBox(
         child: RenderCustomPaint(
+          preferredSize: size,
           painter: TestCallbackPainter(onPaint: () {
             painted = true;
           }),
@@ -27,13 +28,19 @@ void main() {
       );
     }
 
+    // The RenderFittedBox paints if both its size and its child's size are nonempty.
     painted = false;
-    layout(makeFittedBox(), phase: EnginePhase.paint);
+    layout(makeFittedBox(Size(1, 1)), phase: EnginePhase.paint);
     expect(painted, equals(true));
+
+    // The RenderFittedBox should not paint if its child is empty-sized.
+    painted = false;
+    layout(makeFittedBox(Size.zero), phase: EnginePhase.paint);
+    expect(painted, equals(false));
 
     // The RenderFittedBox should not paint if it is empty.
     painted = false;
-    layout(makeFittedBox(), constraints: BoxConstraints.tight(Size.zero), phase: EnginePhase.paint);
+    layout(makeFittedBox(Size(1, 1)), constraints: BoxConstraints.tight(Size.zero), phase: EnginePhase.paint);
     expect(painted, equals(false));
   });
 


### PR DESCRIPTION
## Description

These will help identify where the matrix starts to get wrong. 

Also fixed `RenderFittexBox` to no longer paint with empty child which previously triggered invalid matrix computations (NaN with dividing by 0). See also https://github.com/flutter/flutter/pull/7489

## Related Issues

https://github.com/flutter/flutter/issues/31650
https://github.com/flutter/flutter/issues/31700
https://github.com/flutter/flutter/issues/7431

## Tests

* RenderFittedBox does not paint with empty sizes

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
