### PR TITLE
Make ExpansionPanel can be customized with its right-top indicator

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -87,7 +87,8 @@ class ExpansionPanel {
   final ExpansionPanelHeaderBuilder headerBuilder;
 
   /// The widget builder that builds the expansion panels' indicator.
-  /// If null, use [ExpandIcon] for default
+  ///
+  /// If null, using [ExpandIcon] for default
   final ExpansionPanelIndicatorBuilder expansionIndicator;
 
   /// The body of the expansion panel that's displayed below the header.

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -202,6 +202,12 @@ class ExpansionPanelRadio extends ExpansionPanel {
 ///             title: Text(item.headerValue),
 ///           );
 ///         },
+///         expansionIndicator: (BuildContext context, bool isExpanded) {
+///           return Switch(
+///             value: isExpanded,
+///             onChanged: null,
+///           );
+///         },
 ///         body: ListTile(
 ///           title: Text(item.expandedValue),
 ///           subtitle: Text('To delete this panel, tap the trash can icon'),
@@ -299,6 +305,12 @@ class ExpansionPanelList extends StatefulWidget {
   ///         headerBuilder: (BuildContext context, bool isExpanded) {
   ///           return ListTile(
   ///             title: Text(item.headerValue),
+  ///           );
+  ///         },
+  ///         expansionIndicator: (BuildContext context, bool isExpanded) {
+  ///           return Switch(
+  ///             value: isExpanded,
+  ///             onChanged: null,
   ///           );
   ///         },
   ///         body: ListTile(

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -50,6 +50,10 @@ typedef ExpansionPanelCallback = void Function(int panelIndex, bool isExpanded);
 /// [ExpansionPanel] needs to rebuild.
 typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool isExpanded);
 
+/// Signature for the callback that's called when the expansion indicator of the
+/// [ExpansionPanel] needs to rebuild.
+typedef ExpansionPanelIndicatorBuilder = Widget Function(BuildContext context, bool isExpanded);
+
 /// A material expansion panel. It has a header and a body and can be either
 /// expanded or collapsed. The body of the panel is only visible when it is
 /// expanded.
@@ -73,6 +77,7 @@ class ExpansionPanel {
     @required this.body,
     this.isExpanded = false,
     this.canTapOnHeader = false,
+    this.expansionIndicator,
   }) : assert(headerBuilder != null),
        assert(body != null),
        assert(isExpanded != null),
@@ -80,6 +85,10 @@ class ExpansionPanel {
 
   /// The widget builder that builds the expansion panels' header.
   final ExpansionPanelHeaderBuilder headerBuilder;
+
+  /// The widget builder that builds the expansion panels' indicator.
+  /// If null, use [ExpandIcon] for default
+  final ExpansionPanelIndicatorBuilder expansionIndicator;
 
   /// The body of the expansion panel that's displayed below the header.
   ///
@@ -118,11 +127,13 @@ class ExpansionPanelRadio extends ExpansionPanel {
     @required ExpansionPanelHeaderBuilder headerBuilder,
     @required Widget body,
     bool canTapOnHeader = false,
+    ExpansionPanelIndicatorBuilder expansionIndicator,
   }) : assert(value != null),
       super(
         body: body,
         headerBuilder: headerBuilder,
         canTapOnHeader: canTapOnHeader,
+        expansionIndicator:expansionIndicator,
       );
 
   /// The value that uniquely identifies a radio panel so that the currently
@@ -446,6 +457,24 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         context,
         _isChildExpanded(index),
       );
