### PR TITLE
[flutter_tool] In 'attach' use platform dill etc from the Fuchsia SDK

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'android/android_device.dart';
 import 'application_package.dart';
+import 'artifacts.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/utils.dart';
@@ -273,6 +274,9 @@ abstract class Device {
 
   /// Clear the device's logs.
   void clearLogs();
+
+  /// Optional device-specific artifact overrides.
+  OverrideArtifacts get artifactOverrides => null;
 
   /// Start an app package on the current device.
   ///

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../application_package.dart';
+import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -222,6 +223,16 @@ class FuchsiaDevice extends Device {
 
   @override
   void clearLogs() {}
+
+  @override
+  OverrideArtifacts get artifactOverrides {
+    return _artifactOverrides ??= OverrideArtifacts(
+      parent: Artifacts.instance,
+      platformKernelDill: fuchsiaArtifacts.platformKernelDill,
+      flutterPatchedSdk: fuchsiaArtifacts.flutterPatchedSdk,
+    );
+  }
+  OverrideArtifacts _artifactOverrides;
 
   @override
   bool get supportsScreenshot => false;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -81,7 +81,12 @@ class FuchsiaSdk {
 /// Fuchsia-specific artifacts used to interact with a device.
 class FuchsiaArtifacts {
   /// Creates a new [FuchsiaArtifacts].
-  FuchsiaArtifacts({this.sshConfig, this.devFinder});
+  FuchsiaArtifacts({
+    this.sshConfig,
+    this.devFinder,
+    this.platformKernelDill,
+    this.flutterPatchedSdk,
+  });
 
   /// Creates a new [FuchsiaArtifacts] using the cached Fuchsia SDK.
   ///
@@ -92,6 +97,7 @@ class FuchsiaArtifacts {
   factory FuchsiaArtifacts.find() {
     final String fuchsia = Cache.instance.getArtifactDirectory('fuchsia').path;
     final String tools = fs.path.join(fuchsia, 'tools');
+    final String dartPrebuilts = fs.path.join(tools, 'dart_prebuilts');
 
     // If FUCHSIA_BUILD_DIR is defined, then look for the ssh_config dir
     // relative to it. Next, if FUCHSIA_SSH_CONFIG is defined, then use it.
@@ -99,13 +105,17 @@ class FuchsiaArtifacts {
     File sshConfig;
     if (platform.environment.containsKey(_kFuchsiaBuildDir)) {
       sshConfig = fs.file(fs.path.join(
-          platform.environment[_kFuchsiaSshConfig], 'ssh-keys', 'ssh_config'));
+          platform.environment[_kFuchsiaBuildDir], 'ssh-keys', 'ssh_config'));
     } else if (platform.environment.containsKey(_kFuchsiaSshConfig)) {
       sshConfig = fs.file(platform.environment[_kFuchsiaSshConfig]);
     }
     return FuchsiaArtifacts(
       sshConfig: sshConfig,
       devFinder: fs.file(fs.path.join(tools, 'dev_finder')),
+      platformKernelDill: fs.file(fs.path.join(
+          dartPrebuilts, 'flutter_runner', 'platform_strong.dill')),
+      flutterPatchedSdk: fs.file(fs.path.join(
+          dartPrebuilts, 'flutter_runner')),
     );
   }
 
@@ -119,4 +129,10 @@ class FuchsiaArtifacts {
   /// The location of the dev finder tool used to locate connected
   /// Fuchsia devices.
   final File devFinder;
+
+  /// The location of the Fuchsia-specific platform dill.
+  final File platformKernelDill;
+
+  /// The directory containing [platformKernelDill].
+  final File flutterPatchedSdk;
 }


### PR DESCRIPTION
## Description

This PR:
1. Provides a facility for devices to override artifacts. (So far just those from `OverrideArtifacts`).
2. Uses that in the attach command so that the Fuchsia device can provide the platform dill, etc. from the Fuchsia SDK.

## Related Issues

## Tests

I added the following tests:

Tests of Fuchsia device artifact overriding in fuchsia_device_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
