### PR TITLE
Introduce separate HitTestResults for Box and Sliver

### DIFF
--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -77,6 +77,18 @@ class SectorParentData extends ParentData {
   double theta = 0.0;
 }
 
+/// Base class for [RenderObject]s that live in a polar coordinate space.
+///
+/// In a polar coordinate system each point on a plane is determined by a
+/// distance from a reference point ("radius") and an angle from a reference
+/// direction ("theta").
+///
+/// See also:
+///
+///  * <https://en.wikipedia.org/wiki/Polar_coordinate_system>, which defines
+///    the polar coordinate space.
+///  * [RenderBox], which is the base class for [RenderObject]s that live in a
+///    cartesian coordinate space.
 abstract class RenderSector extends RenderObject {
 
   @override
@@ -608,6 +620,10 @@ class SectorHitTestResult extends HitTestResult {
   ///  * [HitTestResult.wrap], which turns a [SectorHitTestResult] back into a
   ///    generic [HitTestResult].
   SectorHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+
+  // TODO(goderbauer): Add convenience methods to transform hit test positions
+  //    once we have RenderSector implementations that move the origin of their
+  //    children (e.g. RenderSectorTransform analogues to RenderTransform).
 }
 
 /// A hit test entry used by [RenderSector].

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -136,7 +136,7 @@ abstract class RenderSector extends RenderObject {
         theta < parentData.theta || theta >= parentData.theta + deltaTheta)
       return false;
     hitTestChildren(result, radius: radius, theta: theta);
-    result.add(SliverHitTestEntry(this, radius: radius, theta: theta));
+    result.add(SectorHitTestEntry(this, radius: radius, theta: theta));
     return true;
   }
   void hitTestChildren(SectorHitTestResult result, { double radius, double theta }) { }
@@ -611,11 +611,11 @@ class SectorHitTestResult extends HitTestResult {
 }
 
 /// A hit test entry used by [RenderSector].
-class SliverHitTestEntry extends HitTestEntry {
+class SectorHitTestEntry extends HitTestEntry {
   /// Creates a box hit test entry.
   ///
   /// The [radius] and [theta] argument must not be null.
-  SliverHitTestEntry(RenderSector target, { @required this.radius,  @required this.theta })
+  SectorHitTestEntry(RenderSector target, { @required this.radius,  @required this.theta })
       : assert(radius != null),
         assert(theta != null),
         super(target);

--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
 
 const double kTwoPi = 2 * math.pi;
 
@@ -130,15 +131,15 @@ abstract class RenderSector extends RenderObject {
   @override
   Rect get semanticBounds => Rect.fromLTWH(-deltaRadius, -deltaRadius, 2.0 * deltaRadius, 2.0 * deltaRadius);
 
-  bool hitTest(HitTestResult result, { double radius, double theta }) {
+  bool hitTest(SectorHitTestResult result, { double radius, double theta }) {
     if (radius < parentData.radius || radius >= parentData.radius + deltaRadius ||
         theta < parentData.theta || theta >= parentData.theta + deltaTheta)
       return false;
     hitTestChildren(result, radius: radius, theta: theta);
-    result.add(HitTestEntry(this));
+    result.add(SliverHitTestEntry(this, radius: radius, theta: theta));
     return true;
   }
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) { }
+  void hitTestChildren(SectorHitTestResult result, { double radius, double theta }) { }
 
   double deltaRadius;
   double deltaTheta;
@@ -190,7 +191,7 @@ class RenderSectorWithChildren extends RenderDecoratedSector with ContainerRende
   RenderSectorWithChildren(BoxDecoration decoration) : super(decoration);
 
   @override
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) {
+  void hitTestChildren(SectorHitTestResult result, { double radius, double theta }) {
     RenderSector child = lastChild;
     while (child != null) {
       if (child.hitTest(result, radius: radius, theta: theta))
@@ -530,7 +531,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (child == null)
       return false;
     double x = position.dx;
@@ -547,7 +548,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
       return false;
     if (theta > child.deltaTheta)
       return false;
-    child.hitTest(result, radius: radius, theta: theta);
+    child.hitTest(SectorHitTestResult.wrap(result), radius: radius, theta: theta);
     result.add(BoxHitTestEntry(this, position));
     return true;
   }
@@ -584,4 +585,49 @@ class RenderSolidColor extends RenderDecoratedSector {
       decoration = BoxDecoration(color: backgroundColor);
     }
   }
+}
+
+/// The result of performing a hit test on [RenderSector]s.
+class SectorHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderSector].
+  SectorHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [SectorHitTestResult] protocol for hit testing on [RenderSector]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderSector]-world and the non-[RenderSector]-world to convert a (subtype of)
+  /// [HitTestResult] to a [SectorHitTestResult] for hit testing on [RenderSector]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [SectorHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [SectorHitTestResult] back into a
+  ///    generic [HitTestResult].
+  SectorHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+}
+
+/// A hit test entry used by [RenderSector].
+class SliverHitTestEntry extends HitTestEntry {
+  /// Creates a box hit test entry.
+  ///
+  /// The [radius] and [theta] argument must not be null.
+  SliverHitTestEntry(RenderSector target, { @required this.radius,  @required this.theta })
+      : assert(radius != null),
+        assert(theta != null),
+        super(target);
+
+  @override
+  RenderSector get target => super.target;
+
+  /// The radius component of the hit test position in the local coordinates of
+  /// [target].
+  final double radius;
+
+  /// The theta component of the hit test position in the local coordinates of
+  /// [target].
+  final double theta;
 }

--- a/examples/layers/test/sector_layout_test.dart
+++ b/examples/layers/test/sector_layout_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/src/sector_layout.dart';
+
+void main() {
+  group('hit testing', () {
+    test('SectorHitTestResult wrapping HitTestResult', () {
+      final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+
+      final HitTestResult wrapped = HitTestResult();
+      wrapped.add(entry1);
+      expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+
+      final SectorHitTestResult wrapping = SectorHitTestResult.wrap(wrapped);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1]));
+      expect(wrapping.path, same(wrapped.path));
+
+      wrapping.add(entry2);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+
+      wrapped.add(entry3);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    });
+  });
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
+}

--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -714,16 +714,24 @@ class _RenderCupertinoAlert extends RenderBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    bool isHit = false;
     final MultiChildLayoutParentData contentSectionParentData = contentSection.parentData;
     final MultiChildLayoutParentData actionsSectionParentData = actionsSection.parentData;
-    if (contentSection.hitTest(result, position: position - contentSectionParentData.offset)) {
-      isHit = true;
-    } else if (actionsSection.hitTest(result,
-        position: position - actionsSectionParentData.offset)) {
-      isHit = true;
-    }
-    return isHit;
+    return result.addWithPaintOffset(
+             offset: contentSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - contentSectionParentData.offset);
+               return contentSection.hitTest(result, position: transformed);
+             },
+           )
+        || result.addWithPaintOffset(
+             offset: actionsSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - actionsSectionParentData.offset);
+               return actionsSection.hitTest(result, position: transformed);
+             },
+           );
   }
 }
 

