### PR TITLE
Document that offsets are returned in logical pixels

### DIFF
--- a/packages/flutter_driver/lib/src/common/geometry.dart
+++ b/packages/flutter_driver/lib/src/common/geometry.dart
@@ -27,11 +27,11 @@ enum OffsetType {
 
 EnumIndex<OffsetType> _offsetTypeIndex = EnumIndex<OffsetType>(OffsetType.values);
 
-/// A Flutter Driver command that return the [offsetType] from the RenderObject
+/// A Flutter Driver command that returns the [offsetType] from the RenderObject
 /// identified by [finder].
 ///
 /// The requested offset is returned in logical pixels, which can be translated
-/// to device pixels via the [Window.devicePixelRatio].
+/// to device pixels via [Window.devicePixelRatio].
 class GetOffset extends CommandWithTarget {
   /// The `finder` looks for an element to get its rect.
   GetOffset(SerializableFinder finder,  this.offsetType, { Duration timeout }) : super(finder, timeout: timeout);
@@ -56,20 +56,20 @@ class GetOffset extends CommandWithTarget {
 /// The result of the [GetRect] command.
 ///
 /// The offset is provided in logical pixels, which can be translated
-/// to device pixels via the [Window.devicePixelRatio].
+/// to device pixels via [Window.devicePixelRatio].
 class GetOffsetResult extends Result {
   /// Creates a result with the offset defined by [dx] and [dy].
   const GetOffsetResult({ this.dx = 0.0, this.dy = 0.0});
 
   /// The x component of the offset in logical pixels.
   ///
-  /// The value can be translated to device pixels via the
+  /// The value can be translated to device pixels via
   /// [Window.devicePixelRatio].
   final double dx;
 
   /// The y component of the offset in logical pixels.
   ///
-  /// The value can be translated to device pixels via the
+  /// The value can be translated to device pixels via
   /// [Window.devicePixelRatio].
   final double dy;
 

--- a/packages/flutter_driver/lib/src/common/geometry.dart
+++ b/packages/flutter_driver/lib/src/common/geometry.dart
@@ -29,6 +29,9 @@ EnumIndex<OffsetType> _offsetTypeIndex = EnumIndex<OffsetType>(OffsetType.values
 
 /// A Flutter Driver command that return the [offsetType] from the RenderObject
 /// identified by [finder].
+///
+/// The requested offset is returned in logical pixels, which can be translated
+/// to device pixels via the [Window.devicePixelRatio].
 class GetOffset extends CommandWithTarget {
   /// The `finder` looks for an element to get its rect.
   GetOffset(SerializableFinder finder,  this.offsetType, { Duration timeout }) : super(finder, timeout: timeout);
@@ -51,14 +54,23 @@ class GetOffset extends CommandWithTarget {
 }
 
 /// The result of the [GetRect] command.
+///
+/// The offset is provided in logical pixels, which can be translated
+/// to device pixels via the [Window.devicePixelRatio].
 class GetOffsetResult extends Result {
   /// Creates a result with the offset defined by [dx] and [dy].
   const GetOffsetResult({ this.dx = 0.0, this.dy = 0.0});
 
-  /// The x component of the offset.
+  /// The x component of the offset in logical pixels.
+  ///
+  /// The value can be translated to device pixels via the
+  /// [Window.devicePixelRatio].
   final double dx;
 
-  /// The y component of the offset.
+  /// The y component of the offset in logical pixels.
+  ///
+  /// The value can be translated to device pixels via the
+  /// [Window.devicePixelRatio].
   final double dy;
 
   /// Deserializes the result from JSON.

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -485,7 +485,7 @@ class FlutterDriver {
   /// Returns the point at the top left of the widget identified by `finder`.
   ///
   /// The offset is expressed in logical pixels and can be translated to
-  /// device pixels via the [Window.devicePixelRatio].
+  /// device pixels via [Window.devicePixelRatio].
   Future<DriverOffset> getTopLeft(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.topLeft, timeout: timeout);
   }
@@ -493,7 +493,7 @@ class FlutterDriver {
   /// Returns the point at the top right of the widget identified by `finder`.
   ///
   /// The offset is expressed in logical pixels and can be translated to
-  /// device pixels via the [Window.devicePixelRatio].
+  /// device pixels via [Window.devicePixelRatio].
   Future<DriverOffset> getTopRight(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.topRight, timeout: timeout);
   }
@@ -501,7 +501,7 @@ class FlutterDriver {
   /// Returns the point at the bottom left of the widget identified by `finder`.
   ///
   /// The offset is expressed in logical pixels and can be translated to
-  /// device pixels via the [Window.devicePixelRatio].
+  /// device pixels via [Window.devicePixelRatio].
   Future<DriverOffset> getBottomLeft(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.bottomLeft, timeout: timeout);
   }
@@ -509,7 +509,7 @@ class FlutterDriver {
   /// Returns the point at the bottom right of the widget identified by `finder`.
   ///
   /// The offset is expressed in logical pixels and can be translated to
-  /// device pixels via the [Window.devicePixelRatio].
+  /// device pixels via [Window.devicePixelRatio].
   Future<DriverOffset> getBottomRight(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.bottomRight, timeout: timeout);
   }
@@ -517,7 +517,7 @@ class FlutterDriver {
   /// Returns the point at the center of the widget identified by `finder`.
   ///
   /// The offset is expressed in logical pixels and can be translated to
-  /// device pixels via the [Window.devicePixelRatio].
+  /// device pixels via [Window.devicePixelRatio].
   Future<DriverOffset> getCenter(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.center, timeout: timeout);
   }

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -483,26 +483,41 @@ class FlutterDriver {
   }
 
   /// Returns the point at the top left of the widget identified by `finder`.
+  ///
+  /// The offset is expressed in logical pixels and can be translated to
+  /// device pixels via the [Window.devicePixelRatio].
   Future<DriverOffset> getTopLeft(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.topLeft, timeout: timeout);
   }
 
   /// Returns the point at the top right of the widget identified by `finder`.
+  ///
+  /// The offset is expressed in logical pixels and can be translated to
+  /// device pixels via the [Window.devicePixelRatio].
   Future<DriverOffset> getTopRight(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.topRight, timeout: timeout);
   }
 
   /// Returns the point at the bottom left of the widget identified by `finder`.
+  ///
+  /// The offset is expressed in logical pixels and can be translated to
+  /// device pixels via the [Window.devicePixelRatio].
   Future<DriverOffset> getBottomLeft(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.bottomLeft, timeout: timeout);
   }
 
   /// Returns the point at the bottom right of the widget identified by `finder`.
+  ///
+  /// The offset is expressed in logical pixels and can be translated to
+  /// device pixels via the [Window.devicePixelRatio].
   Future<DriverOffset> getBottomRight(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.bottomRight, timeout: timeout);
   }
 
   /// Returns the point at the center of the widget identified by `finder`.
+  ///
+  /// The offset is expressed in logical pixels and can be translated to
+  /// device pixels via the [Window.devicePixelRatio].
   Future<DriverOffset> getCenter(SerializableFinder finder, { Duration timeout }) async {
     return _getOffset(finder, OffsetType.center, timeout: timeout);
   }


### PR DESCRIPTION
## Description

Make documentation more specific to avoid user confusion.

## Related Issues

None

## Tests

I added the following tests:

None, doc only change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
