### PR TITLE
Transform PointerEvents to the local coordinate system of the event receiver

### DIFF
--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
 
 const double kTwoPi = 2 * math.pi;
 
@@ -130,15 +131,15 @@ abstract class RenderSector extends RenderObject {
   @override
   Rect get semanticBounds => Rect.fromLTWH(-deltaRadius, -deltaRadius, 2.0 * deltaRadius, 2.0 * deltaRadius);
 
-  bool hitTest(HitTestResult result, { double radius, double theta }) {
+  bool hitTest(SectorHitTestResult result, { double radius, double theta }) {
     if (radius < parentData.radius || radius >= parentData.radius + deltaRadius ||
         theta < parentData.theta || theta >= parentData.theta + deltaTheta)
       return false;
     hitTestChildren(result, radius: radius, theta: theta);
-    result.add(HitTestEntry(this));
+    result.add(SectorHitTestEntry(this, radius: radius, theta: theta));
     return true;
   }
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) { }
+  void hitTestChildren(SectorHitTestResult result, { double radius, double theta }) { }
 
   double deltaRadius;
   double deltaTheta;
@@ -190,7 +191,7 @@ class RenderSectorWithChildren extends RenderDecoratedSector with ContainerRende
   RenderSectorWithChildren(BoxDecoration decoration) : super(decoration);
 
   @override
-  void hitTestChildren(HitTestResult result, { double radius, double theta }) {
+  void hitTestChildren(SectorHitTestResult result, { double radius, double theta }) {
     RenderSector child = lastChild;
     while (child != null) {
       if (child.hitTest(result, radius: radius, theta: theta))
@@ -530,7 +531,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (child == null)
       return false;
     double x = position.dx;
@@ -547,7 +548,7 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
       return false;
     if (theta > child.deltaTheta)
       return false;
-    child.hitTest(result, radius: radius, theta: theta);
+    child.hitTest(SectorHitTestResult.wrap(result), radius: radius, theta: theta);
     result.add(BoxHitTestEntry(this, position));
     return true;
   }
@@ -584,4 +585,49 @@ class RenderSolidColor extends RenderDecoratedSector {
       decoration = BoxDecoration(color: backgroundColor);
     }
   }
+}
+
+/// The result of performing a hit test on [RenderSector]s.
+class SectorHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderSector].
+  SectorHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [SectorHitTestResult] protocol for hit testing on [RenderSector]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderSector]-world and the non-[RenderSector]-world to convert a (subtype of)
+  /// [HitTestResult] to a [SectorHitTestResult] for hit testing on [RenderSector]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [SectorHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [SectorHitTestResult] back into a
+  ///    generic [HitTestResult].
+  SectorHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+}
+
+/// A hit test entry used by [RenderSector].
+class SectorHitTestEntry extends HitTestEntry {
+  /// Creates a box hit test entry.
+  ///
+  /// The [radius] and [theta] argument must not be null.
+  SectorHitTestEntry(RenderSector target, { @required this.radius,  @required this.theta })
+      : assert(radius != null),
+        assert(theta != null),
+        super(target);
+
+  @override
+  RenderSector get target => super.target;
+
+  /// The radius component of the hit test position in the local coordinates of
+  /// [target].
+  final double radius;
+
+  /// The theta component of the hit test position in the local coordinates of
+  /// [target].
+  final double theta;
 }

--- a/examples/layers/test/sector_layout_test.dart
+++ b/examples/layers/test/sector_layout_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/src/sector_layout.dart';
+
+void main() {
+  group('hit testing', () {
+    test('SectorHitTestResult wrapping HitTestResult', () {
+      final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
+      final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+
+      final HitTestResult wrapped = HitTestResult();
+      wrapped.add(entry1);
+      expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+
+      final SectorHitTestResult wrapping = SectorHitTestResult.wrap(wrapped);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1]));
+      expect(wrapping.path, same(wrapped.path));
+
+      wrapping.add(entry2);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+
+      wrapped.add(entry3);
+      expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+      expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    });
+  });
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
+}

--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -713,17 +713,25 @@ class _RenderCupertinoAlert extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
-    bool isHit = false;
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     final MultiChildLayoutParentData contentSectionParentData = contentSection.parentData;
     final MultiChildLayoutParentData actionsSectionParentData = actionsSection.parentData;
-    if (contentSection.hitTest(result, position: position - contentSectionParentData.offset)) {
-      isHit = true;
-    } else if (actionsSection.hitTest(result,
-        position: position - actionsSectionParentData.offset)) {
-      isHit = true;
-    }
-    return isHit;
+    return result.addWithPaintOffset(
+             offset: contentSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - contentSectionParentData.offset);
+               return contentSection.hitTest(result, position: transformed);
+             },
+           )
+        || result.addWithPaintOffset(
+             offset: actionsSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - actionsSectionParentData.offset);
+               return actionsSection.hitTest(result, position: transformed);
+             },
+           );
   }
 }
 
@@ -1261,7 +1269,7 @@ class _RenderCupertinoAlertActions extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -775,16 +775,25 @@ class _RenderCupertinoDialog extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
-    bool isHit = false;
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     final BoxParentData contentSectionParentData = contentSection.parentData;
     final BoxParentData actionsSectionParentData = actionsSection.parentData;
-    if (contentSection.hitTest(result, position: position - contentSectionParentData.offset)) {
-      isHit = true;
-    } else if (actionsSection.hitTest(result, position: position - actionsSectionParentData.offset)) {
-      isHit = true;
-    }
-    return isHit;
+    return result.addWithPaintOffset(
+             offset: contentSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - contentSectionParentData.offset);
+               return contentSection.hitTest(result, position: transformed);
+             },
+           )
+        || result.addWithPaintOffset(
+             offset: actionsSectionParentData.offset,
+             position: position,
+             hitTest: (HitTestResult result, Offset transformed) {
+               assert(transformed == position - actionsSectionParentData.offset);
+               return actionsSection.hitTest(result, position: transformed);
+             },
+           );
   }
 }
 
