### PR TITLE
More const conversions

### DIFF
--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -48,7 +48,7 @@ class HoverClientState extends State<HoverClient> {
 }
 
 class HoverFeedback extends StatefulWidget {
-  HoverFeedback({Key key}) : super(key: key);
+  const HoverFeedback({Key key}) : super(key: key);
 
   @override
   _HoverFeedbackState createState() => _HoverFeedbackState();
@@ -502,7 +502,7 @@ void main() {
       await gesture.addPointer();
 
       await tester.pumpWidget(
-        Center(child: HoverFeedback()),
+        Center(child: const HoverFeedback()),
       );
 
       await gesture.moveTo(tester.getCenter(find.byType(Text)));
@@ -519,7 +519,7 @@ void main() {
       expect(HoverClientState.numExits, equals(1));
 
       await tester.pumpWidget(
-        Center(child: HoverFeedback()),
+        Center(child: const HoverFeedback()),
       );
       await tester.pump();
       expect(HoverClientState.numEntries, equals(2));

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -502,7 +502,7 @@ void main() {
       await gesture.addPointer();
 
       await tester.pumpWidget(
-        Center(child: const HoverFeedback()),
+        const Center(child: HoverFeedback()),
       );
 
       await gesture.moveTo(tester.getCenter(find.byType(Text)));
@@ -519,7 +519,7 @@ void main() {
       expect(HoverClientState.numExits, equals(1));
 
       await tester.pumpWidget(
-        Center(child: const HoverFeedback()),
+        const Center(child: HoverFeedback()),
       );
       await tester.pump();
       expect(HoverClientState.numEntries, equals(2));

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -8,10 +8,10 @@ import 'package:flutter/rendering.dart';
 
 void main() {
   testWidgets('Sliver with keep alive without key - should dispose after reodering', (WidgetTester tester) async {
-    List<Widget> childList= <Widget>[
-      const WidgetTest0(text: 'child 0', keepAlive: true),
-      const WidgetTest1(text: 'child 1', keepAlive: true),
-      const WidgetTest2(text: 'child 2', keepAlive: true),
+    List<Widget> childList= const <Widget>[
+      WidgetTest0(text: 'child 0', keepAlive: true),
+      WidgetTest1(text: 'child 1', keepAlive: true),
+      WidgetTest2(text: 'child 2', keepAlive: true),
     ];
     await tester.pumpWidget(SwitchingChildListTest(children: childList));
     final _WidgetTest0State state0 = tester.state(find.byType(WidgetTest0));
@@ -31,10 +31,10 @@ void main() {
   });
 
   testWidgets('Sliver without keep alive without key - should dispose after reodering', (WidgetTester tester) async {
-    List<Widget> childList= <Widget>[
-      const WidgetTest0(text: 'child 0'),
-      const WidgetTest1(text: 'child 1'),
-      const WidgetTest2(text: 'child 2'),
+    List<Widget> childList= const <Widget>[
+      WidgetTest0(text: 'child 0'),
+      WidgetTest1(text: 'child 1'),
+      WidgetTest2(text: 'child 2'),
     ];
     await tester.pumpWidget(SwitchingChildListTest(children: childList));
     final _WidgetTest0State state0 = tester.state(find.byType(WidgetTest0));

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -8,10 +8,10 @@ import 'package:flutter/rendering.dart';
 
 void main() {
   testWidgets('Sliver with keep alive without key - should dispose after reodering', (WidgetTester tester) async {
-    List<Widget> childList= const <Widget>[
-      WidgetTest0(text: 'child 0', keepAlive: true),
-      WidgetTest1(text: 'child 1', keepAlive: true),
-      WidgetTest2(text: 'child 2', keepAlive: true),
+    List<Widget> childList= <Widget>[
+      const WidgetTest0(text: 'child 0', keepAlive: true),
+      const WidgetTest1(text: 'child 1', keepAlive: true),
+      const WidgetTest2(text: 'child 2', keepAlive: true),
     ];
     await tester.pumpWidget(SwitchingChildListTest(children: childList));
     final _WidgetTest0State state0 = tester.state(find.byType(WidgetTest0));
@@ -31,10 +31,10 @@ void main() {
   });
 
   testWidgets('Sliver without keep alive without key - should dispose after reodering', (WidgetTester tester) async {
-    List<Widget> childList= const <Widget>[
-      WidgetTest0(text: 'child 0'),
-      WidgetTest1(text: 'child 1'),
-      WidgetTest2(text: 'child 2'),
+    List<Widget> childList= <Widget>[
+      const WidgetTest0(text: 'child 0'),
+      const WidgetTest1(text: 'child 1'),
+      const WidgetTest2(text: 'child 2'),
     ];
     await tester.pumpWidget(SwitchingChildListTest(children: childList));
     final _WidgetTest0State state0 = tester.state(find.byType(WidgetTest0));


### PR DESCRIPTION
## Description

More fixes to un-gate a roll of the linter into the SDK.

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8913933942025815776/+/steps/analyze_flutter/0/stdout

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
