### PR TITLE
fix FlutterDriver timeout

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -448,15 +448,11 @@ class FlutterDriver {
   }
 
   /// Waits until [finder] locates the target.
-  ///
-  /// If the command times out, show a message saying things seem to be taking a long time.
   Future<void> waitFor(SerializableFinder finder, { Duration timeout }) async {
     await _sendCommand(WaitFor(finder, timeout: timeout));
   }
 
   /// Waits until [finder] can no longer locate the target.
-  ///
-  /// If the command times out, show a message saying things seem to be taking a long time.
   Future<void> waitForAbsent(SerializableFinder finder, { Duration timeout }) async {
     await _sendCommand(WaitForAbsent(finder, timeout: timeout));
   }

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -102,16 +102,6 @@ Future<T> _warnIfSlow<T>({
   return future..timeout(timeout, onTimeout: () { _log.warning(message); });
 }
 
-Duration _maxDuration(Duration a, Duration b) {
-  if (a == null)
-    return b;
-  if (b == null)
-    return a;
-  if (a > b)
-    return a;
-  return b;
-}
-
 /// A convenient accessor to frequently used finders.
 ///
 /// Examples:
@@ -416,7 +406,7 @@ class FlutterDriver {
       ).then<Map<String, dynamic>>((Object value) => value);
       response = await _warnIfSlow<Map<String, dynamic>>(
         future: future,
-        timeout: _maxDuration(command.timeout, _kUnusuallyLongTimeout),
+        timeout: command.timeout ?? _kUnusuallyLongTimeout,
         message: '${command.kind} message is taking a long time to complete...',
       );
       _logCommunication('<<< $response');
@@ -458,11 +448,15 @@ class FlutterDriver {
   }
 
   /// Waits until [finder] locates the target.
+  ///
+  /// If the command times out, show a message saying things seem to be taking a long time.
   Future<void> waitFor(SerializableFinder finder, { Duration timeout }) async {
     await _sendCommand(WaitFor(finder, timeout: timeout));
   }
 
   /// Waits until [finder] can no longer locate the target.
+  ///
+  /// If the command times out, show a message saying things seem to be taking a long time.
   Future<void> waitForAbsent(SerializableFinder finder, { Duration timeout }) async {
     await _sendCommand(WaitForAbsent(finder, timeout: timeout));
   }

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -63,7 +63,8 @@ const List<TimelineStream> _defaultStreams = <TimelineStream>[TimelineStream.all
 
 /// How long to wait before showing a message saying that
 /// things seem to be taking a long time.
-const Duration _kUnusuallyLongTimeout = Duration(seconds: 5);
+@visibleForTesting
+const Duration kUnusuallyLongTimeout = Duration(seconds: 5);
 
 /// The amount of time we wait prior to making the next attempt to connect to
 /// the VM service.
@@ -324,7 +325,7 @@ class FlutterDriver {
       // register it. If that happens, show a message but continue waiting.
       await _warnIfSlow<String>(
         future: whenServiceExtensionReady,
-        timeout: _kUnusuallyLongTimeout,
+        timeout: kUnusuallyLongTimeout,
         message: 'Flutter Driver extension is taking a long time to become available. '
                  'Ensure your test app (often "lib/main.dart") imports '
                  '"package:flutter_driver/driver_extension.dart" and '
@@ -406,7 +407,7 @@ class FlutterDriver {
       ).then<Map<String, dynamic>>((Object value) => value);
       response = await _warnIfSlow<Map<String, dynamic>>(
         future: future,
-        timeout: command.timeout ?? _kUnusuallyLongTimeout,
+        timeout: command.timeout ?? kUnusuallyLongTimeout,
         message: '${command.kind} message is taking a long time to complete...',
       );
       _logCommunication('<<< $response');
@@ -726,7 +727,7 @@ class FlutterDriver {
   /// operation.
   Future<void> startTracing({
     List<TimelineStream> streams = _defaultStreams,
-    Duration timeout = _kUnusuallyLongTimeout,
+    Duration timeout = kUnusuallyLongTimeout,
   }) async {
     assert(streams != null && streams.isNotEmpty);
     assert(timeout != null);
@@ -753,7 +754,7 @@ class FlutterDriver {
   /// operation exceeds the specified timeout; it does not actually cancel the
   /// operation.
   Future<Timeline> stopTracingAndDownloadTimeline({
-    Duration timeout = _kUnusuallyLongTimeout,
+    Duration timeout = kUnusuallyLongTimeout,
   }) async {
     assert(timeout != null);
     try {
@@ -822,7 +823,7 @@ class FlutterDriver {
   /// operation exceeds the specified timeout; it does not actually cancel the
   /// operation.
   Future<void> clearTimeline({
-    Duration timeout = _kUnusuallyLongTimeout,
+    Duration timeout = kUnusuallyLongTimeout,
   }) async {
     assert(timeout != null);
     try {

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -15,9 +15,6 @@ import 'package:quiver/testing/async.dart';
 
 import 'common.dart';
 
-/// Default timeout value.
-const Duration _kDefaultTimeout = Duration(seconds: 5);
-
 /// Magical timeout value that's different from the default.
 const Duration _kTestTimeout = Duration(milliseconds: 1234);
 const String _kSerializedTestTimeout = '1234';
@@ -399,7 +396,7 @@ void main() {
         FakeAsync().run((FakeAsync time) {
           driver.waitFor(find.byTooltip('foo'));
           expect(log, <String>[]);
-          time.elapse(_kDefaultTimeout);
+          time.elapse(kUnusuallyLongTimeout);
         });
         expect(log, <String>['[warning] FlutterDriver: waitFor message is taking a long time to complete...']);
         await logSub.cancel();
@@ -413,9 +410,10 @@ void main() {
           return Completer<Map<String, dynamic>>().future;
         });
         FakeAsync().run((FakeAsync time) {
-          driver.waitFor(find.byTooltip('foo'), timeout: _kTestTimeout);
+          final Duration customTimeout = kUnusuallyLongTimeout - const Duration(seconds: 1);
+          driver.waitFor(find.byTooltip('foo'), timeout: customTimeout);
           expect(log, <String>[]);
-          time.elapse(_kTestTimeout);
+          time.elapse(customTimeout);
         });
         expect(log, <String>['[warning] FlutterDriver: waitFor message is taking a long time to complete...']);
         await logSub.cancel();


### PR DESCRIPTION
## Description
FlutterDriver method's timeout is unexpected, I think.
example : waitFor, waitForAbsent, tap and so on.

If I pass timeout argument less than 5 seconds (ex: 3 seconds), I expect waitFor method times out in 3 seconds. But, waitFor mathod times out in 5 seconds.

→ I changed the behavior. So, now, _the behavior matches document_.

## Related Issues

* https://github.com/flutter/flutter/pull/26736

## Tests

I added the test to ensure that custom timeout works.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
