### PR TITLE
Create a builder that builds a widget that a wraps routes of Navigator.

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -90,6 +90,7 @@ class CupertinoApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.navigatorRoutesWrapperBuilder,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -190,6 +191,11 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
+
+  /// A builder that builds a widget that a wraps routes of Navigator.
+  ///
+  /// The child must be part of the returned widget tree.
+  final TransitionBuilder navigatorRoutesWrapperBuilder;
 
   @override
   _CupertinoAppState createState() => _CupertinoAppState();
@@ -307,6 +313,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
               onPressed: onPressed,
             );
           },
+          navigatorRoutesWrapperBuilder: widget.navigatorRoutesWrapperBuilder,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -110,6 +110,7 @@ class MaterialApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.navigatorRoutesWrapperBuilder,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -357,6 +358,11 @@ class MaterialApp extends StatefulWidget {
   ///  * <https://material.io/design/layout/spacing-methods.html>
   final bool debugShowMaterialGrid;
 
+  /// A builder that builds a widget that a wraps routes of Navigator.
+  ///
+  /// The child must be part of the returned widget tree.
+  final TransitionBuilder navigatorRoutesWrapperBuilder;
+
   @override
   _MaterialAppState createState() => _MaterialAppState();
 }
@@ -515,6 +521,7 @@ class _MaterialAppState extends State<MaterialApp> {
           mini: true,
         );
       },
+      navigatorRoutesWrapperBuilder: widget.navigatorRoutesWrapperBuilder,
     );
 
     assert(() {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -163,6 +163,7 @@ class WidgetsApp extends StatefulWidget {
     this.debugShowWidgetInspector = false,
     this.debugShowCheckedModeBanner = true,
     this.inspectorSelectButtonBuilder,
+    this.navigatorRoutesWrapperBuilder,
   }) : assert(navigatorObservers != null),
        assert(routes != null),
        assert(
@@ -676,6 +677,11 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final bool debugShowCheckedModeBanner;
 
+  /// A builder that builds a widget that a wraps routes of Navigator.
+  ///
+  /// The child must be part of the returned widget tree.
+  final TransitionBuilder navigatorRoutesWrapperBuilder;
+
   /// If true, forces the performance overlay to be visible in all instances.
   ///
   /// Used by the `showPerformanceOverlay` observatory extension.
@@ -1096,6 +1102,7 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
         onGenerateRoute: _onGenerateRoute,
         onUnknownRoute: _onUnknownRoute,
         observers: widget.navigatorObservers,
+        routesWrapperBuilder: widget.navigatorRoutesWrapperBuilder,
       );
     }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -752,6 +752,7 @@ class Navigator extends StatefulWidget {
     @required this.onGenerateRoute,
     this.onUnknownRoute,
     this.observers = const <NavigatorObserver>[],
+    this.routesWrapperBuilder,
   }) : assert(onGenerateRoute != null),
        super(key: key);
 
@@ -784,6 +785,11 @@ class Navigator extends StatefulWidget {
 
   /// A list of observers for this navigator.
   final List<NavigatorObserver> observers;
+
+  /// A builder that builds a widget that a wraps routes of Navigator.
+  ///
+  /// The child must be part of the returned widget tree.
+  final TransitionBuilder routesWrapperBuilder;
 
   /// The default name for the [initialRoute].
   ///
@@ -2195,6 +2201,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           node: focusScopeNode,
           autofocus: true,
           child: Overlay(
+            onstageWrapperBuilder: widget.routesWrapperBuilder,
             key: _overlayKey,
             initialEntries: _initialOverlayEntries,
           ),

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -203,6 +203,7 @@ class Overlay extends StatefulWidget {
   const Overlay({
     Key key,
     this.initialEntries = const <OverlayEntry>[],
+    this.onstageWrapperBuilder,
   }) : assert(initialEntries != null),
        super(key: key);
 
@@ -220,6 +221,11 @@ class Overlay extends StatefulWidget {
   ///
   /// To remove an entry from an [Overlay], use [OverlayEntry.remove].
   final List<OverlayEntry> initialEntries;
+
+  /// A builder that builds a widget that a wraps all Entries of Overlay.
+  ///
+  /// The child must be part of the returned widget tree.
+  final TransitionBuilder onstageWrapperBuilder;
 
   /// The state from the closest instance of this class that encloses the given context.
   ///
@@ -460,13 +466,22 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
         offstageChildren.add(TickerMode(enabled: false, child: _OverlayEntry(entry)));
       }
     }
-    return _Theatre(
+
+    Widget result = _Theatre(
       onstage: Stack(
         fit: StackFit.expand,
         children: onstageChildren.reversed.toList(growable: false),
       ),
       offstage: offstageChildren,
     );
+
+    final Function(BuildContext context, Widget child) onstageWrapperBuilder =
+        widget.onstageWrapperBuilder;
+    if (onstageWrapperBuilder != null) {
+      result = onstageWrapperBuilder(context, result);
+    }
+
+    return result;
   }
 
   @override

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -62,4 +62,30 @@ void main() {
     expect(find.text('Select All'), findsOneWidget);
     expect(find.text('Thu Oct 4 '), findsOneWidget);
   });
