### PR TITLE
Build the solution on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -615,6 +615,9 @@ class WindowsProject {
   // The MSBuild project file.
   File get vcprojFile => _editableDirectory.childFile('Runner.vcxproj');
 
+  // The MSBuild solution file.
+  File get solutionFile => _editableDirectory.childFile('Runner.sln');
+
   /// The file where the VS build will write the name of the built app.
   ///
   /// Ideally this will be replaced in the future with inspection of the project.

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -38,16 +38,16 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
   );
 
   final String configuration = buildInfo.isDebug ? 'Debug' : 'Release';
-  final String projectPath = windowsProject.vcprojFile.path;
+  final String solutionPath = windowsProject.solutionFile.path;
   // Run the script with a relative path to the project using the enclosing
   // directory as the workingDirectory, to avoid hitting the limit on command
   // lengths in batch scripts if the absolute path to the project is long.
   final Process process = await processManager.start(<String>[
     buildScript,
     vcvarsScript,
-    fs.path.basename(projectPath),
+    fs.path.basename(solutionPath),
     configuration,
-  ], workingDirectory: fs.path.dirname(projectPath));
+  ], workingDirectory: fs.path.dirname(solutionPath));
   final Status status = logger.startProgress(
     'Building Windows application...',
     timeout: null,

--- a/packages/flutter_tools/test/commands/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands/build_windows_test.dart
@@ -25,7 +25,7 @@ void main() {
   final MockPlatform windowsPlatform = MockPlatform()
       ..environment['PROGRAMFILES(X86)'] = r'C:\Program Files (x86)\';
   final MockPlatform notWindowsPlatform = MockPlatform();
-  const String projectPath = r'C:\windows\Runner.vcxproj';
+  const String solutionPath = r'C:\windows\Runner.sln';
   const String visualStudioPath = r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community';
   const String vcvarsPath = visualStudioPath + r'\VC\Auxiliary\Build\vcvars64.bat';
 
@@ -63,7 +63,7 @@ void main() {
   testUsingContext('Windows build fails when there is no vcvars64.bat', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file(projectPath).createSync(recursive: true);
+    fs.file(solutionPath).createSync(recursive: true);
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'windows']
     ), throwsA(isInstanceOf<ToolExit>()));
@@ -87,7 +87,7 @@ void main() {
   testUsingContext('Windows build fails on non windows platform', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file(projectPath).createSync(recursive: true);
+    fs.file(solutionPath).createSync(recursive: true);
     enableVcvarsMocking();
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
@@ -103,7 +103,7 @@ void main() {
   testUsingContext('Windows build invokes msbuild and writes generated files', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file(projectPath).createSync(recursive: true);
+    fs.file(solutionPath).createSync(recursive: true);
     enableVcvarsMocking();
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
@@ -111,9 +111,9 @@ void main() {
     when(mockProcessManager.start(<String>[
       r'C:\packages\flutter_tools\bin\vs_build.bat',
       vcvarsPath,
-      fs.path.basename(projectPath),
+      fs.path.basename(solutionPath),
       'Release',
-    ], workingDirectory: fs.path.dirname(projectPath))).thenAnswer((Invocation invocation) async {
+    ], workingDirectory: fs.path.dirname(solutionPath))).thenAnswer((Invocation invocation) async {
       return mockProcess;
     });
 


### PR DESCRIPTION
## Description

Switch from building Runner.vcxproj to Runner.sln on Windows, to allow
for multiple-project builds (e.g., separate plugin projects).

## Related Issues

None

## Tests

I added the following tests: None. Updated existing test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
