### PR TITLE
Allow DSS to be dragged when its children do not fill extent

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -271,7 +271,7 @@ class _DraggableSheetExtent {
     if (availablePixels == 0) {
       return;
     }
-    currentExtent += delta / availablePixels;
+    currentExtent += delta / availablePixels * maxExtent;
     DraggableScrollableNotification(
       minExtent: minExtent,
       maxExtent: maxExtent,
@@ -280,9 +280,6 @@ class _DraggableSheetExtent {
       context: context,
     ).dispatch(context);
   }
-
-  @override
-  String toString() => '$runtimeType{$minExtent $currentExtent $maxExtent $availablePixels}';
 }
 
 class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -262,6 +262,9 @@ class _DraggableSheetExtent {
   }
   double get currentExtent => _currentExtent.value;
 
+  double get additionalMinExtent => isAtMin ? 0.0 : 1.0;
+  double get additionalMaxExtent => isAtMax ? 0.0 : 1.0;
+
   /// The scroll position gets inputs in terms of pixels, but the extent is
   /// expected to be expressed as a number between 0..1.
   void addPixelDelta(double delta, BuildContext context) {
@@ -277,6 +280,9 @@ class _DraggableSheetExtent {
       context: context,
     ).dispatch(context);
   }
+
+  @override
+  String toString() => '$runtimeType{$minExtent $currentExtent $maxExtent $availablePixels}';
 }
 
 class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
@@ -425,6 +431,17 @@ class _DraggableScrollableSheetScrollPosition
   VoidCallback _dragCancelCallback;
   final _DraggableSheetExtent extent;
   bool get listShouldScroll => pixels > 0.0;
+
+  @override
+  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
+    // We need to provide some extra extent if we haven't yet reached the max or
+    // min extents. Otherwise, a list with fewer children than the extent of
+    // the available space will get stuck.
+    return super.applyContentDimensions(
+      minScrollExtent - extent.additionalMinExtent,
+      maxScrollExtent + extent.additionalMaxExtent,
+    );
+  }
 
   @override
   void applyUserOffset(double delta) {

--- a/packages/flutter/test/material/modal_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/modal_bottom_sheet_test.dart
@@ -297,6 +297,7 @@ void main() {
               children: <TestSemantics>[
                 TestSemantics(
                   flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                  actions: <SemanticsAction>[SemanticsAction.scrollDown, SemanticsAction.scrollUp],
                   children: <TestSemantics>[
                     TestSemantics(
                       label: 'BottomSheet',

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -8,7 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Widget _boilerplate(VoidCallback onButtonPressed) {
+  Widget _boilerplate(VoidCallback onButtonPressed, {
+    int itemCount = 100,
+    double initialChildSize = .5,
+  }) {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: Stack(
@@ -20,12 +23,13 @@ void main() {
           DraggableScrollableSheet(
             maxChildSize: 1.0,
             minChildSize: .25,
+            initialChildSize: initialChildSize,
             builder: (BuildContext context, ScrollController scrollController) {
               return Container(
                 color: const Color(0xFFABCDEF),
                 child: ListView.builder(
                   controller: scrollController,
-                  itemCount: 100,
+                  itemCount: itemCount,
                   itemBuilder: (BuildContext context, int index) => Text('Item $index'),
                 ),
               );
@@ -72,6 +76,23 @@ void main() {
         expect(find.text('Item 1'), findsOneWidget);
         expect(find.text('Item 21'), findsNothing);
         expect(find.text('Item 36'), findsNothing);
+      });
+
+      testWidgets('Can be dragged down when list is shorter than full height', (WidgetTester tester) async {
+        await tester.pumpWidget(_boilerplate(null, itemCount: 30, initialChildSize: .25));
+
+        expect(find.text('Item 1').hitTestable(), findsOneWidget);
+        expect(find.text('Item 29').hitTestable(), findsNothing);
+
+        await tester.drag(find.text('Item 1'), const Offset(0, -325));
+        await tester.pumpAndSettle();
+        expect(find.text('Item 1').hitTestable(), findsOneWidget);
+        expect(find.text('Item 29').hitTestable(), findsOneWidget);
+
+        await tester.drag(find.text('Item 1'), const Offset(0, 325));
+        await tester.pumpAndSettle();
+        expect(find.text('Item 1').hitTestable(), findsOneWidget);
+        expect(find.text('Item 29').hitTestable(), findsNothing);
       });
 
       testWidgets('Can be dragged up and cover its container and scroll in single motion, and then dragged back down', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

A `DraggableScrollableSheet` whose children will never fill its full available child height today will get "stuck" when dragged up to the full available extent of the children in the list.  This is because the scroll position ends up thinking it doesn't have any extent left to give. This PR adds to the available min/max extent if we're not actually at min/max extent.

This results in the following behavior:

- If a child list is at its "natural" max extent, it will continue to get dragged up until it reaches the parent's max extent.  It can be dragged down as well.  It will never actually scroll its contents.

While working on this, I also noticed that setting the maxChildSize to < 1.0 will make the dragging not "stick" to the finger.  This contains a fix for that - I'd split it out but then I'd have a weird merge conflict for the tests.

## Related Issues

Fixes #31739 

## Tests

New test to cover this scenario (smaller sized list can still be dragged up and down and doesn't get stuck).

New tests to check where the top of the container ends up when dragging for some values of maxChildSize.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
