### PR TITLE
Add a template for plugin issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/PLUGIN_ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/PLUGIN_ISSUE.md
@@ -1,0 +1,63 @@
+
+---
+name: I have a problem with one of the plugins in the flutter/plugins repository.
+about: You are having an issue with one of the plugins from the flutter/plugins repository or with the plugin infrastructure (platform channels, platform views, dependency systems, etc...).
+title: ''
+labels: plugin
+assignees: ''
+
+---
+
+<!-- Thank you for using Flutter!
+
+     If you are looking for support, please check out our documentation
+     or consider asking a question on Stack Overflow:
+      * https://flutter.dev/
+      * https://api.flutter.dev/
+      * https://stackoverflow.com/questions/tagged/flutter?sort=frequent
+
+     If you have found a bug or if our documentation doesn't have an answer
+     to what you're looking for, then fill our the template below. Please read
+     our guide to filing a bug first: https://flutter.dev/docs/resources/bug-reports
+-->
+
+## Steps to Reproduce
+
+<!--
+     Please tell us exactly how to reproduce the problem you are running into.
+
+     Please attach a small application (ideally just one main.dart file) that
+     reproduces the problem. You could use https://gist.github.com/ for this.
+
+     If the problem is with your application's rendering, then please attach
+     a screenshot and explain what the problem is.
+-->
+
+1. ...
+2. ...
+3. ...
+
+## Logs
+
+<!--
+      Run your application with `flutter run --verbose` and attach all the
+      log output below between the lines with the backticks. If there is an
+      exception, please see if the error message includes enough information
+      to explain how to solve the issue.
+-->
+
+```
+```
+
+<!--
+     Run `flutter analyze` and attach any output of that command below.
+     If there are any analysis errors, try resolving them before filing this issue.
+-->
+
+```
+```
+
+<!-- Finally, paste the output of running `flutter doctor -v` here. -->
+
+```
+```


### PR DESCRIPTION
## Description

Adds an issue template for plugin issues.
We mainly need this to auto-apply the `plugin` label as at plugin triage we filter by this label.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [N/A] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
