### PR TITLE
Improving Finnish translations for Cupertino.

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fi.arb
@@ -3,7 +3,7 @@
   "datePickerHourSemanticsLabelOther": "klo $hour",
   "datePickerMinuteSemanticsLabelOne": "1 minuutti",
   "datePickerMinuteSemanticsLabelOther": "$minute minuuttia",
-  "datePickerDateOrder": "mdy",
+  "datePickerDateOrder": "dmy",
   "datePickerDateTimeOrder": "date_time_dayPeriod",
   "anteMeridiemAbbreviation": "ap",
   "postMeridiemAbbreviation": "ip",
@@ -17,6 +17,6 @@
   "timerPickerSecondLabelOther": "s",
   "cutButtonLabel": "Leikkaa",
   "copyButtonLabel": "Kopioi",
-  "pasteButtonLabel": "Liitä",
+  "pasteButtonLabel": "Sijoita",
   "selectAllButtonLabel": "Valitse kaikki"
 }

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -2995,7 +2995,7 @@ class CupertinoLocalizationFi extends GlobalCupertinoLocalizations {
   String get cutButtonLabel => r'Leikkaa';
 
   @override
-  String get datePickerDateOrderString => r'mdy';
+  String get datePickerDateOrderString => r'dmy';
 
   @override
   String get datePickerDateTimeOrderString => r'date_time_dayPeriod';
@@ -3037,7 +3037,7 @@ class CupertinoLocalizationFi extends GlobalCupertinoLocalizations {
   String get datePickerMinuteSemanticsLabelZero => null;
 
   @override
-  String get pasteButtonLabel => r'Liitä';
+  String get pasteButtonLabel => r'Sijoita';
 
   @override
   String get postMeridiemAbbreviation => r'ip';


### PR DESCRIPTION
## Description

I would like to improve couple of Finnish Cupertino translations. I know that you want those translations to match exacly to what iOS have at the moment. So I would change couple of things:

- In Finland we use dmy format and not mdy
- In iOS Finnish translation for "Paste" is "Sijoita". Even though "Liitä" is correct otherwise.

<img width="272" alt="Screenshot 2019-05-31 at 15 41 20" src="https://user-images.githubusercontent.com/17140689/58706588-32728600-83bb-11e9-9579-9e1ddc26f45f.png">

## Related Issues

Merged PR that I want to add these improvements: #32513

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
