### PR TITLE
Fix #31764: Show appropriate error message when fonts pubspec.yaml isn't iterable

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -398,11 +398,13 @@ void _validateFonts(YamlList fonts, List<String> errors) {
     if (fontMap['family'] != null && fontMap['family'] is! String) {
       errors.add('Font family must either be null or a String.');
     }
-    if (fontMap['fonts'] != null && fontMap['fonts'] is! YamlList) {
-      errors.add('Expected "fonts" to either be null or a list.');
-    }
     if (fontMap['fonts'] == null) {
       continue;
+    } else {
+      if (fontMap['fonts'] is! YamlList) {
+        errors.add('Expected "fonts" to either be null or a list.');
+        continue;
+      }
     }
     for (final YamlMap fontListItem in fontMap['fonts']) {
       for (final MapEntry<dynamic, dynamic> kvp in fontListItem.entries) {

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -400,11 +400,9 @@ void _validateFonts(YamlList fonts, List<String> errors) {
     }
     if (fontMap['fonts'] == null) {
       continue;
-    } else {
-      if (fontMap['fonts'] is! YamlList) {
-        errors.add('Expected "fonts" to either be null or a list.');
-        continue;
-      }
+    } else if (fontMap['fonts'] is! YamlList) {
+      errors.add('Expected "fonts" to either be null or a list.');
+      continue;
     }
     for (final YamlMap fontListItem in fontMap['fonts']) {
       for (final MapEntry<dynamic, dynamic> kvp in fontListItem.entries) {

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -497,11 +497,8 @@ flutter:
 ''';
       final dynamic flutterManifest = FlutterManifest.createFromString(manifest);
 
-      expect(flutterManifest, isNull);
+      expect(flutterManifest, null);
       expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));
-
-    }, overrides: <Type, Generator>{
-      Logger: () => BufferLogger(),
     });
   });
 

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 
@@ -463,6 +465,7 @@ flutter:
         expectedBuildNumber: null,
       );
     });
+
     test('parses no version clause', () async {
       const String manifest = '''
 name: test
@@ -477,6 +480,28 @@ flutter:
         expectedBuildName: null,
         expectedBuildNumber: null,
       );
+    });
+
+    testUsingContext('returns proper error when font detail is malformed', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  fonts:
+    - family: foo
+      fonts:
+        -asset: a/bar
+''';
+      final dynamic flutterManifest = FlutterManifest.createFromString(manifest);
+
+      expect(flutterManifest, isNull);
+      expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));
+
+    }, overrides: <Type, Generator>{
+      Logger: () => BufferLogger(),
     });
   });
 

--- a/packages/flutter_tools/test/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/flutter_manifest_test.dart
@@ -482,7 +482,8 @@ flutter:
       );
     });
 
-    testUsingContext('returns proper error when font detail is malformed', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/31764
+    testUsingContext('Returns proper error when font detail is malformed', () async {
       final BufferLogger logger = context.get<Logger>();
       const String manifest = '''
 name: test
@@ -495,7 +496,7 @@ flutter:
       fonts:
         -asset: a/bar
 ''';
-      final dynamic flutterManifest = FlutterManifest.createFromString(manifest);
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
 
       expect(flutterManifest, null);
       expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));


### PR DESCRIPTION
Currently, the pubspec.yaml validator checks if "fonts" isn't a YamlList, but it doesn't exit the loop.  This causes the inner loop to run when `fontMap['fonts']` isn't a list, which results in this exception: `TypeError: type 'YamlMap' is not a subtype of type 'Iterable'`

Fixes #31764