### PR TITLE
Fixed several issues with confirmDismiss handling on the LeaveBehindItem demo.

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -230,20 +230,16 @@ class _LeaveBehindListItem extends StatelessWidget {
         confirmDismiss: !confirmDismiss ? null : (DismissDirection dismissDirection) async {
           switch(dismissDirection) {
             case DismissDirection.endToStart:
-              if (await _showConfirmationDialog(context, 'archive'))
-                _handleArchive();
-              break;
+              return await _showConfirmationDialog(context, 'archive') == true;
             case DismissDirection.startToEnd:
-              if (await _showConfirmationDialog(context, 'delete'))
-                _handleDelete();
-              break;
+              return await _showConfirmationDialog(context, 'delete') == true;
             case DismissDirection.horizontal:
             case DismissDirection.vertical:
             case DismissDirection.up:
             case DismissDirection.down:
               assert(false);
           }
-          return true;
+          return false;
         },
         background: Container(
           color: theme.primaryColor,


### PR DESCRIPTION
## Description

There are a couple of logic issues with the confirmDismiss handling in the LeaveBehindItem demo in the gallery. This PR fixes:

- The `confirmDismiss` callback was not always returning a `true` or `false` value
- The `confirmDismiss` callback was implementing the removal of the item itself instead of just confirming the operation

## Related Issues

Fixes #33016

## Tests

No tests were changed for this.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
