### PR TITLE
Update consolidateHttpClientResponseBytes() to use compressionState

### DIFF
--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -43,10 +43,8 @@ typedef BytesReceivedCallback = void Function(int cumulative, int total);
 /// bytes from this method (assuming the response is sending compressed bytes),
 /// set both [HttpClient.autoUncompress] to false and the `autoUncompress`
 /// parameter to false.
-// TODO(tvolkert): Remove the [client] param once https://github.com/dart-lang/sdk/issues/36971 is fixed.
 Future<Uint8List> consolidateHttpClientResponseBytes(
   HttpClientResponse response, {
-  HttpClient client,
   bool autoUncompress = true,
   BytesReceivedCallback onBytesReceived,
 }) {
@@ -58,15 +56,21 @@ Future<Uint8List> consolidateHttpClientResponseBytes(
   int expectedContentLength = response.contentLength;
   if (expectedContentLength == -1)
     expectedContentLength = null;
-  if (response.headers?.value(HttpHeaders.contentEncodingHeader) == 'gzip') {
-    if (client?.autoUncompress ?? true) {
+  switch (response.compressionState) {
+    case HttpClientResponseCompressionState.compressed:
+      if (autoUncompress) {
+        // We need to un-compress the bytes as they come in.
+        sink = gzip.decoder.startChunkedConversion(output);
+      }
+      break;
+    case HttpClientResponseCompressionState.decompressed:
       // response.contentLength will not match our bytes stream, so we declare
       // that we don't know the expected content length.
       expectedContentLength = null;
-    } else if (autoUncompress) {
-      // We need to un-compress the bytes as they come in.
-      sink = gzip.decoder.startChunkedConversion(output);
-    }
+      break;
+    case HttpClientResponseCompressionState.notCompressed:
+      // Fall-through.
+      break;
   }
 
   int bytesReceived = 0;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -552,7 +552,6 @@ class NetworkImage extends ImageProvider<NetworkImage> {
 
       final Uint8List bytes = await consolidateHttpClientResponseBytes(
         response,
-        client: _httpClient,
         onBytesReceived: (int cumulative, int total) {
           chunkEvents.add(ImageChunkEvent(
             cumulativeBytesLoaded: cumulative,

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -14,17 +14,11 @@ void main() {
   group(consolidateHttpClientResponseBytes, () {
     final List<int> chunkOne = <int>[0, 1, 2, 3, 4, 5];
     final List<int> chunkTwo = <int>[6, 7, 8, 9, 10];
-    MockHttpClient client;
     MockHttpClientResponse response;
-    MockHttpHeaders headers;
 
     setUp(() {
-      client = MockHttpClient();
       response = MockHttpClientResponse();
-      headers = MockHttpHeaders();
-      when(client.autoUncompress).thenReturn(true);
-      when(response.headers).thenReturn(headers);
-      when(headers.value(HttpHeaders.contentEncodingHeader)).thenReturn(null);
+      when(response.compressionState).thenReturn(HttpClientResponseCompressionState.notCompressed);
       when(response.listen(
          any,
          onDone: anyNamed('onDone'),
@@ -50,7 +44,7 @@ void main() {
       when(response.contentLength)
           .thenReturn(chunkOne.length + chunkTwo.length);
       final List<int> bytes =
-          await consolidateHttpClientResponseBytes(response, client: client);
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
@@ -58,7 +52,7 @@ void main() {
     test('Converts a compressed HttpClientResponse with contentLength to bytes', () async {
       when(response.contentLength).thenReturn(chunkOne.length);
       final List<int> bytes =
-          await consolidateHttpClientResponseBytes(response, client: client);
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
@@ -66,7 +60,7 @@ void main() {
     test('Converts an HttpClientResponse without contentLength to bytes', () async {
       when(response.contentLength).thenReturn(-1);
       final List<int> bytes =
-          await consolidateHttpClientResponseBytes(response, client: client);
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
@@ -77,7 +71,6 @@ void main() {
       final List<int> records = <int>[];
       await consolidateHttpClientResponseBytes(
         response,
-        client: client,
         onBytesReceived: (int cumulative, int total) {
           records.addAll(<int>[cumulative, total]);
         },
@@ -114,7 +107,7 @@ void main() {
       });
       when(response.contentLength).thenReturn(-1);
 
-      expect(consolidateHttpClientResponseBytes(response, client: client),
+      expect(consolidateHttpClientResponseBytes(response),
           throwsA(isInstanceOf<Exception>()));
     });
 
@@ -122,7 +115,6 @@ void main() {
       when(response.contentLength).thenReturn(-1);
       final Future<List<int>> result = consolidateHttpClientResponseBytes(
         response,
-        client: client,
         onBytesReceived: (int cumulative, int total) {
           throw 'misbehaving callback';
         },
@@ -137,7 +129,7 @@ void main() {
       final List<int> gzippedChunkTwo = gzipped.sublist(gzipped.length ~/ 2);
 
       setUp(() {
-        when(headers.value(HttpHeaders.contentEncodingHeader)).thenReturn('gzip');
+        when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.listen(
           any,
           onDone: anyNamed('onDone'),
@@ -159,27 +151,26 @@ void main() {
         });
       });
 
-      test('Uncompresses GZIP bytes if autoUncompress is true and response.autoUncompress is false', () async {
-        when(client.autoUncompress).thenReturn(false);
+      test('Uncompresses GZIP bytes if autoUncompress is true and response.compressionState is compressed', () async {
+        when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
-        final List<int> bytes = await consolidateHttpClientResponseBytes(response, client: client);
+        final List<int> bytes = await consolidateHttpClientResponseBytes(response);
         expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       });
 
-      test('returns gzipped bytes if autoUncompress is false and response.autoUncompress is false', () async {
-        when(client.autoUncompress).thenReturn(false);
+      test('returns gzipped bytes if autoUncompress is false and response.compressionState is compressed', () async {
+        when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
-        final List<int> bytes = await consolidateHttpClientResponseBytes(response, client: client, autoUncompress: false);
+        final List<int> bytes = await consolidateHttpClientResponseBytes(response, autoUncompress: false);
         expect(bytes, gzipped);
       });
 
       test('Notifies onBytesReceived with gzipped numbers', () async {
-        when(client.autoUncompress).thenReturn(false);
+        when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
         final List<int> records = <int>[];
         await consolidateHttpClientResponseBytes(
           response,
-          client: client,
           onBytesReceived: (int cumulative, int total) {
             records.addAll(<int>[cumulative, total]);
           },
@@ -193,13 +184,13 @@ void main() {
         ]);
       });
 
-      test('Notifies onBytesReceived with expectedContentLength of -1 if response.autoUncompress is true', () async {
+      test('Notifies onBytesReceived with expectedContentLength of -1 if response.compressionState is decompressed', () async {
         final int syntheticTotal = (chunkOne.length + chunkTwo.length) * 2;
+        when(response.compressionState).thenReturn(HttpClientResponseCompressionState.decompressed);
         when(response.contentLength).thenReturn(syntheticTotal);
         final List<int> records = <int>[];
         await consolidateHttpClientResponseBytes(
           response,
-          client: client,
           onBytesReceived: (int cumulative, int total) {
             records.addAll(<int>[cumulative, total]);
           },
@@ -216,6 +207,4 @@ void main() {
   });
 }
 
-class MockHttpClient extends Mock implements HttpClient {}
 class MockHttpClientResponse extends Mock implements HttpClientResponse {}
-class MockHttpHeaders extends Mock implements HttpHeaders {}


### PR DESCRIPTION
## Description

This updates `consolidateHttpClientResponseBytes()` to use the new
`HttpClientResponse.compressionState` API that was recently added in the SDK.

## Related Issues

https://github.com/flutter/flutter/issues/32374

## Tests

I updated the existing test coverage.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change, because the argument that's being removed has not yet and will not ever make it to the stable channel.