+      final Widget expansionIndicator = child.expansionIndicator != null
+          ? InkResponse(
+        onTap: !child.canTapOnHeader
+            ? () => _handlePressed(_isChildExpanded(index), index)
+            : null,
+        child: child
+            .expansionIndicator(
+          context,
+          _isChildExpanded(index),
+        ),
+      )
+          : ExpandIcon(
+        isExpanded: _isChildExpanded(index),
+        padding: const EdgeInsets.all(16.0),
+        onPressed: !child.canTapOnHeader
+            ? (bool isExpanded) => _handlePressed(isExpanded, index)
+            : null,
+      );
       final Row header = Row(
         children: <Widget>[
           Expanded(
@@ -461,13 +490,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           ),
           Container(
             margin: const EdgeInsetsDirectional.only(end: 8.0),
-            child: ExpandIcon(
-              isExpanded: _isChildExpanded(index),
-              padding: const EdgeInsets.all(16.0),
-              onPressed: !child.canTapOnHeader
-                ? (bool isExpanded) => _handlePressed(isExpanded, index)
-                : null,
-            ),
+            child: expansionIndicator,
           ),
         ],
       );

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -202,12 +202,6 @@ class ExpansionPanelRadio extends ExpansionPanel {
 ///             title: Text(item.headerValue),
 ///           );
 ///         },
-///         expansionIndicator: (BuildContext context, bool isExpanded) {
-///           return Switch(
-///             value: isExpanded,
-///             onChanged: null,
-///           );
-///         },
 ///         body: ListTile(
 ///           title: Text(item.expandedValue),
 ///           subtitle: Text('To delete this panel, tap the trash can icon'),
@@ -305,12 +299,6 @@ class ExpansionPanelList extends StatefulWidget {
   ///         headerBuilder: (BuildContext context, bool isExpanded) {
   ///           return ListTile(
   ///             title: Text(item.headerValue),
-  ///           );
-  ///         },
-  ///         expansionIndicator: (BuildContext context, bool isExpanded) {
-  ///           return Switch(
-  ///             value: isExpanded,
-  ///             onChanged: null,
   ///           );
   ///         },
   ///         body: ListTile(

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -88,7 +88,24 @@ class ExpansionPanel {
 
   /// The widget builder that builds the expansion panels' indicator.
   ///
-  /// If null, using [ExpandIcon] for default
+  /// If null, [ExpandIcon] will be used as the expansion icon by default.
+  ///
+  /// {@tool sample}
+  ///
+  /// ```dart
+  /// ExpansionPanel(
+  ///  isExpanded: true,
+  ///  headerBuilder: (context, isExpanded) =>
+  ///      Text("This is ExpansionPanel's header"),
+  ///  expansionIndicator: (context, isExpanded) =>
+  ///      Switch(value: isExpanded, onChanged: null,),
+  ///  body: ListTile(
+  ///    title: Text("This is title for ExpansionPanel's body"),
+  ///    subtitle: Text(
+  ///        "This is subtitle for ExpansionPanel's body"),),);
+  /// ```
+  /// {@end-tool}
+  ///
   final ExpansionPanelIndicatorBuilder expansionIndicator;
 
   /// The body of the expansion panel that's displayed below the header.
@@ -458,24 +475,32 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         context,
         _isChildExpanded(index),
       );
-      final Widget expansionIndicator = child.expansionIndicator != null
-          ? InkResponse(
-        onTap: !child.canTapOnHeader
-            ? () => _handlePressed(_isChildExpanded(index), index)
-            : null,
-        child: child
-            .expansionIndicator(
-          context,
-          _isChildExpanded(index),
-        ),
-      )
-          : ExpandIcon(
-        isExpanded: _isChildExpanded(index),
-        padding: const EdgeInsets.all(16.0),
-        onPressed: !child.canTapOnHeader
-            ? (bool isExpanded) => _handlePressed(isExpanded, index)
-            : null,
-      );
+
+      Widget expansionIndicator;
+      if (child.expansionIndicator != null) {
+        expansionIndicator = InkResponse(
+          child: child.expansionIndicator(
+            context,
+            _isChildExpanded(index),
+          ),
+          onTap: !child.canTapOnHeader
+              ? () {
+            _handlePressed(_isChildExpanded(index), index);
+          }
+              : null,
+        );
+      } else {
+        expansionIndicator = ExpandIcon(
+          isExpanded: _isChildExpanded(index),
+          padding: const EdgeInsets.all(16.0),
+          onPressed: !child.canTapOnHeader
+              ? (bool isExpanded) {
+            _handlePressed(isExpanded, index);
+          }
+              : null,
+        );
+      }
+
       final Row header = Row(
         children: <Widget>[
           Expanded(


### PR DESCRIPTION
## Description

Add an option for ExpansionPanelList: expansionIndicator, which can be customiszed by users to change it to another one if needed;

## Related Issues

https://github.com/flutter/flutter/issues/32802

## Tests
<img width="390" alt="cb-1" src="https://user-images.githubusercontent.com/17942332/57923590-4a370e00-78d5-11e9-8069-704f3a334e37.png">
<img width="399" alt="cb" src="https://user-images.githubusercontent.com/17942332/57923596-4d31fe80-78d5-11e9-9ab3-cae70cfb178b.png">

