### PR TITLE
Include advice about dispose in TextEditingController api 

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -127,7 +127,7 @@ enum OverlayVisibilityMode {
 ///    Design UI conventions.
 ///  * [EditableText], which is the raw text editing control at the heart of a
 ///    [TextField].
-///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
 class CupertinoTextField extends StatefulWidget {
   /// Creates an iOS-style text field.
   ///

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -116,6 +116,9 @@ enum OverlayVisibilityMode {
 /// The text field has an overridable [decoration] that, by default, draws a
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
+/// 
+/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// This will ensure we discard any resources used by the object.
 ///
 /// See also:
 ///
@@ -124,6 +127,7 @@ enum OverlayVisibilityMode {
 ///    Design UI conventions.
 ///  * [EditableText], which is the raw text editing control at the heart of a
 ///    [TextField].
+///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
 class CupertinoTextField extends StatefulWidget {
   /// Creates an iOS-style text field.
   ///

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -117,7 +117,7 @@ enum OverlayVisibilityMode {
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
 /// 
-/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///
 /// See also:

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -116,7 +116,7 @@ enum OverlayVisibilityMode {
 /// The text field has an overridable [decoration] that, by default, draws a
 /// rounded rectangle border around the text field. If you set the [decoration]
 /// property to null, the decoration will be removed entirely.
-/// 
+///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -64,7 +64,7 @@ typedef InputCounterWidgetBuilder = Widget Function(
 ///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
-/// 
+///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -65,7 +65,7 @@ typedef InputCounterWidgetBuilder = Widget Function(
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 /// 
-/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///
 /// {@tool sample}
@@ -94,7 +94,7 @@ typedef InputCounterWidgetBuilder = Widget Function(
 ///    [TextField]. The [EditableText] widget is rarely used directly unless
 ///    you are implementing an entirely different design language, such as
 ///    Cupertino.
-///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
 class TextField extends StatefulWidget {
   /// Creates a Material Design text field.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -62,6 +62,10 @@ typedef InputCounterWidgetBuilder = Widget Function(
 /// tapped an ink splash that paints on the material is triggered, see
 /// [ThemeData.splashFactory].
 ///
+/// Remember to [dispose] the TextEditingController when it is no longer needed. 
+/// This will ensure we discard any resources used by the object. 
+/// 
+///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -68,6 +68,9 @@ typedef InputCounterWidgetBuilder = Widget Function(
 ///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
+/// 
+  /// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+  /// This will ensure we discard any resources used by the object.
 ///
 /// {@tool sample}
 /// This example shows how to create a [TextField] that will obscure input. The
@@ -95,6 +98,7 @@ typedef InputCounterWidgetBuilder = Widget Function(
 ///    [TextField]. The [EditableText] widget is rarely used directly unless
 ///    you are implementing an entirely different design language, such as
 ///    Cupertino.
+///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
 class TextField extends StatefulWidget {
   /// Creates a Material Design text field.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -62,15 +62,11 @@ typedef InputCounterWidgetBuilder = Widget Function(
 /// tapped an ink splash that paints on the material is triggered, see
 /// [ThemeData.splashFactory].
 ///
-/// Remember to [dispose] the TextEditingController when it is no longer needed. 
-/// This will ensure we discard any resources used by the object. 
-/// 
-///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 /// 
-  /// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
-  /// This will ensure we discard any resources used by the object.
+/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// This will ensure we discard any resources used by the object.
 ///
 /// {@tool sample}
 /// This example shows how to create a [TextField] that will obscure input. The

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -28,6 +28,9 @@ import 'theme.dart';
 ///
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
+/// 
+  /// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+  /// This will ensure we discard any resources used by the object.
 ///
 /// For a documentation about the various parameters, see [TextField].
 ///
@@ -60,6 +63,7 @@ import 'theme.dart';
 ///    integration.
 ///  * [InputDecorator], which shows the labels and other visual elements that
 ///    surround the actual text editing widget.
+///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
 class TextFormField extends FormField<String> {
   /// Creates a [FormField] that contains a [TextField].
   ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -29,8 +29,8 @@ import 'theme.dart';
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
 /// 
-  /// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
-  /// This will ensure we discard any resources used by the object.
+/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// This will ensure we discard any resources used by the object.
 ///
 /// For a documentation about the various parameters, see [TextField].
 ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -29,7 +29,7 @@ import 'theme.dart';
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
 /// 
-/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///
 /// For a documentation about the various parameters, see [TextField].
@@ -63,7 +63,7 @@ import 'theme.dart';
 ///    integration.
 ///  * [InputDecorator], which shows the labels and other visual elements that
 ///    surround the actual text editing widget.
-///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
 class TextFormField extends FormField<String> {
   /// Creates a [FormField] that contains a [TextField].
   ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -28,7 +28,7 @@ import 'theme.dart';
 ///
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
-/// 
+///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3003,7 +3003,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 /// (which defaults to the top-left corner in left-to-right environments and the
 /// top-right corner in right-to-left environments). The positioned children are
 /// then placed relative to the stack according to their top, right, bottom, and
-/// left properties.
+/// left properties. 
 ///
 /// The stack paints its children in order with the first child being at the
 /// bottom. If you want to change the order in which the children paint, you

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3003,7 +3003,8 @@ class ListBody extends MultiChildRenderObjectWidget {
 /// (which defaults to the top-left corner in left-to-right environments and the
 /// top-right corner in right-to-left environments). The positioned children are
 /// then placed relative to the stack according to their top, right, bottom, and
-/// left properties.
+/// left properties. To take the whole space available by any children, you need
+/// to wrap it in a [Positioned.fill] widget.
 ///
 /// The stack paints its children in order with the first child being at the
 /// bottom. If you want to change the order in which the children paint, you

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3003,7 +3003,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 /// (which defaults to the top-left corner in left-to-right environments and the
 /// top-right corner in right-to-left environments). The positioned children are
 /// then placed relative to the stack according to their top, right, bottom, and
-/// left properties. 
+/// left properties.
 ///
 /// The stack paints its children in order with the first child being at the
 /// bottom. If you want to change the order in which the children paint, you

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3003,8 +3003,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 /// (which defaults to the top-left corner in left-to-right environments and the
 /// top-right corner in right-to-left environments). The positioned children are
 /// then placed relative to the stack according to their top, right, bottom, and
-/// left properties. To take the whole space available by any children, you need
-/// to wrap it in a [Positioned.fill] widget.
+/// left properties.
 ///
 /// The stack paints its children in order with the first child being at the
 /// bottom. If you want to change the order in which the children paint, you

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -65,6 +65,9 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 /// The [text] or [selection] properties can be set from within a listener
 /// added to this controller. If both properties need to be changed then the
 /// controller's [value] should be set instead.
+/// 
+/// Remember to [dispose] the TextEditingController when it is no longer needed. 
+/// This will ensure we discard any resources used by the object.
 ///
 /// {@tool snippet --template=stateful_widget_material}
 /// This example creates a [TextField] with a [TextEditingController] whose

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -66,9 +66,8 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 /// added to this controller. If both properties need to be changed then the
 /// controller's [value] should be set instead.
 /// 
-/// Remember to [dispose] the TextEditingController when it is no longer needed. 
+/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
 /// This will ensure we discard any resources used by the object.
-///
 /// {@tool snippet --template=stateful_widget_material}
 /// This example creates a [TextField] with a [TextEditingController] whose
 /// change listener forces the entered text to be lower case and keeps the
@@ -115,6 +114,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 ///    with a [TextEditingController].
 ///  * [EditableText], which is a raw region of editable text that can be
 ///    controlled with a [TextEditingController].
+///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
 class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// Creates a controller for an editable text field.
   ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -65,7 +65,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 /// The [text] or [selection] properties can be set from within a listener
 /// added to this controller. If both properties need to be changed then the
 /// controller's [value] should be set instead.
-/// 
+///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 /// {@tool snippet --template=stateful_widget_material}

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -66,7 +66,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 /// added to this controller. If both properties need to be changed then the
 /// controller's [value] should be set instead.
 /// 
-/// Remember to [dispose] the [TextEditingController] when it is no longer needed. 
+/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
 /// This will ensure we discard any resources used by the object.
 /// {@tool snippet --template=stateful_widget_material}
 /// This example creates a [TextField] with a [TextEditingController] whose
@@ -114,7 +114,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 ///    with a [TextEditingController].
 ///  * [EditableText], which is a raw region of editable text that can be
 ///    controlled with a [TextEditingController].
-///  * <https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller>
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
 class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// Creates a controller for an editable text field.
   ///


### PR DESCRIPTION
The same note in https://flutter.dev/docs/cookbook/forms/text-field-changes

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29324

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

