### PR TITLE
Fix nested listeners so that ancestor listeners can also receive enter/exit/move events.

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -79,6 +79,7 @@ class _TrackedAnnotation {
 /// It is used by the [MouseTracker] to fetch annotations for the mouse
 /// position.
 typedef MouseDetectorAnnotationFinder = MouseTrackerAnnotation Function(Offset offset);
+//typedef MouseDetectorAnnotationFinder = Iterable<MouseTrackerAnnotation> Function(Offset offset);
 
 /// Keeps state about which objects are interested in tracking mouse positions
 /// and notifies them when a mouse pointer enters, moves, or leaves an annotated
@@ -269,6 +270,76 @@ class MouseTracker extends ChangeNotifier {
       }
     }
   }
+
+//  void collectMousePositions() {
+//    void exitAnnotation(_TrackedAnnotation trackedAnnotation, int deviceId) {
+//      if (trackedAnnotation.annotation?.onExit != null && trackedAnnotation.activeDevices.contains(deviceId)) {
+//        trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(_lastMouseEvent[deviceId]));
+//        trackedAnnotation.activeDevices.remove(deviceId);
+//      }
+//    }
+//
+//    void exitAllDevices(_TrackedAnnotation trackedAnnotation) {
+//      if (trackedAnnotation.activeDevices.isNotEmpty) {
+//        final Set<int> deviceIds = trackedAnnotation.activeDevices.toSet();
+//        for (int deviceId in deviceIds) {
+//          exitAnnotation(trackedAnnotation, deviceId);
+//        }
+//      }
+//    }
+//
+//    // This indicates that all mouse pointers were removed, or none have been
+//    // connected yet. If no mouse is connected, then we want to make sure that
+//    // all active annotations are exited.
+//    if (!mouseIsConnected) {
+//      _trackedAnnotations.values.forEach(exitAllDevices);
+//      return;
+//    }
+//
+//    for (int deviceId in _lastMouseEvent.keys) {
+//      final PointerEvent lastEvent = _lastMouseEvent[deviceId];
+//      final Iterable<MouseTrackerAnnotation> hits = <MouseTrackerAnnotation> [annotationFinder(lastEvent.position)];
+//
+//      // No annotation was found at this position for this deviceId, so send an
+//      // exit to all active tracked annotations, since none of them were hit.
+//      if (hits.isEmpty) {
+//        // Send an exit to all tracked animations tracking this deviceId.
+//        for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
+//          exitAnnotation(trackedAnnotation, deviceId);
+//        }
+//        continue;
+//      }
+//
+//      final Set<_TrackedAnnotation> hitAnnotations = hits.map<_TrackedAnnotation>((MouseTrackerAnnotation hit) => _findAnnotation(hit)).toSet();
+//      for (_TrackedAnnotation hitAnnotation in hitAnnotations) {
+//        if (!hitAnnotation.activeDevices.contains(deviceId)) {
+//          // A tracked annotation that just became active and needs to have an enter
+//          // event sent to it.
+//          hitAnnotation.activeDevices.add(deviceId);
+//          if (hitAnnotation.annotation?.onEnter != null) {
+//            hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
+//          }
+//        }
+//        if (hitAnnotation.annotation?.onHover != null && lastEvent is PointerHoverEvent) {
+//          hitAnnotation.annotation.onHover(lastEvent);
+//        }
+//
+//        // Tell any tracked annotations that weren't hit that they are no longer
+//        // active.
+//        for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
+//          if (hitAnnotations.contains(trackedAnnotation)) {
+//            continue;
+//          }
+//          if (trackedAnnotation.activeDevices.contains(deviceId)) {
+//            if (trackedAnnotation.annotation?.onExit != null) {
+//              trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(lastEvent));
+//            }
+//            trackedAnnotation.activeDevices.remove(deviceId);
+//          }
+//        }
+//      }
+//    }
+//  }
 
   void _addMouseEvent(int deviceId, PointerEvent event) {
     final bool wasConnected = mouseIsConnected;

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -78,8 +78,7 @@ class _TrackedAnnotation {
 ///
 /// It is used by the [MouseTracker] to fetch annotations for the mouse
 /// position.
-typedef MouseDetectorAnnotationFinder = MouseTrackerAnnotation Function(Offset offset);
-//typedef MouseDetectorAnnotationFinder = Iterable<MouseTrackerAnnotation> Function(Offset offset);
+typedef MouseDetectorAnnotationFinder = Iterable<MouseTrackerAnnotation> Function(Offset offset);
 
 /// Keeps state about which objects are interested in tracking mouse positions
 /// and notifies them when a mouse pointer enters, moves, or leaves an annotated
@@ -230,116 +229,48 @@ class MouseTracker extends ChangeNotifier {
 
     for (int deviceId in _lastMouseEvent.keys) {
       final PointerEvent lastEvent = _lastMouseEvent[deviceId];
-      final MouseTrackerAnnotation hit = annotationFinder(lastEvent.position);
+      final Iterable<MouseTrackerAnnotation> hits = annotationFinder(lastEvent.position);
 
       // No annotation was found at this position for this deviceId, so send an
       // exit to all active tracked annotations, since none of them were hit.
-      if (hit == null) {
+      if (hits.isEmpty) {
         // Send an exit to all tracked animations tracking this deviceId.
         for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
           exitAnnotation(trackedAnnotation, deviceId);
         }
-        return;
+        continue;
       }
 
-      final _TrackedAnnotation hitAnnotation = _findAnnotation(hit);
-      if (!hitAnnotation.activeDevices.contains(deviceId)) {
-        // A tracked annotation that just became active and needs to have an enter
-        // event sent to it.
-        hitAnnotation.activeDevices.add(deviceId);
-        if (hitAnnotation.annotation?.onEnter != null) {
-          hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
-        }
-      }
-      if (hitAnnotation.annotation?.onHover != null && lastEvent is PointerHoverEvent) {
-        hitAnnotation.annotation.onHover(lastEvent);
-      }
-
-      // Tell any tracked annotations that weren't hit that they are no longer
-      // active.
-      for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
-        if (hitAnnotation == trackedAnnotation) {
-          continue;
-        }
-        if (trackedAnnotation.activeDevices.contains(deviceId)) {
-          if (trackedAnnotation.annotation?.onExit != null) {
-            trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(lastEvent));
+      final Set<_TrackedAnnotation> hitAnnotations = hits.map<_TrackedAnnotation>((MouseTrackerAnnotation hit) => _findAnnotation(hit)).toSet();
+      for (_TrackedAnnotation hitAnnotation in hitAnnotations) {
+        if (!hitAnnotation.activeDevices.contains(deviceId)) {
+          // A tracked annotation that just became active and needs to have an enter
+          // event sent to it.
+          hitAnnotation.activeDevices.add(deviceId);
+          if (hitAnnotation.annotation?.onEnter != null) {
+            hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
           }
-          trackedAnnotation.activeDevices.remove(deviceId);
+        }
+        if (hitAnnotation.annotation?.onHover != null && lastEvent is PointerHoverEvent) {
+          hitAnnotation.annotation.onHover(lastEvent);
+        }
+
+        // Tell any tracked annotations that weren't hit that they are no longer
+        // active.
+        for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
+          if (hitAnnotations.contains(trackedAnnotation)) {
+            continue;
+          }
+          if (trackedAnnotation.activeDevices.contains(deviceId)) {
+            if (trackedAnnotation.annotation?.onExit != null) {
+              trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(lastEvent));
+            }
+            trackedAnnotation.activeDevices.remove(deviceId);
+          }
         }
       }
     }
   }
-
-//  void collectMousePositions() {
-//    void exitAnnotation(_TrackedAnnotation trackedAnnotation, int deviceId) {
-//      if (trackedAnnotation.annotation?.onExit != null && trackedAnnotation.activeDevices.contains(deviceId)) {
-//        trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(_lastMouseEvent[deviceId]));
-//        trackedAnnotation.activeDevices.remove(deviceId);
-//      }
-//    }
-//
-//    void exitAllDevices(_TrackedAnnotation trackedAnnotation) {
-//      if (trackedAnnotation.activeDevices.isNotEmpty) {
-//        final Set<int> deviceIds = trackedAnnotation.activeDevices.toSet();
-//        for (int deviceId in deviceIds) {
-//          exitAnnotation(trackedAnnotation, deviceId);
-//        }
-//      }
-//    }
-//
-//    // This indicates that all mouse pointers were removed, or none have been
-//    // connected yet. If no mouse is connected, then we want to make sure that
-//    // all active annotations are exited.
-//    if (!mouseIsConnected) {
-//      _trackedAnnotations.values.forEach(exitAllDevices);
-//      return;
-//    }
-//
-//    for (int deviceId in _lastMouseEvent.keys) {
-//      final PointerEvent lastEvent = _lastMouseEvent[deviceId];
-//      final Iterable<MouseTrackerAnnotation> hits = <MouseTrackerAnnotation> [annotationFinder(lastEvent.position)];
-//
-//      // No annotation was found at this position for this deviceId, so send an
-//      // exit to all active tracked annotations, since none of them were hit.
-//      if (hits.isEmpty) {
-//        // Send an exit to all tracked animations tracking this deviceId.
-//        for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
-//          exitAnnotation(trackedAnnotation, deviceId);
-//        }
-//        continue;
-//      }
-//
-//      final Set<_TrackedAnnotation> hitAnnotations = hits.map<_TrackedAnnotation>((MouseTrackerAnnotation hit) => _findAnnotation(hit)).toSet();
-//      for (_TrackedAnnotation hitAnnotation in hitAnnotations) {
-//        if (!hitAnnotation.activeDevices.contains(deviceId)) {
-//          // A tracked annotation that just became active and needs to have an enter
-//          // event sent to it.
-//          hitAnnotation.activeDevices.add(deviceId);
-//          if (hitAnnotation.annotation?.onEnter != null) {
-//            hitAnnotation.annotation.onEnter(PointerEnterEvent.fromMouseEvent(lastEvent));
-//          }
-//        }
-//        if (hitAnnotation.annotation?.onHover != null && lastEvent is PointerHoverEvent) {
-//          hitAnnotation.annotation.onHover(lastEvent);
-//        }
-//
-//        // Tell any tracked annotations that weren't hit that they are no longer
-//        // active.
-//        for (_TrackedAnnotation trackedAnnotation in _trackedAnnotations.values) {
-//          if (hitAnnotations.contains(trackedAnnotation)) {
-//            continue;
-//          }
-//          if (trackedAnnotation.activeDevices.contains(deviceId)) {
-//            if (trackedAnnotation.annotation?.onExit != null) {
-//              trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(lastEvent));
-//            }
-//            trackedAnnotation.activeDevices.remove(deviceId);
-//          }
-//        }
-//      }
-//    }
-//  }
 
   void _addMouseEvent(int deviceId, PointerEvent event) {
     final bool wasConnected = mouseIsConnected;

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -231,7 +231,7 @@ class MouseTracker extends ChangeNotifier {
       final PointerEvent lastEvent = _lastMouseEvent[deviceId];
       final Iterable<MouseTrackerAnnotation> hits = annotationFinder(lastEvent.position);
 
-      // No annotation was found at this position for this deviceId, so send an
+      // No annotations were found at this position for this deviceId, so send an
       // exit to all active tracked annotations, since none of them were hit.
       if (hits.isEmpty) {
         // Send an exit to all tracked animations tracking this deviceId.

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -248,9 +248,9 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       // here.
       debugDumpLayerTree();
       final Iterable<MouseTrackerAnnotation> annotations = renderView.layer
-          .findAll<MouseTrackerAnnotation>(offset);
+          .findAll<MouseTrackerAnnotation>(offset * window.devicePixelRatio);
       print('Annotations: $annotations');
-      return annotations.isEmpty ? null : annotations.first;
+      return annotations;
     });
   }
 

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -246,11 +246,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       // Layer hit testing is done using device pixels, so we have to convert
       // the logical coordinates of the event location back to device pixels
       // here.
-      debugDumpLayerTree();
-      final Iterable<MouseTrackerAnnotation> annotations = renderView.layer
-          .findAll<MouseTrackerAnnotation>(offset * window.devicePixelRatio);
-      print('Annotations: $annotations');
-      return annotations;
+      return renderView.layer.findAll<MouseTrackerAnnotation>(offset * window.devicePixelRatio);
     });
   }
 

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -246,8 +246,11 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       // Layer hit testing is done using device pixels, so we have to convert
       // the logical coordinates of the event location back to device pixels
       // here.
