### PR TITLE
ExpandIcon Custom Colors

### DIFF
--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -252,8 +252,9 @@ class Colors {
 
   /// Black with 38% opacity.
   ///
-  /// Used for disabled icons and the placeholder text in data tables in light
-  /// themes.
+  /// For light themes, i.e. when the Theme's [ThemeData.brightness] is
+  /// [Brightness.light], this color is used for disabled icons and for
+  /// placeholder text in [DataTable].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
@@ -302,7 +303,7 @@ class Colors {
   ///  * [Typography.white], which uses this color for its text styles.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white70, white54, white50, white30, white12, white10], which are variants on this color
+  ///  * [white70, white60, white54, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
   ///  * [black], a solid black color.
   ///  * [transparent], a fully-transparent color.
@@ -319,26 +320,14 @@ class Colors {
   ///  * [Typography.white], which uses this color for its text styles.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white54, white50, white30, white12, white10], which are variants on this color
+  ///  * [white, white60, white54, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white70 = Color(0xB3FFFFFF);
 
-  /// White with 54% opacity.
+  /// White with 60% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
-  ///
-  /// See also:
-  ///
-  ///  * [ExpandIcon], which uses this color for dark themes.
-  ///  * [Theme.of], which allows you to select colors from the current theme
-  ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white50, white30, white12, white10], which are variants on this color
-  ///    but with different opacities.
-  static const Color white54 = Color(0x8AFFFFFF);
-
-  /// White with 50% opacity.
-  ///
-  /// Used for disabled icons in dark themes.
+  /// Used for medium-emphasis text and hint text when [Theme.brightness] is
+  /// set to [Brightness.dark].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
@@ -349,7 +338,19 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [white, white54, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
-  static const Color white50 = Color(0x7DFFFFFF);
+  static const Color white60 = Color(0x99FFFFFF);
+
+  /// White with 54% opacity.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
+  ///
+  /// See also:
+  ///
+  ///  * [Theme.of], which allows you to select colors from the current theme
+  ///    rather than hard-coding colors in your build methods.
+  ///  * [white, white60, white30, white12, white10], which are variants on this color
+  ///    but with different opacities.
+  static const Color white54 = Color(0x8AFFFFFF);
 
   /// White with 30% opacity.
   ///
@@ -362,7 +363,7 @@ class Colors {
   ///  * [ThemeData.disabledColor], which uses this color by default in dark themes.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white54, white50, white70, white12, white10], which are variants on this color
+  ///  * [white, white60, white54, white70, white12, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white30 = Color(0x4DFFFFFF);
 
@@ -374,7 +375,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white54, white50, white70, white30, white10], which are variants on this color
+  ///  * [white, white60, white54, white70, white30, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white24 = Color(0x3DFFFFFF);
 
@@ -386,7 +387,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white54, white50, white70, white30, white10], which are variants on this color
+  ///  * [white, white60, white54, white70, white30, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white12 = Color(0x1FFFFFFF);
 
@@ -396,7 +397,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white54, white50, white70, white30, white12], which are variants on this color
+  ///  * [white, white60, white54, white70, white30, white12], which are variants on this color
   ///    but with different opacities.
   ///  * [transparent], a fully-transparent color, not far from this one.
   static const Color white10 = Color(0x1AFFFFFF);

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -242,8 +242,6 @@ class Colors {
 
   /// Black with 45% opacity.
   ///
-  /// Used for disabled icons.
-  ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
@@ -254,7 +252,8 @@ class Colors {
 
   /// Black with 38% opacity.
   ///
-  /// Used for the placeholder text in data tables in light themes.
+  /// Used for disabled icons and the placeholder text in data tables in light
+  /// themes.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
@@ -303,7 +302,7 @@ class Colors {
   ///  * [Typography.white], which uses this color for its text styles.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white70, white30, white12, white10], which are variants on this color
+  ///  * [white70, white54, white50, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
   ///  * [black], a solid black color.
   ///  * [transparent], a fully-transparent color.
@@ -320,7 +319,7 @@ class Colors {
   ///  * [Typography.white], which uses this color for its text styles.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white30, white12, white10], which are variants on this color
+  ///  * [white, white54, white50, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white70 = Color(0xB3FFFFFF);
 
@@ -333,11 +332,26 @@ class Colors {
   ///  * [ExpandIcon], which uses this color for dark themes.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white30, white12, white10], which are variants on this color
+  ///  * [white, white50, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white54 = Color(0x8AFFFFFF);
 
-  /// White with 32% opacity.
+  /// White with 54% opacity.
+  ///
+  /// Used for disabled icons in dark themes.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
+  ///
+  /// See also:
+  ///
+  ///  * [ExpandIcon], which uses this color for dark themes.
+  ///  * [Theme.of], which allows you to select colors from the current theme
+  ///    rather than hard-coding colors in your build methods.
+  ///  * [white, white54, white30, white12, white10], which are variants on this color
+  ///    but with different opacities.
+  static const Color white50 = Color(0x7DFFFFFF);
+
+  /// White with 30% opacity.
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in dark themes.
   ///
@@ -348,7 +362,7 @@ class Colors {
   ///  * [ThemeData.disabledColor], which uses this color by default in dark themes.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  ///  * [white, white70, white12, white10], which are variants on this color
+  ///  * [white, white54, white50, white70, white12, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white30 = Color(0x4DFFFFFF);
 
@@ -360,7 +374,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white70, white30, white10], which are variants on this color
+  ///  * [white, white54, white50, white70, white30, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white24 = Color(0x3DFFFFFF);
 
@@ -372,7 +386,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white70, white30, white10], which are variants on this color
+  ///  * [white, white54, white50, white70, white30, white10], which are variants on this color
   ///    but with different opacities.
   static const Color white12 = Color(0x1FFFFFFF);
 
@@ -382,7 +396,7 @@ class Colors {
   ///
   /// See also:
   ///
-  ///  * [white, white70, white30, white12], which are variants on this color
+  ///  * [white, white54, white50, white70, white30, white12], which are variants on this color
   ///    but with different opacities.
   ///  * [transparent], a fully-transparent color, not far from this one.
   static const Color white10 = Color(0x1AFFFFFF);

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -336,7 +336,7 @@ class Colors {
   ///    but with different opacities.
   static const Color white54 = Color(0x8AFFFFFF);
 
-  /// White with 54% opacity.
+  /// White with 50% opacity.
   ///
   /// Used for disabled icons in dark themes.
   ///

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -65,9 +65,9 @@ class ExpandIcon extends StatefulWidget {
 
   /// The color of the icon.
   ///
-  /// Defaults to [Colors.black87] when the theme's
+  /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white] when it is [Brightness.dark]
+  /// [Colors.white70] when it is [Brightness.dark]
   final Color color;
 
   /// The color of the icon when it is disabled,
@@ -80,7 +80,7 @@ class ExpandIcon extends StatefulWidget {
 
   /// The color of the icon when the icon is expanded.
   ///
-  /// Defaults to [Colors.black87] when the theme's
+  /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
   /// [Colors.white] when it is [Brightness.dark]
   final Color expandedColor;
@@ -141,25 +141,9 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
 
     switch(Theme.of(context).brightness) {
       case Brightness.light:
-        return Colors.black87;
+        return Colors.black54;
       case Brightness.dark:
-        return Colors.white;
-    }
-
-    assert(false);
-    return null;
-  }
-
-  Color get _disabledIconColor {
-    if (widget.disabledColor != null) {
-      return widget.disabledColor;
-    }
-
-    switch(Theme.of(context).brightness) {
-      case Brightness.light:
-        return Colors.black38;
-      case Brightness.dark:
-        return Colors.white50;
+        return Colors.white70;
     }
 
     assert(false);
@@ -178,7 +162,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       child: IconButton(
         padding: widget.padding,
         color: _iconColor,
-        disabledColor: _disabledIconColor,
+        disabledColor: widget.disabledColor,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -65,20 +65,24 @@ class ExpandIcon extends StatefulWidget {
 
   /// The color of the icon.
   ///
-  /// Defaults to [Colors.black54] when the theme's
+  /// Defaults to [Colors.black87] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white54] when it is [Brightness.dark]  final Color color;
+  /// [Colors.white] when it is [Brightness.dark]
   final Color color;
 
   /// The color of the icon when it is disabled,
   /// i.e. if [onPressed] is null.
   ///
-  /// Defaults to [Colors.grey.shade400] when the theme's
+  /// Defaults to [Colors.black38] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white10] when it is [Brightness.dark]
+  /// [Colors.white50] when it is [Brightness.dark]
   final Color disabledColor;
 
-  // add expandedColor
+  /// The color of the icon when the icon is expanded.
+  ///
+  /// Defaults to [Colors.black87] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white] when it is [Brightness.dark]
   final Color expandedColor;
 
   @override
@@ -127,15 +131,29 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   }
 
   Color get _iconColor {
-    if (widget.color != null) {
-      return widget.color;
-    }
-
-    switch(Theme.of(context).brightness) {
-      case Brightness.light:
-        return Colors.black54;
-      case Brightness.dark:
-        return Colors.white54;
+    if (widget.onPressed == null) {
+      if (widget.disabledColor != null) {
+        return widget.disabledColor;
+      }
+      switch(Theme.of(context).brightness) {
+        case Brightness.light:
+          return Colors.black38;
+        case Brightness.dark:
+          return Colors.white50;
+      }
+    } else {
+      if (widget.isExpanded && widget.expandedColor != null) {
+        return widget.expandedColor;
+      }
+      if (!widget.isExpanded && widget.color != null) {
+        return widget.color;
+      }
+      switch(Theme.of(context).brightness) {
+        case Brightness.light:
+          return Colors.black87;
+        case Brightness.dark:
+          return Colors.white;
+      }
     }
 
     assert(false);

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -135,7 +135,9 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   Color get _iconColor {
     if (widget.isExpanded && widget.expandedColor != null) {
       return widget.expandedColor;
-    } else if (!widget.isExpanded && widget.color != null) {
+    }
+
+    if (widget.color != null) {
       return widget.color;
     }
 

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -31,6 +31,9 @@ class ExpandIcon extends StatefulWidget {
     this.size = 24.0,
     @required this.onPressed,
     this.padding = const EdgeInsets.all(8.0),
+    this.color,
+    this.disabledColor,
+    this.expandedColor,
   }) : assert(isExpanded != null),
        assert(size != null),
        assert(padding != null),
@@ -58,6 +61,25 @@ class ExpandIcon extends StatefulWidget {
   ///
   /// This property must not be null. It defaults to 8.0 padding on all sides.
   final EdgeInsetsGeometry padding;
+
+
+  /// The color of the icon.
+  ///
+  /// Defaults to [Colors.black54] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white54] when it is [Brightness.dark]  final Color color;
+  final Color color;
+
+  /// The color of the icon when it is disabled,
+  /// i.e. if [onPressed] is null.
+  ///
+  /// Defaults to [Colors.grey.shade400] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white10] when it is [Brightness.dark]
+  final Color disabledColor;
+
+  // add expandedColor
+  final Color expandedColor;
 
   @override
   _ExpandIconState createState() => _ExpandIconState();
@@ -104,19 +126,34 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       widget.onPressed(widget.isExpanded);
   }
 
+  Color get _iconColor {
+    if (widget.color != null) {
+      return widget.color;
+    }
+
+    switch(Theme.of(context).brightness) {
+      case Brightness.light:
+        return Colors.black54;
+      case Brightness.dark:
+        return Colors.white54;
+    }
+
+    assert(false);
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final ThemeData theme = Theme.of(context);
     final String onTapHint = widget.isExpanded ? localizations.expandedIconTapHint : localizations.collapsedIconTapHint;
 
     return Semantics(
       onTapHint: widget.onPressed == null ? null : onTapHint,
       child: IconButton(
         padding: widget.padding,
-        color: theme.brightness == Brightness.dark ? Colors.white54 : Colors.black54,
+        color: _iconColor,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -133,30 +133,33 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   // Default icon colors and opacities are based on the
   // [Material Design specifications](https://material.io/design/iconography/system-icons.html#color).
   Color get _iconColor {
-    if (widget.onPressed == null) {
-      if (widget.disabledColor != null) {
-        return widget.disabledColor;
-      }
+    if (widget.isExpanded && widget.expandedColor != null) {
+      return widget.expandedColor;
+    } else if (!widget.isExpanded && widget.color != null) {
+      return widget.color;
+    }
 
-      switch(Theme.of(context).brightness) {
-        case Brightness.light:
-          return Colors.black38;
-        case Brightness.dark:
-          return Colors.white50;
-      }
-    } else {
-      if (widget.isExpanded && widget.expandedColor != null) {
-        return widget.expandedColor;
-      } else if (!widget.isExpanded && widget.color != null) {
-        return widget.color;
-      }
+    switch(Theme.of(context).brightness) {
+      case Brightness.light:
+        return Colors.black87;
+      case Brightness.dark:
+        return Colors.white;
+    }
 
-      switch(Theme.of(context).brightness) {
-        case Brightness.light:
-          return Colors.black87;
-        case Brightness.dark:
-          return Colors.white;
-      }
+    assert(false);
+    return null;
+  }
+
+  Color get _disabledIconColor {
+    if (widget.disabledColor != null) {
+      return widget.disabledColor;
+    }
+
+    switch(Theme.of(context).brightness) {
+      case Brightness.light:
+        return Colors.black38;
+      case Brightness.dark:
+        return Colors.white50;
     }
 
     assert(false);
@@ -175,6 +178,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       child: IconButton(
         padding: widget.padding,
         color: _iconColor,
+        disabledColor: _disabledIconColor,
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -22,6 +22,10 @@ import 'theme.dart';
 ///
 /// See [IconButton] for a more general implementation of a pressable button
 /// with an icon.
+///
+/// See also:
+///
+///  * https://material.io/design/iconography/system-icons.html
 class ExpandIcon extends StatefulWidget {
   /// Creates an [ExpandIcon] with the given padding, and a callback that is
   /// triggered when the icon is pressed.
@@ -67,7 +71,8 @@ class ExpandIcon extends StatefulWidget {
   ///
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white70] when it is [Brightness.dark]
+  /// [Colors.white70] when it is [Brightness.dark]. This adheres to the
+  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
   final Color color;
 
   /// The color of the icon when it is disabled,
@@ -75,14 +80,16 @@ class ExpandIcon extends StatefulWidget {
   ///
   /// Defaults to [Colors.black38] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white50] when it is [Brightness.dark]
+  /// [Colors.white50] when it is [Brightness.dark]. This adheres to the
+  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
   final Color disabledColor;
 
   /// The color of the icon when the icon is expanded.
   ///
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white] when it is [Brightness.dark]
+  /// [Colors.white] when it is [Brightness.dark]. This adheres to the
+  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
   final Color expandedColor;
 
   @override

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -71,8 +71,9 @@ class ExpandIcon extends StatefulWidget {
   ///
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white70] when it is [Brightness.dark]. This adheres to the
-  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
+  /// [Colors.white60] when it is [Brightness.dark]. This adheres to the
+  /// Material Design specifications for [icons](https://material.io/design/iconography/system-icons.html#color)
+  /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color color;
 
   /// The color of the icon when it is disabled,
@@ -81,7 +82,8 @@ class ExpandIcon extends StatefulWidget {
   /// Defaults to [Colors.black38] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
   /// [Colors.white50] when it is [Brightness.dark]. This adheres to the
-  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
+  /// Material Design specifications for [icons](https://material.io/design/iconography/system-icons.html#color)
+  /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color disabledColor;
 
   /// The color of the icon when the icon is expanded.
@@ -89,7 +91,8 @@ class ExpandIcon extends StatefulWidget {
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
   /// [Colors.white] when it is [Brightness.dark]. This adheres to the
-  /// [Material Design specifications](https://material.io/design/iconography/system-icons.html#color)
+  /// Material Design specifications for [icons](https://material.io/design/iconography/system-icons.html#color)
+  /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color expandedColor;
 
   @override

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -81,7 +81,7 @@ class ExpandIcon extends StatefulWidget {
   ///
   /// Defaults to [Colors.black38] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
-  /// [Colors.white50] when it is [Brightness.dark]. This adheres to the
+  /// [Colors.white30] when it is [Brightness.dark]. This adheres to the
   /// Material Design specifications for [icons](https://material.io/design/iconography/system-icons.html#color)
   /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color disabledColor;

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -137,8 +137,11 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       widget.onPressed(widget.isExpanded);
   }
 
-  // Default icon colors and opacities are based on the
-  // [Material Design specifications](https://material.io/design/iconography/system-icons.html#color).
+  /// Default icon colors and opacities for when [Theme.brightness] is set to
+  /// [Brightness.light] are based on the
+  /// [Material Design system icon specifications](https://material.io/design/iconography/system-icons.html#color).
+  /// Icon colors and opacities for [Brightness.dark] are based on the
+  /// [Material Design dark theme specifications](https://material.io/design/color/dark-theme.html#ui-application)
   Color get _iconColor {
     if (widget.isExpanded && widget.expandedColor != null) {
       return widget.expandedColor;
@@ -152,7 +155,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       case Brightness.light:
         return Colors.black54;
       case Brightness.dark:
-        return Colors.white70;
+        return Colors.white60;
     }
 
     assert(false);

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -130,11 +130,14 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       widget.onPressed(widget.isExpanded);
   }
 
+  // Default icon colors and opacities are based on the
+  // [Material Design specifications](https://material.io/design/iconography/system-icons.html#color).
   Color get _iconColor {
     if (widget.onPressed == null) {
       if (widget.disabledColor != null) {
         return widget.disabledColor;
       }
+
       switch(Theme.of(context).brightness) {
         case Brightness.light:
           return Colors.black38;
@@ -144,10 +147,10 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
     } else {
       if (widget.isExpanded && widget.expandedColor != null) {
         return widget.expandedColor;
-      }
-      if (!widget.isExpanded && widget.color != null) {
+      } else if (!widget.isExpanded && widget.color != null) {
         return widget.color;
       }
+
       switch(Theme.of(context).brightness) {
         case Brightness.light:
           return Colors.black87;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -249,7 +249,7 @@ class ThemeData extends Diagnosticable {
       splashColor: splashColor,
       materialTapTargetSize: materialTapTargetSize,
     );
-    disabledColor ??= isDark ? Colors.white30 : Colors.black38;
+    disabledColor ??= isDark ? Colors.white50 : Colors.black38;
     highlightColor ??= isDark ? _kDarkThemeHighlightColor : _kLightThemeHighlightColor;
     splashColor ??= isDark ? _kDarkThemeSplashColor : _kLightThemeSplashColor;
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -249,7 +249,7 @@ class ThemeData extends Diagnosticable {
       splashColor: splashColor,
       materialTapTargetSize: materialTapTargetSize,
     );
-    disabledColor ??= isDark ? Colors.white50 : Colors.black38;
+    disabledColor ??= isDark ? Colors.white30 : Colors.black38;
     highlightColor ??= isDark ? _kDarkThemeHighlightColor : _kLightThemeHighlightColor;
     splashColor ??= isDark ? _kDarkThemeSplashColor : _kLightThemeSplashColor;
 

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -58,19 +58,19 @@ void main() {
 
     expect(expanded, isFalse);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.white70));
+    expect(iconTheme.data.color, equals(Colors.white60));
 
     await tester.tap(find.byType(ExpandIcon));
     await tester.pumpAndSettle();
     expect(expanded, isTrue);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.white70));
+    expect(iconTheme.data.color, equals(Colors.white60));
 
     await tester.tap(find.byType(ExpandIcon));
     await tester.pumpAndSettle();
     expect(expanded, isFalse);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.white70));
+    expect(iconTheme.data.color, equals(Colors.white60));
   });
 
   testWidgets('ExpandIcon disabled', (WidgetTester tester) async {
@@ -92,7 +92,7 @@ void main() {
     await tester.pumpAndSettle();
 
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.white50));
+    expect(iconTheme.data.color, equals(Colors.white30));
   });
 
   testWidgets('ExpandIcon test isExpanded does not trigger callback', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -5,8 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Widget wrap({ Widget child }) {
+Widget wrap({ Widget child, ThemeData theme }) {
   return MaterialApp(
+    theme: theme,
     home: Center(
       child: Material(child: child),
     ),
@@ -16,6 +17,7 @@ Widget wrap({ Widget child }) {
 void main() {
   testWidgets('ExpandIcon test', (WidgetTester tester) async {
     bool expanded = false;
+    IconTheme iconTheme;
     await tester.pumpWidget(wrap(
       child: ExpandIcon(
         onPressed: (bool isExpanded) {
@@ -25,22 +27,39 @@ void main() {
     ));
 
     expect(expanded, isFalse);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.black87));
+
     await tester.tap(find.byType(ExpandIcon));
-    expect(expanded, isTrue);
     await tester.pumpAndSettle();
+    expect(expanded, isTrue);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.black87));
+
     await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
     expect(expanded, isFalse);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.black87));
   });
 
   testWidgets('ExpandIcon disabled', (WidgetTester tester) async {
+    IconTheme iconTheme;
     await tester.pumpWidget(wrap(
-      child: const ExpandIcon(
-        onPressed: null,
-      ),
+      child: const ExpandIcon(onPressed: null),
     ));
 
-    final IconTheme iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
     expect(iconTheme.data.color, equals(Colors.black38));
+
+    await tester.pumpWidget(wrap(
+      child: const ExpandIcon(onPressed: null),
+      theme: ThemeData(brightness: Brightness.dark),
+    ));
+    await tester.pumpAndSettle();
+
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.white50));
   });
 
   testWidgets('ExpandIcon test isExpanded does not trigger callback', (WidgetTester tester) async {
@@ -116,4 +135,9 @@ void main() {
     ));
     handle.dispose();
   });
+
+  // expandIcon color passed in
+    // enabled
+    // disabled
+    // expanded
 }

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -232,7 +232,7 @@ void main() {
     IconTheme iconTheme;
 
     await tester.pumpWidget(wrap(
-      child: ExpandIcon(
+      child: const ExpandIcon(
         isExpanded: false,
         onPressed: null,
         disabledColor: Colors.cyan,
@@ -243,7 +243,7 @@ void main() {
     expect(iconTheme.data.color, equals(Colors.cyan));
 
     await tester.pumpWidget(wrap(
-      child: ExpandIcon(
+      child: const ExpandIcon(
         isExpanded: false,
         onPressed: null,
         color: Colors.indigo,
@@ -255,14 +255,14 @@ void main() {
     expect(iconTheme.data.color, equals(Colors.cyan));
 
     await tester.pumpWidget(wrap(
-      child: ExpandIcon(
+      child: const ExpandIcon(
         isExpanded: true,
         onPressed: null,
         disabledColor: Colors.cyan,
       ),
     ));
     await tester.pumpWidget(wrap(
-      child: ExpandIcon(
+      child: const ExpandIcon(
         isExpanded: true,
         onPressed: null,
         expandedColor: Colors.teal,

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -229,12 +229,11 @@ void main() {
   });
 
   testWidgets('ExpandIcon uses custom disabled icon color', (WidgetTester tester) async {
-    bool expanded = false;
     IconTheme iconTheme;
 
     await tester.pumpWidget(wrap(
       child: ExpandIcon(
-        isExpanded: true,
+        isExpanded: false,
         onPressed: null,
         disabledColor: Colors.cyan,
       ),
@@ -247,6 +246,26 @@ void main() {
       child: ExpandIcon(
         isExpanded: false,
         onPressed: null,
+        color: Colors.indigo,
+        disabledColor: Colors.cyan,
+      ),
+    ));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.cyan));
+
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: true,
+        onPressed: null,
+        disabledColor: Colors.cyan,
+      ),
+    ));
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: true,
+        onPressed: null,
+        expandedColor: Colors.teal,
         disabledColor: Colors.cyan,
       ),
     ));

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -45,7 +45,7 @@ void main() {
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
     expect(iconTheme.data.color, equals(Colors.black54));
 
-    // Dark Mode tests
+    // Dark mode tests
     await tester.pumpWidget(wrap(
       child: ExpandIcon(
         onPressed: (bool isExpanded) {
@@ -169,8 +169,89 @@ void main() {
     handle.dispose();
   });
 
-  // expandIcon color passed in
-    // enabled
-    // disabled
-    // expanded
+  testWidgets('ExpandIcon uses custom icon color and expanded icon color', (WidgetTester tester) async {
+    bool expanded = false;
+    IconTheme iconTheme;
+
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+        return ExpandIcon(
+          isExpanded: expanded,
+          onPressed: (bool isExpanded) {
+            setState(() {
+              expanded = !isExpanded;
+            });
+          },
+          color: Colors.indigo,
+        );
+      }),
+    ));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.indigo));
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.indigo));
+
+    expanded = false;
+
+    await tester.pumpWidget(wrap(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+        return ExpandIcon(
+          isExpanded: expanded,
+          onPressed: (bool isExpanded) {
+            setState(() {
+              expanded = !isExpanded;
+            });
+          },
+          color: Colors.indigo,
+          expandedColor: Colors.teal,
+        );
+      }),
+    ));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.indigo));
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.teal));
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.indigo));
+  });
+
+  testWidgets('ExpandIcon uses custom disabled icon color', (WidgetTester tester) async {
+    bool expanded = false;
+    IconTheme iconTheme;
+
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: true,
+        onPressed: null,
+        disabledColor: Colors.cyan,
+      ),
+    ));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.cyan));
+
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: false,
+        onPressed: null,
+        disabledColor: Colors.cyan,
+      ),
+    ));
+    await tester.pumpAndSettle();
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.cyan));
+  });
 }

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -27,7 +27,7 @@ void main() {
     expect(expanded, isFalse);
     await tester.tap(find.byType(ExpandIcon));
     expect(expanded, isTrue);
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
     await tester.tap(find.byType(ExpandIcon));
     expect(expanded, isFalse);
   });
@@ -117,4 +117,3 @@ void main() {
     handle.dispose();
   });
 }
