### PR TITLE
SliverAppBar shape property

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -687,6 +687,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.floating,
     @required this.pinned,
     @required this.snapConfiguration,
+    @required this.shape,
   }) : assert(primary || topPadding == 0.0),
        _bottomHeight = bottom?.preferredSize?.height ?? 0.0;
 
@@ -711,6 +712,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final double topPadding;
   final bool floating;
   final bool pinned;
+  final ShapeBorder shape;
 
   final double _bottomHeight;
 
@@ -765,6 +767,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         primary: primary,
         centerTitle: centerTitle,
         titleSpacing: titleSpacing,
+        shape: shape,
         toolbarOpacity: toolbarOpacity,
         bottomOpacity: pinned ? 1.0 : (visibleMainHeight / _bottomHeight).clamp(0.0, 1.0),
       ),
@@ -908,6 +911,7 @@ class SliverAppBar extends StatefulWidget {
     this.floating = false,
     this.pinned = false,
     this.snap = false,
+    this.shape,
   }) : assert(automaticallyImplyLeading != null),
        assert(forceElevated != null),
        assert(primary != null),
@@ -1125,6 +1129,12 @@ class SliverAppBar extends StatefulWidget {
   ///    behavior of the app bar in combination with [floating].
   final bool pinned;
 
+  /// The material's shape as well its shadow.
+  ///
+  /// A shadow is only displayed if the [elevation] is greater than
+  /// zero.
+  final ShapeBorder shape;
+
   /// If [snap] and [floating] are true then the floating app bar will "snap"
   /// into view.
   ///
@@ -1221,6 +1231,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           topPadding: topPadding,
           floating: widget.floating,
           pinned: widget.pinned,
+          shape: widget.shape,
           snapConfiguration: _snapConfiguration,
         ),
       ),

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1425,7 +1425,6 @@ void main() {
 
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
-
     const double appBarHeight = 256.0;
     bool snap = true;
 
@@ -1486,6 +1485,26 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('AppBar shape default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppBar(
+          leading: const Text('L'),
+          title: const Text('No Scaffold'),
+          actions: const <Widget>[Text('A1'), Text('A2')],
+        ),
+      ),
+    );
+
+    final Finder appBarFinder = find.byType(AppBar);
+    AppBar getAppBarWidget(Finder finder) => tester.widget<AppBar>(finder);
+    expect(getAppBarWidget(appBarFinder).shape, null);
+
+    final Finder materialFinder = find.byType(Material);
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    expect(getMaterialWidget(materialFinder).shape, null);
+  });
+
   testWidgets('AppBar with shape', (WidgetTester tester) async {
     const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(15.0))
@@ -1495,26 +1514,43 @@ void main() {
         home: AppBar(
           leading: const Text('L'),
           title: const Text('No Scaffold'),
-          shape: roundedRectangleBorder,
           actions: const <Widget>[Text('A1'), Text('A2')],
+          shape: roundedRectangleBorder,
         ),
       ),
     );
 
     final Finder appBarFinder = find.byType(AppBar);
-
-    AppBar getAppBarWidget() {
-      return tester.widget<AppBar>(appBarFinder);
-    }
-
-    expect(getAppBarWidget().shape, roundedRectangleBorder);
+    AppBar getAppBarWidget(Finder finder) => tester.widget<AppBar>(finder);
+    expect(getAppBarWidget(appBarFinder).shape, roundedRectangleBorder);
 
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget() {
-      return tester.widget<Material>(materialFinder);
-    }
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    expect(getMaterialWidget(materialFinder).shape, roundedRectangleBorder);
+  });
 
-    expect(getMaterialWidget().shape, roundedRectangleBorder);
+  testWidgets('SliverAppBar shape default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              leading: Text('L'),
+              title: Text('No Scaffold'),
+              actions: <Widget>[Text('A1'), Text('A2')],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Finder sliverAppBarFinder = find.byType(SliverAppBar);
+    SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
+    expect(getSliverAppBarWidget(sliverAppBarFinder).shape, null);
+
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    final Finder materialFinder = find.byType(Material);
+    expect(getMaterialWidget(materialFinder).shape, null);
   });
 
   testWidgets('SliverAppBar with shape', (WidgetTester tester) async {
@@ -1528,8 +1564,8 @@ void main() {
             SliverAppBar(
               leading: Text('L'),
               title: Text('No Scaffold'),
-              shape: roundedRectangleBorder,
               actions: <Widget>[Text('A1'), Text('A2')],
+              shape: roundedRectangleBorder,
             ),
           ],
         ),
@@ -1537,17 +1573,11 @@ void main() {
     );
 
     final Finder sliverAppBarFinder = find.byType(SliverAppBar);
-    SliverAppBar getAppBarWidget() {
-      return tester.widget<SliverAppBar>(sliverAppBarFinder);
-    }
+    SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
+    expect(getSliverAppBarWidget(sliverAppBarFinder).shape, roundedRectangleBorder);
 
-    expect(getAppBarWidget().shape, roundedRectangleBorder);
-
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget() {
-      return tester.widget<Material>(materialFinder);
-    }
-
-    expect(getMaterialWidget().shape, roundedRectangleBorder);
+    expect(getMaterialWidget(materialFinder).shape, roundedRectangleBorder);
   });
 }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1487,7 +1487,9 @@ void main() {
   });
 
   testWidgets('AppBar with shape', (WidgetTester tester) async {
-    const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0)));
+    const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(15.0))
+    );
     await tester.pumpWidget(
       MaterialApp(
         home: AppBar(
@@ -1503,6 +1505,40 @@ void main() {
 
     AppBar getAppBarWidget() {
       return tester.widget<AppBar>(appBarFinder);
+    }
+
+    expect(getAppBarWidget().shape, roundedRectangleBorder);
+
+    final Finder materialFinder = find.byType(Material);
+    Material getMaterialWidget() {
+      return tester.widget<Material>(materialFinder);
+    }
+
+    expect(getMaterialWidget().shape, roundedRectangleBorder);
+  });
+
+  testWidgets('SliverAppBar with shape', (WidgetTester tester) async {
+    const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(15.0)),
+    );
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              leading: Text('L'),
+              title: Text('No Scaffold'),
+              shape: roundedRectangleBorder,
+              actions: <Widget>[Text('A1'), Text('A2')],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Finder sliverAppBarFinder = find.byType(SliverAppBar);
+    SliverAppBar getAppBarWidget() {
+      return tester.widget<SliverAppBar>(sliverAppBarFinder);
     }
 
     expect(getAppBarWidget().shape, roundedRectangleBorder);

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1548,8 +1548,8 @@ void main() {
     SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
     expect(getSliverAppBarWidget(sliverAppBarFinder).shape, null);
 
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
     final Finder materialFinder = find.byType(Material);
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, null);
   });
 
@@ -1576,8 +1576,8 @@ void main() {
     SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
     expect(getSliverAppBarWidget(sliverAppBarFinder).shape, roundedRectangleBorder);
 
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
     final Finder materialFinder = find.byType(Material);
+    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, roundedRectangleBorder);
   });
 }


### PR DESCRIPTION
## Description

Submitting a PR in place of https://github.com/flutter/flutter/pull/32591, since contributor hasn't been responding to PR feedback. Adds `shape` property to SliverAppBar. Also formatted some of the other tests to be more readable, as well as updating the `AppBar` tests for default shape.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31656

## Tests

I added the following tests:

- A test to verify that the `shape` property was passed down to the Material widget applying the shape
- Tests to ensure that `shape` defaults to `null` when `shape` is not explicitly passed in.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
