### PR TITLE
Adjust macOS build flow

### DIFF
--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -41,7 +41,7 @@ fi
 
 # Copy the framework and handle local engine builds.
 framework_name="FlutterMacOS.framework"
-derived_dir="${SOURCE_ROOT}/../build/macos/Build/Products/flutter_framework"
+derived_dir="${SOURCE_ROOT}/Flutter"
 framework_path="${FLUTTER_ROOT}/bin/cache/artifacts/engine/darwin-x64"
 flutter_framework="${framework_path}/${framework_name}"
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -37,8 +37,7 @@ String flutterMacOSFrameworkDir(BuildMode mode) {
 /// useMacOSConfig: Optional parameter that controls whether we use the macOS
 /// project file instead. Defaults to false.
 ///
-/// symrootOverride: Optional parameter to specifify the symroot instead of
-/// the default relative path.
+/// setSymroot: Optional parameter to control whether to set SYMROOT.
 ///
 /// targetOverride: Optional parameter, if null or unspecified the default value
 /// from xcode_backend.sh is used 'lib/main.dart'.
@@ -47,7 +46,7 @@ Future<void> updateGeneratedXcodeProperties({
   @required BuildInfo buildInfo,
   String targetOverride,
   bool useMacOSConfig = false,
-  String symrootOverride,
+  bool setSymroot = true,
 }) async {
   final StringBuffer localsBuffer = StringBuffer();
 
@@ -66,13 +65,8 @@ Future<void> updateGeneratedXcodeProperties({
   // The build outputs directory, relative to FLUTTER_APPLICATION_PATH.
   localsBuffer.writeln('FLUTTER_BUILD_DIR=${getBuildDirectory()}');
 
-  final String buildDirectory = useMacOSConfig
-      ? getMacOSBuildDirectory()
-      : getIosBuildDirectory();
-  if (symrootOverride != null) {
-    localsBuffer.writeln('SYMROOT=$symrootOverride');
-  } else {
-    localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../$buildDirectory');
+  if (setSymroot) {
+    localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
   }
 
   if (!project.isModule) {

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -18,7 +18,6 @@ import '../project.dart';
 // TODO(jonahwilliams): refactor to share code with the existing iOS code.
 Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) async {
   final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
-  final String symrootOverride = fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products');
   if (!flutterBuildDir.existsSync()) {
     flutterBuildDir.createSync(recursive: true);
   }
@@ -27,7 +26,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     project: flutterProject,
     buildInfo: buildInfo,
     useMacOSConfig: true,
-    symrootOverride: symrootOverride,
+    setSymroot: false,
   );
   // Set debug or release mode.
   String config = 'Debug';
@@ -44,7 +43,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     '-scheme', 'Runner',
     '-derivedDataPath', flutterBuildDir.absolute.path,
     'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-    'SYMROOT=$symrootOverride',
+    'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
   ], runInShell: true);
   final Status status = logger.startProgress(
     'Building macOS application...',


### PR DESCRIPTION
## Description

- Removes SYMROOT from the Generated.xcconfig. Having it causes current
  versions of Xcode to switch the project's build output to "Legacy",
  which causes anything not overridden to use a project-relative build
  directory instead of a shared directory in DerivedData, breaking
  anything with subprojects that it depends on.
  This means that `flutter run` and builds from Xcode will use
  completely different build directories, but that each should be
  internally consistent.

- Moves the FlutterMacOS.framework to $SRCROOT/Flutter. This is
  consistent with the approach we're moving to for all desktop
  platforms, and avoids issues finding it now that SYMROOT doesn't match
  for the two different build modes.

## Related Issues

Fixes #32494

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

(Technically it's breaking for desktop, but we don't have any stability expectations for desktop yet.)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
