### PR TITLE
Fix text scaling of strut style

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -959,7 +959,7 @@ class TextStyle extends Diagnosticable {
       strutStyle: strutStyle == null ? null : ui.StrutStyle(
         fontFamily: strutStyle.fontFamily,
         fontFamilyFallback: strutStyle.fontFamilyFallback,
-        fontSize: strutStyle.fontSize * textScaleFactor,
+        fontSize: strutStyle.fontSize == null ? null : strutStyle.fontSize * textScaleFactor,
         height: strutStyle.height,
         leading: strutStyle.leading,
         fontWeight: strutStyle.fontWeight,

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -959,7 +959,7 @@ class TextStyle extends Diagnosticable {
       strutStyle: strutStyle == null ? null : ui.StrutStyle(
         fontFamily: strutStyle.fontFamily,
         fontFamilyFallback: strutStyle.fontFamilyFallback,
-        fontSize: strutStyle.fontSize,
+        fontSize: strutStyle.fontSize * textScaleFactor,
         height: strutStyle.height,
         leading: strutStyle.leading,
         fontWeight: strutStyle.fontWeight,

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -356,11 +356,11 @@ void main() {
   });
 
   test('TextStyle strut textScaleFactor', () {
-    TextStyle style0 = TextStyle(fontSize: 10);
-    ui.ParagraphStyle paragraphStyle0 = style0.getParagraphStyle(textScaleFactor: 2.5);
+    const TextStyle style0 = TextStyle(fontSize: 10);
+    final ui.ParagraphStyle paragraphStyle0 = style0.getParagraphStyle(textScaleFactor: 2.5);
 
-    TextStyle style1 = TextStyle(fontSize: 25);
-    ui.ParagraphStyle paragraphStyle1 = style1.getParagraphStyle(textScaleFactor: 1);
+    const TextStyle style1 = TextStyle(fontSize: 25);
+    final ui.ParagraphStyle paragraphStyle1 = style1.getParagraphStyle(textScaleFactor: 1);
 
     expect(paragraphStyle0 == paragraphStyle1, true);
   });

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -354,4 +354,14 @@ void main() {
     expect(TextStyle.lerp(redPaintTextStyle, bluePaintTextStyle, .25).background.color, red);
     expect(TextStyle.lerp(redPaintTextStyle, bluePaintTextStyle, .75).background.color, blue);
   });
+
+  test('TextStyle strut textScaleFactor', () {
+    TextStyle style0 = TextStyle(fontSize: 10);
+    ui.ParagraphStyle paragraphStyle0 = style0.getParagraphStyle(textScaleFactor: 2.5);
+
+    TextStyle style1 = TextStyle(fontSize: 25);
+    ui.ParagraphStyle paragraphStyle1 = style1.getParagraphStyle(textScaleFactor: 1);
+
+    expect(paragraphStyle0 == paragraphStyle1, true);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/32278.

The textScaleFactor is now multiplied into the StrutStyle fontSize like it is in TextStyle.