### PR TITLE
Add stateful_widget_animation snippet template

### DIFF
--- a/dev/snippets/config/templates/README.md
+++ b/dev/snippets/config/templates/README.md
@@ -86,3 +86,8 @@ follows:
 - [`stateless_widget_scaffold`](stateless_widget_scaffold.tmpl) : Similar to
   `stateless_widget_material`, except that it wraps the stateless widget with a
   Scaffold.
+
+- [`stateful_widget_animation`](stateful_widget_animation.tmpl) : Similar to
+  `stateful_widget`, except that it declares an `AnimationController` instance
+  variable called `_controller`, and it properly initializes the controller
+  in `initState()` and properly disposes of the controller in `dispose()`.

--- a/dev/snippets/config/templates/stateful_widget_animation.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_animation.tmpl
@@ -1,0 +1,53 @@
+// Flutter code sample for {{id}}
+
+{{description}}
+
+import 'package:flutter/widgets.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This Widget is the main application widget.
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Flutter Code Sample',
+      home: MyStatefulWidget(),
+      color: const Color(0xffffffff),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  {{code}}
+}


### PR DESCRIPTION
## Description

This introduces a new Dartdoc snippet template, similar
to the standard stateful widget template, but with an animation
controller, properly initialized and disposed.

## Related Issues

https://github.com/flutter/flutter/issues/32374

## Tests

N/A

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
