### PR TITLE
Removing old golden checkout for integration test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:meta/meta.dart';
-import 'package:flutter_goldens_client/client.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -137,17 +137,6 @@ class UpdatePackagesCommand extends FlutterCommand {
       });
     }
 
-    // The dev/integration_tests/android_views integration test depends on an assets
-    // package that is in the goldens repository. We need to make sure that the goldens
-    // repository is cloned locally before we verify or update pubspecs.
-    printStatus('Cloning goldens repository...');
-    try {
-      final GoldensClient goldensClient = GoldensClient();
-      await goldensClient.prepare();
-    } on NonZeroExitCode catch (e) {
-      throwToolExit(e.stderr, exitCode: e.exitCode);
-    }
-
     if (isVerifyOnly) {
       bool needsUpdate = false;
       printStatus('Verifying pubspecs...');


### PR DESCRIPTION
## Description

Checking out the goldens repository is no longer necessary here, as it is handled instead as a dependency of the integration tests: [here](https://github.com/flutter/flutter/blob/3ebebebb8dfb1825dc3547fbacacfd9d26d62e0f/dev/integration_tests/android_views/pubspec.yaml#L13)

## Related Issues

This was found in preparation for integrating with Skia Gold for golden file testing.  

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
