### PR TITLE
Use reverseDuration on Tooltip and InkWell

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -166,6 +166,7 @@ class _BorderContainer extends StatefulWidget {
 
 class _BorderContainerState extends State<_BorderContainer> with TickerProviderStateMixin {
   static const Duration _kFocusInDuration = Duration(milliseconds: 45);
+  static const Duration _kFocusOutDuration = Duration(milliseconds: 15);
   static const Duration _kHoverDuration = Duration(milliseconds: 15);
 
   AnimationController _controller;
@@ -183,7 +184,7 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
     super.initState();
     _focusColorController = AnimationController(
       duration: _kFocusInDuration,
-      // TODO(gspencer): use reverseDuration set to 15ms, once available.
+      reverseDuration: _kFocusOutDuration,
       value: widget.isFocused ? 1.0 : 0.0,
       vsync: this,
     );

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -149,7 +149,11 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   void initState() {
     super.initState();
     _mouseIsConnected = RendererBinding.instance.mouseTracker.mouseIsConnected;
-    _controller = AnimationController(duration: _fadeInDuration, vsync: this)
+    _controller = AnimationController(
+      duration: _fadeInDuration,
+      reverseDuration: _fadeOutDuration,
+      vsync: this,
+    )
       ..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
     RendererBinding.instance.mouseTracker.addListener(_handleMouseTrackerChange);
@@ -226,7 +230,6 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   void _createNewEntry() {
     final RenderBox box = context.findRenderObject();
     final Offset target = box.localToGlobal(box.size.center(Offset.zero));
-    assert(_fadeOutDuration < _fadeInDuration);
 
     // We create this widget outside of the overlay entry's builder to prevent
     // updated values from happening to leak into the overlay when the overlay
@@ -239,14 +242,6 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       animation: CurvedAnimation(
         parent: _controller,
         curve: Curves.fastOutSlowIn,
-        // Add an interval here to make the fade out use a different (shorter)
-        // duration than the fade in. If _kFadeOutDuration is made longer than
-        // _kFadeInDuration, then the equation below will need to change.
-        reverseCurve: Interval(
-          0.0,
-          _fadeOutDuration.inMilliseconds / _fadeInDuration.inMilliseconds,
-          curve: Curves.fastOutSlowIn,
-        ),
       ),
       target: target,
       verticalOffset: widget.verticalOffset,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2140,8 +2140,7 @@ void main() {
     );
 
     expect(getContainerColor(tester), equals(focusColor));
-    // TODO(gspencer): convert this to 15ms once reverseDuration for AnimationController lands.
-    await tester.pump(const Duration(milliseconds: 45));
+    await tester.pump(const Duration(milliseconds: 15));
     expect(getContainerColor(tester), equals(fillColor));
   });
 


### PR DESCRIPTION
## Description

This puts the new `AnimationController` `reverseDuration` argument to use in two places: focus for InkWells and fade out for Tooltips.

## Tests

I modified that InkWell test to look at the correct reverse duration.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
