### PR TITLE
Prep for engine roll

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -96,7 +96,7 @@ class TestWindow implements Window {
   }
 
   // TODO(dnfield): Remove this ignore once custom embedders have had time to catch up
-  // And make this proeprty actually wrap _window.viewPadding.
+  // And make this property actually wrap _window.viewPadding.
   // @override
   // ignore: annotate_overrides, public_member_api_docs
   WindowPadding get viewPadding => _viewPaddingTestValue ?? _window.padding;
@@ -112,7 +112,7 @@ class TestWindow implements Window {
     onMetricsChanged();
   }
 
-  // @override
+  @override
   WindowPadding get padding => _paddingTestValue ?? _window.padding;
   WindowPadding _paddingTestValue;
   /// Hides the real padding and reports the given [paddingTestValue] instead.

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -95,7 +95,24 @@ class TestWindow implements Window {
     onMetricsChanged();
   }
 
-  @override
+  // TODO(dnfield): Remove this ignore once custom embedders have had time to catch up
+  // And make this proeprty actually wrap _window.viewPadding.
+  // @override
+  // ignore: annotate_overrides, public_member_api_docs
+  WindowPadding get viewPadding => _viewPaddingTestValue ?? _window.padding;
+  WindowPadding _viewPaddingTestValue;
+  /// Hides the real padding and reports the given [paddingTestValue] instead.
+  set viewPaddingTestValue(WindowPadding viewPaddingTestValue) {
+    _viewPaddingTestValue = viewPaddingTestValue;
+    onMetricsChanged();
+  }
+  /// Deletes any existing test padding and returns to using the real padding.
+  void clearViewPaddingTestValue() {
+    _viewPaddingTestValue = null;
+    onMetricsChanged();
+  }
+
+  // @override
   WindowPadding get padding => _paddingTestValue ?? _window.padding;
   WindowPadding _paddingTestValue;
   /// Hides the real padding and reports the given [paddingTestValue] instead.


### PR DESCRIPTION
This is needed so that the auto-roller will be able to roll the engine (flutter/engine@ 79c6ce19a1e9a63d828bfdebf1842f36a98de7e0) into the framework.  We should leave it as is for about a week so that internal customers that get the framework before they get the engine have a chance to catch up.

Once that's done, we can remove the ignore, uncomment the annotation, and make it wrap the correct new value.