### PR TITLE
Report CompileTime metric in flutter build aot --report-timings.

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -203,7 +203,7 @@ class AOTSnapshotter {
     // }
 
     final SnapshotType snapshotType = SnapshotType(platform, buildMode);
-    final int genSnapshotExitCode = await _timedStep('gen_snapshot', () => genSnapshot.run(
+    final int genSnapshotExitCode = await _timedStep('snapshot(CompileTime)', () => genSnapshot.run(
       snapshotType: snapshotType,
       additionalArgs: genSnapshotArgs,
       iosArch: iosArch,
@@ -315,7 +315,7 @@ class AOTSnapshotter {
 
     final String depfilePath = fs.path.join(outputPath, 'kernel_compile.d');
     final KernelCompiler kernelCompiler = await kernelCompilerFactory.create(flutterProject);
-    final CompilerOutput compilerOutput = await _timedStep('frontend', () => kernelCompiler.compile(
+    final CompilerOutput compilerOutput = await _timedStep('frontend(CompileTime)', () => kernelCompiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath, mode: buildMode),
       mainPath: mainPath,
       packagesPath: packagesPath,
@@ -361,7 +361,7 @@ class AOTSnapshotter {
     final Stopwatch sw = Stopwatch()..start();
     final T value = await action();
     if (reportTimings) {
-      printStatus('$marker(RunTime): ${sw.elapsedMilliseconds} ms.');
+      printStatus('$marker: ${sw.elapsedMilliseconds} ms.');
     }
     return value;
   }

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -525,7 +525,7 @@ void main() {
 
       expect(genSnapshotExitCode, 0);
       expect(genSnapshot.callCount, 1);
-      expect(bufferLogger.statusText, matches(RegExp(r'gen_snapshot\(RunTime\): \d+ ms.')));
+      expect(bufferLogger.statusText, matches(RegExp(r'snapshot\(CompileTime\): \d+ ms.')));
     }, overrides: contextOverrides);
   });
 


### PR DESCRIPTION
This is the correct metric to report for compilation time benchmarks rather
than RunTime. Rename the 'gen_snapshot' value to merely 'snapshot' for
backwards compatibility and overall simplicity.

This change simplifies Dart's benchmarking of Flutter by making it easier to
adopt --report-timings (made for Dart to use), which makes the benchmarks
much more robust.

## Description

This changes matches what the Dart benchmarking infrastructure needs a little better than the existing behavior. I don't believe anything else is using --report-timings, so this should be fine to slightly change.

## Related Issues

The --report-timings flag was introduced in #30032 for use by dart's benchmarking infrastructure.

## Tests

I updated the existing test to test the new behavior. I couldn't figure out how to run the test though, `cd packages/flutter_tools $ flutter test test/base/build_test.dart` failed to me with `Failed to load test harness. Are you missing a dependency on flutter_test?` and `FileSystemException(uri=org-dartlang-untranslatable-uri:package%3Aflutter_test%2Fflutter_test.dart; message=StandardFileSystem only supports file:* and data:* URIs)`. Let's see if the PR checks work here on github.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
