### PR TITLE
Correct handling of InputDecoration.hintMaxLines=null (fixed issue #32830)

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2005,7 +2005,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       child: Text(
         decoration.hintText,
         style: hintStyle,
-        overflow: TextOverflow.ellipsis,
+        overflow : decoration.hintMaxLines == 1 ? TextOverflow.ellipsis : TextOverflow.clip,
         textAlign: textAlign,
         maxLines: decoration.hintMaxLines,
       ),

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2005,7 +2005,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       child: Text(
         decoration.hintText,
         style: hintStyle,
-        overflow : decoration.hintMaxLines == 1 ? TextOverflow.ellipsis : TextOverflow.clip,
+        overflow: decoration.hintMaxLines == 1 ? TextOverflow.ellipsis : TextOverflow.clip,
         textAlign: textAlign,
         maxLines: decoration.hintMaxLines,
       ),


### PR DESCRIPTION
## Description

As per [hintMaxLine](https://api.flutter.dev/flutter/material/InputDecoration/hintMaxLines.html) Docs "This value is passed along to the Text.maxLines attribute of the Text widget used to display the hint text. TextOverflow.ellipsis is used to handle the overflow when it is limited to single line."

According to issue "So I expect that when both maxLines and hintMaxLines are null, the hint should keep growing and wrap to 2nd, 3rd, etc line. Instead, I see that it gets truncated with ellipsis"

Now the behaviour is when hintMaxlines is set to 1, it will get truncated with ellipsis, if hintMaxLines set to null the hint will not truncated, but it will go to 2nd line and so on..

## Related Issues

issue #32830 is fixed

## Tests

I added the following tests:

I have tested and it works perfectly.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
