### PR TITLE
add dismissOnTap in botton sheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -5,10 +5,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
-import 'bottom_sheet_theme.dart';
 import 'colors.dart';
 import 'debug.dart';
 import 'material.dart';
@@ -16,9 +14,9 @@ import 'material_localizations.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
-const Duration _bottomSheetDuration = Duration(milliseconds: 200);
-const double _minFlingVelocity = 700.0;
-const double _closeProgressThreshold = 0.5;
+const Duration _kBottomSheetDuration = Duration(milliseconds: 200);
+const double _kMinFlingVelocity = 700.0;
+const double _kCloseProgressThreshold = 0.5;
 
 /// A material design bottom sheet.
 ///
@@ -57,19 +55,16 @@ class BottomSheet extends StatefulWidget {
     Key key,
     this.animationController,
     this.enableDrag = true,
-    this.backgroundColor,
-    this.elevation,
-    this.shape,
+    this.elevation = 0.0,
     @required this.onClosing,
     @required this.builder,
   }) : assert(enableDrag != null),
        assert(onClosing != null),
        assert(builder != null),
-       assert(elevation == null || elevation >= 0.0),
+       assert(elevation != null && elevation >= 0.0),
        super(key: key);
 
-  /// The animation controller that controls the bottom sheet's entrance and
-  /// exit animations.
+  /// The animation that controls the bottom sheet's position.
   ///
   /// The BottomSheet widget will manipulate the position of this animation, it
   /// is not just a passive observer.
