### PR TITLE
CupertinoTabScaffold crash fix

### DIFF
--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -66,7 +66,7 @@ void main() {
       ),
     );
 
-    expect(tabsPainted, <int>[0]);
+    expect(tabsPainted, const <int>[0]);
     RichText tab1 = tester.widget(find.descendant(
       of: find.text('Tab 1'),
       matching: find.byType(RichText),
@@ -81,7 +81,7 @@ void main() {
     await tester.tap(find.text('Tab 2'));
     await tester.pump();
 
-    expect(tabsPainted, <int>[0, 1]);
+    expect(tabsPainted, const <int>[0, 1]);
     tab1 = tester.widget(find.descendant(
       of: find.text('Tab 1'),
       matching: find.byType(RichText),
@@ -96,9 +96,9 @@ void main() {
     await tester.tap(find.text('Tab 1'));
     await tester.pump();
 
-    expect(tabsPainted, <int>[0, 1, 0]);
+    expect(tabsPainted, const <int>[0, 1, 0]);
     // CupertinoTabBar's onTap callbacks are passed on.
-    expect(selectedTabs, <int>[1, 0]);
+    expect(selectedTabs, const <int>[1, 0]);
   });
 
   testWidgets('Tabs are lazy built and moved offstage when inactive', (WidgetTester tester) async {
@@ -116,7 +116,7 @@ void main() {
       ),
     );
 
-    expect(tabsBuilt, <int>[0]);
+    expect(tabsBuilt, const <int>[0]);
     expect(find.text('Page 1'), findsOneWidget);
     expect(find.text('Page 2'), findsNothing);
 
@@ -124,14 +124,14 @@ void main() {
     await tester.pump();
 
     // Both tabs are built but only one is onstage.
-    expect(tabsBuilt, <int>[0, 0, 1]);
+    expect(tabsBuilt, const <int>[0, 0, 1]);
     expect(find.text('Page 1', skipOffstage: false), isOffstage);
     expect(find.text('Page 2'), findsOneWidget);
 
     await tester.tap(find.text('Tab 1'));
     await tester.pump();
 
-    expect(tabsBuilt, <int>[0, 0, 1, 0, 1]);
+    expect(tabsBuilt, const <int>[0, 0, 1, 0, 1]);
     expect(find.text('Page 1'), findsOneWidget);
     expect(find.text('Page 2', skipOffstage: false), isOffstage);
   });
@@ -256,12 +256,12 @@ void main() {
       ),
     );
 
-    expect(tabsPainted, <int>[1]);
+    expect(tabsPainted, const <int>[1]);
 
     controller.index = 0;
     await tester.pump();
 
-    expect(tabsPainted, <int>[1, 0]);
+    expect(tabsPainted, const <int>[1, 0]);
     // onTap is not called when changing tabs programmatically.
     expect(selectedTabs, isEmpty);
 
@@ -269,8 +269,8 @@ void main() {
     await tester.tap(find.text('Tab 2'));
     await tester.pump();
 
-    expect(tabsPainted, <int>[1, 0, 1]);
-    expect(selectedTabs, <int>[1]);
+    expect(tabsPainted, const <int>[1, 0, 1]);
+    expect(selectedTabs, const <int>[1]);
   });
 
   testWidgets('Programmatic tab switching by passing in a new controller', (WidgetTester tester) async {
@@ -292,7 +292,7 @@ void main() {
       ),
     );
 
-    expect(tabsPainted, <int>[0]);
+    expect(tabsPainted, const <int>[0]);
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -311,7 +311,7 @@ void main() {
       ),
     );
 
-    expect(tabsPainted, <int>[0, 1]);
+    expect(tabsPainted, const <int>[0, 1]);
     // onTap is not called when changing tabs programmatically.
     expect(selectedTabs, isEmpty);
 
@@ -319,8 +319,8 @@ void main() {
     await tester.tap(find.text('Tab 1'));
     await tester.pump();
 
-    expect(tabsPainted, <int>[0, 1, 0]);
-    expect(selectedTabs, <int>[0]);
+    expect(tabsPainted, const <int>[0, 1, 0]);
+    expect(selectedTabs, const <int>[0]);
   });
 
   testWidgets('Tab bar respects themes', (WidgetTester tester) async {
@@ -482,18 +482,18 @@ void main() {
       ),
     );
 
-    expect(tabsBuilt, <int>[0]);
+    expect(tabsBuilt, const <int>[0]);
     // selectedTabs list is appended to on onTap callbacks. We didn't tap
     // any tabs yet.
-    expect(selectedTabs, <int>[]);
+    expect(selectedTabs, const <int>[]);
     tabsBuilt.clear();
 
     await tester.tap(find.text('Tab 4'));
     await tester.pump();
 
     // Tabs 1 and 4 are built but only one is onstage.
-    expect(tabsBuilt, <int>[0, 3]);
-    expect(selectedTabs, <int>[3]);
+    expect(tabsBuilt, const <int>[0, 3]);
+    expect(selectedTabs, const <int>[3]);
     expect(find.text('Page 1', skipOffstage: false), isOffstage);
     expect(find.text('Page 4'), findsOneWidget);
     tabsBuilt.clear();
@@ -515,10 +515,10 @@ void main() {
       )
     );
 
-    expect(tabsBuilt, <int>[0, 1]);
+    expect(tabsBuilt, const <int>[0, 1]);
     // We didn't tap on any additional tabs to invoke the onTap callback. We
     // just deleted a tab.
-    expect(selectedTabs, <int>[3]);
+    expect(selectedTabs, const <int>[3]);
     // Tab 1 was previously built so it's rebuilt again, albeit offstage.
     expect(find.text('Different page 1', skipOffstage: false), isOffstage);
     // Since all the tabs after tab 2 are deleted, tab 2 is now the last tab and
@@ -533,7 +533,7 @@ void main() {
     expect(find.text('Page 4', skipOffstage: false), findsNothing);
   });
 
