### PR TITLE
Ignore some JSON RPC errors

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -959,6 +959,14 @@ void restoreVmServiceConnectFunction() {
 /// The JSON RPC 2 spec says that a notification from a client must not respond
 /// to the client. It's possible the client sent a notification as a "ping", but
 /// the service isn't set up yet to respond.
+///
+/// For example, if the client sends a notification message to the server for
+/// 'streamNotify', but the server has not finished loading, it will throw an
+/// exception. Since the message is a notification, the server follows the
+/// specification and does not send a response back, but is left with an
+/// unhandled exception. That exception is safe for us to ignore - the client
+/// is signaling that it will try again later if it doesn't get what it wants
+/// here by sending a notification.
 bool _ignoreRpcError(dynamic error) {
   if (error is rpc.RpcException) {
     final rpc.RpcException exception = error;

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -967,6 +967,10 @@ void restoreVmServiceConnectFunction() {
 /// unhandled exception. That exception is safe for us to ignore - the client
 /// is signaling that it will try again later if it doesn't get what it wants
 /// here by sending a notification.
+// This may be ignoring too many exceptions. It would be best to rewrite
+// the client code to not use notifications so that it gets error replies back
+// and can decide what to do from there.
+// TODO(dnfield): https://github.com/flutter/flutter/issues/31813
 bool _ignoreRpcError(dynamic error) {
   if (error is rpc.RpcException) {
     final rpc.RpcException exception = error;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -42,6 +42,10 @@ RpcPeerConnectionFunction fuchsiaVmServiceConnectionFunction = _waitAndConnect;
 /// unhandled exception. That exception is safe for us to ignore - the client
 /// is signaling that it will try again later if it doesn't get what it wants
 /// here by sending a notification.
+// This may be ignoring too many exceptions. It would be best to rewrite
+// the client code to not use notifications so that it gets error replies back
+// and can decide what to do from there.
+// TODO(dnfield): https://github.com/flutter/flutter/issues/31813
 bool _ignoreRpcError(dynamic error) {
   if (error is json_rpc.RpcException) {
     final json_rpc.RpcException exception = error;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -34,6 +34,14 @@ RpcPeerConnectionFunction fuchsiaVmServiceConnectionFunction = _waitAndConnect;
 /// The JSON RPC 2 spec says that a notification from a client must not respond
 /// to the client. It's possible the client sent a notification as a "ping", but
 /// the service isn't set up yet to respond.
+///
+/// For example, if the client sends a notification message to the server for
+/// 'streamNotify', but the server has not finished loading, it will throw an
+/// exception. Since the message is a notification, the server follows the
+/// specification and does not send a response back, but is left with an
+/// unhandled exception. That exception is safe for us to ignore - the client
+/// is signaling that it will try again later if it doesn't get what it wants
+/// here by sending a notification.
 bool _ignoreRpcError(dynamic error) {
   if (error is json_rpc.RpcException) {
     final json_rpc.RpcException exception = error;


### PR DESCRIPTION
This is an improvement on https://github.com/flutter/flutter/pull/31868 which didn't work because the errors are coming back as strings in some cases.

Addresses https://github.com/flutter/flutter/issues/31813