@@ -1693,7 +1702,7 @@ class _RenderCupertinoDialogActions extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -703,13 +703,21 @@ class _RenderSegmentedControl<T> extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     RenderBox child = lastChild;
     while (child != null) {
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
       if (childParentData.surroundingRect.contains(position)) {
-        return child.hitTest(result, position: (Offset.zero & child.size).center);
+        final Offset center = (Offset.zero & child.size).center;
+        return result.addWithRawTransform(
+          transform: MatrixUtils.forceToPoint(center),
+          position: center,
+          hitTest: (HitTestResult result, Offset position) {
+            assert(position == center);
+            return child.hitTest(result, position: center);
+          },
+        );
       }
       child = childParentData.previousSibling;
     }

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -195,7 +195,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     }
     for (HitTestEntry entry in hitTestResult.path) {
       try {
-        entry.target.handleEvent(event, entry);
+        entry.target.handleEvent(event.transformed(entry.transform), entry);
       } catch (exception, stack) {
         FlutterError.reportError(FlutterErrorDetailsForPointerEventDispatcher(
           exception: exception,

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -20,13 +20,27 @@ class DragDownDetails {
   /// Creates details for a [GestureDragDownCallback].
   ///
   /// The [globalPosition] argument must not be null.
-  DragDownDetails({ this.globalPosition = Offset.zero })
-    : assert(globalPosition != null);
+  DragDownDetails({
+    this.globalPosition = Offset.zero,
+    Offset localPosition,
+  }) : assert(globalPosition != null),
+       localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
   ///
   /// Defaults to the origin if not specified in the constructor.
+  ///
+  /// See also:
+  ///
+  ///  * [localPosition], which is the [globalPosition] transformed to the
+  ///    coordinate space of the event receiver.
   final Offset globalPosition;
+
+  /// The local position in the coordinate system of the event receiver at
+  /// which the pointer contacted the screen.
+  ///
+  /// Defaults to [globalPosition] if not specified in the constructor.
+  final Offset localPosition;
 
   @override
   String toString() => '$runtimeType($globalPosition)';
@@ -52,8 +66,12 @@ class DragStartDetails {
   /// Creates details for a [GestureDragStartCallback].
   ///
   /// The [globalPosition] argument must not be null.
-  DragStartDetails({ this.sourceTimeStamp, this.globalPosition = Offset.zero })
-    : assert(globalPosition != null);
+  DragStartDetails({
+    this.sourceTimeStamp,
+    this.globalPosition = Offset.zero,
+    Offset localPosition,
+  }) : assert(globalPosition != null),
+       localPosition = localPosition ?? globalPosition;
 
   /// Recorded timestamp of the source pointer event that triggered the drag
   /// event.
@@ -64,7 +82,18 @@ class DragStartDetails {
   /// The global position at which the pointer contacted the screen.
   ///
   /// Defaults to the origin if not specified in the constructor.
+  ///
+  /// See also:
+  ///
+  ///  * [localPosition], which is the [globalPosition] transformed to the
+  ///    coordinate space of the event receiver.
   final Offset globalPosition;
+
+  /// The local position in the coordinate system of the event receiver at
+  /// which the pointer contacted the screen.
+  ///
+  /// Defaults to [globalPosition] if not specified in the constructor.
+  final Offset localPosition;
 
   // TODO(ianh): Expose the current position, so that you can have a no-jump
   // drag even when disambiguating (though of course it would lag the finger
@@ -104,10 +133,12 @@ class DragUpdateDetails {
     this.delta = Offset.zero,
     this.primaryDelta,
     @required this.globalPosition,
+    Offset localPosition,
   }) : assert(delta != null),
        assert(primaryDelta == null
            || (primaryDelta == delta.dx && delta.dy == 0.0)
-           || (primaryDelta == delta.dy && delta.dx == 0.0));
+           || (primaryDelta == delta.dy && delta.dx == 0.0)),
+       localPosition = localPosition ?? globalPosition;
 
   /// Recorded timestamp of the source pointer event that triggered the drag
   /// event.
@@ -115,7 +146,8 @@ class DragUpdateDetails {
   /// Could be null if triggered from proxied events such as accessibility.
   final Duration sourceTimeStamp;
 
-  /// The amount the pointer has moved since the previous update.
+  /// The amount the pointer has moved in the coordinate space of the event
+  /// receiver since the previous update.
   ///
   /// If the [GestureDragUpdateCallback] is for a one-dimensional drag (e.g.,
   /// a horizontal or vertical drag), then this offset contains only the delta
@@ -124,7 +156,8 @@ class DragUpdateDetails {
   /// Defaults to zero if not specified in the constructor.
   final Offset delta;
 
-  /// The amount the pointer has moved along the primary axis since the previous
+  /// The amount the pointer has moved along the primary axis in the coordinate
+  /// space of the event receiver since the previous
   /// update.
   ///
   /// If the [GestureDragUpdateCallback] is for a one-dimensional drag (e.g.,
@@ -137,7 +170,18 @@ class DragUpdateDetails {
   final double primaryDelta;
 
   /// The pointer's global position when it triggered this update.
+  ///
+  /// See also:
+  ///
+  ///  * [localPosition], which is the [globalPosition] transformed to the
+  ///    coordinate space of the event receiver.
   final Offset globalPosition;
+
+  /// The local position in the coordinate system of the event receiver at
+  /// which the pointer contacted the screen.
+  ///
+  /// Defaults to [globalPosition] if not specified in the constructor.
+  final Offset localPosition;
 
   @override
   String toString() => '$runtimeType($delta)';

--- a/packages/flutter/lib/src/gestures/eager.dart
+++ b/packages/flutter/lib/src/gestures/eager.dart
@@ -20,7 +20,7 @@ class EagerGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   void addAllowedPointer(PointerDownEvent event) {
     // We call startTrackingPointer as this is where OneSequenceGestureRecognizer joins the arena.
-    startTrackingPointer(event.pointer);
+    startTrackingPointer(event.pointer, event.transform);
     resolve(GestureDisposition.accepted);
     stopTrackingPointer(event.pointer);
   }

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -5,6 +5,7 @@
 import 'dart:ui' show Offset, PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 export 'dart:ui' show Offset, PointerDeviceKind;
 
@@ -135,7 +136,9 @@ abstract class PointerEvent extends Diagnosticable {
     this.kind = PointerDeviceKind.touch,
     this.device = 0,
     this.position = Offset.zero,
+    Offset localPosition,
     this.delta = Offset.zero,
+    Offset localDelta,
     this.buttons = 0,
     this.down = false,
     this.obscured = false,
@@ -153,7 +156,11 @@ abstract class PointerEvent extends Diagnosticable {
     this.tilt = 0.0,
     this.platformData = 0,
     this.synthesized = false,
-  });
+    this.transform,
+    this.original,
+  }) : localPosition = localPosition ?? position,
+       localDelta = localDelta ?? delta;
+
 
   /// Time of event dispatch, relative to an arbitrary timeline.
   final Duration timeStamp;
@@ -170,13 +177,45 @@ abstract class PointerEvent extends Diagnosticable {
 
   /// Coordinate of the position of the pointer, in logical pixels in the global
   /// coordinate space.
+  ///
+  /// See also:
+  ///
+  ///  * [localPosition], which is the [position] transformed into the local
+  ///    coordinate system of the event receiver.
   final Offset position;
+
+  /// The [position] transformed into the event receiver's local coordinate
+  /// system according to [transform].
+  ///
+  /// If this event has not been transformed, [position] is returned as-is.
+  ///
+  /// See also:
+  ///
+  ///  * [globalPosition], which is the position in the global coordinate
+  ///    system of the screen.
+  final Offset localPosition;
 
   /// Distance in logical pixels that the pointer moved since the last
   /// [PointerMoveEvent].
   ///
   /// This value is always 0.0 for down, up, and cancel events.
+  ///
+  /// See also:
+  ///
+  ///  * [localDelta], which is the [delta] transformed into the local
+  ///    coordinate space of the event receiver.
   final Offset delta;
+
+  /// The [delta] transformed into the event receiver's local coordinate
+  /// system according to [transform].
+  ///
+  /// If this event has not been transformed, [delta] is returned as-is.
+  ///
+  /// See also:
+  ///
+  ///  * [delta], which is the distance the pointer moved in the global
+  ///    coordinate system of the screen.
+  final Offset localDelta;
 
   /// Bit field using the *Button constants such as [kPrimaryMouseButton],
   /// [kSecondaryStylusButton], etc.
@@ -323,11 +362,50 @@ abstract class PointerEvent extends Diagnosticable {
   /// the difference between the 2 events in that case.
   final bool synthesized;
 
+  /// The transformation used to transform this event from the global coordinate
+  /// space into the coordinate space of the event receiver.
+  ///
+  /// This value affects what is returned by [localPosition] and [localDelta].
+  /// If this value is null, it is treated as the identity transformation.
+  ///
+  /// Unlike a paint transform, this transform usually does not contain any
+  /// "perspective" components, meaning that the third row and the third column
+  /// of the matrix should be equal to "0, 0, 1, 0". This ensures that
+  /// [localPosition] describes the point in the local coordinate system of the
+  /// event receiver at which the user is actually touching the screen.
+  ///
+  /// See also:
+  ///
+  ///  * [transformed], which transforms this event into a different coordinate
+  ///    space.
+  final Matrix4 transform;
+
+  /// The original [PointerEvent] before it was transformed by [transform].
+  ///
+  /// If [transform] is null or the identity transformation this may be null.
+  final PointerEvent original;
+
+  /// Transforms the event from the global coordinate space into the coordinate
+  /// space of an event receiver.
+  ///
+  /// The coordinate space of the event receiver is described by `transform`. A
+  /// null value for `transform` is treated as the identity transformation.
+  ///
+  /// The method may return the same object instance if for example the
+  /// transformation has no effect on the event.
+  ///
+  /// Transforms are not commutative. If this method is called on a
+  /// [PointerEvent] that has a non-null [transform] value, that value will be
+  /// overridden by the provided `transform`.
+  PointerEvent transformed(Matrix4 transform);
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('position', position));
+    properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition, defaultValue: position, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<Offset>('delta', delta, defaultValue: Offset.zero, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<Offset>('localDelta', localDelta, defaultValue: delta, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<Duration>('timeStamp', timeStamp, defaultValue: Duration.zero, level: DiagnosticLevel.debug));
     properties.add(IntProperty('pointer', pointer, level: DiagnosticLevel.debug));
     properties.add(EnumProperty<PointerDeviceKind>('kind', kind, level: DiagnosticLevel.debug));
@@ -356,6 +434,61 @@ abstract class PointerEvent extends Diagnosticable {
   String toStringFull() {
     return toString(minLevel: DiagnosticLevel.fine);
   }
+
+  /// Returns the transformation of `position` into the coordinate system
+  /// described by `transform`.
+  ///
+  /// The z-value of `position` is assumed to be 0.0. If `transform` is null,
+  /// `position` is returned as-is.
+  static Offset transformPosition(Matrix4 transform, Offset position) {
+    if (transform == null) {
+      return position;
+    }
+    final Vector3 position3 = Vector3(position.dx, position.dy, 0.0);
+    final Vector3 transformed3 = transform.perspectiveTransform(position3);
+    return Offset(transformed3.x, transformed3.y);
+  }
+
+  /// Transforms `untransformedDelta` into the coordinate system described by
+  /// `transform`.
+  ///
+  /// It uses the provided `untransformedEndPosition` and
+  /// `transformedEndPosition` of the provided delta to increase accuracy.
+  ///
+  /// If `transform` is null, `untransformedDelta` is returned.
+  static Offset transformDeltaViaPositions({
+    @required Offset untransformedEndPosition,
+    Offset transformedEndPosition,
+    @required Offset untransformedDelta,
+    @required Matrix4 transform,
+  }) {
+    if (transform == null) {
+      return untransformedDelta;
+    }
+    // We could transform the delta directly with the transformation matrix.
+    // While that is mathematically equivalent, in practice we are seeing a
+    // greater precision error with that approach. Instead, we are transforming
+    // start and end point of the delta separately and calculate the delta in
+    // the new space for greater accuracy.
+    transformedEndPosition ??= transformPosition(transform, untransformedEndPosition);
+    final Offset transformedStartPosition = transformPosition(transform, untransformedEndPosition - untransformedDelta);
+    return transformedEndPosition - transformedStartPosition;
+  }
+
+  /// Takes a transform matrix meant for painting and returns a matrix that can
+  /// be used to transform [PointerEvent]s for hit testing.
+  ///
+  /// This method removes the "perspective" component from `paintTransform` by
+  /// setting the third column and third row of the matrix to "0, 0, 1, 0".
+  /// The resulting matrix can be used to determine the point in the local
+  /// coordinate system of the transformed component that is exactly under the
+  /// user's finger when the user is touching the screen.
+  static Matrix4 paintTransformToPointerEventTransform(Matrix4 paintTransform) {
+    final Vector4 vector = Vector4(0, 0, 1, 0);
+    return paintTransform.clone()
+      ..setColumn(2, vector)
+      ..setRow(2, vector);
+  }
 }
 
 /// The device has started tracking the pointer.
@@ -371,6 +504,7 @@ class PointerAddedEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     bool obscured = false,
     double pressureMin = 1.0,
     double pressureMax = 1.0,
@@ -380,11 +514,14 @@ class PointerAddedEvent extends PointerEvent {
     double radiusMax = 0.0,
     double orientation = 0.0,
     double tilt = 0.0,
+    Matrix4 transform,
+    PointerAddedEvent original,
   }) : super(
          timeStamp: timeStamp,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          obscured: obscured,
          pressure: 0.0,
          pressureMin: pressureMin,
@@ -395,7 +532,34 @@ class PointerAddedEvent extends PointerEvent {
          radiusMax: radiusMax,
          orientation: orientation,
          tilt: tilt,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerAddedEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerAddedEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: PointerEvent.transformPosition(transform, position),
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The device is no longer tracking the pointer.
@@ -416,6 +580,8 @@ class PointerRemovedEvent extends PointerEvent {
     double distanceMax = 0.0,
     double radiusMin = 0.0,
     double radiusMax = 0.0,
+    Matrix4 transform,
+    PointerRemovedEvent original,
   }) : super(
          timeStamp: timeStamp,
          kind: kind,
@@ -428,7 +594,29 @@ class PointerRemovedEvent extends PointerEvent {
          distanceMax: distanceMax,
          radiusMin: radiusMin,
          radiusMax: radiusMax,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerRemovedEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerRemovedEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distanceMax: distanceMax,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has moved with respect to the device while the pointer is not
@@ -450,7 +638,9 @@ class PointerHoverEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     Offset delta = Offset.zero,
+    Offset localDelta,
     int buttons = 0,
     bool obscured = false,
     double pressureMin = 1.0,
@@ -465,12 +655,16 @@ class PointerHoverEvent extends PointerEvent {
     double orientation = 0.0,
     double tilt = 0.0,
     bool synthesized = false,
+    Matrix4 transform,
+    PointerHoverEvent original,
   }) : super(
          timeStamp: timeStamp,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          delta: delta,
+         localDelta: localDelta,
          buttons: buttons,
          down: false,
          obscured: obscured,
@@ -487,7 +681,47 @@ class PointerHoverEvent extends PointerEvent {
          orientation: orientation,
          tilt: tilt,
          synthesized: synthesized,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerHoverEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    final Offset transformedPosition = PointerEvent.transformPosition(transform, position);
+    return PointerHoverEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: transformedPosition,
+      delta: delta,
+      localDelta: PointerEvent.transformDeltaViaPositions(
+        transform: transform,
+        untransformedDelta: delta,
+        untransformedEndPosition: position,
+        transformedEndPosition: transformedPosition,
+      ),
+      buttons: buttons,
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      synthesized: synthesized,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has moved with respect to the device while the pointer is not
@@ -509,7 +743,9 @@ class PointerEnterEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     Offset delta = Offset.zero,
+    Offset localDelta,
     int buttons = 0,
     bool obscured = false,
     double pressureMin = 1.0,
@@ -524,12 +760,16 @@ class PointerEnterEvent extends PointerEvent {
     double orientation = 0.0,
     double tilt = 0.0,
     bool synthesized = false,
+    Matrix4 transform,
+    PointerEnterEvent original,
   }) : super(
          timeStamp: timeStamp,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          delta: delta,
+         localDelta: localDelta,
          buttons: buttons,
          down: false,
          obscured: obscured,
@@ -546,6 +786,8 @@ class PointerEnterEvent extends PointerEvent {
          orientation: orientation,
          tilt: tilt,
          synthesized: synthesized,
+         transform: transform,
+         original: original,
        );
 
   /// Creates an enter event from a [PointerHoverEvent].
@@ -562,7 +804,9 @@ class PointerEnterEvent extends PointerEvent {
     kind: event?.kind,
     device: event?.device,
     position: event?.position,
+    localPosition: event?.localPosition,
     delta: event?.delta,
+    localDelta: event?.localDelta,
     buttons: event?.buttons,
     obscured: event?.obscured,
     pressureMin: event?.pressureMin,
@@ -577,7 +821,47 @@ class PointerEnterEvent extends PointerEvent {
     orientation: event?.orientation,
     tilt: event?.tilt,
     synthesized: event?.synthesized,
+    transform: event?.transform,
+    original: event?.original,
   );
+
+  @override
+  PointerEnterEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    final Offset transformedPosition = PointerEvent.transformPosition(transform, position);
+    return PointerEnterEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: transformedPosition,
+      delta: delta,
+      localDelta: PointerEvent.transformDeltaViaPositions(
+        transform: transform,
+        untransformedDelta: delta,
+        untransformedEndPosition: position,
+        transformedEndPosition: transformedPosition,
+      ),
+      buttons: buttons,
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      synthesized: synthesized,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has moved with respect to the device while the pointer is not
@@ -599,7 +883,9 @@ class PointerExitEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     Offset delta = Offset.zero,
+    Offset localDelta,
     int buttons = 0,
     bool obscured = false,
     double pressureMin = 1.0,
@@ -614,12 +900,16 @@ class PointerExitEvent extends PointerEvent {
     double orientation = 0.0,
     double tilt = 0.0,
     bool synthesized = false,
+    Matrix4 transform,
+    PointerExitEvent original,
   }) : super(
          timeStamp: timeStamp,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          delta: delta,
+         localDelta: localDelta,
          buttons: buttons,
          down: false,
          obscured: obscured,
@@ -636,6 +926,8 @@ class PointerExitEvent extends PointerEvent {
          orientation: orientation,
          tilt: tilt,
          synthesized: synthesized,
+         transform: transform,
+         original: original,
        );
 
   /// Creates an exit event from a [PointerHoverEvent].
@@ -652,7 +944,9 @@ class PointerExitEvent extends PointerEvent {
     kind: event?.kind,
     device: event?.device,
     position: event?.position,
+    localPosition: event?.localPosition,
     delta: event?.delta,
+    localDelta: event?.localDelta,
     buttons: event?.buttons,
     obscured: event?.obscured,
     pressureMin: event?.pressureMin,
@@ -667,7 +961,47 @@ class PointerExitEvent extends PointerEvent {
     orientation: event?.orientation,
     tilt: event?.tilt,
     synthesized: event?.synthesized,
+    transform: event?.transform,
+    original: event?.original,
   );
+
+  @override
+  PointerExitEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    final Offset transformedPosition = PointerEvent.transformPosition(transform, position);
+    return PointerExitEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: transformedPosition,
+      delta: delta,
+      localDelta: PointerEvent.transformDeltaViaPositions(
+        transform: transform,
+        untransformedDelta: delta,
+        untransformedEndPosition: position,
+        transformedEndPosition: transformedPosition,
+      ),
+      buttons: buttons,
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      synthesized: synthesized,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has made contact with the device.
@@ -681,6 +1015,7 @@ class PointerDownEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     int buttons = kPrimaryButton,
     bool obscured = false,
     double pressure = 1.0,
@@ -694,12 +1029,15 @@ class PointerDownEvent extends PointerEvent {
     double radiusMax = 0.0,
     double orientation = 0.0,
     double tilt = 0.0,
+    Matrix4 transform,
+    PointerDownEvent original,
   }) : super(
          timeStamp: timeStamp,
          pointer: pointer,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          buttons: buttons,
          down: true,
          obscured: obscured,
@@ -715,7 +1053,39 @@ class PointerDownEvent extends PointerEvent {
          radiusMax: radiusMax,
          orientation: orientation,
          tilt: tilt,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerDownEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerDownEvent(
+      timeStamp: timeStamp,
+      pointer: pointer,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: PointerEvent.transformPosition(transform, position),
+      buttons: buttons,
+      obscured: obscured,
+      pressure: pressure,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has moved with respect to the device while the pointer is in
@@ -735,7 +1105,9 @@ class PointerMoveEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     Offset delta = Offset.zero,
+    Offset localDelta,
     int buttons = kPrimaryButton,
     bool obscured = false,
     double pressure = 1.0,
@@ -751,13 +1123,17 @@ class PointerMoveEvent extends PointerEvent {
     double tilt = 0.0,
     int platformData = 0,
     bool synthesized = false,
+    Matrix4 transform,
+    PointerMoveEvent original,
   }) : super(
          timeStamp: timeStamp,
          pointer: pointer,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          delta: delta,
+         localDelta: localDelta,
          buttons: buttons,
          down: true,
          obscured: obscured,
@@ -775,7 +1151,50 @@ class PointerMoveEvent extends PointerEvent {
          tilt: tilt,
          platformData: platformData,
          synthesized: synthesized,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerMoveEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    final Offset transformedPosition = PointerEvent.transformPosition(transform, position);
+
+    return PointerMoveEvent(
+      timeStamp: timeStamp,
+      pointer: pointer,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: transformedPosition,
+      delta: delta,
+      localDelta: PointerEvent.transformDeltaViaPositions(
+        transform: transform,
+        untransformedDelta: delta,
+        untransformedEndPosition: position,
+        transformedEndPosition: transformedPosition,
+      ),
+      buttons: buttons,
+      obscured: obscured,
+      pressure: pressure,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      platformData: platformData,
+      synthesized: synthesized,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// The pointer has stopped making contact with the device.
@@ -789,6 +1208,7 @@ class PointerUpEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     int buttons = 0,
     bool obscured = false,
     // Allow pressure customization here because PointerUpEvent can contain
@@ -805,12 +1225,15 @@ class PointerUpEvent extends PointerEvent {
     double radiusMax = 0.0,
     double orientation = 0.0,
     double tilt = 0.0,
+    Matrix4 transform,
+    PointerUpEvent original,
   }) : super(
          timeStamp: timeStamp,
          pointer: pointer,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          buttons: buttons,
          down: false,
          obscured: obscured,
@@ -826,7 +1249,40 @@ class PointerUpEvent extends PointerEvent {
          radiusMax: radiusMax,
          orientation: orientation,
          tilt: tilt,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerUpEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerUpEvent(
+      timeStamp: timeStamp,
+      pointer: pointer,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: PointerEvent.transformPosition(transform, position),
+      buttons: buttons,
+      obscured: obscured,
+      pressure: pressure,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }
 
 /// An event that corresponds to a discrete pointer signal.
@@ -843,12 +1299,18 @@ abstract class PointerSignalEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.mouse,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
+    Matrix4 transform,
+    PointerSignalEvent original,
   }) : super(
          timeStamp: timeStamp,
          pointer: pointer,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
+         transform: transform,
+         original: original,
        );
 }
 
@@ -865,7 +1327,10 @@ class PointerScrollEvent extends PointerSignalEvent {
     PointerDeviceKind kind = PointerDeviceKind.mouse,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     this.scrollDelta = Offset.zero,
+    Matrix4 transform,
+    PointerScrollEvent original,
   }) : assert(timeStamp != null),
        assert(kind != null),
        assert(device != null),
@@ -876,10 +1341,30 @@ class PointerScrollEvent extends PointerSignalEvent {
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
+         transform: transform,
+         original: original,
        );
 
   /// The amount to scroll, in logical pixels.
   final Offset scrollDelta;
+
+  @override
+  PointerScrollEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerScrollEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: PointerEvent.transformPosition(transform, position),
+      scrollDelta: scrollDelta,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -899,6 +1384,7 @@ class PointerCancelEvent extends PointerEvent {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int device = 0,
     Offset position = Offset.zero,
+    Offset localPosition,
     int buttons = 0,
     bool obscured = false,
     double pressureMin = 1.0,
@@ -912,12 +1398,15 @@ class PointerCancelEvent extends PointerEvent {
     double radiusMax = 0.0,
     double orientation = 0.0,
     double tilt = 0.0,
+    Matrix4 transform,
+    PointerCancelEvent original,
   }) : super(
          timeStamp: timeStamp,
          pointer: pointer,
          kind: kind,
          device: device,
          position: position,
+         localPosition: localPosition,
          buttons: buttons,
          down: false,
          obscured: obscured,
@@ -933,5 +1422,37 @@ class PointerCancelEvent extends PointerEvent {
          radiusMax: radiusMax,
          orientation: orientation,
          tilt: tilt,
+         transform: transform,
+         original: original,
        );
+
+  @override
+  PointerCancelEvent transformed(Matrix4 transform) {
+    if (transform == this.transform) {
+      return this;
+    }
+    return PointerCancelEvent(
+      timeStamp: timeStamp,
+      pointer: pointer,
+      kind: kind,
+      device: device,
+      position: position,
+      localPosition: PointerEvent.transformPosition(transform, position),
+      buttons: buttons,
+      obscured: obscured,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      transform: transform,
+      original: original ?? this,
+    );
+  }
 }

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -51,12 +51,17 @@ class ForcePressDetails {
   /// The [globalPosition] argument must not be null.
   ForcePressDetails({
     @required this.globalPosition,
+    Offset localPosition,
     @required this.pressure,
   }) : assert(globalPosition != null),
-       assert(pressure != null);
+       assert(pressure != null),
+       localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the function was called.
   final Offset globalPosition;
+
+  /// The local position at which the function was called.
+  final Offset localPosition;
 
   /// The pressure of the pointer on the screen.
   final double pressure;
@@ -203,7 +208,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
   /// ```
   final GestureForceInterpolation interpolation;
 
-  Offset _lastPosition;
+  CombinedOffset _lastPosition;
   double _lastPressure;
   _ForceState _state = _ForceState.ready;
 
@@ -215,10 +220,10 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     if (!(event is PointerUpEvent) && event.pressureMax <= 1.0) {
       resolve(GestureDisposition.rejected);
     } else {
-      startTrackingPointer(event.pointer);
+      startTrackingPointer(event.pointer, event.transform);
       if (_state == _ForceState.ready) {
         _state = _ForceState.possible;
-        _lastPosition = event.position;
+        _lastPosition = CombinedOffset.fromEventPosition(event);
       }
     }
   }
@@ -242,7 +247,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
         pressure.isNaN // and interpolation may return NaN for values it doesn't want to support...
       );
 
-      _lastPosition = event.position;
+      _lastPosition = CombinedOffset.fromEventPosition(event);
       _lastPressure = pressure;
 
       if (_state == _ForceState.possible) {
@@ -260,7 +265,8 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
         if (onStart != null) {
           invokeCallback<void>('onStart', () => onStart(ForcePressDetails(
             pressure: pressure,
-            globalPosition: _lastPosition,
+            globalPosition: _lastPosition.global,
+            localPosition: _lastPosition.local,
           )));
         }
       }
@@ -271,6 +277,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
           invokeCallback<void>('onPeak', () => onPeak(ForcePressDetails(
             pressure: pressure,
             globalPosition: event.position,
+            localPosition: event.localPosition,
           )));
         }
       }
@@ -280,6 +287,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
           invokeCallback<void>('onUpdate', () => onUpdate(ForcePressDetails(
             pressure: pressure,
             globalPosition: event.position,
+            localPosition: event.localPosition,
           )));
         }
       }
@@ -295,7 +303,8 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     if (onStart != null && _state == _ForceState.started) {
       invokeCallback<void>('onStart', () => onStart(ForcePressDetails(
         pressure: _lastPressure,
-        globalPosition: _lastPosition,
+        globalPosition: _lastPosition.global,
+        localPosition: _lastPosition.local,
       )));
     }
   }
@@ -311,7 +320,8 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
       if (onEnd != null) {
         invokeCallback<void>('onEnd', () => onEnd(ForcePressDetails(
           pressure: 0.0,
-          globalPosition: _lastPosition,
+          globalPosition: _lastPosition.global,
+          localPosition: _lastPosition.local,
         )));
       }
     }

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -54,12 +54,16 @@ class HitTestEntry {
 
 /// The result of performing a hit test.
 class HitTestResult {
-  /// Creates a hit test result.
+  /// Creates an empty hit test result.
+  HitTestResult() : _path = <HitTestEntry>[];
+
+  /// Wraps `result` (usually a subtype of [HitTestResult]) to create a
+  /// generic [HitTestResult].
   ///
-  /// If the [path] argument is null, the [path] field will be initialized with
-  /// and empty list.
-  HitTestResult({ List<HitTestEntry> path })
-    : _path = path ?? <HitTestEntry>[];
+  /// The [HitTestEntry]s added to the returned [HitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  HitTestResult.wrap(HitTestResult result) : _path = result._path;
 
   /// An unmodifiable list of [HitTestEntry] objects recorded during the hit test.
   ///

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -133,7 +133,9 @@ class HitTestResult {
   @protected
   void pushTransform(Matrix4 transform) {
     assert(transform != null);
-    assert(transform.getRow(2) == Vector4(0, 0, 1, 0) && transform.getColumn(2) == Vector4(0, 0, 1, 0),
+    assert(
+      _vectorMoreOrLessEquals(transform.getRow(2), Vector4(0, 0, 1, 0)) &&
+      _vectorMoreOrLessEquals(transform.getColumn(2), Vector4(0, 0, 1, 0)),
       'The third row and third column of a transform matrix for pointer '
       'events must be Vector4(0, 0, 1, 0) to ensure that a transformed '
       'point is directly under the pointer device. Did you forget to run the paint '
@@ -160,6 +162,12 @@ class HitTestResult {
   void popTransform() {
     assert(_transforms.isNotEmpty);
     _transforms.removeLast();
+  }
+
+  bool _vectorMoreOrLessEquals(Vector4 a, Vector4 b) {
+    const double epsilon = 0.000001;
+    final Vector4 difference = a - b;
+    return difference.storage.every((double component) => component.abs() < epsilon);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -71,7 +71,9 @@ class HitTestEntry {
 /// The result of performing a hit test.
 class HitTestResult {
   /// Creates an empty hit test result.
-  HitTestResult() : _path = <HitTestEntry>[];
+  HitTestResult()
+     : _path = <HitTestEntry>[],
+       _transforms = Queue<Matrix4>();
 
   /// Wraps `result` (usually a subtype of [HitTestResult]) to create a
   /// generic [HitTestResult].
@@ -79,7 +81,9 @@ class HitTestResult {
   /// The [HitTestEntry]s added to the returned [HitTestResult] are also
   /// added to the wrapped `result` (both share the same underlying data
   /// structure to store [HitTestEntry]s).
-  HitTestResult.wrap(HitTestResult result) : _path = result._path;
+  HitTestResult.wrap(HitTestResult result)
+     : _path = result._path,
+       _transforms = result._transforms;
 
   /// An unmodifiable list of [HitTestEntry] objects recorded during the hit test.
   ///
@@ -88,6 +92,8 @@ class HitTestResult {
   /// specific (i.e., first) entry and proceeds in order through the path.
   Iterable<HitTestEntry> get path => _path;
   final List<HitTestEntry> _path;
+
+  final Queue<Matrix4> _transforms;
 
   /// Add a [HitTestEntry] to the path.
   ///
@@ -99,8 +105,6 @@ class HitTestResult {
     entry._transform = _transforms.isEmpty ? null : _transforms.last;
     _path.add(entry);
   }
-
-  final Queue<Matrix4> _transforms = Queue<Matrix4>();
 
   /// Pushes a new transform matrix that is to be applied to all future
   /// [HitTestEntry]s added via [add] until it is removed via [popTransform].

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -164,8 +164,7 @@ class HitTestResult {
     _transforms.removeLast();
   }
 
-  bool _vectorMoreOrLessEquals(Vector4 a, Vector4 b) {
-    const double epsilon = 0.000001;
+  bool _vectorMoreOrLessEquals(Vector4 a, Vector4 b, { double epsilon =  0.000001 }) {
     final Vector4 difference = a - b;
     return difference.storage.every((double component) => component.abs() < epsilon);
   }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -171,8 +171,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       if (onDown != null)
         invokeCallback<void>('onDown', () {
           onDown(DragDownDetails(
-            globalPosition: _initialPosition.local,
-            localPosition: _initialPosition.global,
+            globalPosition: _initialPosition.global,
+            localPosition: _initialPosition.local,
           ));
         });
     } else if (_state == _DragState.accepted) {

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -5,6 +5,7 @@
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import 'events.dart';
 
@@ -13,8 +14,8 @@ typedef PointerRoute = void Function(PointerEvent event);
 
 /// A routing table for [PointerEvent] events.
 class PointerRouter {
-  final Map<int, LinkedHashSet<PointerRoute>> _routeMap = <int, LinkedHashSet<PointerRoute>>{};
-  final LinkedHashSet<PointerRoute> _globalRoutes = LinkedHashSet<PointerRoute>();
+  final Map<int, LinkedHashSet<_RouteEntry>> _routeMap = <int, LinkedHashSet<_RouteEntry>>{};
+  final LinkedHashSet<_RouteEntry> _globalRoutes = LinkedHashSet<_RouteEntry>();
 
   /// Adds a route to the routing table.
   ///
@@ -23,10 +24,10 @@ class PointerRouter {
   ///
   /// Routes added reentrantly within [PointerRouter.route] will take effect when
   /// routing the next event.
-  void addRoute(int pointer, PointerRoute route) {
-    final LinkedHashSet<PointerRoute> routes = _routeMap.putIfAbsent(pointer, () => LinkedHashSet<PointerRoute>());
-    assert(!routes.contains(route));
-    routes.add(route);
+  void addRoute(int pointer, PointerRoute route, [Matrix4 transform]) {
+    final LinkedHashSet<_RouteEntry> routes = _routeMap.putIfAbsent(pointer, () => LinkedHashSet<_RouteEntry>());
+    assert(!routes.any(_RouteEntry.isRoutePredicate(route)));
+    routes.add(_RouteEntry(route: route, transform: transform));
   }
 
   /// Removes a route from the routing table.
@@ -38,9 +39,9 @@ class PointerRouter {
   /// immediately.
   void removeRoute(int pointer, PointerRoute route) {
     assert(_routeMap.containsKey(pointer));
-    final LinkedHashSet<PointerRoute> routes = _routeMap[pointer];
-    assert(routes.contains(route));
-    routes.remove(route);
+    final LinkedHashSet<_RouteEntry> routes = _routeMap[pointer];
+    assert(routes.any(_RouteEntry.isRoutePredicate(route)));
+    routes.removeWhere(_RouteEntry.isRoutePredicate(route));
     if (routes.isEmpty)
       _routeMap.remove(pointer);
   }
@@ -51,9 +52,9 @@ class PointerRouter {
   ///
   /// Routes added reentrantly within [PointerRouter.route] will take effect when
   /// routing the next event.
-  void addGlobalRoute(PointerRoute route) {
-    assert(!_globalRoutes.contains(route));
-    _globalRoutes.add(route);
+  void addGlobalRoute(PointerRoute route, [Matrix4 transform]) {
+    assert(!_globalRoutes.any(_RouteEntry.isRoutePredicate(route)));
+    _globalRoutes.add(_RouteEntry(route: route, transform: transform));
   }
 
   /// Removes a route from the global entry in the routing table.
@@ -64,13 +65,14 @@ class PointerRouter {
   /// Routes removed reentrantly within [PointerRouter.route] will take effect
   /// immediately.
   void removeGlobalRoute(PointerRoute route) {
-    assert(_globalRoutes.contains(route));
-    _globalRoutes.remove(route);
+    assert(_globalRoutes.any(_RouteEntry.isRoutePredicate(route)));
+    _globalRoutes.removeWhere(_RouteEntry.isRoutePredicate(route));
   }
 
-  void _dispatch(PointerEvent event, PointerRoute route) {
+  void _dispatch(PointerEvent event, _RouteEntry entry) {
     try {
-      route(event);
+      event = event.transformed(entry.transform);
+      entry.route(event);
     } catch (exception, stack) {
       FlutterError.reportError(FlutterErrorDetailsForPointerRouter(
         exception: exception,
@@ -78,7 +80,7 @@ class PointerRouter {
         library: 'gesture library',
         context: ErrorDescription('while routing a pointer event'),
         router: this,
-        route: route,
+        route: entry.route,
         event: event,
         informationCollector: () sync* {
           yield DiagnosticsProperty<PointerEvent>('Event', event, style: DiagnosticsTreeStyle.errorProperty);
@@ -92,17 +94,17 @@ class PointerRouter {
   /// Routes are called in the order in which they were added to the
   /// PointerRouter object.
   void route(PointerEvent event) {
-    final LinkedHashSet<PointerRoute> routes = _routeMap[event.pointer];
-    final List<PointerRoute> globalRoutes = List<PointerRoute>.from(_globalRoutes);
+    final LinkedHashSet<_RouteEntry> routes = _routeMap[event.pointer];
+    final List<_RouteEntry> globalRoutes = List<_RouteEntry>.from(_globalRoutes);
     if (routes != null) {
-      for (PointerRoute route in List<PointerRoute>.from(routes)) {
-        if (routes.contains(route))
-          _dispatch(event, route);
+      for (_RouteEntry entry in List<_RouteEntry>.from(routes)) {
+        if (routes.any(_RouteEntry.isRoutePredicate(entry.route)))
+          _dispatch(event, entry);
       }
     }
-    for (PointerRoute route in globalRoutes) {
-      if (_globalRoutes.contains(route))
-        _dispatch(event, route);
+    for (_RouteEntry entry in globalRoutes) {
+      if (_globalRoutes.any(_RouteEntry.isRoutePredicate(entry.route)))
+        _dispatch(event, entry);
     }
   }
 }
@@ -148,4 +150,20 @@ class FlutterErrorDetailsForPointerRouter extends FlutterErrorDetails {
 
   /// The pointer event that was being routed when the exception was raised.
   final PointerEvent event;
+}
+
+typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
+
+class _RouteEntry {
+  const _RouteEntry({
+    @required this.route,
+    @required this.transform,
+  });
+
+  final PointerRoute route;
+  final Matrix4 transform;
+
+  static _RouteEntryPredicate isRoutePredicate(PointerRoute route) {
+    return (_RouteEntry entry) => entry.route == route;
+  }
 }

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -47,9 +47,9 @@ class PointerSignalResolver {
       assert(_currentEvent == null);
       return;
     }
-    assert(_currentEvent == event);
+    assert((_currentEvent.original ?? _currentEvent) == event);
     try {
-    _firstRegisteredCallback(event);
+    _firstRegisteredCallback(_currentEvent);
     } catch (exception, stack) {
       FlutterError.reportError(FlutterErrorDetails(
         exception: exception,

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:ui' show Offset;
 
+import 'package:vector_math/vector_math_64.dart';
 import 'package:flutter/foundation.dart';
 
 import 'arena.dart';
@@ -278,12 +279,16 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
 
   /// Causes events related to the given pointer ID to be routed to this recognizer.
   ///
-  /// The pointer events are delivered to [handleEvent].
+  /// The pointer events are transformed according to `transform` and then delivered
+  /// to [handleEvent]. The value for the `transform` argument is usually obtained
+  /// from [PointerDownEvent.transform] to transform the events from the global
+  /// coordinate space into the coordinate space of the event receiver. It may be
+  /// null if no transformation is necessary.
   ///
   /// Use [stopTrackingPointer] to remove the route added by this function.
   @protected
-  void startTrackingPointer(int pointer) {
-    GestureBinding.instance.pointerRouter.addRoute(pointer, handleEvent);
+  void startTrackingPointer(int pointer, [Matrix4 transform]) {
+    GestureBinding.instance.pointerRouter.addRoute(pointer, handleEvent, transform);
     _trackedPointers.add(pointer);
     assert(!_entries.containsValue(pointer));
     _entries[pointer] = _addPointerToArena(pointer);
@@ -395,8 +400,8 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   /// The ID of the primary pointer this recognizer is tracking.
   int primaryPointer;
 
-  /// The global location at which the primary pointer contacted the screen.
-  Offset initialPosition;
+  /// The location at which the primary pointer contacted the screen.
+  CombinedOffset initialPosition;
 
   // Whether this pointer is accepted by winning the arena or as defined by
   // a subclass calling acceptGesture.
@@ -405,11 +410,11 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
-    startTrackingPointer(event.pointer);
+    startTrackingPointer(event.pointer, event.transform);
     if (state == GestureRecognizerState.ready) {
       state = GestureRecognizerState.possible;
       primaryPointer = event.pointer;
-      initialPosition = event.position;
+      initialPosition = CombinedOffset(local: event.localPosition, global: event.position);
       if (deadline != null)
         _timer = Timer(deadline, didExceedDeadline);
     }
@@ -422,11 +427,11 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
       final bool isPreAcceptSlopPastTolerance =
           !_gestureAccepted &&
           preAcceptSlopTolerance != null &&
-          _getDistance(event) > preAcceptSlopTolerance;
+          _getGlobalDistance(event) > preAcceptSlopTolerance;
       final bool isPostAcceptSlopPastTolerance =
           _gestureAccepted &&
           postAcceptSlopTolerance != null &&
-          _getDistance(event) > postAcceptSlopTolerance;
+          _getGlobalDistance(event) > postAcceptSlopTolerance;
 
       if (event is PointerMoveEvent && (isPreAcceptSlopPastTolerance || isPostAcceptSlopPastTolerance)) {
         resolve(GestureDisposition.rejected);
@@ -483,8 +488,8 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     }
   }
 
-  double _getDistance(PointerEvent event) {
-    final Offset offset = event.position - initialPosition;
+  double _getGlobalDistance(PointerEvent event) {
+    final Offset offset = event.position - initialPosition.global;
     return offset.distance;
   }
 
@@ -493,4 +498,50 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     super.debugFillProperties(properties);
     properties.add(EnumProperty<GestureRecognizerState>('state', state));
   }
+}
+
+/// A container for a [local] and [global] [Offset].
+///
+/// Usually, the [global] [Offset] is in the coordinate space of the screen
+/// after conversion to logical pixels and the [local] offset is the same
+/// [Offset], but transformed to a local coordinate space.
+class CombinedOffset {
+  /// Creates a [CombinedOffset] combining a [local] and [global] [Offset].
+  const CombinedOffset({
+    @required this.local,
+    @required this.global,
+  });
+
+  /// Creates a [CombinedOffset] from [PointerEvent.localPosition] and
+  /// [PointerEvent.position].
+  factory CombinedOffset.fromEventPosition(PointerEvent event) {
+    return CombinedOffset(local: event.localPosition, global: event.position);
+  }
+
+  /// Creates a [CombinedOffset] from [PointerEvent.localDelta] and
+  /// [PointerEvent.delta].
+  factory CombinedOffset.fromEventDelta(PointerEvent event) {
+    return CombinedOffset(local: event.localDelta, global: event.delta);
+  }
+
+  /// A [CombinedOffset] where both [Offset]s are [Offset.zero].
+  static const CombinedOffset zero = CombinedOffset(local: Offset.zero, global: Offset.zero);
+
+  /// The [Offset] in the local coordinate space.
+  final Offset local;
+
+  /// The [Offset] in the global coordinate space after conversion to logical
+  /// pixels.
+  final Offset global;
+
+  /// Adds the `other.global` to [global] and `other.local` to [local].
+  CombinedOffset operator+(CombinedOffset other) {
+    return CombinedOffset(
+      local: local + other.local,
+      global: global + other.global,
+    );
+  }
+
+  @override
+  String toString() => '$runtimeType(local: $local, global: $global)';
 }

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -324,8 +324,18 @@ class _RenderInputPadding extends RenderShiftedBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
-    return super.hitTest(result, position: position) ||
-      child.hitTest(result, position: child.size.center(Offset.zero));
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
+    if (super.hitTest(result, position: position)) {
+      return true;
+    }
+    final Offset center = child.size.center(Offset.zero);
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(center),
+      position: center,
+      hitTest: (HitTestResult result, Offset position) {
+        assert(position == center);
+        return child.hitTest(result, position: center);
+      },
+    );
   }
 }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1740,13 +1740,21 @@ class _RenderChipRedirectingHitDetection extends RenderConstrainedBox {
   _RenderChipRedirectingHitDetection(BoxConstraints additionalConstraints) : super(additionalConstraints: additionalConstraints);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (!size.contains(position))
       return false;
     // Only redirects hit detection which occurs above and below the render object.
     // In order to make this assumption true, I have removed the minimum width
     // constraints, since any reasonable chip would be at least that wide.
-    return child.hitTest(result, position: Offset(position.dx, size.height / 2));
+    final Offset offset = Offset(position.dx, size.height / 2);
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(offset),
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        assert(position == offset);
+        return child.hitTest(result, position: offset);
+      },
+    );
   }
 }
 
@@ -2269,7 +2277,7 @@ class _RenderChip extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (!size.contains(position))
       return false;
     RenderBox hitTestChild;
@@ -2287,7 +2295,18 @@ class _RenderChip extends RenderBox {
           hitTestChild = label ?? avatar;
         break;
     }
-    return hitTestChild?.hitTest(result, position: hitTestChild.size.center(Offset.zero)) ?? false;
+    if (hitTestChild != null) {
+      final Offset center = hitTestChild.size.center(Offset.zero);
+      return result.addWithRawTransform(
+        transform: MatrixUtils.forceToPoint(center),
+        position: position,
+        hitTest: (HitTestResult result, Offset position) {
+          assert(position == center);
+          return hitTestChild.hitTest(result, position: center);
+        },
+      );
+    }
+    return false;
   }
 
   @override

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1287,11 +1287,20 @@ class _RenderDecoration extends RenderBox {
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     for (RenderBox child in _children) {
       // TODO(hansmuller): label must be handled specially since we've transformed it
-      if (child.hitTest(result, position: position - _boxParentData(child).offset))
+      final Offset offset = _boxParentData(child).offset;
+      final bool isHit = result.addWithPaintOffset(
+        offset: offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
+      if (isHit)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1460,11 +1460,19 @@ class _RenderListTile extends RenderBox {
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     assert(position != null);
     for (RenderBox child in _children) {
       final BoxParentData parentData = child.parentData;
-      if (child.hitTest(result, position: position - parentData.offset))
+      final bool isHit = result.addWithPaintOffset(
+          offset: parentData.offset,
+          position: position,
+          hitTest: (HitTestResult result, Offset transformed) {
+            assert(transformed == position - parentData.offset);
+            return child.hitTest(result, position: transformed);
+          }
+      );
+      if (isHit)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1465,12 +1465,12 @@ class _RenderListTile extends RenderBox {
     for (RenderBox child in _children) {
       final BoxParentData parentData = child.parentData;
       final bool isHit = result.addWithPaintOffset(
-          offset: parentData.offset,
-          position: position,
-          hitTest: (HitTestResult result, Offset transformed) {
-            assert(transformed == position - parentData.offset);
-            return child.hitTest(result, position: transformed);
-          }
+        offset: parentData.offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - parentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
       );
       if (isHit)
         return true;

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -249,6 +249,13 @@ class MatrixUtils {
     // Essentially perspective * view * model.
     return result;
   }
+
+  /// Returns a matrix that transforms every point to [offset].
+  static Matrix4 forceToPoint(Offset offset) {
+    return Matrix4.identity()
+      ..setRow(0, Vector4(0, 0, 0, offset.dx))
+      ..setRow(1, Vector4(0, 0, 0, offset.dy));
+  }
 }
 
 /// Returns a list of strings representing the given transform in a format

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -709,12 +709,11 @@ class BoxHitTestResult extends HitTestResult {
   }) {
     assert(hitTest != null);
     if (transform != null) {
-      transform = Matrix4.tryInvert(transform);
+      transform = Matrix4.tryInvert(PointerEvent.paintTransformToPointerEventTransform(transform));
       if (transform == null) {
         // Objects are not visible on screen and cannot be hit-tested.
         return false;
       }
-      transform = PointerEvent.paintTransformToPointerEventTransform(transform);
     }
     return addWithRawTransform(
       transform: transform,

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -612,6 +612,171 @@ class BoxConstraints extends Constraints {
   }
 }
 
+/// Method signature for hit testing a [RenderBox].
+///
+/// Used by [BoxHitTestResult.addWithPaintTransform] to hit test children
+/// of a [RenderBox].
+///
+/// See also:
+///
+///  * [RenderBox.hitTest], which documents more details around hit testing
+///    [RenderBox]s.
+typedef BoxHitTest = bool Function(BoxHitTestResult result, Offset position);
+
+/// The result of performing a hit test on [RenderBox]s.
+class BoxHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderBox].
+  BoxHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [BoxHitTestResult] protocol for hit testing on [RenderBox]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderBox]-world and the non-[RenderBox]-world to convert a (subtype of)
+  /// [HitTestResult] to a [BoxHitTestResult] for hit testing on [RenderBox]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [BoxHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [BoxHitTestResult] back into a
+  ///    generic [HitTestResult].
+  ///  * [SliverHitTestResult.wrap], which turns a [BoxHitTestResult] into a
+  ///    [SliverHitTestResult] for hit testing on [RenderSliver] children.
+  BoxHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+
+  /// Transforms `position` to the local coordinate system of a child before
+  /// hit-testing the child.
+  ///
+  /// Since the provided paint `transform` describes the transform from the
+  /// child to the parent, the matrix is inverted before it is used to transform
+  /// `position` from the coordinate system of the parent to the system of the
+  /// child.
+  ///
+  /// If `transform` is null it will be treated as the identity transform and
+  /// `position` is provided to the `hitTest` callback as-is. If `transform`
+  /// cannot be inverted, the `hitTest` callback is not invoked and false is
+  /// returned. Otherwise, the return value of the `hitTest` callback is
+  /// returned.
+  ///
+  /// The `position` argument may be null, which will be forwarded to the
+  /// `hitTest` callback as-is. Using null as the position can be useful if
+  /// the child speaks a different hit test protocol then the parent and the
+  /// position is not required to do the actual hit testing in that protocol.
+  ///
+  /// {@tool sample}
+  /// This method is used in [RenderBox.hitTestChildren]:
+  ///
+  /// ```dart
+  /// abstract class Foo extends RenderBox {
+  ///
+  ///   final Matrix4 _effectiveTransform = Matrix4.rotationZ(50);
+  ///
+  ///   @override
+  ///   void applyPaintTransform(RenderBox child, Matrix4 transform) {
+  ///     transform.multiply(_effectiveTransform);
+  ///   }
+  ///
+  ///   @override
+  ///   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
+  ///     return result.addWithPaintTransform(
+  ///       transform: _effectiveTransform,
+  ///       position: position,
+  ///       hitTest: (BoxHitTestResult result, Offset position) {
+  ///         return super.hitTestChildren(result, position: position);
+  ///       },
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  ///  * [addWithPaintOffset], which can be used for `transform`s that are just
+  ///    simple matrix translations by an [Offset].
+  ///  * [addWithRawTransform], which takes a transform matrix that is directly
+  ///    used to transform the position without any pre-processing.
+  bool addWithPaintTransform({
+    @required Matrix4 transform,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    if (transform != null) {
+      transform = Matrix4.tryInvert(transform);
+      if (transform == null) {
+        // Objects are not visible on screen and cannot be hit-tested.
+        return false;
+      }
+    }
+    return addWithRawTransform(
+      transform: transform,
+      position: position,
+      hitTest: hitTest,
+    );
+  }
+
+  /// Convenience method for hit testing children, that are translated by
+  /// an [Offset].
+  ///
+  /// This method can be used as a convenience over [addWithPaintTransform] if
+  /// a parent paints a child at an `offset`.
+  ///
+  /// A null value for `offset` is treated as if [Offset.zero] was provided.
+  ///
+  /// Se also:
+  ///
+  ///  * [addWithPaintTransform], which takes a generic paint transform matrix and
+  ///    documents the intended usage of this API in more detail.
+  bool addWithPaintOffset({
+    @required Offset offset,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    return addWithRawTransform(
+      transform: offset != null ? Matrix4.translationValues(-offset.dx, -offset.dy, 0.0) : null,
+      position: position,
+      hitTest: hitTest,
+    );
+  }
+
+  /// Transforms `position` to the local coordinate system of a child before
+  /// hit-testing the child.
+  ///
+  /// Unlike [addWithPaintTransform], the provided `transform` matrix is used
+  /// directly to transform `position` without any pre-processing.
+  ///
+  /// If `transform` is null it will be treated as the identity transform ad
+  /// `position` is provided to the `hitTest` callback as-is.
+  ///
+  /// The function returns the return value of the `hitTest` callback.
+  ///
+  /// The `position` argument may be null, which will be forwarded to the
+  /// `hitTest` callback as-is. Using null as the position can be useful if
+  /// the child speaks a different hit test protocol then the parent and the
+  /// position is not required to do the actual hit testing in that protocol.
+  ///
+  /// Se also:
+  ///
+  ///  * [addWithPaintTransform], which accomplishes the same thing, but takes a
+  ///    _paint_ transform matrix.
+  bool addWithRawTransform({
+    @required Matrix4 transform,
+    @required Offset position,
+    @required BoxHitTest hitTest,
+  }) {
+    assert(hitTest != null);
+    final Offset transformedPosition = position == null || transform == null
+        ? position
+        : MatrixUtils.transformPoint(transform, position);
+    return hitTest(this, transformedPosition);
+  }
+}
+
 /// A hit test entry used by [RenderBox].
 class BoxHitTestEntry extends HitTestEntry {
   /// Creates a box hit test entry.
@@ -1877,13 +2042,18 @@ abstract class RenderBox extends RenderObject {
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
   ///
+  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
+  /// [BoxHitTestResult.addWithPaintOffset], or
+  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
+  /// `position` to the local coordinate system.
+  ///
   /// Hit testing requires layout to be up-to-date but does not require painting
   /// to be up-to-date. That means a render object can rely upon [performLayout]
   /// having been called in [hitTest] but cannot rely upon [paint] having been
   /// called. For example, a render object might be a child of a [RenderOpacity]
   /// object, which calls [hitTest] on its children when its opacity is zero
   /// even through it does not [paint] its children.
-  bool hitTest(HitTestResult result, { @required Offset position }) {
+  bool hitTest(BoxHitTestResult result, { @required Offset position }) {
     assert(() {
       if (!hasSize) {
         if (debugNeedsLayout) {
@@ -1945,10 +2115,15 @@ abstract class RenderBox extends RenderObject {
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
   ///
+  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
+  /// [BoxHitTestResult.addWithPaintOffset], or
+  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
+  /// `position` to the local coordinate system.
+  ///
   /// Used by [hitTest]. If you override [hitTest] and do not call this
   /// function, then you don't need to implement this function.
   @protected
-  bool hitTestChildren(HitTestResult result, { Offset position }) => false;
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) => false;
 
   /// Multiply the transform from the parent's coordinate system to this box's
   /// coordinate system into the given transform.
@@ -2249,12 +2424,20 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
   ///
   ///  * [defaultPaint], which paints the children appropriate for this
   ///    hit-testing strategy.
-  bool defaultHitTestChildren(HitTestResult result, { Offset position }) {
+  bool defaultHitTestChildren(BoxHitTestResult result, { Offset position }) {
     // the x, y parameters have the top left of the node's box as the origin
     ChildType child = lastChild;
     while (child != null) {
       final ParentDataType childParentData = child.parentData;
-      if (child.hitTest(result, position: position - childParentData.offset))
+      final bool isHit = result.addWithPaintOffset(
+        offset: childParentData.offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - childParentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
+      if (isHit)
         return true;
       child = childParentData.previousSibling;
     }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -650,8 +650,10 @@ class BoxHitTestResult extends HitTestResult {
   /// Transforms `position` to the local coordinate system of a child before
   /// hit-testing the child.
   ///
-  /// Since the provided paint `transform` describes the transform from the
-  /// child to the parent, the matrix is inverted before it is used to transform
+  /// The provided paint `transform` (which describes the transform from the
+  /// child to the parent in 3D) is processed by
+  /// [PointerEvent.paintTransformToPointerEventTransform] to remove the
+  /// perspective component and inverted before it is used to transform
   /// `position` from the coordinate system of the parent to the system of the
   /// child.
   ///
@@ -711,6 +713,7 @@ class BoxHitTestResult extends HitTestResult {
         // Objects are not visible on screen and cannot be hit-tested.
         return false;
       }
+      transform = PointerEvent.paintTransformToPointerEventTransform(transform);
     }
     return addWithRawTransform(
       transform: transform,
@@ -773,7 +776,14 @@ class BoxHitTestResult extends HitTestResult {
     final Offset transformedPosition = position == null || transform == null
         ? position
         : MatrixUtils.transformPoint(transform, position);
-    return hitTest(this, transformedPosition);
+    if (transform != null) {
+      pushTransform(transform);
+    }
+    final bool isHit = hitTest(this, transformedPosition);
+    if (transform != null) {
+      popTransform();
+    }
+    return isHit;
   }
 }
 

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -782,7 +782,7 @@ class BoxHitTestEntry extends HitTestEntry {
   /// Creates a box hit test entry.
   ///
   /// The [localPosition] argument must not be null.
-  const BoxHitTestEntry(RenderBox target, this.localPosition)
+  BoxHitTestEntry(RenderBox target, this.localPosition)
     : assert(localPosition != null),
       super(target);
 
@@ -2042,10 +2042,11 @@ abstract class RenderBox extends RenderObject {
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
   ///
-  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
-  /// [BoxHitTestResult.addWithPaintOffset], or
-  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
-  /// `position` to the local coordinate system.
+  /// If transforming is necessary, [HitTestResult.addWithPaintTransform],
+  /// [HitTestResult.addWithPaintOffset], or [HitTestResult.addWithRawTransform] need
+  /// to be invoked by the caller to record the required transform operations
+  /// in the [HitTestResult]. These methods will also help with applying the
+  /// transform to `position`.
   ///
   /// Hit testing requires layout to be up-to-date but does not require painting
   /// to be up-to-date. That means a render object can rely upon [performLayout]
@@ -2115,10 +2116,11 @@ abstract class RenderBox extends RenderObject {
   /// This [RenderBox] is responsible for checking whether the given position is
   /// within its bounds.
   ///
-  /// If transforming is necessary, [BoxHitTestResult.addWithPaintTransform],
-  /// [BoxHitTestResult.addWithPaintOffset], or
-  /// [BoxHitTestResult.addWithRawTransform] should be used to transform
-  /// `position` to the local coordinate system.
+  /// If transforming is necessary, [HitTestResult.addWithPaintTransform],
+  /// [HitTestResult.addWithPaintOffset], or [HitTestResult.addWithRawTransform] need
+  /// to be invoked by the caller to record the required transform operations
+  /// in the [HitTestResult]. These methods will also help with applying the
+  /// transform to `position`.
   ///
   /// Used by [hitTest]. If you override [hitTest] and do not call this
   /// function, then you don't need to implement this function.

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -669,7 +669,8 @@ class BoxHitTestResult extends HitTestResult {
   /// position is not required to do the actual hit testing in that protocol.
   ///
   /// {@tool sample}
-  /// This method is used in [RenderBox.hitTestChildren]:
+  /// This method is used in [RenderBox.hitTestChildren] when the child and
+  /// parent don't share the same origin.
   ///
   /// ```dart
   /// abstract class Foo extends RenderBox {

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -362,7 +362,7 @@ class RenderCustomMultiChildLayoutBox extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 }

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -502,7 +502,7 @@ class RenderCustomPaint extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (_foregroundPainter != null && (_foregroundPainter.hitTest(position) ?? false))
       return true;
     return super.hitTestChildren(result, position: position);

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -937,7 +937,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -369,7 +369,7 @@ class RenderFlow extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     final List<RenderBox> children = getChildrenAsList();
     for (int i = _lastPaintOrder.length - 1; i >= 0; --i) {
       final int childIndex = _lastPaintOrder[i];
@@ -380,15 +380,14 @@ class RenderFlow extends RenderBox
       final Matrix4 transform = childParentData._transform;
       if (transform == null)
         continue;
-      final Matrix4 inverse = Matrix4.zero();
-      final double determinate = inverse.copyInverse(transform);
-      if (determinate == 0.0) {
-        // We cannot invert the transform. That means the child doesn't appear
-        // on screen and cannot be hit.
-        continue;
-      }
-      final Offset childPosition = MatrixUtils.transformPoint(inverse, position);
-      if (child.hitTest(result, position: childPosition))
+      final bool absorbed = result.addWithPaintTransform(
+        transform: transform,
+        position: position,
+        hitTest: (HitTestResult result, Offset position) {
+          return child.hitTest(result, position: position);
+        },
+      );
+      if (absorbed)
         return true;
     }
     return false;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -8,6 +8,7 @@ import 'dart:ui' as ui show EngineLayer, Image, ImageFilter, PathMetric,
                             Picture, PictureRecorder, Scene, SceneBuilder;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -1206,14 +1207,15 @@ class TransformLayer extends OffsetLayer {
   @override
   S find<S>(Offset regionOffset) {
     if (_inverseDirty) {
-      _invertedTransform = Matrix4.tryInvert(transform);
+      _invertedTransform = Matrix4.tryInvert(
+        PointerEvent.paintTransformToPointerEventTransform(transform)
+      );
       _inverseDirty = false;
     }
     if (_invertedTransform == null)
       return null;
-    final Vector4 vector = Vector4(regionOffset.dx, regionOffset.dy, 0.0, 1.0);
-    final Vector4 result = _invertedTransform.transform(vector);
-    return super.find<S>(Offset(result[0], result[1]));
+    final Offset transformed = MatrixUtils.transformPoint(_invertedTransform, regionOffset);
+    return super.find<S>(transformed);
   }
 
   @override
@@ -1949,7 +1951,7 @@ class AnnotatedRegionLayer<T> extends ContainerLayer {
       final S typedResult = untypedResult;
       return typedResult;
     }
-    return super.find<S>(regionOffset);
+    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/list_body.dart
+++ b/packages/flutter/lib/src/rendering/list_body.dart
@@ -265,7 +265,7 @@ class RenderListBody extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -984,9 +984,7 @@ class RenderListWheelViewport
   }
 
   @override
-  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    return false;
-  }
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) => false;
 
   @override
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect rect }) {

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -984,7 +984,7 @@ class RenderListWheelViewport
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -230,7 +230,7 @@ class RenderAndroidView extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (hitTestBehavior == PlatformViewHitTestBehavior.transparent || !size.contains(position))
       return false;
     result.add(BoxHitTestEntry(this, position));
@@ -365,7 +365,7 @@ class RenderUiKitView extends RenderBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (hitTestBehavior == PlatformViewHitTestBehavior.transparent || !size.contains(position))
       return false;
     result.add(BoxHitTestEntry(this, position));

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -381,7 +381,7 @@ class RenderUiKitView extends RenderBox {
       return;
     }
     _gestureRecognizer.addPointer(event);
-    _lastPointerDownEvent = event;
+    _lastPointerDownEvent = event.original ?? event;
   }
 
   // This is registered as a global PointerRoute while the render object is attached.
@@ -389,11 +389,10 @@ class RenderUiKitView extends RenderBox {
     if (event is! PointerDownEvent) {
       return;
     }
-    final Offset localOffset = globalToLocal(event.position);
-    if (!(Offset.zero & size).contains(localOffset)) {
+    if (!(Offset.zero & size).contains(event.localPosition)) {
       return;
     }
-    if (event != _lastPointerDownEvent) {
+    if ((event.original ?? event) != _lastPointerDownEvent) {
       // The pointer event is in the bounds of this render box, but we didn't get it in handleEvent.
       // This means that the pointer event was absorbed by a different render object.
       // Since on the platform side the FlutterTouchIntercepting view is seeing all events that are
@@ -455,7 +454,7 @@ class _UiKitViewGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
-    startTrackingPointer(event.pointer);
+    startTrackingPointer(event.pointer, event.transform);
     for (OneSequenceGestureRecognizer recognizer in _gestureRecognizers) {
       recognizer.addPointer(event);
     }
@@ -528,7 +527,7 @@ class _AndroidViewGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
-    startTrackingPointer(event.pointer);
+    startTrackingPointer(event.pointer, event.transform);
     for (OneSequenceGestureRecognizer recognizer in _gestureRecognizers) {
       recognizer.addPointer(event);
     }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2488,9 +2488,9 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
        super(behavior: behavior, child: child) {
     if (_onPointerEnter != null || _onPointerHover != null || _onPointerExit != null) {
       _hoverAnnotation = MouseTrackerAnnotation(
-        onEnter: _onPointerEnter,
-        onHover: _onPointerHover,
-        onExit: _onPointerExit,
+        onEnter: _onPointerEnterInternal,
+        onHover: _onPointerHoverInternal,
+        onExit: _onPointerExitInternal,
       );
     }
   }
@@ -2563,6 +2563,21 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
   @visibleForTesting
   MouseTrackerAnnotation get hoverAnnotation => _hoverAnnotation;
 
+  void _onPointerEnterInternal(PointerEnterEvent event) {
+    final Matrix4 transform = _getLayerTransform();
+    _onPointerEnter(event.transformed(transform));
+  }
+
+  void _onPointerHoverInternal(PointerHoverEvent event) {
+    final Matrix4 transform = _getLayerTransform();
+    _onPointerHover(event.transformed(transform));
+  }
+
+  void _onPointerExitInternal(PointerExitEvent event) {
+    final Matrix4 transform = _getLayerTransform();
+    _onPointerExit(event.transformed(transform));
+  }
+
   void _updateAnnotations() {
     bool changed = false;
     final bool hadHoverAnnotation = _hoverAnnotation != null;
@@ -2573,9 +2588,9 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     if (RendererBinding.instance.mouseTracker.mouseIsConnected &&
         (_onPointerEnter != null || _onPointerHover != null || _onPointerExit != null)) {
       _hoverAnnotation = MouseTrackerAnnotation(
-        onEnter: _onPointerEnter,
-        onHover: _onPointerHover,
-        onExit: _onPointerExit,
+        onEnter: _onPointerEnterInternal,
+        onHover: _onPointerHoverInternal,
+        onExit: _onPointerExitInternal,
       );
       if (attached) {
         RendererBinding.instance.mouseTracker.attachAnnotation(_hoverAnnotation);
@@ -2591,6 +2606,23 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     if (hadHoverAnnotation != hasHoverAnnotation) {
       markNeedsCompositingBitsUpdate();
     }
+  }
+
+  Matrix4 _getLayerTransform() {
+    assert(_lastAnnotationLayerUsed != null);
+    Matrix4 result = Matrix4.identity();
+    Layer previous = _lastAnnotationLayerUsed;
+    Layer current = previous.parent;
+    while (current?.parent != null) {
+      if (current is ContainerLayer) {
+        final Matrix4 r = Matrix4.identity();
+        current.applyTransform(previous, r);
+        result = PointerEvent.paintTransformToPointerEventTransform(r) * result;
+      }
+      previous = current;
+      current = current.parent;
+    }
+    return Matrix4.tryInvert(result);
   }
 
   @override
@@ -2612,17 +2644,21 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     super.detach();
   }
 
+  Layer _lastAnnotationLayerUsed;
+
   @override
   bool get needsCompositing => _hoverAnnotation != null;
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    _lastAnnotationLayerUsed = null;
     if (_hoverAnnotation != null) {
       final AnnotatedRegionLayer<MouseTrackerAnnotation> layer = AnnotatedRegionLayer<MouseTrackerAnnotation>(
         _hoverAnnotation,
         size: size,
         offset: offset,
       );
+      _lastAnnotationLayerUsed = layer;
       context.pushLayer(layer, super.paint, offset);
     }
     super.paint(context, offset);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2610,7 +2610,7 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
 
   Matrix4 _getLayerTransform() {
     assert(_lastAnnotationLayerUsed != null);
-    Matrix4 result = Matrix4.identity();
+    Matrix4 result = Matrix4.translationValues(_lastAnnotationLayerUsed.offset.dx, _lastAnnotationLayerUsed.offset.dy, 0);
     Layer previous = _lastAnnotationLayerUsed;
     Layer current = previous.parent;
     while (current?.parent != null) {
@@ -2644,7 +2644,7 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
     super.detach();
   }
 
-  Layer _lastAnnotationLayerUsed;
+  AnnotatedRegionLayer<MouseTrackerAnnotation> _lastAnnotationLayerUsed;
 
   @override
   bool get needsCompositing => _hoverAnnotation != null;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -110,7 +110,7 @@ mixin RenderProxyBoxMixin<T extends RenderBox> on RenderBox, RenderObjectWithChi
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return child?.hitTest(result, position: position) ?? false;
   }
 
@@ -155,7 +155,7 @@ abstract class RenderProxyBoxWithHitTestBehavior extends RenderProxyBox {
   HitTestBehavior behavior;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     bool hitTarget = false;
     if (size.contains(position)) {
       hitTarget = hitTestChildren(result, position: position) || hitTestSelf(position);
@@ -1278,7 +1278,7 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
   Rect get _defaultClip => Offset.zero & size;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1354,7 +1354,7 @@ class RenderClipRRect extends _RenderCustomClip<RRect> {
   RRect get _defaultClip => _borderRadius.toRRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1419,7 +1419,7 @@ class RenderClipOval extends _RenderCustomClip<Rect> {
   Rect get _defaultClip => Offset.zero & size;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     _updateClip();
     assert(_clip != null);
     final Offset center = _clip.center;
@@ -1484,7 +1484,7 @@ class RenderClipPath extends _RenderCustomClip<Path> {
   Path get _defaultClip => Path()..addRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1677,7 +1677,7 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -1772,7 +1772,7 @@ class RenderPhysicalShape extends _RenderPhysicalModelBase<Path> {
   Path get _defaultClip => Path()..addRect(Offset.zero & size);
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (_clipper != null) {
       _updateClip();
       assert(_clip != null);
@@ -2120,7 +2120,7 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderTransform objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -2129,17 +2129,15 @@ class RenderTransform extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
-    if (transformHitTests) {
-      final Matrix4 inverse = Matrix4.tryInvert(_effectiveTransform);
-      if (inverse == null) {
-        // We cannot invert the effective transform. That means the child
-        // doesn't appear on screen and cannot be hit.
-        return false;
-      }
-      position = MatrixUtils.transformPoint(inverse, position);
-    }
-    return super.hitTestChildren(result, position: position);
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
+    assert(!transformHitTests || _effectiveTransform != null);
+    return result.addWithPaintTransform(
+      transform: transformHitTests ? _effectiveTransform : null,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -2310,18 +2308,17 @@ class RenderFittedBox extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (size.isEmpty)
       return false;
     _updatePaintData();
-    final Matrix4 inverse = Matrix4.tryInvert(_transform);
-    if (inverse == null) {
-      // We cannot invert the effective transform. That means the child
-      // doesn't appear on screen and cannot be hit.
-      return false;
-    }
-    position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTestChildren(result, position: position);
+    return result.addWithPaintTransform(
+      transform: _transform,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -2379,7 +2376,7 @@ class RenderFractionalTranslation extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderFractionalTranslation objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -2396,15 +2393,17 @@ class RenderFractionalTranslation extends RenderProxyBox {
   bool transformHitTests;
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(!debugNeedsLayout);
-    if (transformHitTests) {
-      position = Offset(
-        position.dx - translation.dx * size.width,
-        position.dy - translation.dy * size.height,
-      );
-    }
-    return super.hitTestChildren(result, position: position);
+    return result.addWithPaintOffset(
+      offset: transformHitTests
+          ? Offset(translation.dx * size.width, translation.dy * size.height)
+          : null,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override
@@ -2928,7 +2927,7 @@ class RenderIgnorePointer extends RenderProxyBox {
   bool get _effectiveIgnoringSemantics => ignoringSemantics == null ? ignoring : ignoringSemantics;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return ignoring ? false : super.hitTest(result, position: position);
   }
 
@@ -3038,7 +3037,7 @@ class RenderOffstage extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return !offstage && super.hitTest(result, position: position);
   }
 
@@ -3134,7 +3133,7 @@ class RenderAbsorbPointer extends RenderProxyBox {
   bool get _effectiveIgnoringSemantics => ignoringSemantics == null ? absorbing : ignoringSemantics;
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     return absorbing
         ? size.contains(position)
         : super.hitTest(result, position: position);
@@ -4674,7 +4673,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   }
 
   @override
-  bool hitTest(HitTestResult result, { Offset position }) {
+  bool hitTest(BoxHitTestResult result, { Offset position }) {
     // RenderFollowerLayer objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed
@@ -4683,15 +4682,14 @@ class RenderFollowerLayer extends RenderProxyBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
-    final Matrix4 inverse = Matrix4.tryInvert(getCurrentTransform());
-    if (inverse == null) {
-      // We cannot invert the effective transform. That means the child
-      // doesn't appear on screen and cannot be hit.
-      return false;
-    }
-    position = MatrixUtils.transformPoint(inverse, position);
-    return super.hitTestChildren(result, position: position);
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
+    return result.addWithPaintTransform(
+      transform: getCurrentTransform(),
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return super.hitTestChildren(result, position: position);
+      },
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/rotated_box.dart
+++ b/packages/flutter/lib/src/rendering/rotated_box.dart
@@ -90,12 +90,17 @@ class RenderRotatedBox extends RenderBox with RenderObjectWithChildMixin<RenderB
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(_paintTransform != null || debugNeedsLayout || child == null);
     if (child == null || _paintTransform == null)
       return false;
-    final Matrix4 inverse = Matrix4.inverted(_paintTransform);
-    return child.hitTest(result, position: MatrixUtils.transformPoint(inverse, position));
+    return result.addWithPaintTransform(
+      transform: _paintTransform,
+      position: position,
+      hitTest: (HitTestResult result, Offset position) {
+        return child.hitTest(result, position: position);
+      },
+    );
   }
 
   void _paintChild(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -72,10 +72,17 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
       final BoxParentData childParentData = child.parentData;
-      return child.hitTest(result, position: position - childParentData.offset);
+      return result.addWithPaintOffset(
+        offset: childParentData.offset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position - childParentData.offset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
     }
     return false;
   }

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -774,6 +774,80 @@ class SliverGeometry extends Diagnosticable {
   }
 }
 
+/// Method signature for hit testing a [RenderSLiver].
+///
+/// Used by [SliverHitTestResult.addWithAxisOffset] to hit test [RenderSliver]
+/// children.
+///
+/// See also:
+///
+///  * [RenderSliver.hitTest], which documents more details around hit testing
+///    [RenderSliver]s.
+typedef SliverHitTest = bool Function(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition });
+
+/// The result of performing a hit test on [RenderSliver]s.
+class SliverHitTestResult extends HitTestResult {
+  /// Creates an empty hit test result for hit testing on [RenderSliver].
+  SliverHitTestResult() : super();
+
+  /// Wraps `result` to create a [HitTestResult] that implements the
+  /// [SliverHitTestResult] protocol for hit testing on [RenderSliver]s.
+  ///
+  /// This method is used by [RenderObject]s that adapt between the
+  /// [RenderSliver]-world and the non-[RenderSliver]-world to convert a
+  /// (subtype of) [HitTestResult] to a [SliverHitTestResult] for hit testing on
+  /// [RenderSliver]s.
+  ///
+  /// The [HitTestEntry]s added to the returned [SliverHitTestResult] are also
+  /// added to the wrapped `result` (both share the same underlying data
+  /// structure to store [HitTestEntry]s).
+  ///
+  /// See also:
+  ///
+  ///  * [HitTestResult.wrap], which turns a [SliverHitTestResult] back into a
+  ///    generic [HitTestResult].
+  ///  * [BoxHitTestResult.wrap], which turns a [SliverHitTestResult] into a
+  ///    [BoxHitTestResult] for hit testing on [RenderBox] children.
+  SliverHitTestResult.wrap(HitTestResult result) : super.wrap(result);
+
+  /// Transforms `mainAxisPosition` and `crossAxisPosition` to the local
+  /// coordinate system of a child before hit-testing the child.
+  ///
+  /// For the transform `mainAxisOffset` is subtracted from `mainAxisPosition`
+  /// and `crossAxisOffset` is subtracted from `crossAxisPosition`.
+  ///
+  /// The `paintOffset` describes how the paint position of a point painted at
+  /// the provided `mainAxisPosition` and `crossAxisPosition` would change after
+  /// `mainAxisOffset` and `crossAxisOffset` have been applied. This
+  /// `paintOffset` is used to properly convert [PointerEvent]s to the local
+  /// coordinate system of the event receiver.
+  ///
+  /// The `paintOffset` may be null if `mainAxisOffset` and `crossAxisOffset` are
+  /// both zero.
+  ///
+  /// The function returns the return value of `hitTest`.
+  bool addWithAxisOffset({
+    @required Offset paintOffset,
+    @required double mainAxisOffset,
+    @required double crossAxisOffset,
+    @required double mainAxisPosition,
+    @required double crossAxisPosition,
+    @required SliverHitTest hitTest,
+  }) {
+    assert(mainAxisOffset != null);
+    assert(crossAxisOffset != null);
+    assert(mainAxisPosition != null);
+    assert(crossAxisPosition != null);
+    assert(hitTest != null);
+    // TODO(goderbauer): use paintOffset when transforming pointer events is implemented.
+    return hitTest(
+      this,
+      mainAxisPosition: mainAxisPosition - mainAxisOffset,
+      crossAxisPosition: crossAxisPosition - crossAxisOffset,
+    );
+  }
+}
+
 /// A hit test entry used by [RenderSliver].
 ///
 /// The coordinate system used by this hit test entry is relative to the
@@ -1186,7 +1260,7 @@ abstract class RenderSliver extends RenderObject {
   /// The most straight-forward way to implement hit testing for a new sliver
   /// render object is to override its [hitTestSelf] and [hitTestChildren]
   /// methods.
-  bool hitTest(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTest(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     if (mainAxisPosition >= 0.0 && mainAxisPosition < geometry.hitTestExtent &&
         crossAxisPosition >= 0.0 && crossAxisPosition < constraints.crossAxisExtent) {
       if (hitTestChildren(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition) ||
@@ -1224,7 +1298,7 @@ abstract class RenderSliver extends RenderObject {
   ///
   /// For a discussion of the semantics of the arguments, see [hitTest].
   @protected
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) => false;
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) => false;
 
   /// Computes the portion of the region from `from` to `to` that is visible,
   /// assuming that only the region from the [SliverConstraints.scrollOffset]
@@ -1514,22 +1588,41 @@ abstract class RenderSliverHelpers implements RenderSliver {
   ///
   /// Calling this for a child that is not visible is not valid.
   @protected
-  bool hitTestBoxChild(HitTestResult result, RenderBox child, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestBoxChild(BoxHitTestResult result, RenderBox child, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     final bool rightWayUp = _getRightWayUp(constraints);
-    double absolutePosition = mainAxisPosition - childMainAxisPosition(child);
-    final double absoluteCrossAxisPosition = crossAxisPosition - childCrossAxisPosition(child);
+    double delta = childMainAxisPosition(child);
+    final double crossAxisDelta = childCrossAxisPosition(child);
+    double absolutePosition = mainAxisPosition - delta;
+    final double absoluteCrossAxisPosition = crossAxisPosition - crossAxisDelta;
+    Offset paintOffset, transformedPosition;
     assert(constraints.axis != null);
     switch (constraints.axis) {
       case Axis.horizontal:
-        if (!rightWayUp)
+        if (!rightWayUp) {
           absolutePosition = child.size.width - absolutePosition;
-        return child.hitTest(result, position: Offset(absolutePosition, absoluteCrossAxisPosition));
+          delta = geometry.paintExtent - child.size.width - delta;
+        }
+        paintOffset = Offset(delta, crossAxisDelta);
+        transformedPosition = Offset(absolutePosition, absoluteCrossAxisPosition);
+        break;
       case Axis.vertical:
-        if (!rightWayUp)
+        if (!rightWayUp) {
           absolutePosition = child.size.height - absolutePosition;
-        return child.hitTest(result, position: Offset(absoluteCrossAxisPosition, absolutePosition));
+          delta = geometry.paintExtent - child.size.height - delta;
+        }
+        paintOffset = Offset(crossAxisDelta, delta);
+        transformedPosition = Offset(absoluteCrossAxisPosition, absolutePosition);
+        break;
     }
-    return false;
+    assert(paintOffset != null);
+    assert(transformedPosition != null);
+    return result.addWithPaintOffset(
+      offset: paintOffset,
+      position: null, // Manually adapting from sliver to box position above.
+      hitTest: (BoxHitTestResult result, Offset _) {
+        return child.hitTest(result, position: transformedPosition);
+      },
+    );
   }
 
   /// Utility function for [applyPaintTransform] for use when the children are
@@ -1614,10 +1707,10 @@ abstract class RenderSliverSingleBoxAdapter extends RenderSliver with RenderObje
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     assert(geometry.hitTestExtent > 0.0);
     if (child != null)
-      return hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+      return hitTestBoxChild(BoxHitTestResult.wrap(result), child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -856,7 +856,7 @@ class SliverHitTestEntry extends HitTestEntry {
   /// Creates a sliver hit test entry.
   ///
   /// The [mainAxisPosition] and [crossAxisPosition] arguments must not be null.
-  const SliverHitTestEntry(
+  SliverHitTestEntry(
     RenderSliver target, {
     @required this.mainAxisPosition,
     @required this.crossAxisPosition,

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -839,12 +839,18 @@ class SliverHitTestResult extends HitTestResult {
     assert(mainAxisPosition != null);
     assert(crossAxisPosition != null);
     assert(hitTest != null);
-    // TODO(goderbauer): use paintOffset when transforming pointer events is implemented.
-    return hitTest(
+    if (paintOffset != null) {
+      pushTransform(Matrix4.translationValues(paintOffset.dx, paintOffset.dy, 0));
+    }
+    final bool isHit = hitTest(
       this,
       mainAxisPosition: mainAxisPosition - mainAxisOffset,
       crossAxisPosition: crossAxisPosition - crossAxisOffset,
     );
+    if (paintOffset != null) {
+      popTransform();
+    }
+    return isHit;
   }
 }
 

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -558,10 +557,11 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     RenderBox child = lastChild;
+    final BoxHitTestResult boxResult = BoxHitTestResult.wrap(result);
     while (child != null) {
-      if (hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition))
+      if (hitTestBoxChild(boxResult, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition))
         return true;
       child = childBefore(child);
     }

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'debug.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -261,9 +260,18 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
-    if (child != null && child.geometry.hitTestExtent > 0.0)
-      return child.hitTest(result, mainAxisPosition: mainAxisPosition - childMainAxisPosition(child), crossAxisPosition: crossAxisPosition - childCrossAxisPosition(child));
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+    if (child != null && child.geometry.hitTestExtent > 0.0) {
+      final SliverPhysicalParentData childParentData = child.parentData;
+      result.addWithAxisOffset(
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+        mainAxisOffset: childMainAxisPosition(child),
+        crossAxisOffset: childCrossAxisPosition(child),
+        paintOffset: childParentData.paintOffset,
+        hitTest: child.hitTest,
+      );
+    }
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -11,7 +11,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -169,10 +168,10 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
   double childMainAxisPosition(covariant RenderObject child) => super.childMainAxisPosition(child);
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     assert(geometry.hitTestExtent > 0.0);
     if (child != null)
-      return hitTestBoxChild(result, child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+      return hitTestBoxChild(BoxHitTestResult.wrap(result), child, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -581,7 +581,7 @@ class RenderStack extends RenderBox
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 
@@ -668,13 +668,20 @@ class RenderIndexedStack extends RenderStack {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { @required Offset position }) {
     if (firstChild == null || index == null)
       return false;
     assert(position != null);
     final RenderBox child = _childAtIndex();
     final StackParentData childParentData = child.parentData;
-    return child.hitTest(result, position: position - childParentData.offset);
+    return result.addWithPaintOffset(
+      offset: childParentData.offset,
+      position: position,
+      hitTest: (HitTestResult result, Offset transformed) {
+        assert(transformed == position - childParentData.offset);
+        return child.hitTest(result, position: transformed);
+      },
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1104,13 +1104,21 @@ class RenderTable extends RenderBox {
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     assert(_children.length == rows * columns);
     for (int index = _children.length - 1; index >= 0; index -= 1) {
       final RenderBox child = _children[index];
       if (child != null) {
         final BoxParentData childParentData = child.parentData;
-        if (child.hitTest(result, position: position - childParentData.offset))
+        final bool isHit = result.addWithPaintOffset(
+          offset: childParentData.offset,
+          position: position,
+          hitTest: (HitTestResult result, Offset transformed) {
+            assert(transformed == position - childParentData.offset);
+            return child.hitTest(result, position: transformed);
+          },
+        );
+        if (isHit)
           return true;
       }
     }

--- a/packages/flutter/lib/src/rendering/texture.dart
+++ b/packages/flutter/lib/src/rendering/texture.dart
@@ -66,9 +66,7 @@ class TextureBox extends RenderBox {
   }
 
   @override
-  bool hitTestSelf(Offset position) {
-    return true;
-  }
+  bool hitTestSelf(Offset position) => true;
 
   @override
   void paint(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -168,7 +168,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// normally be in physical (device) pixels.
   bool hitTest(HitTestResult result, { Offset position }) {
     if (child != null)
-      child.hitTest(result, position: position);
+      child.hitTest(BoxHitTestResult.wrap(result), position: position);
     result.add(HitTestEntry(this));
     return true;
   }

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -10,7 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'object.dart';
 import 'sliver.dart';
@@ -558,7 +557,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     double mainAxisPosition, crossAxisPosition;
     switch (axis) {
       case Axis.vertical:
@@ -572,12 +571,25 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     }
     assert(mainAxisPosition != null);
     assert(crossAxisPosition != null);
+    final SliverHitTestResult sliverResult = SliverHitTestResult.wrap(result);
     for (RenderSliver child in childrenInHitTestOrder) {
-      if (child.geometry.visible && child.hitTest(
-        result,
-        mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),
-        crossAxisPosition: crossAxisPosition,
-      )) {
+      if (!child.geometry.visible) {
+        continue;
+      }
+      final Matrix4 transform = Matrix4.identity();
+      applyPaintTransform(child, transform);
+      final bool isHit = result.addWithPaintTransform(
+        transform: transform,
+        position: null, // Manually adapting from box to sliver position below.
+        hitTest: (HitTestResult result, Offset _) {
+          return child.hitTest(
+            sliverResult,
+            mainAxisPosition: computeChildMainAxisPosition(child, mainAxisPosition),
+            crossAxisPosition: crossAxisPosition,
+          );
+        },
+      );
+      if (isHit) {
         return true;
       }
     }

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -748,7 +748,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return defaultHitTestChildren(result, position: position);
   }
 

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -661,7 +661,7 @@ class _DragAvatar<T> extends Drag {
     _activeTarget = newTarget;
   }
 
-  Iterable<_DragTargetState<T>> _getDragTargets(List<HitTestEntry> path) sync* {
+  Iterable<_DragTargetState<T>> _getDragTargets(Iterable<HitTestEntry> path) sync* {
     // Look for the RenderBoxes that corresponds to the hit target (the hit target
     // widgets build RenderMetaData boxes for us for this purpose).
     for (HitTestEntry entry in path) {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -214,7 +214,7 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     return child?.hitTest(result, position: position) ?? false;
   }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1446,7 +1446,7 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
+  bool hitTestChildren(SliverHitTestResult result, { @required double mainAxisPosition, @required double crossAxisPosition }) {
     if (child != null)
       return child.hitTest(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
     return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -555,10 +555,16 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   }
 
   @override
-  bool hitTestChildren(HitTestResult result, { Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
     if (child != null) {
-      final Offset transformed = position + -_paintOffset;
-      return child.hitTest(result, position: transformed);
+      return result.addWithPaintOffset(
+        offset: _paintOffset,
+        position: position,
+        hitTest: (HitTestResult result, Offset transformed) {
+          assert(transformed == position + -_paintOffset);
+          return child.hitTest(result, position: transformed);
+        },
+      );
     }
     return false;
   }

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import 'gesture_tester.dart';
 
@@ -110,4 +112,342 @@ void main() {
       expect(event.buttons, kPrimaryButton);
     });
   });
+
+  test('paintTransformToPointerEventTransform', () {
+    Matrix4 original = Matrix4.identity();
+    Matrix4 changed = PointerEvent.paintTransformToPointerEventTransform(original);
+    expect(changed, original);
+
+    original = Matrix4.identity()..scale(3.0);
+    changed = PointerEvent.paintTransformToPointerEventTransform(original);
+    expect(changed, isNot(original));
+    original
+      ..setColumn(2, Vector4(0, 0, 1, 0))
+      ..setRow(2, Vector4(0, 0, 1, 0));
+    expect(changed, original);
+  });
+
+  test('transformPosition', () {
+    const Offset position = Offset(20, 30);
+    expect(PointerEvent.transformPosition(null, position), position);
+    expect(PointerEvent.transformPosition(Matrix4.identity(), position), position);
+    final Matrix4 transform = Matrix4.translationValues(10, 20, 0);
+    expect(PointerEvent.transformPosition(transform, position), const Offset(20.0 + 10.0, 30.0 + 20.0));
+  });
+
+  test('transformDeltaViaPositions', () {
+    Offset transformedDelta = PointerEvent.transformDeltaViaPositions(
+      untransformedEndPosition: const Offset(20, 30), 
+      untransformedDelta: const Offset(5, 5), 
+      transform: Matrix4.identity()..scale(2.0, 2.0, 1.0),
+    );
+    expect(transformedDelta, const Offset(10.0, 10.0));
+
+    transformedDelta = PointerEvent.transformDeltaViaPositions(
+      untransformedEndPosition: const Offset(20, 30),
+      transformedEndPosition: const Offset(40, 60),
+      untransformedDelta: const Offset(5, 5),
+      transform: Matrix4.identity()..scale(2.0, 2.0, 1.0),
+    );
+    expect(transformedDelta, const Offset(10.0, 10.0));
+
+    transformedDelta = PointerEvent.transformDeltaViaPositions(
+      untransformedEndPosition: const Offset(20, 30),
+      transformedEndPosition: const Offset(40, 60),
+      untransformedDelta: const Offset(5, 5),
+      transform: null,
+    );
+    expect(transformedDelta, const Offset(5, 5));
+  });
+
+  test('transforming events', () {
+    final Matrix4 transform = (Matrix4.identity()..scale(2.0, 2.0, 1.0)) * Matrix4.translationValues(10.0, 20.0, 0.0);
+    const Offset localPosition = Offset(60, 100);
+    const Offset localDelta = Offset(10, 10);
+
+    const PointerAddedEvent added = PointerAddedEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+    );
+    _expectTransformedEvent(
+      original: added,
+      transform: transform,
+      localPosition: localPosition,
+    );
+
+    const PointerCancelEvent cancel = PointerCancelEvent(
+      timeStamp: Duration(seconds: 2),
+      pointer: 45,
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      buttons: 4,
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+    );
+    _expectTransformedEvent(
+      original: cancel,
+      transform: transform,
+      localPosition: localPosition,
+    );
+
+    const PointerDownEvent down = PointerDownEvent(
+      timeStamp: Duration(seconds: 2),
+      pointer: 45,
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      buttons: 4,
+      obscured: true,
+      pressure: 34,
+      pressureMin: 10,
+      pressureMax: 60,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+    );
+    _expectTransformedEvent(
+      original: down,
+      transform: transform,
+      localPosition: localPosition,
+    );
+
+    const PointerEnterEvent enter = PointerEnterEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      delta: Offset(5, 5),
+      buttons: 4,
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+      synthesized: true,
+    );
+    _expectTransformedEvent(
+      original: enter,
+      transform: transform,
+      localPosition: localPosition,
+      localDelta: localDelta,
+    );
+
+    const PointerExitEvent exit = PointerExitEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      delta: Offset(5, 5),
+      buttons: 4,
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+      synthesized: true,
+    );
+    _expectTransformedEvent(
+      original: exit,
+      transform: transform,
+      localPosition: localPosition,
+      localDelta: localDelta,
+    );
+
+    const PointerHoverEvent hover = PointerHoverEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      delta: Offset(5, 5),
+      buttons: 4,
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+      synthesized: true,
+    );
+    _expectTransformedEvent(
+      original: hover,
+      transform: transform,
+      localPosition: localPosition,
+      localDelta: localDelta,
+    );
+
+    const PointerMoveEvent move = PointerMoveEvent(
+      timeStamp: Duration(seconds: 2),
+      pointer: 45,
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      delta: Offset(5, 5),
+      buttons: 4,
+      obscured: true,
+      pressure: 34,
+      pressureMin: 10,
+      pressureMax: 60,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+      platformData: 10,
+      synthesized: true,
+    );
+    _expectTransformedEvent(
+      original: move,
+      transform: transform,
+      localPosition: localPosition,
+      localDelta: localDelta,
+    );
+
+    const PointerRemovedEvent removed = PointerRemovedEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      obscured: true,
+      pressureMin: 10,
+      pressureMax: 60,
+      distanceMax: 24,
+      radiusMin: 10,
+      radiusMax: 50,
+    );
+    _expectTransformedEvent(
+      original: removed,
+      transform: transform,
+    );
+
+    const PointerScrollEvent scroll = PointerScrollEvent(
+      timeStamp: Duration(seconds: 2),
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+    );
+    _expectTransformedEvent(
+      original: scroll,
+      transform: transform,
+      localPosition: localPosition,
+    );
+
+    const PointerUpEvent up = PointerUpEvent(
+      timeStamp: Duration(seconds: 2),
+      pointer: 45,
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      buttons: 4,
+      obscured: true,
+      pressure: 34,
+      pressureMin: 10,
+      pressureMax: 60,
+      distance: 12,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+    );
+    _expectTransformedEvent(
+      original: up,
+      transform: transform,
+      localPosition: localPosition,
+    );
+  });
+}
+
+void _expectTransformedEvent({
+  @required PointerEvent original,
+  @required Matrix4 transform,
+  Offset localDelta,
+  Offset localPosition,
+}) {
+  expect(original.position, original.localPosition);
+  expect(original.delta, original.localDelta);
+  expect(original.original, isNull);
+  expect(original.transform, isNull);
+
+  final PointerEvent transformed = original.transformed(transform);
+  expect(transformed.original, same(original));
+  expect(transformed.transform, transform);
+  expect(transformed.localDelta, localDelta ?? original.localDelta);
+  expect(transformed.localPosition, localPosition ?? original.localPosition);
+
+  expect(transformed.buttons, original.buttons);
+  expect(transformed.delta, original.delta);
+  expect(transformed.device, original.device);
+  expect(transformed.distance, original.distance);
+  expect(transformed.distanceMax, original.distanceMax);
+  expect(transformed.distanceMin, original.distanceMin);
+  expect(transformed.down, original.down);
+  expect(transformed.kind, original.kind);
+  expect(transformed.obscured, original.obscured);
+  expect(transformed.orientation, original.orientation);
+  expect(transformed.platformData, original.platformData);
+  expect(transformed.pointer, original.pointer);
+  expect(transformed.position, original.position);
+  expect(transformed.pressure, original.pressure);
+  expect(transformed.pressureMax, original.pressureMax);
+  expect(transformed.pressureMin, original.pressureMin);
+  expect(transformed.radiusMajor, original.radiusMajor);
+  expect(transformed.radiusMax, original.radiusMax);
+  expect(transformed.radiusMin, original.radiusMin);
+  expect(transformed.radiusMinor, original.radiusMinor);
+  expect(transformed.size, original.size);
+  expect(transformed.synthesized, original.synthesized);
+  expect(transformed.tilt, original.tilt);
+  expect(transformed.timeStamp, original.timeStamp);
 }

--- a/packages/flutter/test/gestures/hit_test_test.dart
+++ b/packages/flutter/test/gestures/hit_test_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+
+import '../flutter_test_alternative.dart';
+
+void main() {
+  test('wrpped HitTestResult gets HitTestEntry added to wrapping HitTestResult', () async {
+    final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
+    final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
+    final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+
+    final HitTestResult wrapped = HitTestResult();
+    wrapped.add(entry1);
+    expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+
+    final HitTestResult wrapping = HitTestResult.wrap(wrapped);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1]));
+    expect(wrapping.path, same(wrapped.path));
+
+    wrapping.add(entry2);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
+    expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+
+    wrapped.add(entry3);
+    expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+  });
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
+}

--- a/packages/flutter/test/gestures/hit_test_test.dart
+++ b/packages/flutter/test/gestures/hit_test_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import '../flutter_test_alternative.dart';
 
@@ -11,10 +12,13 @@ void main() {
     final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
     final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
     final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+    final Matrix4 transform = Matrix4.translationValues(40.0, 150.0, 0.0);
 
-    final HitTestResult wrapped = HitTestResult();
+    final HitTestResult wrapped = MyHitTestResult()
+      ..publicPushTransform(transform);
     wrapped.add(entry1);
     expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+    expect(entry1.transform, transform);
 
     final HitTestResult wrapping = HitTestResult.wrap(wrapped);
     expect(wrapping.path, equals(<HitTestEntry>[entry1]));
@@ -23,10 +27,12 @@ void main() {
     wrapping.add(entry2);
     expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
     expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+    expect(entry2.transform, transform);
 
     wrapped.add(entry3);
     expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
     expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+    expect(entry3.transform, transform);
   });
 }
 
@@ -35,4 +41,8 @@ class _DummyHitTestTarget implements HitTestTarget {
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     // Nothing to do.
   }
+}
+
+class MyHitTestResult extends HitTestResult {
+  void publicPushTransform(Matrix4 transform) => pushTransform(transform);
 }

--- a/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
+++ b/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import '../flutter_test_alternative.dart';
 
@@ -66,5 +67,23 @@ void main() {
     // Nothing should have changed for the previous event's listeners.
     expect(first.callbackRan, isTrue);
     expect(second.callbackRan, isFalse);
+  });
+
+  test('works with transformed events', () {
+    final PointerSignalResolver resolver = PointerSignalResolver();
+    const PointerSignalEvent originalEvent = PointerScrollEvent();
+    final PointerSignalEvent transformedEvent = originalEvent
+        .transformed(Matrix4.translationValues(10.0, 20.0, 0.0));
+
+    expect(originalEvent, isNot(same(transformedEvent)));
+    expect(transformedEvent.original, same(originalEvent));
+
+    final List<PointerSignalEvent> events = <PointerSignalEvent>[];
+    resolver.register(transformedEvent, (PointerSignalEvent event) {
+      events.add(event);
+    });
+    resolver.resolve(originalEvent);
+
+    expect(events.single, same(transformedEvent));
   });
 }

--- a/packages/flutter/test/gestures/recognizer_test.dart
+++ b/packages/flutter/test/gestures/recognizer_test.dart
@@ -26,4 +26,22 @@ void main() {
     final TestGestureRecognizer recognizer = TestGestureRecognizer(debugOwner: 0);
     expect(recognizer, hasAGoodToStringDeep);
   });
+
+  test('CombinedOffset', () {
+    const CombinedOffset offset = CombinedOffset(
+      local: Offset(10, 20),
+      global: Offset(30, 40),
+    );
+
+    expect(offset.local, const Offset(10, 20));
+    expect(offset.global, const Offset(30, 40));
+
+    final CombinedOffset sum = const CombinedOffset(
+      local: Offset(50, 60),
+      global: Offset(70, 80),
+    ) + offset;
+
+    expect(sum.local, const Offset(60, 80));
+    expect(sum.global, const Offset(100, 120));
+  });
 }

--- a/packages/flutter/test/gestures/transformed_double_tap.dart
+++ b/packages/flutter/test/gestures/transformed_double_tap.dart
@@ -1,0 +1,98 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+
+void main() {
+  testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled up', (WidgetTester tester) async {
+    int doubleTapCount = 0;
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 2.0,
+            child: GestureDetector(
+                onDoubleTap: () {
+                  doubleTapCount++;
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 100,
+                  height: 150,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    // Move just below kTouchSlop should recognize tap.
+    final Offset center = tester.getCenter(find.byKey(redContainer));
+    TestGesture gesture = await tester.startGesture(center);
+    await gesture.up();
+    await tester.pump(kDoubleTapMinTime);
+    gesture = await tester.startGesture(center + const Offset(kDoubleTapSlop - 1, 0));
+    await gesture.up();
+
+    expect(doubleTapCount, 1);
+
+    doubleTapCount = 0;
+
+    gesture = await tester.startGesture(center);
+    await gesture.up();
+    await tester.pump(kDoubleTapMinTime);
+    gesture = await tester.startGesture(center + const Offset(kDoubleTapSlop + 1, 0));
+    await gesture.up();
+
+    expect(doubleTapCount, 0);
+  });
+
+  testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled down', (WidgetTester tester) async {
+    int doubleTapCount = 0;
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 0.5,
+            child: GestureDetector(
+                onDoubleTap: () {
+                  doubleTapCount++;
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 500,
+                  height: 500,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    // Move just below kTouchSlop should recognize tap.
+    final Offset center = tester.getCenter(find.byKey(redContainer));
+    TestGesture gesture = await tester.startGesture(center);
+    await gesture.up();
+    await tester.pump(kDoubleTapMinTime);
+    gesture = await tester.startGesture(center + const Offset(kDoubleTapSlop - 1, 0));
+    await gesture.up();
+
+    expect(doubleTapCount, 1);
+
+    doubleTapCount = 0;
+
+    gesture = await tester.startGesture(center);
+    await gesture.up();
+    await tester.pump(kDoubleTapMinTime);
+    gesture = await tester.startGesture(center + const Offset(kDoubleTapSlop + 1, 0));
+    await gesture.up();
+
+    expect(doubleTapCount, 0);
+  });
+}

--- a/packages/flutter/test/gestures/transformed_long_press_test.dart
+++ b/packages/flutter/test/gestures/transformed_long_press_test.dart
@@ -1,0 +1,206 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+
+void main() {
+  testWidgets('gets local corrdinates', (WidgetTester tester) async {
+    int longPressCount = 0;
+    int longPressUpCount = 0;
+    final List<LongPressEndDetails> endDetails = <LongPressEndDetails>[];
+    final List<LongPressMoveUpdateDetails> moveDetails = <LongPressMoveUpdateDetails>[];
+    final List<LongPressStartDetails> startDetails = <LongPressStartDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+              onLongPress: () {
+                longPressCount++;
+              },
+              onLongPressEnd: (LongPressEndDetails details) {
+                endDetails.add(details);
+              },
+              onLongPressMoveUpdate: (LongPressMoveUpdateDetails details) {
+                moveDetails.add(details);
+              },
+              onLongPressStart: (LongPressStartDetails details) {
+                startDetails.add(details);
+              },
+              onLongPressUp: () {
+                longPressUpCount++;
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              )
+          ),
+        )
+    );
+
+    await tester.longPressAt(tester.getCenter(find.byKey(redContainer)));
+    expect(longPressCount, 1);
+    expect(longPressUpCount, 1);
+    expect(moveDetails, isEmpty);
+    expect(startDetails.single.localPosition, const Offset(50, 75));
+    expect(startDetails.single.globalPosition, const Offset(400, 300));
+    expect(endDetails.single.localPosition, const Offset(50, 75));
+    expect(endDetails.single.globalPosition, const Offset(400, 300));
+  });
+
+  testWidgets('scaled up', (WidgetTester tester) async {
+    int longPressCount = 0;
+    int longPressUpCount = 0;
+    final List<LongPressEndDetails> endDetails = <LongPressEndDetails>[];
+    final List<LongPressMoveUpdateDetails> moveDetails = <LongPressMoveUpdateDetails>[];
+    final List<LongPressStartDetails> startDetails = <LongPressStartDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 2.0,
+            child: GestureDetector(
+                onLongPress: () {
+                  longPressCount++;
+                },
+                onLongPressEnd: (LongPressEndDetails details) {
+                  endDetails.add(details);
+                },
+                onLongPressMoveUpdate: (LongPressMoveUpdateDetails details) {
+                  moveDetails.add(details);
+                },
+                onLongPressStart: (LongPressStartDetails details) {
+                  startDetails.add(details);
+                },
+                onLongPressUp: () {
+                  longPressUpCount++;
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 100,
+                  height: 150,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, 10.0));
+    await tester.pump(kLongPressTimeout);
+    await gesture.up();
+
+    expect(longPressCount, 1);
+    expect(longPressUpCount, 1);
+    expect(startDetails.single.localPosition, const Offset(50, 75));
+    expect(startDetails.single.globalPosition, const Offset(400, 300));
+    expect(endDetails.single.localPosition, const Offset(50, 75 + 10.0 / 2.0));
+    expect(endDetails.single.globalPosition, const Offset(400, 300.0 + 10.0));
+    expect(moveDetails, isEmpty); // moved before long press was detected.
+
+    startDetails.clear();
+    endDetails.clear();
+    longPressCount = 0;
+    longPressUpCount = 0;
+
+    // Move after recognized.
+    gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await tester.pump(kLongPressTimeout);
+    await gesture.moveBy(const Offset(0, 100));
+    await gesture.up();
+
+    expect(longPressCount, 1);
+    expect(longPressUpCount, 1);
+    expect(startDetails.single.localPosition, const Offset(50, 75));
+    expect(startDetails.single.globalPosition, const Offset(400, 300));
+    expect(endDetails.single.localPosition, const Offset(50, 75 + 100.0 / 2.0));
+    expect(endDetails.single.globalPosition, const Offset(400, 300.0 + 100.0));
+    expect(moveDetails.single.localPosition, const Offset(50, 75 + 100.0 / 2.0));
+    expect(moveDetails.single.globalPosition, const Offset(400, 300.0 + 100.0));
+    expect(moveDetails.single.offsetFromOrigin, const Offset(0, 100.0));
+    expect(moveDetails.single.localOffsetFromOrigin, const Offset(0, 100.0 / 2.0));
+  });
+
+  testWidgets('scaled down', (WidgetTester tester) async {
+    int longPressCount = 0;
+    int longPressUpCount = 0;
+    final List<LongPressEndDetails> endDetails = <LongPressEndDetails>[];
+    final List<LongPressMoveUpdateDetails> moveDetails = <LongPressMoveUpdateDetails>[];
+    final List<LongPressStartDetails> startDetails = <LongPressStartDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 0.5,
+            child: GestureDetector(
+                onLongPress: () {
+                  longPressCount++;
+                },
+                onLongPressEnd: (LongPressEndDetails details) {
+                  endDetails.add(details);
+                },
+                onLongPressMoveUpdate: (LongPressMoveUpdateDetails details) {
+                  moveDetails.add(details);
+                },
+                onLongPressStart: (LongPressStartDetails details) {
+                  startDetails.add(details);
+                },
+                onLongPressUp: () {
+                  longPressUpCount++;
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 100,
+                  height: 150,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, 10.0));
+    await tester.pump(kLongPressTimeout);
+    await gesture.up();
+
+    expect(longPressCount, 1);
+    expect(longPressUpCount, 1);
+    expect(startDetails.single.localPosition, const Offset(50, 75));
+    expect(startDetails.single.globalPosition, const Offset(400, 300));
+    expect(endDetails.single.localPosition, const Offset(50, 75 + 10.0 * 2.0));
+    expect(endDetails.single.globalPosition, const Offset(400, 300.0 + 10.0));
+    expect(moveDetails, isEmpty); // moved before long press was detected.
+
+    startDetails.clear();
+    endDetails.clear();
+    longPressCount = 0;
+    longPressUpCount = 0;
+
+    // Move after recognized.
+    gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await tester.pump(kLongPressTimeout);
+    await gesture.moveBy(const Offset(0, 100));
+    await gesture.up();
+
+    expect(longPressCount, 1);
+    expect(longPressUpCount, 1);
+    expect(startDetails.single.localPosition, const Offset(50, 75));
+    expect(startDetails.single.globalPosition, const Offset(400, 300));
+    expect(endDetails.single.localPosition, const Offset(50, 75 + 100.0 * 2.0));
+    expect(endDetails.single.globalPosition, const Offset(400, 300.0 + 100.0));
+    expect(moveDetails.single.localPosition, const Offset(50, 75 + 100.0 * 2.0));
+    expect(moveDetails.single.globalPosition, const Offset(400, 300.0 + 100.0));
+    expect(moveDetails.single.offsetFromOrigin, const Offset(0, 100.0));
+    expect(moveDetails.single.localOffsetFromOrigin, const Offset(0, 100.0 * 2.0));
+  });
+}

--- a/packages/flutter/test/gestures/transformed_monodarg_test.dart
+++ b/packages/flutter/test/gestures/transformed_monodarg_test.dart
@@ -1,0 +1,668 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+
+void main() {
+  group('Horizontal', () {
+    testWidgets('gets local corrdinates', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+            onHorizontalDragCancel: () {
+              dragCancelCount++;
+            },
+            onHorizontalDragDown: (DragDownDetails details) {
+              downDetails.add(details);
+            },
+            onHorizontalDragEnd: (DragEndDetails details) {
+              endDetails.add(details);
+            },
+            onHorizontalDragStart: (DragStartDetails details) {
+              startDetails.add(details);
+            },
+            onHorizontalDragUpdate: (DragUpdateDetails details) {
+              updateDetails.add(details);
+            },
+            child: Container(
+              key: redContainer,
+              width: 100,
+              height: 150,
+              color: Colors.red,
+            ),
+          ),
+        ),
+      );
+
+      await tester.drag(find.byKey(redContainer), const Offset(100, 0));
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50, 75));
+      expect(startDetails.single.globalPosition, const Offset(400, 300));
+      expect(updateDetails.last.localPosition, const Offset(50 + 100.0, 75));
+      expect(updateDetails.last.globalPosition, const Offset(400 + 100.0, 300));
+      expect(
+        updateDetails.fold(Offset.zero, (Offset offset, DragUpdateDetails details) => offset + details.delta),
+        const Offset(100, 0),
+      );
+      expect(
+        updateDetails.fold(0.0, (double offset, DragUpdateDetails details) => offset + details.primaryDelta),
+        100.0,
+      );
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled up', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 2.0,
+            child: GestureDetector(
+              onHorizontalDragCancel: () {
+                dragCancelCount++;
+              },
+              onHorizontalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onHorizontalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onHorizontalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onHorizontalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just above kTouchSlop should recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(kTouchSlop + 1, 0));
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + (kTouchSlop + 1) / 2, 75));
+      expect(startDetails.single.globalPosition, const Offset(400 + (kTouchSlop + 1), 300));
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move just below kTouchSlop does not recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(kTouchSlop - 1, 0));
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move in two separate movements
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(kTouchSlop + 1, 30));
+      await gesture.moveBy(const Offset(100, 10));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + (kTouchSlop + 1) / 2, 75.0 + 30.0 / 2));
+      expect(startDetails.single.globalPosition, const Offset(400 + (kTouchSlop + 1), 300 + 30.0));
+      expect(updateDetails.single.localPosition, startDetails.single.localPosition + const Offset(100.0 / 2, 10 / 2));
+      expect(updateDetails.single.globalPosition, startDetails.single.globalPosition + const Offset(100.0, 10.0));
+      expect(updateDetails.single.delta, const Offset(100.0 / 2, 0.0));
+      expect(updateDetails.single.primaryDelta, 100.0 / 2);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled down', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 0.5,
+            child: GestureDetector(
+              onHorizontalDragCancel: () {
+                dragCancelCount++;
+              },
+              onHorizontalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onHorizontalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onHorizontalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onHorizontalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just above kTouchSlop should recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(kTouchSlop + 1, 0));
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + (kTouchSlop + 1) * 2, 75));
+      expect(startDetails.single.globalPosition, const Offset(400 + (kTouchSlop + 1), 300));
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move just below kTouchSlop does not recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(kTouchSlop - 1, 0));
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move in two separate movements
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(kTouchSlop + 1, 30));
+      await gesture.moveBy(const Offset(100, 10));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + (kTouchSlop + 1) * 2, 75.0 + 30.0 * 2));
+      expect(startDetails.single.globalPosition, const Offset(400 + (kTouchSlop + 1), 300 + 30.0));
+      expect(updateDetails.single.localPosition, startDetails.single.localPosition + const Offset(100.0 * 2, 10.0 * 2.0));
+      expect(updateDetails.single.globalPosition, startDetails.single.globalPosition + const Offset(100.0, 10.0));
+      expect(updateDetails.single.delta, const Offset(100.0 * 2.0, 0.0));
+      expect(updateDetails.single.primaryDelta, 100.0 * 2);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when roateted 45 degrees', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.rotate(
+            angle: math.pi / 4,
+            child: GestureDetector(
+              onHorizontalDragCancel: () {
+                dragCancelCount++;
+              },
+              onHorizontalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onHorizontalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onHorizontalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onHorizontalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just below kTouchSlop should not recognize drag.
+      const Offset moveBy1 = Offset(kTouchSlop/ 2, kTouchSlop / 2);
+      expect(moveBy1.distance, lessThan(kTouchSlop));
+      await tester.drag(find.byKey(redContainer), moveBy1);
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, within(distance: 0.0001, from: const Offset(50, 75)));
+      expect(downDetails.single.globalPosition, within(distance: 0.0001, from: const Offset(400, 300)));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move above kTouchSlop recognizes drag.
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(kTouchSlop, kTouchSlop));
+      await gesture.moveBy(const Offset(3, 4));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition,  within(distance: 0.0001, from: const Offset(50, 75)));
+      expect(downDetails.single.globalPosition,  within(distance: 0.0001, from: const Offset(400, 300)));
+      expect(endDetails, hasLength(1));
+      expect(startDetails, hasLength(1));
+      expect(updateDetails.single.globalPosition, within(distance: 0.0001, from: const Offset(400 + kTouchSlop + 3, 300 + kTouchSlop + 4)));
+      expect(updateDetails.single.delta, within(distance: 0.1, from: const Offset(5, 0.0))); // sqrt(3^2 + 4^2)
+      expect(updateDetails.single.primaryDelta, within(distance: 0.1, from: 5.0)); // sqrt(3^2 + 4^2)
+    });
+  });
+
+  group('Vertical', () {
+    testWidgets('gets local corrdinates', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+            onVerticalDragCancel: () {
+              dragCancelCount++;
+            },
+            onVerticalDragDown: (DragDownDetails details) {
+              downDetails.add(details);
+            },
+            onVerticalDragEnd: (DragEndDetails details) {
+              endDetails.add(details);
+            },
+            onVerticalDragStart: (DragStartDetails details) {
+              startDetails.add(details);
+            },
+            onVerticalDragUpdate: (DragUpdateDetails details) {
+              updateDetails.add(details);
+            },
+            child: Container(
+              key: redContainer,
+              width: 100,
+              height: 150,
+              color: Colors.red,
+            ),
+          ),
+        ),
+      );
+
+      await tester.drag(find.byKey(redContainer), const Offset(0, 100));
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50, 75));
+      expect(startDetails.single.globalPosition, const Offset(400, 300));
+      expect(updateDetails.last.localPosition, const Offset(50, 75 + 100.0));
+      expect(updateDetails.last.globalPosition, const Offset(400, 300 + 100.0));
+      expect(
+        updateDetails.fold(Offset.zero, (Offset offset, DragUpdateDetails details) => offset + details.delta),
+        const Offset(0, 100),
+      );
+      expect(
+        updateDetails.fold(0.0, (double offset, DragUpdateDetails details) => offset + details.primaryDelta),
+        100.0,
+      );
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled up', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 2.0,
+            child: GestureDetector(
+              onVerticalDragCancel: () {
+                dragCancelCount++;
+              },
+              onVerticalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onVerticalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onVerticalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onVerticalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just above kTouchSlop should recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(0, kTouchSlop + 1));
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50, 75 + (kTouchSlop + 1) / 2));
+      expect(startDetails.single.globalPosition, const Offset(400, 300 + (kTouchSlop + 1)));
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move just below kTouchSlop does not recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(0, kTouchSlop - 1));
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move in two separate movements
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(30, kTouchSlop + 1));
+      await gesture.moveBy(const Offset(10, 100));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + 30.0 / 2, 75.0 + (kTouchSlop + 1) / 2));
+      expect(startDetails.single.globalPosition, const Offset(400 + 30.0, 300 + (kTouchSlop + 1)));
+      expect(updateDetails.single.localPosition, startDetails.single.localPosition + const Offset(10.0 / 2, 100.0 / 2));
+      expect(updateDetails.single.globalPosition, startDetails.single.globalPosition + const Offset(10.0, 100.0));
+      expect(updateDetails.single.delta, const Offset(0.0, 100.0 / 2));
+      expect(updateDetails.single.primaryDelta, 100.0 / 2);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled down', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 0.5,
+            child: GestureDetector(
+              onVerticalDragCancel: () {
+                dragCancelCount++;
+              },
+              onVerticalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onVerticalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onVerticalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onVerticalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just above kTouchSlop should recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(0, kTouchSlop + 1));
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50, 75 + (kTouchSlop + 1) * 2));
+      expect(startDetails.single.globalPosition, const Offset(400, 300 + (kTouchSlop + 1)));
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move just below kTouchSlop does not recognize drag.
+      await tester.drag(find.byKey(redContainer), const Offset(0, kTouchSlop - 1));
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move in two separate movements
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(30, kTouchSlop + 1));
+      await gesture.moveBy(const Offset(10, 100));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition, const Offset(50, 75));
+      expect(downDetails.single.globalPosition, const Offset(400, 300));
+      expect(endDetails, hasLength(1));
+      expect(startDetails.single.localPosition, const Offset(50 + 30.0 * 2, 75.0 + (kTouchSlop + 1) * 2));
+      expect(startDetails.single.globalPosition, const Offset(400 + 30.0, 300 + (kTouchSlop + 1)));
+      expect(updateDetails.single.localPosition, startDetails.single.localPosition + const Offset(10.0 * 2, 100.0 * 2.0));
+      expect(updateDetails.single.globalPosition, startDetails.single.globalPosition + const Offset(10.0, 100.0));
+      expect(updateDetails.single.delta, const Offset(0.0, 100.0 * 2.0));
+      expect(updateDetails.single.primaryDelta, 100.0 * 2);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+    });
+
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when roateted 45 degrees', (WidgetTester tester) async {
+      int dragCancelCount = 0;
+      final List<DragDownDetails> downDetails = <DragDownDetails>[];
+      final List<DragEndDetails> endDetails = <DragEndDetails>[];
+      final List<DragStartDetails> startDetails = <DragStartDetails>[];
+      final List<DragUpdateDetails> updateDetails = <DragUpdateDetails>[];
+
+      final Key redContainer = UniqueKey();
+      await tester.pumpWidget(
+        Center(
+          child: Transform.rotate(
+            angle: math.pi / 4,
+            child: GestureDetector(
+              onVerticalDragCancel: () {
+                dragCancelCount++;
+              },
+              onVerticalDragDown: (DragDownDetails details) {
+                downDetails.add(details);
+              },
+              onVerticalDragEnd: (DragEndDetails details) {
+                endDetails.add(details);
+              },
+              onVerticalDragStart: (DragStartDetails details) {
+                startDetails.add(details);
+              },
+              onVerticalDragUpdate: (DragUpdateDetails details) {
+                updateDetails.add(details);
+              },
+              onTap: () {
+                // Competing gesture detector.
+              },
+              child: Container(
+                key: redContainer,
+                width: 100,
+                height: 150,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move just below kTouchSlop should not recognize drag.
+      const Offset moveBy1 = Offset(kTouchSlop/ 2, kTouchSlop / 2);
+      expect(moveBy1.distance, lessThan(kTouchSlop));
+      await tester.drag(find.byKey(redContainer), moveBy1);
+      expect(dragCancelCount, 1);
+      expect(downDetails.single.localPosition, within(distance: 0.0001, from: const Offset(50, 75)));
+      expect(downDetails.single.globalPosition, within(distance: 0.0001, from: const Offset(400, 300)));
+      expect(endDetails, isEmpty);
+      expect(startDetails, isEmpty);
+      expect(updateDetails, isEmpty);
+
+      dragCancelCount = 0;
+      downDetails.clear();
+      endDetails.clear();
+      startDetails.clear();
+      updateDetails.clear();
+
+      // Move above kTouchSlop recognizes drag.
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+      await gesture.moveBy(const Offset(kTouchSlop, kTouchSlop));
+      await gesture.moveBy(const Offset(-4, 3));
+      await gesture.up();
+
+      expect(dragCancelCount, 0);
+      expect(downDetails.single.localPosition,  within(distance: 0.0001, from: const Offset(50, 75)));
+      expect(downDetails.single.globalPosition,  within(distance: 0.0001, from: const Offset(400, 300)));
+      expect(endDetails, hasLength(1));
+      expect(startDetails, hasLength(1));
+      expect(updateDetails.single.globalPosition, within(distance: 0.0001, from: const Offset(400 + kTouchSlop - 4, 300 + kTouchSlop + 3)));
+      expect(updateDetails.single.delta, within(distance: 0.1, from: const Offset(0.0, 5.0))); // sqrt(3^2 + 4^2)
+      expect(updateDetails.single.primaryDelta, within(distance: 0.1, from: 5.0)); // sqrt(3^2 + 4^2)
+    });
+  });
+}

--- a/packages/flutter/test/gestures/transformed_tap_test.dart
+++ b/packages/flutter/test/gestures/transformed_tap_test.dart
@@ -1,0 +1,177 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+
+void main() {
+  testWidgets('gets local corrdinates', (WidgetTester tester) async {
+    int tapCount = 0;
+    int tapCancelCount = 0;
+    final List<TapDownDetails> downDetails = <TapDownDetails>[];
+    final List<TapUpDetails> upDetails = <TapUpDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: GestureDetector(
+          onTap: () {
+            tapCount++;
+          },
+          onTapCancel: () {
+            tapCancelCount++;
+          },
+          onTapDown: (TapDownDetails details) {
+            downDetails.add(details);
+          },
+          onTapUp: (TapUpDetails details) {
+            upDetails.add(details);
+          },
+          child: Container(
+            key: redContainer,
+            width: 100,
+            height: 150,
+            color: Colors.red,
+          )
+        ),
+      )
+    );
+
+    await tester.tapAt(tester.getCenter(find.byKey(redContainer)));
+    expect(tapCount, 1);
+    expect(tapCancelCount, 0);
+    expect(downDetails.single.localPosition, const Offset(50, 75));
+    expect(downDetails.single.globalPosition, const Offset(400, 300));
+    expect(upDetails.single.localPosition, const Offset(50, 75));
+    expect(upDetails.single.globalPosition, const Offset(400, 300));
+  });
+
+  testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled up', (WidgetTester tester) async {
+    int tapCount = 0;
+    int tapCancelCount = 0;
+    final List<TapDownDetails> downDetails = <TapDownDetails>[];
+    final List<TapUpDetails> upDetails = <TapUpDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 2.0,
+            child: GestureDetector(
+                onTap: () {
+                  tapCount++;
+                },
+                onTapCancel: () {
+                  tapCancelCount++;
+                },
+                onTapDown: (TapDownDetails details) {
+                  downDetails.add(details);
+                },
+                onTapUp: (TapUpDetails details) {
+                  upDetails.add(details);
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 100,
+                  height: 150,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    // Move just below kTouchSlop should recognize tap.
+    TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, kTouchSlop - 1));
+    await gesture.up();
+
+    expect(tapCount, 1);
+    expect(tapCancelCount, 0);
+    expect(downDetails.single.localPosition, const Offset(50, 75));
+    expect(downDetails.single.globalPosition, const Offset(400, 300));
+    expect(upDetails.single.localPosition, const Offset(50, 75 + (kTouchSlop - 1) / 2.0));
+    expect(upDetails.single.globalPosition, const Offset(400, 300 + (kTouchSlop - 1)));
+
+    downDetails.clear();
+    upDetails.clear();
+    tapCount = 0;
+    tapCancelCount = 0;
+
+    // Move more then kTouchSlop should cancel.
+    gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, kTouchSlop + 1));
+    await gesture.up();
+    expect(tapCount, 0);
+    expect(tapCancelCount, 1);
+    expect(downDetails.single.localPosition, const Offset(50, 75));
+    expect(downDetails.single.globalPosition, const Offset(400, 300));
+    expect(upDetails, isEmpty);
+  });
+
+  testWidgets('kTouchSlop is evaluated in the global coordinate space when scaled down', (WidgetTester tester) async {
+    int tapCount = 0;
+    int tapCancelCount = 0;
+    final List<TapDownDetails> downDetails = <TapDownDetails>[];
+    final List<TapUpDetails> upDetails = <TapUpDetails>[];
+
+    final Key redContainer = UniqueKey();
+    await tester.pumpWidget(
+        Center(
+          child: Transform.scale(
+            scale: 0.5,
+            child: GestureDetector(
+                onTap: () {
+                  tapCount++;
+                },
+                onTapCancel: () {
+                  tapCancelCount++;
+                },
+                onTapDown: (TapDownDetails details) {
+                  downDetails.add(details);
+                },
+                onTapUp: (TapUpDetails details) {
+                  upDetails.add(details);
+                },
+                child: Container(
+                  key: redContainer,
+                  width: 100,
+                  height: 150,
+                  color: Colors.red,
+                )
+            ),
+          ),
+        )
+    );
+
+    // Move just below kTouchSlop should recognize tap.
+    TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, kTouchSlop - 1));
+    await gesture.up();
+
+    expect(tapCount, 1);
+    expect(tapCancelCount, 0);
+    expect(downDetails.single.localPosition, const Offset(50, 75));
+    expect(downDetails.single.globalPosition, const Offset(400, 300));
+    expect(upDetails.single.localPosition, const Offset(50, 75 + (kTouchSlop - 1) * 2.0));
+    expect(upDetails.single.globalPosition, const Offset(400, 300 + (kTouchSlop - 1)));
+
+    downDetails.clear();
+    upDetails.clear();
+    tapCount = 0;
+    tapCancelCount = 0;
+
+    // Move more then kTouchSlop should cancel.
+    gesture = await tester.startGesture(tester.getCenter(find.byKey(redContainer)));
+    await gesture.moveBy(const Offset(0, kTouchSlop + 1));
+    await gesture.up();
+    expect(tapCount, 0);
+    expect(tapCancelCount, 1);
+    expect(downDetails.single.localPosition, const Offset(50, 75));
+    expect(downDetails.single.globalPosition, const Offset(400, 300));
+    expect(upDetails, isEmpty);
+  });
+}

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1743,8 +1743,8 @@ void main() {
     expect(fourthPos.dx, 0);
     expect(firstPos.dx, fourthPos.dx);
     expect(firstPos.dy, lessThan(fourthPos.dy));
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(firstPos)), isTrue);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(fourthPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(firstPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(fourthPos)), isFalse);
 
     TestGesture gesture = await tester.startGesture(firstPos, pointer: 7);
     await tester.pump();
@@ -1763,8 +1763,8 @@ void main() {
     Offset newFourthPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('Fourth'));
 
     expect(newFirstPos.dy, lessThan(firstPos.dy));
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isFalse);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isTrue);
 
     // Now try scrolling by dragging the selection handle.
     // Long press the middle of the word "won't" in the fourth line.
@@ -1809,8 +1809,8 @@ void main() {
     newFirstPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('First'));
     newFourthPos = textOffsetToPosition(tester, kMoreThanFourLines.indexOf('Fourth'));
     expect(newFirstPos.dy, firstPos.dy);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
-    expect(inputBox.hitTest(HitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFirstPos)), isTrue);
+    expect(inputBox.hitTest(BoxHitTestResult(), position: inputBox.globalToLocal(newFourthPos)), isFalse);
   });
 
   testWidgets('TextField smoke test', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/matrix_utils_test.dart
+++ b/packages/flutter/test/painting/matrix_utils_test.dart
@@ -86,4 +86,39 @@ void main() {
       0.0, moreOrLessEquals(-86.60254037844386), moreOrLessEquals(-50.0), 1.05,
     ]);
   });
+
+  test('forceToPoint', () {
+    const Offset forcedOffset = Offset(20, -30);
+    final Matrix4 forcedTransform = MatrixUtils.forceToPoint(forcedOffset);
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, forcedOffset),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, Offset.zero),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(1, 1)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-1, -1)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-20, 30)),
+      forcedOffset,
+    );
+
+    expect(
+      MatrixUtils.transformPoint(forcedTransform, const Offset(-1.2344, 1422434.23)),
+      forcedOffset,
+    );
+  });
 }

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -265,10 +265,13 @@ void main() {
       final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
       final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
       final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+      final Matrix4 transform = Matrix4.translationValues(40.0, 150.0, 0.0);
 
-      final HitTestResult wrapped = HitTestResult();
+      final HitTestResult wrapped = MyHitTestResult()
+        ..publicPushTransform(transform);
       wrapped.add(entry1);
       expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+      expect(entry1.transform, transform);
 
       final BoxHitTestResult wrapping = BoxHitTestResult.wrap(wrapped);
       expect(wrapping.path, equals(<HitTestEntry>[entry1]));
@@ -277,10 +280,12 @@ void main() {
       wrapping.add(entry2);
       expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
       expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+      expect(entry2.transform, transform);
 
       wrapped.add(entry3);
       expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
       expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+      expect(entry3.transform, transform);
     });
 
     test('addWithPaintTransform', () {
@@ -516,4 +521,8 @@ class _DummyHitTestTarget implements HitTestTarget {
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     // Nothing to do.
   }
+}
+
+class MyHitTestResult extends HitTestResult {
+  void publicPushTransform(Matrix4 transform) => pushTransform(transform);
 }

--- a/packages/flutter/test/rendering/slivers_test.dart
+++ b/packages/flutter/test/rendering/slivers_test.dart
@@ -831,10 +831,13 @@ void main() {
       final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
       final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
       final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());
+      final Matrix4 transform = Matrix4.translationValues(40.0, 150.0, 0.0);
 
-      final HitTestResult wrapped = HitTestResult();
+      final HitTestResult wrapped = MyHitTestResult()
+        ..publicPushTransform(transform);
       wrapped.add(entry1);
       expect(wrapped.path, equals(<HitTestEntry>[entry1]));
+      expect(entry1.transform, transform);
 
       final SliverHitTestResult wrapping = SliverHitTestResult.wrap(wrapped);
       expect(wrapping.path, equals(<HitTestEntry>[entry1]));
@@ -843,10 +846,12 @@ void main() {
       wrapping.add(entry2);
       expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2]));
       expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2]));
