### PR TITLE
[flutter_tool] Use product runner in Fuchsia release build

### DIFF
--- a/packages/flutter_tools/test/commands/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands/build_fuchsia_test.dart
@@ -84,7 +84,8 @@ void main() {
       const String appName = 'app_name';
       fs
           .file(fs.path.join('fuchsia', 'meta', '$appName.cmx'))
-          .createSync(recursive: true);
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{}');
       fs.file('.packages').createSync();
       final File pubspecFile = fs.file('pubspec.yaml')..createSync();
       pubspecFile.writeAsStringSync('name: $appName');
@@ -105,7 +106,8 @@ void main() {
       const String appName = 'app_name';
       fs
           .file(fs.path.join('fuchsia', 'meta', '$appName.cmx'))
-          .createSync(recursive: true);
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{}');
       fs.file('.packages').createSync();
       fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
       final File pubspecFile = fs.file('pubspec.yaml')..createSync();
@@ -127,7 +129,8 @@ void main() {
     const String appName = 'app_name';
     fs
         .file(fs.path.join('fuchsia', 'meta', '$appName.cmx'))
-        .createSync(recursive: true);
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{}');
     fs.file('.packages').createSync();
     fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     final File pubspecFile = fs.file('pubspec.yaml')..createSync();

--- a/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsa_device_test.dart
@@ -434,7 +434,8 @@ void main() {
         app = FuchsiaApp.fromPrebuiltApp(far);
       } else {
         fs.file(fs.path.join('fuchsia', 'meta', '$appName.cmx'))
-          .createSync(recursive: true);
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{}');
         fs.file('.packages').createSync();
         fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
         app = BuildableFuchsiaApp(project: FlutterProject.current().fuchsia);


### PR DESCRIPTION
## Description

Ensures that the cmx file for an app on Fuchsia specifies the flutter runner that matches its build mode.

## Related Issues

#31147

## Tests

Updated build_fuchsia_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
