### PR TITLE
Pick up v1.5.4-hotfix-2 engine for flutter 1.5.4 hotfix branch

### DIFF
--- a/bin/internal/engine.version
+++ b/bin/internal/engine.version
@@ -1,1 +1,1 @@
-ca31a7c57bada458fa7f5c0d3f36bc1af4ccbc79
+52c7a1e849a170be4b2b2fe34142ca2c0a6fea1f


### PR DESCRIPTION
This rolls engine to pick up three cherry-picks for dart sdk with fixes:
```
commit a1668566e563aef64025d0af88a099cbbe847b7e [infra] Bump version file on master to 2.3.0
commit 1f2f848e135f7038dab09d0927fc9f3abfa0c3d1 [vm] Bypass malloc for large Zone allocations to avoid jemalloc leaks.
commit 9818857822aac8f84f36d84e8eea6c554dad5615 Fix an exception in flutter outline when using ui-as-code elements (issue 36772)
```