### PR TITLE
Add debugNetworkImageHttpClientProvider

### DIFF
--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -31,3 +31,12 @@ bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOv
   }());
   return true;
 }
+
+/// Whether [NetworkImage] should use a newly instantiated [HttpClient] when
+/// loading images.
+///
+/// This setting can be overridden for testing to ensure that each test receives
+/// a mock client that hasn't been affected by other tests.
+///
+/// This value is ignored in non-debug builds.
+bool debugNetworkImageUseFreshHttpClient = false;

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -13,27 +13,6 @@ import 'package:flutter/foundation.dart';
 /// version to version (or even from run to run).
 bool debugDisableShadows = false;
 
-/// Returns true if none of the painting library debug variables have been changed.
-///
-/// This function is used by the test framework to ensure that debug variables
-/// haven't been inadvertently changed.
-///
-/// See <https://docs.flutter.io/flutter/rendering/painting-library.html> for
-/// a complete list.
-///
-/// The `debugDisableShadowsOverride` argument can be provided to override
-/// the expected value for [debugDisableShadows]. (This exists because the
-/// test framework itself overrides this value in some cases.)
-bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOverride = false }) {
-  assert(() {
-    if (debugDisableShadows != debugDisableShadowsOverride) {
-      throw FlutterError(reason);
-    }
-    return true;
-  }());
-  return true;
-}
-
 /// Signature for a method that returns an [HttpClient].
 ///
 /// Used by [debugNetworkImageHttpClientProvider].
@@ -49,3 +28,25 @@ typedef HttpClientProvider = HttpClient Function();
 ///
 /// This value is ignored in non-debug builds.
 HttpClientProvider debugNetworkImageHttpClientProvider;
+
+/// Returns true if none of the painting library debug variables have been changed.
+///
+/// This function is used by the test framework to ensure that debug variables
+/// haven't been inadvertently changed.
+///
+/// See <https://docs.flutter.io/flutter/rendering/painting-library.html> for
+/// a complete list.
+///
+/// The `debugDisableShadowsOverride` argument can be provided to override
+/// the expected value for [debugDisableShadows]. (This exists because the
+/// test framework itself overrides this value in some cases.)
+bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOverride = false }) {
+  assert(() {
+    if (debugDisableShadows != debugDisableShadowsOverride ||
+        debugNetworkImageHttpClientProvider != null) {
+      throw FlutterError(reason);
+    }
+    return true;
+  }());
+  return true;
+}

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 
 /// Whether to replace all shadows with solid color blocks.
@@ -32,11 +34,18 @@ bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOv
   return true;
 }
 
-/// Whether [NetworkImage] should use a newly instantiated [HttpClient] when
-/// loading images.
+/// Signature for a method that returns an [HttpClient].
+///
+/// Used by [debugNetworkImageHttpClientProvider].
+typedef HttpClientProvider = HttpClient Function();
+
+/// Provider from which [NetworkImage] will get its [HttpClient] in debug builds.
+///
+/// If this value is unset, [NetworkImage] will use its own internally-managed
+/// [HttpClient].
 ///
 /// This setting can be overridden for testing to ensure that each test receives
 /// a mock client that hasn't been affected by other tests.
 ///
 /// This value is ignored in non-debug builds.
-bool debugNetworkImageUseFreshHttpClient = false;
+HttpClientProvider debugNetworkImageHttpClientProvider;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -511,8 +511,8 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     );
   }
 
-  /// Do not access this field directly; use [_httpClient] instead.
-  static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
+  // Do not access this field directly; use [_httpClient] instead.
+  static final HttpClient _sharedHttpClient = HttpClient();
 
   static HttpClient get _httpClient {
     HttpClient client = _sharedHttpClient;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'binding.dart';
+import 'debug.dart';
 import 'image_cache.dart';
 import 'image_stream.dart';
 
@@ -510,7 +511,18 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     );
   }
 
