### PR TITLE
Support clipBehavior changes in hot reload

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1463,6 +1463,7 @@ class PhysicalModelLayer extends ContainerLayer {
   Clip get clipBehavior => _clipBehavior;
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
+    assert(value != null);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1152,9 +1152,10 @@ abstract class _RenderCustomClip<T> extends RenderProxyBox {
   _RenderCustomClip({
     RenderBox child,
     CustomClipper<T> clipper,
-    this.clipBehavior = Clip.antiAlias,
-  }) : _clipper = clipper,
-       assert(clipBehavior != null),
+    Clip clipBehavior = Clip.antiAlias,
+  }) : assert(clipBehavior != null),
+       _clipper = clipper,
+       _clipBehavior = clipBehavior,
        super(child);
 
   /// If non-null, determines which clip to use on the child.
@@ -1198,7 +1199,14 @@ abstract class _RenderCustomClip<T> extends RenderProxyBox {
   T get _defaultClip;
   T _clip;
 
-  final Clip clipBehavior;
+  Clip get clipBehavior => _clipBehavior;
+  set clipBehavior(Clip value) {
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+    }
+  }
+  Clip _clipBehavior;
 
   @override
   void performLayout() {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -594,7 +594,9 @@ class ClipRect extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderClipRect renderObject) {
-    renderObject.clipper = clipper;
+    renderObject
+      ..clipper = clipper
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -661,6 +663,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderClipRRect renderObject) {
     renderObject
       ..borderRadius = borderRadius
+      ..clipBehavior = clipBehavior
       ..clipper = clipper;
   }
 
@@ -710,7 +713,9 @@ class ClipOval extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderClipOval renderObject) {
-    renderObject.clipper = clipper;
+    renderObject
+      ..clipper = clipper
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -796,7 +801,9 @@ class ClipPath extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderClipPath renderObject) {
-    renderObject.clipper = clipper;
+    renderObject
+      ..clipper = clipper
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -886,6 +893,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderPhysicalModel renderObject) {
     renderObject
       ..shape = shape
+      ..clipBehavior = clipBehavior
       ..borderRadius = borderRadius
       ..elevation = elevation
       ..color = color
@@ -974,6 +982,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderPhysicalShape renderObject) {
     renderObject
       ..clipper = clipper
+      ..clipBehavior = clipBehavior
       ..elevation = elevation
       ..color = color
       ..shadowColor = shadowColor;

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -45,19 +45,80 @@ class _UpdateCountedClipRect extends ClipRect with UpdateCount {
     : super(clipBehavior: clipBehavior);
 }
 
+class _UpdateCountedClipRRect extends ClipRRect with UpdateCount {
+  _UpdateCountedClipRRect({Clip clipBehavior = Clip.antiAlias})
+      : super(clipBehavior: clipBehavior, borderRadius: BorderRadius.circular(1.0));
+}
+
+class _UpdateCountedClipOval extends ClipOval with UpdateCount {
+  _UpdateCountedClipOval({Clip clipBehavior = Clip.antiAlias})
+      : super(clipBehavior: clipBehavior);
+}
+
+class _UpdateCountedClipPath extends ClipPath with UpdateCount {
+  _UpdateCountedClipPath({Clip clipBehavior = Clip.antiAlias})
+      : super(clipBehavior: clipBehavior);
+}
+
 void main() {
   testWidgets('ClipRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(_UpdateCountedClipRect());
 
-    final RenderClipRect renderClipRect = tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderClipRect);
+    final RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
 
-    expect(renderClipRect.clipBehavior, equals(Clip.antiAlias));
-    expect(UpdateCount.updateCount, equals(0));
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
+    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
     await tester.pumpWidget(_UpdateCountedClipRect(clipBehavior: Clip.hardEdge));
 
-    expect(UpdateCount.updateCount, equals(1));  // Check that updateRenderObject is called.
-    expect(renderClipRect.clipBehavior, equals(Clip.hardEdge));
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+  });
+
+  testWidgets('ClipRRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    await tester.pumpWidget(_UpdateCountedClipRRect());
+
+    final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first;
+
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
+    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
+
+    await tester.pumpWidget(_UpdateCountedClipRRect(clipBehavior: Clip.hardEdge));
+
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+  });
+
+  testWidgets('ClipOval updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    await tester.pumpWidget(_UpdateCountedClipOval());
+
+    final RenderClipOval renderClip = tester.allRenderObjects.whereType<RenderClipOval>().first;
+
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
+    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
+
+    await tester.pumpWidget(_UpdateCountedClipOval(clipBehavior: Clip.hardEdge));
+
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+  });
+
+  testWidgets('ClipPath updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    await tester.pumpWidget(_UpdateCountedClipPath());
+
+    final RenderClipPath renderClip = tester.allRenderObjects.whereType<RenderClipPath>().first;
+
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
+    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
+
+    await tester.pumpWidget(_UpdateCountedClipPath(clipBehavior: Clip.hardEdge));
+
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
   testWidgets('ClipPath', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -40,39 +40,24 @@ class ValueClipper<T> extends CustomClipper<T> {
   }
 }
 
-mixin UpdateCount on SingleChildRenderObjectWidget {
-  static int updateCount = 0;
-
-  @override
-  void updateRenderObject(BuildContext context, RenderObject renderObject) {
-    updateCount += 1;
-    super.updateRenderObject(context, renderObject);
-  }
-}
-
 class _UpdateCountedClipRect extends ClipRect with UpdateCount {
-  _UpdateCountedClipRect({Key key, Clip clipBehavior = Clip.hardEdge})
-    : super(key: key, clipBehavior: clipBehavior);
+  _UpdateCountedClipRect({Clip clipBehavior = Clip.antiAlias})
+    : super(clipBehavior: clipBehavior);
 }
 
 void main() {
   testWidgets('ClipRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
-    final GlobalKey key = GlobalKey();
-    await tester.pumpWidget(ClipRect(key: key));
+    await tester.pumpWidget(_UpdateCountedClipRect());
 
-    final ClipRect widget = tester.firstWidget(find.byKey(key));
-    final RenderClipRect renderClipRect = tester.renderObject(find.byWidget(widget));
-//    final RenderClipRect renderClipRect =
-//    tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderClipRect);
+    final RenderClipRect renderClipRect = tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderClipRect);
 
-    expect(renderClipRect.clipBehavior, equals(Clip.hardEdge));
-
-    expect(UpdateCount.updateCount, equals(0));
-    await tester.pumpWidget(ClipRect(key: key, clipBehavior: Clip.antiAlias));
-    await tester.pump();
-
-    expect(UpdateCount.updateCount, equals(1));
     expect(renderClipRect.clipBehavior, equals(Clip.antiAlias));
+    expect(UpdateCount.updateCount, equals(0));
+
+    await tester.pumpWidget(_UpdateCountedClipRect(clipBehavior: Clip.hardEdge));
+
+    expect(UpdateCount.updateCount, equals(1));  // Check that updateRenderObject is called.
+    expect(renderClipRect.clipBehavior, equals(Clip.hardEdge));
   });
 
   testWidgets('ClipPath', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -40,22 +40,22 @@ class ValueClipper<T> extends CustomClipper<T> {
   }
 }
 
