### PR TITLE
Add master channel to performance issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -28,10 +28,15 @@ assignees: ''
 2.  Please attach a small application (ideally just one main.dart file) that
      reproduces the problem. You could use https://gist.github.com/ for this.
 
-3.  Run this app on a physical device using profile mode with Skia tracing
-     enabled, as follows:
+3.  Switch flutter to master channel and run this app on a physical device
+     using profile mode with Skia tracing enabled, as follows:
+       flutter channel master
        flutter run --profile --trace-skia
-       Press ‘P’ to enable the performance overlay.
+     Then press ‘P’ to enable the performance overlay.
+
+     The bleeding edge master channel is encouraged here because Flutter is
+     constantly fixing bugs and improving its performance. Your problem in an
+     older Flutter version may have already been solved in the master channel.
 
 4.  Record a video of the performance issue using another phone so we
      can have an intuitive understanding of what happened. Don’t use


### PR DESCRIPTION
I helped the daily mail debug a performance issue on I/O yesterday. Not
using the master branch could be wasting a lot of time due to old bugs.