-  static final HttpClient _httpClient = HttpClient();
+  /// Do not access this field directly; use [_httpClient] instead.
+  static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
+
+  static HttpClient get _httpClient {
+    HttpClient client = _sharedHttpClient;
+    assert(() {
+      if (debugNetworkImageUseFreshHttpClient)
+        client = HttpClient()..autoUncompress = false;
+      return true;
+    }());
+    return client;
+  }
 
   Future<ui.Codec> _loadAsync(NetworkImage key) async {
     assert(key == this);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -517,8 +517,8 @@ class NetworkImage extends ImageProvider<NetworkImage> {
   static HttpClient get _httpClient {
     HttpClient client = _sharedHttpClient;
     assert(() {
-      if (debugNetworkImageUseFreshHttpClient)
-        client = HttpClient()..autoUncompress = false;
+      if (debugNetworkImageHttpClientProvider != null)
+        client = debugNetworkImageHttpClientProvider();
       return true;
     }());
     return client;

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -16,44 +16,64 @@ import 'image_data.dart';
 import 'mocks_for_image_cache.dart';
 
 void main() {
-  TestRenderingFlutterBinding(); // initializes the imageCache
   group(ImageProvider, () {
-    tearDown(() {
-      imageCache.clear();
+    setUpAll(() {
+      TestRenderingFlutterBinding(); // initializes the imageCache
     });
 
-    test('ImageProvider can evict images', () async {
-      final Uint8List bytes = Uint8List.fromList(kTransparentImage);
-      final MemoryImage imageProvider = MemoryImage(bytes);
-      final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
-      final Completer<void> completer = Completer<void>();
-      stream.addListener((ImageInfo info, bool syncCall) => completer.complete());
-      await completer.future;
+    group('Image cache', () {
+      tearDown(() {
+        imageCache.clear();
+      });
 
-      expect(imageCache.currentSize, 1);
-      expect(await MemoryImage(bytes).evict(), true);
-      expect(imageCache.currentSize, 0);
+      test('ImageProvider can evict images', () async {
+        final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+        final MemoryImage imageProvider = MemoryImage(bytes);
+        final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
+        final Completer<void> completer = Completer<void>();
+        stream.addListener((ImageInfo info, bool syncCall) => completer.complete());
+        await completer.future;
+
+        expect(imageCache.currentSize, 1);
+        expect(await MemoryImage(bytes).evict(), true);
+        expect(imageCache.currentSize, 0);
+      });
+
+      test('ImageProvider.evict respects the provided ImageCache', () async {
+        final ImageCache otherCache = ImageCache();
+        final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+        final MemoryImage imageProvider = MemoryImage(bytes);
+        otherCache.putIfAbsent(imageProvider, () => imageProvider.load(imageProvider));
+        final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
+        final Completer<void> completer = Completer<void>();
+        stream.addListener((ImageInfo info, bool syncCall) => completer.complete());
+        await completer.future;
+
+        expect(otherCache.currentSize, 1);
+        expect(imageCache.currentSize, 1);
+        expect(await imageProvider.evict(cache: otherCache), true);
+        expect(otherCache.currentSize, 0);
+        expect(imageCache.currentSize, 1);
+      });
+
+      test('ImageProvider errors can always be caught', () async {
+        final ErrorImageProvider imageProvider = ErrorImageProvider();
+        final Completer<bool> caughtError = Completer<bool>();
+        FlutterError.onError = (FlutterErrorDetails details) {
+          caughtError.complete(false);
+        };
+        final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
+        stream.addListener((ImageInfo info, bool syncCall) {
+          caughtError.complete(false);
+        }, onError: (dynamic error, StackTrace stackTrace) {
+          caughtError.complete(true);
+        });
+        expect(await caughtError.future, true);
+      });
     });
 
-    test('ImageProvider.evict respects the provided ImageCache', () async {
-      final ImageCache otherCache = ImageCache();
-      final Uint8List bytes = Uint8List.fromList(kTransparentImage);
-      final MemoryImage imageProvider = MemoryImage(bytes);
-      otherCache.putIfAbsent(imageProvider, () => imageProvider.load(imageProvider));
-      final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
-      final Completer<void> completer = Completer<void>();
-      stream.addListener((ImageInfo info, bool syncCall) => completer.complete());
-      await completer.future;
-
-      expect(otherCache.currentSize, 1);
-      expect(imageCache.currentSize, 1);
-      expect(await imageProvider.evict(cache: otherCache), true);
-      expect(otherCache.currentSize, 0);
-      expect(imageCache.currentSize, 1);
-    });
-
-    test('ImageProvider errors can always be caught', () async {
-      final ErrorImageProvider imageProvider = ErrorImageProvider();
+    test('obtainKey errors will be caught', () async {
+      final ImageProvider imageProvider = ObtainKeyErrorImageProvider();
       final Completer<bool> caughtError = Completer<bool>();
       FlutterError.onError = (FlutterErrorDetails details) {
         caughtError.complete(false);
@@ -66,93 +86,16 @@ void main() {
       });
       expect(await caughtError.future, true);
     });
-  });
 
-  test('ImageProvide.obtainKey errors will be caught', () async {
-    final ImageProvider imageProvider = ObtainKeyErrorImageProvider();
-    final Completer<bool> caughtError = Completer<bool>();
-    FlutterError.onError = (FlutterErrorDetails details) {
-      caughtError.complete(false);
-    };
-    final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
-    stream.addListener((ImageInfo info, bool syncCall) {
-      caughtError.complete(false);
-    }, onError: (dynamic error, StackTrace stackTrace) {
-      caughtError.complete(true);
-    });
-    expect(await caughtError.future, true);
-  });
-
-  test('ImageProvider.resolve sync errors will be caught', () async {
-    bool uncaught = false;
-    final Zone testZone = Zone.current.fork(specification: ZoneSpecification(
-      handleUncaughtError: (Zone zone, ZoneDelegate zoneDelegate, Zone parent, Object error, StackTrace stackTrace) {
-        uncaught = true;
-      },
-    ));
-    await testZone.run(() async {
-      final ImageProvider imageProvider = LoadErrorImageProvider();
-      final Completer<bool> caughtError = Completer<bool>();
-      FlutterError.onError = (FlutterErrorDetails details) {
-        throw Error();
-      };
-      final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
-      result.addListener((ImageInfo info, bool syncCall) {
-      }, onError: (dynamic error, StackTrace stackTrace) {
-        caughtError.complete(true);
-      });
-      expect(await caughtError.future, true);
-    });
-    expect(uncaught, false);
-  });
-
-  test('ImageProvider.resolve errors in the completer will be caught', () async {
-    bool uncaught = false;
-    final Zone testZone = Zone.current.fork(specification: ZoneSpecification(
-      handleUncaughtError: (Zone zone, ZoneDelegate zoneDelegate, Zone parent, Object error, StackTrace stackTrace) {
-        uncaught = true;
-      },
-    ));
-    await testZone.run(() async {
-      final ImageProvider imageProvider = LoadErrorCompleterImageProvider();
-      final Completer<bool> caughtError = Completer<bool>();
-      FlutterError.onError = (FlutterErrorDetails details) {
-        throw Error();
-      };
-      final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
-      result.addListener((ImageInfo info, bool syncCall) {
-      }, onError: (dynamic error, StackTrace stackTrace) {
-        caughtError.complete(true);
-      });
-      expect(await caughtError.future, true);
-    });
-    expect(uncaught, false);
-  });
-
-  group(NetworkImage, () {
-    MockHttpClient httpClient;
-
-    setUp(() {
-      httpClient = MockHttpClient();
-      debugNetworkImageHttpClientProvider = () => httpClient;
-    });
-
-    tearDown(() {
-      debugNetworkImageHttpClientProvider = null;
-    });
-
-    test('Disallows null urls', () {
-      expect(() {
-        NetworkImage(nonconst(null));
-      }, throwsAssertionError);
-    });
-
-    test('Propagates http client errors during resolve()', () async {
-      when(httpClient.getUrl(any)).thenThrow(Error());
+    test('resolve sync errors will be caught', () async {
       bool uncaught = false;
-
-      await runZoned(() async {
-        const ImageProvider imageProvider = NetworkImage('asdasdasdas');
+      final Zone testZone = Zone.current.fork(specification: ZoneSpecification(
+        handleUncaughtError: (Zone zone, ZoneDelegate zoneDelegate, Zone parent, Object error, StackTrace stackTrace) {
+          uncaught = true;
+        },
+      ));
+      await testZone.run(() async {
+        final ImageProvider imageProvider = LoadErrorImageProvider();
         final Completer<bool> caughtError = Completer<bool>();
         FlutterError.onError = (FlutterErrorDetails details) {
           throw Error();
@@ -163,12 +106,99 @@ void main() {
           caughtError.complete(true);
         });
         expect(await caughtError.future, true);
-      }, zoneSpecification: ZoneSpecification(
+      });
+      expect(uncaught, false);
+    });
+
+    test('resolve errors in the completer will be caught', () async {
+      bool uncaught = false;
+      final Zone testZone = Zone.current.fork(specification: ZoneSpecification(
         handleUncaughtError: (Zone zone, ZoneDelegate zoneDelegate, Zone parent, Object error, StackTrace stackTrace) {
           uncaught = true;
         },
       ));
+      await testZone.run(() async {
+        final ImageProvider imageProvider = LoadErrorCompleterImageProvider();
+        final Completer<bool> caughtError = Completer<bool>();
+        FlutterError.onError = (FlutterErrorDetails details) {
+          throw Error();
+        };
+        final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
+        result.addListener((ImageInfo info, bool syncCall) {
+        }, onError: (dynamic error, StackTrace stackTrace) {
+          caughtError.complete(true);
+        });
+        expect(await caughtError.future, true);
+      });
       expect(uncaught, false);
+    });
+
+    group(NetworkImage, () {
+      MockHttpClient httpClient;
+
+      setUp(() {
+        httpClient = MockHttpClient();
+        debugNetworkImageHttpClientProvider = () => httpClient;
+      });
+
+      tearDown(() {
+        debugNetworkImageHttpClientProvider = null;
+      });
+
+      test('Disallows null urls', () {
+        expect(() {
+          NetworkImage(nonconst(null));
+        }, throwsAssertionError);
+      });
+
+      test('Uses the HttpClient provided by debugNetworkImageHttpClientProvider if set', () async {
+        when(httpClient.getUrl(any)).thenThrow('client1');
+        final List<dynamic> capturedErrors = <dynamic>[];
+
+        Future<void> loadNetworkImage() async {
+          final NetworkImage networkImage = NetworkImage(nonconst('foo'));
+          final ImageStreamCompleter completer = networkImage.load(networkImage);
+          completer.addListener(
+            (ImageInfo image, bool synchronousCall) { },
+            onError: (dynamic error, StackTrace stackTrace) {
+              capturedErrors.add(error);
+            },
+          );
+          await Future<void>.value();
+        }
+
+        await loadNetworkImage();
+        expect(capturedErrors, <dynamic>['client1']);
+        final MockHttpClient client2 = MockHttpClient();
+        when(client2.getUrl(any)).thenThrow('client2');
+        debugNetworkImageHttpClientProvider = () => client2;
+        await loadNetworkImage();
+        expect(capturedErrors, <dynamic>['client1', 'client2']);
+      });
+
+      test('Propagates http client errors during resolve()', () async {
+        when(httpClient.getUrl(any)).thenThrow(Error());
+        bool uncaught = false;
+
+        await runZoned(() async {
+          const ImageProvider imageProvider = NetworkImage('asdasdasdas');
+          final Completer<bool> caughtError = Completer<bool>();
+          FlutterError.onError = (FlutterErrorDetails details) {
+            throw Error();
+          };
+          final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
+          result.addListener((ImageInfo info, bool syncCall) {
+          }, onError: (dynamic error, StackTrace stackTrace) {
+            caughtError.complete(true);
+          });
+          expect(await caughtError.future, true);
+        }, zoneSpecification: ZoneSpecification(
+          handleUncaughtError: (Zone zone, ZoneDelegate zoneDelegate, Zone parent, Object error, StackTrace stackTrace) {
+            uncaught = true;
+          },
+        ));
+        expect(uncaught, false);
+      });
     });
   });
 }

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -133,21 +133,13 @@ void main() {
     MockHttpClient httpClient;
 
     setUp(() {
-      debugNetworkImageUseFreshHttpClient = true;
       httpClient = MockHttpClient();
+      debugNetworkImageHttpClientProvider = () => httpClient;
     });
 
     tearDown(() {
-      debugNetworkImageUseFreshHttpClient = false;
+      debugNetworkImageHttpClientProvider = null;
     });
-
-    R runWithHttpClientMock<R>(R runnable(), {ZoneSpecification zoneSpecification}) {
-      return HttpOverrides.runZoned<R>(
-        runnable,
-        createHttpClient: (SecurityContext context) => httpClient,
-        zoneSpecification: zoneSpecification,
-      );
-    }
 
     test('Disallows null urls', () {
       expect(() {
@@ -159,7 +151,7 @@ void main() {
       when(httpClient.getUrl(any)).thenThrow(Error());
       bool uncaught = false;
 
-      await runWithHttpClientMock(() async {
+      await runZoned(() async {
         const ImageProvider imageProvider = NetworkImage('asdasdasdas');
         final Completer<bool> caughtError = Completer<bool>();
         FlutterError.onError = (FlutterErrorDetails details) {


### PR DESCRIPTION
## Description

Currently, the fact that NetworkImage uses a static HttpClient
makes it impossible to properly test, as a mock in one test will
be reused in another test. This change fixes that.

## Related Issues

https://github.com/flutter/flutter/issues/32374

## Tests

This change is about preparing for tests that will land in a follow-on
PR - existing tests were restructured in this PR, but no new tests were added
(yet).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
