### PR TITLE
don't send crash reports if on a user branch

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -60,7 +60,7 @@ Future<int> run(
       await runner.run(args);
       await _exit(0);
     } catch (error, stackTrace) {
-      String getVersion() => flutterVersion ?? FlutterVersion.instance.getVersionString();
+      String getVersion() => flutterVersion ?? FlutterVersion.instance.getVersionString(redactUnknownBranches: true);
       return await _handleToolError(error, stackTrace, verbose, args, reportCrashes, getVersion);
     }
     return 0;

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -86,13 +86,10 @@ class CrashReportSender {
     @required String getFlutterVersion(),
   }) async {
     try {
-      if (_usage.suppressAnalytics)
-        return;
-
       final String flutterVersion = getFlutterVersion();
 
       // We don't need to report exceptions happening on user branches
-      if (RegExp(r'^\[user-branch\]\/').hasMatch(flutterVersion)) {
+      if (_usage.suppressAnalytics || RegExp(r'^\[user-branch\]\/').hasMatch(flutterVersion)) {
         return;
       }
 

--- a/packages/flutter_tools/lib/src/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/crash_reporting.dart
@@ -89,9 +89,15 @@ class CrashReportSender {
       if (_usage.suppressAnalytics)
         return;
 
+      final String flutterVersion = getFlutterVersion();
+
+      // We don't need to report exceptions happening on user branches
+      if (RegExp(r'^\[user-branch\]\/').hasMatch(flutterVersion)) {
+        return;
+      }
+
       printStatus('Sending crash report to Google.');
 
-      final String flutterVersion = getFlutterVersion();
       final Uri uri = _baseUrl.replace(
         queryParameters: <String, String>{
           'product': _kProductId,

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -132,8 +132,8 @@ void main() {
         uri = request.url;
 
         return Response(
-            'test-report-id',
-            200,
+          'test-report-id',
+          200,
         );
       }));
 

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -147,8 +147,8 @@ void main() {
       expect(exitCode, 1);
 
       // Verify that the report wasn't sent
-      expect(method, isNull);
-      expect(uri, isNull);
+      expect(method, null);
+      expect(uri, null);
 
       final BufferLogger logger = context.get<Logger>();
       expect(logger.statusText, '');

--- a/packages/flutter_tools/test/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/crash_reporting_test.dart
@@ -123,6 +123,39 @@ void main() {
       Stdio: () => const _NoStderr(),
     });
 
+    testUsingContext('should not send a crash report if on a user-branch', () async {
+      String method;
+      Uri uri;
+
+      CrashReportSender.initializeWith(MockClient((Request request) async {
+        method = request.method;
+        uri = request.url;
+
+        return Response(
+            'test-report-id',
+            200,
+        );
+      }));
+
+      final int exitCode = await tools.run(
+        <String>['crash'],
+        <FlutterCommand>[_CrashCommand()],
+        reportCrashes: true,
+        flutterVersion: '[user-branch]/v1.2.3',
+      );
+
+      expect(exitCode, 1);
+
+      // Verify that the report wasn't sent
+      expect(method, isNull);
+      expect(uri, isNull);
+
+      final BufferLogger logger = context.get<Logger>();
+      expect(logger.statusText, '');
+    }, overrides: <Type, Generator>{
+      Stdio: () => const _NoStderr(),
+    });
+
     testUsingContext('can override base URL', () async {
       Uri uri;
       CrashReportSender.initializeWith(MockClient((Request request) async {


### PR DESCRIPTION
## Description

Addresses below issue. Currently, crash reporting has a lot of crashes from flutter developers working on experimental/feature branches. We should only be reporting crashes from known/official channels.

## Related Issues

[#32038](https://github.com/flutter/flutter/issues/32038)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.