### PR TITLE
Streamline Windows build process

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.bat
+++ b/packages/flutter_tools/bin/tool_backend.bat
@@ -1,0 +1,9 @@
+:: Copyright 2019 The Chromium Authors. All rights reserved.
+:: Use of this source code is governed by a BSD-style license that can be
+:: found in the LICENSE file.
+@echo off
+
+set FLUTTER_BIN_DIR=%FLUTTER_ROOT%\bin
+set DART_BIN_DIR=%FLUTTER_BIN_DIR%\cache\dart-sdk\bin
+
+"%DART_BIN_DIR%\dart" "%FLUTTER_ROOT%\packages\flutter_tools\bin\tool_backend.dart" %*

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -5,7 +5,7 @@
 import 'dart:io'; // ignore: dart_io_import.
 import 'package:path/path.dart' as path; // ignore: package_path_import.
 
-/// Executes the required flutter tasks for a linux build.
+/// Executes the required flutter tasks for a desktop build.
 Future<void> main(List<String> arguments) async {
   final String targetPlatform = arguments[0];
   final String buildMode = arguments[1];
@@ -26,9 +26,9 @@ ERROR: Requested build with Flutter local engine at '$localEngine'
 This engine is not compatible with FLUTTER_BUILD_MODE: '$buildMode'.
 You can fix this by updating the LOCAL_ENGINE environment variable, or
 by running:
-  flutter build linux --local-engine=host_$buildMode
+  flutter build <platform> --local-engine=host_$buildMode
 or
-  flutter build linux --local-engine=host_${buildMode}_unopt
+  flutter build <platform> --local-engine=host_${buildMode}_unopt
 ========================================================================
 ''');
     exit(1);
@@ -38,6 +38,9 @@ or
   switch (targetPlatform) {
     case 'linux-x64':
       cacheDirectory = 'linux/flutter';
+      break;
+    case 'windows-x64':
+      cacheDirectory = 'windows/flutter';
       break;
     default:
       stderr.write('Unsupported target platform $targetPlatform');

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -326,6 +326,8 @@ TargetPlatform getTargetPlatformForName(String platform) {
       return TargetPlatform.darwin_x64;
     case 'linux-x64':
       return TargetPlatform.linux_x64;
+    case 'windows-x64':
+      return TargetPlatform.windows_x64;
     case 'web':
       return TargetPlatform.web;
   }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -399,6 +399,11 @@ String getLinuxBuildDirectory() {
   return fs.path.join(getBuildDirectory(), 'linux');
 }
 
+/// Returns the Windows build output directory.
+String getWindowsBuildDirectory() {
+  return fs.path.join(getBuildDirectory(), 'windows');
+}
+
 /// Returns the Fuchsia build output directory.
 String getFuchsiaBuildDirectory() {
   return fs.path.join(getBuildDirectory(), 'fuchsia');

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -596,15 +596,19 @@ class WindowsProject {
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
+  Directory get _cacheDirectory => _editableDirectory.childDirectory('flutter');
+
   /// Contains definitions for FLUTTER_ROOT, LOCAL_ENGINE, and more flags for
   /// the build.
-  File get generatedPropertySheetFile => _editableDirectory.childDirectory('flutter').childFile('Generated.props');
+  File get generatedPropertySheetFile => _cacheDirectory.childFile('Generated.props');
 
   // The MSBuild project file.
   File get vcprojFile => _editableDirectory.childFile('Runner.vcxproj');
 
-  // Note: The name script file exists as a temporary shim.
-  File get nameScript => _editableDirectory.childFile('name_output.bat');
+  /// The file where the VS build will write the name of the built app.
+  ///
+  /// Ideally this will be replaced in the future with inspection of the project.
+  File get nameFile => _cacheDirectory.childFile('exe_filename');
 }
 
 /// The Linux sub project.

--- a/packages/flutter_tools/lib/src/windows/application_package.dart
+++ b/packages/flutter_tools/lib/src/windows/application_package.dart
@@ -7,8 +7,6 @@ import 'package:meta/meta.dart';
 import '../application_package.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
-import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../project.dart';
 
@@ -61,14 +59,16 @@ class BuildableWindowsApp extends WindowsApp {
 
   @override
   String executable(BuildMode buildMode) {
-    final ProcessResult result = processManager.runSync(<String>[
-      project.nameScript.path,
-      buildMode == BuildMode.debug ? 'debug' : 'release',
-    ]);
-    if (result.exitCode != 0) {
-      throwToolExit('Failed to find Windows project name');
+    final File exeNameFile = project.nameFile;
+    if (!exeNameFile.existsSync()) {
+      throwToolExit('Failed to find Windows executable name');
     }
-    return result.stdout.toString().trim();
+    return fs.path.join(
+        getWindowsBuildDirectory(),
+        'x64',
+        buildMode == BuildMode.debug ? 'Debug' : 'Release',
+        'Runner',
+        exeNameFile.readAsStringSync().trim());
   }
 
   @override

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -14,10 +14,12 @@ import '../project.dart';
 import 'msbuild_utils.dart';
 
 /// Builds the Windows project using msbuild.
-Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo) async {
+Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {String target = 'lib/main.dart'}) async {
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': Cache.flutterRoot,
-    'EXTRA_BUNDLE_FLAGS': buildInfo?.trackWidgetCreation == true ? '--track-widget-creation' : '',
+    'FLUTTER_TARGET': target,
+    'PROJECT_DIR': windowsProject.project.directory.path,
+    'TRACK_WIDGET_CREATION': (buildInfo?.trackWidgetCreation == true).toString(),
   };
   writePropertySheet(windowsProject.generatedPropertySheetFile, environment);
 


### PR DESCRIPTION
## Description

Allows Windows builds to use the same structure and script as Linux
builds now use, calling into tool_backend to manage copying resources to
the project directory and building the bundle.

Also switches from expecting `name_update.bat` to expecting `flutter\exe_filename`
to be written during the build, as with the recent changes to the macOS build, to
reduce the amount of boilerplate needed in a `windows\` project directory.

## Related Issues

#30706

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

This is a breaking change for the desktop workflow, but it is explicitly volatile at this stage.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
