### PR TITLE
Tapping a modal bottom sheet should not dismiss it by default

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
@@ -24,7 +24,7 @@ class ModalBottomSheetDemo extends StatelessWidget {
               return Container(
                 child: Padding(
                   padding: const EdgeInsets.all(32.0),
-                  child: Text('This is the modal bottom sheet. Tap anywhere to dismiss.',
+                  child: Text('This is the modal bottom sheet. Slide down to dismiss.',
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       color: Theme.of(context).accentColor,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -281,43 +281,36 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final String routeLabel = _getRouteLabel(localizations);
 
-    return GestureDetector(
-      excludeFromSemantics: true,
-      onTap: () {
-        if (widget.route.isCurrent)
-          Navigator.pop(context);
-      },
-      child: AnimatedBuilder(
-        animation: widget.route.animation,
-        builder: (BuildContext context, Widget child) {
-          // Disable the initial animation when accessible navigation is on so
-          // that the semantics are added to the tree at the correct time.
-          final double animationValue = mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation.value;
-          return Semantics(
-            scopesRoute: true,
-            namesRoute: true,
-            label: routeLabel,
-            explicitChildNodes: true,
-            child: ClipRect(
-              child: CustomSingleChildLayout(
-                delegate: _ModalBottomSheetLayout(animationValue, widget.isScrollControlled),
-                child: BottomSheet(
-                  animationController: widget.route._animationController,
-                  onClosing: () {
-                    if (widget.route.isCurrent) {
-                      Navigator.pop(context);
-                    }
-                  },
-                  builder: widget.route.builder,
-                  backgroundColor: widget.backgroundColor,
-                  elevation: widget.elevation,
-                  shape: widget.shape,
-                ),
+    return AnimatedBuilder(
+      animation: widget.route.animation,
+      builder: (BuildContext context, Widget child) {
+        // Disable the initial animation when accessible navigation is on so
+        // that the semantics are added to the tree at the correct time.
+        final double animationValue = mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation.value;
+        return Semantics(
+          scopesRoute: true,
+          namesRoute: true,
+          label: routeLabel,
+          explicitChildNodes: true,
+          child: ClipRect(
+            child: CustomSingleChildLayout(
+              delegate: _ModalBottomSheetLayout(animationValue, widget.isScrollControlled),
+              child: BottomSheet(
+                animationController: widget.route._animationController,
+                onClosing: () {
+                  if (widget.route.isCurrent) {
+                    Navigator.pop(context);
+                  }
+                },
+                builder: widget.route.builder,
+                backgroundColor: widget.backgroundColor,
+                elevation: widget.elevation,
+                shape: widget.shape,
               ),
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/gestures.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('Verify that a tap dismisses a modal BottomSheet', (WidgetTester tester) async {
+  testWidgets('Tapping on a modal BottomSheet should not dismiss it', (WidgetTester tester) async {
     BuildContext savedContext;
 
     await tester.pumpWidget(MaterialApp(
@@ -33,28 +33,41 @@ void main() {
       showBottomSheetThenCalled = true;
     });
 
-    await tester.pump(); // bottom sheet show animation starts
-    await tester.pump(const Duration(seconds: 1)); // animation done
+    await tester.pumpAndSettle();
     expect(find.text('BottomSheet'), findsOneWidget);
     expect(showBottomSheetThenCalled, isFalse);
 
-    // Tap on the bottom sheet itself to dismiss it.
+    // Tap on the bottom sheet itself, it should not be dismissed
     await tester.tap(find.text('BottomSheet'));
-    await tester.pump(); // bottom sheet dismiss animation starts
-    expect(showBottomSheetThenCalled, isTrue);
-    await tester.pump(const Duration(seconds: 1)); // last frame of animation (sheet is entirely off-screen, but still present)
-    await tester.pump(const Duration(seconds: 1)); // frame after the animation (sheet has been removed)
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet'), findsOneWidget);
+    expect(showBottomSheetThenCalled, isFalse);
+  });
+
+  testWidgets('Tapping outside a modal BottomSheet should dismiss it', (WidgetTester tester) async {
+    BuildContext savedContext;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+          builder: (BuildContext context) {
+            savedContext = context;
+            return Container();
+          }
+      ),
+    ));
+
+    await tester.pump();
     expect(find.text('BottomSheet'), findsNothing);
 
-    showBottomSheetThenCalled = false;
+    bool showBottomSheetThenCalled = false;
     showModalBottomSheet<void>(
       context: savedContext,
       builder: (BuildContext context) => const Text('BottomSheet'),
     ).then<void>((void value) {
       showBottomSheetThenCalled = true;
     });
-    await tester.pump(); // bottom sheet show animation starts
-    await tester.pump(const Duration(seconds: 1)); // animation done
+
+    await tester.pumpAndSettle();
     expect(find.text('BottomSheet'), findsOneWidget);
     expect(showBottomSheetThenCalled, isFalse);
 

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -406,8 +406,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('modal bottom sheet'), findsOneWidget);
 
-    // Dismiss the modal bottomSheet
-    await tester.tap(find.text('modal bottom sheet'));
+    // Dismiss the modal bottomSheet by tapping above the sheet
+    await tester.tapAt(const Offset(20.0, 20.0));
     await tester.pumpAndSettle();
     expect(find.text('modal bottom sheet'), findsNothing);
     expect(find.text('showModalBottomSheet'), findsOneWidget);


### PR DESCRIPTION
## Description

As pointed out in #20720, our current implementation of the modal bottom sheets aren't following the Material spec, as tapping on a bottom sheet itself will dismiss the sheet. From the [Material Guidelines](https://material.io/design/components/sheets-bottom.html#modal-bottom-sheet), it should be dismissed by:

* Tapping a menu item or action within the bottom sheet
* Tapping the scrim
* Swiping the sheet down
* Using a close affordance within the bottom sheet’s top app bar, if available

The app would be responsible for the first and last as it would be providing the controls in the sheet. The other two are already handled by the bottom sheet implementation, however we also dismiss on a tap.

This PR removes the GestureDetector responsible for dismissing the sheet when the user taps on it. While this doesn't technically break the API, it does change the behavior of modal bottom sheets to bring it in line with the spec.

In the unlikely event that an application actually wanted this behavior they could wrap their bottom sheet content in a GestureDetector to replicate the previous behavior:

```dart
GestureDetector(
   onTap: () => Navigator.pop(context),
   behavior: HitTestBehavior.opaque,
   child: <bottom sheet contents>,
);
```

## Related Issues

Fixes: #20720

## Tests

Modified the test to check to see if a tap *doesn't* dismiss the sheet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change: [announcement](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/flutter-announce/9m39PZCAKkM) 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
