### PR TITLE
Comment out .vscode/ in gitignore for templates

### DIFF
--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -15,8 +15,10 @@
 *.iws
 .idea/
 
-# Visual Studio Code related
-.vscode/
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -15,8 +15,10 @@
 *.iws
 .idea/
 
-# Visual Studio Code related
-.vscode/
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/


### PR DESCRIPTION
The `.vscode` has been in and out of the gitignores in templates a few times. There was some discussion in:

- https://github.com/flutter/flutter/issues/15555
- https://github.com/flutter/flutter/pull/15382

The conclusion was generally not to put IDE-specific things into gitignore. However at some point these were re-added to one template, and then the other template "updated to match". There was more discussion recently at https://github.com/flutter/flutter/pull/27034#issuecomment-488221947.

To avoid going back and forth, this PR comments it out rather than remove it, with a comment explaining. I expect there may be some discussion here. As such, I'm layout all my thoughts in full up-front - sorry for the wall of text :-) I did not comment out any other IDE files because I don't know which ones are truly junk and I don't think "is an IDE-specific file" is a good deciding factor.

I think the reason this came back up is that VS Code's folder is being lumped in with "junk IDEs create automatically and is unnecessary" unfairly, and that the cost of ignoring outweighs the benefit. Files in this folder are the result of explicit user actions and include launch configurations and tasks that may be important to working on a project (for example [Dart-Code's launch configs](https://github.com/Dart-Code/Dart-Code/blob/master/.vscode/launch.json) or [DevTool's tasks](https://github.com/flutter/devtools/blob/master/packages/devtools/.vscode/tasks.json).

It's very valid for users to want to ignore this, but they can easily opt in-to it when they see these files and review the contents. We shouldn't silently not commit them for them to find later when they re-clone that they're missing. I'd be unhappy if my Dart-Code launch configs turned out to not be committed and it seems highly unlikely that this will result in people accidentally ending up with junk in their repositories (since again - these files are not just created by opening the project in VS Code - they require some explicit user actions).

Honestly - there is one niggle with this, in that if you need to put a full path into the workspace settings file it will show up in Git as a change until VS Code supports separate files for workspace and user-specific-workspace settings (https://github.com/Microsoft/vscode/issues/40233). However I believe that's an uncommon case and can be solved with a `.code-workspace` file stored outside the project (which is what I do for Flutter, for this and several other reasons).

