### PR TITLE
A minor bug fix and comment cleanups for focus

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -659,7 +659,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   @mustCallSuper
   FocusAttachment attach(BuildContext context, {FocusOnKeyCallback onKey}) {
     _context = context;
-    _onKey = onKey;
+    _onKey = onKey ?? _onKey;
     _attachment = FocusAttachment._(this);
     return _attachment;
   }

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -723,7 +723,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
   bool previous(FocusNode currentNode) => _move(currentNode, forward: false);
 }
 
-/// A widget that describes an inherited focus policy for focus traversal.
+/// A widget that describes the inherited focus policy for focus traversal.
 ///
 /// By default, traverses in widget order using
 /// [ReadingOrderFocusTraversalPolicy].
@@ -738,7 +738,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
 ///   * [DirectionalFocusTraversalPolicyMixin] a mixin class that implements
 ///     focus traversal in a direction.
 class DefaultFocusTraversal extends InheritedWidget {
-  /// Creates a FocusTraversal object.
+  /// Creates a [DefaultFocusTraversal] object.
   ///
   /// The [child] argument must not be null.
   const DefaultFocusTraversal({
@@ -763,7 +763,7 @@ class DefaultFocusTraversal extends InheritedWidget {
   ///    bottom.
   final FocusTraversalPolicy policy;
 
-  /// Returns the [DefaultFocusTraversal] that most tightly encloses the given
+  /// Returns the [FocusTraversalPolicy] that most tightly encloses the given
   /// [BuildContext].
   ///
   /// The [context] argument must not be null.

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -441,10 +441,10 @@ void main() {
       final FocusAttachment scope1Attachment = scope1.attach(context, onKey: handleEvent);
       final FocusScopeNode scope2 = FocusScopeNode(debugLabel: 'Scope 2');
       final FocusAttachment scope2Attachment = scope2.attach(context, onKey: handleEvent);
-      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1');
-      final FocusAttachment parent1Attachment = parent1.attach(context, onKey: handleEvent);
-      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2');
-      final FocusAttachment parent2Attachment = parent2.attach(context, onKey: handleEvent);
+      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1', onKey: handleEvent);
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2', onKey: handleEvent);
+      final FocusAttachment parent2Attachment = parent2.attach(context);
       final FocusNode child1 = FocusNode(debugLabel: 'Child 1');
       final FocusAttachment child1Attachment = child1.attach(context, onKey: handleEvent);
       final FocusNode child2 = FocusNode(debugLabel: 'Child 2');


### PR DESCRIPTION
## Description

This just fixes up some comments for `DefaultFocusTraversal`, and fixes a minor bug when setting the `onKey` on a `FocusNode` on creation before attaching to it.

## Tests

I modified an existing test to also make sure that `onKey` set on the constructor is not overwritten with null if an `onKey` is not provided to `attach`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
