### PR TITLE
Pin previous build_daemon

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_runner.dart
@@ -27,7 +27,8 @@ import '../project.dart';
 import 'build_script_generator.dart';
 
 /// The minimum version of build_runner we can support in the flutter tool.
-const String kMinimumBuildRunnerVersion = '1.2.8';
+const String kMinimumBuildRunnerVersion = '1.4.0';
+const String kSupportedBuildDaemonVersion = '0.6.1';
 
 /// A wrapper for a build_runner process which delegates to a generated
 /// build script.
@@ -47,7 +48,7 @@ class BuildRunner extends CodeGenerator {
     final File syntheticPubspec = generatedDirectory.childFile('pubspec.yaml');
 
     // Check if contents of builders changed. If so, invalidate build script
-    // and regnerate.
+    // and regenerate.
     final YamlMap builders = flutterProject.builders;
     final List<int> appliedBuilderDigest = _produceScriptId(builders);
     if (scriptIdFile.existsSync() && buildSnapshot.existsSync()) {
@@ -100,6 +101,7 @@ class BuildRunner extends CodeGenerator {
         }
       }
       stringBuffer.writeln('  build_runner: ^$kMinimumBuildRunnerVersion');
+      stringBuffer.writeln('  build_daemon: $kSupportedBuildDaemonVersion');
       await syntheticPubspec.writeAsString(stringBuffer.toString());
 
       await pubGet(


### PR DESCRIPTION
## Description

Using build_daemon 1.0 causes the following exception to be thrown during initialization:

```
[codegen_integration_mac] [STDOUT] stdout: [        ]              log=Setting up file watchers...,
[codegen_integration_mac] [STDOUT] stdout: [        ]            }
[codegen_integration_mac] [STDOUT] stdout: [        ] [        ] ServerLog {
[codegen_integration_mac] [STDOUT] stdout: [        ]              log=Setting up file watchers completed, took 3ms,
[codegen_integration_mac] [STDOUT] stdout: [        ]            }
[codegen_integration_mac] [STDOUT] stdout: [        ] [        ] ServerLog {
[codegen_integration_mac] [STDOUT] stdout: [        ]              log=,
[codegen_integration_mac] [STDOUT] stdout: [        ]            }
[codegen_integration_mac] [STDOUT] stdout: [        ] [  +30 ms] starting build daemon... (completed in 1.2s)
[codegen_integration_mac] [STDOUT] stderr: [ +195 ms] Unhandled exception:
[codegen_integration_mac] [STDOUT] stderr: [        ] Deserializing '[ServerLog, level, INFO, message, About to build [codegen, test]...]' to 'unspecified' failed due to: Tried to construct class "ServerLog" with null field "log". This is forbidden; to allow it, mark "log" with @nullable.
[codegen_integration_mac] [STDOUT] stderr: [        ] #0      BuiltJsonSerializers._deserialize (package:built_value/src/built_json_serializers.dart:125:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #1      BuiltJsonSerializers.deserialize (package:built_value/src/built_json_serializers.dart:104:18)
[codegen_integration_mac] [STDOUT] stderr: [        ] #2      new BuildDaemonClient._.<anonymous closure> (package:build_daemon/client.dart:83:36)
[codegen_integration_mac] [STDOUT] stderr: [        ] #3      _rootRunUnary (dart:async/zone.dart:1132:38)
[codegen_integration_mac] [STDOUT] stderr: [        ] #4      _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #5      _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #6      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #7      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #8      _ForwardingStreamSubscription._add (dart:async/stream_pipe.dart:132:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #9      _ForwardingStream._handleData (dart:async/stream_pipe.dart:98:10)
[codegen_integration_mac] [STDOUT] stderr: [        ] #10     _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:164:13)
[codegen_integration_mac] [STDOUT] stderr: [        ] #11     _rootRunUnary (dart:async/zone.dart:1132:38)
[codegen_integration_mac] [STDOUT] stderr: [        ] #12     _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #13     _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #14     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #15     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #16     _SyncStreamController._sendData (dart:async/stream_controller.dart:764:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #17     _StreamController._add (dart:async/stream_controller.dart:640:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #18     _rootRunUnary (dart:async/zone.dart:1132:38)
[codegen_integration_mac] [STDOUT] stderr: [        ] #19     _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #20     _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #21     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #22     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #23     _SyncStreamController._sendData (dart:async/stream_controller.dart:764:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #24     _StreamController._add (dart:async/stream_controller.dart:640:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #25     _StreamController.add (dart:async/stream_controller.dart:586:5)
[codegen_integration_mac] [STDOUT] stderr: [        ] #26     new _WebSocketImpl._fromSocket.<anonymous closure> (dart:_http/websocket_impl.dart:1138:21)
[codegen_integration_mac] [STDOUT] stderr: [        ] #27     _rootRunUnary (dart:async/zone.dart:1132:38)
[codegen_integration_mac] [STDOUT] stderr: [        ] #28     _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #29     _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #30     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #31     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #32     _SinkTransformerStreamSubscription._add (dart:async/stream_transformers.dart:68:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #33     _EventSinkWrapper.add (dart:async/stream_transformers.dart:15:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #34     _WebSocketProtocolTransformer._messageFrameEnd (dart:_http/websocket_impl.dart:334:22)
[codegen_integration_mac] [STDOUT] stderr: [        ] #35     _WebSocketProtocolTransformer.add (dart:_http/websocket_impl.dart:229:46)
[codegen_integration_mac] [STDOUT] stderr: [        ] #36     _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:120:24)
[codegen_integration_mac] [STDOUT] stderr: [        ] #37     _rootRunUnary (dart:async/zone.dart:1132:38)
[codegen_integration_mac] [STDOUT] stderr: [        ] #38     _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #39     _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #40     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #41     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #42     _SyncStreamController._sendData (dart:async/stream_controller.dart:764:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #43     _StreamController._add (dart:async/stream_controller.dart:640:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #44     _StreamController.add (dart:async/stream_controller.dart:586:5)
[codegen_integration_mac] [STDOUT] stderr: [        ] #45     _Socket._onData (dart:io-patch/socket_patch.dart:1774:41)
[codegen_integration_mac] [STDOUT] stderr: [        ] #46     _rootRunUnary (dart:async/zone.dart:1136:13)
[codegen_integration_mac] [STDOUT] stderr: [        ] #47     _CustomZone.runUnary (dart:async/zone.dart:1029:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #48     _CustomZone.runUnaryGuarded (dart:async/zone.dart:931:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #49     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
[codegen_integration_mac] [STDOUT] stderr: [        ] #50     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #51     _SyncStreamController._sendData (dart:async/stream_controller.dart:764:19)
[codegen_integration_mac] [STDOUT] stderr: [        ] #52     _StreamController._add (dart:async/stream_controller.dart:640:7)
[codegen_integration_mac] [STDOUT] stderr: [        ] #53     _StreamController.add (dart:async/stream_controller.dart:586:5)
[codegen_integration_mac] [STDOUT] stderr: [        ] #54     new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:1323:33)
[codegen_integration_mac] [STDOUT] stderr: [        ] #55     _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:844:14)
[codegen_integration_mac] [STDOUT] stderr: [        ] #56     _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
[codegen_integration_mac] [STDOUT] stderr: [        ] #57     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
[codegen_integration_mac] [STDOUT] stderr: [        ] #58     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:115:13)
[codegen_integration_mac] [STDOUT] stderr: [        ] #59     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:5)
```

pin previous version to prevent failures.

cc @grouma @jakemac53 
