### PR TITLE
fix bad lint commented out

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -139,10 +139,10 @@ linter:
     # - prefer_int_literals # not yet tested
     # - prefer_interpolation_to_compose_strings # not yet tested
     - prefer_is_empty
-    # - prefer_is_not_empty # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    - prefer_is_not_empty
     - prefer_iterable_whereType
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
-    - prefer_null_aware_operators
+    # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
     - prefer_single_quotes
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null


### PR DESCRIPTION
In #32711 I made a mistake commenting out `prefer_is_not_empty` instead of `prefer_null_aware_operators`. This PR fixes that.
