### PR TITLE
Skip flaky date picker tests on Windows

### DIFF
--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
@@ -16,7 +17,11 @@ import 'feedback_tester.dart';
 void main() {
   group('showDatePicker', () {
     _tests();
-  });
+  },
+    // Skip on Windows because this test is quite flaky when run on Windows,
+    // until https://github.com/flutter/flutter/issues/19696 is fixed.
+    skip: Platform.isWindows,
+  );
 }
 
 void _tests() {


### PR DESCRIPTION
## Description

Date picker tests have been flaky on Windows for a long time, and repeatedly require restarting of bots. In the interest of productivity, disabling them on Windows.

## Related Issues

Related to #19696
