### PR TITLE
Use Dart's new direct ELF generator to package AOT blobs as shared libraries in Android APKs

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -429,7 +429,7 @@ Future<void> _buildGradleProjectV2(
     command.add('-Pfilesystem-roots=${buildInfo.fileSystemRoots.join('|')}');
   if (buildInfo.fileSystemScheme != null)
     command.add('-Pfilesystem-scheme=${buildInfo.fileSystemScheme}');
-  if (buildInfo.buildSharedLibrary && androidSdk.ndk != null) {
+  if (buildInfo.buildSharedLibrary) {
     command.add('-Pbuild-shared-library=true');
   }
   if (buildInfo.targetPlatform != null)


### PR DESCRIPTION
This is a replacement for the old implementation of --build-shared-library
that emits an AOT assembly snapshot and feeds it to the Android NDK toolchain.
