### PR TITLE
separate install methods into separate mixin for device class

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -58,7 +58,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
   Future<List<String>> getDiagnostics() async => getAdbDeviceDiagnostics();
 }
 
-class AndroidDevice extends Device {
+class AndroidDevice extends Device with InstallTarget {
   AndroidDevice(
     String id, {
     this.productID,

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -242,11 +242,13 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
   final ApplicationPackage package = await command.applicationPackages
       .getPackageForPlatform(await command.device.targetPlatform);
 
-  if (command.shouldBuild) {
+  final Device device = command.device;
+  if (command.shouldBuild && device is InstallTarget) {
     printTrace('Installing application package.');
-    if (await command.device.isAppInstalled(package))
-      await command.device.uninstallApp(package);
-    await command.device.installApp(package);
+    if (await device.isAppInstalled(package)) {
+      await device.uninstallApp(package);
+    }
+    await device.installApp(package);
   }
 
   final Map<String, dynamic> platformArgs = <String, dynamic>{};

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -51,11 +51,16 @@ Future<bool> installApp(Device device, ApplicationPackage package, { bool uninst
   if (package == null)
     return false;
 
-  if (uninstall && await device.isAppInstalled(package)) {
-    printStatus('Uninstalling old version...');
-    if (!await device.uninstallApp(package))
-      printError('Warning: uninstalling old version failed');
+  if (device is InstallTarget) {
+    if (uninstall && await device.isAppInstalled(package)) {
+      printStatus('Uninstalling old version...');
+      if (!await device.uninstallApp(package)) {
+        printError('Warning: uninstalling old version failed');
+      }
+    }
+    return device.installApp(package);
+  } else {
+    printError('Device: $device does not support installation.');
+    return false;
   }
-
-  return device.installApp(package);
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -204,6 +204,22 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
   String toString() => '$name device discovery';
 }
 
+/// A device which can have programs "installed" on it.
+mixin InstallTarget on Device {
+  /// Check if a version of the given app is already installed
+  Future<bool> isAppInstalled(ApplicationPackage app);
+
+  /// Check if the latest build of the [app] is already installed.
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app);
+
+  /// Install an app package on the current device
+  Future<bool> installApp(ApplicationPackage app);
+
+  /// Uninstall an app package from the current device
+  Future<bool> uninstallApp(ApplicationPackage app);
+}
+
+/// A place where Flutter can run.
 abstract class Device {
 
   Device(this.id);
@@ -238,18 +254,6 @@ abstract class Device {
 
   /// Whether the device is supported for the current project directory.
   bool isSupportedForProject(FlutterProject flutterProject);
-
-  /// Check if a version of the given app is already installed
-  Future<bool> isAppInstalled(ApplicationPackage app);
-
-  /// Check if the latest build of the [app] is already installed.
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app);
-
-  /// Install an app package on the current device
-  Future<bool> installApp(ApplicationPackage app);
-
-  /// Uninstall an app package from the current device
-  Future<bool> uninstallApp(ApplicationPackage app);
 
   /// Check if the device is supported by Flutter
   bool isSupported();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -171,18 +171,6 @@ class FuchsiaDevice extends Device {
   bool get supportsStartPaused => false;
 
   @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => false;
-
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
-
-  @override
-  Future<bool> installApp(ApplicationPackage app) => Future<bool>.value(false);
-
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => false;
-
-  @override
   bool isSupported() => true;
 
   @override

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -111,7 +111,7 @@ class IOSDevices extends PollingDeviceDiscovery {
   Future<List<Device>> pollingGetDevices() => IOSDevice.getAttachedDevices();
 }
 
-class IOSDevice extends Device {
+class IOSDevice extends Device with InstallTarget {
   IOSDevice(String id, { this.name, String sdkVersion })
       : _sdkVersion = sdkVersion,
         super(id) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -213,7 +213,7 @@ class SimDevice {
   bool get isBooted => state == 'Booted';
 }
 
-class IOSSimulator extends Device {
+class IOSSimulator extends Device with InstallTarget {
   IOSSimulator(String id, { this.name, this.category }) : super(id);
 
   @override

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -30,21 +30,6 @@ class LinuxDevice extends Device {
   }
   final DesktopLogReader _logReader = DesktopLogReader();
 
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> installApp(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
-
   @override
   Future<bool> get isLocalEmulator async => false;
 
@@ -102,11 +87,6 @@ class LinuxDevice extends Device {
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.linux_x64;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to uninstall the application.
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => true;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -31,21 +31,6 @@ class MacOSDevice extends Device {
   }
   final DesktopLogReader _deviceLogReader = DesktopLogReader();
 
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> installApp(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
-
   @override
   Future<bool> get isLocalEmulator async => false;
 
@@ -112,11 +97,6 @@ class MacOSDevice extends Device {
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin_x64;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to uninstall the application.
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => true;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -75,15 +75,6 @@ class FlutterTesterDevice extends Device {
   DeviceLogReader getLogReader({ ApplicationPackage app }) => _logReader;
 
   @override
-  Future<bool> installApp(ApplicationPackage app) async => true;
-
-  @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => false;
-
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
-
-  @override
   bool isSupported() => true;
 
   bool _isRunning = false;
@@ -190,9 +181,6 @@ class FlutterTesterDevice extends Device {
     _process = null;
     return true;
   }
-
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => true;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) => true;

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -70,15 +70,6 @@ class WebDevice extends Device {
   }
 
   @override
-  Future<bool> installApp(ApplicationPackage app) async => true;
-
-  @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => true;
-
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
-
-  @override
   Future<bool> get isLocalEmulator async => false;
 
   @override
@@ -131,9 +122,6 @@ class WebDevice extends Device {
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.web;
-
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => true;
 
   Future<void> _basicAssetServer(HttpRequest request) async {
     if (request.method != 'GET') {

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -32,21 +32,6 @@ class WindowsDevice extends Device {
   }
   final DesktopLogReader _logReader = DesktopLogReader();
 
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> installApp(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isAppInstalled(ApplicationPackage app) async => true;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to install the application.
-  @override
-  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
-
   @override
   Future<bool> get isLocalEmulator async => false;
 
@@ -109,11 +94,6 @@ class WindowsDevice extends Device {
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.windows_x64;
-
-  // Since the host and target devices are the same, no work needs to be done
-  // to uninstall the application.
-  @override
-  Future<bool> uninstallApp(ApplicationPackage app) async => true;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/test/commands/drive_test.dart
+++ b/packages/flutter_tools/test/commands/drive_test.dart
@@ -22,7 +22,7 @@ import '../src/mocks.dart';
 void main() {
   group('drive', () {
     DriveCommand command;
-    Device mockDevice;
+    MockDevice mockDevice;
     MemoryFileSystem fs;
     Directory tempDir;
 
@@ -418,12 +418,12 @@ void main() {
   });
 }
 
-class MockDevice extends Mock implements Device {
+class MockDevice extends Mock implements Device, InstallTarget {
   MockDevice() {
     when(isSupported()).thenReturn(true);
   }
 }
 
-class MockAndroidDevice extends Mock implements AndroidDevice { }
+class MockAndroidDevice extends MockDevice implements AndroidDevice { }
 
-class MockLaunchResult extends Mock implements LaunchResult { }
+class MockLaunchResult extends MockDevice implements LaunchResult { }

--- a/packages/flutter_tools/test/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/linux/linux_device_test.dart
@@ -38,10 +38,6 @@ void main() {
       final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
       expect(await device.targetPlatform, TargetPlatform.linux_x64);
       expect(device.name, 'Linux');
-      expect(await device.installApp(linuxApp), true);
-      expect(await device.uninstallApp(linuxApp), true);
-      expect(await device.isLatestBuildInstalled(linuxApp), true);
-      expect(await device.isAppInstalled(linuxApp), true);
       expect(await device.stopApp(linuxApp), true);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/macos/macos_device_test.dart
@@ -39,10 +39,6 @@ void main() {
       when(mockMacOSApp.executable(any)).thenReturn('foo');
       expect(await device.targetPlatform, TargetPlatform.darwin_x64);
       expect(device.name, 'macOS');
-      expect(await device.installApp(mockMacOSApp), true);
-      expect(await device.uninstallApp(mockMacOSApp), true);
-      expect(await device.isLatestBuildInstalled(mockMacOSApp), true);
-      expect(await device.isAppInstalled(mockMacOSApp), true);
       expect(await device.stopApp(mockMacOSApp), false);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/tester/flutter_tester_test.dart
@@ -84,12 +84,6 @@ void main() {
       expect(device.name, 'Flutter test device');
       expect(device.portForwarder, isNot(isNull));
       expect(await device.targetPlatform, TargetPlatform.tester);
-
-      expect(await device.installApp(null), isTrue);
-      expect(await device.isAppInstalled(null), isFalse);
-      expect(await device.isLatestBuildInstalled(null), isFalse);
-      expect(await device.uninstallApp(null), isTrue);
-
       expect(device.isSupported(), isTrue);
     });
 

--- a/packages/flutter_tools/test/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/windows/windows_device_test.dart
@@ -38,10 +38,6 @@ void main() {
       final PrebuiltWindowsApp windowsApp = PrebuiltWindowsApp(executable: 'foo');
       expect(await device.targetPlatform, TargetPlatform.windows_x64);
       expect(device.name, 'Windows');
-      expect(await device.installApp(windowsApp), true);
-      expect(await device.uninstallApp(windowsApp), true);
-      expect(await device.isLatestBuildInstalled(windowsApp), true);
-      expect(await device.isAppInstalled(windowsApp), true);
       expect(await device.stopApp(windowsApp), false);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
## Description

our desktop and web device types don't support installation. These methods are only invoked outside of the device class itself in drive.dart and the install.dart commands. Reduce the boilerplate a bit by spinning these methods out into a mixin.

## Related Issues

https://github.com/flutter/flutter/issues/25377