### PR TITLE
Simplify drawer scrimColor defaults, update tests

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -181,7 +181,7 @@ class DrawerController extends StatefulWidget {
     @required this.alignment,
     this.drawerCallback,
     this.dragStartBehavior = DragStartBehavior.start,
-    this.scrimColor = Colors.black54,
+    this.scrimColor,
   }) : assert(child != null),
        assert(dragStartBehavior != null),
        assert(alignment != null),
@@ -223,7 +223,7 @@ class DrawerController extends StatefulWidget {
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.
   ///
-  /// By default, the color is [Colors.black54]
+  /// By default, the color used is [Colors.black54]
   final Color scrimColor;
 
   @override
@@ -237,7 +237,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   @override
   void initState() {
     super.initState();
-    _color = ColorTween(begin: Colors.transparent, end: widget.scrimColor);
+    _color = ColorTween(begin: Colors.transparent, end: widget.scrimColor ?? Colors.black54,);
     _controller = AnimationController(duration: _kBaseSettleDuration, vsync: this)
       ..addListener(_animationChanged)
       ..addStatusListener(_animationStatusChanged);
@@ -248,6 +248,13 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     _historyEntry?.remove();
     _controller.dispose();
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(DrawerController oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.scrimColor != oldWidget.scrimColor)
+      _color = ColorTween(begin: Colors.transparent, end: widget.scrimColor ?? Colors.black54,);
   }
 
   void _animationChanged() {
@@ -452,7 +459,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
                   onTap: close,
                   child: Semantics(
                     label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
-                    child: Container(
+                    child: Container( // The drawer's "scrim"
                       color: _color.evaluate(_controller),
                     ),
                   ),

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -237,7 +237,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   @override
   void initState() {
     super.initState();
-    _color = ColorTween(begin: Colors.transparent, end: widget.scrimColor ?? Colors.black54,);
+    _color = _buildScrimColorTween();
     _controller = AnimationController(duration: _kBaseSettleDuration, vsync: this)
       ..addListener(_animationChanged)
       ..addStatusListener(_animationStatusChanged);
@@ -254,7 +254,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   void didUpdateWidget(DrawerController oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.scrimColor != oldWidget.scrimColor)
-      _color = ColorTween(begin: Colors.transparent, end: widget.scrimColor ?? Colors.black54,);
+      _color = _buildScrimColorTween();
   }
 
   void _animationChanged() {
@@ -395,6 +395,10 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
   ColorTween _color;
   final GlobalKey _gestureDetectorKey = GlobalKey();
+
+  ColorTween _buildScrimColorTween() {
+    return ColorTween(begin: Colors.transparent, end: widget.scrimColor ?? Colors.black54);
+  }
 
   AlignmentDirectional get _drawerOuterAlignment {
     assert(widget.alignment != null);

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -237,7 +237,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   @override
   void initState() {
     super.initState();
-    _color = _buildScrimColorTween();
+    _scrimColorTween = _buildScrimColorTween();
     _controller = AnimationController(duration: _kBaseSettleDuration, vsync: this)
       ..addListener(_animationChanged)
       ..addStatusListener(_animationStatusChanged);
@@ -254,7 +254,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   void didUpdateWidget(DrawerController oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.scrimColor != oldWidget.scrimColor)
-      _color = _buildScrimColorTween();
+      _scrimColorTween = _buildScrimColorTween();
   }
 
   void _animationChanged() {
@@ -393,7 +393,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
       widget.drawerCallback(false);
   }
 
-  ColorTween _color;
+  ColorTween _scrimColorTween;
   final GlobalKey _gestureDetectorKey = GlobalKey();
 
   ColorTween _buildScrimColorTween() {
@@ -464,7 +464,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
                   child: Semantics(
                     label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
                     child: Container( // The drawer's "scrim"
-                      color: _color.evaluate(_controller),
+                      color: _scrimColorTween.evaluate(_controller),
                     ),
                   ),
                 ),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -904,7 +904,7 @@ class Scaffold extends StatefulWidget {
     this.primary = true,
     this.drawerDragStartBehavior = DragStartBehavior.start,
     this.extendBody = false,
-    this.drawerScrimColor = Colors.black54,
+    this.drawerScrimColor,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(drawerDragStartBehavior != null),


### PR DESCRIPTION
Fix a small bug introduced by https://github.com/flutter/flutter/pull/31025: changing the DrawerController's scrimColor didn't update the DrawerControllerState's cached color Tween.

Simplified the defaulting a little: DrawerController provides the default scrimColor; all scrim color parameters default to null.
