### PR TITLE
Fix ImageStreamListener's hashCode & operator==

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -113,7 +113,7 @@ class ImageStreamListener {
   final ImageErrorListener onError;
 
   @override
-  int get hashCode => hashValues(onImage, onError);
+  int get hashCode => hashValues(onImage, onChunk, onError);
 
   @override
   bool operator ==(dynamic other) {
@@ -121,6 +121,7 @@ class ImageStreamListener {
       return false;
     final ImageStreamListener typedOther = other;
     return onImage == typedOther.onImage
+        && onChunk == typedOther.onChunk
         && onError == typedOther.onError;
   }
 }


### PR DESCRIPTION
## Description

I forgot to add `onChunk` to ImageStreamListener's hashCode & operator== in #33092

## Related Issues

https://github.com/flutter/flutter/issues/32374

## Tests

* Verification of equals and hashCode

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