+
+  testWidgets('Navigator routes wrapper builder', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    bool didBuild = false;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: const Placeholder(),
+        navigatorRoutesWrapperBuilder: (BuildContext context, Widget child) {
+          expect(context.ancestorWidgetOfExactType(CupertinoApp), isNotNull);
+          expect(context.ancestorWidgetOfExactType(WidgetsApp), isNotNull);
+          expect(context.ancestorWidgetOfExactType(Navigator), isNotNull);
+          didBuild = true;
+
+          return Container(key: key, child: child,);
+        },
+      ),
+    );
+    expect(didBuild, isTrue);
+
+    expect(find.byType(CupertinoApp), isNotNull);
+    expect(find.byType(WidgetsApp), isNotNull);
+    expect(find.byType(Overlay), isNotNull);
+    expect(find.byType(Navigator), isNotNull);
+    expect(find.byKey(key), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -607,4 +607,33 @@ void main() {
     expect(themeBeforeBrightnessChange.brightness, Brightness.light);
     expect(themeAfterBrightnessChange.brightness, Brightness.dark);
   });
+
+  testWidgets('Navigator routes wrapper builder', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    bool didBuild = false;
+
+    await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+          ),
+          home: const Placeholder(),
+          navigatorRoutesWrapperBuilder: (BuildContext context, Widget child) {
+            expect(context.ancestorWidgetOfExactType(MaterialApp), isNotNull);
+            expect(context.ancestorWidgetOfExactType(WidgetsApp), isNotNull);
+            expect(context.ancestorWidgetOfExactType(Navigator), isNotNull);
+            didBuild = true;
+
+            return Container(key: key, child: child,);
+          },
+        ),
+    );
+    expect(didBuild, isTrue);
+
+    expect(find.byType(MaterialApp), isNotNull);
+    expect(find.byType(WidgetsApp), isNotNull);
+    expect(find.byType(Overlay), isNotNull);
+    expect(find.byType(Navigator), isNotNull);
+    expect(find.byKey(key), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -17,6 +18,34 @@ void main() {
         color: const Color(0xFF123456),
       ),
     );
+    expect(find.byKey(key), findsOneWidget);
+  });
+
+  testWidgets('Navigator routes wrapper builder', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    bool didBuild = false;
+    await tester.pumpWidget(
+      WidgetsApp(
+        onGenerateRoute: (RouteSettings settings) => null,
+        onUnknownRoute: (RouteSettings settings) {
+          return MaterialPageRoute<dynamic>(builder: (BuildContext context) {
+            return const Placeholder();
+          });
+        },
+        navigatorRoutesWrapperBuilder: (BuildContext context, Widget child) {
+          expect(context.ancestorWidgetOfExactType(WidgetsApp), isNotNull);
+          expect(context.ancestorWidgetOfExactType(Navigator), isNotNull);
+          didBuild = true;
+
+          return Container(key: key, child: child,);
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    expect(didBuild, isTrue);
+
+    expect(find.byType(Overlay), isNotNull);
+    expect(find.byType(Navigator), isNotNull);
     expect(find.byKey(key), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -10,6 +10,18 @@ import 'package:flutter/material.dart';
 
 import 'semantics_tester.dart';
 
+class RoutesWrapperWidget extends StatelessWidget {
+
+  const RoutesWrapperWidget({Key key, this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}
+
 class FirstWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -1013,5 +1025,34 @@ void main() {
     expect(find.text('/D'), findsOneWidget);
     expect(arguments.single, 'pushReplacementNamed');
     arguments.clear();
+  });
+
+  testWidgets('Onstage wrapper', (WidgetTester tester) async {
+    final GlobalKey routeKey = GlobalKey();
+    bool didBuild = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Navigator(
+          routesWrapperBuilder: (BuildContext context, Widget child) {
+            expect(context.ancestorWidgetOfExactType(Material), isNotNull);
+            didBuild = true;
+            return RoutesWrapperWidget(
+              child: child,
+            );
+          },
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<dynamic>(builder: (BuildContext context) {
+              return Placeholder(key: routeKey,);
+            });
+          },
+        ),
+      ),
+    ));
+
+    expect(didBuild, isTrue);
+
+    expect(find.byType(Overlay), isNotNull);
+    expect(find.byType(Navigator), isNotNull);
+    expect(find.byType(RoutesWrapperWidget), isNotNull);
   });
 }

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -612,4 +612,59 @@ void main() {
 
     expect(buildOrder, <int>[3, 4, 1, 2, 0]);
   });
