### PR TITLE
Add blank newline after Dartdoc bulleted list.

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -117,7 +117,9 @@ class CupertinoSwitch extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
+  ///    the different behaviors.
+  ///
   /// {@endtemplate}
   final DragStartBehavior dragStartBehavior;
 

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -217,7 +217,9 @@ class DrawerController extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
+  ///    the different behaviors.
+  ///
   /// {@endtemplate}
   final DragStartBehavior dragStartBehavior;
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -753,7 +753,7 @@ abstract class SliderTickMarkShape {
   /// See also:
   ///
   /// * [SliderThemeData.tickMarkShape], which is the shape that the [Slider]
-  /// uses when painting tick marks.
+  ///   uses when painting tick marks.
   static final SliderTickMarkShape noTickMark = _EmptySliderTickMarkShape();
 }
 
@@ -860,7 +860,7 @@ abstract class SliderComponentShape {
   /// See also:
   ///
   /// * [SliderThemeData.thumbShape], which is the shape that the [Slider]
-  /// uses when painting the thumb.
+  ///   uses when painting the thumb.
   static final SliderComponentShape noThumb = _EmptySliderComponentShape();
 
   /// Special instance of [SliderComponentShape] to skip the overlay drawing.
@@ -868,7 +868,7 @@ abstract class SliderComponentShape {
   /// See also:
   ///
   /// * [SliderThemeData.overlayShape], which is the shape that the [Slider]
-  /// uses when painting the overlay.
+  ///   uses when painting the overlay.
   static final SliderComponentShape noOverlay = _EmptySliderComponentShape();
 }
 
@@ -908,9 +908,9 @@ class _EmptySliderComponentShape extends SliderComponentShape {
 /// See also:
 ///
 /// * [RectangularSliderTrackShape], which is a track shape with sharp
-/// rectangular edges
+///   rectangular edges
 /// * [RoundedRectSliderTrackShape], which is a track shape with round
-/// stadium-like edges.
+///   stadium-like edges.
 ///
 /// The height is set from [SliderThemeData.trackHeight] and the width of the
 /// parent box less the larger of the widths of [SliderThemeData.thumbShape] and

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -462,9 +462,9 @@ class EventChannel {
   /// Returns a broadcast [Stream] which emits events to listeners as follows:
   ///
   /// * a decoded data event (possibly null) for each successful event
-  /// received from the platform plugin;
+  ///   received from the platform plugin;
   /// * an error event containing a [PlatformException] for each error event
-  /// received from the platform plugin.
+  ///   received from the platform plugin.
   ///
   /// Errors occurring during stream activation or deactivation are reported
   /// through the [FlutterError] facility. Stream activation happens only when

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -374,6 +374,7 @@ class WidgetsApp extends StatefulWidget {
   ///  * [Navigator.initialRoute], which is used to implement this property.
   ///  * [Navigator.push], for pushing additional routes.
   ///  * [Navigator.pop], for removing a route from the stack.
+  ///
   /// {@endtemplate}
   final String initialRoute;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -422,6 +422,7 @@ class EditableText extends StatefulWidget {
   /// See also:
   ///
   ///   * {@macro flutter.gestures.monodrag.dragStartExample}
+  ///
   /// {@endtemplate}
   final TextDirection textDirection;
 
@@ -437,6 +438,7 @@ class EditableText extends StatefulWidget {
   /// See also:
   ///
   ///  * [TextCapitalization], for a description of each capitalization behavior.
+  ///
   /// {@endtemplate}
   final TextCapitalization textCapitalization;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -998,6 +998,7 @@ abstract class State<T extends StatefulWidget> extends Diagnosticable {
   ///    to the new one if the updated widget configuration requires
   ///    replacing the object.
   ///  * In [dispose], unsubscribe from the object.
+  ///
   /// {@endtemplate}
   ///
   /// You cannot use [BuildContext.inheritFromWidgetOfExactType] from this

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -199,7 +199,9 @@ class Scrollable extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
+  ///    the different behaviors.
+  ///
   /// {@endtemplate}
   final DragStartBehavior dragStartBehavior;
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -72,7 +72,7 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// See also:
 ///
 ///  * [AutomatedTestWidgetsFlutterBinding.addTime] to learn more about
-/// timeout and how to manually increase timeouts.
+///    timeout and how to manually increase timeouts.
 ///
 /// ## Sample code
 ///


### PR DESCRIPTION
## Description

Our Dartdocs were rendering incorrectly due to a bug in Dartdoc that causes text after a bulleted list that's not separated by a blank line to show as if it's part of the last bullet item.  This PR adds a blank line where necessary to get the Dartdocs to render correctly.

This also fixes up some indentation in some bulleted lists.

## Related Issues

https://github.com/dart-lang/dartdoc/issues/1969

## Tests

N/A

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.