### PR TITLE
[Cupertino]CupertinoNavigationBar support iconTheme like AppBar

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -303,6 +303,7 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
     return CupertinoPageScaffold(
       navigationBar: const CupertinoNavigationBar(
         trailing: ExitButton(),
+        iconTheme: IconThemeData(color: Colors.black, size: 50),
       ),
       child: SafeArea(
         top: false,

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -303,7 +303,6 @@ class Tab1ItemPageState extends State<Tab1ItemPage> {
     return CupertinoPageScaffold(
       navigationBar: const CupertinoNavigationBar(
         trailing: ExitButton(),
-        iconTheme: IconThemeData(color: Colors.black, size: 50),
       ),
       child: SafeArea(
         top: false,

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -954,7 +954,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLargeTitle,
     @required EdgeInsetsDirectional padding,
     @required bool large,
-    @required IconThemeData iconTheme
+    IconThemeData iconTheme
   }) : leading = createLeading(
          leadingKey: keys.leadingKey,
          userLeading: userLeading,
@@ -1062,7 +1062,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLeading,
     @required ModalRoute<dynamic> route,
     @required bool automaticallyImplyLeading,
-    @required IconThemeData iconTheme,
+    IconThemeData iconTheme,
   }) {
     if (
       userLeading != null ||

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -189,6 +189,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   const CupertinoNavigationBar({
     Key key,
     this.leading,
+    this.iconTheme,
     this.automaticallyImplyLeading = true,
     this.automaticallyImplyMiddle = true,
     this.previousPageTitle,
@@ -223,6 +224,13 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// will be automatically created.
   /// {@endtemplate}
   final Widget leading;
+
+  /// {@template flutter.cupertino.navBar.iconTheme}
+  /// The color, opacity, and size to use for nav bar back icons
+  ///
+  /// If this property is null, The default color is DefaultTextStyle.color, size is 34
+  /// {@endtemplate}
+  final IconThemeData iconTheme;
 
   /// {@template flutter.cupertino.navBar.automaticallyImplyLeading}
   /// Controls whether we should try to imply the leading widget if null.
@@ -404,6 +412,7 @@ class _CupertinoNavigationBarState extends State<CupertinoNavigationBar> {
       padding: widget.padding,
       userLargeTitle: null,
       large: false,
+      iconTheme: widget.iconTheme
     );
 
     final Widget navBar = _wrapWithBackground(
@@ -945,6 +954,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLargeTitle,
     @required EdgeInsetsDirectional padding,
     @required bool large,
+    @required IconThemeData iconTheme
   }) : leading = createLeading(
          leadingKey: keys.leadingKey,
          userLeading: userLeading,
@@ -957,6 +967,7 @@ class _NavigationBarStaticComponents {
          userLeading: userLeading,
          route: route,
          automaticallyImplyLeading: automaticallyImplyLeading,
+         iconTheme: iconTheme,
        ),
        backLabel = createBackLabel(
          backLabelKey: keys.backLabelKey,
@@ -1051,6 +1062,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLeading,
     @required ModalRoute<dynamic> route,
     @required bool automaticallyImplyLeading,
+    @required IconThemeData iconTheme,
   }) {
     if (
       userLeading != null ||
@@ -1062,7 +1074,7 @@ class _NavigationBarStaticComponents {
       return null;
     }
 
-    return KeyedSubtree(key: backChevronKey, child: const _BackChevron());
+    return KeyedSubtree(key: backChevronKey, child: _BackChevron(iconTheme: iconTheme));
   }
 
   /// This widget is not decorated with a font since the font style could
@@ -1276,7 +1288,9 @@ class CupertinoNavigationBarBackButton extends StatelessWidget {
 
 
 class _BackChevron extends StatelessWidget {
-  const _BackChevron({ Key key }) : super(key: key);
+  const _BackChevron({ Key key, this.iconTheme }) : super(key: key);
+
+  final IconThemeData iconTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -1290,8 +1304,8 @@ class _BackChevron extends StatelessWidget {
         text: String.fromCharCode(CupertinoIcons.back.codePoint),
         style: TextStyle(
           inherit: false,
-          color: textStyle.color,
-          fontSize: 34.0,
+          color:iconTheme?.color == null ? textStyle.color : iconTheme?.color,
+          fontSize:iconTheme?.size == null ? 34.0 : iconTheme.size,
           fontFamily: CupertinoIcons.back.fontFamily,
           package: CupertinoIcons.back.fontPackage,
         ),

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -954,7 +954,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLargeTitle,
     @required EdgeInsetsDirectional padding,
     @required bool large,
-    IconThemeData iconTheme
+    @required IconThemeData iconTheme
   }) : leading = createLeading(
          leadingKey: keys.leadingKey,
          userLeading: userLeading,
@@ -1062,7 +1062,7 @@ class _NavigationBarStaticComponents {
     @required Widget userLeading,
     @required ModalRoute<dynamic> route,
     @required bool automaticallyImplyLeading,
-    IconThemeData iconTheme,
+    @required IconThemeData iconTheme,
   }) {
     if (
       userLeading != null ||


### PR DESCRIPTION
## Description

I found that the back icon color of the CupertinoNavigationBar is` DefaultTextStyle.color` and cannot support IconTheme, so I added the `iconTheme` property just like the AppBar.

## Related Issues

NO

## Tests

I added the following tests:

I tested the  UI display in cupertino_navigation_demo
```
 navigationBar: const CupertinoNavigationBar(
        trailing: ExitButton(),
        iconTheme: IconThemeData(color: Colors.black, size: 50),
      ),
```
![image](https://user-images.githubusercontent.com/3383471/56986813-5b3a0c80-6bbe-11e9-8d26-2e38461fd835.png)




## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
