### PR TITLE
Slight clarification in the ImageCache docs

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -27,7 +27,7 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// subclasses automatically handle the caching of images.
 ///
 /// A shared instance of this cache is retained by [PaintingBinding] and can be
-/// obtained via the [imageCache] top-level property.
+/// obtained via the [imageCache] top-level property in the [painting] library.
 class ImageCache {
   final Map<Object, _PendingImage> _pendingImages = <Object, _PendingImage>{};
   final Map<Object, _CachedImage> _cache = <Object, _CachedImage>{};

--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -7,7 +7,7 @@ import 'image_stream.dart';
 const int _kDefaultSize = 1000;
 const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 
-/// Class for the [imageCache] object.
+/// Class for caching images.
 ///
 /// Implements a least-recently-used cache of up to 1000 images, and up to 100
 /// MB. The maximum size can be adjusted using [maximumSize] and
@@ -25,6 +25,9 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 ///
 /// Generally this class is not used directly. The [ImageProvider] class and its
 /// subclasses automatically handle the caching of images.
+///
+/// A shared instance of this cache is retained by [PaintingBinding] and can be
+/// obtained via the [imageCache] top-level property.
 class ImageCache {
   final Map<Object, _PendingImage> _pendingImages = <Object, _PendingImage>{};
   final Map<Object, _CachedImage> _cache = <Object, _CachedImage>{};


### PR DESCRIPTION
## Description

It was easy to miss the reference to the top-level `imageCache`
property before.  This calls out the property a little more
explicitly.

## Tests

N/A

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
