### PR TITLE
Add assert that the root widget has been attached.

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -736,6 +736,12 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
     ).attachToRenderTree(buildOwner, renderViewElement);
   }
 
+  /// Whether the [renderViewElement] has been initialized.
+  ///
+  /// This will be false until [runApp] is called (or [WidgetTester.pumpWidget]
+  /// is called in the context of a [TestWidgetsFlutterBinding]).
+  bool get isRootWidgetAttached => _renderViewElement != null;
+
   @override
   Future<void> performReassemble() {
     assert(() {

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -173,6 +173,8 @@ class FlutterDriverExtension {
   /// the result into a subclass of [Result], but that's not strictly required.
   @visibleForTesting
   Future<Map<String, dynamic>> call(Map<String, String> params) async {
+    assert(WidgetsBinding.instance.isRootWidgetAttached,
+        'No root widget is attached; have you remembered to call runApp()?');
     final String commandKind = params['command'];
     try {
       final CommandHandlerCallback commandHandler = _commandHandlers[commandKind];

--- a/packages/flutter_test/lib/src/all_elements.dart
+++ b/packages/flutter_test/lib/src/all_elements.dart
@@ -20,6 +20,15 @@ Iterable<Element> collectAllElementsFrom(
   Element rootElement, {
   @required bool skipOffstage,
 }) {
+  assert(() {
+    if (rootElement == null) {
+      throw FlutterError(
+        'A root widget has not been attached to the render tree. '
+        'Have you remembered to call runApp()?'
+      );
+    }
+    return true;
+  }());
   return CachingIterable<Element>(_DepthFirstChildIterator(rootElement, skipOffstage));
 }
 

--- a/packages/flutter_test/lib/src/all_elements.dart
+++ b/packages/flutter_test/lib/src/all_elements.dart
@@ -20,15 +20,6 @@ Iterable<Element> collectAllElementsFrom(
   Element rootElement, {
   @required bool skipOffstage,
 }) {
-  assert(() {
-    if (rootElement == null) {
-      throw FlutterError(
-        'A root widget has not been attached to the render tree. '
-        'Have you remembered to call runApp()?'
-      );
-    }
-    return true;
-  }());
   return CachingIterable<Element>(_DepthFirstChildIterator(rootElement, skipOffstage));
 }
 


### PR DESCRIPTION
## Description

This change adds an assert that attempts to help the developer root-cause the issue of trying to test their app via flutter driver before having called `runApp()` on the device side.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/32971

## Tests

This is a simple assert, so no new tests were added.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
