### PR TITLE
Add macosPrefix to the pubspec schema for plugins

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -371,7 +371,10 @@ void _validateFlutter(YamlMap yaml, List<String> errors) {
           errors.add('The "androidPackage" must either be null or a string.');
         }
         if (kvp.value['iosPrefix'] != null && kvp.value['iosPrefix'] is! String) {
-          errors.add('The "iosPrefix" must eithe rbe null or a string.');
+          errors.add('The "iosPrefix" must either be null or a string.');
+        }
+        if (kvp.value['macosPrefix'] != null && kvp.value['macosPrefix'] is! String) {
+          errors.add('The "macosPrefix" must either be null or a string.');
         }
         if (kvp.value['pluginClass'] != null && kvp.value['pluginClass'] is! String) {
           errors.add('The "pluginClass" must either be null or a string..');

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -27,16 +27,19 @@ class Plugin {
     this.path,
     this.androidPackage,
     this.iosPrefix,
+    this.macosPrefix,
     this.pluginClass,
   });
 
   factory Plugin.fromYaml(String name, String path, dynamic pluginYaml) {
     String androidPackage;
     String iosPrefix;
+    String macosPrefix;
     String pluginClass;
     if (pluginYaml != null) {
       androidPackage = pluginYaml['androidPackage'];
       iosPrefix = pluginYaml['iosPrefix'] ?? '';
+      macosPrefix = pluginYaml['macosPrefix'] ?? '';
       pluginClass = pluginYaml['pluginClass'];
     }
     return Plugin(
@@ -44,6 +47,7 @@ class Plugin {
       path: path,
       androidPackage: androidPackage,
       iosPrefix: iosPrefix,
+      macosPrefix: macosPrefix,
       pluginClass: pluginClass,
     );
   }
@@ -52,6 +56,7 @@ class Plugin {
   final String path;
   final String androidPackage;
   final String iosPrefix;
+  final String macosPrefix;
   final String pluginClass;
 }
 

--- a/packages/flutter_tools/schema/pubspec_yaml.json
+++ b/packages/flutter_tools/schema/pubspec_yaml.json
@@ -58,6 +58,7 @@
                     "properties": {
                         "androidPackage": { "type": "string" },
                         "iosPrefix": { "type": "string" },
+                        "macosPrefix": { "type": "string" },
                         "pluginClass": { "type": "string" }
                     }
                 }


### PR DESCRIPTION
## Description

Adds a new macosPrefix, which serves the same purpose as iosPrefix but
for macOS plugins.

It is not yet used by the tooling, but this allows for plugins to start
to be written using it in preparation for tooling support for plugins.

## Related Issues

Part of #32718

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
