### PR TITLE
add daemon command to enumerate supported platforms

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -62,16 +62,14 @@ The `shutdown()` command will terminate the flutter daemon. It is not necessary 
 
 ### daemon.getSupportedPlatforms
 
-The `getSupportedPlatforms()` command will enumerate all platforms supported by the project located at the provided
-`projectRoot`. It returns a List of strings which describe the set of all possibly supported platforms. Possible values
-include:
+The `getSupportedPlatforms()` command will enumerate all platforms supported by the project located at the provided `projectRoot`. It returns a Map with the key 'platforms' containing a List of strings which describe the set of all possibly supported platforms. Possible values include:
    - android
    - ios
-   - linux
-   - macos
-   - windows
-   - fuchsia
-   - web
+   - linux #experimental
+   - macos #experimental
+   - windows #experimental
+   - fuchsia #experimental
+   - web #experimental
 
 #### Events
 

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -60,6 +60,19 @@ The `version()` command responds with a String with the protocol version.
 
 The `shutdown()` command will terminate the flutter daemon. It is not necessary to call this before shutting down the daemon; it is perfectly acceptable to just kill the daemon process.
 
+### daemon.getSupportedPlatforms
+
+The `getSupportedPlatforms()` command will enumerate all platforms supported by the project located at the provided
+`projectRoot`. It returns a List of strings which describe the set of all possibly supported platforms. Possible values
+include:
+   - android
+   - ios
+   - linux
+   - macos
+   - windows
+   - fuchsia
+   - web
+
 #### Events
 
 #### daemon.connected

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -307,10 +307,12 @@ class DaemonDomain extends Domain {
   /// This does not filter based on the current workflow restrictions, such
   /// as whether command line tools are installed or whether the host platform
   /// is correct.
-  Future<List<String>> getSupportedPlatforms(Map<String, dynamic> args) async {
+  Future<Map<String, Object>> getSupportedPlatforms(Map<String, dynamic> args) async {
     final String projectRoot = _getStringArg(args, 'projectRoot', required: true);
     final List<String> result = <String>[];
     try {
+      // TODO(jonahwilliams): replace this with a project metadata check once
+      // that has been implemented.
       final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.directory(projectRoot));
       if (flutterProject.linux.existsSync()) {
         result.add('linux');
@@ -333,14 +335,18 @@ class DaemonDomain extends Domain {
       if (flutterProject.fuchsia.existsSync()) {
         result.add('fuchsia');
       }
-      return result;
+      return <String, Object>{
+        'platforms': result,
+      };
     } catch (err) {
       // On any sort of failure, fall back to Android and iOS for backwards
       // comparability.
-      return <String>[
-        'android',
-        'ios',
-      ];
+      return <String, Object>{
+        'platforms': <String>[
+          'android',
+          'ios',
+        ],
+      };
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -338,7 +338,12 @@ class DaemonDomain extends Domain {
       return <String, Object>{
         'platforms': result,
       };
-    } catch (err) {
+    } catch (err, stackTrace) {
+      sendEvent('log', <String, dynamic>{
+        'log': 'Failed to parse project metadata',
+        'stackTrace': stackTrace.toString(),
+        'error': true,
+      });
       // On any sort of failure, fall back to Android and iOS for backwards
       // comparability.
       return <String, Object>{

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -248,6 +248,7 @@ class DaemonDomain extends Domain {
   DaemonDomain(Daemon daemon) : super(daemon, 'daemon') {
     registerHandler('version', version);
     registerHandler('shutdown', shutdown);
+    registerHandler('getSupportedPlatforms', getSupportedPlatforms);
 
     sendEvent(
       'daemon.connected',
@@ -299,6 +300,48 @@ class DaemonDomain extends Domain {
   @override
   void dispose() {
     _subscription?.cancel();
+  }
+
+  /// Enumerates the platforms supported by the provided project.
+  ///
+  /// This does not filter based on the current workflow restrictions, such
+  /// as whether command line tools are installed or whether the host platform
+  /// is correct.
+  Future<List<String>> getSupportedPlatforms(Map<String, dynamic> args) async {
+    final String projectRoot = _getStringArg(args, 'projectRoot', required: true);
+    final List<String> result = <String>[];
+    try {
+      final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.directory(projectRoot));
+      if (flutterProject.linux.existsSync()) {
+        result.add('linux');
+      }
+      if (flutterProject.macos.existsSync()) {
+        result.add('macos');
+      }
+      if (flutterProject.windows.existsSync()) {
+        result.add('windows');
+      }
+      if (flutterProject.ios.existsSync()) {
+        result.add('ios');
+      }
+      if (flutterProject.android.existsSync()) {
+        result.add('android');
+      }
+      if (flutterProject.web.existsSync()) {
+        result.add('web');
+      }
+      if (flutterProject.fuchsia.existsSync()) {
+        result.add('fuchsia');
+      }
+      return result;
+    } catch (err) {
+      // On any sort of failure, fall back to Android and iOS for backwards
+      // comparability.
+      return <String>[
+        'android',
+        'ios',
+      ];
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Based on discussion from last week, returns a list of strings containing each possible platform supported, independent of current devices or workflows. 
