### PR TITLE
Add support for ImageStreamListener.onChunk()

### DIFF
--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -16,7 +16,7 @@ import 'dart:typed_data';
 ///
 /// The `total` parameter will contain the _expected_ total number of bytes to
 /// be received across the wire (extracted from the value of the
-/// `Content-Length` HTTP response header), or -1 if the size of the response
+/// `Content-Length` HTTP response header), or null if the size of the response
 /// body is not known in advance (this is common for HTTP chunked transfer
 /// encoding, which itself is common when a large amount of data is being
 /// returned to the client and the total size of the response may not be known
@@ -56,11 +56,13 @@ Future<Uint8List> consolidateHttpClientResponseBytes(
   final _OutputBuffer output = _OutputBuffer();
   ByteConversionSink sink = output;
   int expectedContentLength = response.contentLength;
+  if (expectedContentLength == -1)
+    expectedContentLength = null;
   if (response.headers?.value(HttpHeaders.contentEncodingHeader) == 'gzip') {
     if (client?.autoUncompress ?? true) {
       // response.contentLength will not match our bytes stream, so we declare
       // that we don't know the expected content length.
-      expectedContentLength = -1;
+      expectedContentLength = null;
     } else if (autoUncompress) {
       // We need to un-compress the bytes as they come in.
       sink = gzip.decoder.startChunkedConversion(output);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -502,8 +502,14 @@ class NetworkImage extends ImageProvider<NetworkImage> {
 
   @override
   ImageStreamCompleter load(NetworkImage key) {
+    // Ownership of this controller is handed off to [_loadAsync]; it is that
+    // method's responsibility to close the controller's stream when the image
+    // has been loaded or an error is thrown.
+    final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
+
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key),
+      codec: _loadAsync(key, chunkEvents),
+      chunkEvents: chunkEvents.stream,
       scale: key.scale,
       informationCollector: () sync* {
         yield DiagnosticsProperty<ImageProvider>('Image provider', this);
@@ -513,7 +519,7 @@ class NetworkImage extends ImageProvider<NetworkImage> {
   }
 
   // Do not access this field directly; use [_httpClient] instead.
-  static final HttpClient _sharedHttpClient = HttpClient();
+  static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
 
   static HttpClient get _httpClient {
     HttpClient client = _sharedHttpClient;
@@ -525,23 +531,36 @@ class NetworkImage extends ImageProvider<NetworkImage> {
     return client;
   }
 
-  Future<ui.Codec> _loadAsync(NetworkImage key) async {
-    assert(key == this);
+  Future<ui.Codec> _loadAsync(
+    NetworkImage key,
+    StreamController<ImageChunkEvent> chunkEvents,
+  ) async {
+    try {
+      assert(key == this);
 
-    final Uri resolved = Uri.base.resolve(key.url);
-    final HttpClientRequest request = await _httpClient.getUrl(resolved);
-    headers?.forEach((String name, String value) {
-      request.headers.add(name, value);
-    });
-    final HttpClientResponse response = await request.close();
-    if (response.statusCode != HttpStatus.ok)
-      throw Exception('HTTP request failed, statusCode: ${response?.statusCode}, $resolved');
+      final Uri resolved = Uri.base.resolve(key.url);
+      final HttpClientRequest request = await _httpClient.getUrl(resolved);
+      headers?.forEach((String name, String value) {
+        request.headers.add(name, value);
+      });
+      final HttpClientResponse response = await request.close();
+      if (response.statusCode != HttpStatus.ok)
+        throw Exception('HTTP request failed, statusCode: ${response?.statusCode}, $resolved');
 
-    final Uint8List bytes = await consolidateHttpClientResponseBytes(response);
-    if (bytes.lengthInBytes == 0)
-      throw Exception('NetworkImage is an empty file: $resolved');
+      final Uint8List bytes = await consolidateHttpClientResponseBytes(
+        response,
+        client: _httpClient,
+        onBytesReceived: (int cumulative, int total) {
+          chunkEvents.add(ImageChunkEvent(cumulative, total));
+        },
+      );
+      if (bytes.lengthInBytes == 0)
+        throw Exception('NetworkImage is an empty file: $resolved');
 
-    return PaintingBinding.instance.instantiateImageCodec(bytes);
+      return PaintingBinding.instance.instantiateImageCodec(bytes);
+    } finally {
+      chunkEvents.close();
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -556,7 +556,7 @@ class NetworkImage extends ImageProvider<NetworkImage> {
         onBytesReceived: (int cumulative, int total) {
           chunkEvents.add(ImageChunkEvent(
             cumulativeBytesLoaded: cumulative,
-            expectedTotalBytes: total == -1 ? null : total,
+            expectedTotalBytes: total,
           ));
         },
       );

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -554,7 +554,10 @@ class NetworkImage extends ImageProvider<NetworkImage> {
         response,
         client: _httpClient,
         onBytesReceived: (int cumulative, int total) {
-          chunkEvents.add(ImageChunkEvent(cumulative, total));
+          chunkEvents.add(ImageChunkEvent(
+            cumulativeBytesLoaded: cumulative,
+            expectedTotalBytes: total == -1 ? null : total,
+          ));
         },
       );
       if (bytes.lengthInBytes == 0)

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -519,6 +519,9 @@ class NetworkImage extends ImageProvider<NetworkImage> {
   }
 
   // Do not access this field directly; use [_httpClient] instead.
+  // We set `autoUncompress` to false to ensure that we can trust the value of
+  // the `Content-Length` HTTP header. We automatically uncompress the content
+  // in our call to [consolidateHttpClientResponseBytes].
   static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
 
   static HttpClient get _httpClient {

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -73,6 +73,7 @@ class ImageStreamListener {
   /// The [onImage] parameter must not be null.
   const ImageStreamListener(
     this.onImage, {
+    this.onChunk,
     this.onError,
   }) : assert(onImage != null);
 
@@ -91,6 +92,19 @@ class ImageStreamListener {
   ///  * [onError], which will be called instead of [onImage] if an error occurs
   ///    during loading.
   final ImageListener onImage;
+
+  /// Callback for getting notified when a chunk of bytes has been received
+  /// during the loading of the image.
+  ///
+  /// This callback may fire many times (e.g. when used with a [NetworkImage],
+  /// where the image bytes are loaded incrementally over the wire) or not at
+  /// all (e.g. when used with a [MemoryImage], where the image bytes are
+  /// already available in memory).
+  ///
+  /// This callback may also continue to fire after the [onImage] callback has
+  /// fired (e.g. for multi-frame images that continue to load after the first
+  /// frame is available).
+  final ImageChunkListener onChunk;
 
   /// Callback for getting notified when an error occurs while loading an image.
   ///
@@ -123,11 +137,60 @@ class ImageStreamListener {
 /// same stack frame as the call to [ImageStream.addListener]).
 typedef ImageListener = void Function(ImageInfo image, bool synchronousCall);
 
+/// Signature for listening to [ImageChunkEvent] events.
+///
+/// Used in [ImageStreamListener].
+typedef ImageChunkListener = void Function(ImageChunkEvent event);
+
 /// Signature for reporting errors when resolving images.
 ///
 /// Used in [ImageStreamListener], as well as by [ImageCache.putIfAbsent] and
 /// [precacheImage], to report errors.
 typedef ImageErrorListener = void Function(dynamic exception, StackTrace stackTrace);
+
+/// An immutable notification of image bytes that have been incrementally loaded.
+///
+/// Chunk events represent progress notifications while an image is being
+/// loaded (e.g. from disk or over the network).
+///
+/// See also:
+///
+///  * [ImageChunkListener], the means by which callers get notified of
+///    these events.
+///  * [Image.imageLoadingBuilder], which allows callers to visually represent
+///    the loading progress of an image at the widget layer.
+@immutable
+class ImageChunkEvent extends Diagnosticable {
+  /// Creates a new chunk event.
+  const ImageChunkEvent(this.cumulativeBytesLoaded, this.expectedTotalBytes)
+      : assert(cumulativeBytesLoaded >= 0),
+        assert(expectedTotalBytes >= -1);
+
+  /// The number of bytes that have been received across the wire thus far.
+  final int cumulativeBytesLoaded;
+
+  /// The expected number of bytes that need to be received to finish loading
+  /// the image.
+  ///
+  /// This value is not necessarily equal to the expected _size_ of the image
+  /// in bytes, as the bytes required to load the image may be compressed.
+  ///
+  /// This value will be -1 if the number is not known in advance. In this way,
+  /// this value matches the semantics of the `Content-Length` HTTP response
+  /// header.
+  ///
+  /// When this value is -1, the chunk event may still be useful as an
+  /// indication that data is loading (and how much), but it cannot represent a
+  /// loading completion percentage.
+  final int expectedTotalBytes;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IntProperty('cumulativeBytesLoaded', cumulativeBytesLoaded));
+    properties.add(IntProperty('expectedTotalBytes', expectedTotalBytes));
+  }
+}
 
 /// A handle to an image resource.
 ///
@@ -504,13 +567,20 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   ///
   /// Immediately starts decoding the first image frame when the codec is ready.
   ///
-  /// [codec] is a future for an initialized [ui.Codec] that will be used to
+  /// `codec` is a future for an initialized [ui.Codec] that will be used to
   /// decode the image.
-  /// [scale] is the linear scale factor for drawing this frames of this image
+  ///
+  /// `scale` is the linear scale factor for drawing this frames of this image
   /// at their intended size.
+  ///
+  /// The `chunkEvents` parameter is an optional stream of notifications about
+  /// the loading progress of the image. If this stream is provided, the events
+  /// produced by the stream will be delivered to registered [ImageChunkListener]s
+  /// (see [addListener]).
   MultiFrameImageStreamCompleter({
     @required Future<ui.Codec> codec,
     @required double scale,
+    Stream<ImageChunkEvent> chunkEvents,
     InformationCollector informationCollector,
   }) : assert(codec != null),
        _informationCollector = informationCollector,
@@ -524,6 +594,29 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
         silent: true,
       );
     });
+    if (chunkEvents != null) {
+      chunkEvents.listen(
+        (ImageChunkEvent event) {
+          if (hasListeners) {
+            final List<ImageChunkListener> localListeners = _listeners
+                .map<ImageChunkListener>((ImageStreamListener listener) => listener.onChunk)
+                .where((ImageChunkListener chunkListener) => chunkListener != null)
+                .toList();
+            for (ImageChunkListener listener in localListeners) {
+              listener(event);
+            }
+          }
+        }, onError: (dynamic error, StackTrace stack) {
+          reportError(
+            context: ErrorDescription('loading an image'),
+            exception: error,
+            stack: stack,
+            informationCollector: informationCollector,
+            silent: true,
+          );
+        },
+      );
+    }
   }
 
   ui.Codec _codec;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -160,9 +160,12 @@ typedef ImageErrorListener = void Function(dynamic exception, StackTrace stackTr
 @immutable
 class ImageChunkEvent extends Diagnosticable {
   /// Creates a new chunk event.
-  const ImageChunkEvent(this.cumulativeBytesLoaded, this.expectedTotalBytes)
+  const ImageChunkEvent({
+    @required this.cumulativeBytesLoaded,
+    @required this.expectedTotalBytes,
+  })
       : assert(cumulativeBytesLoaded >= 0),
-        assert(expectedTotalBytes >= -1);
+        assert(expectedTotalBytes == null || expectedTotalBytes >= 0);
 
   /// The number of bytes that have been received across the wire thus far.
   final int cumulativeBytesLoaded;
@@ -173,11 +176,9 @@ class ImageChunkEvent extends Diagnosticable {
   /// This value is not necessarily equal to the expected _size_ of the image
   /// in bytes, as the bytes required to load the image may be compressed.
   ///
-  /// This value will be -1 if the number is not known in advance. In this way,
-  /// this value matches the semantics of the `Content-Length` HTTP response
-  /// header.
+  /// This value will be null if the number is not known in advance.
   ///
-  /// When this value is -1, the chunk event may still be useful as an
+  /// When this value is null, the chunk event may still be useful as an
   /// indication that data is loading (and how much), but it cannot represent a
   /// loading completion percentage.
   final int expectedTotalBytes;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -398,6 +398,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
     _currentImage = image;
     if (_listeners.isEmpty)
       return;
+    // Make a copy to allow for concurrent modification.
     final List<ImageStreamListener> localListeners =
         List<ImageStreamListener>.from(_listeners);
     for (ImageStreamListener listener in localListeners) {
@@ -458,6 +459,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
       silent: silent,
     );
 
+    // Make a copy to allow for concurrent modification.
     final List<ImageErrorListener> localErrorListeners = _listeners
         .map<ImageErrorListener>((ImageStreamListener listener) => listener.onError)
         .where((ImageErrorListener errorListener) => errorListener != null)
@@ -565,11 +567,11 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   ///
   /// Immediately starts decoding the first image frame when the codec is ready.
   ///
-  /// `codec` is a future for an initialized [ui.Codec] that will be used to
-  /// decode the image.
+  /// The `codec` parameter is a future for an initialized [ui.Codec] that will
+  /// be used to decode the image.
   ///
-  /// `scale` is the linear scale factor for drawing this frames of this image
-  /// at their intended size.
+  /// The `scale` parameter is the linear scale factor for drawing this frames
+  /// of this image at their intended size.
   ///
   /// The `chunkEvents` parameter is an optional stream of notifications about
   /// the loading progress of the image. If this stream is provided, the events
@@ -596,6 +598,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       chunkEvents.listen(
         (ImageChunkEvent event) {
           if (hasListeners) {
+            // Make a copy to allow for concurrent modification.
             final List<ImageChunkListener> localListeners = _listeners
                 .map<ImageChunkListener>((ImageStreamListener listener) => listener.onChunk)
                 .where((ImageChunkListener chunkListener) => chunkListener != null)

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -157,8 +157,6 @@ typedef ImageErrorListener = void Function(dynamic exception, StackTrace stackTr
 ///
 ///  * [ImageChunkListener], the means by which callers get notified of
 ///    these events.
-///  * [Image.imageLoadingBuilder], which allows callers to visually represent
-///    the loading progress of an image at the widget layer.
 @immutable
 class ImageChunkEvent extends Diagnosticable {
   /// Creates a new chunk event.

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -163,9 +163,8 @@ class ImageChunkEvent extends Diagnosticable {
   const ImageChunkEvent({
     @required this.cumulativeBytesLoaded,
     @required this.expectedTotalBytes,
-  })
-      : assert(cumulativeBytesLoaded >= 0),
-        assert(expectedTotalBytes == null || expectedTotalBytes >= 0);
+  }) : assert(cumulativeBytesLoaded >= 0),
+       assert(expectedTotalBytes == null || expectedTotalBytes >= 0);
 
   /// The number of bytes that have been received across the wire thus far.
   final int cumulativeBytesLoaded;

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -207,9 +207,9 @@ void main() {
 
         expect(records, <int>[
           gzippedChunkOne.length,
-          -1,
+          null,
           gzipped.length,
-          -1,
+          null,
         ]);
       });
     });

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -127,6 +127,85 @@ void main() {
     expect(mockCodec.numFramesAsked, 1);
   });
 
+  testWidgets('Chunk events are delivered', (WidgetTester tester) async {
+    final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
+    final Completer<Codec> completer = Completer<Codec>();
+    final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
+    final ImageStreamCompleter imageStream = MultiFrameImageStreamCompleter(
+      codec: completer.future,
+      chunkEvents: streamController.stream,
+      scale: 1.0,
+    );
+
+    imageStream.addListener(ImageStreamListener(
+      (ImageInfo image, bool synchronousCall) { },
+      onChunk: (ImageChunkEvent event) {
+        chunkEvents.add(event);
+      },
+    ));
+    streamController.add(const ImageChunkEvent(1, 3));
+    streamController.add(const ImageChunkEvent(2, 3));
+    await tester.idle();
+
+    expect(chunkEvents.length, 2);
+    expect(chunkEvents[0].cumulativeBytesLoaded, 1);
+    expect(chunkEvents[0].expectedTotalBytes, 3);
+    expect(chunkEvents[1].cumulativeBytesLoaded, 2);
+    expect(chunkEvents[1].expectedTotalBytes, 3);
+  });
+
+  testWidgets('Chunk events are not buffered before listener registration', (WidgetTester tester) async {
+    final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
+    final Completer<Codec> completer = Completer<Codec>();
+    final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
+    final ImageStreamCompleter imageStream = MultiFrameImageStreamCompleter(
+      codec: completer.future,
+      chunkEvents: streamController.stream,
+      scale: 1.0,
+    );
+
+    streamController.add(const ImageChunkEvent(1, 3));
+    await tester.idle();
+    imageStream.addListener(ImageStreamListener(
+      (ImageInfo image, bool synchronousCall) { },
+      onChunk: (ImageChunkEvent event) {
+        chunkEvents.add(event);
+      },
+    ));
+    streamController.add(const ImageChunkEvent(2, 3));
+    await tester.idle();
+
+    expect(chunkEvents.length, 1);
+    expect(chunkEvents[0].cumulativeBytesLoaded, 2);
+    expect(chunkEvents[0].expectedTotalBytes, 3);
+  });
+
+  testWidgets('Chunk errors are reported', (WidgetTester tester) async {
+    final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
+    final Completer<Codec> completer = Completer<Codec>();
+    final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
+    final ImageStreamCompleter imageStream = MultiFrameImageStreamCompleter(
+      codec: completer.future,
+      chunkEvents: streamController.stream,
+      scale: 1.0,
+    );
+
+    imageStream.addListener(ImageStreamListener(
+      (ImageInfo image, bool synchronousCall) { },
+      onChunk: (ImageChunkEvent event) {
+        chunkEvents.add(event);
+      },
+    ));
+    streamController.addError(Error());
+    streamController.add(const ImageChunkEvent(2, 3));
+    await tester.idle();
+
+    expect(tester.takeException(), isNotNull);
+    expect(chunkEvents.length, 1);
+    expect(chunkEvents[0].cumulativeBytesLoaded, 2);
+    expect(chunkEvents[0].expectedTotalBytes, 3);
+  });
+
   testWidgets('getNextFrame future fails', (WidgetTester tester) async {
     final MockCodec mockCodec = MockCodec();
     mockCodec.frameCount = 1;

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -143,8 +143,8 @@ void main() {
         chunkEvents.add(event);
       },
     ));
-    streamController.add(const ImageChunkEvent(1, 3));
-    streamController.add(const ImageChunkEvent(2, 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 2, expectedTotalBytes: 3));
     await tester.idle();
 
     expect(chunkEvents.length, 2);
@@ -164,7 +164,7 @@ void main() {
       scale: 1.0,
     );
 
-    streamController.add(const ImageChunkEvent(1, 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 3));
     await tester.idle();
     imageStream.addListener(ImageStreamListener(
       (ImageInfo image, bool synchronousCall) { },
@@ -172,7 +172,7 @@ void main() {
         chunkEvents.add(event);
       },
     ));
-    streamController.add(const ImageChunkEvent(2, 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 2, expectedTotalBytes: 3));
     await tester.idle();
 
     expect(chunkEvents.length, 1);
@@ -197,7 +197,7 @@ void main() {
       },
     ));
     streamController.addError(Error());
-    streamController.add(const ImageChunkEvent(2, 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 2, expectedTotalBytes: 3));
     await tester.idle();
 
     expect(tester.takeException(), isNotNull);


### PR DESCRIPTION
## Description

This is another step towards supporting image loading
progress notification at the widgets layer.

This adds an `ImageChunkEvent` class along with associated
`ImageChunkListener` callback signature and an `onChunk`
property to `ImageStreamListener`. The events serve to
notify registered listeners when byte chunks are received
while loading an image.

## Related Issues

https://github.com/flutter/flutter/issues/32374

## Tests

I added the following tests:

* Verification that an ImageProvider notifies listeners of chunk events
* Verification that `MultiFrameImageStreamCompleter` delivers chunk events to listeners
* Verification that `MultiFrameImageStreamCompleter` drops chunk events on the floor before listeners are registered (intended behavior).
* Verification that errors reported on the chunk stream that's passed to `MultiFrameImageStreamCompleter` are properly reported.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
