### PR TITLE
Remove obsolete TODOs

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -305,25 +305,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  # TODO(dnfield): Remove these once we're confident it's all working on cirrus
-  # gradle_plugin_test:
-  #   description: >
-  #     Verifies that the Flutter Gradle plugin supports standard and custom Android build types.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["linux/android"]
-
-  # plugin_test:
-  #   description: >
-  #     Checks that the project template works and supports plugins.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["linux/android"]
-
-  # module_test:
-  #   description: >
-  #     Checks that the module project template works and supports add2app on Android.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["linux/android"]
-
   flutter_gallery_instrumentation_test:
     description: >
       Same as flutter_gallery__transition_perf but uses Android instrumentation
@@ -344,25 +325,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  # TODO(dnfield): Remove these once we're confident it's all working on cirrus
-  # flutter_create_offline_test_linux:
-  #   description: >
-  #     Tests the `flutter create --offline` command.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["linux/android"]
-
-  # flutter_create_offline_test_windows:
-  #   description: >
-  #     Tests the `flutter create --offline` command.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["windows/android"]
-
-  # flutter_create_offline_test_mac:
-  #   description: >
-  #     Tests the `flutter create --offline` command.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["mac/android"]
-
   # iOS on-device tests
 
   flavors_test_ios:
@@ -370,19 +332,6 @@ tasks:
       Checks that flavored builds work on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-
-  # TODO(dnfield): Remove these once we're confident it's all working on cirrus
-  # plugin_test_ios:
-  #   description: >
-  #     Checks that the project template works and supports plugins on iOS.
-  #   stage: devicelab_ios
-  #   required_agent_capabilities: ["mac/ios"]
-
-  # module_test_ios:
-  #   description: >
-  #     Checks that the module project template works and supports add2app on iOS.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["mac/ios"]
 
   external_ui_integration_test_ios:
     description: >
@@ -513,13 +462,6 @@ tasks:
       Measures the performance of Dart VM hot patching feature on a Linux host.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-
-  # TODO(dnfield): Remove these once we're confident it's all working on cirrus
-  # dartdocs:
-  #   description: >
-  #     Tracks how many members are still lacking documentation.
-  #   stage: devicelab
-  #   required_agent_capabilities: ["linux/android"]
 
   flutter_test_performance:
     description: >

--- a/dev/tools/java_and_objc_doc.dart
+++ b/dev/tools/java_and_objc_doc.dart
@@ -57,8 +57,6 @@ Future<void> generateDocs(String url, String docName, String checkFile) async {
   output.createSync(recursive: true);
 
   for (ArchiveFile af in archive) {
-    // TODO(dnfield): Archive changed their API so that isFile now returns true
-    // for directories.
     if (!af.name.endsWith('/')) {
       final File file = File('${output.path}/${af.name}');
       file.createSync(recursive: true);


### PR DESCRIPTION
We've been running these tests on Cirrus for a while now - I don't see them going back to the devicelab soon.

I'm also not sure it makes sense to mark the archive issue as a TODO at this point - they changed the API, we now work.