### PR TITLE
Un-mark uncaught_image_error_linux as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -102,7 +102,6 @@ tasks:
       Ensures that an error thrown into the zone can be caught by the ImageStream
       completer
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["linux/android"]
 
   flutter_gallery_android__compile:


### PR DESCRIPTION
uncaught_image_error_linux is marked flaky, but has been green for a long time.
