### PR TITLE
only build asset when there is asset declared in pubspec

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -127,12 +127,13 @@ class TestCommand extends FastFlutterCommand {
       await pubGet(context: PubContext.getVerifyContext(name), skipPubspecYamlCheck: true);
     }
     final bool buildTestAssets = argResults['test-assets'];
-    if (buildTestAssets) {
-      await _buildTestAsset();
-    }
     final List<String> names = argResults['name'];
     final List<String> plainNames = argResults['plain-name'];
     final FlutterProject flutterProject = FlutterProject.current();
+
+    if (buildTestAssets && flutterProject.manifest.assets.isNotEmpty) {
+      await _buildTestAsset();
+    }
 
     Iterable<String> files = argResults.rest.map<String>((String testPath) => fs.path.absolute(testPath)).toList();
 


### PR DESCRIPTION
The asset will no long be built if there is not assets declared in pubspec.yaml.
Changed the asset loading in binding.dart accordingly

https://github.com/flutter/flutter/issues/31511

