### PR TITLE
Added 'enabled' property to the PopupMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -884,14 +884,18 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// the button that was used to create it.
   final Offset offset;
 
-  /// Whether this popup menu button is interactive. Useful for disabling the
-  /// button in the case where the popup menu would be empty.
+  /// Whether this popup menu button is interactive.
   ///
-  /// If false, this button is styled with the disabled color from the
+  /// Must be non-null, defaults to `true`
+  ///
+  /// If `true` the button will respond to presses by displaying the menu.
+  ///
+  /// If `false`, the button is styled with the disabled color from the
   /// current [Theme] and will not respond to presses or show the popup
   /// menu and [onSelected], [onCanceled] and [itemBuilder] will not be called.
   ///
-  /// Must be non-null.
+  /// This can be useful in situations where the app needs to show the button,
+  /// but doesn't currently have anything to show in the menu.
   final bool enabled;
 
   @override

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -663,6 +663,8 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 
 /// Show a popup menu that contains the `items` at `position`.
 ///
+/// `items` should be non-null and not empty.
+///
 /// If `initialValue` is specified then the first item with a matching value
 /// will be highlighted and the value of `position` gives the rectangle whose
 /// vertical center will be aligned with the vertical center of the highlighted
@@ -829,8 +831,10 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.child,
     this.icon,
     this.offset = Offset.zero,
+    this.enabled = true,
   }) : assert(itemBuilder != null),
        assert(offset != null),
+       assert(enabled != null),
        assert(!(child != null && icon != null)), // fails if passed both parameters
        super(key: key);
 
@@ -880,6 +884,16 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// the button that was used to create it.
   final Offset offset;
 
+  /// Whether this popup menu button is interactive. Useful for disabling the
+  /// button in the case where the popup menu would be empty.
+  ///
+  /// If false, this button is styled with the disabled color from the
+  /// current [Theme] and will not respond to presses or show the popup
+  /// menu and [onSelected], [onCanceled] and [itemBuilder] will not be called.
+  ///
+  /// Must be non-null.
+  final bool enabled;
+
   @override
   _PopupMenuButtonState<T> createState() => _PopupMenuButtonState<T>();
 }
@@ -895,24 +909,28 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       ),
       Offset.zero & overlay.size,
     );
-    showMenu<T>(
-      context: context,
-      elevation: widget.elevation,
-      items: widget.itemBuilder(context),
-      initialValue: widget.initialValue,
-      position: position,
-    )
-    .then<void>((T newValue) {
-      if (!mounted)
-        return null;
-      if (newValue == null) {
-        if (widget.onCanceled != null)
-          widget.onCanceled();
-        return null;
-      }
-      if (widget.onSelected != null)
-        widget.onSelected(newValue);
-    });
+    final List<PopupMenuEntry<T>> items = widget.itemBuilder(context);
+    // Only show the menu if there is something to show
+    if (items.isNotEmpty) {
+      showMenu<T>(
+        context: context,
+        elevation: widget.elevation,
+        items: items,
+        initialValue: widget.initialValue,
+        position: position,
+      )
+      .then<void>((T newValue) {
+        if (!mounted)
+          return null;
+        if (newValue == null) {
+          if (widget.onCanceled != null)
+            widget.onCanceled();
+          return null;
+        }
+        if (widget.onSelected != null)
+          widget.onSelected(newValue);
+      });
+    }
   }
 
   Icon _getIcon(TargetPlatform platform) {
@@ -932,14 +950,14 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
     assert(debugCheckHasMaterialLocalizations(context));
     return widget.child != null
       ? InkWell(
-          onTap: showButtonMenu,
+          onTap: widget.enabled ? showButtonMenu : null,
           child: widget.child,
         )
       : IconButton(
           icon: widget.icon ?? _getIcon(Theme.of(context).platform),
           padding: widget.padding,
           tooltip: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
-          onPressed: showButtonMenu,
+          onPressed: widget.enabled ? showButtonMenu : null,
         );
   }
 }

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -126,6 +126,55 @@ void main() {
     expect(cancels, equals(2));
   });
 
+  testWidgets('disabled PopupMenuButton will not call itemBuilder, onSelected or onCanceled', (WidgetTester tester) async {
+    final Key popupButtonKey = UniqueKey();
+    bool itemBuilderCalled = false;
+    bool onSelectedCalled = false;
+    bool onCanceledCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Column(
+            children: <Widget>[
+              PopupMenuButton<int>(
+                key: popupButtonKey,
+                enabled: false,
+                itemBuilder: (BuildContext context) {
+                  itemBuilderCalled = true;
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+                onSelected: (int selected) => onSelectedCalled = true,
+                onCanceled: () => onCanceledCalled = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Try to bring up the popup menu and select the first item from it
+    await tester.tap(find.byKey(popupButtonKey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(popupButtonKey));
+    await tester.pumpAndSettle();
+    expect(itemBuilderCalled, isFalse);
+    expect(onSelectedCalled, isFalse);
+
+    // Try to bring up the popup menu and tap outside it to cancel the menu
+    await tester.tap(find.byKey(popupButtonKey));
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(0.0, 0.0));
+    await tester.pumpAndSettle();
+    expect(itemBuilderCalled, isFalse);
+    expect(onCanceledCalled, isFalse);
+  });
+
   testWidgets('PopupMenuButton is horizontal on iOS', (WidgetTester tester) async {
     Widget build(TargetPlatform platform) {
       return MaterialApp(


### PR DESCRIPTION
## Description

Added a new `enabled` property to the `PopupMenuButton` which is `true` by default, but if it is `false` then the button will be disabled, no menu will be shown and none of the callbacks or `itemBuilder` will be called.  This can be useful for the case where the item list for the menu would be empty. With `enabled` set to `true`, the `PopupMenuButton` should behave as it always has.

For example the snippet from #32255 could be rewritten to handle the empty item list case:

```dart
new PopupMenuButton(
  onSelected: (Server selectedServer) {
    // Run Select Function...
  },
  icon: new Icon(Icons.cloud),
  enabled: serverList.isNotEmpty, // turns off button if there are no items for the menu
  itemBuilder: (BuildContext context) {
    return serverList.map((server) {
      return new PopupMenuItem(
        value: server,
        child: new Text(server.nickname.length > 0 ? server.nickname : server.url, style: new TextStyle(color: Colors.black)),
      );
    }).toList();
  },
),
```

Also updated the documentation for `showMenu` to indicate that it doesn't support empty item lists.

## Related Issues

Fixes #32255

## Tests

I added a test to ensure a disabled `PopupMenuButton` behaves as designed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
