### PR TITLE
Material should not prevent ScrollNotifications from bubbling upwards

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -339,7 +339,7 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
       onNotification: (LayoutChangedNotification notification) {
         final _RenderInkFeatures renderer = _inkFeatureRenderer.currentContext.findRenderObject();
         renderer._didChangeLayout();
-        return true;
+        return false;
       },
       child: _InkFeatures(
         key: _inkFeatureRenderer,


### PR DESCRIPTION
The Material widget stopped the propagation of notifications. This meant that one could not, for example, listen for scroll notifications from outside of a Scaffold.

Fixes https://github.com/flutter/flutter/issues/32679

The dev/devicelab complex_layout_scroll_perf__timeline_summary benchmark doesn't seem to be affected by this change.
