### PR TITLE
Add a FocusNode for AndroidView widgets.

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -50,7 +50,36 @@ typedef PlatformViewCreatedCallback = void Function(int id);
 ///
 /// See also: [PlatformView].
 class PlatformViewsService {
-  PlatformViewsService._();
+  PlatformViewsService._() {
+    SystemChannels.platform_views.setMethodCallHandler(_onMethodCall);
+  }
+
+  static PlatformViewsService _serviceInstance;
+
+  static PlatformViewsService get _instance {
+    _serviceInstance ??= PlatformViewsService._();
+    return _serviceInstance;
+  }
+
+  Future<void> _onMethodCall(MethodCall call) {
+    switch(call.method) {
+      case 'viewFocused':
+        final int id = call.arguments;
+        if (_focusCallbacks.containsKey(id)) {
+          _focusCallbacks[id]();
+        }
+        break;
+      default:
+        throw UnimplementedError('${call.method} was invoked but isn\'t implemented by PlatformViewsService');
+    }
+    return null;
+  }
+
+  /// Maps platform view IDs to focus callbacks.
+  ///
+  /// The callbacks are invoked when the platform view asks to be focused.
+  final Map<int, VoidCallback> _focusCallbacks = <int, VoidCallback>{};
+
 
   /// Creates a controller for a new Android view.
   ///
@@ -68,6 +97,9 @@ class PlatformViewsService {
   /// platform side. It should match the codec passed to the constructor of [PlatformViewFactory](/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html#PlatformViewFactory-io.flutter.plugin.common.MessageCodec-).
   /// This is typically one of: [StandardMessageCodec], [JSONMessageCodec], [StringCodec], or [BinaryCodec].
   ///
+  /// `onFocus` is a callback that will be invoked when the Android View asks to get the
+  /// input focus.
+  ///
   /// The Android view will only be created after [AndroidViewController.setSize] is called for the
   /// first time.
   ///
@@ -79,18 +111,21 @@ class PlatformViewsService {
     @required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic> creationParamsCodec,
+    VoidCallback onFocus,
   }) {
     assert(id != null);
     assert(viewType != null);
     assert(layoutDirection != null);
     assert(creationParams == null || creationParamsCodec != null);
-    return AndroidViewController._(
+    final AndroidViewController controller = AndroidViewController._(
       id,
       viewType,
       creationParams,
       creationParamsCodec,
       layoutDirection,
     );
+    _instance._focusCallbacks[id] = onFocus ?? () {};
+    return controller;
   }
 
   // TODO(amirh): reference the iOS plugin API for registering a UIView factory once it lands.

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
+import '../../widgets.dart';
 import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
@@ -295,16 +296,20 @@ class _AndroidViewState extends State<AndroidView> {
   AndroidViewController _controller;
   TextDirection _layoutDirection;
   bool _initialized = false;
+  FocusNode _focusNode;
 
   static final Set<Factory<OneSequenceGestureRecognizer>> _emptyRecognizersSet =
     <Factory<OneSequenceGestureRecognizer>>{};
 
   @override
   Widget build(BuildContext context) {
-    return _AndroidPlatformView(
+    return Focus(
+      focusNode: _focusNode,
+      child: _AndroidPlatformView(
         controller: _controller,
         hitTestBehavior: widget.hitTestBehavior,
         gestureRecognizers: widget.gestureRecognizers ?? _emptyRecognizersSet,
+      ),
     );
   }
 
@@ -314,6 +319,7 @@ class _AndroidViewState extends State<AndroidView> {
     }
     _initialized = true;
     _createNewAndroidView();
+    _focusNode = FocusNode(debugLabel: 'AndroidView(id: $_id)');
   }
 
   @override
@@ -369,6 +375,9 @@ class _AndroidViewState extends State<AndroidView> {
       layoutDirection: _layoutDirection,
       creationParams: widget.creationParams,
       creationParamsCodec: widget.creationParamsCodec,
+      onFocus: () {
+        _focusNode.requestFocus();
+      }
     );
     if (widget.onPlatformViewCreated != null) {
       _controller.addOnPlatformViewCreatedListener(widget.onPlatformViewCreated);

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -7,9 +7,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
-import '../../widgets.dart';
 import 'basic.dart';
 import 'debug.dart';
+import 'focus_manager.dart';
+import 'focus_scope.dart';
 import 'framework.dart';
 
 /// Embeds an Android view in the Widget hierarchy.

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -32,6 +32,12 @@ class FakeAndroidPlatformViewsController {
     _registeredViewTypes.add(viewType);
   }
 
+  void invokeViewFocused(int viewId) {
+    final MethodCodec codec = SystemChannels.platform_views.codec;
+    final ByteData data = codec.encodeMethodCall(MethodCall('viewFocused', viewId));
+    BinaryMessages.handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData data) {});
+  }
+
   Future<dynamic> _onMethodCall(MethodCall call) {
     switch(call.method) {
       case 'create':


### PR DESCRIPTION
## Description

The PlatformViewsService listens for `viewFocused` calls on the
`platform_views system` channel and fires a callback that focuses the
focus node for the relevant AndroidView widget.

## Related Issues

https://github.com/flutter/flutter/issues/19718

## Tests

I added the following tests:

* Test that when the `viewFocused` method channel method is invoked the AndroidView's focus node is getting focused.
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.