### PR TITLE
Default optional bool param to false

### DIFF
--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -44,7 +44,7 @@ Future<int> runTests(
   FlutterProject flutterProject,
   String icudtlPath,
   Directory coverageDirectory,
-  bool web,
+  bool web = false,
 }) async {
   // Compute the command-line arguments for package:test.
   final List<String> testArgs = <String>[];


### PR DESCRIPTION
In runTests, we previously now default the optional boolean `web`
parameter to false to ensure (or at least improve the odds) that the
conditional on line 70 evaluates to true or false.