-  // Regression test for #33455
+  // Regression test for https://github.com/flutter/flutter/issues/33455
   testWidgets('Adding new tabs does not crash the app', (WidgetTester tester) async {
     final List<int> tabsPainted = <int>[];
     final CupertinoTabController controller = CupertinoTabController(initialIndex: 0);
@@ -552,12 +552,12 @@ void main() {
                 onPaint: () { tabsPainted.add(index); }
               ),
             );
-          }
+          },
         ),
-      )
+      ),
     );
 
-    expect(tabsPainted, <int> [0]);
+    expect(tabsPainted, const <int> [0]);
 
     // Increase the num of tabs to 20.
     await tester.pumpWidget(
@@ -567,26 +567,25 @@ void main() {
             items: List<BottomNavigationBarItem>.generate(20, tabGenerator),
           ),
           controller: controller,
-          tabBuilder:
-          (BuildContext context, int index) {
+          tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
               child: Text('Page ${index + 1}'),
               painter: TestCallbackPainter(
                 onPaint: () { tabsPainted.add(index); }
               ),
             );
-          }
+          },
         ),
-      )
+      ),
     );
 
-    expect(tabsPainted, <int> [0, 0]);
+    expect(tabsPainted, const <int> [0, 0]);
 
     await tester.tap(find.text('Tab 19'));
     await tester.pump();
 
     // Tapping the tabs should still work.
-    expect(tabsPainted, <int>[0, 0, 18]);
+    expect(tabsPainted, const <int>[0, 0, 18]);
   });
 
   testWidgets('If a controller is initially provided then the parent stops doing so for rebuilds, '
@@ -610,12 +609,12 @@ void main() {
                   onPaint: () { tabsPainted.add(index); }
                 ),
               );
-            }
+            },
           ),
         )
       );
 
-      expect(tabsPainted, <int> [0]);
+      expect(tabsPainted, const <int> [0]);
 
       await tester.pumpWidget(
         CupertinoApp(
@@ -632,24 +631,24 @@ void main() {
                   onPaint: () { tabsPainted.add(index); }
                 ),
               );
-            }
+            },
           ),
         )
       );
 
-      expect(tabsPainted, <int> [0, 0]);
+      expect(tabsPainted, const <int> [0, 0]);
 
       await tester.tap(find.text('Tab 2'));
       await tester.pump();
 
       // Tapping the tabs should still work.
-      expect(tabsPainted, <int>[0, 0, 1]);
+      expect(tabsPainted, const <int>[0, 0, 1]);
 
       oldController.index = 10;
       await tester.pump();
 
       // Changing [index] of the oldController should not work.
-      expect(tabsPainted, <int> [0, 0, 1]);
+      expect(tabsPainted, const <int> [0, 0, 1]);
   });
 
   testWidgets('Do not call dispose on a controller that we do not own'
@@ -666,7 +665,7 @@ void main() {
             controller: mockController,
             tabBuilder: (BuildContext context, int index) => const Placeholder(),
           ),
-        )
+        ),
       );
 
       expect(mockController.numOfListeners, 1);
@@ -681,7 +680,7 @@ void main() {
             controller: null,
             tabBuilder: (BuildContext context, int index) => const Placeholder(),
           ),
-        )
+        ),
       );
 
       expect(mockController.numOfListeners, 0);
@@ -700,7 +699,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) => const Placeholder()
         ),
-      )
+      ),
     );
     expect(find.text('Tab 1'), findsOneWidget);
     expect(find.text('Tab 2'), findsOneWidget);
@@ -717,7 +716,7 @@ void main() {
           controller: controller,
           tabBuilder: (BuildContext context, int index) => const Placeholder()
         ),
-      )
+      ),
     );
 
     // Should not crash here.
@@ -747,9 +746,9 @@ void main() {
                     return CustomPaint(
                       painter: TestCallbackPainter(
                         onPaint: () => tabsPainted0.add(index)
-                      )
+                      ),
                     );
-                  }
+                  },
                 ),
                 CupertinoTabScaffold(
                   tabBar: CupertinoTabBar(
@@ -760,14 +759,14 @@ void main() {
                     return CustomPaint(
                       painter: TestCallbackPainter(
                         onPaint: () => tabsPainted1.add(index)
-                      )
+                      ),
                     );
-                  }
+                  },
                 ),
-              ]
-            )
-          )
-        )
+              ],
+            ),
+          ),
+        ),
       );
       expect(tabsPainted0, const <int>[2]);
       expect(tabsPainted1, const <int>[2]);
@@ -794,14 +793,14 @@ void main() {
                     return CustomPaint(
                       painter: TestCallbackPainter(
                         onPaint: () => tabsPainted0.add(index)
-                      )
+                      ),
                     );
-                  }
+                  },
                 ),
-              ]
-            )
-          )
-        )
+              ],
+            ),
+          ),
+        ),
       );
 
       expect(tabsPainted0, const <int>[2, 0, 1]);


### PR DESCRIPTION
## Description

- Fix index out of range
- Advise against changing tabs in the docs

## Related Issues

Fixes #33455

## Tests

I added the following tests:

- Adding a new tab does not crash the app

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
