### PR TITLE
Add DiagnosticableMixin

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2828,7 +2828,10 @@ class DiagnosticPropertiesBuilder {
 ///
 ///  * [DiagnosticableTree], which extends this class to also describe the
 ///    children of a tree structured object.
-///  * [Diagnosticable.debugFillProperties], which lists best practices
+///  * [DiagnosticableMixin], which provides the implementation for
+///    [Diagnosticable], and can be used to add diagnostics to classes which
+///    already have a base class.
+///  * [DiagnosticableMixin.debugFillProperties], which lists best practices
 ///    for specifying the properties of a [DiagnosticsNode]. The most common use
 ///    case is to override [debugFillProperties] defining custom properties for
 ///    a subclass of [DiagnosticableTreeMixin] using the existing
@@ -2840,11 +2843,39 @@ class DiagnosticPropertiesBuilder {
 ///  * [DiagnosticsProperty], which should be used to create leaf diagnostic
 ///    nodes without properties or children. There are many
 ///    [DiagnosticsProperty] subclasses to handle common use cases.
-abstract class Diagnosticable {
+abstract class Diagnosticable with DiagnosticableMixin {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const Diagnosticable();
+}
 
+/// A mixin class that provides the implementation for [Diagnosticable].
+///
+/// This mixin can be used to add diagnostics to a class which already has an
+/// base class.
+///
+/// The string debug representation is generated from the intermediate
+/// [DiagnosticsNode] representation. The [DiagnosticsNode] representation is
+/// also used by debugging tools displaying interactive trees of objects and
+/// properties.
+///
+/// See also:
+///
+///  * [debugFillProperties], which lists best practices for specifying the
+///    properties of a [DiagnosticsNode]. The most common use case is to
+///    override [debugFillProperties] defining custom properties for a subclass
+///    of [DiagnosticableTreeMixin] using the existing [DiagnosticsProperty]
+///    subclasses.
+///  * [DiagnosticableTree], which extends this class to also describe the
+///    children of a tree structured object.
+///  * [DiagnosticableTree.debugDescribeChildren], which lists best practices
+///    for describing the children of a [DiagnosticsNode]. Typically the base
+///    class already describes the children of a node properly or a node has
+///    no children.
+///  * [DiagnosticsProperty], which should be used to create leaf diagnostic
+///    nodes without properties or children. There are many
+///    [DiagnosticsProperty] subclasses to handle common use cases.
+mixin DiagnosticableMixin {
   /// A brief description of this object, usually just the [runtimeType] and the
   /// [hashCode].
   ///


### PR DESCRIPTION
## Description

This adds `DiagnosticableMixin` as a mixin class that provides the implementaion for `Diagnosticable`, so that we can now add diagnostics to classes which already have a base class.

I encountered a problem when I had objects that were `ChangeNotifiers`: I also wanted them to be `Diagnosticable`, but they couldn't be, since `Diagnosticable` declares a constructor. This change fixes that limitation.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
