### PR TITLE
Tap the current tab bar item to pop to the first route

### DIFF
--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -211,7 +211,7 @@ class _SegmentedControlState<T> extends State<CupertinoSegmentedControl<T>>
   }
 
   bool _updateColors() {
-    assert(mounted, 'This should only be called after didUpdateDependencies');
+    assert(mounted, 'This should only be called after didChangeDependencies');
     bool changed = false;
     final Color selectedColor = widget.selectedColor ?? CupertinoTheme.of(context).primaryColor;
     if (_selectedColor != selectedColor) {
@@ -250,7 +250,7 @@ class _SegmentedControlState<T> extends State<CupertinoSegmentedControl<T>>
   }
 
   void _updateAnimationControllers() {
-    assert(mounted, 'This should only be called after didUpdateDependencies');
+    assert(mounted, 'This should only be called after didChangeDependencies');
     for (AnimationController controller in _selectionControllers) {
       controller.dispose();
     }

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -100,8 +100,8 @@ class CupertinoTabController extends ChangeNotifier {
   }
 }
 
-/// An object that holds at most one listener, who will be notified when the
-/// tab item that corresponds to the encompassing [CupertinoTabScaffold]'s
+/// An object that holds at most one listener. The current listener will be notified
+/// when the tab item that corresponds to the encompassing [CupertinoTabScaffold]'s
 /// current tab is tapped.
 ///
 /// See also:

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -115,7 +115,7 @@ class CupertinoTabViewTapNotifier {
   static CupertinoTabViewTapNotifier of(BuildContext context) {
     final _TapNotifierWidget notifierWidget = context
       .inheritFromWidgetOfExactType(_TapNotifierWidget);
-    return notifierWidget.notifier;
+    return notifierWidget?.notifier;
   }
 
   /// Set the listener of this [CupertinoTabViewTapNotifier] and drop any

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -105,27 +105,25 @@ class CupertinoTabViewTapNotifier {
 
   static CupertinoTabViewTapNotifier of(BuildContext context) {
     final _TapNotifierWidget notifierWidget = context
-    .ancestorWidgetOfExactType(_TapNotifierWidget);
-
+      .inheritFromWidgetOfExactType(_TapNotifierWidget);
     return notifierWidget.notifier;
   }
 
   void updateListener(VoidCallback listener) {
-    if (_onTapCurrentTab == listener) {
-      return;
-    }
+    print('update listener: $listener');
     _onTapCurrentTab = listener;
   }
 }
 
-class _TapNotifierWidget extends StatelessWidget {
-  const _TapNotifierWidget({ Key key, this.notifier, this.child }) : super(key: key);
+class _TapNotifierWidget extends InheritedWidget {
+  const _TapNotifierWidget({ Key key, @required this.notifier, Widget child })
+    : assert(notifier != null),
+      super(key: key, child: child);
 
-  final Widget child;
   final CupertinoTabViewTapNotifier notifier;
 
   @override
-  Widget build(BuildContext context) => child;
+  bool updateShouldNotify(_TapNotifierWidget oldWidget) => notifier != oldWidget.notifier;
 }
 
 /// Implements a tabbed iOS application's root layout and behavior structure.

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -100,6 +100,26 @@ class CupertinoTabController extends ChangeNotifier {
   }
 }
 
+class _CupertinoTabViewTapNotifier extends ChangeNotifier {
+  VoidCallback currentListener;
+
+  @override
+  void addListener(VoidCallback listener) {
+    if (currentListener != null) {
+      removeListener(listener);
+    }
+    currentListener = listener;
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    assert(identical(listener, currentListener));
+    currentListener = null;
+    super.removeListener(listener);
+  }
+}
+
 /// Implements a tabbed iOS application's root layout and behavior structure.
 ///
 /// The scaffold lays out the tab bar at the bottom and the content between or
@@ -274,12 +294,17 @@ class CupertinoTabScaffold extends StatefulWidget {
   /// Defaults to true and cannot be null.
   final bool resizeToAvoidBottomInset;
 
+  static ChangeNotifier of(BuildContext context) {
+
+  }
+
   @override
   _CupertinoTabScaffoldState createState() => _CupertinoTabScaffoldState();
 }
 
 class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> {
   CupertinoTabController _controller;
+  final _CupertinoTabViewTapNotifier _notifier = _CupertinoTabViewTapNotifier();
 
   @override
   void initState() {

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -100,17 +100,27 @@ class CupertinoTabController extends ChangeNotifier {
   }
 }
 
+/// An object that holds at most one listener, who will be notified when the
+/// tab item that corresponds to the encompassing [CupertinoTabScaffold]'s
+/// current tab is tapped.
+///
+/// See also:
+///
+/// * [CupertinoTabView], a widget that listens to [CupertinoTabViewTapNotifier].
 class CupertinoTabViewTapNotifier {
+  CupertinoTabViewTapNotifier._();
   VoidCallback _onTapCurrentTab;
 
+  /// The closest [CupertinoTabViewTapNotifier] instance given the build context.
   static CupertinoTabViewTapNotifier of(BuildContext context) {
     final _TapNotifierWidget notifierWidget = context
       .inheritFromWidgetOfExactType(_TapNotifierWidget);
     return notifierWidget.notifier;
   }
 
+  /// Set the listener of this [CupertinoTabViewTapNotifier] and drop any
+  /// existing listener.
   void updateListener(VoidCallback listener) {
-    print('update listener: $listener');
     _onTapCurrentTab = listener;
   }
 }
@@ -465,6 +475,7 @@ class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> {
       _controller.removeListener(_onCurrentIndexChange);
     }
 
+    _tapNotifiers = null;
     super.dispose();
   }
 }
@@ -536,7 +547,7 @@ class _TabSwitchingViewState extends State<_TabSwitchingView> {
         final bool active = index == widget.currentTabIndex;
 
         if (active || tabs[index] != null) {
-          widget.tapNotifiers[index] ??= CupertinoTabViewTapNotifier();
+          widget.tapNotifiers[index] ??= CupertinoTabViewTapNotifier._();
           tabs[index] = _TapNotifierWidget(
             notifier: widget.tapNotifiers[index],
             child: widget.tabBuilder(context, index)

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -162,8 +162,13 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
   @override
   void didUpdateWidget(CupertinoTabView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.navigatorKey != oldWidget.navigatorKey
-        || widget.navigatorObservers != oldWidget.navigatorObservers) {
+    if (widget.navigatorKey != oldWidget.navigatorKey && _heroController.navigator != null) {
+      // If the existing `_heroController` already has a navigator, replace it
+      // with a new controller.
+      _heroController = CupertinoApp.createCupertinoHeroController();
+      _updateObservers();
+    }
+    if (widget.navigatorObservers != oldWidget.navigatorObservers) {
       _updateObservers();
     }
   }

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -126,6 +126,16 @@ class CupertinoTabView extends StatefulWidget {
   /// This list of observers is not shared with ancestor or descendant [Navigator]s.
   final List<NavigatorObserver> navigatorObservers;
 
+  @protected
+  void onTapWhenActive() {
+    if (navigatorKey != null) {
+      final NavigatorState navigator = navigatorKey.currentState;
+      if (navigator.canPop()) {
+        navigator.popUntil((Route<dynamic> route) => route.isFirst);
+      }
+    }
+  }
+
   @override
   _CupertinoTabViewState createState() {
     return _CupertinoTabViewState();
@@ -153,6 +163,14 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     }
   }
 
+  @override
+  void didChangeDependencies() {
+    CupertinoTabViewTapNotifier.of(context)
+      ?.updateListener(widget.onTapWhenActive);
+
+    super.didChangeDependencies();
+  }
+
   void _updateObserversAndKey() {
     _navigatorObservers =
         List<NavigatorObserver>.from(widget.navigatorObservers)
@@ -162,10 +180,6 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
 
   @override
   Widget build(BuildContext context) {
-    final CupertinoTabViewTapNotifier notifier = CupertinoTabViewTapNotifier.of(context);
-    if (notifier != null) {
-      notifier.updateListener(_onTapWhenActive);
-    }
     return Navigator(
       key: _effectiveNavigatorKey,
       onGenerateRoute: _onGenerateRoute,
@@ -226,12 +240,5 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
       return true;
     }());
     return result;
-  }
-
-  void _onTapWhenActive() {
-    final NavigatorState navigator = _effectiveNavigatorKey.currentState;
-    if (navigator.canPop()) {
-      navigator.popUntil((Route<dynamic> route) => route.isFirst);
-    }
   }
 }

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -13,8 +13,7 @@ import 'tab_scaffold.dart' show CupertinoTabViewTapNotifier;
 /// A typical tab view used as the content of each tab in a [CupertinoTabScaffold]
 /// where multiple tabs with parallel navigation states and history can
 /// co-exist.
-///
-/// [CupertinoTabView] configures the top-level [Navigator] to search for routes
+/// /// [CupertinoTabView] configures the top-level [Navigator] to search for routes
 /// in the following order:
 ///
 ///  1. For the `/` route, the [builder] property, if non-null, is used.
@@ -126,13 +125,19 @@ class CupertinoTabView extends StatefulWidget {
   /// This list of observers is not shared with ancestor or descendant [Navigator]s.
   final List<NavigatorObserver> navigatorObservers;
 
+  /// Called when the corresponding item in [CupertinoTabScaffold.tabBar] is
+  /// tapped while this [CupertinoTabView] is the actively displayed tab of the
+  /// encompassing [CupertinoTabScaffold].
+  ///
+  /// The default implementation does not do anything unless a non-null
+  /// [navigatorKey] is specified, in which case it will attempt to call
+  /// [Navigator.pop] until the bottom-most route is the current route of the
+  /// [Navigator].
   @protected
   void onTapWhenActive() {
-    if (navigatorKey != null) {
-      final NavigatorState navigator = navigatorKey.currentState;
-      if (navigator.canPop()) {
-        navigator.popUntil((Route<dynamic> route) => route.isFirst);
-      }
+    final NavigatorState navigator = navigatorKey?.currentState;
+    if (navigator?.canPop() == true) {
+      navigator.popUntil((Route<dynamic> route) => route.isFirst);
     }
   }
 
@@ -145,13 +150,12 @@ class CupertinoTabView extends StatefulWidget {
 class _CupertinoTabViewState extends State<CupertinoTabView> {
   HeroController _heroController;
   List<NavigatorObserver> _navigatorObservers;
-  GlobalKey<NavigatorState> _effectiveNavigatorKey;
 
   @override
   void initState() {
     super.initState();
     _heroController = CupertinoApp.createCupertinoHeroController();
-    _updateObserversAndKey();
+    _updateObservers();
   }
 
   @override
@@ -159,7 +163,7 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     super.didUpdateWidget(oldWidget);
     if (widget.navigatorKey != oldWidget.navigatorKey
         || widget.navigatorObservers != oldWidget.navigatorObservers) {
-      _updateObserversAndKey();
+      _updateObservers();
     }
   }
 
@@ -171,17 +175,16 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     super.didChangeDependencies();
   }
 
-  void _updateObserversAndKey() {
+  void _updateObservers() {
     _navigatorObservers =
         List<NavigatorObserver>.from(widget.navigatorObservers)
           ..add(_heroController);
-    _effectiveNavigatorKey = widget.navigatorKey ?? GlobalKey<NavigatorState>();
   }
 
   @override
   Widget build(BuildContext context) {
     return Navigator(
-      key: _effectiveNavigatorKey,
+      key: widget.navigatorKey,
       onGenerateRoute: _onGenerateRoute,
       onUnknownRoute: _onUnknownRoute,
       observers: _navigatorObservers,

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -13,7 +13,8 @@ import 'tab_scaffold.dart' show CupertinoTabViewTapNotifier;
 /// A typical tab view used as the content of each tab in a [CupertinoTabScaffold]
 /// where multiple tabs with parallel navigation states and history can
 /// co-exist.
-/// /// [CupertinoTabView] configures the top-level [Navigator] to search for routes
+///
+/// [CupertinoTabView] configures the top-level [Navigator] to search for routes
 /// in the following order:
 ///
 ///  1. For the `/` route, the [builder] property, if non-null, is used.

--- a/packages/flutter/test/cupertino/tab_view_test.dart
+++ b/packages/flutter/test/cupertino/tab_view_test.dart
@@ -1,0 +1,110 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
+
+import '../painting/mocks_for_image_cache.dart';
+
+typedef IntCallback = void Function(int);
+
+class MockNavigatorObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) => stackDepth++;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic> previousRoute) => stackDepth--;
+}
+
+final List<int> tabsPainted = <int>[];
+final List<int> selectedTabs = <int>[];
+final CupertinoTabController controller = CupertinoTabController();
+MockNavigatorObserver mockObserver;
+int stackDepth = 0;
+
+final List<GlobalKey<NavigatorState>> keys = List<GlobalKey<NavigatorState>>.generate(
+  100,
+  (_) => GlobalKey<NavigatorState>(),
+);
+
+IndexedWidgetBuilder buildTabView(WidgetBuilder builder) {
+  return (BuildContext context, int index) {
+    return CupertinoTabView(
+      navigatorKey: keys[index],
+      builder: builder,
+      navigatorObservers: <NavigatorObserver>[mockObserver],
+    );
+  };
+}
+
+Widget defaultBuilder(BuildContext context) {
+  return CupertinoButton(
+    onPressed: () => CupertinoPageRoute<dynamic>(builder: defaultBuilder),
+    child: const Text('push'),
+  );
+}
+
+Widget buildBoilerplate({
+    int numOfTabs = 10,
+    int selectedTab = 0,
+    IntCallback onTap,
+    IndexedWidgetBuilder tabBuilder
+}) {
+  return CupertinoApp(
+    home: CupertinoTabScaffold(
+      tabBar: CupertinoTabBar(
+        items: List<BottomNavigationBarItem>.generate(
+          numOfTabs,
+          (int index) => BottomNavigationBarItem(
+            icon: const ImageIcon(TestImageProvider(24, 24)),
+            title: Text('Tab ${index + 1}'),
+          ),
+        ),
+        onTap: onTap ?? (_) => null,
+      ),
+      controller: controller,
+      tabBuilder: tabBuilder ?? buildTabView(defaultBuilder),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    selectedTabs.clear();
+    tabsPainted.clear();
+    controller.index = 0;
+    mockObserver = MockNavigatorObserver();
+  });
+
+  FutureOr<void> push(int times, WidgetTester tester) async {
+    if (times < 1) {
+      expect(stackDepth, times);
+      return;
+    }
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+
+    return await push(times - 1, tester);
+  }
+
+  void verifyPop(int times) {
+    if (times < 1) {
+      verifyZeroInteractions(mockObserver);
+      return;
+    }
+    verify(mockObserver.didPop(any, any));
+    return verifyPop(times - 1);
+  }
+
+  testWidgets('tap when active works', (WidgetTester tester) async {
+    await tester.pumpWidget(buildBoilerplate());
+    await push(15, tester);
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump(const Duration(seconds: 2));
+
+    verifyPop(15);
+  });
+}

--- a/packages/flutter/test/cupertino/tab_view_test.dart
+++ b/packages/flutter/test/cupertino/tab_view_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../painting/mocks_for_image_cache.dart';
+import '../painting/mocks_for_image_cache.dart' show TestImageProvider;
 
 typedef IntCallback = void Function(int);
 

--- a/packages/flutter/test/cupertino/tab_view_test.dart
+++ b/packages/flutter/test/cupertino/tab_view_test.dart
@@ -38,7 +38,6 @@ class TestCupertinoTabView extends CupertinoTabView {
 final List<int> tabsPainted = <int>[];
 final List<int> selectedTabs = <int>[];
 final CupertinoTabController controller = CupertinoTabController();
-//MockNavigatorObserver mockObserver;
 int stackDepth = 0;
 
 final List<GlobalKey<NavigatorState>> keys = List<GlobalKey<NavigatorState>>.generate(

--- a/packages/flutter/test/cupertino/tab_view_test.dart
+++ b/packages/flutter/test/cupertino/tab_view_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'dart:async';
 
 import '../painting/mocks_for_image_cache.dart';
 
@@ -12,16 +12,33 @@ typedef IntCallback = void Function(int);
 
 class MockNavigatorObserver extends NavigatorObserver {
   @override
-  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) => stackDepth++;
+  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
+    stackDepth++;
+  }
 
   @override
-  void didPop(Route<dynamic> route, Route<dynamic> previousRoute) => stackDepth--;
+  void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {
+    stackDepth--;
+  }
+}
+
+class TestCupertinoTabView extends CupertinoTabView {
+  const TestCupertinoTabView({
+    Key key,
+    WidgetBuilder builder,
+    this.onTap,
+  }) : super(key: key, builder: builder);
+
+  final VoidCallback onTap;
+
+  @override
+  void onTapWhenActive() => onTap();
 }
 
 final List<int> tabsPainted = <int>[];
 final List<int> selectedTabs = <int>[];
 final CupertinoTabController controller = CupertinoTabController();
-MockNavigatorObserver mockObserver;
+//MockNavigatorObserver mockObserver;
 int stackDepth = 0;
 
 final List<GlobalKey<NavigatorState>> keys = List<GlobalKey<NavigatorState>>.generate(
@@ -34,14 +51,14 @@ IndexedWidgetBuilder buildTabView(WidgetBuilder builder) {
     return CupertinoTabView(
       navigatorKey: keys[index],
       builder: builder,
-      navigatorObservers: <NavigatorObserver>[mockObserver],
+      navigatorObservers: <NavigatorObserver>[MockNavigatorObserver()]
     );
   };
 }
 
 Widget defaultBuilder(BuildContext context) {
   return CupertinoButton(
-    onPressed: () => CupertinoPageRoute<dynamic>(builder: defaultBuilder),
+    onPressed: () => Navigator.push<void>(context, CupertinoPageRoute<void>(builder: defaultBuilder)),
     child: const Text('push'),
   );
 }
@@ -75,36 +92,127 @@ void main() {
     selectedTabs.clear();
     tabsPainted.clear();
     controller.index = 0;
-    mockObserver = MockNavigatorObserver();
+    stackDepth = 0;
   });
 
   FutureOr<void> push(int times, WidgetTester tester) async {
-    if (times < 1) {
-      expect(stackDepth, times);
-      return;
+    final int initialStackDepth = stackDepth;
+    for(int i = 0; i < times; i++) {
+      await tester.tap(find.text('push'));
+      await tester.pumpAndSettle();
+      expect(stackDepth, initialStackDepth + i + 1);
     }
-    await tester.tap(find.text('push'));
-    await tester.pumpAndSettle();
-
-    return await push(times - 1, tester);
-  }
-
-  void verifyPop(int times) {
-    if (times < 1) {
-      verifyZeroInteractions(mockObserver);
-      return;
-    }
-    verify(mockObserver.didPop(any, any));
-    return verifyPop(times - 1);
+    expect(stackDepth, times + initialStackDepth);
   }
 
   testWidgets('tap when active works', (WidgetTester tester) async {
     await tester.pumpWidget(buildBoilerplate());
+    // The initial route has been pushed.
+    expect(stackDepth, 1);
+
     await push(15, tester);
 
     await tester.tap(find.text('Tab 1'));
-    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    // The animation should play out as if there were only one route was popped.
+    expect(tester.binding.hasScheduledFrame, isFalse);
 
-    verifyPop(15);
+    // Only the bottom-most route is left.
+    expect(stackDepth, 1);
+  });
+
+  testWidgets('tap when active still works, after switching back to tab 1 from a different tab',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(buildBoilerplate());
+      // The initial route has been pushed.
+      expect(stackDepth, 1);
+
+      await push(15, tester);
+
+      await tester.tap(find.text('Tab 2'));
+      await tester.pump();
+      // Now there're 2 initial routes, and 15 more.
+      expect(stackDepth, 17);
+
+      // Now there're 2 initial routes, and 15 + 20 more.
+      await push(20, tester);
+      expect(stackDepth, 37);
+
+      await tester.tap(find.text('Tab 1'));
+      await tester.pump();
+      await tester.tap(find.text('Tab 1'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // Only the bottom-most routes are left in tab 1.
+      expect(stackDepth, 2 + 20);
+
+      await tester.tap(find.text('Tab 2'));
+      await tester.pump();
+      await tester.tap(find.text('Tab 2'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+      expect(stackDepth, 2);
+  });
+
+  testWidgets('tap when active does not do anything if there is nothing to pop',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(buildBoilerplate());
+      // The initial route has been pushed.
+      expect(stackDepth, 1);
+
+      await tester.tap(find.text('Tab 1'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(stackDepth, 1);
+
+      await push(15, tester);
+      await tester.tap(find.text('Tab 1'));
+      await tester.pump();
+  });
+
+  testWidgets('Overriding onTapWhenActive works', (WidgetTester tester) async {
+    int tapCount = 0;
+    await tester.pumpWidget(buildBoilerplate(
+      tabBuilder: (BuildContext context, int index) {
+        return TestCupertinoTabView(builder: defaultBuilder, onTap: () => tapCount++);
+      },
+    ));
+
+    expect(tapCount, 0);
+    for (int i = 5; i > 0; i--) {
+      await tester.tap(find.text('Tab $i'));
+      await tester.pump();
+      // Only tapping on the active tap counts.
+      expect(tapCount, 0);
+    }
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump();
+    expect(tapCount, 1);
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump();
+    expect(tapCount, 2);
+
+    await tester.tap(find.text('Tab 1'));
+    await tester.pump();
+    expect(tapCount, 3);
+
+    // Switch away before starting from 0 again.
+    await tester.tap(find.text('Tab 10'));
+    await tester.pump();
+
+    // Double tap works.
+    for (int i = 0; i < 10; i++) {
+      final int snapshot = tapCount;
+      await tester.tap(find.text('Tab ${i+1}'));
+      await tester.pump();
+      await tester.tap(find.text('Tab ${i+1}'));
+      await tester.pump();
+      expect(tapCount, snapshot + 1);
+    }
   });
 }


### PR DESCRIPTION
## Description

Tapping the current tab bar item in a `UITabController` brings the user back to the root view controller, if the user is already in the root view controller it will try to scroll the child `UITableViewController` to the top.  This is the first step to implementing such behavior.

## Related Issues

flutter/flutter#104705

## Tests

See `tab_view_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
