### PR TITLE
Handle notification errors

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -934,9 +934,18 @@ void restoreVmServiceConnectFunction() {
 }
 
 void _unhandledJsonRpcError(dynamic error, dynamic stack) {
+  if (error is rpc.RpcException) {
+    final rpc.RpcException rpcException = error;
+    if (rpcException.data != null && rpcException.data['id'] == null) {
+      // This can happen, e.g., if a client tries to call us before methods have
+      // been registered, but the client doesn't care for a response.
+      _log.trace('RPC client sent a notification that resulted in an error:\n$error');
+      return;
+    }
+    assert(false, 'json_rpc_2 failed to send an exception back to the client.');
+  }
   _log.trace('Unhandled RPC error:\n$error\n$stack');
-  // TODO(dnfield): https://github.com/flutter/flutter/issues/31813
-  // assert(false);
+  assert(false);
 }
 
 /// Waits for a real Dart VM service to become available, then connects using

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -237,6 +237,16 @@ class VMService {
   }
 
   static void _unhandledError(dynamic error, dynamic stack) {
+    if (error is rpc.RpcException) {
+      final rpc.RpcException rpcException = error;
+      if (rpcException.data != null && rpcException.data['id'] == null) {
+        // This can happen, e.g., if a client tries to call us before methods have
+        // been registered, but the client doesn't care for a response.
+        logger.printTrace('RPC client sent a notification that resulted in an error:\n$error');
+        return;
+      }
+      assert(false, 'json_rpc_2 failed to send an exception back to the client.');
+    }
     logger.printTrace('Error in internal implementation of JSON RPC.\n$error\n$stack');
     assert(false);
   }

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -33,6 +33,14 @@ RpcPeerConnectionFunction fuchsiaVmServiceConnectionFunction = _waitAndConnect;
 
 
 void _unhandledJsonRpcError(dynamic error, dynamic stack) {
+  if (error is json_rpc.RpcException) {
+    final json_rpc.RpcException rpcException = error;
+    if (rpcException.data != null && rpcException.data['id'] == null) {
+      // This can happen, e.g., if a client tries to call us before methods have
+      // been registered, but the client doesn't care for a response.
+      return;
+    }
+  }
   _log.fine('Error in internalimplementation of JSON RPC.\n$error\n$stack');
 }
 


### PR DESCRIPTION
## Description

This specifies the unhandled JSON RPC errors to ignore notification related errors.

Per the spec, the server is not to send anything back to the client on a notification.  If, however, the client sends a notification for a method that isn't registered, the RPC server is now pumping that back to our handler.  This adds logic to the handlers to log and ignore these exceptions.  The logs may be helpful for developers working on VM service communication, but not helpful otherwise.  Historically, these exceptions were swallowed.

## Related Issues

Addresses part of https://github.com/flutter/flutter/issues/31813 - see also #28531 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
