### PR TITLE
[flutter_tool] Don't look for Fuchsia artifacts on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -111,6 +111,10 @@ class FuchsiaArtifacts {
   /// FUCHSIA_SSH_CONFIG) to find the ssh configuration needed to talk to
   /// a device.
   factory FuchsiaArtifacts.find() {
+    if (!platform.isLinux && !platform.isMacOS) {
+      // Don't try to find the artifacts on platforms that are not supported.
+      return FuchsiaArtifacts();
+    }
     final String fuchsia = Cache.instance.getArtifactDirectory('fuchsia').path;
     final String tools = fs.path.join(fuchsia, 'tools');
     final String dartPrebuilts = fs.path.join(tools, 'dart_prebuilts');


### PR DESCRIPTION
## Description

Instead of checking for Fuchsia artifact file existence on an unsupported platform, just give null.

## Tests

No change in behavior.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
