### PR TITLE
fixed 33347 fill the gap during performLayout in SliverGrid and Slive…

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -211,9 +211,9 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       trailingChildWithLayout = firstChild;
     }
 
-    while (targetLastIndex == null || indexOf(trailingChildWithLayout) < targetLastIndex) {
+    for (int index = indexOf(trailingChildWithLayout) + 1; targetLastIndex == null || index <= targetLastIndex; ++index) {
       RenderBox child = childAfter(trailingChildWithLayout);
-      if (child == null) {
+      if (child == null || indexOf(child) != index) {
         child = insertAndLayoutChild(childConstraints, after: trailingChildWithLayout);
         if (child == null) {
           // We have run out of children.
@@ -225,6 +225,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       trailingChildWithLayout = child;
       assert(child != null);
       final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
+      assert(childParentData.index == index);
       childParentData.layoutOffset = indexToLayoutOffset(itemExtent, childParentData.index);
     }
 

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -579,7 +579,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       final SliverGridGeometry gridGeometry = layout.getGeometryForChildIndex(index);
       final BoxConstraints childConstraints = gridGeometry.getBoxConstraints(constraints);
       RenderBox child = childAfter(trailingChildWithLayout);
-      if (child == null) {
+      if (child == null || indexOf(child) != index) {
         child = insertAndLayoutChild(childConstraints, after: trailingChildWithLayout);
         if (child == null) {
           // We have run out of children.

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -196,6 +196,73 @@ void main() {
     expect(find.text('BOTTOM'), findsOneWidget);
   });
 
+  testWidgets('SliverGrid Correctly layout children after rearranging', (WidgetTester tester) async {
+      await tester.pumpWidget(const TestSliverGrid(
+        <Widget>[
+          Text('item0', key: Key('0')),
+          Text('item1', key: Key('1')),
+        ]
+      ));
+      await tester.pumpWidget(const TestSliverGrid(
+        <Widget>[
+          Text('item0', key: Key('0')),
+          Text('item3', key: Key('3')),
+          Text('item4', key: Key('4')),
+          Text('item1', key: Key('1')),
+        ]
+      ));
+      expect(find.text('item0'), findsOneWidget);
+      expect(find.text('item3'), findsOneWidget);
+      expect(find.text('item4'), findsOneWidget);
+      expect(find.text('item1'), findsOneWidget);
+
+      final Offset item0Location = tester.getCenter(find.text('item0'));
+      final Offset item3Location = tester.getCenter(find.text('item3'));
+      final Offset item4Location = tester.getCenter(find.text('item4'));
+      final Offset item1Location = tester.getCenter(find.text('item1'));
+
+      expect(isRight(item0Location, item3Location) && sameHorizontal(item0Location, item3Location), true);
+      expect(isBelow(item0Location, item4Location) && sameVertical(item0Location, item4Location), true);
+      expect(isBelow(item0Location, item1Location) && isRight(item0Location, item1Location), true);
+    },
+  );
+
+  testWidgets('SliverFixedExtentList Correctly layout children after rearranging', (WidgetTester tester) async {
+      await tester.pumpWidget(const TestSliverFixedExtentList(
+          <Widget>[
+            Text('item0', key: Key('0')),
+            Text('item2', key: Key('2')),
+            Text('item1', key: Key('1')),
+          ]
+      ));
+      await tester.pumpWidget(const TestSliverFixedExtentList(
+          <Widget>[
+            Text('item0', key: Key('0')),
+            Text('item3', key: Key('3')),
+            Text('item1', key: Key('1')),
+            Text('item4', key: Key('4')),
+            Text('item2', key: Key('2')),
+          ]
+      ));
+      expect(find.text('item0'), findsOneWidget);
+      expect(find.text('item3'), findsOneWidget);
+      expect(find.text('item1'), findsOneWidget);
+      expect(find.text('item4'), findsOneWidget);
+      expect(find.text('item2'), findsOneWidget);
+
+      final Offset item0Location = tester.getCenter(find.text('item0'));
+      final Offset item3Location = tester.getCenter(find.text('item3'));
+      final Offset item1Location = tester.getCenter(find.text('item1'));
+      final Offset item4Location = tester.getCenter(find.text('item4'));
+      final Offset item2Location = tester.getCenter(find.text('item2'));
+
+      expect(isBelow(item0Location, item3Location) && sameVertical(item0Location, item3Location), true);
+      expect(isBelow(item3Location, item1Location) && sameVertical(item3Location, item1Location), true);
+      expect(isBelow(item1Location, item4Location) && sameVertical(item1Location, item4Location), true);
+      expect(isBelow(item4Location, item2Location) && sameVertical(item4Location, item2Location), true);
+    },
+  );
+
   testWidgets('Can override ErrorWidget.build', (WidgetTester tester) async {
     const Text errorText = Text('error');
     final ErrorWidgetBuilder oldBuilder = ErrorWidget.builder;
@@ -211,4 +278,57 @@ void main() {
     expect(tester.takeException(), 'builder');
     ErrorWidget.builder = oldBuilder;
   });
+}
+
+bool isRight(Offset a, Offset b) => b.dx > a.dx;
+bool isBelow(Offset a, Offset b) => b.dy > a.dy;
+bool sameHorizontal(Offset a, Offset b) => b.dy == a.dy;
+bool sameVertical(Offset a, Offset b) => b.dx == a.dx;
+
+class TestSliverGrid extends StatelessWidget {
+  const TestSliverGrid(this.children);
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: CustomScrollView(
+        slivers: <Widget> [
+          SliverGrid(
+            delegate: SliverChildListDelegate(
+              children,
+            ),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+            ),
+          ),
+        ],
+      )
+    );
+  }
+}
+
+class TestSliverFixedExtentList extends StatelessWidget {
+  const TestSliverFixedExtentList(this.children);
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget> [
+            SliverFixedExtentList(
+              itemExtent: 10.0,
+              delegate: SliverChildListDelegate(
+                children,
+              ),
+            ),
+          ],
+        )
+    );
+  }
 }


### PR DESCRIPTION
…rFixedExtentList

## Description

Rearrange sliver children will result in gap in the middle of children list, those gap supposed be filled out during the perform layout. SliverList does fill out the gap while SliverGrid and SliverFixExtentList does not which cause crashes. This PR fixes it

## Related Issues

https://github.com/flutter/flutter/issues/33347

## Tests

I added the following tests:

https://github.com/chunhtai/flutter/blob/1f7ee0e65b86eda45b39a7fd8a3a0908793c337d/packages/flutter/test/widgets/slivers_test.dart#L199
https://github.com/chunhtai/flutter/blob/1f7ee0e65b86eda45b39a7fd8a3a0908793c337d/packages/flutter/test/widgets/slivers_test.dart#L221

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