-      return renderView.layer
-          .find<MouseTrackerAnnotation>(offset * window.devicePixelRatio);
+      debugDumpLayerTree();
+      final Iterable<MouseTrackerAnnotation> annotations = renderView.layer
+          .findAll<MouseTrackerAnnotation>(offset);
+      print('Annotations: $annotations');
+      return annotations.isEmpty ? null : annotations.first;
     });
   }
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -60,6 +60,9 @@ class _ProxyLayer extends Layer {
 
   @override
   S find<S>(Offset regionOffset) => _layer.find(regionOffset);
+
+  @override
+  Iterable<S> findAll<S>(Offset regionOffset) => <S>[];
 }
 
 /// A [Canvas] that multicasts all method calls to a main canvas and a
@@ -2799,6 +2802,9 @@ class _InspectorOverlayLayer extends Layer {
 
   @override
   S find<S>(Offset regionOffset) => null;
+
+  @override
+  Iterable<S> findAll<S>(Offset regionOffset) => <S>[];
 }
 
 const double _kScreenEdgeMargin = 10.0;

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -74,22 +74,6 @@ void main() {
       );
     });
 
-//    setUp(() {
-//      clear();
-//      isInHitRegionOne = true;
-//      isInHitRegionTwo = false;
-//      tracker = MouseTracker(
-//        GestureBinding.instance.pointerRouter,
-//        (Offset _) {
-//          if (isInHitRegionOne)
-//            return annotation;
-//          else if (isInHitRegionTwo)
-//            return partialAnnotation;
-//          return null;
-//        },
-//      );
-//    });
-
     test('receives and processes mouse hover events', () {
       final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
         ui.PointerData(

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -59,36 +59,36 @@ void main() {
       move.clear();
     }
 
-//    setUp(() {
-//      clear();
-//      isInHitRegionOne = true;
-//      isInHitRegionTwo = false;
-//      tracker = MouseTracker(
-//        GestureBinding.instance.pointerRouter,
-//            (Offset _) sync* {
-//          if (isInHitRegionOne)
-//            yield annotation;
-//          else if (isInHitRegionTwo)
-//            yield partialAnnotation;
-//        },
-//      );
-//    });
-
     setUp(() {
       clear();
       isInHitRegionOne = true;
       isInHitRegionTwo = false;
       tracker = MouseTracker(
         GestureBinding.instance.pointerRouter,
-        (Offset _) {
+            (Offset _) sync* {
           if (isInHitRegionOne)
-            return annotation;
+            yield annotation;
           else if (isInHitRegionTwo)
-            return partialAnnotation;
-          return null;
+            yield partialAnnotation;
         },
       );
     });
+
+//    setUp(() {
+//      clear();
+//      isInHitRegionOne = true;
+//      isInHitRegionTwo = false;
+//      tracker = MouseTracker(
+//        GestureBinding.instance.pointerRouter,
+//        (Offset _) {
+//          if (isInHitRegionOne)
+//            return annotation;
+//          else if (isInHitRegionTwo)
+//            return partialAnnotation;
+//          return null;
+//        },
+//      );
+//    });
 
     test('receives and processes mouse hover events', () {
       final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -59,6 +59,21 @@ void main() {
       move.clear();
     }
 
+//    setUp(() {
+//      clear();
+//      isInHitRegionOne = true;
+//      isInHitRegionTwo = false;
+//      tracker = MouseTracker(
+//        GestureBinding.instance.pointerRouter,
+//            (Offset _) sync* {
+//          if (isInHitRegionOne)
+//            yield annotation;
+//          else if (isInHitRegionTwo)
+//            yield partialAnnotation;
+//        },
+//      );
+//    });
+
     setUp(() {
       clear();
       isInHitRegionOne = true;

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -223,6 +223,23 @@ void main() {
       expect(transformLayer.findAll<int>(const Offset(0.0, 530.0)), equals(<int>[2]));
     });
 
+    test('finds multiple nested, overlapping regions', () {
+      final ContainerLayer parent = ContainerLayer();
+
+      int index = 0;
+      final List<AnnotatedRegionLayer<int>> layers = <AnnotatedRegionLayer<int>>[
+        AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0)),
+        AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0)),
+      ];
+      for (ContainerLayer layer in layers) {
+        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0));
+        layer.append(annotatedRegionLayer);
+        parent.append(layer);
+      }
+
+      expect(parent.findAll<int>(const Offset(0.0, 0.0)), equals(<int>[3, 1, 2, 0,]));
+    });
+
     test('looks for child AnnotatedRegions before parents', () {
       final AnnotatedRegionLayer<int> parent = AnnotatedRegionLayer<int>(1);
       final AnnotatedRegionLayer<int> child1 = AnnotatedRegionLayer<int>(2);

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
-  group(AnnotatedRegion, () {
+  group('$AnnotatedRegion find', () {
     test('finds the first value in a OffsetLayer when sized', () {
       final ContainerLayer containerLayer = ContainerLayer();
       final List<OffsetLayer> layers = <OffsetLayer>[
@@ -134,6 +134,139 @@ void main() {
       parent.transform = Matrix4.diagonal3Values(1.0, 1.0, 1.0);
 
       expect(parent.find<int>(const Offset(0.0, 0.0)), 1);
+    });
+  });
+  group('$AnnotatedRegion findAll', () {
+    test('finds the first value in a OffsetLayer when sized', () {
+      final ContainerLayer containerLayer = ContainerLayer();
+      final List<OffsetLayer> layers = <OffsetLayer>[
+        OffsetLayer(offset: Offset.zero),
+        OffsetLayer(offset: const Offset(0.0, 100.0)),
+        OffsetLayer(offset: const Offset(0.0, 200.0)),
+      ];
+      int i = 0;
+      for (OffsetLayer layer in layers) {
+        layer.append(AnnotatedRegionLayer<int>(i, size: const Size(200.0, 100.0)));
+        containerLayer.append(layer);
+        i += 1;
+      }
+
+      expect(containerLayer.findAll<int>(const Offset(0.0, 1.0)), equals(<int>[0]));
+      expect(containerLayer.findAll<int>(const Offset(0.0, 101.0)),equals(<int>[1]));
+      expect(containerLayer.findAll<int>(const Offset(0.0, 201.0)), equals(<int>[2]));
+    });
+
+    test('finds a value within the clip in a ClipRectLayer', () {
+      final ContainerLayer containerLayer = ContainerLayer();
+      final List<ClipRectLayer> layers = <ClipRectLayer>[
+        ClipRectLayer(clipRect: const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0)),
+        ClipRectLayer(clipRect: const Rect.fromLTRB(0.0, 100.0, 100.0, 200.0)),
+        ClipRectLayer(clipRect: const Rect.fromLTRB(0.0, 200.0, 100.0, 300.0)),
+      ];
+      int i = 0;
+      for (ClipRectLayer layer in layers) {
+        layer.append(AnnotatedRegionLayer<int>(i));
+        containerLayer.append(layer);
+        i += 1;
+      }
+
+      expect(containerLayer.findAll<int>(const Offset(0.0, 1.0)), equals(<int>[0]));
+      expect(containerLayer.findAll<int>(const Offset(0.0, 101.0)), equals(<int>[1]));
+      expect(containerLayer.findAll<int>(const Offset(0.0, 201.0)), equals(<int>[2]));
+    });
+
+
+    test('finds a value within the clip in a ClipRRectLayer', () {
+      final ContainerLayer containerLayer = ContainerLayer();
+      final List<ClipRRectLayer> layers = <ClipRRectLayer>[
+        ClipRRectLayer(clipRRect: RRect.fromLTRBR(0.0, 0.0, 100.0, 100.0, const Radius.circular(4.0))),
+        ClipRRectLayer(clipRRect: RRect.fromLTRBR(0.0, 100.0, 100.0, 200.0, const Radius.circular(4.0))),
+        ClipRRectLayer(clipRRect: RRect.fromLTRBR(0.0, 200.0, 100.0, 300.0, const Radius.circular(4.0))),
+      ];
+      int i = 0;
+      for (ClipRRectLayer layer in layers) {
+        layer.append(AnnotatedRegionLayer<int>(i));
+        containerLayer.append(layer);
+        i += 1;
+      }
+
+      expect(containerLayer.findAll<int>(const Offset(5.0, 5.0)), equals(<int>[0]));
+      expect(containerLayer.findAll<int>(const Offset(5.0, 105.0)), equals(<int>[1]));
+      expect(containerLayer.findAll<int>(const Offset(5.0, 205.0)), equals(<int>[2]));
+    });
+
+    test('finds a value under a TransformLayer', () {
+      final Matrix4 transform = Matrix4(
+        2.625, 0.0, 0.0, 0.0,
+        0.0, 2.625, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+      );
+      final TransformLayer transformLayer = TransformLayer(transform: transform);
+      final List<OffsetLayer> layers = <OffsetLayer>[
+        OffsetLayer(),
+        OffsetLayer(offset: const Offset(0.0, 100.0)),
+        OffsetLayer(offset: const Offset(0.0, 200.0)),
+      ];
+      int i = 0;
+      for (OffsetLayer layer in layers) {
+        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(i, size: const Size(100.0, 100.0));
+        layer.append(annotatedRegionLayer);
+        transformLayer.append(layer);
+        i += 1;
+      }
+
+      expect(transformLayer.findAll<int>(const Offset(0.0, 100.0)), equals(<int>[0]));
+      expect(transformLayer.findAll<int>(const Offset(0.0, 200.0)), equals(<int>[0]));
+      expect(transformLayer.findAll<int>(const Offset(0.0, 270.0)), equals(<int>[1]));
+      expect(transformLayer.findAll<int>(const Offset(0.0, 400.0)), equals(<int>[1]));
+      expect(transformLayer.findAll<int>(const Offset(0.0, 530.0)), equals(<int>[2]));
+    });
+
+    test('looks for child AnnotatedRegions before parents', () {
+      final AnnotatedRegionLayer<int> parent = AnnotatedRegionLayer<int>(1);
+      final AnnotatedRegionLayer<int> child1 = AnnotatedRegionLayer<int>(2);
+      final AnnotatedRegionLayer<int> child2 = AnnotatedRegionLayer<int>(3);
+      final AnnotatedRegionLayer<int> child3 = AnnotatedRegionLayer<int>(4);
+      final ContainerLayer layer = ContainerLayer();
+      parent.append(child1);
+      parent.append(child2);
+      parent.append(child3);
+      layer.append(parent);
+
+      expect(parent.findAll<int>(Offset.zero), equals(<int>[4, 3, 2, 1]));
+    });
+
+    test('looks for correct type', () {
+      final AnnotatedRegionLayer<int> child1 = AnnotatedRegionLayer<int>(1);
+      final AnnotatedRegionLayer<String> child2 = AnnotatedRegionLayer<String>('hello');
+      final ContainerLayer layer = ContainerLayer();
+      layer.append(child2);
+      layer.append(child1);
+
+      expect(layer.findAll<String>(Offset.zero), equals(<String>['hello']));
+    });
+
+    test('does not clip Layer.find on an AnnotatedRegion with an unrelated type', () {
+      final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
+      final AnnotatedRegionLayer<String> parent = AnnotatedRegionLayer<String>('hello', size: const Size(10.0, 10.0));
+      final ContainerLayer layer = ContainerLayer();
+      parent.append(child);
+      layer.append(parent);
+
+      expect(layer.findAll<int>(const Offset(100.0, 100.0)), equals(<int>[1]));
+    });
+
+    test('handles non-invertable transforms', () {
+      final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
+      final TransformLayer parent = TransformLayer(transform: Matrix4.diagonal3Values(0.0, 1.0, 1.0));
+      parent.append(child);
+
+      expect(parent.findAll<int>(const Offset(0.0, 0.0)), equals(<int>[]));
+
+      parent.transform = Matrix4.diagonal3Values(1.0, 1.0, 1.0);
+
+      expect(parent.findAll<int>(const Offset(0.0, 0.0)), equals(<int>[1]));
     });
   });
 }

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -135,7 +135,7 @@ void main() {
       expect(enter.position, equals(const Offset(400.0, 300.0)));
       expect(exit, isNull);
     });
-    testWidgets('detects pointer exit', (WidgetTester tester) async {
+    testWidgets('detects pointer exiting', (WidgetTester tester) async {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
@@ -195,6 +195,69 @@ void main() {
       expect(exit, isNotNull);
       expect(exit.position, equals(const Offset(400.0, 300.0)));
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
+    });
+    testWidgets('Hover works with nested listeners', (WidgetTester tester) async {
+      final UniqueKey key1 = UniqueKey();
+      final UniqueKey key2 = UniqueKey();
+      final List<PointerEnterEvent> enter1 = <PointerEnterEvent>[];
+      final List<PointerHoverEvent> move1 = <PointerHoverEvent>[];
+      final List<PointerExitEvent> exit1 = <PointerExitEvent>[];
+      final List<PointerEnterEvent> enter2 = <PointerEnterEvent>[];
+      final List<PointerHoverEvent> move2 = <PointerHoverEvent>[];
+      final List<PointerExitEvent> exit2 = <PointerExitEvent>[];
+      void clearLists() {
+        enter1.clear();
+        move1.clear();
+        exit1.clear();
+        enter2.clear();
+        move2.clear();
+        exit2.clear();
+      }
+
+      await tester.pumpWidget(Container());
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(const Offset(400.0, 0.0));
+      await tester.pump();
+      await tester.pumpWidget(
+        Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Listener(
+              onPointerEnter: (PointerEnterEvent details) => enter1.add(details),
+              onPointerHover: (PointerHoverEvent details) => move1.add(details),
+              onPointerExit: (PointerExitEvent details) => exit1.add(details),
+              key: key1,
+              child: Listener(
+                key: key2,
+                onPointerEnter: (PointerEnterEvent details) => enter2.add(details),
+                onPointerHover: (PointerHoverEvent details) => move2.add(details),
+                onPointerExit: (PointerExitEvent details) => exit2.add(details),
+                child: Container(
+                  width: 100.0,
+                  height: 100.0,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+      final RenderPointerListener renderListener1 = tester.renderObject(find.byKey(key1));
+      final RenderPointerListener renderListener2 = tester.renderObject(find.byKey(key2));
+      final Offset center = tester.getCenter(find.byKey(key2));
+      await gesture.moveTo(center);
+      await tester.pump();
+      expect(move2, isNotEmpty);
+      expect(enter2, isNotEmpty);
+      expect(exit2, isEmpty);
+      expect(move1, isNotEmpty);
+      expect(move1.last.position, equals(center));
+      expect(enter1, isNotEmpty);
+      expect(enter1.last.position, equals(center));
+      expect(exit1, isEmpty);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+      clearLists();
     });
     testWidgets('Hover transfers between two listeners', (WidgetTester tester) async {
       final UniqueKey key1 = UniqueKey();
@@ -341,6 +404,7 @@ void main() {
       final Offset bottomLeft = tester.getBottomLeft(find.byKey(key));
       expect(topRight.dx - topLeft.dx, scaleFactor * localWidth);
       expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
+      print('Rect: ${tester.getRect(find.byKey(key))}');
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.moveTo(topLeft - const Offset(1, 1));

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -228,14 +228,16 @@ void main() {
               onPointerHover: (PointerHoverEvent details) => move1.add(details),
               onPointerExit: (PointerExitEvent details) => exit1.add(details),
               key: key1,
-              child: Listener(
-                key: key2,
-                onPointerEnter: (PointerEnterEvent details) => enter2.add(details),
-                onPointerHover: (PointerHoverEvent details) => move2.add(details),
-                onPointerExit: (PointerExitEvent details) => exit2.add(details),
-                child: Container(
-                  width: 100.0,
-                  height: 100.0,
+              child: Container(
+                width: 200,
+                height: 200,
+                padding: const EdgeInsets.all(50.0),
+                child: Listener(
+                  key: key2,
+                  onPointerEnter: (PointerEnterEvent details) => enter2.add(details),
+                  onPointerHover: (PointerHoverEvent details) => move2.add(details),
+                  onPointerExit: (PointerExitEvent details) => exit2.add(details),
+                  child: Container(),
                 ),
               ),
             ),
@@ -244,7 +246,7 @@ void main() {
       );
       final RenderPointerListener renderListener1 = tester.renderObject(find.byKey(key1));
       final RenderPointerListener renderListener2 = tester.renderObject(find.byKey(key2));
-      final Offset center = tester.getCenter(find.byKey(key2));
+      Offset center = tester.getCenter(find.byKey(key2));
       await gesture.moveTo(center);
       await tester.pump();
       expect(move2, isNotEmpty);
@@ -254,6 +256,22 @@ void main() {
       expect(move1.last.position, equals(center));
       expect(enter1, isNotEmpty);
       expect(enter1.last.position, equals(center));
+      expect(exit1, isEmpty);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+      clearLists();
+
+      // Now make sure that exiting the child only triggers the child exit, not
+      // the parent too.
+      center = center - const Offset(75.0, 0.0);
+      await gesture.moveTo(center);
+      await tester.pumpAndSettle();
+      expect(move2, isEmpty);
+      expect(enter2, isEmpty);
+      expect(exit2, isNotEmpty);
+      expect(move1, isNotEmpty);
+      expect(move1.last.position, equals(center));
+      expect(enter1, isEmpty);
       expect(exit1, isEmpty);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);


### PR DESCRIPTION
## Description

This changes `Listener` to trigger enter/move/exit in all `Listener`s below the pointer, not just the leaf region (the first region hit).  This is because we need to allow listeners to be nested so that, say, a widget that handles changing color on hover, but also is wrapped in a `Tooltip` (that handles hover) can trigger both actions, not just one.

To that end, I added a `findAll` to `Layer`, similar to the existing `find` method that was previously used. It returns an iterator over annotated layers which match the given data type.

Since the `findAll` is implemented as returning an Iterable (and is `sync*`), I re-implemented the `find` routines as just returning the first result from `findAll`, since that should be just as efficient, and would then prevent duplication in the implementation.

## Tests

I added the following tests:
 - Tests for `findAll` similar to `find`, as well as extra tests having to do with returned order of results (which is leaf first, then ancestors).
 - Tests for `Listener` that assure that nested listeners do the right thing.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change. Although it does change the behavior of Listener, it is a bug fix in that previously nested listeners would not have been functional (the parent listeners would have been ignored), and now they are functional (not ignored).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
