### PR TITLE
[Trivial] Move dropdownValue into State in DropdownButton sample docs

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -535,11 +535,10 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// This sample shows a `DropdownButton` whose value is one of
 /// "One", "Two", "Free", or "Four".
 ///
-/// ```dart preamble
-/// String dropdownValue = 'One';
-/// ```
-///
 /// ```dart
+/// String dropdownValue = 'One';
+///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Center(


### PR DESCRIPTION
The dropdown button's displayed value, `dropdownValue`, was a global. This moves it into `State<MyStatefulWidget>`.