+      expect(entry2.transform, transform);
 
       wrapped.add(entry3);
       expect(wrapping.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
       expect(wrapped.path, equals(<HitTestEntry>[entry1, entry2, entry3]));
+      expect(entry3.transform, transform);
     });
 
     test('addWithAxisOffset', () {
@@ -920,4 +925,8 @@ class _DummyHitTestTarget implements HitTestTarget {
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     // Nothing to do.
   }
+}
+
+class MyHitTestResult extends HitTestResult {
+  void publicPushTransform(Matrix4 transform) => pushTransform(transform);
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -347,6 +349,275 @@ void main() {
       // TransformLayer for `Transform.scale` is removed again as transform is
       // executed directly on the canvas.
       expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
+    });
+  });
+
+  group('transformed events', () {
+    testWidgets('simple offset for touch', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      await tester.pumpWidget(
+        Center(
+          child: Listener(
+            onPointerDown: (PointerDownEvent event) {
+              events.add(event);
+            },
+            onPointerUp: (PointerUpEvent event) {
+            events.add(event);
+            },
+            onPointerMove: (PointerMoveEvent event) {
+              events.add(event);
+            },
+            onPointerEnter: (PointerEnterEvent event) {
+              events.add(event);
+            },
+            onPointerHover: (PointerHoverEvent event) {
+              events.add(event);
+            },
+            onPointerExit: (PointerExitEvent event) {
+              events.add(event);
+            },
+            child: Container(
+              key: key,
+              color: Colors.red,
+              height: 100,
+              width: 100,
+            ),
+          ),
+        ),
+      );
+      const Offset moved = Offset(20, 30);
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(moved);
+      await gesture.up();
+
+      expect(events, hasLength(3));
+      final PointerDownEvent down = events[0];
+      final PointerMoveEvent move = events[1];
+      final PointerUpEvent up = events[2];
+
+      final Matrix4 expectedTransform = Matrix4.translationValues(-topLeft.dx, -topLeft.dy, 0);
+
+      expect(center, isNot(const Offset(50, 50)));
+
+      expect(down.localPosition, const Offset(50, 50));
+      expect(down.position, center);
+      expect(down.delta, Offset.zero);
+      expect(down.localDelta, Offset.zero);
+      expect(down.transform, expectedTransform);
+
+      expect(move.localPosition, const Offset(50, 50) + moved);
+      expect(move.position, center + moved);
+      expect(move.delta, moved);
+      expect(move.localDelta, moved);
+      expect(move.transform, expectedTransform);
+
+      expect(up.localPosition, const Offset(50, 50) + moved);
+      expect(up.position, center + moved);
+      expect(up.delta, Offset.zero);
+      expect(up.localDelta, Offset.zero);
+      expect(up.transform, expectedTransform);
+    });
+
+    testWidgets('scaled for touch', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      const double scaleFactor = 2;
+
+      await tester.pumpWidget(
+        Align(
+          alignment: Alignment.topLeft,
+          child: Transform(
+            transform: Matrix4.identity()..scale(scaleFactor),
+            child: Listener(
+              onPointerDown: (PointerDownEvent event) {
+                events.add(event);
+              },
+              onPointerUp: (PointerUpEvent event) {
+                events.add(event);
+              },
+              onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+      const Offset moved = Offset(20, 30);
+      final Offset center = tester.getCenter(find.byKey(key));
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(moved);
+      await gesture.up();
+
+      expect(events, hasLength(3));
+      final PointerDownEvent down = events[0];
+      final PointerMoveEvent move = events[1];
+      final PointerUpEvent up = events[2];
+
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
+
+      expect(center, isNot(const Offset(50, 50)));
+
+      expect(down.localPosition, const Offset(50, 50));
+      expect(down.position, center);
+      expect(down.delta, Offset.zero);
+      expect(down.localDelta, Offset.zero);
+      expect(down.transform, expectedTransform);
+
+      expect(move.localPosition, const Offset(50, 50) + moved / scaleFactor);
+      expect(move.position, center + moved);
+      expect(move.delta, moved);
+      expect(move.localDelta, moved / scaleFactor);
+      expect(move.transform, expectedTransform);
+
+      expect(up.localPosition, const Offset(50, 50) + moved / scaleFactor);
+      expect(up.position, center + moved);
+      expect(up.delta, Offset.zero);
+      expect(up.localDelta, Offset.zero);
+      expect(up.transform, expectedTransform);
+    });
+
+    testWidgets('scaled and offset for touch', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      const double scaleFactor = 2;
+
+      await tester.pumpWidget(
+        Center(
+          child: Transform(
+            transform: Matrix4.identity()..scale(scaleFactor),
+            child: Listener(
+              onPointerDown: (PointerDownEvent event) {
+                events.add(event);
+              },
+              onPointerUp: (PointerUpEvent event) {
+                events.add(event);
+              },
+              onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+      const Offset moved = Offset(20, 30);
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(moved);
+      await gesture.up();
+
+      expect(events, hasLength(3));
+      final PointerDownEvent down = events[0];
+      final PointerMoveEvent move = events[1];
+      final PointerUpEvent up = events[2];
+
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0)
+        ..translate(-topLeft.dx, -topLeft.dy, 0);
+
+      expect(center, isNot(const Offset(50, 50)));
+
+      expect(down.localPosition, const Offset(50, 50));
+      expect(down.position, center);
+      expect(down.delta, Offset.zero);
+      expect(down.localDelta, Offset.zero);
+      expect(down.transform, expectedTransform);
+
+      expect(move.localPosition, const Offset(50, 50) + moved / scaleFactor);
+      expect(move.position, center + moved);
+      expect(move.delta, moved);
+      expect(move.localDelta, moved / scaleFactor);
+      expect(move.transform, expectedTransform);
+
+      expect(up.localPosition, const Offset(50, 50) + moved / scaleFactor);
+      expect(up.position, center + moved);
+      expect(up.delta, Offset.zero);
+      expect(up.localDelta, Offset.zero);
+      expect(up.transform, expectedTransform);
+    });
+
+    testWidgets('rotated for touch', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      await tester.pumpWidget(
+        Center(
+          child: Transform(
+            transform: Matrix4.identity()..rotateZ(math.pi / 2), // 90 degrees clockwise
+            child: Listener(
+              onPointerDown: (PointerDownEvent event) {
+                events.add(event);
+              },
+              onPointerUp: (PointerUpEvent event) {
+                events.add(event);
+              },
+              onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+      const Offset moved = Offset(20, 30);
+      final Offset downPosition = tester.getCenter(find.byKey(key)) + const Offset(10, 5);
+      final TestGesture gesture = await tester.startGesture(downPosition);
+      await gesture.moveBy(moved);
+      await gesture.up();
+
+      expect(events, hasLength(3));
+      final PointerDownEvent down = events[0];
+      final PointerMoveEvent move = events[1];
+      final PointerUpEvent up = events[2];
+
+      const Offset offset = Offset((800 - 100) / 2, (600 - 100) / 2);
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..rotateZ(-math.pi / 2)
+        ..translate(-offset.dx, -offset.dy, 0.0);
+
+      final Offset localDownPosition = const Offset(50, 50) + const Offset(5, -10);
+      expect(down.localPosition, within(distance: 0.001, from: localDownPosition));
+      expect(down.position, downPosition);
+      expect(down.delta, Offset.zero);
+      expect(down.localDelta, Offset.zero);
+      expect(down.transform, expectedTransform);
+
+      const Offset localDelta = Offset(30, -20);
+      expect(move.localPosition, within(distance: 0.001, from: localDownPosition + localDelta));
+      expect(move.position, downPosition + moved);
+      expect(move.delta, moved);
+      expect(move.localDelta, localDelta);
+      expect(move.transform, expectedTransform);
+
+      expect(up.localPosition, within(distance: 0.001, from: localDownPosition + localDelta));
+      expect(up.position, downPosition + moved);
+      expect(up.delta, Offset.zero);
+      expect(up.localDelta, Offset.zero);
+      expect(up.transform, expectedTransform);
     });
   });
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -353,7 +353,7 @@ void main() {
   });
 
   group('transformed events', () {
-    testWidgets('simple offset for touch', (WidgetTester tester) async {
+    testWidgets('simple offset for touch/signal', (WidgetTester tester) async {
       final List<PointerEvent> events = <PointerEvent>[];
       final Key key = UniqueKey();
 
@@ -369,13 +369,7 @@ void main() {
             onPointerMove: (PointerMoveEvent event) {
               events.add(event);
             },
-            onPointerEnter: (PointerEnterEvent event) {
-              events.add(event);
-            },
-            onPointerHover: (PointerHoverEvent event) {
-              events.add(event);
-            },
-            onPointerExit: (PointerExitEvent event) {
+            onPointerSignal: (PointerSignalEvent event) {
               events.add(event);
             },
             child: Container(
@@ -420,9 +414,89 @@ void main() {
       expect(up.delta, Offset.zero);
       expect(up.localDelta, Offset.zero);
       expect(up.transform, expectedTransform);
+
+      events.clear();
+      await scrollAt(center, tester);
+      expect(events.single.localPosition, const Offset(50, 50));
+      expect(events.single.position, center);
+      expect(events.single.delta, Offset.zero);
+      expect(events.single.localDelta, Offset.zero);
+      expect(events.single.transform, expectedTransform);
     });
 
-    testWidgets('scaled for touch', (WidgetTester tester) async {
+    testWidgets('simple offset for mouse hover', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      await tester.pumpWidget(
+        Center(
+          child: Listener(
+            onPointerEnter: (PointerEnterEvent event) {
+              events.add(event);
+            },
+            onPointerHover: (PointerHoverEvent event) {
+              events.add(event);
+            },
+            onPointerExit: (PointerExitEvent event) {
+              events.add(event);
+            },
+            child: Container(
+              key: key,
+              color: Colors.red,
+              height: 100,
+              width: 100,
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+      expect(center, isNot(const Offset(50, 50)));
+
+      final Matrix4 expectedTransform = Matrix4.translationValues(-topLeft.dx, -topLeft.dy, 0);
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(center);
+      await tester.pump();
+      expect(events, hasLength(2));
+      expect(events.first, isA<PointerEnterEvent>());
+      expect(events.first.transform, expectedTransform);
+      expect(events.first.localPosition, const Offset(50, 50));
+      expect(events.first.position, center);
+      expect(events.first.delta, Offset.zero);
+      expect(events.first.localDelta, Offset.zero);
+      expect(events.last, isA<PointerHoverEvent>());
+      expect(events.last.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(50, 50));
+      expect(events.last.position, center);
+      expect(events.last.delta, Offset.zero);
+      expect(events.last.localDelta, Offset.zero);
+
+      events.clear();
+      await gesture.moveTo(topLeft);
+      await tester.pump();
+      expect(events.single, isA<PointerHoverEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(0, 0));
+      expect(events.last.position, topLeft);
+      expect(events.last.delta, topLeft - center);
+      expect(events.last.localDelta, const Offset(-50, -50));
+
+      events.clear();
+      await gesture.moveBy(const Offset(-1, -1));
+      await tester.pump();
+      expect(events.single, isA<PointerExitEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(-1, -1));
+      expect(events.last.position, topLeft - const Offset(1, 1));
+      expect(events.last.delta, const Offset(-1, -1));
+      expect(events.last.localDelta, const Offset(-1, -1));
+
+      events.clear();
+    });
+
+    testWidgets('scaled for touch/signal', (WidgetTester tester) async {
       final List<PointerEvent> events = <PointerEvent>[];
       final Key key = UniqueKey();
 
@@ -441,6 +515,9 @@ void main() {
                 events.add(event);
               },
               onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              onPointerSignal: (PointerSignalEvent event) {
                 events.add(event);
               },
               child: Container(
@@ -486,7 +563,132 @@ void main() {
       expect(up.delta, Offset.zero);
       expect(up.localDelta, Offset.zero);
       expect(up.transform, expectedTransform);
+
+      events.clear();
+      await scrollAt(center, tester);
+      expect(events.single.localPosition, const Offset(50, 50));
+      expect(events.single.position, center);
+      expect(events.single.delta, Offset.zero);
+      expect(events.single.localDelta, Offset.zero);
+      expect(events.single.transform, expectedTransform);
     });
+
+//    testWidgets('scaled for mouse hover', (WidgetTester tester) async {
+//      final List<PointerEvent> events = <PointerEvent>[];
+//      final Key key = UniqueKey();
+//
+//      const double scaleFactor = 2;
+//
+//      await tester.pumpWidget(
+//        Align(
+//          alignment: Alignment.topLeft,
+//          child: Transform(
+//            transform: Matrix4.identity()..scale(scaleFactor),
+//            child: Listener(
+//              onPointerEnter: (PointerEnterEvent event) {
+//                events.add(event);
+//              },
+//              onPointerHover: (PointerHoverEvent event) {
+//                events.add(event);
+//              },
+//              onPointerExit: (PointerExitEvent event) {
+//                events.add(event);
+//              },
+//              child: Container(
+//                key: key,
+//                color: Colors.red,
+//                height: 100,
+//                width: 100,
+//              ),
+//            ),
+//          ),
+//        ),
+//      );
+//
+//      debugDumpLayerTree();
+//
+//      final Offset center = tester.getCenter(find.byKey(key));
+//      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+//      expect(center, isNot(const Offset(50, 50)));
+//
+//      final Matrix4 expectedTransform = Matrix4.identity()
+//        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
+//
+//      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+//      await gesture.moveTo(center);
+//      await tester.pump();
+////      expect(events, hasLength(2));
+////      expect(events.first, isA<PointerEnterEvent>());
+////      expect(events.first.transform, expectedTransform);
+////      expect(events.first.localPosition, const Offset(50, 50));
+////      expect(events.first.position, center);
+////      expect(events.first.delta, Offset.zero);
+////      expect(events.first.localDelta, Offset.zero);
+////      expect(events.last, isA<PointerHoverEvent>());
+////      expect(events.last.transform, expectedTransform);
+////      expect(events.last.localPosition, const Offset(50, 50));
+////      expect(events.last.position, center);
+////      expect(events.last.delta, Offset.zero);
+////      expect(events.last.localDelta, Offset.zero);
+//
+//      events.clear();
+//      await gesture.moveTo(topLeft);
+//      await tester.pump();
+//      print(events.first.transform);
+////      expect(events.single, isA<PointerHoverEvent>());
+////      expect(events.single.transform, expectedTransform);
+////      expect(events.last.localPosition, const Offset(0, 0));
+////      expect(events.last.position, topLeft);
+////      expect(events.last.delta, topLeft - center);
+////      expect(events.last.localDelta, const Offset(-50, -50));
+////
+//      events.clear();
+//      await gesture.moveBy(const Offset(-1, -1));
+//      await tester.pump();
+//      print(events.first.transform);
+////      expect(events.single, isA<PointerExitEvent>());
+////      expect(events.single.transform, expectedTransform);
+////      expect(events.last.localPosition, const Offset(-1, -1));
+////      expect(events.last.position, topLeft - const Offset(1, 1));
+////      expect(events.last.delta, const Offset(-1, -1));
+////      expect(events.last.localDelta, const Offset(-1, -1));
+//
+//      events.clear();
+//
+////      const Offset moved = Offset(20, 30);
+////      final Offset center = tester.getCenter(find.byKey(key));
+////      final TestGesture gesture = await tester.startGesture(center);
+////      await gesture.moveBy(moved);
+////      await gesture.up();
+////
+////      expect(events, hasLength(3));
+////      final PointerDownEvent down = events[0];
+////      final PointerMoveEvent move = events[1];
+////      final PointerUpEvent up = events[2];
+////
+////      final Matrix4 expectedTransform = Matrix4.identity()
+////        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
+////
+////      expect(center, isNot(const Offset(50, 50)));
+////
+////      expect(down.localPosition, const Offset(50, 50));
+////      expect(down.position, center);
+////      expect(down.delta, Offset.zero);
+////      expect(down.localDelta, Offset.zero);
+////      expect(down.transform, expectedTransform);
+////
+////      expect(move.localPosition, const Offset(50, 50) + moved / scaleFactor);
+////      expect(move.position, center + moved);
+////      expect(move.delta, moved);
+////      expect(move.localDelta, moved / scaleFactor);
+////      expect(move.transform, expectedTransform);
+////
+////      expect(up.localPosition, const Offset(50, 50) + moved / scaleFactor);
+////      expect(up.position, center + moved);
+////      expect(up.delta, Offset.zero);
+////      expect(up.localDelta, Offset.zero);
+////      expect(up.transform, expectedTransform);
+//    });
 
     testWidgets('scaled and offset for touch', (WidgetTester tester) async {
       final List<PointerEvent> events = <PointerEvent>[];
@@ -506,6 +708,9 @@ void main() {
                 events.add(event);
               },
               onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              onPointerSignal: (PointerSignalEvent event) {
                 events.add(event);
               },
               child: Container(
@@ -553,6 +758,14 @@ void main() {
       expect(up.delta, Offset.zero);
       expect(up.localDelta, Offset.zero);
       expect(up.transform, expectedTransform);
+
+      events.clear();
+      await scrollAt(center, tester);
+      expect(events.single.localPosition, const Offset(50, 50));
+      expect(events.single.position, center);
+      expect(events.single.delta, Offset.zero);
+      expect(events.single.localDelta, Offset.zero);
+      expect(events.single.transform, expectedTransform);
     });
 
     testWidgets('rotated for touch', (WidgetTester tester) async {
@@ -571,6 +784,9 @@ void main() {
                 events.add(event);
               },
               onPointerMove: (PointerMoveEvent event) {
+                events.add(event);
+              },
+              onPointerSignal: (PointerSignalEvent event) {
                 events.add(event);
               },
               child: Container(
@@ -618,6 +834,22 @@ void main() {
       expect(up.delta, Offset.zero);
       expect(up.localDelta, Offset.zero);
       expect(up.transform, expectedTransform);
+
+      events.clear();
+      await scrollAt(downPosition, tester);
+      expect(events.single.localPosition, within(distance: 0.001, from: localDownPosition));
+      expect(events.single.position, downPosition);
+      expect(events.single.delta, Offset.zero);
+      expect(events.single.localDelta, Offset.zero);
+      expect(events.single.transform, expectedTransform);
     });
   });
+}
+
+Future<void> scrollAt(Offset position, WidgetTester tester) {
+  final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+  // Create a hover event so that |testPointer| has a location when generating the scroll.
+  testPointer.hover(position);
+  final HitTestResult result = tester.hitTestOnBinding(position);
+  return tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 20.0)), result);
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -573,124 +573,86 @@ void main() {
       expect(events.single.transform, expectedTransform);
     });
 
-//    testWidgets('scaled for mouse hover', (WidgetTester tester) async {
-//      final List<PointerEvent> events = <PointerEvent>[];
-//      final Key key = UniqueKey();
-//
-//      const double scaleFactor = 2;
-//
-//      await tester.pumpWidget(
-//        Align(
-//          alignment: Alignment.topLeft,
-//          child: Transform(
-//            transform: Matrix4.identity()..scale(scaleFactor),
-//            child: Listener(
-//              onPointerEnter: (PointerEnterEvent event) {
-//                events.add(event);
-//              },
-//              onPointerHover: (PointerHoverEvent event) {
-//                events.add(event);
-//              },
-//              onPointerExit: (PointerExitEvent event) {
-//                events.add(event);
-//              },
-//              child: Container(
-//                key: key,
-//                color: Colors.red,
-//                height: 100,
-//                width: 100,
-//              ),
-//            ),
-//          ),
-//        ),
-//      );
-//
-//      debugDumpLayerTree();
-//
-//      final Offset center = tester.getCenter(find.byKey(key));
-//      final Offset topLeft = tester.getTopLeft(find.byKey(key));
-//      expect(center, isNot(const Offset(50, 50)));
-//
-//      final Matrix4 expectedTransform = Matrix4.identity()
-//        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
-//
-//      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-//      await gesture.moveTo(center);
-//      await tester.pump();
-////      expect(events, hasLength(2));
-////      expect(events.first, isA<PointerEnterEvent>());
-////      expect(events.first.transform, expectedTransform);
-////      expect(events.first.localPosition, const Offset(50, 50));
-////      expect(events.first.position, center);
-////      expect(events.first.delta, Offset.zero);
-////      expect(events.first.localDelta, Offset.zero);
-////      expect(events.last, isA<PointerHoverEvent>());
-////      expect(events.last.transform, expectedTransform);
-////      expect(events.last.localPosition, const Offset(50, 50));
-////      expect(events.last.position, center);
-////      expect(events.last.delta, Offset.zero);
-////      expect(events.last.localDelta, Offset.zero);
-//
-//      events.clear();
-//      await gesture.moveTo(topLeft);
-//      await tester.pump();
-//      print(events.first.transform);
-////      expect(events.single, isA<PointerHoverEvent>());
-////      expect(events.single.transform, expectedTransform);
-////      expect(events.last.localPosition, const Offset(0, 0));
-////      expect(events.last.position, topLeft);
-////      expect(events.last.delta, topLeft - center);
-////      expect(events.last.localDelta, const Offset(-50, -50));
-////
-//      events.clear();
-//      await gesture.moveBy(const Offset(-1, -1));
-//      await tester.pump();
-//      print(events.first.transform);
-////      expect(events.single, isA<PointerExitEvent>());
-////      expect(events.single.transform, expectedTransform);
-////      expect(events.last.localPosition, const Offset(-1, -1));
-////      expect(events.last.position, topLeft - const Offset(1, 1));
-////      expect(events.last.delta, const Offset(-1, -1));
-////      expect(events.last.localDelta, const Offset(-1, -1));
-//
-//      events.clear();
-//
-////      const Offset moved = Offset(20, 30);
-////      final Offset center = tester.getCenter(find.byKey(key));
-////      final TestGesture gesture = await tester.startGesture(center);
-////      await gesture.moveBy(moved);
-////      await gesture.up();
-////
-////      expect(events, hasLength(3));
-////      final PointerDownEvent down = events[0];
-////      final PointerMoveEvent move = events[1];
-////      final PointerUpEvent up = events[2];
-////
-////      final Matrix4 expectedTransform = Matrix4.identity()
-////        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
-////
-////      expect(center, isNot(const Offset(50, 50)));
-////
-////      expect(down.localPosition, const Offset(50, 50));
-////      expect(down.position, center);
-////      expect(down.delta, Offset.zero);
-////      expect(down.localDelta, Offset.zero);
-////      expect(down.transform, expectedTransform);
-////
-////      expect(move.localPosition, const Offset(50, 50) + moved / scaleFactor);
-////      expect(move.position, center + moved);
-////      expect(move.delta, moved);
-////      expect(move.localDelta, moved / scaleFactor);
-////      expect(move.transform, expectedTransform);
-////
-////      expect(up.localPosition, const Offset(50, 50) + moved / scaleFactor);
-////      expect(up.position, center + moved);
-////      expect(up.delta, Offset.zero);
-////      expect(up.localDelta, Offset.zero);
-////      expect(up.transform, expectedTransform);
-//    });
+    testWidgets('scaled for mouse hover', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
 
-    testWidgets('scaled and offset for touch', (WidgetTester tester) async {
+      const double scaleFactor = 2;
+
+      await tester.pumpWidget(
+        Align(
+          alignment: Alignment.topLeft,
+          child: Transform(
+            transform: Matrix4.identity()..scale(scaleFactor),
+            child: Listener(
+              onPointerEnter: (PointerEnterEvent event) {
+                events.add(event);
+              },
+              onPointerHover: (PointerHoverEvent event) {
+                events.add(event);
+              },
+              onPointerExit: (PointerExitEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset bottomRight = tester.getBottomRight(find.byKey(key));
+      expect(center, isNot(const Offset(50, 50)));
+
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0);
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(center);
+      await tester.pump();
+      expect(events, hasLength(2));
+      expect(events.first, isA<PointerEnterEvent>());
+      expect(events.first.transform, expectedTransform);
+      expect(events.first.localPosition, const Offset(50, 50));
+      expect(events.first.position, center);
+      expect(events.first.delta, Offset.zero);
+      expect(events.first.localDelta, Offset.zero);
+      expect(events.last, isA<PointerHoverEvent>());
+      expect(events.last.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(50, 50));
+      expect(events.last.position, center);
+      expect(events.last.delta, Offset.zero);
+      expect(events.last.localDelta, Offset.zero);
+
+      events.clear();
+      await gesture.moveTo(bottomRight - const Offset(2, 2));
+      await tester.pump();
+      expect(events.single, isA<PointerHoverEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(99, 99));
+      expect(events.last.position, bottomRight - const Offset(2, 2));
+      expect(events.last.delta, bottomRight - const Offset(2, 2) - center);
+      expect(events.last.localDelta, const Offset(49, 49));
+
+      events.clear();
+      await gesture.moveBy(const Offset(4, 4));
+      await tester.pump();
+      expect(events.single, isA<PointerExitEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(101, 101));
+      expect(events.last.position, bottomRight + const Offset(2, 2));
+      expect(events.last.delta, const Offset(4, 4));
+      expect(events.last.localDelta, const Offset(2, 2));
+
+      events.clear();
+    });
+
+    testWidgets('scaled and offset for touch/signal', (WidgetTester tester) async {
       final List<PointerEvent> events = <PointerEvent>[];
       final Key key = UniqueKey();
 
@@ -768,14 +730,93 @@ void main() {
       expect(events.single.transform, expectedTransform);
     });
 
-    testWidgets('rotated for touch', (WidgetTester tester) async {
+    testWidgets('scaled and offset for hover', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      const double scaleFactor = 2;
+
+      await tester.pumpWidget(
+        Center(
+          child: Transform(
+            transform: Matrix4.identity()..scale(scaleFactor),
+            child: Listener(
+              onPointerEnter: (PointerEnterEvent event) {
+                events.add(event);
+              },
+              onPointerHover: (PointerHoverEvent event) {
+                events.add(event);
+              },
+              onPointerExit: (PointerExitEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset topLeft = tester.getTopLeft(find.byKey(key));
+      expect(center, isNot(const Offset(50, 50)));
+
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..scale(1 / scaleFactor, 1 / scaleFactor, 1.0)
+        ..translate(-topLeft.dx, -topLeft.dy, 0);
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(center);
+      await tester.pump();
+      expect(events, hasLength(2));
+      expect(events.first, isA<PointerEnterEvent>());
+      expect(events.first.transform, expectedTransform);
+      expect(events.first.localPosition, const Offset(50, 50));
+      expect(events.first.position, center);
+      expect(events.first.delta, Offset.zero);
+      expect(events.first.localDelta, Offset.zero);
+      expect(events.last, isA<PointerHoverEvent>());
+      expect(events.last.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(50, 50));
+      expect(events.last.position, center);
+      expect(events.last.delta, Offset.zero);
+      expect(events.last.localDelta, Offset.zero);
+
+      events.clear();
+      await gesture.moveTo(topLeft);
+      await tester.pump();
+      expect(events.single, isA<PointerHoverEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(0, 0));
+      expect(events.last.position, topLeft);
+      expect(events.last.delta, topLeft - center);
+      expect(events.last.localDelta, const Offset(-50, -50));
+
+      events.clear();
+      await gesture.moveBy(const Offset(-2, -2));
+      await tester.pump();
+      expect(events.single, isA<PointerExitEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(-1, -1));
+      expect(events.last.position, topLeft - const Offset(2, 2));
+      expect(events.last.delta, const Offset(-2, -2));
+      expect(events.last.localDelta, const Offset(-1, -1));
+
+      events.clear();
+    });
+
+    testWidgets('rotated for touch/signal', (WidgetTester tester) async {
       final List<PointerEvent> events = <PointerEvent>[];
       final Key key = UniqueKey();
 
       await tester.pumpWidget(
         Center(
           child: Transform(
-            transform: Matrix4.identity()..rotateZ(math.pi / 2), // 90 degrees clockwise
+            transform: Matrix4.identity()
+              ..rotateZ(math.pi / 2), // 90 degrees clockwise around Container origin
             child: Listener(
               onPointerDown: (PointerDownEvent event) {
                 events.add(event);
@@ -842,6 +883,84 @@ void main() {
       expect(events.single.delta, Offset.zero);
       expect(events.single.localDelta, Offset.zero);
       expect(events.single.transform, expectedTransform);
+    });
+
+    testWidgets('rotated for  hover', (WidgetTester tester) async {
+      final List<PointerEvent> events = <PointerEvent>[];
+      final Key key = UniqueKey();
+
+      await tester.pumpWidget(
+        Center(
+          child: Transform(
+            transform: Matrix4.identity()
+              ..rotateZ(math.pi / 2), // 90 degrees clockwise around Container origin
+          child: Listener(
+              onPointerEnter: (PointerEnterEvent event) {
+                events.add(event);
+              },
+              onPointerHover: (PointerHoverEvent event) {
+                events.add(event);
+              },
+              onPointerExit: (PointerExitEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.red,
+                height: 100,
+                width: 150,
+              ),
+            ),
+          ),
+        ),
+      );
+      final Offset center = tester.getCenter(find.byKey(key));
+      final Offset topLeft = tester.getTopLeft(find.byKey(key)); // topRight in global coordinates
+      expect(center, isNot(const Offset(50, 50)));
+
+      const Offset offset = Offset((800 - 150) / 2, (600 - 100) / 2);
+      final Matrix4 expectedTransform = Matrix4.identity()
+        ..rotateZ(-math.pi / 2)
+        ..translate(-offset.dx, -offset.dy, 0.0);
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(center);
+      await tester.pump();
+      expect(events, hasLength(2));
+      expect(events.first, isA<PointerEnterEvent>());
+      expect(events.first.transform, expectedTransform);
+      expect(events.first.localPosition, within(distance: 0.001, from: const Offset(75, 50)));
+      expect(events.first.position, center);
+      expect(events.first.delta, Offset.zero);
+      expect(events.first.localDelta, Offset.zero);
+      expect(events.last, isA<PointerHoverEvent>());
+      expect(events.last.transform, expectedTransform);
+      expect(events.last.localPosition, within(distance: 0.001, from: const Offset(75, 50)));
+      expect(events.last.position, center);
+      expect(events.last.delta, Offset.zero);
+      expect(events.last.localDelta, Offset.zero);
+
+      events.clear();
+      await gesture.moveTo(topLeft);
+      await tester.pump();
+      expect(events.single, isA<PointerHoverEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(0, 0));
+      expect(events.last.position, topLeft);
+      expect(events.last.delta, const Offset(50, -75));
+      expect(events.last.localDelta, within(distance: 0.001, from: const Offset(-75, -50)));
+
+      events.clear();
+      await gesture.moveBy(const Offset(1, -2));
+      await tester.pump();
+      expect(events.single, isA<PointerExitEvent>());
+      expect(events.single.transform, expectedTransform);
+      expect(events.last.localPosition, const Offset(-2, -1));
+      expect(events.last.position, topLeft + const Offset(1, -2));
+      expect(events.last.delta, const Offset(1, -2));
+      expect(events.last.localDelta, const Offset(-2, -1));
+
+      events.clear();
     });
   });
 }

--- a/packages/flutter/test/widgets/transformed_scrollable_test.dart
+++ b/packages/flutter/test/widgets/transformed_scrollable_test.dart
@@ -139,33 +139,80 @@ void main() {
     expect(controller.offset, 30.0); // 100.0 - 70.0
   });
 
-//  testWidgets('Perspective transform on scrollable', (WidgetTester tester) async {
-//    final ScrollController controller = ScrollController();
-//    await tester.pumpWidget(
-//      MaterialApp(
-//        home: Transform(
-//          transform: Matrix4.identity()
-//            ..setEntry(3, 2, 0.001)
-//            ..rotateY(-0.01 * 90),
-//          child: Center(
-//            child: Container(
-//              width: 200,
-//              child: ListView.builder(
-//                controller: controller,
-//                cacheExtent: 0.0,
-//                itemBuilder: (BuildContext context, int index) {
-//                  return Container(
-//                    height: 100.0,
-//                    color: index % 2 == 0 ? Colors.blue : Colors.red,
-//                    child: Text('Tile $index'),
-//                  );
-//                },
-//              ),
-//            ),
-//          ),
-//        ),
-//      ),
-//    );
-//    expect(controller.offset, 0.0);
-//  });
+  testWidgets('Perspective transform on scrollable', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Transform(
+          transform: Matrix4.identity()
+            ..setEntry(3, 2, 0.001)
+            ..rotateX(math.pi / 4),
+          child: Center(
+            child: Container(
+              width: 200,
+              child: ListView.builder(
+                controller: controller,
+                cacheExtent: 0.0,
+                itemBuilder: (BuildContext context, int index) {
+                  return Container(
+                    height: 100.0,
+                    color: index % 2 == 0 ? Colors.blue : Colors.red,
+                    child: Text('Tile $index'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(controller.offset, 0.0);
+
+    // We want to test that the point in the ListView that the finger touches
+    // on the screen stays under the finger as the finger scrolls the ListView
+    // in vertical direction. For this, we pick a point in the ListView (here
+    // the center of Tile 5) and calculate its position in the coordinate space
+    // of the screen. We then place our finger on that point and drag that
+    // point up in vertical direction. After the scroll activity is done,
+    // we verify that - in the coordinate space of the screen (!) - the point
+    // has moved the same distance as the finger. Due to the perspective
+    // transform the point will have moved more distance in the *local*
+    // coordinate system of the ListView.
+
+    // Calculate where the center of Tile 5 is located in the coordinate
+    // space of the screen. We cannot use `tester.getCenter` because it
+    // does not properly remove the perspective component from the transform
+    // to give us the place on the screen at which we need to touch the screen
+    // to have the center of Tile 5 directly under our finger.
+    final RenderBox tile5 = tester.renderObject(find.text('Tile 5'));
+    final Offset pointOnScreenStart = MatrixUtils.transformPoint(
+      PointerEvent.paintTransformToPointerEventTransform(tile5.getTransformTo(null)),
+      tile5.size.center(Offset.zero),
+    );
+
+    // Place the finger on the tracked point and move the finger upwards for
+    // 50 pixels to scroll the ListView (the ListView's scroll offset will
+    // move more then 50 pixels due to the perspective transform).
+    await tester.dragFrom(pointOnScreenStart, const Offset(0.0, -50.0));
+    await tester.pump();
+
+    // Get the new position of the tracked point in the screen's coordinate
+    // system.
+    final Offset pointOnScreenEnd = MatrixUtils.transformPoint(
+      PointerEvent.paintTransformToPointerEventTransform(tile5.getTransformTo(null)),
+      tile5.size.center(Offset.zero),
+    );
+
+    // The tracked point (in the coordinate space of the screen) and the finger
+    // should have moved the same vertical distance over the screen.
+    expect(
+      pointOnScreenStart.dy - pointOnScreenEnd.dy,
+      within(distance: 0.00001, from: 50.0),
+    );
+
+    // While the point traveled the same distance as the finger in the
+    // coordinate space of the screen, the scroll view actually moved far more
+    // pixels in its local coordinate system due to the perspective transform.
+    expect(controller.offset, greaterThan(100));
+  });
 }

--- a/packages/flutter/test/widgets/transformed_scrollable_test.dart
+++ b/packages/flutter/test/widgets/transformed_scrollable_test.dart
@@ -1,0 +1,171 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/gestures.dart';
+
+void main() {
+  testWidgets('Scrollable scaled up', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Transform.scale(
+          scale: 2.0,
+          child: Center(
+            child: Container(
+              width: 200,
+              child: ListView.builder(
+                controller: controller,
+                cacheExtent: 0.0,
+                itemBuilder: (BuildContext context, int index) {
+                  return Container(
+                    height: 100.0,
+                    color: index % 2 == 0 ? Colors.blue : Colors.red,
+                    child: Text('Tile $index'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(controller.offset, 0.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, -100.0));
+    await tester.pump();
+    expect(controller.offset, 50.0); // 100.0 / 2.0
+
+    await tester.drag(find.byType(ListView), const Offset(80.0, -70.0));
+    await tester.pump();
+    expect(controller.offset, 85.0); // 50.0 + (70.0 / 2)
+
+    await tester.drag(find.byType(ListView), const Offset(100.0, 0.0));
+    await tester.pump();
+    expect(controller.offset, 85.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, 85.0));
+    await tester.pump();
+    expect(controller.offset, 42.5); // 85.0 - (85.0 / 2)
+  });
+
+  testWidgets('Scrollable scaled down', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Transform.scale(
+          scale: 0.5,
+          child: Center(
+            child: Container(
+              width: 200,
+              child: ListView.builder(
+                controller: controller,
+                cacheExtent: 0.0,
+                itemBuilder: (BuildContext context, int index) {
+                  return Container(
+                    height: 100.0,
+                    color: index % 2 == 0 ? Colors.blue : Colors.red,
+                    child: Text('Tile $index'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(controller.offset, 0.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, -100.0));
+    await tester.pump();
+    expect(controller.offset, 200.0); // 100.0 * 2.0
+
+    await tester.drag(find.byType(ListView), const Offset(80.0, -70.0));
+    await tester.pump();
+    expect(controller.offset, 340.0); // 200.0 + (70.0 * 2)
+
+    await tester.drag(find.byType(ListView), const Offset(100.0, 0.0));
+    await tester.pump();
+    expect(controller.offset, 340.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, 170.0));
+    await tester.pump();
+    expect(controller.offset, 0.0); // 340.0 - (170.0 * 2)
+  });
+
+  testWidgets('Scrollable rotated 90 degrees', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Transform.rotate(
+          angle: math.pi / 2,
+          child: Center(
+            child: Container(
+              width: 200,
+              child: ListView.builder(
+                controller: controller,
+                cacheExtent: 0.0,
+                itemBuilder: (BuildContext context, int index) {
+                  return Container(
+                    height: 100.0,
+                    color: index % 2 == 0 ? Colors.blue : Colors.red,
+                    child: Text('Tile $index'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(controller.offset, 0.0);
+
+    await tester.drag(find.byType(ListView), const Offset(100.0, 0.0));
+    await tester.pump();
+    expect(controller.offset, 100.0);
+
+    await tester.drag(find.byType(ListView), const Offset(0.0, -100.0));
+    await tester.pump();
+    expect(controller.offset, 100.0);
+
+    await tester.drag(find.byType(ListView), const Offset(-70.0, -50.0));
+    await tester.pump();
+    expect(controller.offset, 30.0); // 100.0 - 70.0
+  });
+
+//  testWidgets('Perspective transform on scrollable', (WidgetTester tester) async {
+//    final ScrollController controller = ScrollController();
+//    await tester.pumpWidget(
+//      MaterialApp(
+//        home: Transform(
+//          transform: Matrix4.identity()
+//            ..setEntry(3, 2, 0.001)
+//            ..rotateY(-0.01 * 90),
+//          child: Center(
+//            child: Container(
+//              width: 200,
+//              child: ListView.builder(
+//                controller: controller,
+//                cacheExtent: 0.0,
+//                itemBuilder: (BuildContext context, int index) {
+//                  return Container(
+//                    height: 100.0,
+//                    color: index % 2 == 0 ? Colors.blue : Colors.red,
+//                    child: Text('Tile $index'),
+//                  );
+//                },
+//              ),
+//            ),
+//          ),
+//        ),
+//      ),
+//    );
+//    expect(controller.offset, 0.0);
+//  });
+}


### PR DESCRIPTION
## Description

Before this change, `PointerEvent`s would always be expressed in the global coordinate system of the screen. The change adds `localPosition` and `localDelta` to `PointerEvent`s, which are expressed in the local coordinate system of the event receiver. This means - among other things - that scrolling now sticks to your finger even if the Scrollable has been scaled up or down. Furthermore, a rotated scrollable can now be scrolled by moving the finger in the (rotated) direction of the scrollview.

Furthermore, this change also fixes hit testing for perspective transforms. For example, if a view is rotated along its x axis, buttons now continue to react to touch events.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29916
Fixes https://github.com/flutter/flutter/issues/18408
Fixes #31958

## Tests

I added the following tests:

* wrapping HitTestResult and its subclasses
* transforming PointerEvents and related helper methods
* PointerRouter transforms events before delivering them to the route
* PointerSignalResolver delivers the transformed event
* Tests for changed GestureRecognizers to ensure they work in transformed subtrees
* Tests for new MatrixUtil functions
* Tests for position transforming methods on BoxHitTestResult and SliverHitTestResult
* Listener receives transformed events for touch/signal/mouse
* Scrolling now works as expected (sticks to the finger) in transformed subtrees (incl. perspective transform).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change: https://groups.google.com/forum/#!topic/flutter-announce/CnYVAz5dR4U

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
