### PR TITLE
apply fp hack to Flex

### DIFF
--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -31,3 +31,10 @@ const bool kProfileMode = bool.fromEnvironment('dart.vm.profile', defaultValue: 
 /// a particular block of code will not be executed in debug mode, and hence
 /// can be removed.
 const bool kDebugMode = !kReleaseMode && !kProfileMode;
+
+/// The epsilon of tolerable double precision error.
+///
+/// This is used in various places in the framework to allow for floating point
+/// precision loss in calculations. Differences below this threshold are safe to
+/// disregard.
+const double precisionErrorTolerance = 1e-10;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -829,22 +829,27 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }
 
     // Align items along the main axis.
-    final double idealSize = canFlex && mainAxisSize == MainAxisSize.max ? maxMainSize : allocatedSize;
+    // Unfortunately, using full precision floating point here causes false
+    // positives on the overflow detection.
+    // We apply a similar hack here as _applyFloatingPointHack in
+    // text_painter.dart.
+    final double idealSize = canFlex && mainAxisSize == MainAxisSize.max
+      ? maxMainSize.ceilToDouble()
+      : allocatedSize.ceilToDouble();
     double actualSize;
-    double actualSizeDelta;
     switch (_direction) {
       case Axis.horizontal:
         size = constraints.constrain(Size(idealSize, crossSize));
-        actualSize = size.width;
-        crossSize = size.height;
+        actualSize = size.width.ceilToDouble();
+        crossSize = size.height.ceilToDouble();
         break;
       case Axis.vertical:
         size = constraints.constrain(Size(crossSize, idealSize));
-        actualSize = size.height;
-        crossSize = size.width;
+        actualSize = size.height.ceilToDouble();
+        crossSize = size.width.ceilToDouble();
         break;
     }
-    actualSizeDelta = actualSize - allocatedSize;
+    final double actualSizeDelta = (actualSize - allocatedSize).ceilToDouble();
     _overflow = math.max(0.0, -actualSizeDelta);
 
     final double remainingSpace = math.max(0.0, actualSizeDelta);

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -470,6 +470,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
 
   // Set during layout if overflow occurred on the main axis.
   double _overflow;
+  // Check whether any meaningful overflow is present. Values below an epsilon
+  // are treated as not overflowing.
   bool get _hasOverflow => _overflow > 1e-9;
 
   @override

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -472,7 +472,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _overflow;
   // Check whether any meaningful overflow is present. Values below an epsilon
   // are treated as not overflowing.
