### PR TITLE
CupertinoTextField double tap drag to expand selection

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -549,8 +549,24 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     _editableTextKey.currentState.showToolbar();
   }
 
-  void _handleDoubleTapDown(TapDownDetails details) {
-    _renderEditable.selectWord(cause: SelectionChangedCause.tap);
+  void _handleDoubleTapUp(TapUpDetails details) {
+    _renderEditable.selectWord(cause: SelectionChangedCause.doubleTap);
+    _editableTextKey.currentState.showToolbar();
+  }
+
+  void _handleDoubleLongTapStart(LongPressStartDetails details) {
+    _renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+  }
+
+  void _handleDoubleLongTapMoveUpdate(LongPressMoveUpdateDetails details) {
+    _renderEditable.selectWordsInRange(
+      from: details.globalPosition - details.offsetFromOrigin,
+      to: details.globalPosition,
+      cause: SelectionChangedCause.longPress
+    );
+  }
+
+  void _handleDoubleLongTapEnd(LongPressEndDetails details) {
     _editableTextKey.currentState.showToolbar();
   }
 
@@ -787,7 +803,10 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
               onSingleLongTapStart: _handleSingleLongTapStart,
               onSingleLongTapMoveUpdate: _handleSingleLongTapMoveUpdate,
               onSingleLongTapEnd: _handleSingleLongTapEnd,
-              onDoubleTapDown: _handleDoubleTapDown,
+              onDoubleTapUp: _handleDoubleTapUp,
+              onDoubleLongTapStart: _handleDoubleLongTapStart,
+              onDoubleLongTapMoveUpdate: _handleDoubleLongTapMoveUpdate,
+              onDoubleLongTapEnd: _handleDoubleLongTapEnd,
               onDragSelectionStart: _handleMouseDragSelectionStart,
               onDragSelectionUpdate: _handleMouseDragSelectionUpdate,
               onDragSelectionEnd: _handleMouseDragSelectionEnd,

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -151,7 +151,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   ///  * [onLongPress], which has the same timing but without the location data.
   GestureLongPressStartCallback onLongPressStart;
 
-  /// Callback for moving the gesture after the lang press is recognized.
+  /// Callback for moving the gesture after the long press is recognized.
   GestureLongPressMoveUpdateCallback onLongPressMoveUpdate;
 
   /// Called when the pointer stops contacting the screen after the long-press.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -747,7 +747,8 @@ class TextSelectionGestureDetector extends StatefulWidget {
 
   /// Called for a single long tap that's sustained for longer than
   /// [kLongPressTimeout] but not necessarily lifted. Not called for a
-  /// double-tap-hold, which calls [onDoubleTapDown] instead.
+  /// double-tap-hold, which calls [onDoubleTapDown] and [onDoubleLongTapStart]
+  /// instead.
   final GestureLongPressStartCallback onSingleLongTapStart;
 
   /// Called after [onSingleLongTapStart] when the pointer is dragged.
@@ -759,13 +760,23 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// Called after a momentary hold or a short tap that is close in space and
   /// time (within [kDoubleTapTimeout]) to a previous short tap.
   final GestureTapDownCallback onDoubleTapDown;
+
+  /// Called after [onDoubleTapDown] when the pointer is lifted, unless
+  /// [onDoubleLongTapStart] is triggered.
   final GestureTapUpCallback onDoubleTapUp;
 
   /// Called when a mouse starts dragging to select text.
   final GestureDragStartCallback onDragSelectionStart;
 
+  /// Called after [onDoubleTapDown], when the second tap is sustained for longer
+  /// than [kLongPressTimeout], but not necessarily lifted.
   final GestureLongPressStartCallback onDoubleLongTapStart;
+
+  /// Called after [onDoubleLongTapStart], when the pointer is dragged.
   final GestureLongPressMoveUpdateCallback onDoubleLongTapMoveUpdate;
+
+  /// Called after [onDoubleLongTapStart] and potentially
+  /// [onDoubleLongTapMoveUpdate], when the pointer is lifted.
   final GestureLongPressEndCallback onDoubleLongTapEnd;
 
   /// Called repeatedly as a mouse moves while dragging.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -709,6 +709,10 @@ class TextSelectionGestureDetector extends StatefulWidget {
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
     this.onDoubleTapDown,
+    this.onDoubleTapUp,
+    this.onDoubleLongTapStart,
+    this.onDoubleLongTapMoveUpdate,
+    this.onDoubleLongTapEnd,
     this.onDragSelectionStart,
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
@@ -755,9 +759,14 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// Called after a momentary hold or a short tap that is close in space and
   /// time (within [kDoubleTapTimeout]) to a previous short tap.
   final GestureTapDownCallback onDoubleTapDown;
+  final GestureTapUpCallback onDoubleTapUp;
 
   /// Called when a mouse starts dragging to select text.
   final GestureDragStartCallback onDragSelectionStart;
+
+  final GestureLongPressStartCallback onDoubleLongTapStart;
+  final GestureLongPressMoveUpdateCallback onDoubleLongTapMoveUpdate;
+  final GestureLongPressEndCallback onDoubleLongTapEnd;
 
   /// Called repeatedly as a mouse moves while dragging.
   ///
@@ -826,7 +835,10 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
       }
       _lastTapOffset = details.globalPosition;
       _doubleTapTimer = Timer(kDoubleTapTimeout, _doubleTapTimeout);
+    } else if (widget.onDoubleTapUp != null) {
+      widget.onDoubleTapUp(details);
     }
+
     _isDoubleTap = false;
   }
 
