### PR TITLE
Pass bottomsheet child into AnimatedBuilder.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -289,6 +289,18 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
       },
       child: AnimatedBuilder(
         animation: widget.route.animation,
+        child: BottomSheet(
+          animationController: widget.route._animationController,
+          onClosing: () {
+            if (widget.route.isCurrent) {
+              Navigator.pop(context);
+            }
+          },
+          builder: widget.route.builder,
+          backgroundColor: widget.backgroundColor,
+          elevation: widget.elevation,
+          shape: widget.shape,
+        ),
         builder: (BuildContext context, Widget child) {
           // Disable the initial animation when accessible navigation is on so
           // that the semantics are added to the tree at the correct time.
@@ -301,18 +313,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
             child: ClipRect(
               child: CustomSingleChildLayout(
                 delegate: _ModalBottomSheetLayout(animationValue, widget.isScrollControlled),
-                child: BottomSheet(
-                  animationController: widget.route._animationController,
-                  onClosing: () {
-                    if (widget.route.isCurrent) {
-                      Navigator.pop(context);
-                    }
-                  },
-                  builder: widget.route.builder,
-                  backgroundColor: widget.backgroundColor,
-                  elevation: widget.elevation,
-                  shape: widget.shape,
-                ),
+                child: child
               ),
             ),
           );


### PR DESCRIPTION
## Description

*This will fix performance issue when closing / opening / moving bottomsheet.  Moved BottomSheet child into AnimatedBuilder child so no useless builds are done with the child. This PR should give a major performance boost to bottomsheet*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