-class _UpdateCountedClipRect extends ClipRect with UpdateCount {
+class _UpdateCountedClipRect extends ClipRect {
   _UpdateCountedClipRect({Clip clipBehavior = Clip.antiAlias})
     : super(clipBehavior: clipBehavior);
 }
 
-class _UpdateCountedClipRRect extends ClipRRect with UpdateCount {
+class _UpdateCountedClipRRect extends ClipRRect {
   _UpdateCountedClipRRect({Clip clipBehavior = Clip.antiAlias})
       : super(clipBehavior: clipBehavior, borderRadius: BorderRadius.circular(1.0));
 }
 
-class _UpdateCountedClipOval extends ClipOval with UpdateCount {
+class _UpdateCountedClipOval extends ClipOval {
   _UpdateCountedClipOval({Clip clipBehavior = Clip.antiAlias})
       : super(clipBehavior: clipBehavior);
 }
 
-class _UpdateCountedClipPath extends ClipPath with UpdateCount {
+class _UpdateCountedClipPath extends ClipPath {
   _UpdateCountedClipPath({Clip clipBehavior = Clip.antiAlias})
       : super(clipBehavior: clipBehavior);
 }
@@ -66,13 +66,10 @@ void main() {
 
     final RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
     await tester.pumpWidget(_UpdateCountedClipRect(clipBehavior: Clip.hardEdge));
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
@@ -81,13 +78,10 @@ void main() {
 
     final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
     await tester.pumpWidget(_UpdateCountedClipRRect(clipBehavior: Clip.hardEdge));
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
@@ -96,13 +90,10 @@ void main() {
 
     final RenderClipOval renderClip = tester.allRenderObjects.whereType<RenderClipOval>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
     await tester.pumpWidget(_UpdateCountedClipOval(clipBehavior: Clip.hardEdge));
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
@@ -111,13 +102,10 @@ void main() {
 
     final RenderClipPath renderClip = tester.allRenderObjects.whereType<RenderClipPath>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
     await tester.pumpWidget(_UpdateCountedClipPath(clipBehavior: Clip.hardEdge));
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -40,7 +40,41 @@ class ValueClipper<T> extends CustomClipper<T> {
   }
 }
 
+mixin UpdateCount on SingleChildRenderObjectWidget {
+  static int updateCount = 0;
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    updateCount += 1;
+    super.updateRenderObject(context, renderObject);
+  }
+}
+
+class _UpdateCountedClipRect extends ClipRect with UpdateCount {
+  _UpdateCountedClipRect({Key key, Clip clipBehavior = Clip.hardEdge})
+    : super(key: key, clipBehavior: clipBehavior);
+}
+
 void main() {
+  testWidgets('ClipRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(ClipRect(key: key));
+
+    final ClipRect widget = tester.firstWidget(find.byKey(key));
+    final RenderClipRect renderClipRect = tester.renderObject(find.byWidget(widget));
+//    final RenderClipRect renderClipRect =
+//    tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderClipRect);
+
+    expect(renderClipRect.clipBehavior, equals(Clip.hardEdge));
+
+    expect(UpdateCount.updateCount, equals(0));
+    await tester.pumpWidget(ClipRect(key: key, clipBehavior: Clip.antiAlias));
+    await tester.pump();
+
+    expect(UpdateCount.updateCount, equals(1));
+    expect(renderClipRect.clipBehavior, equals(Clip.antiAlias));
+  });
+
   testWidgets('ClipPath', (WidgetTester tester) async {
     await tester.pumpWidget(
       ClipPath(

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -15,24 +15,48 @@ class _UpdateCountedPhysicalModel extends PhysicalModel with UpdateCount {
     : super(clipBehavior: clipBehavior, color: Colors.red);
 }
 
+class _UpdateCountedPhysicalShape extends PhysicalShape with UpdateCount {
+  _UpdateCountedPhysicalShape({Clip clipBehavior = Clip.none})
+      : super(clipBehavior: clipBehavior, color: Colors.red, clipper: ShapeBorderClipper(shape: CircleBorder()));
+}
+
 void main() {
   testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(home: _UpdateCountedPhysicalModel()),
     );
 
-    final RenderPhysicalModel renderPhysicalModel =
-        tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderPhysicalModel);
+    final RenderPhysicalModel renderPhysicalModel = tester.allRenderObjects.whereType<RenderPhysicalModel>().first;
 
-    expect(UpdateCount.updateCount, equals(0));
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
     expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
       MaterialApp(home: _UpdateCountedPhysicalModel(clipBehavior: Clip.antiAlias)),
     );
 
-    expect(UpdateCount.updateCount, equals(1));  // Check that updateRenderObject is called.
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderPhysicalModel.clipBehavior, equals(Clip.antiAlias));
+  });
+
+  testWidgets('PhysicalShape updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: _UpdateCountedPhysicalShape()),
+    );
+
+    final RenderPhysicalShape renderPhysicalShape = tester.allRenderObjects.whereType<RenderPhysicalShape>().first;
+
+    UpdateCount.value = 0;
+    expect(UpdateCount.value, equals(0));
+    expect(renderPhysicalShape.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(
+      MaterialApp(home: _UpdateCountedPhysicalShape(clipBehavior: Clip.antiAlias)),
+    );
+
+    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
+    expect(renderPhysicalShape.clipBehavior, equals(Clip.antiAlias));
   });
 
   testWidgets('PhysicalModel - creates a physical model layer when it needs compositing', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -10,12 +10,12 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _UpdateCountedPhysicalModel extends PhysicalModel with UpdateCount {
+class _UpdateCountedPhysicalModel extends PhysicalModel {
   _UpdateCountedPhysicalModel({Clip clipBehavior = Clip.none})
     : super(clipBehavior: clipBehavior, color: Colors.red);
 }
 
-class _UpdateCountedPhysicalShape extends PhysicalShape with UpdateCount {
+class _UpdateCountedPhysicalShape extends PhysicalShape {
   _UpdateCountedPhysicalShape({Clip clipBehavior = Clip.none})
       : super(clipBehavior: clipBehavior, color: Colors.red, clipper: ShapeBorderClipper(shape: CircleBorder()));
 }
@@ -28,15 +28,12 @@ void main() {
 
     final RenderPhysicalModel renderPhysicalModel = tester.allRenderObjects.whereType<RenderPhysicalModel>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
       MaterialApp(home: _UpdateCountedPhysicalModel(clipBehavior: Clip.antiAlias)),
     );
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderPhysicalModel.clipBehavior, equals(Clip.antiAlias));
   });
 
@@ -47,15 +44,12 @@ void main() {
 
     final RenderPhysicalShape renderPhysicalShape = tester.allRenderObjects.whereType<RenderPhysicalShape>().first;
 
-    UpdateCount.value = 0;
-    expect(UpdateCount.value, equals(0));
     expect(renderPhysicalShape.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
       MaterialApp(home: _UpdateCountedPhysicalShape(clipBehavior: Clip.antiAlias)),
     );
 
-    expect(UpdateCount.value, equals(1));  // Check that updateRenderObject is called.
     expect(renderPhysicalShape.clipBehavior, equals(Clip.antiAlias));
   });
 

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -10,17 +10,9 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _UpdateCountedPhysicalModel extends PhysicalModel {
+class _UpdateCountedPhysicalModel extends PhysicalModel with UpdateCount {
   _UpdateCountedPhysicalModel({Clip clipBehavior = Clip.none})
     : super(clipBehavior: clipBehavior, color: Colors.red);
-
-  static int updateCount = 0;
-
-  @override
-  void updateRenderObject(BuildContext context, RenderPhysicalModel renderObject) {
-    updateCount += 1;
-    super.updateRenderObject(context, renderObject);
-  }
 }
 
 void main() {
@@ -32,16 +24,14 @@ void main() {
     final RenderPhysicalModel renderPhysicalModel =
         tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderPhysicalModel);
 
-    expect(_UpdateCountedPhysicalModel.updateCount, equals(0));
+    expect(UpdateCount.updateCount, equals(0));
     expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
       MaterialApp(home: _UpdateCountedPhysicalModel(clipBehavior: Clip.antiAlias)),
     );
 
-    // Check that updateRenderObject is called.
-    expect(_UpdateCountedPhysicalModel.updateCount, equals(1));
-
+    expect(UpdateCount.updateCount, equals(1));  // Check that updateRenderObject is called.
     expect(renderPhysicalModel.clipBehavior, equals(Clip.antiAlias));
   });
 

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -10,7 +10,41 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class _UpdateCountedPhysicalModel extends PhysicalModel {
+  _UpdateCountedPhysicalModel({Clip clipBehavior = Clip.none})
+    : super(clipBehavior: clipBehavior, color: Colors.red);
+
+  static int updateCount = 0;
+
+  @override
+  void updateRenderObject(BuildContext context, RenderPhysicalModel renderObject) {
+    updateCount += 1;
+    super.updateRenderObject(context, renderObject);
+  }
+}
+
 void main() {
+  testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: _UpdateCountedPhysicalModel()),
+    );
+
+    final RenderPhysicalModel renderPhysicalModel =
+        tester.allRenderObjects.firstWhere((RenderObject object) => object is RenderPhysicalModel);
+
+    expect(_UpdateCountedPhysicalModel.updateCount, equals(0));
+    expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(
+      MaterialApp(home: _UpdateCountedPhysicalModel(clipBehavior: Clip.antiAlias)),
+    );
+
+    // Check that updateRenderObject is called.
+    expect(_UpdateCountedPhysicalModel.updateCount, equals(1));
+
+    expect(renderPhysicalModel.clipBehavior, equals(Clip.antiAlias));
+  });
+
   testWidgets('PhysicalModel - creates a physical model layer when it needs compositing', (WidgetTester tester) async {
     debugDisableShadows = false;
     await tester.pumpWidget(

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -762,14 +762,3 @@ class _TestTicker extends Ticker {
     super.dispose();
   }
 }
-
-mixin UpdateCount on RenderObjectWidget {
-  /// How many times that [updateRenderObject] is called.
-  static int value = 0;
-
-  @override
-  void updateRenderObject(BuildContext context, RenderObject renderObject) {
-    value += 1;
-    super.updateRenderObject(context, renderObject);
-  }
-}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -762,3 +762,14 @@ class _TestTicker extends Ticker {
     super.dispose();
   }
 }
+
+mixin UpdateCount on SingleChildRenderObjectWidget {
+  /// How many times that [updateRenderObject] is called.
+  static int updateCount = 0;
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    updateCount += 1;
+    super.updateRenderObject(context, renderObject);
+  }
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -763,13 +763,13 @@ class _TestTicker extends Ticker {
   }
 }
 
-mixin UpdateCount on SingleChildRenderObjectWidget {
+mixin UpdateCount on RenderObjectWidget {
   /// How many times that [updateRenderObject] is called.
-  static int updateCount = 0;
+  static int value = 0;
 
   @override
   void updateRenderObject(BuildContext context, RenderObject renderObject) {
-    updateCount += 1;
+    value += 1;
     super.updateRenderObject(context, renderObject);
   }
 }


### PR DESCRIPTION
## Description

Make `_RenderCustomClip`'s `clipBehavior` non-final so we can update it during `updateRenderObject`. This will support `clipBehavior` changes in hot reload.

## Related Issues

Fixes #30863

## Tests

I added the following tests:

* ClipRect updates clipBehavior in updateRenderObject
* ClipRRect updates clipBehavior in updateRenderObject
* ClipOval updates clipBehavior in updateRenderObject
* ClipPath updates clipBehavior in updateRenderObject
* PhysicalModel updates clipBehavior in updateRenderObject
* PhysicalShape updates clipBehavior in updateRenderObject

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
