### PR TITLE
Rename `flutter packages` to `flutter pub`

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -565,7 +565,7 @@ linter:
     if (stdout.isNotEmpty && stdout.first == 'Building flutter tool...') {
       stdout.removeAt(0);
     }
-    if (stdout.isNotEmpty && stdout.first.startsWith('Running "flutter packages get" in ')) {
+    if (stdout.isNotEmpty && stdout.first.startsWith('Running "flutter pub get" in ')) {
       stdout.removeAt(0);
     }
     _exitCode = result.exitCode;

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -108,7 +108,7 @@ fi
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.
-(cd "$FLUTTER_ROOT/dev/tools" && "$FLUTTER" packages get)
+(cd "$FLUTTER_ROOT/dev/tools" && "$FLUTTER" pub get)
 (cd "$FLUTTER_ROOT/dev/tools" && "$PUB" get)
 (cd "$FLUTTER_ROOT" && "$DART" "$FLUTTER_ROOT/dev/tools/dartdoc.dart")
 (cd "$FLUTTER_ROOT" && "$DART" "$FLUTTER_ROOT/dev/tools/java_and_objc_doc.dart")

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -59,7 +59,7 @@ Future<int> runTest({bool coverage = false}) async {
       step = TestStep.buildingFlutterTool;
     } else if (step == TestStep.testPassed && entry.contains('Collecting coverage information...')) {
       // ignore this line
-    } else if (step.index < TestStep.runningPubGet.index && entry == 'Running "flutter packages get" in automated_tests...') {
+    } else if (step.index < TestStep.runningPubGet.index && entry == 'Running "flutter pub get" in automated_tests...') {
       // ignore this line
       step = TestStep.runningPubGet;
     } else if (step.index < TestStep.testWritesFirstCarriageReturn.index && entry == '') {

--- a/dev/devicelab/bin/tasks/run_release_test.dart
+++ b/dev/devicelab/bin/tasks/run_release_test.dart
@@ -54,7 +54,7 @@ void main() {
         throw 'flutter run --release had output on standard error.';
       if (stdout.first.startsWith('Building flutter tool...'))
         stdout.removeAt(0);
-      if (stdout.first.startsWith('Running "flutter packages get" in ui...'))
+      if (stdout.first.startsWith('Running "flutter pub get" in ui...'))
         stdout.removeAt(0);
       if (stdout.first.startsWith('Initializing gradle...'))
         stdout.removeAt(0);

--- a/dev/integration_tests/android_views/ios/Podfile
+++ b/dev/integration_tests/android_views/ios/Podfile
@@ -41,7 +41,7 @@ target 'Runner' do
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
   if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter packages get is executed first."
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'

--- a/examples/flutter_gallery/README.md
+++ b/examples/flutter_gallery/README.md
@@ -16,7 +16,7 @@ the [Flutter Setup](https://flutter.dev/setup/) guide.
 ### Building and installing the Flutter app
 
 * `cd $FLUTTER_ROOT/examples/flutter_gallery`
-* `flutter packages get`
+* `flutter pub get`
 * `flutter run --release`
 
 The `flutter run --release` command both builds and installs the Flutter app.

--- a/examples/platform_view/ios/Podfile
+++ b/examples/platform_view/ios/Podfile
@@ -35,7 +35,7 @@ target 'Runner' do
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
   if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter packages get is executed first."
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'

--- a/examples/stocks/README.md
+++ b/examples/stocks/README.md
@@ -15,7 +15,7 @@ the [Flutter Setup](https://flutter.dev/setup/) guide.
 ### Building and installing the stocks demo app
 
 * `cd $FLUTTER_ROOT/examples/stocks`
-* `flutter packages get`
+* `flutter pub get`
 * `flutter run --release`
 
 The `flutter run --release` command both builds and installs the Flutter app.

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -56,11 +56,11 @@ class CreateCommand extends FlutterCommand {
   CreateCommand() {
     argParser.addFlag('pub',
       defaultsTo: true,
-      help: 'Whether to run "flutter packages get" after the project has been created.',
+      help: 'Whether to run "flutter pub get" after the project has been created.',
     );
     argParser.addFlag('offline',
       defaultsTo: false,
-      help: 'When "flutter packages get" is run by the create command, this indicates '
+      help: 'When "flutter pub get" is run by the create command, this indicates '
         'whether to run it in offline mode or not. In offline mode, it will need to '
         'have all dependencies already available in the pub cache to succeed.',
     );

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -27,10 +27,10 @@ class PackagesCommand extends FlutterCommand {
   }
 
   @override
-  final String name = 'packages';
+  final String name = 'pub';
 
   @override
-  List<String> get aliases => const <String>['pub'];
+  List<String> get aliases => const <String>['packages'];
 
   @override
   final String description = 'Commands for managing Flutter packages.';
@@ -65,7 +65,7 @@ class PackagesGetCommand extends FlutterCommand {
 
   @override
   String get invocation {
-    return '${runner.executableName} packages $name [<target directory>]';
+    return '${runner.executableName} pub $name [<target directory>]';
   }
 
   Future<void> _runPubGet (String directory) async {
@@ -127,7 +127,7 @@ class PackagesTestCommand extends FlutterCommand {
 
   @override
   String get invocation {
-    return '${runner.executableName} packages test [<tests...>]';
+    return '${runner.executableName} pub test [<tests...>]';
   }
 
   @override
@@ -157,7 +157,7 @@ class PackagesForwardCommand extends FlutterCommand {
 
   @override
   String get invocation {
-    return '${runner.executableName} packages $_commandName [<arguments...>]';
+    return '${runner.executableName} pub $_commandName [<arguments...>]';
   }
 
   @override
@@ -174,7 +174,7 @@ class PackagesPassthroughCommand extends FlutterCommand {
   }
 
   @override
-  String get name => 'pub';
+  String get name => 'packages';
 
   @override
   String get description {

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -174,7 +174,7 @@ class PackagesPassthroughCommand extends FlutterCommand {
   }
 
   @override
-  String get name => 'packages';
+  String get name => 'pub';
 
   @override
   String get description {

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -64,7 +64,7 @@ class PackageMap {
     String message = '$packagesPath does not exist.';
     final String pubspecPath = fs.path.absolute(fs.path.dirname(packagesPath), 'pubspec.yaml');
     if (fs.isFileSync(pubspecPath))
-      message += '\nDid you run "flutter packages get" in this directory?';
+      message += '\nDid you run "flutter pub get" in this directory?';
     else
       message += '\nDid you run this command from the same directory as your pubspec.yaml file?';
     return message;

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -93,7 +93,7 @@ Future<void> pubGet({
   if (!checkLastModified || _shouldRunPubGet(pubSpecYaml: pubSpecYaml, dotPackages: dotPackages)) {
     final String command = upgrade ? 'upgrade' : 'get';
     final Status status = logger.startProgress(
-      'Running "flutter packages $command" in ${fs.path.basename(directory)}...',
+      'Running "flutter pub $command" in ${fs.path.basename(directory)}...',
       timeout: timeoutConfiguration.slowOperation,
     );
     final List<String> args = <String>['--verbosity=warning'];

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -106,7 +106,7 @@ abstract class FlutterCommand extends Command<void> {
 
   bool _usesIpv6Flag = false;
 
-  bool get shouldRunPub => _usesPubOption && argResults['pub'];
+  bool get shouldRunPub => _usesPubOption && argResults['packages'];
 
   bool get shouldUpdateCache => true;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -106,7 +106,7 @@ abstract class FlutterCommand extends Command<void> {
 
   bool _usesIpv6Flag = false;
 
-  bool get shouldRunPub => _usesPubOption && argResults['packages'];
+  bool get shouldRunPub => _usesPubOption && argResults['pub'];
 
   bool get shouldUpdateCache => true;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -594,7 +594,7 @@ abstract class FlutterCommand extends Command<void> {
       }
 
       // Validate the current package map only if we will not be running "pub get" later.
-      if (parent?.name != 'pub' && !(_usesPubOption && argResults['packages'])) {
+      if (parent?.name != 'pub' && !(_usesPubOption && argResults['pub'])) {
         final String error = PackageMap(PackageMap.globalPackagesPath).checkValid();
         if (error != null)
           throw ToolExit(error);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -139,7 +139,7 @@ abstract class FlutterCommand extends Command<void> {
   void usesPubOption() {
     argParser.addFlag('pub',
       defaultsTo: true,
-      help: 'Whether to run "flutter packages get" before executing this command.');
+      help: 'Whether to run "flutter pub get" before executing this command.');
     _usesPubOption = true;
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -594,7 +594,7 @@ abstract class FlutterCommand extends Command<void> {
       }
 
       // Validate the current package map only if we will not be running "pub get" later.
-      if (parent?.name != 'packages' && !(_usesPubOption && argResults['pub'])) {
+      if (parent?.name != 'pub' && !(_usesPubOption && argResults['packages'])) {
         final String error = PackageMap(PackageMap.globalPackagesPath).checkValid();
         if (error != null)
           throw ToolExit(error);

--- a/packages/flutter_tools/templates/cocoapods/Podfile-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-objc
@@ -41,7 +41,7 @@ target 'Runner' do
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
   if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter packages get is executed first."
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'

--- a/packages/flutter_tools/templates/cocoapods/Podfile-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-swift
@@ -43,7 +43,7 @@ target 'Runner' do
   # Flutter Pods
   generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
   if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter packages get is executed first."
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
   generated_xcode_build_settings.map { |p|
     if p[:name] == 'FLUTTER_FRAMEWORK_DIR'

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb
@@ -23,7 +23,7 @@ end
 def flutter_root(f)
     generated_xcode_build_settings = parse_KV_file(File.join(f, File.join('.ios', 'Flutter', 'Generated.xcconfig')))
     if generated_xcode_build_settings.empty?
-        puts "Generated.xcconfig must exist. Make sure `flutter packages get` is executed in #{f}."
+        puts "Generated.xcconfig must exist. Make sure `flutter pub get` is executed in #{f}."
         exit
     end
     generated_xcode_build_settings.map { |p|

--- a/packages/flutter_tools/test/commands/test_test.dart
+++ b/packages/flutter_tools/test/commands/test_test.dart
@@ -106,7 +106,7 @@ Future<void> _testFile(String testName, String workingDirectory, String testDire
   final List<String> output = exec.stdout.split('\n');
   if (output.first == 'Waiting for another flutter command to release the startup lock...')
     output.removeAt(0);
-  if (output.first.startsWith('Running "flutter packages get" in'))
+  if (output.first.startsWith('Running "flutter pub get" in'))
     output.removeAt(0);
   output.add('<<stderr>>');
   output.addAll(exec.stderr.split('\n'));

--- a/packages/flutter_tools/test/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/dart/pub_get_test.dart
@@ -39,26 +39,26 @@ void main() {
       });
       time.elapse(const Duration(milliseconds: 500));
       expect(testLogger.statusText,
-        'Running "flutter packages get" in /...\n'
+        'Running "flutter pub get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n',
       );
       expect(processMock.lastPubEnvironment, contains('flutter_cli:flutter_tests'));
       expect(processMock.lastPubCache, isNull);
       time.elapse(const Duration(milliseconds: 500));
       expect(testLogger.statusText,
-        'Running "flutter packages get" in /...\n'
+        'Running "flutter pub get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n'
         'pub get failed (69) -- attempting retry 2 in 2 seconds...\n',
       );
       time.elapse(const Duration(seconds: 1));
       expect(testLogger.statusText,
-        'Running "flutter packages get" in /...\n'
+        'Running "flutter pub get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n'
         'pub get failed (69) -- attempting retry 2 in 2 seconds...\n',
       );
       time.elapse(const Duration(seconds: 100)); // from t=0 to t=100
       expect(testLogger.statusText,
-        'Running "flutter packages get" in /...\n'
+        'Running "flutter pub get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n'
         'pub get failed (69) -- attempting retry 2 in 2 seconds...\n'
         'pub get failed (69) -- attempting retry 3 in 4 seconds...\n' // at t=1
@@ -69,7 +69,7 @@ void main() {
       );
       time.elapse(const Duration(seconds: 200)); // from t=0 to t=200
       expect(testLogger.statusText,
-        'Running "flutter packages get" in /...\n'
+        'Running "flutter pub get" in /...\n'
         'pub get failed (69) -- attempting retry 1 in 1 second...\n'
         'pub get failed (69) -- attempting retry 2 in 2 seconds...\n'
         'pub get failed (69) -- attempting retry 3 in 4 seconds...\n'

--- a/packages/flutter_tools/test/integration/test_utils.dart
+++ b/packages/flutter_tools/test/integration/test_utils.dart
@@ -43,7 +43,7 @@ dependencies:
 Future<void> getPackages(String folder) async {
   final List<String> command = <String>[
     fs.path.join(getFlutterRoot(), 'bin', 'flutter'),
-    'packages',
+    'pub',
     'get',
   ];
   final Process process = await processManager.start(command, workingDirectory: folder);
@@ -52,5 +52,5 @@ Future<void> getPackages(String folder) async {
   final int exitCode = await process.exitCode;
   if (exitCode != 0)
     throw Exception(
-        'flutter packages get failed: ${errorOutput.toString()}');
+        'flutter pub get failed: ${errorOutput.toString()}');
 }

--- a/packages/flutter_tools/test/ios/mac_test.dart
+++ b/packages/flutter_tools/test/ios/mac_test.dart
@@ -360,7 +360,7 @@ Error launching application on iPhone.''',
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
-Running "flutter packages get" in flutter_gallery...  0.6s
+Running "flutter pub get" in flutter_gallery...  0.6s
 Launching lib/main.dart on x in release mode...
 Running pod install...                                1.2s
 Running Xcode build...                                1.4s


### PR DESCRIPTION
## Description

This is the last step in the rebrand of Flutter/Dart "packages" back to use "pub" consistently.

## Related Issues

`flutter pub` support was added earlier in https://github.com/flutter/flutter/pull/30115.

Pub site rebrand already landed: https://pub.dev

## Breaking Change

This is non-breaking as `flutter packages` is now an alias for `flutter pub` (prior to this change the opposite was the case).
