### PR TITLE
Add mustRunAfter on mergeAssets task to force task ordering

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -507,6 +507,7 @@ class FlutterPlugin implements Plugin<Project> {
                 } else {
                     dependsOn variant.mergeAssets
                     dependsOn "clean${variant.mergeAssets.name.capitalize()}"
+                    variant.mergeAssets.mustRunAfter("clean${variant.mergeAssets.name.capitalize()}")
                     into variant.mergeAssets.outputDir
                 }
                 flutterTasks.each { flutterTask -> 


### PR DESCRIPTION
## Description

This PR changes the `flutter.gradle` file to guarantee that the `mergeAssets` task runs after `cleanMergeAssets` task.

The way the task is configured right now doesn't ensure the order of execution and when we execute the `flutter build appbundle` the `cleanMergeAssets` was being executed after `mergeAssets`. This removed all the native assets from the bundle and caused issue #30846.

## Related Issues

Resolves:
- #30846 

## Tests

Since we've just changed the gradle file we didn't add any test to check the behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

Co-authored-by: Miguel Lemos <miguelslemos@gmail.com>