### PR TITLE
use the --disable-server-feature-completion cli arg to the analysis server

### DIFF
--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -37,6 +37,8 @@ class AnalysisServer {
     final List<String> command = <String>[
       fs.path.join(sdkPath, 'bin', 'dart'),
       snapshot,
+      '--disable-server-feature-completion',
+      '--disable-server-feature-search',
       '--sdk',
       sdkPath,
     ];


### PR DESCRIPTION
- use the --disable-server-feature-completion cli arg to the analysis server
- fix https://github.com/dart-lang/sdk/issues/36881

This uses the new `--disable-server-feature-completion` flag to the analysis server in the implementation of `flutter analyze`. This should re-coup most or all of the above perf regression.

@scheglov 