### PR TITLE
Make Hover Listener respect transforms

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2566,6 +2566,7 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
 
   void _updateAnnotations() {
     bool changed = false;
+    final bool hadHoverAnnotation = _hoverAnnotation != null;
     if (_hoverAnnotation != null && attached) {
       RendererBinding.instance.mouseTracker.detachAnnotation(_hoverAnnotation);
       changed = true;
@@ -2587,6 +2588,10 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     if (changed) {
       markNeedsPaint();
     }
+    final bool hasHoverAnnotation = _hoverAnnotation != null;
+    if (hadHoverAnnotation != hasHoverAnnotation) {
+      markNeedsCompositingBitsUpdate();
+    }
   }
 
   @override
@@ -2607,6 +2612,9 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     RendererBinding.instance.mouseTracker.removeListener(_updateAnnotations);
     super.detach();
   }
+
+  @override
+  bool get needsCompositing => _hoverAnnotation != null;
 
   @override
   void paint(PaintingContext context, Offset offset) {

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -318,7 +318,7 @@ void main() {
       // No TransformLayer for `Transform.scale` is added because composting is
       // not required and therefore the transform is executed on the canvas
       // directly. (One TransformLayer is always present for the root
-      // transformation.)
+      // transform.)
       expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
 
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
@@ -231,6 +232,72 @@ void main() {
       expect(exit2, isEmpty);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isFalse);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
+    });
+
+    testWidgets('works with transform', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/31986.
+      final Key key = UniqueKey();
+      const double scaleFactor = 2.0;
+      const double localWidth = 150.0;
+      const double localHeight = 100.0;
+      final List<PointerEvent> events = <PointerEvent>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Transform.scale(
+              scale: scaleFactor,
+              child: Listener(
+                onPointerEnter: (PointerEnterEvent event) {
+                  events.add(event);
+                },
+                onPointerHover: (PointerHoverEvent event) {
+                  events.add(event);
+                },
+                onPointerExit: (PointerExitEvent event) {
+                  events.add(event);
+                },
+                child: Container(
+                  key: key,
+                  color: Colors.blue,
+                  height: localHeight,
+                  width: localWidth,
+                  child: const Text('Hi'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+      final Offset topRight = tester.getTopRight(find.byKey(key));
+      final Offset bottomLeft = tester.getBottomLeft(find.byKey(key));
+      expect(topRight.dx - topLeft.dx, scaleFactor * localWidth);
+      expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(topLeft - const Offset(1, 1));
+      await tester.pump();
+      expect(events, isEmpty);
+
+      await gesture.moveTo(topLeft + const Offset(1, 1));
+      await tester.pump();
+      expect(events, hasLength(2));
+      expect(events.first, isA<PointerEnterEvent>());
+      expect(events.last, isA<PointerHoverEvent>());
+      events.clear();
+
+      await gesture.moveTo(bottomLeft + const Offset(1, -1));
+      await tester.pump();
+      expect(events.single, isA<PointerHoverEvent>());
+      expect(events.single.delta, const Offset(0.0, scaleFactor * localHeight - 2));
+      events.clear();
+
+      await gesture.moveTo(bottomLeft + const Offset(1, 1));
+      await tester.pump();
+      expect(events.single, isA<PointerExitEvent>());
+      events.clear();
     });
   });
 }


### PR DESCRIPTION
## Description

Before this change a `RenderPointerListener` that had active hover listeners (`onPointerEnter`, `onPointerHover`, `onPointerExit`) would drop any previous transforms on the floor if nobody else in that subtree required compositing. With this change `RenderPointerListener` itself now requests compositing if one of the hover listeners is set.

Debugging notes: If Nobody in a subtree requests compositing, the `RenderTransform` will execute the provided transform directly on the canvas instead of introducing a `TransformLayer`. When the `RenderPointerListener` pushes a new `AnnotatedRegionLayer` to make hover detection work, a new canvas for a new `PictureLayer` is created and all subsequent render objects draw into this new canvas, which doesn't know anything about the transform. Hence, the transform is ignored for all following draw operations.
If you push a layer, you need to request compositing to ensure that everything works correctly. Ideally, we should have an assert somewhere ensuring this.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31986.

## Tests

I added the following tests:

* A test to verify that `RenderPointerListener` with active hover listeners doesn't drop the transforms on the floor.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