+
+  testWidgets('Onstage wrapper', (WidgetTester tester) async {
+    final GlobalKey overlayKey = GlobalKey();
+    bool didBuild = false;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          key: overlayKey,
+          onstageWrapperBuilder: (BuildContext context, Widget child) {
+            final Directionality directionality =
+            context.ancestorWidgetOfExactType(Directionality);
+            expect(directionality, isNotNull);
+
+            didBuild = true;
+            return Opacity(
+              child: child, opacity: 1.0,
+            );
+          },
+        ),
+      ),
+    );
+    expect(didBuild, isTrue);
+    final RenderObject theater = overlayKey.currentContext.findRenderObject();
+
+    expect(theater, hasAGoodToStringDeep);
+    expect(
+      theater.toStringDeep(minLevel: DiagnosticLevel.fine),
+      equalsIgnoringHashCodes(
+          'RenderOpacity#88d39\n'
+              ' │ parentData: <none>\n'
+              ' │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
+              ' │ size: Size(800.0, 600.0)\n'
+              ' │ opacity: 1.0\n'
+              ' │\n'
+              ' └─child: _RenderTheatre#60e1b\n'
+              '   │ parentData: <none> (can use size)\n'
+              '   │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
+              '   │ size: Size(800.0, 600.0)\n'
+              '   │\n'
+              '   ├─onstage: RenderStack#90d61\n'
+              '   ╎   parentData: not positioned; offset=Offset(0.0, 0.0) (can use\n'
+              '   ╎     size)\n'
+              '   ╎   constraints: BoxConstraints(w=800.0, h=600.0)\n'
+              '   ╎   size: Size(800.0, 600.0)\n'
+              '   ╎   alignment: AlignmentDirectional.topStart\n'
+              '   ╎   textDirection: ltr\n'
+              '   ╎   fit: expand\n'
+              '   ╎   overflow: clip\n'
+              '   ╎\n'
+              '   └╌no offstage children\n'
+              ''
+      ),
+    );
+  });
 }


### PR DESCRIPTION
## Description

I add builder wrapper of navigator routers for access Navigator from above routers of widgets tree. 
It is allow me access to Navigator from root widget and control navigation of application. for example I can create abstract Router for Viewmodel or Presenter and control app routing from logic layer without clearly communication with "View" layer. 

you say why not wrap MaterialApp in to RootWidget? but in but in this case I will not have access to MediaQuuery, Navigator etc.

you say why you push to navigator RootRoute as first route  and control Navigation from him? because netx routes will be have back arrow on AppBar. And I can accidentally pop her from Navigaton. It is no way.

you say why not create custom App with  WidgetApp and Navigator? no way, because I want use all features of MaterialApp  or CupertionApp which encapsulated in exist Widget.

below is an example;

```
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: Scaffold(
        appBar: AppBar(),
      ),
      navigatorRoutesWrapperBuilder: (BuildContext context, Widget child) {
        return RootWidget(
          child: child,
        );
      },
    );
  }
}

class RootWidget extends StatefulWidget {
  final Widget child;

  RootWidget({Key key, this.child}) : super(key: key);

  @override
  _RootWidgetState createState() => _RootWidgetState();
}

class _RootWidgetState extends State<RootWidget> {

  RootAppBloc _bloc;

  @override
  void initState() {
    _bloc = RootAppBloc();
    super.initState();

    _bloc.pushLoginScreen.listen((_) {
      Route<dynamic> route = MaterialPageRoute<dynamic>(builder: (BuildContext context) {
        return Text('login');
      });

      Navigator.of(context).pushAndRemoveUntil(route, (Route<dynamic> route) {
        return false;
      });
    });

    _bloc.pushMainScreen.listen((_) {
      // some code
    });
  }

  @override
  Widget build(BuildContext context) {
    return widget.child;
  }
}

class RootAppBloc {
  Stream<void> pushMainScreen;
  Stream<void> pushLoginScreen;
}
```

## Related Issues

-

## Tests

I added the following tests:

Test builder of CupertinoApp
Test builder of MaterialApp
Test builder of WidgetsApp
Test builder of Navigator
Test builder of Overlay

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