@@ -88,18 +83,11 @@ class BottomSheet extends StatefulWidget {
   /// [Material] widget.
   final WidgetBuilder builder;
 
-  /// If true, the bottom sheet can be dragged up and down and dismissed by
-  /// swiping downards.
+  /// If true, the bottom sheet can dragged up and down and dismissed by swiping
+  /// downwards.
   ///
   /// Default is true.
   final bool enableDrag;
-
-  /// The bottom sheet's background color.
-  ///
-  /// Defines the bottom sheet's [Material.color].
-  ///
-  /// Defaults to null and falls back to [Material]'s default.
-  final Color backgroundColor;
 
   /// The z-coordinate at which to place this material relative to its parent.
   ///
@@ -108,25 +96,13 @@ class BottomSheet extends StatefulWidget {
   /// Defaults to 0. The value is non-negative.
   final double elevation;
 
-  /// The shape of the bottom sheet.
-  ///
-  /// Defines the bottom sheet's [Material.shape].
-  ///
-  /// Defaults to null and falls back to [Material]'s default.
-  final ShapeBorder shape;
-
   @override
   _BottomSheetState createState() => _BottomSheetState();
 
-  /// Creates an [AnimationController] suitable for a
-  /// [BottomSheet.animationController].
-  ///
-  /// This API available as a convenience for a Material compliant bottom sheet
-  /// animation. If alternative animation durations are required, a different
-  /// animation controller could be provided.
+  /// Creates an animation controller suitable for controlling a [BottomSheet].
   static AnimationController createAnimationController(TickerProvider vsync) {
     return AnimationController(
-      duration: _bottomSheetDuration,
+      duration: _kBottomSheetDuration,
       debugLabel: 'BottomSheet',
       vsync: vsync,
     );
@@ -145,56 +121,35 @@ class _BottomSheetState extends State<BottomSheet> {
   bool get _dismissUnderway => widget.animationController.status == AnimationStatus.reverse;
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    assert(widget.enableDrag);
     if (_dismissUnderway)
       return;
     widget.animationController.value -= details.primaryDelta / (_childHeight ?? details.primaryDelta);
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    assert(widget.enableDrag);
     if (_dismissUnderway)
       return;
-    if (details.velocity.pixelsPerSecond.dy > _minFlingVelocity) {
+    if (details.velocity.pixelsPerSecond.dy > _kMinFlingVelocity) {
       final double flingVelocity = -details.velocity.pixelsPerSecond.dy / _childHeight;
-      if (widget.animationController.value > 0.0) {
+      if (widget.animationController.value > 0.0)
         widget.animationController.fling(velocity: flingVelocity);
-      }
-      if (flingVelocity < 0.0) {
+      if (flingVelocity < 0.0)
         widget.onClosing();
-      }
-    } else if (widget.animationController.value < _closeProgressThreshold) {
+    } else if (widget.animationController.value < _kCloseProgressThreshold) {
       if (widget.animationController.value > 0.0)
         widget.animationController.fling(velocity: -1.0);
       widget.onClosing();
     } else {
       widget.animationController.forward();
-   }
-  }
-
-  bool extentChanged(DraggableScrollableNotification notification) {
-    if (notification.extent == notification.minExtent) {
-      widget.onClosing();
     }
-    return false;
   }
 
   @override
   Widget build(BuildContext context) {
-    final BottomSheetThemeData bottomSheetTheme = Theme.of(context).bottomSheetTheme;
-    final Color color = widget.backgroundColor ?? bottomSheetTheme.backgroundColor;
-    final double elevation = widget.elevation ?? bottomSheetTheme.elevation ?? 0;
-    final ShapeBorder shape = widget.shape ?? bottomSheetTheme.shape;
-
     final Widget bottomSheet = Material(
       key: _childKey,
-      color: color,
-      elevation: elevation,
-      shape: shape,
-      child: NotificationListener<DraggableScrollableNotification>(
-        onNotification: extentChanged,
-        child: widget.builder(context),
-      ),
+      elevation: widget.elevation,
+      child: widget.builder(context),
     );
     return !widget.enableDrag ? bottomSheet : GestureDetector(
       onVerticalDragUpdate: _handleDragUpdate,
@@ -211,11 +166,11 @@ class _BottomSheetState extends State<BottomSheet> {
 
 
 // MODAL BOTTOM SHEETS
+
 class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
-  _ModalBottomSheetLayout(this.progress, this.isScrollControlled);
+  _ModalBottomSheetLayout(this.progress);
 
   final double progress;
-  final bool isScrollControlled;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
@@ -223,9 +178,7 @@ class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
       minWidth: constraints.maxWidth,
       maxWidth: constraints.maxWidth,
       minHeight: 0.0,
-      maxHeight: isScrollControlled
-        ? constraints.maxHeight
-        : constraints.maxHeight * 9.0 / 16.0,
+      maxHeight: constraints.maxHeight * 9.0 / 16.0,
     );
   }
 
@@ -241,76 +194,57 @@ class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
 }
 
 class _ModalBottomSheet<T> extends StatefulWidget {
-  const _ModalBottomSheet({
-    Key key,
-    this.route,
-    this.backgroundColor,
-    this.elevation,
-    this.shape,
-    this.isScrollControlled = false,
-  }) : assert(isScrollControlled != null),
-       super(key: key);
+  const _ModalBottomSheet({ Key key, this.route }) : super(key: key);
 
   final _ModalBottomSheetRoute<T> route;
-  final bool isScrollControlled;
-  final Color backgroundColor;
-  final double elevation;
-  final ShapeBorder shape;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
 }
 
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
-  String _getRouteLabel(MaterialLocalizations localizations) {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-        return '';
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return localizations.dialogLabel;
-    }
-    return null;
-  }
-
   @override
   Widget build(BuildContext context) {
-    assert(debugCheckHasMediaQuery(context));
-    assert(debugCheckHasMaterialLocalizations(context));
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final String routeLabel = _getRouteLabel(localizations);
+    String routeLabel;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        routeLabel = '';
+        break;
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        routeLabel = localizations.dialogLabel;
+        break;
+    }
 
-    return AnimatedBuilder(
-      animation: widget.route.animation,
-      builder: (BuildContext context, Widget child) {
-        // Disable the initial animation when accessible navigation is on so
-        // that the semantics are added to the tree at the correct time.
-        final double animationValue = mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation.value;
-        return Semantics(
-          scopesRoute: true,
-          namesRoute: true,
-          label: routeLabel,
-          explicitChildNodes: true,
-          child: ClipRect(
-            child: CustomSingleChildLayout(
-              delegate: _ModalBottomSheetLayout(animationValue, widget.isScrollControlled),
-              child: BottomSheet(
-                animationController: widget.route._animationController,
-                onClosing: () {
-                  if (widget.route.isCurrent) {
-                    Navigator.pop(context);
-                  }
-                },
-                builder: widget.route.builder,
-                backgroundColor: widget.backgroundColor,
-                elevation: widget.elevation,
-                shape: widget.shape,
+    return GestureDetector(
+      excludeFromSemantics: true,
+      onTap: () => widget.route.dismissOnTap ? Navigator.pop(context) : {},
+      child: AnimatedBuilder(
+        animation: widget.route.animation,
+        builder: (BuildContext context, Widget child) {
+          // Disable the initial animation when accessible navigation is on so
+          // that the semantics are added to the tree at the correct time.
+          final double animationValue = mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation.value;
+          return Semantics(
+            scopesRoute: true,
+            namesRoute: true,
+            label: routeLabel,
+            explicitChildNodes: true,
+            child: ClipRect(
+              child: CustomSingleChildLayout(
+                delegate: _ModalBottomSheetLayout(animationValue),
+                child: BottomSheet(
+                  animationController: widget.route._animationController,
+                  onClosing: () => Navigator.pop(context),
+                  builder: widget.route.builder,
+                ),
               ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }
@@ -318,25 +252,18 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   _ModalBottomSheetRoute({
     this.builder,
+    this.dismissOnTap,
     this.theme,
     this.barrierLabel,
-    this.backgroundColor,
-    this.elevation,
-    this.shape,
-    @required this.isScrollControlled,
     RouteSettings settings,
-  }) : assert(isScrollControlled != null),
-       super(settings: settings);
+  }) : super(settings: settings);
 
   final WidgetBuilder builder;
   final ThemeData theme;
-  final bool isScrollControlled;
-  final Color backgroundColor;
-  final double elevation;
-  final ShapeBorder shape;
+  final bool dismissOnTap;
 
   @override
-  Duration get transitionDuration => _bottomSheetDuration;
+  Duration get transitionDuration => _kBottomSheetDuration;
 
   @override
   bool get barrierDismissible => true;
@@ -348,7 +275,6 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   Color get barrierColor => Colors.black54;
 
   AnimationController _animationController;
-
 
   @override
   AnimationController createAnimationController() {
@@ -364,13 +290,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
     Widget bottomSheet = MediaQuery.removePadding(
       context: context,
       removeTop: true,
-      child: _ModalBottomSheet<T>(
-        route: this,
-        backgroundColor: backgroundColor,
-        elevation: elevation,
-        shape: shape,
-        isScrollControlled: isScrollControlled
-      ),
+      child: _ModalBottomSheet<T>(route: this),
     );
     if (theme != null)
       bottomSheet = Theme(data: theme, child: bottomSheet);
@@ -394,12 +314,6 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// corresponding widget can be safely removed from the tree before the bottom
 /// sheet is closed.
 ///
-/// The `isScrollControlled` parameter specifies whether this is a route for
-/// a bottom sheet that will utilize [DraggableScrollableSheet]. If you wish
-/// to have a bottom sheet that has a scrollable child such as a [ListView] or
-/// a [GridView] and have the bottom sheet be draggable, you should set this
-/// parameter to true.
-///
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///
@@ -413,30 +327,20 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 Future<T> showModalBottomSheet<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
-  Color backgroundColor,
-  double elevation,
-  ShapeBorder shape,
-  bool isScrollControlled = false,
+  bool dismissOnTap = true,
 }) {
   assert(context != null);
   assert(builder != null);
-  assert(isScrollControlled != null);
-  assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
-
   return Navigator.push(context, _ModalBottomSheetRoute<T>(
     builder: builder,
+    dismissOnTap: dismissOnTap,
     theme: Theme.of(context, shadowThemeOnly: true),
-    isScrollControlled: isScrollControlled,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-    backgroundColor: backgroundColor,
-    elevation: elevation,
-    shape: shape,
   ));
 }
 
-/// Shows a material design bottom sheet in the nearest [Scaffold] ancestor. If
-/// you wish to show a persistent bottom sheet, use [Scaffold.bottomSheet].
+/// Shows a persistent material design bottom sheet in the nearest [Scaffold].
 ///
 /// Returns a controller that can be used to close and otherwise manipulate the
 /// bottom sheet.
@@ -452,6 +356,10 @@ Future<T> showModalBottomSheet<T>({
 /// To create a persistent bottom sheet that is not a [LocalHistoryEntry] and
 /// does not add a back button to the enclosing Scaffold's appbar, use the
 /// [Scaffold.bottomSheet] constructor parameter.
+///
+/// A persistent bottom sheet shows information that supplements the primary
+/// content of the app. A persistent bottom sheet remains visible even when
+/// the user interacts with other parts of the app.
 ///
 /// A closely related widget is a modal bottom sheet, which is an alternative
 /// to a menu or a dialog and prevents the user from interacting with the rest
@@ -472,18 +380,8 @@ Future<T> showModalBottomSheet<T>({
 PersistentBottomSheetController<T> showBottomSheet<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
-  Color backgroundColor,
-  double elevation,
-  ShapeBorder shape,
 }) {
   assert(context != null);
   assert(builder != null);
-  assert(debugCheckHasScaffold(context));
-
-  return Scaffold.of(context).showBottomSheet<T>(
-    builder,
-    backgroundColor: backgroundColor,
-    elevation: elevation,
-    shape: shape,
-  );
+  return Scaffold.of(context).showBottomSheet<T>(builder);
 }


### PR DESCRIPTION
dismissOnTap is used to change the default behaviour of the bottom sheet
if dismissOnTap is true (by default) then the bottom sheet will dismiss by on tap event inside it.
if dismissOnTap is false then the bottom sheet will not dismiss by on tap event event inside it.

example: 
showModalBottomSheet(
      context: context,
      dismissOnTap: false,
      builder: (BuildContext bc){
          return null;
      }
    );