### PR TITLE
Build macOS via workspace, rather than project

### DIFF
--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -38,7 +38,7 @@ Future<void> buildMacOS(FlutterProject flutterProject, BuildInfo buildInfo) asyn
     '/usr/bin/env',
     'xcrun',
     'xcodebuild',
-    '-project', flutterProject.macos.xcodeProjectFile.path,
+    '-workspace', flutterProject.macos.xcodeWorkspace.path,
     '-configuration', '$config',
     '-scheme', 'Runner',
     '-derivedDataPath', flutterBuildDir.absolute.path,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -571,6 +571,8 @@ class MacOSProject {
 
   final FlutterProject project;
 
+  static const String _hostAppBundleName = 'Runner';
+
   bool existsSync() => project.directory.childDirectory('macos').existsSync();
 
   Directory get _editableDirectory => project.directory.childDirectory('macos');
@@ -582,7 +584,10 @@ class MacOSProject {
   File get generatedXcodePropertiesFile => _cacheDirectory.childFile('Generated.xcconfig');
 
   /// The Xcode project file.
-  Directory get xcodeProjectFile => _editableDirectory.childDirectory('Runner.xcodeproj');
+  Directory get xcodeProject => _editableDirectory.childDirectory('$_hostAppBundleName.xcodeproj');
+
+  /// The Xcode workspace file.
+  Directory get xcodeWorkspace => _editableDirectory.childDirectory('$_hostAppBundleName.xcworkspace');
 
   /// The file where the Xcode build will write the name of the built app.
   ///

--- a/packages/flutter_tools/test/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands/build_macos_test.dart
@@ -75,7 +75,7 @@ void main() {
       '/usr/bin/env',
       'xcrun',
       'xcodebuild',
-      '-project', flutterProject.macos.xcodeProjectFile.path,
+      '-workspace', flutterProject.macos.xcodeWorkspace.path,
       '-configuration', 'Debug',
       '-scheme', 'Runner',
       '-derivedDataPath', flutterBuildDir.absolute.path,


### PR DESCRIPTION
## Description

This is necesasry to integrate CocoaPods, since CocoaPods operates
primarily on the workspace rather than the project.

## Related Issues

#32718

## Tests

I added the following tests: None. Updated existing build test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

Yes for desktop, since it requires adding an xcworkspace, but desktop build flow is explicitly not stable.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
