### PR TITLE
Double double tap toggles instead of error

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -721,8 +721,9 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         from: details.globalPosition,
         cause: SelectionChangedCause.forcePress,
       );
-      if (_shouldShowSelectionToolbar)
+      if (_shouldShowSelectionToolbar) {
         _editableTextKey.currentState.showToolbar();
+      }
     }
   }
 
@@ -796,8 +797,9 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   void _handleDoubleTapDown(TapDownDetails details) {
     if (widget.selectionEnabled) {
       _renderEditable.selectWord(cause: SelectionChangedCause.doubleTap);
-      if (_shouldShowSelectionToolbar)
-        _editableTextKey.currentState.showToolbar();
+      if (_shouldShowSelectionToolbar) {
+        _editableText.toggleToolbar();
+      }
     }
   }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -722,7 +722,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         cause: SelectionChangedCause.forcePress,
       );
       if (_shouldShowSelectionToolbar) {
-        _editableTextKey.currentState.showToolbar();
+        _editableTextKey.currentState.toggleToolbar();
       }
     }
   }
@@ -790,8 +790,10 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   }
 
   void _handleSingleLongTapEnd(LongPressEndDetails details) {
-    if (_shouldShowSelectionToolbar)
-      _editableTextKey.currentState.showToolbar();
+    if (widget.selectionEnabled) {
+      if (_shouldShowSelectionToolbar)
+        _editableTextKey.currentState.toggleToolbar();
+    }
   }
 
   void _handleDoubleTapDown(TapDownDetails details) {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5035,6 +5035,36 @@ void main() {
   );
 
   testWidgets(
+    'double long press toggles selection menu',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: '',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Long press shows the selection menu.
+      await tester.longPressAt(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      expect(find.text('PASTE'), findsOneWidget);
+
+      // Double tap again hides the selection menu.
+      await tester.longPressAt(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      expect(find.text('PASTE'), findsNWidgets(0));
+    },
+  );
+
+  testWidgets(
     'double tap hold selects word (iOS)',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5001,6 +5001,40 @@ void main() {
   );
 
   testWidgets(
+    'double double tap toggles selection menu',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: '',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Double tap on the same location shows the selection menu.
+      await tester.tapAt(textOffsetToPosition(tester, 0));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      expect(find.text('PASTE'), findsOneWidget);
+
+      // Double tap again hides the selection menu.
+      await tester.tapAt(textOffsetToPosition(tester, 0));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(textOffsetToPosition(tester, 0));
+      await tester.pump();
+      expect(find.text('PASTE'), findsNWidgets(0));
+    },
+  );
+
+  testWidgets(
     'double tap hold selects word (iOS)',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(


### PR DESCRIPTION
## Description

An error was being logged when the user double tapped twice on an empty part of a TextField.  This was because we would attempt to show the selection toolbar when it already was being shown.

This PR solves this by toggling the selection menu instead.  On native Android, it looks like a double tap doesn't show the selection menu at all.  As we continue to work on matching native behavior for text editing we should implement that behavior, but for now this seems logical and prevents an error.

![doubledouble](https://user-images.githubusercontent.com/389558/58838262-07826f00-8613-11e9-9405-f70303ce2a82.gif)


## Related Issues

Closes https://github.com/flutter/flutter/issues/33740