### PR TITLE
Update enabled color for outlined text fields.

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1830,11 +1830,12 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (decoration.filled) {
       return themeData.hintColor;
     }
+    final Color enabledColor = themeData.colorScheme.onSurface.withOpacity(0.38);
     if (isHovering) {
       final Color hoverColor = decoration.hoverColor ?? themeData.inputDecorationTheme?.hoverColor ?? themeData.hoverColor;
-      return Color.alphaBlend(hoverColor.withOpacity(0.16), themeData.colorScheme.onSurface.withOpacity(0.12));
+      return Color.alphaBlend(hoverColor.withOpacity(0.12), enabledColor);
     }
-    return themeData.colorScheme.onSurface.withOpacity(0.12);
+    return enabledColor;
   }
 
   Color _getFillColor(ThemeData themeData) {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2048,7 +2048,7 @@ void main() {
     const Color fillColor = Color(0x0A000000);
     const Color hoverColor = Color(0xFF00FF00);
     const Color disabledColor = Color(0x05000000);
-    const Color enabledBorderColor = Color(0x1f000000);
+    const Color enabledBorderColor = Color(0x61000000);
 
     Future<void> pumpDecorator({bool hovering, bool enabled = true, bool filled = true}) async {
       return await tester.pumpWidget(
@@ -2092,7 +2092,7 @@ void main() {
     expect(getContainerColor(tester), equals(disabledColor));
 
     // Test outline text field.
-    const Color blendedHoverColor = Color(0x43009c00);
+    const Color blendedHoverColor = Color(0x74004400);
     await pumpDecorator(hovering: false, filled: false);
     await tester.pumpAndSettle();
     expect(getBorderColor(tester), equals(enabledBorderColor));
@@ -2123,7 +2123,7 @@ void main() {
   testWidgets('InputDecorator draws and animates focusColor', (WidgetTester tester) async {
     const Color focusColor = Color(0xFF0000FF);
     const Color disabledColor = Color(0x05000000);
-    const Color enabledBorderColor = Color(0x1f000000);
+    const Color enabledBorderColor = Color(0x61000000);
 
     Future<void> pumpDecorator({bool focused, bool enabled = true, bool filled = true}) async {
       return await tester.pumpWidget(


### PR DESCRIPTION
## Description

Resets the enabled color for outline text field default borders to "On Surface 38%" instead of "On Surface 12%" to match spec.  Also fixes the hover overlay to be "On Surface 12%" to match spec.
