### PR TITLE
Wait for reassemble on hot reload

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -300,16 +300,18 @@ abstract class BindingBase {
   Future<void> performReassemble() {
     FlutterError.resetErrorCount();
     assert(() {
+      final bool onBeginWasNull = window.onBeginFrame == null;
       if (_debugLastOnBeginFrame != null) {
         assert(window.onBeginFrame == null);
         window.onBeginFrame = _debugLastOnBeginFrame;
       }
-      assert(window.onBeginFrame != null);
+      assert( onBeginWasNull || window.onBeginFrame != null);
+      final bool onDrawWasNull = window.onDrawFrame == null;
       if (_debugLastOnDrawFrame != null) {
         assert(window.onDrawFrame == null);
         window.onDrawFrame = _debugLastOnDrawFrame;
       }
-      assert(window.onDrawFrame != null);
+      assert(onDrawWasNull || window.onDrawFrame != null);
       _debugLastOnBeginFrame = null;
       _debugLastOnDrawFrame = null;
       return true;

--- a/packages/flutter/test/foundation/reassemble_test.dart
+++ b/packages/flutter/test/foundation/reassemble_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:ui' show FrameCallback;
 
 import 'package:flutter/foundation.dart';
 import '../flutter_test_alternative.dart';
@@ -25,5 +26,18 @@ void main() {
   test('Pointer events are locked during reassemble', () async {
     await binding.reassembleApplication();
     expect(binding.wasLocked, isTrue);
+  });
+
+  test('Reassemble restores callbacks after waitForReassemble', () async {
+    final FrameCallback onBeginFrame = (Duration duration) {};
+    final VoidCallback onDrawFrame = () {};
+    binding.window.onBeginFrame = onBeginFrame;
+    binding.window.onDrawFrame = onDrawFrame;
+    await binding.waitForReassemble();
+    expect(binding.window.onBeginFrame, isNull);
+    expect(binding.window.onDrawFrame, isNull);
+    await binding.reassembleApplication();
+    expect(binding.window.onBeginFrame, equals(onBeginFrame));
+    expect(binding.window.onDrawFrame, equals(onDrawFrame));
   });
 }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1304,6 +1304,10 @@ class Isolate extends ServiceObjectOwner {
     );
   }
 
+  Future<Map<String, dynamic>> flutterWaitForReassemble() {
+    return invokeFlutterExtensionRpcRaw('ext.flutter.waitForReassemble');
+  }
+
   Future<Map<String, dynamic>> flutterReassemble() {
     return invokeFlutterExtensionRpcRaw('ext.flutter.reassemble');
   }


### PR DESCRIPTION
## Description

In the documentation for reassemble, we claim that we will call it before calling build again on hot reload.  Unfortunately, this doesn't always happen when animations are at play, and is a problem for clients like Flutter Hooks that rely on `reassemble` being called before `build`.

This patch does not solve the problem in a universal way - it is still possible that someone could stuff business logic in a `Timer` and expect that we effectively pause the timer.  This patch would allow for solving that by overriding the `waitForReassemble` method that we added - solving the general case here though would likely require changes to the Dart VM that are very non-trivial and potentially risky, and it would be best to have a concrete use case before attempting them.

This patch does cause animations to pause for the duration of the hot reload, and then start at their new point in time - i.e., it drops the frames that would have rendered during a hot reload.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/26503
A previous attempt was discussed at https://github.com/flutter/flutter/pull/26983.  Unlike that attempt, this one does not hijack the system resume status, and does not cause the engine to stop animating (we just stop listening to the engine's animation callbacks).

## Tests

I added the following tests:

Binding tests, test to make sure we restore the callbacks when we call reassembleApplication.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
