### PR TITLE
Fix a missing_return analyzer error in a code example

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -35,6 +35,7 @@ import 'will_pop_scope.dart';
 ///             if (value.isEmpty) {
 ///               return 'Please enter some text';
 ///             }
+///             return null;
 ///           },
 ///         ),
 ///         Padding(


### PR DESCRIPTION
This will fix a failure in dev/bots/analyze-sample-code.dart when using
the tip of tree Dart SDK.