### PR TITLE
Remove deprecated decodedCacheRatioCap

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -10,8 +10,6 @@ import 'package:flutter/services.dart' show ServicesBinding;
 import 'image_cache.dart';
 import 'shader_warm_up.dart';
 
-const double _kDefaultDecodedCacheRatioCap = 0.0;
-
 /// Binding for the painting library.
 ///
 /// Hooks into the cache eviction logic to clear the image cache.
@@ -71,50 +69,9 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   @protected
   ImageCache createImageCache() => ImageCache();
 
-  /// The maximum multiple of the compressed image size used when caching an
-  /// animated image.
-  ///
-  /// Individual frames of animated images can be cached into memory to avoid
-  /// using CPU to re-decode them for every loop in the animation. This behavior
-  /// will result in out-of-memory crashes when decoding large (or large numbers
-  /// of) animated images so is disabled by default. Set this value to control
-  /// how much memory each animated image is allowed to use for caching decoded
-  /// frames compared to its compressed size. For example, setting this to `2.0`
-  /// means that a 400KB GIF would be allowed at most to use 800KB of memory
-  /// caching unessential decoded frames. A setting of `1.0` or less disables
-  /// all caching of unessential decoded frames. See
-  /// [_kDefaultDecodedCacheRatioCap] for the default value.
-  ///
-  /// @deprecated The in-memory cache of decoded frames causes issues with
-  /// memory consumption. Soon this API and the in-memory cache will be removed.
-  /// See
-  /// [flutter/flutter#26081](https://github.com/flutter/flutter/issues/26081)
-  /// for more context.
-  @deprecated
-  double get decodedCacheRatioCap => _kDecodedCacheRatioCap;
-  double _kDecodedCacheRatioCap = _kDefaultDecodedCacheRatioCap;
-  /// Changes the maximum multiple of compressed image size used when caching an
-  /// animated image.
-  ///
-  /// Changing this value only affects new images, not images that have already
-  /// been decoded.
-  ///
-  /// @deprecated The in-memory cache of decoded frames causes issues with
-  /// memory consumption. Soon this API and the in-memory cache will be removed.
-  /// See
-  /// [flutter/flutter#26081](https://github.com/flutter/flutter/issues/26081)
-  /// for more context.
-  @deprecated
-  set decodedCacheRatioCap(double value) {
-    assert (value != null);
-    assert (value >= 0.0);
-    _kDecodedCacheRatioCap = value;
-  }
-
-  // ignore: deprecated_member_use_from_same_package
   /// Calls through to [dart:ui] with [decodedCacheRatioCap] from [ImageCache].
   Future<ui.Codec> instantiateImageCodec(Uint8List list) {
-    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use_from_same_package
+    return ui.instantiateImageCodec(list);
   }
 
   @override

--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -14,16 +14,6 @@ import 'painting_utils.dart';
 void main() {
   final PaintingBindingSpy binding = PaintingBindingSpy();
 
-  test('decodedCacheRatio', () async {
-    // final PaintingBinding binding = PaintingBinding.instance;
-    // Has default value.
-    expect(binding.decodedCacheRatioCap, isNot(null)); // ignore: deprecated_member_use_from_same_package
-
-    // Can be set.
-    binding.decodedCacheRatioCap = 1.0; // ignore: deprecated_member_use_from_same_package
-    expect(binding.decodedCacheRatioCap, 1.0); // ignore: deprecated_member_use_from_same_package
-  });
-
   test('instantiateImageCodec used for loading images', () async {
     expect(binding.instantiateImageCodecCalledCount, 0);
 

--- a/packages/flutter/test/painting/painting_utils.dart
+++ b/packages/flutter/test/painting/painting_utils.dart
@@ -16,7 +16,7 @@ class PaintingBindingSpy extends BindingBase with ServicesBinding, PaintingBindi
   @override
   Future<ui.Codec> instantiateImageCodec(Uint8List list) {
     counter++;
-    return ui.instantiateImageCodec(list, decodedCacheRatioCap: decodedCacheRatioCap); // ignore: deprecated_member_use_from_same_package
+    return ui.instantiateImageCodec(list);
   }
 
   @override


### PR DESCRIPTION
## Description

Remove deprecated decodedCacheRatioCap.

## Related Issues

flutter/flutter#26081

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). https://groups.google.com/forum/#!topic/flutter-announce/xbYfKcpXbi0
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
