### PR TITLE
Make file copying async with a limited pool

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -242,7 +242,7 @@ class TestCommand extends FastFlutterCommand {
       throwToolExit('Error: Failed to build asset bundle');
     }
     if (_needRebuild(assetBundle.entries)) {
-      writeBundle(fs.directory(fs.path.join('build', 'unit_test_assets')),
+      await writeBundle(fs.directory(fs.path.join('build', 'unit_test_assets')),
           assetBundle.entries);
     }
   }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -53,7 +53,7 @@ abstract class DevFSContent {
   ///
   /// Requires that the `destination` directory already exists, but the target
   /// file need not.
-  void copyToFile(File destination);
+  Future<void> copyToFile(File destination);
 }
 
 /// File content to be copied to the device.
@@ -139,8 +139,8 @@ class DevFSFileContent extends DevFSContent {
   List<int> contentsAsBytes() => _getFile().readAsBytesSync().cast<int>();
 
   @override
-  void copyToFile(File destination) {
-    _getFile().copySync(destination.path);
+  Future<void> copyToFile(File destination) async {
+    await _getFile().copy(destination.path);
   }
 }
 
@@ -181,8 +181,8 @@ class DevFSByteContent extends DevFSContent {
   List<int> contentsAsBytes() => _bytes;
 
   @override
-  void copyToFile(File destination) {
-    destination.writeAsBytesSync(contentsAsBytes());
+  Future<void> copyToFile(File destination) async {
+    await destination.writeAsBytes(contentsAsBytes());
   }
 }
 

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -52,7 +52,7 @@ Future<void> _buildAssets(
 
   final Map<String, DevFSContent> assetEntries =
       Map<String, DevFSContent>.from(assets.entries);
-  writeBundle(fs.directory(assetDir), assetEntries);
+  await writeBundle(fs.directory(assetDir), assetEntries);
 
   final String appName = fuchsiaProject.project.manifest.appName;
   final String outDir = getFuchsiaBuildDirectory();

--- a/packages/flutter_tools/lib/src/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_web_runner.dart
@@ -120,7 +120,7 @@ class ResidentWebRunner extends ResidentRunner {
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
     }
-    writeBundle(fs.directory(getAssetBuildDirectory()), assetBundle.entries);
+    await writeBundle(fs.directory(getAssetBuildDirectory()), assetBundle.entries);
 
     // Step 2: Start an HTTP server
     _server = WebAssetServer(flutterProject, target, ipv6);

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -119,7 +119,7 @@ class WebDevice extends Device {
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
     }
-    writeBundle(fs.directory(getAssetBuildDirectory()), assetBundle.entries);
+    await writeBundle(fs.directory(getAssetBuildDirectory()), assetBundle.entries);
 
     _package = package;
     _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);


### PR DESCRIPTION
## Description

To fix the performance regression while still preventing us from running out of file descriptors on macOS. Use a limited pool of 100 resources to asynchronously copy files when building the manifest

