### PR TITLE
Add clarification in Animation's listener API docs

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -63,6 +63,8 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
 
   /// Stop calling the listener every time the value of the animation changes.
   ///
+  /// If `listener` is not currently registered as a listener, this is a no-op.
+  ///
   /// Listeners can be added with [addListener].
   @override
   void removeListener(VoidCallback listener);
@@ -73,6 +75,9 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   void addStatusListener(AnimationStatusListener listener);
 
   /// Stops calling the listener every time the status of the animation changes.
+  ///
+  /// If `listener` is not currently registered as a status listener, this is
+  /// a no-op.
   ///
   /// Listeners can be added with [addStatusListener].
   void removeStatusListener(AnimationStatusListener listener);

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -63,7 +63,8 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
 
   /// Stop calling the listener every time the value of the animation changes.
   ///
-  /// If `listener` is not currently registered as a listener, this is a no-op.
+  /// If `listener` is not currently registered as a listener, this method does
+  /// nothing.
   ///
   /// Listeners can be added with [addListener].
   @override
@@ -76,8 +77,8 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
 
   /// Stops calling the listener every time the status of the animation changes.
   ///
-  /// If `listener` is not currently registered as a status listener, this is
-  /// a no-op.
+  /// If `listener` is not currently registered as a status listener, this
+  /// method does nothing.
   ///
   /// Listeners can be added with [addStatusListener].
   void removeStatusListener(AnimationStatusListener listener);


### PR DESCRIPTION
## Description

This change adds a minor documentation sentence to `Animation.removeListener()` and `Animation.removeStatusListener()`.

## Tests

N/A

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
