### PR TITLE
Correct typos

### DIFF
--- a/dev/bots/README.md
+++ b/dev/bots/README.md
@@ -21,7 +21,7 @@ the app stores. It is configured by the [.cirrus.yml](/.cirrus.yml).
 We also have post-commit testing with actual devices, in what we call our
 [devicelab](../devicelab/README.md).
 
-## LUCI (Layered Universal Continuous Intergration)
+## LUCI (Layered Universal Continuous Integration)
 
 A [set of recipes](https://chromium.googlesource.com/chromium/tools/build.git/+/master/scripts/slave/recipes/flutter)
 are run on Windows, Linux, and Mac machines. The configuration for how many

--- a/dev/bots/flutter_compact_formatter.dart
+++ b/dev/bots/flutter_compact_formatter.dart
@@ -11,7 +11,7 @@ final Stopwatch _stopwatch = Stopwatch();
 
 /// A wrapper around package:test's JSON reporter.
 ///
-/// This class behaves similarly to the compact reporter, but supresses all
+/// This class behaves similarly to the compact reporter, but suppresses all
 /// output except for progress until the end of testing. In other words, errors,
 /// [print] calls, and skipped test messages will not be printed during the run
 /// of the suite.

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -1,4 +1,4 @@
-# Flutter (https://flutter.dev) Developement Environment for Linux
+# Flutter (https://flutter.dev) Development Environment for Linux
 # ===============================================================
 #
 # This environment passes all Linux Flutter Doctor checks and is sufficient

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -94,7 +94,7 @@ Future<int> runTest({bool coverage = false}) async {
   if (result != 0)
     throw Exception('flutter test failed with exit code $result');
   if (badLines > 0)
-    throw Exception('flutter test renderered unexpected output ($badLines bad lines)');
+    throw Exception('flutter test rendered unexpected output ($badLines bad lines)');
   if (step != TestStep.testPassed)
     throw Exception('flutter test did not finish (only reached step $step)');
   print('elapsed time: ${clock.elapsedMilliseconds}ms');

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -102,7 +102,7 @@ Future<Map<String, double>> _readJsonResults(Process process) {
       final String jsonOutput = jsonBuf.toString();
 
       // If we end up here and have already parsed the results, it suggests that
-      // we have recieved output from another test because our `flutter run`
+      // we have received output from another test because our `flutter run`
       // process did not terminate correctly.
       // https://github.com/flutter/flutter/issues/19096#issuecomment-402756549
       if (resultsHaveBeenParsed) {

--- a/dev/snippets/config/templates/README.md
+++ b/dev/snippets/config/templates/README.md
@@ -69,7 +69,7 @@ follows:
   Identical to the `stateful_widget` template, except that the default code
   block is inserted as the `build` function in a
   StatelessWidget. There is no need to include the @override before the build
-  funciton (the template adds this for you).
+  function (the template adds this for you).
 
 - [`stateful_widget_material`](stateful_widget_material.tmpl) : Similar to
   `stateful_widget`, except that it imports the material library, and uses

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -23,7 +23,7 @@ class LocaleInfo implements Comparable<LocaleInfo> {
   });
 
   /// Simple parser. Expects the locale string to be in the form of 'language_script_COUNTRY'
-  /// where the langauge is 2 characters, script is 4 characters with the first uppercase,
+  /// where the language is 2 characters, script is 4 characters with the first uppercase,
   /// and country is 2-3 characters and all uppercase.
   ///
   /// 'language_COUNTRY' or 'language_script' are also valid. Missing fields will be null.

--- a/examples/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
+++ b/examples/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
@@ -433,7 +433,7 @@ class _GestureTransformableState extends State<GestureTransformable> with Ticker
     if (gestureType == null) {
       // Decide which type of gesture this is by comparing the amount of scale
       // and rotation in the gesture, if any. Scale starts at 1 and rotation
-      // starts at 0. Translate will have 0 scale and 0 rotation becuase it uses
+      // starts at 0. Translate will have 0 scale and 0 rotation because it uses
       // only one finger.
       if ((details.scale - 1).abs() > details.rotation.abs()) {
         gestureType = _GestureType.scale;

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -320,7 +320,7 @@ class PageTransitionsTheme extends Diagnosticable {
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 
-  // Just used to the buidlers Map to a list with one PageTransitionsBuilder per platform
+  // Just used to the builders Map to a list with one PageTransitionsBuilder per platform
   // for the operator == overload.
   List<PageTransitionsBuilder> _all(Map<TargetPlatform, PageTransitionsBuilder> builders) {
     return TargetPlatform.values.map((TargetPlatform platform) => builders[platform]).toList();

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -629,7 +629,7 @@ class TextPainter {
 
   // Holds the TextPosition and caretPrototype the last caret metrics were
   // computed with. When new values are passed in, we recompute the caret metrics.
-  // only as nessecary.
+  // only as necessary.
   TextPosition _previousCaretPosition;
   Rect _previousCaretPrototype;
 

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -232,7 +232,7 @@ class GLFWKeyHelper with KeyHelper {
       case ModifierKey.shiftModifier:
       case ModifierKey.altModifier:
       case ModifierKey.metaModifier:
-       // Neither GLFW or X11 provide a distiction between left and right modifiers, so defaults to KeyboardSide.any.
+       // Neither GLFW or X11 provide a distinction between left and right modifiers, so defaults to KeyboardSide.any.
        // https://code.woboq.org/qt5/include/X11/X.h.html#_M/ShiftMask
        return KeyboardSide.any;
       case ModifierKey.capsLockModifier:

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -47,7 +47,7 @@ typedef ScrollableWidgetBuilder = Widget Function(
 /// [ScrollableWidgetBuilder] does not use provided [ScrollController], the
 /// sheet will remain at the initialChildSize.
 ///
-/// By default, the widget will expand its non-occupied area to fill availble
+/// By default, the widget will expand its non-occupied area to fill available
 /// space in the parent. If this is not desired, e.g. because the parent wants
 /// to position sheet based on the space it is taking, the [expand] property
 /// may be set to false.
@@ -157,7 +157,7 @@ class DraggableScrollableSheet extends StatefulWidget {
 /// [DraggableScrollableSheet] widgets notify their ancestors when the size of
 /// the sheet changes. When the extent of the sheet changes via a drag,
 /// this notification bubbles up through the tree, which means a given
-/// [NotificationListener] will recieve notifications for all descendant
+/// [NotificationListener] will receive notifications for all descendant
 /// [DraggableScrollableSheet] widgets. To focus on notifications from the
 /// nearest [DraggableScorllableSheet] descendant, check that the [depth]
 /// property of the notification is zero.

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -217,7 +217,7 @@ class UiKitView extends StatefulWidget {
        assert(creationParams == null || creationParamsCodec != null),
        super(key: key);
 
-  // TODO(amirh): reference the iOS API doc once avaliable.
+  // TODO(amirh): reference the iOS API doc once available.
   /// The unique identifier for iOS view type to be embedded by this widget.
   ///
   /// A PlatformViewFactory for this type must have been registered.

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1701,7 +1701,7 @@ mixin WidgetInspectorService {
       return true;
     }
     if (value is! Element || !isWidgetCreationTracked()) {
-      // Creation locations are not availabe so include all nodes in the
+      // Creation locations are not available so include all nodes in the
       // summary tree.
       return true;
     }

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -285,7 +285,7 @@ void main() {
         );
 
         // Drag the minute picker to the next slot (03 -> 06).
-        // The `initialDateTime` and the `minuteInterval` values are specifically choosen
+        // The `initialDateTime` and the `minuteInterval` values are specifically chosen
         // so that `find.text` finds exactly one widget.
         await tester.drag(find.text('03'), _kRowOffset);
         await tester.pump();

--- a/packages/flutter/test/gestures/double_tap_test.dart
+++ b/packages/flutter/test/gestures/double_tap_test.dart
@@ -740,7 +740,7 @@ void main() {
       doubleTap.dispose();
     });
 
-    testGesture('A primary double tap recognizer does not form competion with a secondary tap recognizer', (GestureTester tester) {
+    testGesture('A primary double tap recognizer does not form competition with a secondary tap recognizer', (GestureTester tester) {
       doubleTap.addPointer(down6);
       tapSecondary.addPointer(down6);
       tester.closeArena(down6.pointer);
@@ -749,7 +749,7 @@ void main() {
       expect(recognized, <String>['tapSecondary']);
     });
 
-    testGesture('A primary double tap recognizer forms competion with a primary tap recognizer', (GestureTester tester) {
+    testGesture('A primary double tap recognizer forms competition with a primary tap recognizer', (GestureTester tester) {
       doubleTap.addPointer(down1);
       tapPrimary.addPointer(down1);
       tester.closeArena(down1.pointer);

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -767,7 +767,7 @@ void main() {
       pan.dispose();
     });
 
-    testGesture('A primary pan recognizer does not form competion with a secondary tap recognizer', (GestureTester tester) {
+    testGesture('A primary pan recognizer does not form competition with a secondary tap recognizer', (GestureTester tester) {
       final TestPointer pointer = TestPointer(
         1,
         PointerDeviceKind.touch,
@@ -783,7 +783,7 @@ void main() {
       expect(recognized, <String>['tapSecondary']);
     });
 
-    testGesture('A primary pan recognizer forms competion with a primary tap recognizer', (GestureTester tester) {
+    testGesture('A primary pan recognizer forms competition with a primary tap recognizer', (GestureTester tester) {
       final TestPointer pointer = TestPointer(
         1,
         PointerDeviceKind.touch,
@@ -805,7 +805,7 @@ void main() {
   testGesture('A secondary drag should not trigger primary', (GestureTester tester) {
     final List<String> recognized = <String>[];
     final TapGestureRecognizer tap = TapGestureRecognizer()
-      ..onTap = () {}; // Need a listener to enable competetion.
+      ..onTap = () {}; // Need a listener to enable competition.
     final PanGestureRecognizer pan = PanGestureRecognizer()
       ..onDown = (DragDownDetails details) {
         recognized.add('primaryDown');

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -520,7 +520,7 @@ void main() {
       longPress.dispose();
     });
 
-    testGesture('A primary long press recognizer does not form competion with a secondary tap recognizer', (GestureTester tester) {
+    testGesture('A primary long press recognizer does not form competition with a secondary tap recognizer', (GestureTester tester) {
       longPress.addPointer(down3);
       tapSecondary.addPointer(down3);
       tester.closeArena(down3.pointer);
@@ -529,7 +529,7 @@ void main() {
       expect(recognized, <String>['tapSecondary']);
     });
 
-    testGesture('A primary long press recognizer forms competion with a primary tap recognizer', (GestureTester tester) {
+    testGesture('A primary long press recognizer forms competition with a primary tap recognizer', (GestureTester tester) {
       longPress.addPointer(down);
       tapPrimary.addPointer(down);
       tester.closeArena(down.pointer);

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -681,7 +681,7 @@ void main() {
       secondary.dispose();
     });
 
-    testGesture('A primary tap recognizer does not form competion with a secondary tap recognizer', (GestureTester tester) {
+    testGesture('A primary tap recognizer does not form competition with a secondary tap recognizer', (GestureTester tester) {
       primary.addPointer(down1);
       secondary.addPointer(down1);
       tester.closeArena(1);
@@ -694,7 +694,7 @@ void main() {
       expect(recognized, <String>['primaryUp']);
     });
 
-    testGesture('A primary tap recognizer forms competion with another primary tap recognizer', (GestureTester tester) {
+    testGesture('A primary tap recognizer forms competition with another primary tap recognizer', (GestureTester tester) {
       primary.addPointer(down1);
       primary2.addPointer(down1);
       tester.closeArena(1);

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -571,7 +571,7 @@ void main() {
     expect(_getMaterial(tester).color, equals(color));
   });
 
-  testWidgets('Shifting BottomNavigationBar background color is overriden by item color', (WidgetTester tester) async {
+  testWidgets('Shifting BottomNavigationBar background color is overridden by item color', (WidgetTester tester) async {
     const Color itemColor = Colors.yellow;
     const Color backgroundColor = Colors.blue;
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -66,7 +66,7 @@ void main() {
     bodyBox = tester.renderObject(find.byKey(bodyKey));
     expect(bodyBox.size, equals(const Size(800.0, 544.0)));
 
-    // Backwards compatiblity: deprecated resizeToAvoidBottomPadding flag
+    // Backwards compatibility: deprecated resizeToAvoidBottomPadding flag
     await tester.pumpWidget(boilerplate(MediaQuery(
       data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 100.0)),
       child: Scaffold(

--- a/packages/flutter_goldens_client/lib/client.dart
+++ b/packages/flutter_goldens_client/lib/client.dart
@@ -183,7 +183,7 @@ class NonZeroExitCode implements Exception {
 
   /// The code that the process will signal to the operating system.
   ///
-  /// By definiton, this is not zero.
+  /// By definition, this is not zero.
   final int exitCode;
 
   /// The message to show on standard error.

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -403,7 +403,7 @@ class TestGesture {
     return TestAsyncUtils.guard<void>(() {
       if (_pointer._isDown) {
         assert(_result != null,
-            'Move events with the pointer down must be preceeded by a down '
+            'Move events with the pointer down must be preceded by a down '
             'event that captures a hit test result.');
         return _dispatcher(_pointer.move(location, timeStamp: timeStamp), _result);
       } else {

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -72,7 +72,7 @@ BuildApp() {
       EchoError "========================================================================"
       EchoError "ERROR: Unknown FLUTTER_BUILD_MODE: ${build_mode}."
       EchoError "Valid values are 'Debug', 'Profile', or 'Release' (case insensitive)."
-      EchoError "This is controlled by the FLUTTER_BUILD_MODE environment varaible."
+      EchoError "This is controlled by the FLUTTER_BUILD_MODE environment variable."
       EchoError "If that is not set, the CONFIGURATION environment variable is used."
       EchoError ""
       EchoError "You can fix this by either adding an appropriately named build"

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -131,7 +131,7 @@ abstract class Logger {
   /// The `timeout` argument sets a duration after which an additional message
   /// may be shown saying that the operation is taking a long time. (Not all
   /// [Status] subclasses show such a message.) Set this to null if the
-  /// operation can legitimately take an abritrary amount of time (e.g. waiting
+  /// operation can legitimately take an arbitrary amount of time (e.g. waiting
   /// for the user).
   ///
   /// The `progressId` argument provides an ID that can be used to identify

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -13,7 +13,7 @@ import 'dart/package_map.dart';
 import 'globals.dart';
 import 'project.dart';
 
-// Arbitrarily choosen multi-root file scheme. This is used to configure the
+// Arbitrarily chosen multi-root file scheme. This is used to configure the
 // frontend_server to resolve a package uri to multiple filesystem directories.
 // In this case, the source directory and a generated directory.
 const String kMultiRootScheme = 'org-dartlang-app';

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -72,7 +72,7 @@ class UpgradeCommandRunner {
         );
       }
     }
-    // If there are uncomitted changes we might be on the right commit but
+    // If there are uncommitted changes we might be on the right commit but
     // we should still warn.
     if (!force && await hasUncomittedChanges()) {
       throwToolExit(

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -38,7 +38,7 @@ class KernelCompilerFactory {
 
 typedef CompilerMessageConsumer = void Function(String message, { bool emphasis, TerminalColor color });
 
-/// The target model describes the set of core libraries that are availible within
+/// The target model describes the set of core libraries that are available within
 /// the SDK.
 class TargetModel {
   /// Parse a [TargetModel] from a raw string.
@@ -734,7 +734,7 @@ class ResidentCompiler {
   }
 
   Future<dynamic> shutdown() async {
-    // Server was never sucessfully created.
+    // Server was never successfully created.
     if (_server == null) {
       return 0;
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -190,7 +190,7 @@ class FuchsiaPackageServer {
   /// Usees [FuchiaPM.newrepo] and [FuchsiaPM.serve] to spin up a new Fuchsia
   /// package server.
   ///
-  /// Returns false if ther repo could not be created or the server could not
+  /// Returns false if the repo could not be created or the server could not
   /// be spawned, and true otherwise.
   Future<bool> start() async {
     if (_process != null) {

--- a/packages/flutter_tools/lib/src/fuchsia/tiles_ctl.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/tiles_ctl.dart
@@ -84,7 +84,7 @@ class FuchsiaTilesCtl {
   /// Instructs tiles on the device to begin running the app at [url] in a new
   /// tile.
   ///
-  /// The app is passed the arguemnts in [args]. Flutter apps receive these
+  /// The app is passed the arguments in [args]. Flutter apps receive these
   /// arguments as arguments to `main()`. [url] should be formatted as a
   /// Fuchsia-style package url, e.g.:
   ///     fuchsia-pkg://fuchsia.com/flutter_gallery#meta/flutter_gallery.cmx

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -591,7 +591,7 @@ class MacOSProject {
 
   /// The file where the Xcode build will write the name of the built app.
   ///
-  /// Ideally this will be replaced in the future with inpection of the Runner
+  /// Ideally this will be replaced in the future with inspection of the Runner
   /// scheme's target.
   File get nameFile => _cacheDirectory.childFile('.app_filename');
 }

--- a/packages/flutter_tools/test/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/commands/daemon_test.dart
@@ -195,7 +195,7 @@ void main() {
       await commands.close();
     });
 
-    testUsingContext('device.getDevices reports avaiable devices', () async {
+    testUsingContext('device.getDevices reports available devices', () async {
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(

--- a/packages/flutter_tools/test/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/commands/doctor_test.dart
@@ -190,7 +190,7 @@ void main() {
     });
   });
 
-  group('doctor with overriden validators', () {
+  group('doctor with overridden validators', () {
     testUsingContext('validate non-verbose output format for run without issues', () async {
       expect(await doctor.diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(

--- a/packages/flutter_tools/test/commands/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands/upgrade_test.dart
@@ -50,7 +50,7 @@ void main() {
       expect(await result, null);
     });
 
-    test('throws tool exit with uncommited changes', () async {
+    test('throws tool exit with uncommitted changes', () async {
       fakeCommandRunner.willHaveUncomittedChanges = true;
       final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
         false,
@@ -60,7 +60,7 @@ void main() {
       expect(result, throwsA(isA<ToolExit>()));
     });
 
-    test('does not throw tool exit with uncommited changes and force', () async {
+    test('does not throw tool exit with uncommitted changes and force', () async {
       fakeCommandRunner.willHaveUncomittedChanges = true;
       final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
         true,


### PR DESCRIPTION
## Description

Corects a bnuch of typeos throuhgout teh Fluter codebsae.

Made use of the `misspell` tool:
https://github.com/client9/misspell

## Related Issues

n/a

## Tests

No new tests were added.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
