### PR TITLE
Add cast to prepare for package:file update

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -46,7 +46,7 @@ abstract class DevFSContent {
   Stream<List<int>> contentsAsStream();
 
   Stream<List<int>> contentsAsCompressedStream() {
-    return contentsAsStream().transform<List<int>>(gzip.encoder);
+    return contentsAsStream().cast<List<int>>().transform<List<int>>(gzip.encoder);
   }
 
   /// Return the list of files this content depends on.


### PR DESCRIPTION
## Description

An update to `package:file` has changed `File.openRead()` to return a `Stream<Uint8List>`.  This is in preparation for a breaking SDK change to the API of `File.openRead()`.  In response, we need to cast this stream to a `Stream<List<int>>` before running it through a stream transformer that requires a `List<int>`.

## Related Issues

https://github.com/dart-lang/sdk/issues/36900

## Tests

N/A - this was already caught by tests in the attempted bump of `package:file`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
