### PR TITLE
Fix CupertinoSliverRefreshControl onRefresh callback

### DIFF
--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -463,8 +463,7 @@ class _CupertinoSliverRefreshControlState extends State<CupertinoSliverRefreshCo
             // user supplied and we're always here in the middle of the sliver's
             // performLayout.
             SchedulerBinding.instance.addPostFrameCallback((Duration timestamp) {
-              refreshTask = widget.onRefresh()
-              ..whenComplete(() {
+              refreshTask = widget.onRefresh()..whenComplete(() {
                 if (mounted) {
                   setState(() => refreshTask = null);
                   // Trigger one more transition because by this time, BoxConstraint's

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -463,7 +463,8 @@ class _CupertinoSliverRefreshControlState extends State<CupertinoSliverRefreshCo
             // user supplied and we're always here in the middle of the sliver's
             // performLayout.
             SchedulerBinding.instance.addPostFrameCallback((Duration timestamp) {
-              refreshTask = widget.onRefresh()..then((_) {
+              refreshTask = widget.onRefresh()
+              ..whenComplete(() {
                 if (mounted) {
                   setState(() => refreshTask = null);
                   // Trigger one more transition because by this time, BoxConstraint's

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -29,7 +29,7 @@ void main() {
     double refreshIndicatorExtent,
   ) => mockHelper.builder(context, refreshState, pulledExtent, refreshTriggerPullDistance, refreshIndicatorExtent);
 
-  final Function onRefresh = () => mockHelper.refreshTask();
+  Future<void> onRefresh() => mockHelper.refreshTask();
 
   setUp(() {
     mockHelper = MockHelper();
@@ -52,6 +52,7 @@ void main() {
         }
         return refreshIndicator;
       });
+
     when(mockHelper.refreshTask()).thenAnswer((_) => refreshCompleter.future);
   });
 
@@ -370,6 +371,95 @@ void main() {
         verifyNoMoreInteractions(mockHelper);
 
         debugDefaultTargetPlatformOverride = null;
+      },
+    );
+
+    testWidgets(
+      'refreshing task keeps the sliver expanded forever until fail',
+      (WidgetTester tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        final FlutterError error = FlutterError('Oops');
+        double errorCount = 0;
+
+        runZoned(() async {
+          refreshCompleter = Completer<void>.sync();
+
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  CupertinoSliverRefreshControl(
+                    builder: builder,
+                    onRefresh: onRefresh,
+                  ),
+                  buildAListOfStuff(),
+                ],
+              ),
+            ),
+          );
+
+          await tester.drag(find.text('0'), const Offset(0.0, 150.0), touchSlopY: 0);
+          await tester.pump();
+          // Let it start snapping back.
+          await tester.pump(const Duration(milliseconds: 50));
+
+          verifyInOrder(<void>[
+              mockHelper.builder(
+                any,
+                RefreshIndicatorMode.armed,
+                150.0,
+                100.0, // Default value.
+                60.0, // Default value.
+              ),
+              mockHelper.refreshTask(),
+              mockHelper.builder(
+                any,
+                RefreshIndicatorMode.armed,
+                argThat(moreOrLessEquals(127.10396988577114)),
+                100.0, // Default value.
+                60.0, // Default value.
+              ),
+          ]);
+
+          // Reaches refresh state and sliver's at 60.0 in height after a while.
+          await tester.pump(const Duration(seconds: 1));
+          verify(mockHelper.builder(
+              any,
+              RefreshIndicatorMode.refresh,
+              60.0,
+              100.0, // Default value.
+              60.0, // Default value.
+          ));
+
+          // Stays in that state forever until future completes.
+          await tester.pump(const Duration(seconds: 1000));
+          verifyNoMoreInteractions(mockHelper);
+          expect(
+            tester.getTopLeft(find.widgetWithText(Container, '0')),
+            const Offset(0.0, 60.0),
+          );
+
+          refreshCompleter.completeError(error);
+          await tester.pump();
+
+          verify(mockHelper.builder(
+              any,
+              RefreshIndicatorMode.done,
+              60.0,
+              100.0, // Default value.
+              60.0, // Default value.
+          ));
+          verifyNoMoreInteractions(mockHelper);
+        },
+        onError: (dynamic e) {
+          expect(e, error);
+          expect(errorCount, 0);
+          errorCount++;
+        }
+      );
+
+      debugDefaultTargetPlatformOverride = null;
       },
     );
 

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -402,18 +402,37 @@ void main() {
           await tester.drag(find.text('0'), const Offset(0.0, 150.0), touchSlopY: 0);
           await tester.pump();
           // Let it start snapping back.
+          await tester.pump(const Duration(milliseconds: 50));
+
+          verifyInOrder(<void>[
+            mockHelper.builder(
+              any,
+              RefreshIndicatorMode.armed,
+              150.0,
+              100.0, // Default value.
+              60.0, // Default value.
+            ),
+            mockHelper.refreshTask(),
+            mockHelper.builder(
+              any,
+              RefreshIndicatorMode.armed,
+              argThat(moreOrLessEquals(127.10396988577114)),
+              100.0, // Default value.
+              60.0, // Default value.
+            ),
+          ]);
+
           // Reaches refresh state and sliver's at 60.0 in height after a while.
           await tester.pump(const Duration(seconds: 1));
           verify(mockHelper.builder(
-              any,
-              RefreshIndicatorMode.refresh,
-              60.0,
-              100.0, // Default value.
-              60.0, // Default value.
+            any,
+            RefreshIndicatorMode.refresh,
+            60.0,
+            100.0, // Default value.
+            60.0, // Default value.
           ));
 
-          clearInteractions(mockHelper);
-          // Stays in that state forever until future completes with error.
+          // Stays in that state forever until future completes.
           await tester.pump(const Duration(seconds: 1000));
           verifyNoMoreInteractions(mockHelper);
           expect(
@@ -425,11 +444,11 @@ void main() {
           await tester.pump();
 
           verify(mockHelper.builder(
-              any,
-              RefreshIndicatorMode.done,
-              60.0,
-              100.0, // Default value.
-              60.0, // Default value.
+            any,
+            RefreshIndicatorMode.done,
+            60.0,
+            100.0, // Default value.
+            60.0, // Default value.
           ));
           verifyNoMoreInteractions(mockHelper);
         },

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -375,7 +375,7 @@ void main() {
     );
 
     testWidgets(
-      'refreshing task keeps the sliver expanded forever until fail',
+      'refreshing task keeps the sliver expanded forever until completes with error',
       (WidgetTester tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
         final FlutterError error = FlutterError('Oops');
@@ -402,26 +402,6 @@ void main() {
           await tester.drag(find.text('0'), const Offset(0.0, 150.0), touchSlopY: 0);
           await tester.pump();
           // Let it start snapping back.
-          await tester.pump(const Duration(milliseconds: 50));
-
-          verifyInOrder(<void>[
-              mockHelper.builder(
-                any,
-                RefreshIndicatorMode.armed,
-                150.0,
-                100.0, // Default value.
-                60.0, // Default value.
-              ),
-              mockHelper.refreshTask(),
-              mockHelper.builder(
-                any,
-                RefreshIndicatorMode.armed,
-                argThat(moreOrLessEquals(127.10396988577114)),
-                100.0, // Default value.
-                60.0, // Default value.
-              ),
-          ]);
-
           // Reaches refresh state and sliver's at 60.0 in height after a while.
           await tester.pump(const Duration(seconds: 1));
           verify(mockHelper.builder(
@@ -432,7 +412,8 @@ void main() {
               60.0, // Default value.
           ));
 
-          // Stays in that state forever until future completes.
+          clearInteractions(mockHelper);
+          // Stays in that state forever until future completes with error.
           await tester.pump(const Duration(seconds: 1000));
           verifyNoMoreInteractions(mockHelper);
           expect(


### PR DESCRIPTION
## Description

Replace `CupertinoSliverRefreshControl.onRefresh`'s `then` callback with `whenCompleted` callback, so when `onRefresh` completes with error the sliver refresh control retracts like when it completes with value.

## Related Issues

Fixes #31382

## Tests

I added the following tests:

- refreshing task keeps the sliver expanded forever until completes with error

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
