### PR TITLE
Make FlutterProject factories synchronous

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -117,7 +117,7 @@ Future<void> run(List<String> args) async {
     CoverageCollector collector;
     if (argResults['coverage']) {
       collector = CoverageCollector(
-        flutterProject: await FlutterProject.current(),
+        flutterProject: FlutterProject.current(),
         coverageDirectory: coverageDirectory,
       );
       if (!argResults.options.contains(_kOptionTestDirectory)) {

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -373,7 +373,7 @@ class AndroidDevice extends Device {
 
     if (!prebuiltApplication || androidSdk.licensesAvailable && androidSdk.latestVersion == null) {
       printTrace('Building APK');
-      final FlutterProject project = await FlutterProject.current();
+      final FlutterProject project = FlutterProject.current();
       await buildApk(
           project: project,
           target: mainPath,

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -112,7 +112,7 @@ Future<GradleProject> _gradleProject() async {
 /// potentially downloaded.
 Future<void> checkGradleDependencies() async {
   final Status progress = logger.startProgress('Ensuring gradle dependencies are up to date...', timeout: timeoutConfiguration.slowOperation);
-  final FlutterProject flutterProject = await FlutterProject.current();
+  final FlutterProject flutterProject = FlutterProject.current();
   final String gradle = await _ensureGradle(flutterProject);
   await runCheckedAsync(
     <String>[gradle, 'dependencies'],
@@ -126,7 +126,7 @@ Future<void> checkGradleDependencies() async {
 // Note: Dependencies are resolved and possibly downloaded as a side-effect
 // of calculating the app properties using Gradle. This may take minutes.
 Future<GradleProject> _readGradleProject() async {
-  final FlutterProject flutterProject = await FlutterProject.current();
+  final FlutterProject flutterProject = FlutterProject.current();
   final String gradle = await _ensureGradle(flutterProject);
   updateLocalProperties(project: flutterProject);
   final Status status = logger.startProgress('Resolving dependencies...', timeout: timeoutConfiguration.slowOperation);

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -43,27 +43,27 @@ class ApplicationPackageFactory {
           await checkGradleDependencies();
         }
         return applicationBinary == null
-            ? await AndroidApk.fromAndroidProject((await FlutterProject.current()).android)
+            ? await AndroidApk.fromAndroidProject(FlutterProject.current().android)
             : AndroidApk.fromApk(applicationBinary);
       case TargetPlatform.ios:
         return applicationBinary == null
-            ? IOSApp.fromIosProject((await FlutterProject.current()).ios)
+            ? IOSApp.fromIosProject(FlutterProject.current().ios)
             : IOSApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.tester:
         return FlutterTesterApp.fromCurrentDirectory();
       case TargetPlatform.darwin_x64:
         return applicationBinary == null
-            ? MacOSApp.fromMacOSProject((await FlutterProject.current()).macos)
+            ? MacOSApp.fromMacOSProject(FlutterProject.current().macos)
             : MacOSApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.web:
-        return WebApplicationPackage(await FlutterProject.current());
+        return WebApplicationPackage(FlutterProject.current());
       case TargetPlatform.linux_x64:
         return applicationBinary == null
-            ? LinuxApp.fromLinuxProject((await FlutterProject.current()).linux)
+            ? LinuxApp.fromLinuxProject(FlutterProject.current().linux)
             : LinuxApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.windows_x64:
         return applicationBinary == null
-            ? WindowsApp.fromWindowsProject((await FlutterProject.current()).windows)
+            ? WindowsApp.fromWindowsProject(FlutterProject.current().windows)
             : WindowsApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.fuchsia:
         return null;
@@ -395,10 +395,10 @@ class ApplicationPackageStore {
       case TargetPlatform.android_arm64:
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
-        android ??= await AndroidApk.fromAndroidProject((await FlutterProject.current()).android);
+        android ??= await AndroidApk.fromAndroidProject(FlutterProject.current().android);
         return android;
       case TargetPlatform.ios:
-        iOS ??= IOSApp.fromIosProject((await FlutterProject.current()).ios);
+        iOS ??= IOSApp.fromIosProject(FlutterProject.current().ios);
         return iOS;
       case TargetPlatform.darwin_x64:
       case TargetPlatform.linux_x64:

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -112,7 +112,7 @@ class _ManifestAssetBundle implements AssetBundle {
     packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
     FlutterManifest flutterManifest;
     try {
-      flutterManifest = await FlutterManifest.createFromPath(manifestPath);
+      flutterManifest = FlutterManifest.createFromPath(manifestPath);
     } catch (e) {
       printStatus('Error detected in pubspec.yaml:', emphasis: true);
       printError('$e');
@@ -162,7 +162,7 @@ class _ManifestAssetBundle implements AssetBundle {
       final Uri package = packageMap.map[packageName];
       if (package != null && package.scheme == 'file') {
         final String packageManifestPath = fs.path.fromUri(package.resolve('../pubspec.yaml'));
-        final FlutterManifest packageFlutterManifest = await FlutterManifest.createFromPath(packageManifestPath);
+        final FlutterManifest packageFlutterManifest = FlutterManifest.createFromPath(packageManifestPath);
         if (packageFlutterManifest == null)
           continue;
         // Skip the app itself

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -88,7 +88,7 @@ class AOTSnapshotter {
   }) async {
     FlutterProject flutterProject;
     if (fs.file('pubspec.yaml').existsSync()) {
-      flutterProject = await FlutterProject.current();
+      flutterProject = FlutterProject.current();
     }
     if (!_isValidAotPlatform(platform, buildMode)) {
       printError('${getNameForTargetPlatform(platform)} does not support AOT compilation.');
@@ -304,7 +304,7 @@ class AOTSnapshotter {
     @required bool trackWidgetCreation,
     List<String> extraFrontEndOptions = const <String>[],
   }) async {
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     final Directory outputDir = fs.directory(outputPath);
     outputDir.createSync(recursive: true);
 

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -70,7 +70,7 @@ Future<void> build({
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= fs.path.absolute(PackageMap.globalPackagesPath);
   applicationKernelFilePath ??= getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation);
-  final FlutterProject flutterProject = await FlutterProject.current();
+  final FlutterProject flutterProject = FlutterProject.current();
 
   if (compilationTraceFilePath != null) {
     if (buildMode != BuildMode.dynamicProfile && buildMode != BuildMode.dynamicRelease) {

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -115,7 +115,7 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
         'sdkRoot, packagesPath are not supported when using the experimental '
         'build* pipeline');
     }
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     codeGenerator.updatePackages(flutterProject);
     final CodegenDaemon codegenDaemon = await codeGenerator.daemon(flutterProject);
     codegenDaemon.startBuild();

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -160,7 +160,7 @@ class AttachCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     Cache.releaseLockEarly();
 

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -48,7 +48,7 @@ class BuildApkCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     await buildApk(
-      project: await FlutterProject.current(),
+      project: FlutterProject.current(),
       target: targetFile,
       buildInfo: getBuildInfo(),
     );

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -41,7 +41,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     await buildAppBundle(
-      project: await FlutterProject.current(),
+      project: FlutterProject.current(),
       target: targetFile,
       buildInfo: getBuildInfo(),
     );

--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
+++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
@@ -52,7 +52,7 @@ class BuildLinuxCommand extends BuildSubCommand {
   Future<FlutterCommandResult> runCommand() async {
     Cache.releaseLockEarly();
     final BuildInfo buildInfo = getBuildInfo();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     if (!platform.isLinux) {
       throwToolExit('"build linux" only supported on Linux hosts.');
     }

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -52,7 +52,7 @@ class BuildMacosCommand extends BuildSubCommand {
   Future<FlutterCommandResult> runCommand() async {
     Cache.releaseLockEarly();
     final BuildInfo buildInfo = getBuildInfo();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     if (!platform.isMacOS) {
       throwToolExit('"build macos" only supported on macOS hosts.');
     }

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -51,7 +51,7 @@ class BuildWindowsCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     Cache.releaseLockEarly();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     final BuildInfo buildInfo = getBuildInfo();
     if (!platform.isWindows) {
       throwToolExit('"build windows" only supported on Windows hosts.');

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -27,7 +27,7 @@ class CleanCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     final Directory buildDir = fs.directory(getBuildDirectory());
 
     printStatus("Deleting '${buildDir.path}${fs.path.separator}'.");

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -304,7 +304,7 @@ class CreateCommand extends FlutterCommand {
 
     String organization = argResults['org'];
     if (!argResults.wasParsed('org')) {
-      final FlutterProject project = await FlutterProject.fromDirectory(projectDir);
+      final FlutterProject project = FlutterProject.fromDirectory(projectDir);
       final Set<String> existingOrganizations = project.organizationNames;
       if (existingOrganizations.length == 1) {
         organization = existingOrganizations.first;
@@ -385,7 +385,7 @@ class CreateCommand extends FlutterCommand {
       printStatus('Your module code is in $relativeMainPath.');
     } else {
       // Run doctor; tell the user the next steps.
-      final FlutterProject project = await FlutterProject.fromPath(projectDirPath);
+      final FlutterProject project = FlutterProject.fromPath(projectDirPath);
       final FlutterProject app = project.hasExampleApp ? project.example : project;
       final String relativeAppPath = fs.path.normalize(fs.path.relative(app.directory.path));
       final String relativeAppMain = fs.path.join(relativeAppPath, 'lib', 'main.dart');
@@ -443,7 +443,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         directory: directory.path,
         offline: argResults['offline'],
       );
-      final FlutterProject project = await FlutterProject.fromDirectory(directory);
+      final FlutterProject project = FlutterProject.fromDirectory(directory);
       await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
     }
     return generatedCount;
@@ -480,7 +480,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         offline: argResults['offline'],
       );
     }
-    final FlutterProject project = await FlutterProject.fromDirectory(directory);
+    final FlutterProject project = FlutterProject.fromDirectory(directory);
     gradle.updateLocalProperties(project: project, requireAndroidSdk: false);
 
     final String projectName = templateContext['projectName'];
@@ -501,7 +501,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
   Future<int> _generateApp(Directory directory, Map<String, dynamic> templateContext, { bool overwrite = false }) async {
     int generatedCount = 0;
     generatedCount += _renderTemplate('app', directory, templateContext, overwrite: overwrite);
-    final FlutterProject project = await FlutterProject.fromDirectory(directory);
+    final FlutterProject project = FlutterProject.fromDirectory(directory);
     generatedCount += _injectGradleWrapper(project);
 
     if (argResults['with-driver-test']) {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -345,7 +345,7 @@ class AppDomain extends Domain {
     // We change the current working directory for the duration of the `start` command.
     final Directory cwd = fs.currentDirectory;
     fs.currentDirectory = fs.directory(projectDirectory);
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     final FlutterDevice flutterDevice = await FlutterDevice.create(
       device,

--- a/packages/flutter_tools/lib/src/commands/generate.dart
+++ b/packages/flutter_tools/lib/src/commands/generate.dart
@@ -29,7 +29,7 @@ class GenerateCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     Cache.releaseLockEarly();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     final CodegenDaemon codegenDaemon = await codeGenerator.daemon(flutterProject);
     codegenDaemon.startBuild();
     await for (CodegenStatus codegenStatus in codegenDaemon.buildResults) {

--- a/packages/flutter_tools/lib/src/commands/inject_plugins.dart
+++ b/packages/flutter_tools/lib/src/commands/inject_plugins.dart
@@ -28,7 +28,7 @@ class InjectPluginsCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final FlutterProject project = await FlutterProject.current();
+    final FlutterProject project = FlutterProject.current();
     refreshPluginsList(project, checkProjects: true);
     await injectPlugins(project, checkProjects: true);
     final bool result = hasPlugins(project);

--- a/packages/flutter_tools/lib/src/commands/make_host_app_editable.dart
+++ b/packages/flutter_tools/lib/src/commands/make_host_app_editable.dart
@@ -36,7 +36,7 @@ class MakeHostAppEditableCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() async {
     await super.validateCommand();
-    _project = await FlutterProject.current();
+    _project = FlutterProject.current();
     if (!_project.isModule)
       throw ToolExit("Only projects created using 'flutter create -t module' can have their host apps made editable.");
   }

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -93,7 +93,7 @@ class PackagesGetCommand extends FlutterCommand {
     }
 
     await _runPubGet(target);
-    final FlutterProject rootProject = await FlutterProject.fromPath(target);
+    final FlutterProject rootProject = FlutterProject.fromPath(target);
     await rootProject.ensureReadyForPlatformSpecificTooling(checkProjects: true);
 
     // Get/upgrade packages in example app as well

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -365,7 +365,7 @@ class RunCommand extends RunCommandBase {
       expFlags = argResults[FlutterOptions.kEnableExperiment];
     }
     final List<FlutterDevice> flutterDevices = <FlutterDevice>[];
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
     for (Device device in devices) {
       final FlutterDevice flutterDevice = await FlutterDevice.create(
         device,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -132,7 +132,7 @@ class TestCommand extends FastFlutterCommand {
     }
     final List<String> names = argResults['name'];
     final List<String> plainNames = argResults['plain-name'];
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     Iterable<String> files = argResults.rest.map<String>((String testPath) => fs.path.absolute(testPath)).toList();
 
@@ -170,7 +170,7 @@ class TestCommand extends FastFlutterCommand {
     CoverageCollector collector;
     if (argResults['coverage'] || argResults['merge-coverage']) {
       collector = CoverageCollector(
-        flutterProject: await FlutterProject.current(),
+        flutterProject: FlutterProject.current(),
       );
     }
 

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -230,7 +230,7 @@ class KernelCompiler {
     );
     FlutterProject flutterProject;
     if (fs.file('pubspec.yaml').existsSync()) {
-      flutterProject = await FlutterProject.current();
+      flutterProject = FlutterProject.current();
     }
 
     // TODO(cbracken): eliminate pathFilter.

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
@@ -27,22 +25,22 @@ class FlutterManifest {
   }
 
   /// Returns null on invalid manifest. Returns empty manifest on missing file.
-  static Future<FlutterManifest> createFromPath(String path) async {
+  static FlutterManifest createFromPath(String path) {
     if (path == null || !fs.isFileSync(path))
       return _createFromYaml(null);
-    final String manifest = await fs.file(path).readAsString();
+    final String manifest = fs.file(path).readAsStringSync();
     return createFromString(manifest);
   }
 
   /// Returns null on missing or invalid manifest
   @visibleForTesting
-  static Future<FlutterManifest> createFromString(String manifest) async {
+  static FlutterManifest createFromString(String manifest) {
     return _createFromYaml(loadYaml(manifest));
   }
 
-  static Future<FlutterManifest> _createFromYaml(dynamic yamlDocument) async {
+  static FlutterManifest _createFromYaml(dynamic yamlDocument) {
     final FlutterManifest pubspec = FlutterManifest._();
-    if (yamlDocument != null && !await _validate(yamlDocument))
+    if (yamlDocument != null && !_validate(yamlDocument))
       return null;
 
     final Map<dynamic, dynamic> yamlMap = yamlDocument;
@@ -289,7 +287,7 @@ String buildSchemaPath(FileSystem fs) {
 /// This method should be kept in sync with the schema in
 /// `$FLUTTER_ROOT/packages/flutter_tools/schema/pubspec_yaml.json`,
 /// but avoid introducing depdendencies on packages for simple validation.
-Future<bool> _validate(YamlMap manifest) async {
+bool _validate(YamlMap manifest) {
   final List<String> errors = <String>[];
   for (final MapEntry<dynamic, dynamic> kvp in manifest.entries) {
     if (kvp.key is! String) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -365,7 +365,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // copied over to a location that is suitable for Xcodebuild to find them.
   await _addServicesToBundle(app.project.hostAppRoot);
 
-  final FlutterProject project = await FlutterProject.current();
+  final FlutterProject project = FlutterProject.current();
   await updateGeneratedXcodeProperties(
     project: project,
     targetOverride: targetOverride,

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -73,7 +73,7 @@ class LinuxDevice extends Device {
   }) async {
     _lastBuiltMode = debuggingOptions.buildInfo.mode;
     if (!prebuiltApplication) {
-      await buildLinux((await FlutterProject.current()).linux, debuggingOptions.buildInfo);
+      await buildLinux(FlutterProject.current().linux, debuggingOptions.buildInfo);
     }
     await stopApp(package);
     final Process process = await processManager.start(<String>[

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -75,7 +75,7 @@ class MacOSDevice extends Device {
     // Stop any running applications with the same executable.
     if (!prebuiltApplication) {
       Cache.releaseLockEarly();
-      await buildMacOS(await FlutterProject.current(), debuggingOptions?.buildInfo);
+      await buildMacOS(FlutterProject.current(), debuggingOptions?.buildInfo);
     }
     // Make sure to call stop app after we've built.
     await stopApp(package);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -39,12 +39,12 @@ class FlutterProject {
 
   /// Returns a future that completes with a [FlutterProject] view of the given directory
   /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
-  static Future<FlutterProject> fromDirectory(Directory directory) async {
+  static FlutterProject fromDirectory(Directory directory) {
     assert(directory != null);
-    final FlutterManifest manifest = await _readManifest(
+    final FlutterManifest manifest = _readManifest(
       directory.childFile(bundle.defaultManifestPath).path,
     );
-    final FlutterManifest exampleManifest = await _readManifest(
+    final FlutterManifest exampleManifest = _readManifest(
       _exampleDirectory(directory).childFile(bundle.defaultManifestPath).path,
     );
     return FlutterProject(directory, manifest, exampleManifest);
@@ -52,11 +52,11 @@ class FlutterProject {
 
   /// Returns a future that completes with a [FlutterProject] view of the current directory.
   /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
-  static Future<FlutterProject> current() => fromDirectory(fs.currentDirectory);
+  static FlutterProject current() => fromDirectory(fs.currentDirectory);
 
   /// Returns a future that completes with a [FlutterProject] view of the given directory.
   /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
-  static Future<FlutterProject> fromPath(String path) => fromDirectory(fs.directory(path));
+  static FlutterProject fromPath(String path) => fromDirectory(fs.directory(path));
 
   /// The location of this project.
   final Directory directory;
@@ -149,8 +149,8 @@ class FlutterProject {
   ///
   /// Completes with an empty [FlutterManifest], if the file does not exist.
   /// Completes with a ToolExit on validation error.
-  static Future<FlutterManifest> _readManifest(String path) async {
-    final FlutterManifest manifest = await FlutterManifest.createFromPath(path);
+  static FlutterManifest _readManifest(String path) {
+    final FlutterManifest manifest = FlutterManifest.createFromPath(path);
     if (manifest == null)
       throwToolExit('Please correct the pubspec.yaml file at $path');
     return manifest;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1047,7 +1047,7 @@ Future<String> getMissingPackageHintForPlatform(TargetPlatform platform) async {
     case TargetPlatform.android_arm64:
     case TargetPlatform.android_x64:
     case TargetPlatform.android_x86:
-      final FlutterProject project = await FlutterProject.current();
+      final FlutterProject project = FlutterProject.current();
       final String manifestPath = fs.path.relative(project.android.appManifestFile.path);
       return 'Is your project missing an $manifestPath?\nConsider running "flutter create ." to create one.';
     case TargetPlatform.ios:

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -474,7 +474,7 @@ abstract class FlutterCommand extends Command<void> {
 
     if (shouldRunPub) {
       await pubGet(context: PubContext.getVerifyContext(name));
-      final FlutterProject project = await FlutterProject.current();
+      final FlutterProject project = FlutterProject.current();
       await project.ensureReadyForPlatformSpecificTooling(checkProjects: true);
     }
 
@@ -531,7 +531,7 @@ abstract class FlutterCommand extends Command<void> {
     // then filter then list by those supported in the current project. If
     // this ends up with a single device we can proceed as normal.
     if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices && !deviceManager.hasSpecifiedDeviceId) {
-      final FlutterProject flutterProject = await FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.current();
       devices.removeWhere((Device device) => !device.isSupportedForProject(flutterProject));
     }
 

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -74,7 +74,7 @@ class WindowsDevice extends Device {
     bool ipv6 = false,
   }) async {
     if (!prebuiltApplication) {
-      await buildWindows((await FlutterProject.current()).windows, debuggingOptions.buildInfo);
+      await buildWindows(FlutterProject.current().windows, debuggingOptions.buildInfo);
     }
     await stopApp(package);
     final Process process = await processManager.start(<String>[

--- a/packages/flutter_tools/test/android/android_device_test.dart
+++ b/packages/flutter_tools/test/android/android_device_test.dart
@@ -170,7 +170,7 @@ flutter:
   module: {}
 ''');
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -181,7 +181,7 @@ flutter:
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
     fs.directory('android').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -191,7 +191,7 @@ flutter:
   testUsingContext('isSupportedForProject is false with no host app and no module', () async {
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/android/gradle_test.dart
+++ b/packages/flutter_tools/test/android/gradle_test.dart
@@ -33,7 +33,7 @@ void main() {
         // This test is written to fail if our bots get Android SDKs in the future: shouldBeToolExit
         // will be null and our expectation would fail. That would remind us to make these tests
         // hermetic before adding Android SDKs to the bots.
-        updateLocalProperties(project: await FlutterProject.current());
+        updateLocalProperties(project: FlutterProject.current());
       } on Exception catch (e) {
         shouldBeToolExit = e;
       }
@@ -264,7 +264,7 @@ someOtherTask
       writeEmptySchemaFile(fs);
 
       updateLocalProperties(
-        project: await FlutterProject.fromPath('path/to/project'),
+        project: FlutterProject.fromPath('path/to/project'),
         buildInfo: buildInfo,
         requireAndroidSdk: false,
       );

--- a/packages/flutter_tools/test/application_package_test.dart
+++ b/packages/flutter_tools/test/application_package_test.dart
@@ -59,7 +59,7 @@ void main() {
         environment: anyNamed('environment'),
       )).thenAnswer((_) async => ProcessResult(1, 0, 'stdout', 'stderr'));
       when(mockProcessManager.runSync(any)).thenReturn(ProcessResult(1, 0, 'stdout', 'stderr'));
-      final FlutterProject project = await FlutterProject.current();
+      final FlutterProject project = FlutterProject.current();
       gradle = fs.file(project.android.hostAppGradleRoot.childFile(
         platform.isWindows ? 'gradlew.bat' : 'gradlew',
       ).path)..createSync(recursive: true);
@@ -95,7 +95,7 @@ void main() {
 
     testUsingContext('Licenses available, build tools not, apk exists', () async {
       when(sdk.latestVersion).thenReturn(null);
-      final FlutterProject project = await FlutterProject.current();
+      final FlutterProject project = FlutterProject.current();
       final File gradle = project.android.hostAppGradleRoot.childFile(
         platform.isWindows ? 'gradlew.bat' : 'gradlew',
       )..createSync(recursive: true);
@@ -281,7 +281,7 @@ void main() {
     testUsingContext('returns null when there is no ios or .ios directory', () async {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
-      final BuildableIOSApp iosApp = IOSApp.fromIosProject((await FlutterProject.fromDirectory(fs.currentDirectory)).ios);
+      final BuildableIOSApp iosApp = IOSApp.fromIosProject(FlutterProject.fromDirectory(fs.currentDirectory).ios);
 
       expect(iosApp, null);
     }, overrides: overrides);
@@ -290,7 +290,7 @@ void main() {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
       fs.file('ios/FooBar.xcodeproj').createSync(recursive: true);
-      final BuildableIOSApp iosApp = IOSApp.fromIosProject((await FlutterProject.fromDirectory(fs.currentDirectory)).ios);
+      final BuildableIOSApp iosApp = IOSApp.fromIosProject(FlutterProject.fromDirectory(fs.currentDirectory).ios);
 
       expect(iosApp, null);
     }, overrides: overrides);
@@ -299,7 +299,7 @@ void main() {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
       fs.file('ios/Runner.xcodeproj').createSync(recursive: true);
-      final BuildableIOSApp iosApp = IOSApp.fromIosProject((await FlutterProject.fromDirectory(fs.currentDirectory)).ios);
+      final BuildableIOSApp iosApp = IOSApp.fromIosProject(FlutterProject.fromDirectory(fs.currentDirectory).ios);
 
       expect(iosApp, null);
     }, overrides: overrides);

--- a/packages/flutter_tools/test/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands/build_linux_test.dart
@@ -100,7 +100,7 @@ BINARY_NAME=fizz_bar
 ''');
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(makefileExecutableName(flutterProject.linux), 'fizz_bar');
   }, overrides: <Type, Generator>{FileSystem: () => MemoryFileSystem()});

--- a/packages/flutter_tools/test/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands/build_macos_test.dart
@@ -68,7 +68,7 @@ void main() {
     fs.directory('macos').createSync();
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.fromDirectory(fs.currentDirectory);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
     final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
 
     when(mockProcessManager.start(<String>[

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -532,7 +532,7 @@ void main() {
 
     String tmpProjectDir = fs.path.join(tempDir.path, 'hello_flutter');
     await runner.run(<String>['create', '--template=app', '--no-pub', '--org', 'com.example', tmpProjectDir]);
-    FlutterProject project = await FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
+    FlutterProject project = FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
     expect(
         project.ios.productBundleIdentifier,
         'com.example.helloFlutter',
@@ -544,7 +544,7 @@ void main() {
 
     tmpProjectDir = fs.path.join(tempDir.path, 'test_abc');
     await runner.run(<String>['create', '--template=app', '--no-pub', '--org', 'abc^*.1#@', tmpProjectDir]);
-    project = await FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
+    project = FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
     expect(
         project.ios.productBundleIdentifier,
         'abc.1.testAbc',
@@ -556,7 +556,7 @@ void main() {
 
     tmpProjectDir = fs.path.join(tempDir.path, 'flutter_project');
     await runner.run(<String>['create', '--template=app', '--no-pub', '--org', '#+^%', tmpProjectDir]);
-    project = await FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
+    project = FlutterProject.fromDirectory(fs.directory(tmpProjectDir));
     expect(
         project.ios.productBundleIdentifier,
         'flutterProject.untitled',
@@ -681,7 +681,7 @@ void main() {
     );
     projectDir.childDirectory('.ios').deleteSync(recursive: true);
     await _createProject(projectDir, <String>[], <String>[]);
-    final FlutterProject project = await FlutterProject.fromDirectory(projectDir);
+    final FlutterProject project = FlutterProject.fromDirectory(projectDir);
     expect(
       project.ios.productBundleIdentifier,
       'com.bar.foo.flutterProject',
@@ -715,7 +715,7 @@ void main() {
     );
     projectDir.childDirectory('ios').deleteSync(recursive: true);
     await _createProject(projectDir, <String>['--no-pub'], <String>[]);
-    final FlutterProject project = await FlutterProject.fromDirectory(projectDir);
+    final FlutterProject project = FlutterProject.fromDirectory(projectDir);
     expect(
       project.ios.productBundleIdentifier,
       'com.bar.foo.flutterProject',
@@ -742,7 +742,7 @@ void main() {
         'android/src/main/java/com/example/flutter_project/FlutterProjectPlugin.java',
       ],
     );
-    final FlutterProject project = await FlutterProject.fromDirectory(projectDir);
+    final FlutterProject project = FlutterProject.fromDirectory(projectDir);
     expect(
       project.example.ios.productBundleIdentifier,
       'com.bar.foo.flutterProjectExample',

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   group('FlutterManifest', () {
     testUsingContext('is empty when the pubspec.yaml file is empty', () async {
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString('');
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString('');
       expect(flutterManifest.isEmpty, true);
       expect(flutterManifest.appName, '');
       expect(flutterManifest.usesMaterialDesign, false);
@@ -37,7 +37,7 @@ dependencies:
   flutter:
     sdk: flutter
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest, isNotNull);
       expect(flutterManifest.isEmpty, false);
       expect(flutterManifest.appName, 'test');
@@ -56,7 +56,7 @@ dependencies:
 flutter:
   uses-material-design: true
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.usesMaterialDesign, true);
     });
 
@@ -72,7 +72,7 @@ flutter:
     - a/foo
     - a/bar
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.assets.length, 2);
       expect(flutterManifest.assets[0], Uri.parse('a/foo'));
       expect(flutterManifest.assets[1], Uri.parse('a/bar'));
@@ -91,7 +91,7 @@ flutter:
       fonts:
         - asset: a/bar
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
       expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
@@ -123,7 +123,7 @@ flutter:
         - asset: a/bar
           weight: 400
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
       expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
@@ -160,7 +160,7 @@ flutter:
           weight: 400
           style: italic
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
 
       expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
@@ -204,7 +204,7 @@ flutter:
           asset: a/baz
           style: italic
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final dynamic expectedFontsDescriptor = <dynamic>[
           {'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}, // ignore: always_specify_types
           {'fonts': [{'asset': 'a/baz'}, {'style': 'italic', 'weight': 400, 'asset': 'a/baz'}], 'family': 'bar'}, // ignore: always_specify_types
@@ -265,7 +265,7 @@ flutter:
           weight: 400
           style: italic
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
 
       final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
       expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
@@ -304,7 +304,7 @@ flutter:
           style: italic
     - family: bar
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
       expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
       final List<Font> fonts = flutterManifest.fonts;
@@ -338,7 +338,7 @@ flutter:
       fonts:
         - weight: 400
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
 
       expect(flutterManifest.fontsDescriptor, <dynamic>[]);
       final List<Font> fonts = flutterManifest.fonts;
@@ -353,7 +353,7 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isEmpty, false);
       expect(flutterManifest.isModule, false);
       expect(flutterManifest.isPlugin, false);
@@ -367,7 +367,7 @@ flutter:
   module:
     androidPackage: com.example
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isModule, true);
       expect(flutterManifest.androidPackage, 'com.example');
     });
@@ -379,7 +379,7 @@ flutter:
   plugin:
     androidPackage: com.example
 ''';
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isPlugin, true);
       expect(flutterManifest.androidPackage, 'com.example');
     });
@@ -390,7 +390,7 @@ flutter:
       String expectedBuildName,
       String expectedBuildNumber,
     }) async {
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.appVersion, expectedAppVersion);
       expect(flutterManifest.buildName, expectedBuildName);
       expect(flutterManifest.buildNumber, expectedBuildNumber);
@@ -490,7 +490,7 @@ dependencies:
 flutter:
 ''';
 
-      final FlutterManifest flutterManifest = await FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isEmpty, false);
     }
 

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -57,7 +57,7 @@ void main() {
     fs = MemoryFileSystem();
     mockProcessManager = MockProcessManager();
     mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-    projectUnderTest = await FlutterProject.fromDirectory(fs.directory('project'));
+    projectUnderTest = FlutterProject.fromDirectory(fs.directory('project'));
     projectUnderTest.ios.xcodeProject.createSync(recursive: true);
     cocoaPodsUnderTest = CocoaPods();
     pretendPodVersionIs('1.5.0');
@@ -156,7 +156,7 @@ void main() {
         'SWIFT_VERSION': '4.0',
       });
 
-      final FlutterProject project = await FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromPath('project');
       cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Swift podfile template');
@@ -168,7 +168,7 @@ void main() {
     testUsingContext('does not recreate Podfile when already present', () async {
       projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Existing Podfile');
 
-      final FlutterProject project = await FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromPath('project');
       cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Existing Podfile');
@@ -179,7 +179,7 @@ void main() {
     testUsingContext('does not create Podfile when we cannot interpret Xcode projects', () async {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
 
-      final FlutterProject project = await FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromPath('project');
       cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.existsSync(), false);
@@ -197,7 +197,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing release config');
 
-      final FlutterProject project = await FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromPath('project');
       cocoaPodsUnderTest.setupPodfile(project.ios);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
@@ -225,7 +225,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing release config');
 
-      final FlutterProject project = await FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromPath('project');
       await injectPlugins(project);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();

--- a/packages/flutter_tools/test/ios/devices_test.dart
+++ b/packages/flutter_tools/test/ios/devices_test.dart
@@ -196,7 +196,7 @@ flutter:
   module: {}
 ''');
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -207,7 +207,7 @@ flutter:
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
     fs.directory('ios').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -217,7 +217,7 @@ flutter:
   testUsingContext('IOSDevice.isSupportedForProject is false with no host app and no module', () async {
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSDevice('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/ios/simulators_test.dart
@@ -427,7 +427,7 @@ flutter:
   module: {}
 ''');
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -438,7 +438,7 @@ flutter:
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
     fs.directory('ios').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -448,7 +448,7 @@ flutter:
   testUsingContext('IOSDevice.isSupportedForProject is false with no host app and no module', () async {
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/ios/xcodeproj_test.dart
@@ -287,7 +287,7 @@ Information about project "Runner":
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
-      final FlutterProject project = await FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -305,7 +305,7 @@ Information about project "Runner":
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, targetPlatform: TargetPlatform.ios);
-      final FlutterProject project = await FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -323,7 +323,7 @@ Information about project "Runner":
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
-      final FlutterProject project = await FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -342,7 +342,7 @@ Information about project "Runner":
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, targetPlatform: TargetPlatform.ios);
 
-      final FlutterProject project = await FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -382,7 +382,7 @@ Information about project "Runner":
       writeEmptySchemaFile(fs);
 
       await updateGeneratedXcodeProperties(
-        project: await FlutterProject.fromPath('path/to/project'),
+        project: FlutterProject.fromPath('path/to/project'),
         buildInfo: buildInfo,
       );
 

--- a/packages/flutter_tools/test/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/linux/linux_device_test.dart
@@ -66,7 +66,7 @@ void main() {
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
     fs.directory('linux').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(LinuxDevice().isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
@@ -76,7 +76,7 @@ void main() {
   testUsingContext('LinuxDevice.isSupportedForProject is false with no host app', () async {
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
-    final FlutterProject flutterProject = await FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.current();
 
     expect(LinuxDevice().isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/macos/macos_device_test.dart
@@ -113,7 +113,7 @@ tester    17193   0.0  0.2  4791128  37820   ??  S     2:27PM   0:00.09 /Applica
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
       fs.directory('macos').createSync();
-      final FlutterProject flutterProject = await FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.current();
 
       expect(MacOSDevice().isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
@@ -123,7 +123,7 @@ tester    17193   0.0  0.2  4791128  37820   ??  S     2:27PM   0:00.09 /Applica
     testUsingContext('isSupportedForProject is false with no host app', () async {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
-      final FlutterProject flutterProject = await FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.current();
 
       expect(MacOSDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 import 'src/common.dart';
@@ -24,8 +25,8 @@ void main() {
   group('Project', () {
     group('construction', () {
       testInMemory('fails on null directory', () async {
-        await expectLater(
-          FlutterProject.fromDirectory(null),
+        expect(
+          () => FlutterProject.fromDirectory(null),
           throwsA(isInstanceOf<AssertionError>()),
         );
       });
@@ -35,9 +36,10 @@ void main() {
         directory.childFile('pubspec.yaml')
           ..createSync(recursive: true)
           ..writeAsStringSync(invalidPubspec);
-        await expectToolExitLater(
-          FlutterProject.fromDirectory(directory),
-          contains('pubspec.yaml'),
+
+        expect(
+          () => FlutterProject.fromDirectory(directory),
+          throwsA(isInstanceOf<Exception>()),
         );
       });
 
@@ -46,17 +48,17 @@ void main() {
         directory.childDirectory('example').childFile('pubspec.yaml')
           ..createSync(recursive: true)
           ..writeAsStringSync(invalidPubspec);
-        await expectToolExitLater(
-          FlutterProject.fromDirectory(directory),
-          contains('pubspec.yaml'),
+
+        expect(
+          () => FlutterProject.fromDirectory(directory),
+          throwsA(isInstanceOf<Exception>()),
         );
       });
 
       testInMemory('treats missing pubspec.yaml as empty', () async {
         final Directory directory = fs.directory('myproject')
           ..createSync(recursive: true);
-        expect(
-          (await FlutterProject.fromDirectory(directory)).manifest.isEmpty,
+        expect((FlutterProject.fromDirectory(directory)).manifest.isEmpty,
           true,
         );
       });
@@ -67,7 +69,7 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync(validPubspec);
         expect(
-          (await FlutterProject.fromDirectory(directory)).manifest.appName,
+          FlutterProject.fromDirectory(directory).manifest.appName,
           'hello',
         );
       });
@@ -75,15 +77,15 @@ void main() {
       testInMemory('sets up location', () async {
         final Directory directory = fs.directory('myproject');
         expect(
-          (await FlutterProject.fromDirectory(directory)).directory.absolute.path,
+          FlutterProject.fromDirectory(directory).directory.absolute.path,
           directory.absolute.path,
         );
         expect(
-          (await FlutterProject.fromPath(directory.path)).directory.absolute.path,
+          FlutterProject.fromPath(directory.path).directory.absolute.path,
           directory.absolute.path,
         );
         expect(
-          (await FlutterProject.current()).directory.absolute.path,
+          FlutterProject.current().directory.absolute.path,
           fs.currentDirectory.absolute.path,
         );
       });
@@ -380,6 +382,7 @@ flutter:
 
 /// Executes the [testMethod] in a context where the file system
 /// is in memory.
+@isTest
 void testInMemory(String description, Future<void> testMethod()) {
   Cache.flutterRoot = getFlutterRoot();
   final FileSystem testFileSystem = MemoryFileSystem(

--- a/packages/flutter_tools/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/test_compiler_test.dart
@@ -21,7 +21,7 @@ void main() {
       final MockResidentCompiler residentCompiler = MockResidentCompiler();
       final TestCompiler testCompiler = FakeTestCompiler(
         false,
-        await FlutterProject.current(),
+        FlutterProject.current(),
         residentCompiler,
       );
       when(residentCompiler.recompile(
@@ -46,7 +46,7 @@ void main() {
       final MockResidentCompiler residentCompiler = MockResidentCompiler();
       final TestCompiler testCompiler = FakeTestCompiler(
         false,
-        await FlutterProject.current(),
+        FlutterProject.current(),
         residentCompiler,
       );
       when(residentCompiler.recompile(

--- a/packages/flutter_tools/test/web/devices_test.dart
+++ b/packages/flutter_tools/test/web/devices_test.dart
@@ -20,7 +20,7 @@ void main() {
     FlutterProject flutterProject;
 
     setUp(() async {
-      flutterProject = await FlutterProject.fromPath(fs.path.join(getFlutterRoot(), 'dev', 'integration_tests', 'web'));
+      flutterProject = FlutterProject.fromPath(fs.path.join(getFlutterRoot(), 'dev', 'integration_tests', 'web'));
       when(mockWebCompiler.compile(
         target: anyNamed('target'),
         minify: anyNamed('minify'),

--- a/packages/flutter_tools/test/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/windows/windows_device_test.dart
@@ -65,7 +65,7 @@ void main() {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
       fs.directory('windows').createSync();
-      final FlutterProject flutterProject = await FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.current();
 
       expect(WindowsDevice().isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
@@ -75,7 +75,7 @@ void main() {
     testUsingContext('isSupportedForProject is false with no host app', () async {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
-      final FlutterProject flutterProject = await FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.current();
 
       expect(WindowsDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/tool/tool_coverage.dart
+++ b/packages/flutter_tools/tool/tool_coverage.dart
@@ -44,7 +44,7 @@ Future<void> main(List<String> arguments) async {
   final ArgResults argResults = argParser.parse(arguments);
   await runInContext(() async {
     final CoverageCollector coverageCollector = CoverageCollector(
-      flutterProject: await FlutterProject.current(),
+      flutterProject: FlutterProject.current(),
     );
     /// A temp directory to create synthetic test files in.
     final Directory tempDirectory = Directory.systemTemp.createTempSync('_flutter_coverage')


### PR DESCRIPTION
## Description

These methods were async due to another unnecessarily async function and a readAsString instead of readAsString sync call. Since we prefer to use the sync methods when possible, I've fixed the above and removed the awaits from the project.