### PR TITLE
Restructure macOS project files

### DIFF
--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -41,7 +41,7 @@ fi
 
 # Copy the framework and handle local engine builds.
 framework_name="FlutterMacOS.framework"
-derived_dir="${SOURCE_ROOT}/Flutter"
+ephemeral_dir="${SOURCE_ROOT}/Flutter/ephemeral"
 framework_path="${FLUTTER_ROOT}/bin/cache/artifacts/engine/darwin-x64"
 flutter_framework="${framework_path}/${framework_name}"
 
@@ -66,9 +66,9 @@ if [[ -n "$LOCAL_ENGINE" ]]; then
   flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/${framework_name}"
 fi
 
-RunCommand mkdir -p -- "$derived_dir"
-RunCommand rm -rf -- "${derived_dir}/${framework_name}"
-RunCommand cp -Rp -- "${flutter_framework}" "${derived_dir}"
+RunCommand mkdir -p -- "$ephemeral_dir"
+RunCommand rm -rf -- "${ephemeral_dir}/${framework_name}"
+RunCommand cp -Rp -- "${flutter_framework}" "${ephemeral_dir}"
 
 # Set the build mode
 build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -580,27 +580,38 @@ class MacOSProject {
 
   static const String _hostAppBundleName = 'Runner';
 
-  bool existsSync() => project.directory.childDirectory('macos').existsSync();
+  bool existsSync() => _macOSDirectory.existsSync();
 
-  Directory get _editableDirectory => project.directory.childDirectory('macos');
+  Directory get _macOSDirectory => project.directory.childDirectory('macos');
 
-  Directory get _cacheDirectory => _editableDirectory.childDirectory('Flutter');
+  /// The directory in the project that is managed by Flutter. As much as
+  /// possible, files that are edited by Flutter tooling after initial project
+  /// creation should live here.
+  Directory get managedDirectory => _macOSDirectory.childDirectory('Flutter');
+
+  /// The subdirectory of [managedDirectory] that contains files that are
+  /// generated on the fly. All generated files that are not intended to be
+  /// checked in should live here.
+  Directory get ephemeralDirectory => managedDirectory.childDirectory('ephemeral');
 
   /// Contains definitions for FLUTTER_ROOT, LOCAL_ENGINE, and more flags for
   /// the Xcode build.
-  File get generatedXcodePropertiesFile => _cacheDirectory.childFile('Generated.xcconfig');
+  File get generatedXcodePropertiesFile => ephemeralDirectory.childFile('Flutter-Generated.xcconfig');
+
+  /// The Flutter-managed Xcode config file for [mode].
+  File xcodeConfigFor(String mode) => managedDirectory.childFile('Flutter-$mode.xcconfig');
 
   /// The Xcode project file.
-  Directory get xcodeProject => _editableDirectory.childDirectory('$_hostAppBundleName.xcodeproj');
+  Directory get xcodeProject => _macOSDirectory.childDirectory('$_hostAppBundleName.xcodeproj');
 
   /// The Xcode workspace file.
-  Directory get xcodeWorkspace => _editableDirectory.childDirectory('$_hostAppBundleName.xcworkspace');
+  Directory get xcodeWorkspace => _macOSDirectory.childDirectory('$_hostAppBundleName.xcworkspace');
 
   /// The file where the Xcode build will write the name of the built app.
   ///
   /// Ideally this will be replaced in the future with inspection of the Runner
   /// scheme's target.
-  File get nameFile => _cacheDirectory.childFile('.app_filename');
+  File get nameFile => ephemeralDirectory.childFile('.app_filename');
 }
 
 /// The Windows sub project


### PR DESCRIPTION
## Description

Rather than macos/Flutter containing a mixture of files that should and
shouldn't be checked in, create clear locations for:
- Files that are "owned" by Flutter, but should be checked in
  (Flutter/). This will contain files like the top-level Flutter
  xcconfigs, generated plugin registrants, etc.
- Files that are generated by Flutter on the fly, and should not be
  checked in (Flutter/ephemeral/). This will contain Flutter SDK caches,
  the generated xcconfig, etc.

Also adds Flutter-owned Debug and Release xcconfig variants, in
preparation for PodSpec tooling.

## Related Issues

None.

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

(This is a breaking change, but only for macOS, which is explicitly unstable.)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