-  bool get _hasOverflow => _overflow > 1e-9;
+  bool get _hasOverflow => _overflow > precisionErrorTolerance;
 
   @override
   void setupParentData(RenderBox child) {

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -686,9 +686,6 @@ class SliverGeometry extends Diagnosticable {
   ///  * [RenderViewport.cacheExtent] for a description of a viewport's cache area.
   final double cacheExtent;
 
-  /// The epsilon of tolerable double precision error.
-  static const double precisionErrorTolerance = 1e-10;
-
   /// Asserts that this geometry is internally consistent.
   ///
   /// Does nothing if asserts are disabled. Always returns true.

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -120,7 +120,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
 
       final double firstChildScrollOffset = earliestScrollOffset - paintExtentOf(firstChild);
       // firstChildScrollOffset may contain double precision error
-      if (firstChildScrollOffset < -SliverGeometry.precisionErrorTolerance) {
+      if (firstChildScrollOffset < -precisionErrorTolerance) {
         // The first child doesn't fit within the viewport (underflow) and
         // there may be additional children above it. Find the real first child
         // and then correct the scroll position so that there's room for all and

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -26,6 +26,7 @@ void main() {
     const double slightlyLarger = 438.8571428571429;
     const double slightlySmaller = 438.85714285714283;
     final List<dynamic> exceptions = <dynamic>[];
+    final FlutterExceptionHandler oldHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };
@@ -48,6 +49,7 @@ void main() {
     pumpFrame(phase: EnginePhase.paint);
 
     expect(exceptions, isEmpty);
+    FlutterError.onError = oldHandler;
   });
 
   test('Vertical Overflow', () {

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -20,6 +20,38 @@ void main() {
     expect(flex.size.height, equals(200.0), reason: 'flex height');
   });
 
+  test('Inconsequential overflow is ignored', () {
+    // These values are meant to simulate slight rounding errors in addition
+    // or subtraction in the layout code for Flex.
+    const double slightlyLarger = 438.8571428571429;
+    const double slightlySmaller = 438.85714285714283;
+    final List<dynamic> exceptions = <dynamic>[];
+    FlutterError.onError = (FlutterErrorDetails details) {
+      exceptions.add(details.exception);
+    };
+    const BoxConstraints square = BoxConstraints.tightFor(width: slightlyLarger, height: 100.0);
+    final RenderConstrainedBox box1 = RenderConstrainedBox(additionalConstraints: square);
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      mainAxisSize: MainAxisSize.min,
+    );
+    final RenderConstrainedOverflowBox parent = RenderConstrainedOverflowBox(
+      minWidth: 0.0,
+      maxWidth: slightlySmaller,
+      minHeight: 0.0,
+      maxHeight: 400.0,
+      child: flex,
+    );
+    flex.add(box1);
+    expect(exceptions, isEmpty);
+
+    layout(parent);
+    expect(flex.size, const Size(slightlySmaller, 100.0));
+    pumpFrame(phase: EnginePhase.paint);
+
+    expect(exceptions, isEmpty);
+  });
+
   test('Vertical Overflow', () {
     final RenderConstrainedBox flexible = RenderConstrainedBox(
       additionalConstraints: const BoxConstraints.expand()

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -43,8 +43,6 @@ void main() {
       child: flex,
     );
     flex.add(box1);
-    expect(exceptions, isEmpty);
-
     layout(parent);
     expect(flex.size, const Size(slightlySmaller, 100.0));
     pumpFrame(phase: EnginePhase.paint);

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -207,10 +207,11 @@ Matcher isInstanceOf<T>() => test_package.TypeMatcher<T>();
 /// Asserts that two [double]s are equal, within some tolerated error.
 ///
 /// Two values are considered equal if the difference between them is within
-/// 1e-10 of the larger one. This is an arbitrary value which can be adjusted
-/// using the `epsilon` argument. This matcher is intended to compare floating
-/// point numbers that are the result of different sequences of operations, such
-/// that they may have accumulated slightly different errors.
+/// [precisionErrorTolerance] of the larger one. This is an arbitrary value
+/// which can be adjusted using the `epsilon` argument. This matcher is intended
+/// to compare floating point numbers that are the result of different sequences
+/// of operations, such that they may have accumulated slightly different
+/// errors.
 ///
 /// See also:
 ///
@@ -218,24 +219,25 @@ Matcher isInstanceOf<T>() => test_package.TypeMatcher<T>();
 ///    required and not named.
 ///  * [inInclusiveRange], which matches if the argument is in a specified
 ///    range.
-Matcher moreOrLessEquals(double value, { double epsilon = 1e-10 }) {
+Matcher moreOrLessEquals(double value, { double epsilon = precisionErrorTolerance }) {
   return _MoreOrLessEquals(value, epsilon);
 }
 
 /// Asserts that two [Rect]s are equal, within some tolerated error.
 ///
 /// Two values are considered equal if the difference between them is within
-/// 1e-10 of the larger one. This is an arbitrary value which can be adjusted
-/// using the `epsilon` argument. This matcher is intended to compare floating
-/// point numbers that are the result of different sequences of operations, such
-/// that they may have accumulated slightly different errors.
+/// [precisionErrorTolerance] of the larger one. This is an arbitrary value
+/// which can be adjusted using the `epsilon` argument. This matcher is intended
+/// to compare floating point numbers that are the result of different sequences
+/// of operations, such that they may have accumulated slightly different
+/// errors.
 ///
 /// See also:
 ///
 ///  * [moreOrLessEquals], which is for [double]s.
 ///  * [within], which offers a generic version of this functionality that can
 ///    be used to match [Rect]s as well as other types.
-Matcher rectMoreOrLessEquals(Rect value, { double epsilon = 1e-10 }) {
+Matcher rectMoreOrLessEquals(Rect value, { double epsilon = precisionErrorTolerance }) {
   return _IsWithinDistance<Rect>(_rectDistance, value, epsilon);
 }
 


### PR DESCRIPTION
## Description

The google3 roll is failing due to this right now. It seems to be related to the 64 bit rect change, although it's hard to tease out exactly why. The internal test case is also not failing on a local emulator, but consistently fails on emulator that is actually used for the test.

This applies the same floating point hack as used by `TextPainter` to `Flex`.  It means that very small epsilons will be ignored when calculating whether there is overflow for a `Flex`.

## Related Issues

Internal roll failures.

## Tests

I added the following tests:

A test that fails without this logic, by hard coding accumulated values from the actually failing test for our internal customer.  The test simulates the actual case in which multiple widgets/renderobjects are calculated with a simpler, hard coded version.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