@@ -901,19 +913,26 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
   void _handleLongPressStart(LongPressStartDetails details) {
     if (!_isDoubleTap && widget.onSingleLongTapStart != null) {
       widget.onSingleLongTapStart(details);
+    } else if (_isDoubleTap && widget.onDoubleLongTapStart != null) {
+      widget.onDoubleLongTapStart(details);
     }
   }
 
   void _handleLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
     if (!_isDoubleTap && widget.onSingleLongTapMoveUpdate != null) {
       widget.onSingleLongTapMoveUpdate(details);
+    } else if(_isDoubleTap && widget.onDoubleLongTapMoveUpdate != null) {
+      widget.onDoubleLongTapMoveUpdate(details);
     }
   }
 
   void _handleLongPressEnd(LongPressEndDetails details) {
     if (!_isDoubleTap && widget.onSingleLongTapEnd != null) {
       widget.onSingleLongTapEnd(details);
+    } else if(_isDoubleTap && widget.onDoubleLongTapEnd != null) {
+      widget.onDoubleLongTapEnd(details);
     }
+
     _isDoubleTap = false;
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -470,7 +470,7 @@ class TextSelectionOverlay {
         textPosition = newSelection.base;
         break;
       case _TextSelectionHandlePosition.end:
-        textPosition =newSelection.extent;
+        textPosition = newSelection.extent;
         break;
     }
     selectionDelegate.textEditingValue = _value.copyWith(selection: newSelection, composing: TextRange.empty);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1334,13 +1334,13 @@ void main() {
       // Hold the press.
       await tester.pump(const Duration(milliseconds: 500));
 
+      // Selected text shows nothing.
+      expect(find.byType(CupertinoButton), findsNothing);
+
       expect(
         controller.selection,
         const TextSelection(baseOffset: 8, extentOffset: 12),
       );
-
-      // Selected text shows 3 toolbar buttons.
-      expect(find.byType(CupertinoButton), findsNWidgets(3));
 
       await gesture.up();
       await tester.pump();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1355,6 +1355,78 @@ void main() {
   );
 
   testWidgets(
+    'double long press drag moves the cursor under the drag and shows toolbar on lift',
+    (WidgetTester tester) async {
+      const String text = 'abc def ghi';
+      final TextEditingController controller = TextEditingController(
+        text: text,
+      );
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoTextField(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+
+      final Offset ePos = textOffsetToPosition(tester, text.indexOf('e'));
+
+      // First tap.
+      await tester.tapAt(ePos);
+      await tester.pump();
+
+      final TestGesture gesture =
+          await tester.startGesture(ePos);
+      await tester.pump(const Duration(seconds: 2));
+
+      // Toolbar only shows up on long press up.
+      expect(find.byType(CupertinoButton), findsNothing);
+
+      // 'def' is selected.
+      expect(controller.selection.baseOffset, text.indexOf('d'));
+      expect(controller.selection.extentOffset, text.indexOf('f') + 1);
+
+      // Move to 'h'
+      await gesture.moveTo(textOffsetToPosition(tester, text.indexOf('h')));
+      await tester.pump();
+
+      // 'def ghi' is selected.
+      expect(controller.selection.baseOffset, text.indexOf('d'));
+      expect(controller.selection.extentOffset, text.indexOf('i') + 1);
+
+     /*
+      TODO(LongCatIsLooong): uncomment after fixing
+      https://github.com/flutter/flutter/issues/32339
+
+      expect(controller.selection.extentOffset, text.indexOf('h') + 1);
+
+      // Now move backwards from 'h' to 'b'
+      await gesture.moveTo(textOffsetToPosition(tester, text.indexOf('b')));
+      await tester.pump();
+
+      // 'bc def' is selected.
+      expect(controller.selection.baseOffset, text.indexOf('b'));
+      expect(controller.selection.extentOffset, text.indexOf('f') + 1);
+
+      // Now move backwards from 'b' to 'd'
+      await gesture.moveTo(textOffsetToPosition(tester, text.indexOf('d')));
+      await tester.pump();
+
+      // 'def' is selected. Note it's not 'de'.
+      expect(controller.selection.baseOffset, text.indexOf('d'));
+      expect(controller.selection.extentOffset, text.indexOf('f') + 1);
+      */
+      await gesture.up();
+      await tester.pump();
+
+      // The toolbar now shows up.
+      expect(find.byType(CupertinoButton), findsNWidgets(3));
+    },
+  );
+
+  testWidgets(
     'tap after a double tap select is not affected',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(


### PR DESCRIPTION
## Description

Implements double tap (the second tap has to be a long press) drag to expand selection on iOS. 

#### Will be handled in a separate PR:
Edge case not handled: #32344
Fidelity issue: #32339

#### Current limitation:
Tap + swipe (or drag) in quick succession where the starting touch point of the swipe gesture is close enough to the tap, may not be recognized as a double tap drag. The second gesture has to be recognized by the `LongPressGestureRecognizer` for this to work. In other words, it won't work if you start dragging immediately after the second tap down. This seems to trigger expandable selection in native iOS `UITextField`.

## Related Issues

Fixes #23973

## Tests

I added the following tests:

- double long press drag moves the cursor under the drag and shows toolbar on lift
- onDoubleTapUp
  - called after onDoubleTapDown, if the second tap is lifted right away
  - should not be called after onDoubleTapDown if the second touch down is followed by a drag
  - should not be called after onDoubleTapDown if the second touch down ended up being a long press
- double long tap
  - triggered after onDoubleTapDown, if the second tap is a long press
  - should not trigger after onDoubleTapDown, if the second tap is not a long press
  - should not trigger after onDoubleTapDown, if the second touch down pointer starts dragging before turning into a long press
  - drag after the long press is a long press drag

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
