### PR TITLE
Allow flutter web to be compiled with flutter

### DIFF
--- a/examples/flutter_gallery/lib/main_web.dart
+++ b/examples/flutter_gallery/lib/main_web.dart
@@ -1,0 +1,16 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Thanks for checking out Flutter!
+// Like what you see? Tweet us @FlutterDev
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'gallery/app.dart';
+
+Future<void> main() async {
+  await ui.webOnlyInitializePlatform(); // ignore: undefined_function
+  runApp(const GalleryApp());
+}

--- a/examples/flutter_gallery/web/index.html
+++ b/examples/flutter_gallery/web/index.html
@@ -1,0 +1,12 @@
+<!-- Copyright 2019 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Flutter Gallery</title>
+    </head>
+    <body>
+        <script src="main.dart.js"></script>
+    </body>
+</html>

--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -38,6 +38,3 @@ const bool kDebugMode = !kReleaseMode && !kProfileMode;
 /// precision loss in calculations. Differences below this threshold are safe to
 /// disregard.
 const double precisionErrorTolerance = 1e-10;
-
-/// A constant that is true if the application was compiled to JavaScript.
-const bool kIsWeb = identical(1, 1.0);

--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -38,3 +38,6 @@ const bool kDebugMode = !kReleaseMode && !kProfileMode;
 /// precision loss in calculations. Differences below this threshold are safe to
 /// disregard.
 const double precisionErrorTolerance = 1e-10;
+
+/// A constant that is true if the application was compiled to JavaScript.
+const bool kIsWeb = identical(1, 1.0);

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'assertions.dart';
+import 'constants.dart';
 
 /// The platform that user interaction should adapt to target.
 ///
@@ -50,15 +51,19 @@ enum TargetPlatform {
 // (since doing so would be a big breaking change).
 TargetPlatform get defaultTargetPlatform {
   TargetPlatform result;
-  if (Platform.isIOS) {
-    result = TargetPlatform.iOS;
-  } else if (Platform.isAndroid) {
+  if (kIsWeb) {
     result = TargetPlatform.android;
-  } else if (Platform.isFuchsia) {
-    result = TargetPlatform.fuchsia;
+  } else {
+    if (Platform.isIOS) {
+      result = TargetPlatform.iOS;
+    } else if (Platform.isAndroid) {
+      result = TargetPlatform.android;
+    } else if (Platform.isFuchsia) {
+      result = TargetPlatform.fuchsia;
+    }
   }
   assert(() {
-    if (Platform.environment.containsKey('FLUTTER_TEST'))
+    if (!kIsWeb && Platform.environment.containsKey('FLUTTER_TEST'))
       result = TargetPlatform.android;
     return true;
   }());

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -50,6 +50,8 @@ enum TargetPlatform {
 // and we'd never be able to introduce dedicated behavior for that platform
 // (since doing so would be a big breaking change).
 TargetPlatform get defaultTargetPlatform {
+  // TODO(jonahwilliams): consider where this constant should live.
+  const bool kIsWeb = identical(1, 1.0);
   TargetPlatform result;
   if (kIsWeb) {
     result = TargetPlatform.android;

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -5,7 +5,6 @@
 import 'dart:io' show Platform;
 
 import 'assertions.dart';
-import 'constants.dart';
 
 /// The platform that user interaction should adapt to target.
 ///

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/asset.dart';
-import 'package:flutter_tools/src/base/common.dart';
-
 import '../application_package.dart';
+import '../asset.dart';
+import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';


### PR DESCRIPTION
## Description

~~Adds a `kIsWeb` constant which can be used to avoid calling unsupported io methods. Defaults the targetPlatform to android until we can add and test browser detection.~~ Removed for now

Fixes asset serving in flutter run for the web version.

Adds a new main_web for the gallery.
