### PR TITLE
enable lint prefer_null_aware_operators

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -142,6 +142,7 @@ linter:
     - prefer_is_not_empty
     - prefer_iterable_whereType
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    - prefer_null_aware_operators
     - prefer_single_quotes
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -252,9 +252,7 @@ class SnippetGenerator {
         metadata.addAll(<String, Object>{
           'id': id,
           'file': path.basename(outputFile.path),
-          'description': description != null
-              ? description.mergedContent
-              : null,
+          'description': description?.mergedContent,
         });
         metadataFile.writeAsStringSync(jsonEncoder.convert(metadata));
         break;


### PR DESCRIPTION
## Description

Enable lint [prefer_null_aware_operators](https://dart-lang.github.io/linter/lints/prefer_null_aware_operators.html).
