### PR TITLE
Prepare for API addition to HttpClientResponse

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1762,6 +1762,10 @@ class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse 
   @override
   int get contentLength => -1;
 
+  // @override
+  // TODO(tvolkert): Uncomment @override annotation once SDK change lands.
+  bool get autoUncompress => true;
+
   @override
   List<Cookie> get cookies => null;
 


### PR DESCRIPTION
## Description

This adds the `autoUncompress` getter to flutter_test's `_MockHttpResponse` class. This is in preparation for when that getter will be added to the API of `HttpClientResponse`.

## Related Issues

https://github.com/dart-lang/sdk/issues/36971

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
