### PR TITLE
Cupertino Turkish Translation

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tr.arb
@@ -1,0 +1,22 @@
+{
+  "datePickerHourSemanticsLabelOne": "bir saat",
+  "datePickerHourSemanticsLabelOther": "$hour saat",
+  "datePickerMinuteSemanticsLabelOne": "bir dakika",
+  "datePickerMinuteSemanticsLabelOther": "$minute dakika",
+  "datePickerDateOrder": "dmy",
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "anteMeridiemAbbreviation": "ÖÖ",
+  "postMeridiemAbbreviation": "ÖS",
+  "todayLabel": "Bugün",
+  "alertDialogLabel": "Uyarı",
+  "timerPickerHourLabelOne": "saat",
+  "timerPickerHourLabelOther": "saat",
+  "timerPickerMinuteLabelOne": "dk.",
+  "timerPickerMinuteLabelOther": "dk.",
+  "timerPickerSecondLabelOne": "sn.",
+  "timerPickerSecondLabelOther": "sn.",
+  "cutButtonLabel": "Kes",
+  "copyButtonLabel": "Kopyala",
+  "pasteButtonLabel": "Yapıştır",
+  "selectAllButtonLabel": "Tümünü Seç"
+}

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -197,6 +197,94 @@ class CupertinoLocalizationFr extends GlobalCupertinoLocalizations {
   String get todayLabel => r'aujourd' "'" r'hui';
 }
 
+/// The translations for Turkish (`tr`).
+class CupertinoLocalizationTr extends GlobalCupertinoLocalizations {
+  /// Create an instance of the translation bundle for Turkish.
+  ///
+  /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
+  const CupertinoLocalizationTr({
+    String localeName = 'tr',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat dayFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat singleDigitHourFormat,
+    @required intl.DateFormat singleDigitMinuteFormat,
+    @required intl.DateFormat doubleDigitMinuteFormat,
+    @required intl.DateFormat singleDigitSecondFormat,
+    @required intl.NumberFormat decimalFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    dayFormat: dayFormat,
+    mediumDateFormat: mediumDateFormat,
+    singleDigitHourFormat: singleDigitHourFormat,
+    singleDigitMinuteFormat: singleDigitMinuteFormat,
+    doubleDigitMinuteFormat: doubleDigitMinuteFormat,
+    singleDigitSecondFormat: singleDigitSecondFormat,
+    decimalFormat: decimalFormat,
+  );
+
+  @override
+  String get alertDialogLabel => r'Uyarı';
+
+  @override
+  String get anteMeridiemAbbreviation => r'ÖÖ';
+
+  @override
+  String get copyButtonLabel => r'Kopyala';
+
+  @override
+  String get cutButtonLabel => r'Kes';
+
+  @override
+  String get datePickerDateOrderString => r'dmy';
+
+  @override
+  String get datePickerDateTimeOrderString => r'date_time_dayPeriod';
+
+  @override
+  String get datePickerHourSemanticsLabelOne => r'bir saat';
+
+  @override
+  String get datePickerHourSemanticsLabelOther => r'$hour saat';
+
+  @override
+  String get datePickerMinuteSemanticsLabelOne => r'bir dakika';
+
+  @override
+  String get datePickerMinuteSemanticsLabelOther => r'$minute dakika';
+
+  @override
+  String get pasteButtonLabel => r'Yapıştır';
+
+  @override
+  String get postMeridiemAbbreviation => r'ÖS';
+
+  @override
+  String get selectAllButtonLabel => r'Tümünü Seç';
+
+  @override
+  String get timerPickerHourLabelOne => r'saat';
+
+  @override
+  String get timerPickerHourLabelOther => r'saat';
+
+  @override
+  String get timerPickerMinuteLabelOne => r'dk.';
+
+  @override
+  String get timerPickerMinuteLabelOther => r'dk.';
+
+  @override
+  String get timerPickerSecondLabelOne => r'sn.';
+
+  @override
+  String get timerPickerSecondLabelOther => r'sn.';
+
+  @override
+  String get todayLabel => r'Bugün';
+}
+
 /// The set of supported languages, as language code strings.
 ///
 /// The [GlobalCupertinoLocalizations.delegate] can generate localizations for
@@ -211,6 +299,7 @@ class CupertinoLocalizationFr extends GlobalCupertinoLocalizations {
 final Set<String> kCupertinoSupportedLanguages = HashSet<String>.from(const <String>[
   'en', // English
   'fr', // French
+  'tr', // Turkish
 ]);
 
 /// Creates a [GlobalCupertinoLocalizations] instance for the given `locale`.
@@ -225,6 +314,7 @@ final Set<String> kCupertinoSupportedLanguages = HashSet<String>.from(const <Str
 /// {@template flutter.localizations.cupertino.languages}
 ///  * `en` - English
 ///  * `fr` - French
+///  * `tr` - Turkish
 /// {@endtemplate}
 ///
 /// Generally speaking, this method is only intended to be used by
@@ -245,6 +335,8 @@ GlobalCupertinoLocalizations getCupertinoTranslation(
       return CupertinoLocalizationEn(fullYearFormat: fullYearFormat, dayFormat: dayFormat, mediumDateFormat: mediumDateFormat, singleDigitHourFormat: singleDigitHourFormat, singleDigitMinuteFormat: singleDigitMinuteFormat, doubleDigitMinuteFormat: doubleDigitMinuteFormat, singleDigitSecondFormat: singleDigitSecondFormat, decimalFormat: decimalFormat);
     case 'fr':
       return CupertinoLocalizationFr(fullYearFormat: fullYearFormat, dayFormat: dayFormat, mediumDateFormat: mediumDateFormat, singleDigitHourFormat: singleDigitHourFormat, singleDigitMinuteFormat: singleDigitMinuteFormat, doubleDigitMinuteFormat: doubleDigitMinuteFormat, singleDigitSecondFormat: singleDigitSecondFormat, decimalFormat: decimalFormat);
+    case 'tr':
+      return CupertinoLocalizationTr(fullYearFormat: fullYearFormat, dayFormat: dayFormat, mediumDateFormat: mediumDateFormat, singleDigitHourFormat: singleDigitHourFormat, singleDigitMinuteFormat: singleDigitMinuteFormat, doubleDigitMinuteFormat: doubleDigitMinuteFormat, singleDigitSecondFormat: singleDigitSecondFormat, decimalFormat: decimalFormat);
   }
   assert(false, 'getCupertinoTranslation() called for unsupported locale "$locale"');
   return null;


### PR DESCRIPTION
## Description

Turkish translations added for Cupertino. 
/cc @xster 

Maybe @nyener can help you verify.

## Related Issues

#13452

## Tests


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