--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -719,7 +719,7 @@ class _RenderCupertinoAlert extends RenderBox {
     return result.addWithPaintOffset(
              offset: contentSectionParentData.offset,
              position: position,
-             hitTest: (HitTestResult result, Offset transformed) {
+             hitTest: (BoxHitTestResult result, Offset transformed) {
                assert(transformed == position - contentSectionParentData.offset);
                return contentSection.hitTest(result, position: transformed);
              },
@@ -727,7 +727,7 @@ class _RenderCupertinoAlert extends RenderBox {
         || result.addWithPaintOffset(
              offset: actionsSectionParentData.offset,
              position: position,
-             hitTest: (HitTestResult result, Offset transformed) {
+             hitTest: (BoxHitTestResult result, Offset transformed) {
                assert(transformed == position - actionsSectionParentData.offset);
                return actionsSection.hitTest(result, position: transformed);
              },

--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -713,7 +713,7 @@ class _RenderCupertinoAlert extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     bool isHit = false;
     final MultiChildLayoutParentData contentSectionParentData = contentSection.parentData;
     final MultiChildLayoutParentData actionsSectionParentData = actionsSection.parentData;
@@ -1261,7 +1261,7 @@ class _RenderCupertinoAlertActions extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -775,7 +775,7 @@ class _RenderCupertinoDialog extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     bool isHit = false;
     final BoxParentData contentSectionParentData = contentSection.parentData;
     final BoxParentData actionsSectionParentData = actionsSection.parentData;
@@ -1693,7 +1693,7 @@ class _RenderCupertinoDialogActions extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -781,7 +781,7 @@ class _RenderCupertinoDialog extends RenderBox {
     return result.addWithPaintOffset(
              offset: contentSectionParentData.offset,
              position: position,
-             hitTest: (HitTestResult result, Offset transformed) {
+             hitTest: (BoxHitTestResult result, Offset transformed) {
                assert(transformed == position - contentSectionParentData.offset);
                return contentSection.hitTest(result, position: transformed);
              },
@@ -789,7 +789,7 @@ class _RenderCupertinoDialog extends RenderBox {
         || result.addWithPaintOffset(
              offset: actionsSectionParentData.offset,
              position: position,
-             hitTest: (HitTestResult result, Offset transformed) {
+             hitTest: (BoxHitTestResult result, Offset transformed) {
                assert(transformed == position - actionsSectionParentData.offset);
                return actionsSection.hitTest(result, position: transformed);
              },

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -776,15 +776,24 @@ class _RenderCupertinoDialog extends RenderBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    bool isHit = false;
     final BoxParentData contentSectionParentData = contentSection.parentData;
     final BoxParentData actionsSectionParentData = actionsSection.parentData;
-    if (contentSection.hitTest(result, position: position - contentSectionParentData.offset)) {
-      isHit = true;
-    } else if (actionsSection.hitTest(result, position: position - actionsSectionParentData.offset)) {
-      isHit = true;
-    }
-    return isHit;
+    return result.addWithPaintOffset(
+             offset: contentSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - contentSectionParentData.offset);
+               return contentSection.hitTest(result, position: transformed);
+             },
+           )
+        || result.addWithPaintOffset(
+             offset: actionsSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - actionsSectionParentData.offset);
+               return actionsSection.hitTest(result, position: transformed);
+             },
+           );
   }
 }
 

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -709,7 +709,15 @@ class _RenderSegmentedControl<T> extends RenderBox
     while (child != null) {
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
       if (childParentData.surroundingRect.contains(position)) {
-        return child.hitTest(result, position: (Offset.zero & child.size).center);
+        final Offset center = (Offset.zero & child.size).center;
+        return result.addWithRawTransform(
+          transform: MatrixUtils.forceToPoint(center),
+          position: center,
+          hitTest: (HitTestResult result, Offset position) {
+            assert(position == center);
+            return child.hitTest(result, position: center);
+          },
+        );
       }
       child = childParentData.previousSibling;
     }

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -703,7 +703,7 @@ class _RenderSegmentedControl<T> extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     RenderBox child = lastChild;
     while (child != null) {

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -713,7 +713,7 @@ class _RenderSegmentedControl<T> extends RenderBox
         return result.addWithRawTransform(
           transform: MatrixUtils.forceToPoint(center),
           position: center,
-          hitTest: (HitTestResult result, Offset position) {
+          hitTest: (BoxHitTestResult result, Offset position) {
             assert(position == center);
             return child.hitTest(result, position: center);
           },

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -54,12 +54,16 @@ class HitTestEntry {
 
 /// The result of performing a hit test.
 class HitTestResult {
-  /// Creates a hit test result.
+  /// Creates an empty hit test result.
+  HitTestResult() : _path = <HitTestEntry>[];
+
+  /// Wraps `result` (usually a subtype of [HitTestResult]) to create a
+  /// generic [HitTestResult].
   ///
-  /// If the [path] argument is null, the [path] field will be initialized with
-  /// and empty list.
-  HitTestResult({ List<HitTestEntry> path })
-    : _path = path ?? <HitTestEntry>[];
+  /// The [HitTestEntry]s added to the returned [HitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  HitTestResult.wrap(HitTestResult result) : _path = result._path;
 
   /// An unmodifiable list of [HitTestEntry] objects recorded during the hit test.
   ///

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -324,7 +324,7 @@ class _RenderInputPadding extends RenderShiftedBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return super.hitTest(result, position: position) ||
       child.hitTest(result, position: child.size.center(Offset.zero));
   }

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -332,7 +332,7 @@ class _RenderInputPadding extends RenderShiftedBox {
     return result.addWithRawTransform(
       transform: MatrixUtils.forceToPoint(center),
       position: center,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         assert(position == center);
         return child.hitTest(result, position: center);
       },

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -325,7 +325,17 @@ class _RenderInputPadding extends RenderShiftedBox {
 
   @override
   bool hitTest(BoxHitTestResult result, { Offset position }) {
-    return super.hitTest(result, position: position) ||
-      child.hitTest(result, position: child.size.center(Offset.zero));
+    if (super.hitTest(result, position: position)) {
+      return true;
+    }
+    final Offset center = child.size.center(Offset.zero);
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(center),
+      position: center,
+      hitTest: (HitTestResult result, Offset position) {
+        assert(position == center);
+        return child.hitTest(result, position: center);
+      },
+    );
   }
 }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1746,7 +1746,15 @@ class _RenderChipRedirectingHitDetection extends RenderConstrainedBox {
     // Only redirects hit detection which occurs above and below the render object.
     // In order to make this assumption true, I have removed the minimum width
     // constraints, since any reasonable chip would be at least that wide.
-    return child.hitTest(result, position: Offset(position.dx, size.height / 2));
+    final Offset offset = Offset(position.dx, size.height / 2);
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(offset),
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        assert(position == offset);
+        return child.hitTest(result, position: offset);
+      },
+    );
   }
 }
 
@@ -2276,7 +2284,18 @@ class _RenderChip extends RenderBox {
           hitTestChild = label ?? avatar;
         break;
     }
-    return hitTestChild?.hitTest(result, position: hitTestChild.size.center(Offset.zero)) ?? false;
+    if (hitTestChild != null) {
+      final Offset center = hitTestChild.size.center(Offset.zero);
+      return result.addWithRawTransform(
+        transform: MatrixUtils.forceToPoint(center),
+        position: position,
+        hitTest: (HitTestResult result, Offset position) {
+          assert(position == center);
+          return hitTestChild.hitTest(result, position: center);
+        },
+      );
+    }
+    return false;
   }
 
   @override

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1740,7 +1740,7 @@ class _RenderChipRedirectingHitDetection extends RenderConstrainedBox {
   _RenderChipRedirectingHitDetection(BoxConstraints additionalConstraints) : super(additionalConstraints: additionalConstraints);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (!size.contains(position))
       return false;
     // Only redirects hit detection which occurs above and below the render object.
@@ -2258,7 +2258,7 @@ class _RenderChip extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (!size.contains(position))
       return false;
     RenderBox hitTestChild;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1750,7 +1750,7 @@ class _RenderChipRedirectingHitDetection extends RenderConstrainedBox {
     return result.addWithRawTransform(
       transform: MatrixUtils.forceToPoint(offset),
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         assert(position == offset);
         return child.hitTest(result, position: offset);
       },
@@ -2289,7 +2289,7 @@ class _RenderChip extends RenderBox {
       return result.addWithRawTransform(
         transform: MatrixUtils.forceToPoint(center),
         position: position,
-        hitTest: (HitTestResult result, Offset position) {
+        hitTest: (BoxHitTestResult result, Offset position) {
           assert(position == center);
           return hitTestChild.hitTest(result, position: center);
         },

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1284,7 +1284,7 @@ class _RenderDecoration extends RenderBox {
       final bool isHit = result.addWithPaintOffset(
         offset: offset,
         position: position,
-        hitTest: (HitTestResult result, Offset transformed) {
+        hitTest: (BoxHitTestResult result, Offset transformed) {
           assert(transformed == position - offset);
           return child.hitTest(result, position: transformed);
         },

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1280,7 +1280,16 @@ class _RenderDecoration extends RenderBox {
     assert(position != null);
     for (RenderBox child in _children) {
       // TODO(hansmuller): label must be handled specially since we've transformed it
-      if (child.hitTest(result, position: position - _boxParentData(child).offset))
+      final Offset offset = _boxParentData(child).offset;
+      final bool isHit = result.addWithPaintOffset(
+        offset: offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
+      if (isHit)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1276,7 +1276,7 @@ class _RenderDecoration extends RenderBox {
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     for (RenderBox child in _children) {
       // TODO(hansmuller): label must be handled specially since we've transformed it

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1464,7 +1464,15 @@ class _RenderListTile extends RenderBox {
     assert(position != null);
     for (RenderBox child in _children) {
       final BoxParentData parentData = child.parentData;
-      if (child.hitTest(result, position: position - parentData.offset))
+      final bool isHit = result.addWithPaintOffset(
+          offset: parentData.offset,
+          position: position,
+          hitTest: (HitTestResult result, Offset transformed) {
+            assert(transformed == position - parentData.offset);
+            return child.hitTest(result, position: transformed);
+          }
+      );
+      if (isHit)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1465,12 +1465,12 @@ class _RenderListTile extends RenderBox {
     for (RenderBox child in _children) {
       final BoxParentData parentData = child.parentData;
       final bool isHit = result.addWithPaintOffset(
-          offset: parentData.offset,
-          position: position,
-          hitTest: (HitTestResult result, Offset transformed) {
-            assert(transformed == position - parentData.offset);
-            return child.hitTest(result, position: transformed);
-          }
+        offset: parentData.offset,
+        position: position,
+        hitTest: (BoxHitTestResult result, Offset transformed) {
+          assert(transformed == position - parentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
       );
       if (isHit)
         return true;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1460,7 +1460,7 @@ class _RenderListTile extends RenderBox {
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     for (RenderBox child in _children) {
       final BoxParentData parentData = child.parentData;

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -246,6 +246,13 @@ class MatrixUtils {
     // Essentially perspective * view * model.
     return result;
   }
+
+  /// Returns a matrix that transforms every point to [offset].
+  static Matrix4 forceToPoint(Offset offset) {
+    return Matrix4.identity()
+      ..setRow(0, Vector4(0, 0, 0, offset.dx))
+      ..setRow(1, Vector4(0, 0, 0, offset.dy));
+  }
 }
 
 /// Returns a list of strings representing the given transform in a format

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -617,24 +617,27 @@ class BoxConstraints extends Constraints {
 /// See also:
 ///
 ///  * [RenderBox.hitTest], which documents more details around hit testing
-///    [RenderBox]s.
+///    [RenderBox]es.
 typedef BoxHitTest = bool Function(BoxHitTestResult result, Offset position);
 
-/// The result of performing a hit test on [RenderBox]s.
+/// The result of performing a hit test on [RenderBox]es.
+///
+/// An instance of this class is provided to [RenderBox.hitTest] to record the
+/// result of the hit test.
 class BoxHitTestResult extends HitTestResult {
   /// Creates an empty hit test result for hit testing on [RenderBox].
   BoxHitTestResult() : super();
 
   /// Wraps `result` to create a [HitTestResult] that implements the
-  /// [BoxHitTestResult] protocol for hit testing on [RenderBox]s.
+  /// [BoxHitTestResult] protocol for hit testing on [RenderBox]es.
   ///
   /// This method is used by [RenderObject]s that adapt between the
   /// [RenderBox]-world and the non-[RenderBox]-world to convert a (subtype of)
-  /// [HitTestResult] to a [BoxHitTestResult] for hit testing on [RenderBox]s.
+  /// [HitTestResult] to a [BoxHitTestResult] for hit testing on [RenderBox]es.
   ///
-  /// The [HitTestEntry]s added to the returned [BoxHitTestResult] are also
-  /// added to the wrapped `result` (both share the same underlying data
-  /// structure to store [HitTestEntry]s).
+  /// The [HitTestEntry] instances added to the returned [BoxHitTestResult] are
+  /// also added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry] instances).
   ///
   /// See also:
   ///
@@ -644,8 +647,12 @@ class BoxHitTestResult extends HitTestResult {
   ///    [SliverHitTestResult] for hit testing on [RenderSliver] children.
   BoxHitTestResult.wrap(HitTestResult result) : super.wrap(result);
 
-  /// Transforms `position` to the local coordinate system of a child before
+  /// Transforms `position` to the local coordinate system of a child for
   /// hit-testing the child.
+  ///
+  /// The actual hit testing of the child needs to be implemented in the
+  /// provided `hitTest` callback, which is invoked with the transformed
+  /// `position` as argument.
   ///
   /// Since the provided paint `transform` describes the transform from the
   /// child to the parent, the matrix is inverted before it is used to transform
@@ -719,6 +726,10 @@ class BoxHitTestResult extends HitTestResult {
   /// Convenience method for hit testing children, that are translated by
   /// an [Offset].
   ///
+  /// The actual hit testing of the child needs to be implemented in the
+  /// provided `hitTest` callback, which is invoked with the transformed
+  /// `position` as argument.
+  ///
   /// This method can be used as a convenience over [addWithPaintTransform] if
   /// a parent paints a child at an `offset`.
   ///
@@ -741,8 +752,12 @@ class BoxHitTestResult extends HitTestResult {
     );
   }
 
-  /// Transforms `position` to the local coordinate system of a child before
+  /// Transforms `position` to the local coordinate system of a child for
   /// hit-testing the child.
+  ///
+  /// The actual hit testing of the child needs to be implemented in the
+  /// provided `hitTest` callback, which is invoked with the transformed
+  /// `position` as argument.
   ///
   /// Unlike [addWithPaintTransform], the provided `transform` matrix is used
   /// directly to transform `position` without any pre-processing.

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -609,6 +609,31 @@ class BoxConstraints extends Constraints {
   }
 }
 
+/// The result of performing a hit test on [RenderBox]s.
+class BoxHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderBox].
+  BoxHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [BoxHitTestResult] protocol for hit testing on [RenderBox]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderBox]-world and the non-[RenderBox]-world to convert a (subtype of)
+  /// [HitTestResult] to a [BoxHitTestResult] for hit testing on [RenderBox]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [BoxHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [BoxHitTestResult] back into a
+  ///    generic [HitTestResult].
+  ///  * [SliverHitTestResult.wrap], which turns a [BoxHitTestResult] into a
+  ///    [SliverHitTestResult] for hit testing on [RenderSliver] children.
+  BoxHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+}
+
 /// A hit test entry used by [RenderBox].
 class BoxHitTestEntry extends HitTestEntry {
   /// Creates a box hit test entry.
@@ -1882,7 +1907,7 @@ abstract class RenderBox extends RenderObject {
   /// called. For example, a render object might be a child of a [RenderOpacity]
   /// object, which calls [hitTest] on its children when its opacity is zero
   /// even through it does not [paint] its children.
-  bool hitTest(HitTestResult result, { @required Offset position }) {
+  bool hitTest(BoxHitTestResult result, { @required Offset position }) {
     assert(() {
       if (!hasSize) {
         if (debugNeedsLayout) {
@@ -1947,7 +1972,7 @@ abstract class RenderBox extends RenderObject {
   /// Used by [hitTest]. If you override [hitTest] and do not call this
   /// function, then you don't need to implement this function.
   @protected
-  bool hitTestChildren(HitTestResult result, { Offset position }) => false;
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) => false;
 
   /// Multiply the transform from the parent's coordinate system to this box's
   /// coordinate system into the given transform.
@@ -2248,7 +2273,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
   ///
   ///  * [defaultPaint], which paints the children appropriate for this
   ///    hit-testing strategy.
-  bool defaultHitTestChildren(HitTestResult result, { Offset position }) {
+  bool defaultHitTestChildren(BoxHitTestResult result, { Offset position }) {
     // the x, y parameters have the top left of the node's box as the origin
     ChildType child = lastChild;
     while (child != null) {

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -609,6 +609,17 @@ class BoxConstraints extends Constraints {
   }
 }
 
+/// Method signature for hit testing a [RenderBox].
+///
+/// Used by [BoxHitTestResult.addWithPaintTransform] to hit test children
+/// of a [RenderBox].
+///
+/// See also:
+///
+///  * [RenderBox.hitTest], which documents more details around hit testing
+///    [RenderBox]s.
+typedef BoxHitTest = bool Function(BoxHitTestResult result, Offset position);
+
 /// The result of performing a hit test on [RenderBox]s.
 class BoxHitTestResult extends HitTestResult {
   /// Creates an empty hit test result for hit testing on [RenderBox].
@@ -632,6 +643,135 @@ class BoxHitTestResult extends HitTestResult {
   ///  * [SliverHitTestResult.wrap], which turns a [BoxHitTestResult] into a
   ///    [SliverHitTestResult] for hit testing on [RenderSliver] children.
   BoxHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+
+  /// Transforms `position` to the local coordinate system of a child before
+  /// hit-testing the child.
+  ///
+  /// Since the provided paint `transform` describes the transform from the
+  /// child to the parent, the matrix is inverted before it is used to transform
+  /// `position` from the coordinate system of the parent to the system of the
+  /// child.
+  ///
+  /// If `transform` is null it will be treated as the identity transform and
+  /// `position` is provided to the `hitTest` callback as-is. If `transform`
+  /// cannot be inverted, the `hitTest` callback is not invoked and false is
+  /// returned. Otherwise, the return value of the `hitTest` callback is
+  /// returned.
+  ///
+  /// The `position` argument may be null, which will be forwarded to the
+  /// `hitTest` callback as-is. Using null as the position can be useful if
+  /// the child speaks a different hit test protocol then the parent and the
+  /// position is not required to do the actual hit testing in that protocol.
+  ///
+  /// {@tool sample}
+  /// This method is used in [RenderBox.hitTestChildren]:
+  ///
+  /// ```dart
+  /// abstract class Foo extends RenderBox {
+  ///
+  ///   final Matrix4 _effectiveTransform = Matrix4.rotationZ(50);
+  ///
+  ///   @override
+  ///   void applyPaintTransform(RenderBox child, Matrix4 transform) {
+  ///     transform.multiply(_effectiveTransform);
+  ///   }
+  ///
+  ///   @override
+  ///   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
+  ///     return result.addWithPaintTransform(
+  ///       transform: _effectiveTransform,
+  ///       position: position,
+  ///       hitTest: (BoxHitTestResult result, Offset position) {
+  ///         return super.hitTestChildren(result, position: position);
+  ///       },
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  ///  * [addWithPaintOffset], which can be used for `transform`s that are just
+  ///    simple matrix translations by an [Offset].
+  ///  * [addWithRawTransform], which takes a transform matrix that is directly
+  ///    used to transform the position without any pre-processing.
+  bool addWithPaintTransform({
+    @required Matrix4 transform,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    if (transform != null) {
+      transform = Matrix4.tryInvert(transform);
+      if (transform == null) {
+        // Objects are not visible on screen and cannot be hit-tested.
+        return false;
+      }
+    }
+    return addWithRawTransform(
+      transform: transform,
+      position: position,
+      hitTest: hitTest,
+    );
+  }
+
+  /// Convenience method for hit testing children, that are translated by
+  /// an [Offset].
+  ///
+  /// This method can be used as a convenience over [addWithPaintTransform] if
+  /// a parent paints a child at an `offset`.
+  ///
+  /// A null value for `offset` is treated as if [Offset.zero] was provided.
+  ///
+  /// Se also:
+  ///
+  ///  * [addWithPaintTransform], which takes a generic paint transform matrix and
+  ///    documents the intended usage of this API in more detail.
+  bool addWithPaintOffset({
+    @required Offset offset,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    return addWithRawTransform(
+      transform: offset != null ? Matrix4.translationValues(-offset.dx, -offset.dy, 0.0) : null,
+      position: position,
+      hitTest: hitTest,
+    );
+  }
+
+  /// Transforms `position` to the local coordinate system of a child before
+  /// hit-testing the child.
+  ///
+  /// Unlike [addWithPaintTransform], the provided `transform` matrix is used
+  /// directly to transform `position` without any pre-processing.
+  ///
+  /// If `transform` is null it will be treated as the identity transform ad
+  /// `position` is provided to the `hitTest` callback as-is.
+  ///
+  /// The function returns the return value of the `hitTest` callback.
+  ///
+  /// The `position` argument may be null, which will be forwarded to the
+  /// `hitTest` callback as-is. Using null as the position can be useful if
+  /// the child speaks a different hit test protocol then the parent and the
+  /// position is not required to do the actual hit testing in that protocol.
+  ///
+  /// Se also:
+  ///
+  ///  * [addWithPaintTransform], which accomplishes the same thing, but takes a
+  ///    _paint_ transform matrix.
+  bool addWithRawTransform({
+    @required Matrix4 transform,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    final Offset transformedPosition = position == null || transform == null
+        ? position
+        : MatrixUtils.transformPoint(transform, position);
+    return hitTest(this, transformedPosition);
+  }
 }
 
 /// A hit test entry used by [RenderBox].
@@ -1901,6 +2041,11 @@ abstract class RenderBox extends RenderObject {
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
   ///
+  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
+  /// [BoxHitTestResult.addWithPaintOffset], or
+  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
+  /// `position` to the local coordinate system.
+  ///
   /// Hit testing requires layout to be up-to-date but does not require painting
   /// to be up-to-date. That means a render object can rely upon [performLayout]
   /// having been called in [hitTest] but cannot rely upon [paint] having been
@@ -1968,6 +2113,11 @@ abstract class RenderBox extends RenderObject {
   /// coordinates to its location relative to the origin of this [RenderBox].
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
+  ///
+  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
+  /// [BoxHitTestResult.addWithPaintOffset], or
+  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
+  /// `position` to the local coordinate system.
   ///
   /// Used by [hitTest]. If you override [hitTest] and do not call this
   /// function, then you don't need to implement this function.
@@ -2278,7 +2428,15 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
     ChildType child = lastChild;
     while (child != null) {
       final ParentDataType childParentData = child.parentData;
-      if (child.hitTest(result, position: position - childParentData.offset))
+      final bool isHit = result.addWithPaintOffset(
+        offset: childParentData.offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - childParentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
+      if (isHit)
         return true;
       child = childParentData.previousSibling;
     }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2431,7 +2431,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
       final bool isHit = result.addWithPaintOffset(
         offset: childParentData.offset,
         position: position,
-        hitTest: (HitTestResult result, Offset transformed) {
+        hitTest: (BoxHitTestResult result, Offset transformed) {
           assert(transformed == position - childParentData.offset);
           return child.hitTest(result, position: transformed);
         },

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -362,7 +362,7 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -497,7 +497,7 @@ class RenderCustomPaint extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (_foregroundPainter != null && (_foregroundPainter.hitTest(position) ?? false))
       return true;
     return super.hitTestChildren(result, position: position);

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -932,7 +932,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -369,7 +369,7 @@ class RenderFlow extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     final List<RenderBox> children = getChildrenAsList();
     for (int i = _lastPaintOrder.length - 1; i >= 0; --i) {
       final int childIndex = _lastPaintOrder[i];

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -383,7 +383,7 @@ class RenderFlow extends RenderBox
       final bool absorbed = result.addWithPaintTransform(
         transform: transform,
         position: position,
-        hitTest: (HitTestResult result, Offset position) {
+        hitTest: (BoxHitTestResult result, Offset position) {
           return child.hitTest(result, position: position);
         },
       );

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -380,15 +380,14 @@ class RenderFlow extends RenderBox
       final Matrix4 transform = childParentData._transform;
       if (transform == null)
         continue;
-      final Matrix4 inverse = Matrix4.zero();
-      final double determinate = inverse.copyInverse(transform);
-      if (determinate == 0.0) {
-        // We cannot invert the transform. That means the child doesn't appear
-        // on screen and cannot be hit.
-        continue;
-      }
-      final Offset childPosition = MatrixUtils.transformPoint(inverse, position);
-      if (child.hitTest(result, position: childPosition))
+      final bool absorbed = result.addWithPaintTransform(
+        transform: transform,
+        position: position,
+        hitTest: (HitTestResult result, Offset position) {
+          return child.hitTest(result, position: position);
+        },
+      );
+      if (absorbed)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/rendering/list_body.dart
+++ b/packages/flutter/lib/src/rendering/list_body.dart
@@ -265,7 +265,7 @@ class RenderListBody extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -947,7 +947,7 @@ class RenderListWheelViewport
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -230,7 +230,7 @@ class RenderAndroidView extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (hitTestBehavior == PlatformViewHitTestBehavior.transparent || !size.contains(position))
       return false;
     result.add(BoxHitTestEntry(this, position));
@@ -365,7 +365,7 @@ class RenderUiKitView extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (hitTestBehavior == PlatformViewHitTestBehavior.transparent || !size.contains(position))
       return false;
     result.add(BoxHitTestEntry(this, position));

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2126,7 +2126,7 @@ class RenderTransform extends RenderProxyBox {
     return result.addWithPaintTransform(
       transform: transformHitTests ? _effectiveTransform : null,
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         return super.hitTestChildren(result, position: position);
       },
     );
@@ -2307,7 +2307,7 @@ class RenderFittedBox extends RenderProxyBox {
     return result.addWithPaintTransform(
       transform: _transform,
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         return super.hitTestChildren(result, position: position);
       },
     );
@@ -2392,7 +2392,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
           ? Offset(translation.dx * size.width, translation.dy * size.height)
           : null,
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         return super.hitTestChildren(result, position: position);
       },
     );
@@ -4665,7 +4665,7 @@ class RenderFollowerLayer extends RenderProxyBox {
     return result.addWithPaintTransform(
       transform: getCurrentTransform(),
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         return super.hitTestChildren(result, position: position);
       },
     );

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -110,7 +110,7 @@ mixin RenderProxyBoxMixin<T extends RenderBox> on RenderBox, RenderObjectWithChi
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return child?.hitTest(result, position: position) ?? false;
   }
 
@@ -155,7 +155,7 @@ abstract class RenderProxyBoxWithHitTestBehavior extends RenderProxyBox {
   HitTestBehavior behavior;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     bool hitTarget = false;
     if (size.contains(position)) {
       hitTarget = hitTestChildren(result, position: position) || hitTestSelf(position);
@@ -1270,7 +1270,7 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
   Rect get _defaultClip => Offset.zero & size;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1346,7 +1346,7 @@ class RenderClipRRect extends _RenderCustomClip<RRect> {
   RRect get _defaultClip => _borderRadius.toRRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1411,7 +1411,7 @@ class RenderClipOval extends _RenderCustomClip<Rect> {
   Rect get _defaultClip => Offset.zero & size;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     _updateClip();
     assert(_clip != null);
     final Offset center = _clip.center;
@@ -1476,7 +1476,7 @@ class RenderClipPath extends _RenderCustomClip<Path> {
   Path get _defaultClip => Path()..addRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1669,7 +1669,7 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1764,7 +1764,7 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
   Path get _defaultClip => Path()..addRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -2112,7 +2112,7 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderTransform objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -2121,7 +2121,7 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (transformHitTests) {
       final Matrix4 inverse = Matrix4.tryInvert(_effectiveTransform);
       if (inverse == null) {
@@ -2302,7 +2302,7 @@ class RenderFittedBox extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (size.isEmpty)
       return false;
     _updatePaintData();
@@ -2371,7 +2371,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderFractionalTranslation objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -2388,7 +2388,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
   bool transformHitTests;
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(!debugNeedsLayout);
     if (transformHitTests) {
       position = Offset(
@@ -2907,7 +2907,7 @@ class RenderIgnorePointer extends RenderProxyBox {
   bool get _effectiveIgnoringSemantics => ignoringSemantics == null ? ignoring : ignoringSemantics;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return ignoring ? false : super.hitTest(result, position: position);
   }
 
@@ -3017,7 +3017,7 @@ class RenderOffstage extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return !offstage && super.hitTest(result, position: position);
   }
 
@@ -3113,7 +3113,7 @@ class RenderAbsorbPointer extends RenderProxyBox {
   bool get _effectiveIgnoringSemantics => ignoringSemantics == null ? absorbing : ignoringSemantics;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return absorbing
         ? size.contains(position)
         : super.hitTest(result, position: position);
@@ -4653,7 +4653,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderFollowerLayer objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -4662,7 +4662,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     final Matrix4 inverse = Matrix4.tryInvert(getCurrentTransform());
     if (inverse == null) {
       // We cannot invert the effective transform. That means the child

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2122,16 +2122,14 @@ class RenderTransform extends RenderProxyBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    if (transformHitTests) {
-      final Matrix4 inverse = Matrix4.tryInvert(_effectiveTransform);
-      if (inverse == null) {
-        // We cannot invert the effective transform. That means the child
-        // doesn't appear on screen and cannot be hit.
-        return false;
-      }
-      position = MatrixUtils.transformPoint(inverse, position);
-    }
-    return super.hitTestChildren(result, position: position);
+    assert(!transformHitTests || _effectiveTransform != null);
+    return result.addWithPaintTransform(
+      transform: transformHitTests ? _effectiveTransform : null,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -2306,14 +2304,13 @@ class RenderFittedBox extends RenderProxyBox {
     if (size.isEmpty)
       return false;
     _updatePaintData();
-    final Matrix4 inverse = Matrix4.tryInvert(_transform);
-    if (inverse == null) {
-      // We cannot invert the effective transform. That means the child
-      // doesn't appear on screen and cannot be hit.
-      return false;
-    }
-    position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTestChildren(result, position: position);
+    return result.addWithPaintTransform(
+      transform: _transform,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -2390,13 +2387,15 @@ class RenderFractionalTranslation extends RenderProxyBox {
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(!debugNeedsLayout);
-    if (transformHitTests) {
-      position = Offset(
-        position.dx - translation.dx * size.width,
-        position.dy - translation.dy * size.height,
-      );
-    }
-    return super.hitTestChildren(result, position: position);
+    return result.addWithPaintOffset(
+      offset: transformHitTests
+          ? Offset(translation.dx * size.width, translation.dy * size.height)
+          : null,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -4663,14 +4662,13 @@ class RenderFollowerLayer extends RenderProxyBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    final Matrix4 inverse = Matrix4.tryInvert(getCurrentTransform());
-    if (inverse == null) {
-      // We cannot invert the effective transform. That means the child
-      // doesn't appear on screen and cannot be hit.
-      return false;
-    }
-    position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTestChildren(result, position: position);
+    return result.addWithPaintTransform(
+      transform: getCurrentTransform(),
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -97,7 +97,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
     return result.addWithPaintTransform(
       transform: _paintTransform,
       position: position,
-      hitTest: (HitTestResult result, Offset position) {
+      hitTest: (BoxHitTestResult result, Offset position) {
         return child.hitTest(result, position: position);
       },
     );

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -94,8 +94,13 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
     assert(_paintTransform != null || debugNeedsLayout || child == null);
     if (child == null || _paintTransform == null)
       return false;
-    final Matrix4 inverse = Matrix4.inverted(_paintTransform);
-    return child.hitTest(result, position: MatrixUtils.transformPoint(inverse, position));
+    return result.addWithPaintTransform(
+      transform: _paintTransform,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return child.hitTest(result, position: position);
+      },
+    );
   }
 
   void _paintChild(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -90,7 +90,7 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(_paintTransform != null || debugNeedsLayout || child == null);
     if (child == null || _paintTransform == null)
       return false;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -75,7 +75,14 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
       final BoxParentData childParentData = child.parentData;
-      return child.hitTest(result, position: position - childParentData.offset);
+      return result.addWithPaintOffset(
+        offset: childParentData.offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - childParentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
     }
     return false;
   }

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -72,7 +72,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
       final BoxParentData childParentData = child.parentData;
       return child.hitTest(result, position: position - childParentData.offset);

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -78,7 +78,7 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
       return result.addWithPaintOffset(
         offset: childParentData.offset,
         position: position,
-        hitTest: (HitTestResult result, Offset transformed) {
+        hitTest: (BoxHitTestResult result, Offset transformed) {
           assert(transformed == position - childParentData.offset);
           return child.hitTest(result, position: transformed);
         },

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -778,6 +778,9 @@ class SliverGeometry extends Diagnosticable {
 typedef SliverHitTest = bool Function(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition });
 
 /// The result of performing a hit test on [RenderSliver]s.
+///
+/// An instance of this class is provided to [RenderSliver.hitTest] to record
+/// the result of the hit test.
 class SliverHitTestResult extends HitTestResult {
   /// Creates an empty hit test result for hit testing on [RenderSliver].
   SliverHitTestResult() : super();
@@ -790,9 +793,9 @@ class SliverHitTestResult extends HitTestResult {
   /// (subtype of) [HitTestResult] to a [SliverHitTestResult] for hit testing on
   /// [RenderSliver]s.
   ///
-  /// The [HitTestEntry]s added to the returned [SliverHitTestResult] are also
-  /// added to the wrapped `result` (both share the same underlying data
-  /// structure to store [HitTestEntry]s).
+  /// The [HitTestEntry] instances added to the returned [SliverHitTestResult]
+  /// are also added to the wrapped `result` (both share the same underlying
+  /// data structure to store [HitTestEntry] instances).
   ///
   /// See also:
   ///
@@ -803,7 +806,11 @@ class SliverHitTestResult extends HitTestResult {
   SliverHitTestResult.wrap(HitTestResult result) : super.wrap(result);
 
   /// Transforms `mainAxisPosition` and `crossAxisPosition` to the local
-  /// coordinate system of a child before hit-testing the child.
+  /// coordinate system of a child for hit-testing the child.
+  ///
+  /// The actual hit testing of the child needs to be implemented in the
+  /// provided `hitTest` callback, which is invoked with the transformed
+  /// `position` as argument.
   ///
   /// For the transform `mainAxisOffset` is subtracted from `mainAxisPosition`
   /// and `crossAxisOffset` is subtracted from `crossAxisPosition`.

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -766,6 +766,32 @@ class SliverGeometry extends Diagnosticable {
   }
 }
 
+/// The result of performing a hit test on [RenderSliver]s.
+class SliverHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderSliver].
+  SliverHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [SliverHitTestResult] protocol for hit testing on [RenderSliver]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderSliver]-world and the non-[RenderSliver]-world to convert a
+  /// (subtype of) [HitTestResult] to a [SliverHitTestResult] for hit testing on
+  /// [RenderSliver]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [SliverHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [SliverHitTestResult] back into a
+  ///    generic [HitTestResult].
+  ///  * [BoxHitTestResult.wrap], which turns a [SliverHitTestResult] into a
+  ///    [BoxHitTestResult] for hit testing on [RenderBox] children.
+  SliverHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+}
+
 /// A hit test entry used by [RenderSliver].
 ///
 /// The coordinate system used by this hit test entry is relative to the
@@ -1167,7 +1193,7 @@ abstract class RenderSliver extends RenderObject {
   /// The most straight-forward way to implement hit testing for a new sliver
   /// render object is to override its [hitTestSelf] and [hitTestChildren]
   /// methods.
-  bool hitTest(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTest(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     if (mainAxisPosition >= 0.0 && mainAxisPosition < geometry.hitTestExtent &&
         crossAxisPosition >= 0.0 && crossAxisPosition < constraints.crossAxisExtent) {
       if (hitTestChildren(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition) ||
@@ -1205,7 +1231,7 @@ abstract class RenderSliver extends RenderObject {
   ///
   /// For a discussion of the semantics of the arguments, see [hitTest].
   @protected
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) => false;
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) => false;
 
   /// Computes the portion of the region from `from` to `to` that is visible,
   /// assuming that only the region from the [SliverConstraints.scrollOffset]
@@ -1495,7 +1521,7 @@ abstract class RenderSliverHelpers implements RenderSliver {
   ///
   /// Calling this for a child that is not visible is not valid.
   @protected
-  bool hitTestBoxChild(HitTestResult result, RenderBox child, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestBoxChild(BoxHitTestResult result, RenderBox child, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     final bool rightWayUp = _getRightWayUp(constraints);
     double absolutePosition = mainAxisPosition - childMainAxisPosition(child);
     final double absoluteCrossAxisPosition = crossAxisPosition - childCrossAxisPosition(child);
@@ -1595,10 +1621,10 @@ abstract class RenderSliverSingleBoxAdapter extends RenderSliver with RenderObje
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     assert(geometry.hitTestExtent > 0.0);
     if (child != null)
-      return hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+      return hitTestBoxChild(BoxHitTestResult.wrap(result), child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -478,10 +477,11 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     RenderBox child = lastChild;
+    final BoxHitTestResult boxResult = BoxHitTestResult.wrap(result);
     while (child != null) {
-      if (hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition))
+      if (hitTestBoxChild(boxResult, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition))
         return true;
       child = childBefore(child);
     }

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -261,8 +261,17 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
 
   @override
   bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
-    if (child != null && child.geometry.hitTestExtent > 0.0)
-      return child.hitTest(result, mainAxisPosition: mainAxisPosition - childMainAxisPosition(child), crossAxisPosition: crossAxisPosition - childCrossAxisPosition(child));
+    if (child != null && child.geometry.hitTestExtent > 0.0) {
+      final SliverPhysicalParentData childParentData = child.parentData;
+      result.addWithAxisOffset(
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+        mainAxisOffset: childMainAxisPosition(child),
+        crossAxisOffset: childCrossAxisPosition(child),
+        paintOffset: childParentData.paintOffset,
+        hitTest: child.hitTest,
+      );
+    }
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'debug.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -261,7 +260,7 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     if (child != null && child.geometry.hitTestExtent > 0.0)
       return child.hitTest(result, mainAxisPosition: mainAxisPosition - childMainAxisPosition(child), crossAxisPosition: crossAxisPosition - childCrossAxisPosition(child));
     return false;

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -11,7 +11,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -169,10 +168,10 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
   double childMainAxisPosition(covariant RenderObject child) => super.childMainAxisPosition(child);
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     assert(geometry.hitTestExtent > 0.0);
     if (child != null)
-      return hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+      return hitTestBoxChild(BoxHitTestResult.wrap(result), child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -581,7 +581,7 @@ class RenderStack extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 
@@ -668,7 +668,7 @@ class RenderIndexedStack extends RenderStack {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     if (firstChild == null || index == null)
       return false;
     assert(position != null);

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -674,7 +674,14 @@ class RenderIndexedStack extends RenderStack {
     assert(position != null);
     final RenderBox child = _childAtIndex();
     final StackParentData childParentData = child.parentData;
-    return child.hitTest(result, position: position - childParentData.offset);
+    return result.addWithPaintOffset(
+      offset: childParentData.offset,
+      position: position,
+      hitTest: (HitTestResult result, Offset transformed) {
+        assert(transformed == position - childParentData.offset);
+        return child.hitTest(result, position: transformed);
+      },
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -677,7 +677,7 @@ class RenderIndexedStack extends RenderStack {
     return result.addWithPaintOffset(
       offset: childParentData.offset,
       position: position,
-      hitTest: (HitTestResult result, Offset transformed) {
+      hitTest: (BoxHitTestResult result, Offset transformed) {
         assert(transformed == position - childParentData.offset);
         return child.hitTest(result, position: transformed);
       },

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1110,7 +1110,15 @@ class RenderTable extends RenderBox {
       final RenderBox child = _children[index];
       if (child != null) {
         final BoxParentData childParentData = child.parentData;
-        if (child.hitTest(result, position: position - childParentData.offset))
+        final bool isHit = result.addWithPaintOffset(
+          offset: childParentData.offset,
+          position: position,
+          hitTest: (HitTestResult result, Offset transformed) {
+            assert(transformed == position - childParentData.offset);
+            return child.hitTest(result, position: transformed);
+          },
+        );
+        if (isHit)
           return true;
       }
     }

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1113,7 +1113,7 @@ class RenderTable extends RenderBox {
         final bool isHit = result.addWithPaintOffset(
           offset: childParentData.offset,
           position: position,
-          hitTest: (HitTestResult result, Offset transformed) {
+          hitTest: (BoxHitTestResult result, Offset transformed) {
             assert(transformed == position - childParentData.offset);
             return child.hitTest(result, position: transformed);
           },

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1104,7 +1104,7 @@ class RenderTable extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(_children.length == rows * columns);
     for (int index = _children.length - 1; index >= 0; index -= 1) {
       final RenderBox child = _children[index];

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -168,7 +168,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// normally be in physical (device) pixels.
   bool hitTest(HitTestResult result, { Offset position }) {
     if (child != null)
-      child.hitTest(result, position: position);
+      child.hitTest(BoxHitTestResult.wrap(result), position: position);
     result.add(HitTestEntry(this));
     return true;
   }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -581,7 +581,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       final bool isHit = result.addWithPaintTransform(
         transform: transform,
         position: null, // Manually adapting from box to sliver position below.
-        hitTest: (HitTestResult result, Offset _) {
+        hitTest: (BoxHitTestResult result, Offset _) {
           return child.hitTest(
             sliverResult,
             mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -10,7 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -558,7 +557,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     double mainAxisPosition, crossAxisPosition;
     switch (axis) {
       case Axis.vertical:
@@ -572,9 +571,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     }
     assert(mainAxisPosition != null);
     assert(crossAxisPosition != null);
+    final SliverHitTestResult sliverResult = SliverHitTestResult.wrap(result);
     for (RenderSliver child in childrenInHitTestOrder) {
       if (child.geometry.visible && child.hitTest(
-        result,
+        sliverResult,
         mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),
         crossAxisPosition: crossAxisPosition,
       )) {

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -573,11 +573,23 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     assert(crossAxisPosition != null);
     final SliverHitTestResult sliverResult = SliverHitTestResult.wrap(result);
     for (RenderSliver child in childrenInHitTestOrder) {
-      if (child.geometry.visible && child.hitTest(
-        sliverResult,
-        mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),
-        crossAxisPosition: crossAxisPosition,
-      )) {
+      if (!child.geometry.visible) {
+        continue;
+      }
+      final Matrix4 transform = Matrix4.identity();
+      applyPaintTransform(child, transform);
+      final bool isHit = result.addWithPaintTransform(
+        transform: transform,
+        position: null, // Manually adapting from box to sliver position below.
+        hitTest: (HitTestResult result, Offset _) {
+          return child.hitTest(
+            sliverResult,
+            mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),
+            crossAxisPosition: crossAxisPosition,
+          );
+        },
+      );
+      if (isHit) {
         return true;
       }
     }

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -748,7 +748,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -214,7 +214,7 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return child?.hitTest(result, position: position) ?? false;
   }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1446,7 +1446,7 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     if (child != null)
       return child.hitTest(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -555,7 +555,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
       final Offset transformed = position + -_paintOffset;
       return child.hitTest(result, position: transformed);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -560,7 +560,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
       return result.addWithPaintOffset(
         offset: _paintOffset,
         position: position,
-        hitTest: (HitTestResult result, Offset transformed) {
+        hitTest: (BoxHitTestResult result, Offset transformed) {
           assert(transformed == position + -_paintOffset);
           return child.hitTest(result, position: transformed);
         },

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -557,8 +557,14 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
-      final Offset transformed = position + -_paintOffset;
-      return child.hitTest(result, position: transformed);
+      return result.addWithPaintOffset(
+        offset: _paintOffset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position + -_paintOffset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
     }
     return false;
   }

--- a/packages/flutter/test/gestures/hit_test_test.dart
+++ b/packages/flutter/test/gestures/hit_test_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+
+import '../flutter_test_alternative.dart';
+
+void main() {
+  test('wrpped HitTestResult gets HitTestEntry added to wrapping HitTestResult', () async {
+    final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
+    final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
+    final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+
+    final HitTestResult wrapped = HitTestResult();
+    wrapped.add(entry1);
+    expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+
+    final HitTestResult wrapping = HitTestResult.wrap(wrapped);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1]));
+    expect(wrapping.path, same(wrapped.path));
+
+    wrapping.add(entry2);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
+    expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+
+    wrapped.add(entry3);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+  });
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
+}

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1635,8 +1635,8 @@ void main() {
     expect(fourthPos.dx, 0);
     expect(firstPos.dx, fourthPos.dx);
     expect(firstPos.dy, lessThan(fourthPos.dy));
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(firstPos)), isTrue);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(fourthPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(firstPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(fourthPos)), isFalse);
 
     TestGesture gesture = await tester.startGesture(firstPos, pointer: 7);
     await tester.pump();
@@ -1655,8 +1655,8 @@ void main() {
     Offset newFourthPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('Fourth'));
 
     expect(newFirstPos.dy, lessThan(firstPos.dy));
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isFalse);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isTrue);
 
     // Now try scrolling by dragging the selection handle.
     // Long press the middle of the word "won't" in the fourth line.
@@ -1701,8 +1701,8 @@ void main() {
     newFirstPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('First'));
     newFourthPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('Fourth'));
     expect(newFirstPos.dy, firstPos.dy);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
   });
 
   testWidgets('TextField smoke test', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/matrix_utils_test.dart
+++ b/packages/flutter/test/painting/matrix_utils_test.dart
@@ -86,4 +86,39 @@ void main() {
       0.0, moreOrLessEquals(-86.60254037844386), moreOrLessEquals(-50.0), 1.05,
     ]);
   });
+
+  test('forceToPoint', () {
+    const Offset forcedOffset = Offset(20, -30);
+    final Matrix4 forcedTransform = MatrixUtils.forceToPoint(forcedOffset);
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, forcedOffset),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, Offset.zero),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(1, 1)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-1, -1)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-20, 30)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-1.2344, 1422434.23)),
+      forcedOffset,
+    );
+  });
 }

--- a/packages/flutter/test/rendering/slivers_test.dart
+++ b/packages/flutter/test/rendering/slivers_test.dart
@@ -200,7 +200,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 300.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 700.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(130.0, 150.0));
     expect(result.path.first.target, equals(c));
   });
@@ -254,7 +254,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, -100.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, -500.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(150.0, 350.0));
     expect(result.path.first.target, equals(c));
   });
@@ -343,7 +343,7 @@ void main() {
     expect(_getPaintOrigin(sliverD), const Offset(300.0, 0.0));
     expect(_getPaintOrigin(sliverE), const Offset(700.0, 0.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(150.0, 450.0));
     expect(result.path.first.target, equals(c));
   });
@@ -397,7 +397,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(100.0, 0.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(-300.0, 0.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(550.0, 150.0));
     expect(result.path.first.target, equals(c));
   });
@@ -471,7 +471,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 300.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 700.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(130.0, 150.0));
     expect(result.path.first.target, equals(c));
   });
@@ -525,7 +525,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, -100.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, -500.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(150.0, 350.0));
     expect(result.path.first.target, equals(c));
   });
@@ -579,7 +579,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(300.0, 0.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 0.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(150.0, 450.0));
     expect(result.path.first.target, equals(c));
   });
@@ -633,7 +633,7 @@ void main() {
     expect(d.localToGlobal(const Offset(0.0, 0.0)), const Offset(100.0, 0.0));
     expect(e.localToGlobal(const Offset(0.0, 0.0)), const Offset(-300.0, 0.0));
 
-    final HitTestResult result = HitTestResult();
+    final BoxHitTestResult result = BoxHitTestResult();
     root.hitTest(result, position: const Offset(550.0, 150.0));
     expect(result.path.first.target, equals(c));
   });

--- a/packages/flutter/test/rendering/slivers_test.dart
+++ b/packages/flutter/test/rendering/slivers_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -824,4 +825,99 @@ void main() {
     // offset is not expected to impact the precedingScrollExtent.
     expect(sliver3.constraints.precedingScrollExtent, 300.0);
   });
+
+  group('hit testing', () {
+    test('SliverHitTestResult wrapping HitTestResult', () {
+      final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+
+      final HitTestResult wrapped = HitTestResult();
+      wrapped.add(entry1);
+      expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+
+      final SliverHitTestResult wrapping = SliverHitTestResult.wrap(wrapped);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1]));
+      expect(wrapping.path, same(wrapped.path));
+
+      wrapping.add(entry2);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+
+      wrapped.add(entry3);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    });
+
+    test('addWithAxisOffset', () {
+      final SliverHitTestResult result = SliverHitTestResult();
+      final List<double> mainAxisPositions = <double>[];
+      final List<double> crossAxisPositions = <double>[];
+      const Offset paintOffsetDummy = Offset.zero;
+
+      bool isHit = result.addWithAxisOffset(
+        paintOffset: paintOffsetDummy,
+        mainAxisOffset: 0.0,
+        crossAxisOffset: 0.0,
+        mainAxisPosition: 0.0,
+        crossAxisPosition: 0.0,
+        hitTest: (SliverHitTestResult result, { double mainAxisPosition, double crossAxisPosition }) {
+          expect(result, isNotNull);
+          mainAxisPositions.add(mainAxisPosition);
+          crossAxisPositions.add(crossAxisPosition);
+          return true;
+        },
+      );
+      expect(isHit, isTrue);
+      expect(mainAxisPositions.single, 0.0);
+      expect(crossAxisPositions.single, 0.0);
+      mainAxisPositions.clear();
+      crossAxisPositions.clear();
+
+      isHit = result.addWithAxisOffset(
+        paintOffset: paintOffsetDummy,
+        mainAxisOffset: 5.0,
+        crossAxisOffset: 6.0,
+        mainAxisPosition: 10.0,
+        crossAxisPosition: 20.0,
+        hitTest: (SliverHitTestResult result, { double mainAxisPosition, double crossAxisPosition }) {
+          expect(result, isNotNull);
+          mainAxisPositions.add(mainAxisPosition);
+          crossAxisPositions.add(crossAxisPosition);
+          return false;
+        },
+      );
+      expect(isHit, isFalse);
+      expect(mainAxisPositions.single, 10.0 - 5.0);
+      expect(crossAxisPositions.single, 20.0 - 6.0);
+      mainAxisPositions.clear();
+      crossAxisPositions.clear();
+
+      isHit = result.addWithAxisOffset(
+        paintOffset: paintOffsetDummy,
+        mainAxisOffset: -5.0,
+        crossAxisOffset: -6.0,
+        mainAxisPosition: 10.0,
+        crossAxisPosition: 20.0,
+        hitTest: (SliverHitTestResult result, { double mainAxisPosition, double crossAxisPosition }) {
+          expect(result, isNotNull);
+          mainAxisPositions.add(mainAxisPosition);
+          crossAxisPositions.add(crossAxisPosition);
+          return false;
+        },
+      );
+      expect(isHit, isFalse);
+      expect(mainAxisPositions.single, 10.0 + 5.0);
+      expect(crossAxisPositions.single, 20.0 + 6.0);
+      mainAxisPositions.clear();
+      crossAxisPositions.clear();
+    });
+  });
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
 }


### PR DESCRIPTION
## Description

Introduces a `BoxHitTestResult` for `RenderBox` subtypes and `SliverHitTestResult` for `RenderSliver` subtypes. These replace the generic `HitTestResult` for those subtypes and allow us to implement Sliver and Box specific hit test helpers in those new classes (see https://github.com/flutter/flutter/pull/31222 for context).

## Related Issues

https://github.com/flutter/flutter/issues/29916

## Tests

It's mostly a refactoring of existing functionality. Added tests for the newly introduced  `BoxHitTestResult` and `SliverHitTestResult`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]):
  * Methods that used to take a generic `HitTestResult` now take either `BoxHitTestResult` or `SliverHitTestResult`, https://groups.google.com/forum/#!topic/flutter-announce/CnYVAz5dR4U

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
