### PR TITLE
rename foreground and background to light and dark

### DIFF
--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -277,13 +277,14 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
       } else {
         targetContrastRatio = kMinimumRatioNormalText;
       }
-      if (contrastRatio - targetContrastRatio >= delta)
+      if (contrastRatio - targetContrastRatio >= delta) {
         return result + const Evaluation.pass();
+      }
       return result + Evaluation.fail(
         '$node:\nExpected contrast ratio of at least '
         '$targetContrastRatio but found ${contrastRatio.toStringAsFixed(2)} for a font size of $fontSize. '
-        'The computed foreground color was: ${report.lightColor}, '
-        'The computed background color was: ${report.darkColor}\n'
+        'The computed light color was: ${report.lightColor}, '
+        'The computed dark color was: ${report.darkColor}\n'
         'See also: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html'
       );
     }

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -126,7 +126,7 @@ void main() {
         'SemanticsNode#21(Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), label: "this is a test",'
         ' textDirection: ltr):\nExpected contrast ratio of at least '
         '4.5 but found 1.17 for a font size of 14.0. The '
-        'computed foreground color was: Color(0xfffafafa), The computed background color was:'
+        'computed light color was: Color(0xfffafafa), The computed dark color was:'
         ' Color(0xffffeb3b)\n'
         'See also: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html');
       handle.dispose();


### PR DESCRIPTION
## Description

foreground and background are not accurate, we should surface what we think of these colors internally: dark and light

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31933

##