### PR TITLE
Notify previous previous route to update Cupertino Title

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1871,8 +1871,10 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       }
     });
     newRoute.didChangeNext(null);
-    if (oldRoute != null)
+    if (oldRoute != null){
       oldRoute.didChangeNext(newRoute);
+      newRoute.didChangePrevious(oldRoute);
+    }
     for (NavigatorObserver observer in widget.observers) {
       observer.didPush(newRoute, oldRoute);
       for (Route<dynamic> removedRoute in removedRoutes)


### PR DESCRIPTION
DEPRECATED go to https://github.com/flutter/flutter/pull/49951
## Description

Setup: Use to navigate 'Navigator.pushAndRemoveUntil' with CupertinoPageRoute. 
Now: previousTitle in CupertinoPageRoute is always null. Instead of text in back button of Cupertino navigation bar renders error message. 
After fix: proper text with previous title at back button of Cupertino navigation bar 

## Tests

Don't know what kind of test we have to implement.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
