### PR TITLE
[fuchsia] Add support for the 'device' command using the SDK

### DIFF
--- a/bin/internal/fuchsia.version
+++ b/bin/internal/fuchsia.version
@@ -1,1 +1,1 @@
-Ow5Xdviq7OwKr7XNuf-Bw0nBMeAr849mFn7gc_RUpzUC
+mfXzGfxNWcf6BHsv083b56vQcj96yCo0exBFBdjE4gMC

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -72,7 +72,7 @@ Future<T> runInContext<T>(
       DoctorValidatorsProvider: () => DoctorValidatorsProvider.defaultInstance,
       EmulatorManager: () => EmulatorManager(),
       FuchsiaSdk: () => FuchsiaSdk(),
-      FuchsiaArtifacts: () => FuchsiaArtifacts(),
+      FuchsiaArtifacts: () => FuchsiaArtifacts.find(),
       FuchsiaWorkflow: () => FuchsiaWorkflow(),
       Flags: () => const EmptyFlags(),
       FlutterVersion: () => FlutterVersion(const SystemClock()),

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -7,8 +7,10 @@ import 'dart:async';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/process_manager.dart';
+import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart';
 
@@ -23,8 +25,6 @@ FuchsiaArtifacts get fuchsiaArtifacts => context.get<FuchsiaArtifacts>();
 /// This workflow assumes development within the fuchsia source tree,
 /// including a working fx command-line tool in the user's PATH.
 class FuchsiaSdk {
-  static const List<String> _syslogCommand = <String>['fx', 'syslog', '--clock', 'Local'];
-
   /// Example output:
   ///    $ dev_finder list -full
   ///    > 192.168.42.56 paper-pulp-bush-angel
@@ -42,19 +42,33 @@ class FuchsiaSdk {
   /// Returns the fuchsia system logs for an attached device.
   ///
   /// Does not currently support multiple attached devices.
-  Stream<String> syslogs() {
+  Stream<String> syslogs(String id) {
     Process process;
     try {
-      final StreamController<String> controller = StreamController<String>(onCancel: () {
+      final StreamController<String> controller =
+          StreamController<String>(onCancel: () {
         process.kill();
       });
-      processManager.start(_syslogCommand).then((Process newProcess) {
+      if (fuchsiaArtifacts.sshConfig == null) {
+        return null;
+      }
+      const String remoteCommand = 'log_listener --clock Local';
+      final List<String> cmd = <String>[
+        'ssh',
+        '-F',
+        fuchsiaArtifacts.sshConfig.absolute.path,
+        id,
+        remoteCommand
+      ];
+      processManager.start(cmd).then((Process newProcess) {
         if (controller.isClosed) {
           return;
         }
         process = newProcess;
         process.exitCode.whenComplete(controller.close);
-        controller.addStream(process.stdout.transform(utf8.decoder).transform(const LineSplitter()));
+        controller.addStream(process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter()));
       });
       return controller.stream;
     } catch (exception) {
@@ -68,6 +82,35 @@ class FuchsiaSdk {
 class FuchsiaArtifacts {
   /// Creates a new [FuchsiaArtifacts].
   FuchsiaArtifacts({this.sshConfig, this.devFinder});
+
+  /// Creates a new [FuchsiaArtifacts] using the cached Fuchsia SDK.
+  ///
+  /// Finds tools under bin/cache/artifacts/fuchsia/tools.
+  /// Queries environment variables (first FUCHSIA_BUILD_DIR, then
+  /// FUCHSIA_SSH_CONFIG) to find the ssh configuration needed to talk to
+  /// a device.
+  factory FuchsiaArtifacts.find() {
+    final String fuchsia = Cache.instance.getArtifactDirectory('fuchsia').path;
+    final String tools = fs.path.join(fuchsia, 'tools');
+
+    // If FUCHSIA_BUILD_DIR is defined, then look for the ssh_config dir
+    // relative to it. Next, if FUCHSIA_SSH_CONFIG is defined, then use it.
+    // TODO(zra): Consider passing the ssh config path in with a flag.
+    File sshConfig;
+    if (platform.environment.containsKey(_kFuchsiaBuildDir)) {
+      sshConfig = fs.file(fs.path.join(
+          platform.environment[_kFuchsiaSshConfig], 'ssh-keys', 'ssh_config'));
+    } else if (platform.environment.containsKey(_kFuchsiaSshConfig)) {
+      sshConfig = fs.file(platform.environment[_kFuchsiaSshConfig]);
+    }
+    return FuchsiaArtifacts(
+      sshConfig: sshConfig,
+      devFinder: fs.file(fs.path.join(tools, 'dev_finder')),
+    );
+  }
+
+  static const String _kFuchsiaSshConfig = 'FUCHSIA_SSH_CONFIG';
+  static const String _kFuchsiaBuildDir = 'FUCHSIA_BUILD_DIR';
 
   /// The location of the SSH configuration file used to interact with a
   /// Fuchsia device.

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -66,7 +66,8 @@ void main() {
       any,
       environment: anyNamed('environment'),
       workingDirectory: anyNamed('workingDirectory'),
-    )).thenAnswer((Invocation invocation) => Future<ProcessResult>.value(mockProcessResult));
+    )).thenAnswer((Invocation invocation) =>
+        Future<ProcessResult>.value(mockProcessResult));
     when(mockProcessResult.exitCode).thenReturn(1);
     when<String>(mockProcessResult.stdout).thenReturn('');
     when<String>(mockProcessResult.stderr).thenReturn('');
@@ -79,7 +80,8 @@ void main() {
       any,
       environment: anyNamed('environment'),
       workingDirectory: anyNamed('workingDirectory'),
-    )).thenAnswer((Invocation invocation) => Future<ProcessResult>.value(emptyStdoutProcessResult));
+    )).thenAnswer((Invocation invocation) =>
+        Future<ProcessResult>.value(emptyStdoutProcessResult));
     when(emptyStdoutProcessResult.exitCode).thenReturn(0);
     when<String>(emptyStdoutProcessResult.stdout).thenReturn('');
     when<String>(emptyStdoutProcessResult.stderr).thenReturn('');
@@ -92,23 +94,26 @@ void main() {
       } on ToolExit catch (err) {
         toolExit = err;
       }
-      expect(toolExit.message, contains('No Dart Observatories found. Are you running a debug build?'));
+      expect(
+          toolExit.message,
+          contains(
+              'No Dart Observatories found. Are you running a debug build?'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => emptyStdoutProcessManager,
       FuchsiaArtifacts: () => FuchsiaArtifacts(
-        sshConfig: mockFile,
-        devFinder: mockFile,
-      ),
+            sshConfig: mockFile,
+            devFinder: mockFile,
+          ),
     });
 
     group('device logs', () {
       const String exampleUtcLogs = '''
-[2018-11-09 01:27:45][3][297950920][log] INFO: example_app(flutter): Error doing thing
+[2018-11-09 01:27:45][3][297950920][log] INFO: example_app.cmx(flutter): Error doing thing
 [2018-11-09 01:27:58][46257][46269][foo] INFO: Using a thing
 [2018-11-09 01:29:58][46257][46269][foo] INFO: Blah blah blah
-[2018-11-09 01:29:58][46257][46269][foo] INFO: other_app(flutter): Do thing
+[2018-11-09 01:29:58][46257][46269][foo] INFO: other_app.cmx(flutter): Do thing
 [2018-11-09 01:30:02][41175][41187][bar] INFO: Invoking a bar
-[2018-11-09 01:30:12][52580][52983][log] INFO: example_app(flutter): Did thing this time
+[2018-11-09 01:30:12][52580][52983][log] INFO: example_app.cmx(flutter): Did thing this time
 
   ''';
       final MockProcessManager mockProcessManager = MockProcessManager();
@@ -116,10 +121,16 @@ void main() {
       Completer<int> exitCode;
       StreamController<List<int>> stdout;
       StreamController<List<int>> stderr;
-      when(mockProcessManager.start(any)).thenAnswer((Invocation _) => Future<Process>.value(mockProcess));
+      when(mockProcessManager.start(any))
+          .thenAnswer((Invocation _) => Future<Process>.value(mockProcess));
       when(mockProcess.exitCode).thenAnswer((Invocation _) => exitCode.future);
       when(mockProcess.stdout).thenAnswer((Invocation _) => stdout.stream);
       when(mockProcess.stderr).thenAnswer((Invocation _) => stderr.stream);
+
+      final MockFile devFinder = MockFile();
+      final MockFile sshConfig = MockFile();
+      when(devFinder.absolute).thenReturn(devFinder);
+      when(sshConfig.absolute).thenReturn(sshConfig);
 
       setUp(() {
         stdout = StreamController<List<int>>(sync: true);
@@ -133,7 +144,8 @@ void main() {
 
       testUsingContext('can be parsed for an app', () async {
         final FuchsiaDevice device = FuchsiaDevice('id', name: 'tester');
-        final DeviceLogReader reader = device.getLogReader(app: FuchsiaModulePackage(name: 'example_app'));
+        final DeviceLogReader reader = device.getLogReader(
+            app: FuchsiaModulePackage(name: 'example_app.cmx'));
         final List<String> logLines = <String>[];
         final Completer<void> lock = Completer<void>();
         reader.logLines.listen((String line) {
@@ -155,11 +167,14 @@ void main() {
       }, overrides: <Type, Generator>{
         ProcessManager: () => mockProcessManager,
         SystemClock: () => SystemClock.fixed(DateTime(2018, 11, 9, 1, 25, 45)),
+        FuchsiaArtifacts: () =>
+            FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
       });
 
       testUsingContext('cuts off prior logs', () async {
         final FuchsiaDevice device = FuchsiaDevice('id', name: 'tester');
-        final DeviceLogReader reader = device.getLogReader(app: FuchsiaModulePackage(name: 'example_app'));
+        final DeviceLogReader reader = device.getLogReader(
+            app: FuchsiaModulePackage(name: 'example_app.cmx'));
         final List<String> logLines = <String>[];
         final Completer<void> lock = Completer<void>();
         reader.logLines.listen((String line) {
@@ -178,6 +193,8 @@ void main() {
       }, overrides: <Type, Generator>{
         ProcessManager: () => mockProcessManager,
         SystemClock: () => SystemClock.fixed(DateTime(2018, 11, 9, 1, 29, 45)),
+        FuchsiaArtifacts: () =>
+            FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
       });
 
       testUsingContext('can be parsed for all apps', () async {
@@ -205,12 +222,15 @@ void main() {
       }, overrides: <Type, Generator>{
         ProcessManager: () => mockProcessManager,
         SystemClock: () => SystemClock.fixed(DateTime(2018, 11, 9, 1, 25, 45)),
+        FuchsiaArtifacts: () =>
+            FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
       });
     });
   });
 
   group(FuchsiaIsolateDiscoveryProtocol, () {
-    Future<Uri> findUri(List<MockFlutterView> views, String expectedIsolateName) {
+    Future<Uri> findUri(
+        List<MockFlutterView> views, String expectedIsolateName) {
       final MockPortForwarder portForwarder = MockPortForwarder();
       final MockVMService vmService = MockVMService();
       final MockVM vm = MockVM();
@@ -220,33 +240,43 @@ void main() {
       for (MockFlutterView view in views) {
         view.owner = vm;
       }
-      final MockFuchsiaDevice fuchsiaDevice = MockFuchsiaDevice('123', portForwarder, false);
-      final FuchsiaIsolateDiscoveryProtocol discoveryProtocol = FuchsiaIsolateDiscoveryProtocol(
+      final MockFuchsiaDevice fuchsiaDevice =
+          MockFuchsiaDevice('123', portForwarder, false);
+      final FuchsiaIsolateDiscoveryProtocol discoveryProtocol =
+          FuchsiaIsolateDiscoveryProtocol(
         fuchsiaDevice,
         expectedIsolateName,
         (Uri uri) async => vmService,
         true, // only poll once.
       );
-      when(fuchsiaDevice.servicePorts()).thenAnswer((Invocation invocation) async => <int>[1]);
-      when(portForwarder.forward(1)).thenAnswer((Invocation invocation) async => 2);
-      when(vmService.getVM()).thenAnswer((Invocation invocation) => Future<void>.value(null));
-      when(vmService.refreshViews()).thenAnswer((Invocation invocation) => Future<void>.value(null));
+      when(fuchsiaDevice.servicePorts())
+          .thenAnswer((Invocation invocation) async => <int>[1]);
+      when(portForwarder.forward(1))
+          .thenAnswer((Invocation invocation) async => 2);
+      when(vmService.getVM())
+          .thenAnswer((Invocation invocation) => Future<void>.value(null));
+      when(vmService.refreshViews())
+          .thenAnswer((Invocation invocation) => Future<void>.value(null));
       when(vmService.httpAddress).thenReturn(Uri.parse('example'));
       return discoveryProtocol.uri;
     }
-    testUsingContext('can find flutter view with matching isolate name', () async {
+
+    testUsingContext('can find flutter view with matching isolate name',
+        () async {
       const String expectedIsolateName = 'foobar';
       final Uri uri = await findUri(<MockFlutterView>[
         MockFlutterView(null), // no ui isolate.
         MockFlutterView(MockIsolate('wrong name')), // wrong name.
         MockFlutterView(MockIsolate(expectedIsolateName)), // matching name.
       ], expectedIsolateName);
-      expect(uri.toString(), 'http://${InternetAddress.loopbackIPv4.address}:0/');
+      expect(
+          uri.toString(), 'http://${InternetAddress.loopbackIPv4.address}:0/');
     }, overrides: <Type, Generator>{
       Logger: () => StdoutLogger(),
     });
 
-    testUsingContext('can handle flutter view without matching isolate name', () async {
+    testUsingContext('can handle flutter view without matching isolate name',
+        () async {
       const String expectedIsolateName = 'foobar';
       final Future<Uri> uri = findUri(<MockFlutterView>[
         MockFlutterView(null), // no ui isolate.

--- a/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsia_workflow_test.dart
@@ -12,37 +12,47 @@ import '../src/common.dart';
 import '../src/context.dart';
 
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
+
 class MockFile extends Mock implements File {}
 
 void main() {
-  group('android workflow', () {
+  group('Fuchsia workflow', () {
     final MockFile devFinder = MockFile();
     final MockFile sshConfig = MockFile();
     when(devFinder.absolute).thenReturn(devFinder);
     when(sshConfig.absolute).thenReturn(sshConfig);
 
-    testUsingContext('can not list and launch devices if there is not ssh config and dev finder', () {
+    testUsingContext(
+        'can not list and launch devices if there is not ssh config and dev finder',
+        () {
       expect(fuchsiaWorkflow.canLaunchDevices, false);
       expect(fuchsiaWorkflow.canListDevices, false);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: null, sshConfig: null),
+      FuchsiaArtifacts: () =>
+          FuchsiaArtifacts(devFinder: null, sshConfig: null),
     });
 
-    testUsingContext('can not list and launch devices if there is not ssh config and dev finder', () {
+    testUsingContext(
+        'can not list and launch devices if there is not ssh config and dev finder',
+        () {
       expect(fuchsiaWorkflow.canLaunchDevices, false);
       expect(fuchsiaWorkflow.canListDevices, true);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: devFinder, sshConfig: null),
+      FuchsiaArtifacts: () =>
+          FuchsiaArtifacts(devFinder: devFinder, sshConfig: null),
     });
 
-    testUsingContext('can list and launch devices supported if there is a `fx` command', () {
+    testUsingContext(
+        'can list and launch devices supported with sufficient SDK artifacts',
+        () {
       expect(fuchsiaWorkflow.canLaunchDevices, true);
       expect(fuchsiaWorkflow.canListDevices, true);
       expect(fuchsiaWorkflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
-      FuchsiaArtifacts: () => FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
+      FuchsiaArtifacts: () =>
+          FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
     });
   });
 }


### PR DESCRIPTION
## Description

This PR adds `FuchsiaArtifacts.find()` and makes various adjustments such that the
command `flutter devices` works using the Fuchsia SDK artifacts.

It also updates the Fuchsia SDK hash. In a separate change we'll need separate
hashes/artifacts for Linux and MacOS.

## Related Issues

A bit of ramp-up for #31142 - #31147

## Tests

Adjusted test in fuchsia_device_tests.dart and fuchsia_workflow_tests.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
