### PR TITLE
[WIP] Refactor attach code to be more device agnostic and remove debug port

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -540,6 +540,30 @@ class AndroidDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.android.existsSync();
   }
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+    int observatoryPort,
+  }) async {
+    ProtocolDiscovery observatoryDiscovery;
+    Uri observatoryUri;
+    try {
+      observatoryDiscovery = ProtocolDiscovery.observatory(
+        getLogReader(),
+        portForwarder: portForwarder,
+        ipv6: ipv6,
+      );
+      printStatus('Waiting for a connection from Flutter on $name...');
+      observatoryUri = await observatoryDiscovery.uri;
+      printStatus('Done.'); // FYI, this message is used as a sentinel in tests.
+    } finally {
+      await observatoryDiscovery?.cancel();
+    }
+    return observatoryUri;
+  }
 }
 
 Map<String, String> parseAdbDeviceProperties(String str) {

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -4,22 +4,14 @@
 
 import 'dart:async';
 
-import 'package:multicast_dns/multicast_dns.dart';
-
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../commands/daemon.dart';
 import '../compile.dart';
 import '../device.dart';
-import '../fuchsia/fuchsia_device.dart';
-import '../globals.dart';
-import '../ios/devices.dart';
-import '../ios/simulators.dart';
 import '../project.dart';
-import '../protocol_discovery.dart';
 import '../resident_runner.dart';
 import '../run_cold.dart';
 import '../run_hot.dart';
@@ -61,13 +53,6 @@ class AttachCommand extends FlutterCommand {
     usesFuchsiaOptions(hide: !verboseHelp);
     argParser
       ..addOption(
-        'debug-port',
-        hide: !verboseHelp,
-        help: 'Device port where the observatory is listening. Requires '
-        '--disable-service-auth-codes to also be provided to the Flutter '
-        'application at launch, otherwise this command will fail to connect to '
-        'the application. In general, --debug-uri should be used instead.',
-      )..addOption(
         'debug-uri',
         help: 'The URI at which the observatory is listening.',
       )..addOption(
@@ -108,17 +93,6 @@ class AttachCommand extends FlutterCommand {
   @override
   final String description = 'Attach to a running application.';
 
-  int get debugPort {
-    if (argResults['debug-port'] == null)
-      return null;
-    try {
-      return int.parse(argResults['debug-port']);
-    } catch (error) {
-      throwToolExit('Invalid port for `--debug-port`: $error');
-    }
-    return null;
-  }
-
   Uri get debugUri {
     if (argResults['debug-uri'] == null) {
       return null;
@@ -137,107 +111,50 @@ class AttachCommand extends FlutterCommand {
   @override
   Future<void> validateCommand() async {
     await super.validateCommand();
-    if (await findTargetDevice() == null)
-      throwToolExit(null);
-    debugPort;
-    if (debugPort == null && debugUri == null && argResults.wasParsed(FlutterCommand.ipv6Flag)) {
+    if (await findTargetDevice() == null) {
+      throwToolExit('No connected devices.');
+    }
+    if (debugUri == null && argResults.wasParsed(FlutterCommand.ipv6Flag)) {
       throwToolExit(
-        'When the --debug-port or --debug-uri is unknown, this command determines '
-        'the value of --ipv6 on its own.',
+        'When --debug-uri is unknown, this command determines the value of '
+        '--ipv6 on its own.',
       );
     }
-    if (debugPort == null && debugUri == null && argResults.wasParsed(FlutterCommand.observatoryPortOption)) {
+    if (debugUri == null && argResults.wasParsed(FlutterCommand.observatoryPortOption)) {
       throwToolExit(
-        'When the --debug-port or --debug-uri is unknown, this command does not use '
-        'the value of --observatory-port.',
+        'When --debug-uri is unknown, this command does not use the value of '
+        '--observatory-port.',
       );
-    }
-    if (debugPort != null && debugUri != null) {
-      throwToolExit(
-        'Either --debugPort or --debugUri can be provided, not both.');
     }
   }
 
   @override
   Future<FlutterCommandResult> runCommand() async {
     final FlutterProject flutterProject = await FlutterProject.current();
-
     Cache.releaseLockEarly();
-
     await _validateArguments();
 
     writePidFile(argResults['pid-file']);
 
     final Device device = await findTargetDevice();
-    Future<int> getDevicePort() async {
-      if (debugPort != null) {
-        return debugPort;
-      }
-      // This call takes a non-trivial amount of time, and only iOS devices and
-      // simulators support it.
-      // If/when we do this on Android or other platforms, we can update it here.
-      if (device is IOSDevice || device is IOSSimulator) {
-      }
-      return null;
+    Daemon daemon;
+    if (argResults['machine']) {
+      daemon = Daemon(
+        stdinCommandStream, stdoutCommandResponse,
+        notifyingLogger: NotifyingLogger(),
+        logToStdout: true,
+      );
     }
-    final int devicePort = await getDevicePort();
-
-    final Daemon daemon = argResults['machine']
-      ? Daemon(stdinCommandStream, stdoutCommandResponse,
-            notifyingLogger: NotifyingLogger(), logToStdout: true)
-      : null;
 
     Uri observatoryUri;
-    bool usesIpv6 = ipv6;
-    final String ipv6Loopback = InternetAddress.loopbackIPv6.address;
-    final String ipv4Loopback = InternetAddress.loopbackIPv4.address;
-    final String hostname = usesIpv6 ? ipv6Loopback : ipv4Loopback;
-
-    bool attachLogger = false;
-    if (devicePort == null  && debugUri == null) {
-      if (device is FuchsiaDevice) {
-        attachLogger = true;
-        final String module = argResults['module'];
-        if (module == null)
-          throwToolExit('\'--module\' is required for attaching to a Fuchsia device');
-        usesIpv6 = device.ipv6;
-        FuchsiaIsolateDiscoveryProtocol isolateDiscoveryProtocol;
-        try {
-          isolateDiscoveryProtocol = device.getIsolateDiscoveryProtocol(module);
-          observatoryUri = await isolateDiscoveryProtocol.uri;
-          printStatus('Done.'); // FYI, this message is used as a sentinel in tests.
-        } catch (_) {
-          isolateDiscoveryProtocol?.dispose();
-          final List<ForwardedPort> ports = device.portForwarder.forwardedPorts.toList();
-          for (ForwardedPort port in ports) {
-            await device.portForwarder.unforward(port);
-          }
-          rethrow;
-        }
-      } else if ((device is IOSDevice) || (device is IOSSimulator)) {
-        final MDnsObservatoryDiscoveryResult result = await MDnsObservatoryDiscovery().query(applicationId: appId);
-        observatoryUri = await _buildObservatoryUri(device, hostname, result.port, result.authCode);
-      }
-      // If MDNS discovery fails or we're not on iOS, fallback to ProtocolDiscovery.
-      if (observatoryUri == null) {
-        ProtocolDiscovery observatoryDiscovery;
-        try {
-          observatoryDiscovery = ProtocolDiscovery.observatory(
-            device.getLogReader(),
-            portForwarder: device.portForwarder,
-          );
-          printStatus('Waiting for a connection from Flutter on ${device.name}...');
-          observatoryUri = await observatoryDiscovery.uri;
-          // Determine ipv6 status from the scanned logs.
-          usesIpv6 = observatoryDiscovery.ipv6;
-          printStatus('Done.'); // FYI, this message is used as a sentinel in tests.
-        } finally {
-          await observatoryDiscovery?.cancel();
-        }
-      }
+    if (debugUri == null) {
+      observatoryUri = await device.attach(
+        ipv6: ipv6,
+        isolateFilter: argResults['module'],
+        applicationId: appId,
+      );
     } else {
-      observatoryUri = await _buildObservatoryUri(device,
-          debugUri?.host ?? hostname, devicePort ?? debugUri.port, debugUri?.path);
+      observatoryUri = await _buildObservatoryUri(device, debugUri?.host, debugUri.port, debugUri?.path);
     }
     try {
       final bool useHot = getBuildInfo().isDebug;
@@ -265,18 +182,16 @@ class AttachCommand extends FlutterCommand {
             usesTerminalUI: daemon == null,
             projectRootPath: argResults['project-root'],
             dillOutputPath: argResults['output-dill'],
-            ipv6: usesIpv6,
+            ipv6: ipv6,
             flutterProject: flutterProject,
           )
         : ColdRunner(
             flutterDevices,
             target: targetFile,
             debuggingOptions: debuggingOptions,
-            ipv6: usesIpv6,
+            ipv6: ipv6,
           );
-      if (attachLogger) {
-        flutterDevice.startEchoingDeviceLog();
-      }
+      flutterDevice.startEchoingDeviceLog();
 
       int result;
       if (daemon != null) {
@@ -300,8 +215,9 @@ class AttachCommand extends FlutterCommand {
         result = await runner.attach();
         assert(result != null);
       }
-      if (result != 0)
+      if (result != 0) {
         throwToolExit(null, exitCode: result);
+      }
     } finally {
       final List<ForwardedPort> ports = device.portForwarder.forwardedPorts.toList();
       for (ForwardedPort port in ports) {
@@ -313,8 +229,7 @@ class AttachCommand extends FlutterCommand {
 
   Future<void> _validateArguments() async { }
 
-  Future<Uri> _buildObservatoryUri(Device device,
-      String host, int devicePort, [String authCode]) async {
+  Future<Uri> _buildObservatoryUri(Device device, String host, int devicePort, [String authCode]) async {
     String path = '/';
     if (authCode != null) {
       path = authCode;
@@ -324,8 +239,7 @@ class AttachCommand extends FlutterCommand {
     if (!path.endsWith('/')) {
       path += '/';
     }
-    final int localPort = observatoryPort
-        ?? await device.portForwarder.forward(devicePort);
+    final int localPort = observatoryPort ?? await device.portForwarder.forward(devicePort);
     return Uri(scheme: 'http', host: host, port: localPort, path: path);
   }
 }
@@ -359,133 +273,4 @@ class HotRunnerFactory {
     stayResident: stayResident,
     ipv6: ipv6,
   );
-}
-
-class MDnsObservatoryDiscoveryResult {
-  MDnsObservatoryDiscoveryResult(this.port, this.authCode);
-  final int port;
-  final String authCode;
-}
-
-/// A wrapper around [MDnsClient] to find a Dart observatory instance.
-class MDnsObservatoryDiscovery {
-  /// Creates a new [MDnsObservatoryDiscovery] object.
-  ///
-  /// The [client] parameter will be defaulted to a new [MDnsClient] if null.
-  /// The [applicationId] parameter may be null, and can be used to
-  /// automatically select which application to use if multiple are advertising
-  /// Dart observatory ports.
-  MDnsObservatoryDiscovery({MDnsClient mdnsClient})
-    : client = mdnsClient ?? MDnsClient();
-
-  /// The [MDnsClient] used to do a lookup.
-  final MDnsClient client;
-
-  static const String dartObservatoryName = '_dartobservatory._tcp.local';
-
-  /// Executes an mDNS query for a Dart Observatory.
-  ///
-  /// The [applicationId] parameter may be used to specify which application
-  /// to find.  For Android, it refers to the package name; on iOS, it refers to
-  /// the bundle ID.
-  ///
-  /// If it is not null, this method will find the port and authentication code
-  /// of the Dart Observatory for that application. If it cannot find a Dart
-  /// Observatory matching that application identifier, it will call
-  /// [throwToolExit].
-  ///
-  /// If it is null and there are multiple ports available, the user will be
-  /// prompted with a list of available observatory ports and asked to select
-  /// one.
-  ///
-  /// If it is null and there is only one available instance of Observatory,
-  /// it will return that instance's information regardless of what application
-  /// the Observatory instance is for.
-  Future<MDnsObservatoryDiscoveryResult> query({String applicationId}) async {
-    printStatus('Checking for advertised Dart observatories...');
-    try {
-      await client.start();
-      final List<PtrResourceRecord> pointerRecords = await client
-          .lookup<PtrResourceRecord>(
-            ResourceRecordQuery.serverPointer(dartObservatoryName),
-          )
-          .toList();
-      if (pointerRecords.isEmpty) {
-        return null;
-      }
-      // We have no guarantee that we won't get multiple hits from the same
-      // service on this.
-      final List<String> uniqueDomainNames = pointerRecords
-          .map<String>((PtrResourceRecord record) => record.domainName)
-          .toSet()
-          .toList();
-
-      String domainName;
-      if (applicationId != null) {
-        for (String name in uniqueDomainNames) {
-          if (name.toLowerCase().startsWith(applicationId.toLowerCase())) {
-            domainName = name;
-            break;
-          }
-        }
-        if (domainName == null) {
-          throwToolExit('Did not find a observatory port advertised for $applicationId.');
-        }
-      } else if (uniqueDomainNames.length > 1) {
-        final StringBuffer buffer = StringBuffer();
-        buffer.writeln('There are multiple observatory ports available.');
-        buffer.writeln('Rerun this command with one of the following passed in as the appId:');
-        buffer.writeln('');
-         for (final String uniqueDomainName in uniqueDomainNames) {
-          buffer.writeln('  flutter attach --app-id ${uniqueDomainName.replaceAll('.$dartObservatoryName', '')}');
-        }
-        throwToolExit(buffer.toString());
-      } else {
-        domainName = pointerRecords[0].domainName;
-      }
-      printStatus('Checking for available port on $domainName');
-      // Here, if we get more than one, it should just be a duplicate.
-      final List<SrvResourceRecord> srv = await client
-          .lookup<SrvResourceRecord>(
-            ResourceRecordQuery.service(domainName),
-          )
-          .toList();
-      if (srv.isEmpty) {
-        return null;
-      }
-      if (srv.length > 1) {
-        printError('Unexpectedly found more than one observatory report for $domainName '
-                   '- using first one (${srv.first.port}).');
-      }
-      printStatus('Checking for authentication code for $domainName');
-      final List<TxtResourceRecord> txt = await client
-        .lookup<TxtResourceRecord>(
-            ResourceRecordQuery.text(domainName),
-        )
-        ?.toList();
-      if (txt == null || txt.isEmpty) {
-        return MDnsObservatoryDiscoveryResult(srv.first.port, '');
-      }
-      String authCode = '';
-      const String authCodePrefix = 'authCode=';
-      String raw = txt.first.text;
-      // TXT has a format of [<length byte>, text], so if the length is 2,
-      // that means that TXT is empty.
-      if (raw.length > 2) {
-        // Remove length byte from raw txt.
-        raw = raw.substring(1);
-        if (raw.startsWith(authCodePrefix)) {
-          authCode = raw.substring(authCodePrefix.length);
-          // The Observatory currently expects a trailing '/' as part of the
-          // URI, otherwise an invalid authentication code response is given.
-          if (!authCode.endsWith('/')) {
-            authCode += '/';
-          }
-        }
-      }
-      return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
-    } finally {
-      client.stop();
-    }
-  }
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -9,6 +9,7 @@ import 'android/android_device.dart';
 import 'application_package.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
+import 'base/io.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'desktop.dart';
@@ -251,6 +252,13 @@ abstract class Device {
   /// Uninstall an app package from the current device
   Future<bool> uninstallApp(ApplicationPackage app);
 
+  /// Attach to an application running on this device.
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  });
+
   /// Check if the device is supported by Flutter
   bool isSupported();
 
@@ -323,6 +331,27 @@ abstract class Device {
     if (other is! Device)
       return false;
     return id == other.id;
+  }
+
+  Future<Uri> buildObservatoryUri({bool ipv6, int devicePort, String authCode}) async {
+    String path = '/';
+    if (authCode != null) {
+      path = authCode;
+    }
+    // Not having a trailing slash can cause problems in some situations.
+    // Ensure that there's one present.
+    if (!path.endsWith('/')) {
+      path += '/';
+    }
+    final int localPort = await portForwarder.forward(devicePort);
+    return Uri(
+      scheme: 'http',
+      host: ipv6
+          ? InternetAddress.loopbackIPv6.address
+          : InternetAddress.loopbackIPv4.address,
+      port: localPort,
+      path: path,
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -22,6 +22,7 @@ import '../protocol_discovery.dart';
 import 'code_signing.dart';
 import 'ios_workflow.dart';
 import 'mac.dart';
+import 'mdns_observatory.dart';
 
 const String _kIdeviceinstallerInstructions =
     'To work with iOS devices, please install ideviceinstaller. To install, run:\n'
@@ -406,6 +407,20 @@ class IOSDevice extends Device {
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.ios.existsSync();
+  }
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  }) async {
+    final MDnsObservatoryDiscoveryResult result = await MDnsObservatoryDiscovery().query(applicationId: applicationId);
+    return buildObservatoryUri(
+      ipv6: ipv6,
+      devicePort: result.port,
+      authCode: result.authCode,
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/mdns_observatory.dart
+++ b/packages/flutter_tools/lib/src/ios/mdns_observatory.dart
@@ -1,0 +1,137 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:multicast_dns/multicast_dns.dart';
+
+import '../base/common.dart';
+import '../globals.dart';
+
+class MDnsObservatoryDiscoveryResult {
+  MDnsObservatoryDiscoveryResult(this.port, this.authCode);
+  final int port;
+  final String authCode;
+}
+
+/// A wrapper around [MDnsClient] to find a Dart observatory instance.
+class MDnsObservatoryDiscovery {
+  /// Creates a new [MDnsObservatoryDiscovery] object.
+  ///
+  /// The [client] parameter will be defaulted to a new [MDnsClient] if null.
+  /// The [applicationId] parameter may be null, and can be used to
+  /// automatically select which application to use if multiple are advertising
+  /// Dart observatory ports.
+  MDnsObservatoryDiscovery({MDnsClient mdnsClient})
+    : client = mdnsClient ?? MDnsClient();
+
+  /// The [MDnsClient] used to do a lookup.
+  final MDnsClient client;
+
+  static const String dartObservatoryName = '_dartobservatory._tcp.local';
+
+  /// Executes an mDNS query for a Dart Observatory.
+  ///
+  /// The [applicationId] parameter may be used to specify which application
+  /// to find.  For Android, it refers to the package name; on iOS, it refers to
+  /// the bundle ID.
+  ///
+  /// If it is not null, this method will find the port and authentication code
+  /// of the Dart Observatory for that application. If it cannot find a Dart
+  /// Observatory matching that application identifier, it will call
+  /// [throwToolExit].
+  ///
+  /// If it is null and there are multiple ports available, the user will be
+  /// prompted with a list of available observatory ports and asked to select
+  /// one.
+  ///
+  /// If it is null and there is only one available instance of Observatory,
+  /// it will return that instance's information regardless of what application
+  /// the Observatory instance is for.
+  Future<MDnsObservatoryDiscoveryResult> query({String applicationId}) async {
+    printStatus('Checking for advertised Dart observatories...');
+    try {
+      await client.start();
+      final List<PtrResourceRecord> pointerRecords = await client
+          .lookup<PtrResourceRecord>(
+            ResourceRecordQuery.serverPointer(dartObservatoryName),
+          )
+          .toList();
+      if (pointerRecords.isEmpty) {
+        return null;
+      }
+      // We have no guarantee that we won't get multiple hits from the same
+      // service on this.
+      final List<String> uniqueDomainNames = pointerRecords
+          .map<String>((PtrResourceRecord record) => record.domainName)
+          .toSet()
+          .toList();
+
+      String domainName;
+      if (applicationId != null) {
+        for (String name in uniqueDomainNames) {
+          if (name.toLowerCase().startsWith(applicationId.toLowerCase())) {
+            domainName = name;
+            break;
+          }
+        }
+        if (domainName == null) {
+          throwToolExit('Did not find a observatory port advertised for $applicationId.');
+        }
+      } else if (uniqueDomainNames.length > 1) {
+        final StringBuffer buffer = StringBuffer();
+        buffer.writeln('There are multiple observatory ports available.');
+        buffer.writeln('Rerun this command with one of the following passed in as the appId:');
+        buffer.writeln('');
+         for (final String uniqueDomainName in uniqueDomainNames) {
+          buffer.writeln('  flutter attach --app-id ${uniqueDomainName.replaceAll('.$dartObservatoryName', '')}');
+        }
+        throwToolExit(buffer.toString());
+      } else {
+        domainName = pointerRecords[0].domainName;
+      }
+      printStatus('Checking for available port on $domainName');
+      // Here, if we get more than one, it should just be a duplicate.
+      final List<SrvResourceRecord> srv = await client
+          .lookup<SrvResourceRecord>(
+            ResourceRecordQuery.service(domainName),
+          )
+          .toList();
+      if (srv.isEmpty) {
+        return null;
+      }
+      if (srv.length > 1) {
+        printError('Unexpectedly found more than one observatory report for $domainName '
+                   '- using first one (${srv.first.port}).');
+      }
+      printStatus('Checking for authentication code for $domainName');
+      final List<TxtResourceRecord> txt = await client
+        .lookup<TxtResourceRecord>(
+            ResourceRecordQuery.text(domainName),
+        )
+        ?.toList();
+      if (txt == null || txt.isEmpty) {
+        return MDnsObservatoryDiscoveryResult(srv.first.port, '');
+      }
+      String authCode = '';
+      const String authCodePrefix = 'authCode=';
+      String raw = txt.first.text;
+      // TXT has a format of [<length byte>, text], so if the length is 2,
+      // that means that TXT is empty.
+      if (raw.length > 2) {
+        // Remove length byte from raw txt.
+        raw = raw.substring(1);
+        if (raw.startsWith(authCodePrefix)) {
+          authCode = raw.substring(authCodePrefix.length);
+          // The Observatory currently expects a trailing '/' as part of the
+          // URI, otherwise an invalid authentication code response is given.
+          if (!authCode.endsWith('/')) {
+            authCode += '/';
+          }
+        }
+      }
+      return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
+    } finally {
+      client.stop();
+    }
+  }
+}

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -23,6 +23,7 @@ import '../project.dart';
 import '../protocol_discovery.dart';
 import 'ios_workflow.dart';
 import 'mac.dart';
+import 'mdns_observatory.dart';
 
 const String _xcrunPath = '/usr/bin/xcrun';
 
@@ -478,6 +479,20 @@ class IOSSimulator extends Device {
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.ios.existsSync();
+  }
+
+  @override
+  Future<Uri> attach({
+    String isolateFilter,
+    String applicationId,
+    bool ipv6,
+  }) async {
+    final MDnsObservatoryDiscoveryResult result = await MDnsObservatoryDiscovery().query(applicationId: applicationId);
+    return buildObservatoryUri(
+      ipv6: ipv6,
+      devicePort: result.port,
+      authCode: result.authCode,
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -115,6 +115,15 @@ class LinuxDevice extends Device {
 
   // Track the last built mode from startApp.
   BuildMode _lastBuiltMode;
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  }) {
+    throw UnsupportedError('Linux devices must specify an observatory uri');
+  }
 }
 
 class LinuxDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -122,6 +122,15 @@ class MacOSDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.macos.existsSync();
   }
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  }) {
+    throw UnsupportedError('macOS devices must specify an observatory uri');
+  }
 }
 
 class MacOSDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -196,6 +196,15 @@ class FlutterTesterDevice extends Device {
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) => true;
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  }) {
+    throw UnsupportedError('flutter_tester devices must specify an observatory uri');
+  }
 }
 
 class FlutterTesterDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -171,6 +171,17 @@ class WebDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.web.existsSync();
   }
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+    String authCode,
+    int observatoryPort,
+  }) {
+    throw UnsupportedError('web devices must specify an observatory uri');
+  }
 }
 
 class WebDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -119,6 +119,15 @@ class WindowsDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.windows.existsSync();
   }
+
+  @override
+  Future<Uri> attach({
+    bool ipv6,
+    String isolateFilter,
+    String applicationId,
+  }) {
+    throw UnsupportedError('Windows devices must specify an observatory uri');
+  }
 }
 
 class WindowsDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/test/commands/attach_test.dart
+++ b/packages/flutter_tools/test/commands/attach_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/ios/mdns_observatory.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:meta/meta.dart';


### PR DESCRIPTION

## Description

The attach logic should delegate to a method on the device class instead if doing `is` checks on the device type - standard cleanup.

We should not be maintaining both command line options for ports and for full URIs. We should migrate the remaining clients to provide full URIs to the attach command. It's not obvious at all what the correct fix is when the --debug-port option fails.
