### PR TITLE
Add implementation of ignoreWebNumericQuirks

### DIFF
--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -49,6 +49,7 @@ export 'dart:async' show Future;
 export 'src/accessibility.dart';
 export 'src/all_elements.dart';
 export 'src/binding.dart';
+export 'src/browser.dart';
 export 'src/controller.dart';
 export 'src/finders.dart';
 export 'src/goldens.dart';

--- a/packages/flutter_test/lib/src/browser.dart
+++ b/packages/flutter_test/lib/src/browser.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 const bool _kIsCompiledToJavaScript = identical(0, 0.0);
-final RegExp _doubleFormatter = RegExp('([0-9]+)\.0');
+final RegExp _doubleFormatter = RegExp(r'(\d)\.0\b');
 
 /// Automatically reformats a String containing doubles for the web.
 ///

--- a/packages/flutter_test/lib/src/browser.dart
+++ b/packages/flutter_test/lib/src/browser.dart
@@ -1,0 +1,22 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const bool _kIsCompiledToJavaScript = identical(0, 0.0);
+final RegExp _doubleFormatter = RegExp('([0-9]+)\.0');
+
+/// Automatically reformats a String containing doubles for the web.
+///
+/// In the Dart VM or native Dart runtimes, [double.toString()] on whole number
+/// values will have a trailing `.0`. In Browsers, the equivalent
+/// Number.toString does not include this trailing `.0`, which can result in
+/// differently formatted output strings in places such as debug messages or
+/// diagnostic nodes.
+String ignoreWebNumericQuirks(String input) {
+  if (_kIsCompiledToJavaScript) {
+    return input.replaceAllMapped(_doubleFormatter, (Match match) {
+      return match.group(1);
+    });
+  }
+  return input;
+}


### PR DESCRIPTION
## Description

In the Dart VM or native Dart runtimes, [double.toString()] on whole number values will have a trailing `.0`. In Browsers, the equivalent Number.toString does not include this trailing `.0`, which can result in
 differently formatted output strings in places such as debug messages or  diagnostic nodes.

https://github.com/flutter/flutter/pull/33349