### PR TITLE
[flutter_tool] Improve Fuchsia 'run' tests

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
@@ -4,6 +4,7 @@
 
 import '../base/common.dart';
 import '../base/process.dart';
+import '../globals.dart';
 import 'fuchsia_sdk.dart';
 
 // Usage: dev_finder <flags> <subcommand> <subcommand args>
@@ -31,7 +32,11 @@ class FuchsiaDevFinder {
       '-full'
     ];
     final RunResult result = await runAsync(command);
-    return (result.exitCode == 0) ? result.stdout.split('\n') : null;
+    if (result.exitCode != 0) {
+      printError('dev_finder failed: ${result.stderr}');
+      return null;
+    }
+    return result.stdout.split('\n');
   }
 
   /// Returns the host address by which the device [deviceName] should use for
@@ -51,6 +56,10 @@ class FuchsiaDevFinder {
       deviceName
     ];
     final RunResult result = await runAsync(command);
-    return (result.exitCode == 0) ? result.stdout.trim() : null;
+    if (result.exitCode != 0) {
+      printError('dev_finder failed: ${result.stderr}');
+      return null;
+    }
+    return result.stdout.trim();
   }
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -50,6 +50,9 @@ class FuchsiaSdk {
       return null;
     }
     final List<String> devices = await fuchsiaDevFinder.list();
+    if (devices == null) {
+      return null;
+    }
     return devices.isNotEmpty ? devices[0] : null;
   }
 


### PR DESCRIPTION
## Description

This PR adds new tests and cleans up some existing tests of the 'run' command for Fuchsia devices.

## Tests

I added the following tests:

Tests in packages/flutter_tools/test/fuchsia/fuchsia_device_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
