### PR TITLE
Prefer null-aware operators

### DIFF
--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -266,7 +266,7 @@ class GestureArenaManager {
   bool _debugLogDiagnostic(int pointer, String message, [ _GestureArena state ]) {
     assert(() {
       if (debugPrintGestureArenaDiagnostics) {
-        final int count = state != null ? state.members.length : null;
+        final int count = state?.members.length;
         final String s = count != 1 ? 's' : '';
         debugPrint('Gesture arena ${pointer.toString().padRight(4)} ❙ $message${ count != null ? " with $count member$s." : ""}');
       }

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -606,7 +606,7 @@ class RadialGradient extends Gradient {
       radius * rect.shortestSide,
       colors, _impliedStops(), tileMode,
       null, // transform
-      focal == null  ? null : focal.resolve(textDirection).withinRect(rect),
+      focal?.resolve(textDirection).withinRect(rect),
       focalRadius * rect.shortestSide,
     );
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -518,7 +518,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
       onListen: _start,
       onCancel: _stop,
     );
-    _appName = app == null ? null : app.name.replaceAll('.app', '');
+    _appName = app?.name.replaceAll('.app', '');
   }
 
   final IOSSimulator device;


### PR DESCRIPTION
## Description

An upcoming analyzer change will yield some new warnings during `flutter analyze` -- this change addresses the guidance from those warnings.

## Tests

Since this change is addressing existing test failures (tests in the flutter repo, run from the analyzer repo upstream), no new tests were necessary.
 
## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