-

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -18,6 +18,8 @@ void main() {
   testWidgets('ExpandIcon test', (WidgetTester tester) async {
     bool expanded = false;
     IconTheme iconTheme;
+
+    // Light mode tests
     await tester.pumpWidget(wrap(
       child: ExpandIcon(
         onPressed: (bool isExpanded) {
@@ -25,33 +27,64 @@ void main() {
         }
       ),
     ));
+    await tester.pumpAndSettle();
 
     expect(expanded, isFalse);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.black87));
+    expect(iconTheme.data.color, equals(Colors.black54));
 
     await tester.tap(find.byType(ExpandIcon));
     await tester.pumpAndSettle();
     expect(expanded, isTrue);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.black87));
+    expect(iconTheme.data.color, equals(Colors.black54));
 
     await tester.tap(find.byType(ExpandIcon));
     await tester.pumpAndSettle();
     expect(expanded, isFalse);
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
-    expect(iconTheme.data.color, equals(Colors.black87));
+    expect(iconTheme.data.color, equals(Colors.black54));
+
+    // Dark Mode tests
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        onPressed: (bool isExpanded) {
+          expanded = !expanded;
+        },
+      ),
+      theme: ThemeData(brightness: Brightness.dark),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(expanded, isFalse);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.white70));
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+    expect(expanded, isTrue);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.white70));
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+    expect(expanded, isFalse);
+    iconTheme = tester.firstWidget(find.byType(IconTheme).last);
+    expect(iconTheme.data.color, equals(Colors.white70));
   });
 
   testWidgets('ExpandIcon disabled', (WidgetTester tester) async {
     IconTheme iconTheme;
+    // Light mode test
     await tester.pumpWidget(wrap(
       child: const ExpandIcon(onPressed: null),
     ));
+    await tester.pumpAndSettle();
 
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
     expect(iconTheme.data.color, equals(Colors.black38));
 
+    // Dark mode test
     await tester.pumpWidget(wrap(
       child: const ExpandIcon(onPressed: null),
       theme: ThemeData(brightness: Brightness.dark),

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -5,19 +5,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+Widget wrap({ Widget child }) {
+  return MaterialApp(
+    home: Center(
+      child: Material(child: child),
+    ),
+  );
+}
+
 void main() {
   testWidgets('ExpandIcon test', (WidgetTester tester) async {
     bool expanded = false;
-
-    await tester.pumpWidget(
-      wrap(
-          child: ExpandIcon(
-            onPressed: (bool isExpanded) {
-              expanded = !expanded;
-            }
-          )
-      )
-    );
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        onPressed: (bool isExpanded) {
+          expanded = !expanded;
+        }
+      ),
+    ));
 
     expect(expanded, isFalse);
     await tester.tap(find.byType(ExpandIcon));
@@ -28,13 +33,11 @@ void main() {
   });
 
   testWidgets('ExpandIcon disabled', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      wrap(
-          child: const ExpandIcon(
-            onPressed: null
-          )
-      )
-    );
+    await tester.pumpWidget(wrap(
+      child: const ExpandIcon(
+        onPressed: null,
+      ),
+    ));
 
     final IconTheme iconTheme = tester.firstWidget(find.byType(IconTheme).last);
     expect(iconTheme.data.color, equals(Colors.black38));
@@ -43,27 +46,23 @@ void main() {
   testWidgets('ExpandIcon test isExpanded does not trigger callback', (WidgetTester tester) async {
     bool expanded = false;
 
-    await tester.pumpWidget(
-      wrap(
-          child: ExpandIcon(
-            isExpanded: false,
-            onPressed: (bool isExpanded) {
-              expanded = !expanded;
-            },
-          )
-      )
-    );
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: false,
+        onPressed: (bool isExpanded) {
+          expanded = !expanded;
+        },
+      ),
+    ));
 
-    await tester.pumpWidget(
-      wrap(
-          child: ExpandIcon(
-            isExpanded: true,
-            onPressed: (bool isExpanded) {
-              expanded = !expanded;
-            },
-        )
-      )
-    );
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: true,
+        onPressed: (bool isExpanded) {
+          expanded = !expanded;
+        },
+      ),
+    ));
 
     expect(expanded, isFalse);
   });
