### PR TITLE
Remove references to HttpClientResponseCompressionState

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1763,9 +1763,18 @@ class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse 
   @override
   int get contentLength => -1;
 
+  // TODO(tvolkert): Update (flutter/flutter#33791)
+  /*
   @override
   HttpClientResponseCompressionState get compressionState {
     return HttpClientResponseCompressionState.decompressed;
+  }
+  */
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #compressionState) {
+      return null;
+    }
+    return super.noSuchMethod(invocation);
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1770,6 +1770,7 @@ class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse 
     return HttpClientResponseCompressionState.decompressed;
   }
   */
+  @override
   dynamic noSuchMethod(Invocation invocation) {
     if (invocation.memberName == #compressionState) {
       return null;

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -47,7 +47,8 @@ export 'dart:io'
         HttpClient,
         HttpClientRequest,
         HttpClientResponse,
-        HttpClientResponseCompressionState,
+        // TODO(tvolkert): Uncomment (flutter/flutter#33791)
+        //HttpClientResponseCompressionState,
         HttpHeaders,
         HttpRequest,
         HttpServer,

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -1257,9 +1257,18 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
   @override
   String get reasonPhrase => '<reason phrase>';
 
+  // TODO(tvolkert): Update (flutter/flutter#33791)
+  /*
   @override
   HttpClientResponseCompressionState get compressionState {
     return HttpClientResponseCompressionState.decompressed;
+  }
+  */
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #compressionState) {
+      return null;
+    }
+    return super.noSuchMethod(invocation);
   }
 
   @override

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -1264,12 +1264,6 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
     return HttpClientResponseCompressionState.decompressed;
   }
   */
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #compressionState) {
-      return null;
-    }
-    return super.noSuchMethod(invocation);
-  }
 
   @override
   StreamSubscription<List<int>> listen(
@@ -1284,6 +1278,10 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
+    // TODO(tvolkert): Update (flutter/flutter#33791)
+    if (invocation.memberName == #compressionState) {
+      return null;
+    }
     throw 'io.HttpClientResponse - $invocation';
   }
 }


### PR DESCRIPTION
## Description

Google hasn't rolled the requisite Dart SDK yet, so we need to avoid these references until that happens.

## Related Issues

https://github.com/flutter/flutter/issues/33791

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.