### PR TITLE
[flutter_tool] Log an Android X related failure to analytics

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -20,6 +20,8 @@ import '../cache.dart';
 import '../flutter_manifest.dart';
 import '../globals.dart';
 import '../project.dart';
+import '../runner/flutter_command.dart';
+import '../usage.dart';
 import 'android_sdk.dart';
 import 'android_studio.dart';
 
@@ -468,6 +470,11 @@ Future<void> _buildGradleProjectV2(
       printError('The Gradle failure may have been because of AndroidX incompatibilities in this Flutter app.');
       printError('See https://goo.gl/CP92wY for more information on the problem and how to fix it.');
       printError('*******************************************************************************************');
+      String commandName = '';
+      if (FlutterCommand.current != null) {
+        commandName = '-${FlutterCommand.current.name}';
+      }
+      flutterUsage.sendEvent('build$commandName', 'android-x-failure');
     }
     throwToolExit('Gradle task $assembleTask failed with exit code $exitCode', exitCode: exitCode);
   }


### PR DESCRIPTION
## Description

This PR logs a gradle build failure related to Android X to analytics.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
