### PR TITLE
Add widget of the week videos

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -44,6 +44,8 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 /// use the static [of] method from an item's input callback.
 ///
 /// This widget is similar to one created by [ListView.builder].
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=ZtfItHwFlZ8}
 class AnimatedList extends StatefulWidget {
   /// Creates a scrolling container that animates items when they are inserted or removed.
   const AnimatedList({

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4253,6 +4253,8 @@ class Column extends Flex {
 /// [Flex] must contain only [StatelessWidget]s or [StatefulWidget]s (not other
 /// kinds of widgets, like [RenderObjectWidget]s).
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=CI7x0mAZiY0}
+///
 /// See also:
 ///
 ///  * [Expanded], which forces the child to expand to fill the available space.

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -87,6 +87,8 @@ enum DragAnchor {
 /// [childWhenDragging] when one or more drags are underway. Otherwise, this
 /// widget always displays [child].
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=QzA4c4QHZCY}
+///
 /// See also:
 ///
 ///  * [DragTarget]

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -25,6 +25,8 @@ typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, W
 /// listener of the [ValueListenable] and call the [builder] with updated values
 /// when the value changes.
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=s-ZG-jS5QHQ}
+///
 /// ## Performance optimizations
 ///
 /// If your [builder] function contains a subtree that does not depend on the


### PR DESCRIPTION
## Description

This adds widget of the week video embeddings to the documentation blocks of the following widgets:

* AnimatedList
* Flexible
* Draggable
* ValueListenableBuilder

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