@@ -71,16 +70,14 @@ void main() {
   testWidgets('ExpandIcon is rotated initially if isExpanded is true on first build', (WidgetTester tester) async {
     bool expanded = true;
 
-    await tester.pumpWidget(
-        wrap(
-            child: ExpandIcon(
-              isExpanded: expanded,
-              onPressed: (bool isExpanded) {
-                expanded = !isExpanded;
-              },
-            )
-        )
-    );
+    await tester.pumpWidget(wrap(
+      child: ExpandIcon(
+        isExpanded: expanded,
+        onPressed: (bool isExpanded) {
+          expanded = !isExpanded;
+        },
+      ),
+    ));
     final RotationTransition rotation = tester.firstWidget(find.byType(RotationTransition));
     expect(rotation.turns.value, 0.5);
   });
@@ -89,10 +86,10 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
     await tester.pumpWidget(wrap(
-        child: ExpandIcon(
-          isExpanded: true,
-          onPressed: (bool _) { },
-        )
+      child: ExpandIcon(
+        isExpanded: true,
+        onPressed: (bool _) { },
+      ),
     ));
 
     expect(tester.getSemantics(find.byType(ExpandIcon)), matchesSemantics(
@@ -107,7 +104,7 @@ void main() {
       child: ExpandIcon(
         isExpanded: false,
         onPressed: (bool _) { },
-      )
+      ),
     ));
 
     expect(tester.getSemantics(find.byType(ExpandIcon)), matchesSemantics(
@@ -121,10 +118,3 @@ void main() {
   });
 }
 
-Widget wrap({ Widget child }) {
-  return MaterialApp(
-    home: Center(
-      child: Material(child: child),
-    ),
-  );
-}


### PR DESCRIPTION
## Description

- Adds custom icon color, expanded icon color, and disabled icon colors to the ExpandIcon widget. As part of this change, ExpandIcon now uses Colors.white60 instead of Colors.white54 when dark theme is used.
- ~Updates the dark mode [ThemeData.disabledColor](https://api.flutter.dev/flutter/material/ThemeData/disabledColor.html) value to match the [Material Design specification](https://material.io/design/interaction/states.html#disabled).~ See https://github.com/flutter/flutter/issues/33149
- Fixes the Colors.white30's documented opacity value, which was incorrectly stating it was 32% opacity instead of 30%.

This takes over https://github.com/flutter/flutter/pull/31053

## Related Issues

https://github.com/flutter/flutter/issues/18992
https://github.com/flutter/flutter/pull/21328

## Tests

I added the following tests:

- Tests to verify default light/dark mode ExpandIcon's color and its disabled color
- Tests to verify ExpandIcon takes custom icon color, expanded icon color, and disabled icon color

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]) - https://groups.google.com/forum/#!topic/flutter-announce/22w45SnuZXM
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
