### PR TITLE
Don't print warning message when running benchmarks test.

### DIFF
--- a/packages/flutter/test/scheduler/benchmarks_test.dart
+++ b/packages/flutter/test/scheduler/benchmarks_test.dart
@@ -63,6 +63,9 @@ Future<void> main() async {
 
       expect(endFramesBegun, equals(startFramesBegun + 1));
       expect(endFramesDrawn, equals(startFramesDrawn + 1));
-    });
+    },
+    // We are not interested in the performance of the "benchmark", we are just
+    // testing the behavior. So it's OK that asserts are enabled.
+    mayRunWithAsserts: true);
   });
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -135,7 +135,7 @@ void testWidgets(
 ///
 /// Benchmarks must not be run in checked mode, because the performance is not
 /// representative. To avoid this, this function will print a big message if it
-/// is run in checked mode. Unit tests of this method pass [mayRunWithAsserts],
+/// is run in checked mode. Unit tests of this method pass `mayRunWithAsserts`,
 /// but it should not be used for actual benchmarking.
 ///
 /// Example:
@@ -154,9 +154,10 @@ void testWidgets(
 ///       });
 ///       exit(0);
 ///     }
-Future<void> benchmarkWidgets(WidgetTesterCallback callback, {bool mayRunWithAsserts: false}) {
+Future<void> benchmarkWidgets(WidgetTesterCallback callback, {bool mayRunWithAsserts = false}) {
   assert(() {
-    if (mayRunWithAsserts) return true;
+    if (mayRunWithAsserts)
+      return true;
 
     print('┏╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍┓');
     print('┇ ⚠ THIS BENCHMARK IS BEING RUN WITH ASSERTS ENABLED ⚠  ┇');

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -133,8 +133,10 @@ void testWidgets(
 /// If the callback is asynchronous, make sure you `await` the call
 /// to [benchmarkWidgets], otherwise it won't run!
 ///
-/// Benchmarks must not be run in checked mode. To avoid this, this
-/// function will print a big message if it is run in checked mode.
+/// Benchmarks must not be run in checked mode, because the performance is not
+/// representative. To avoid this, this function will print a big message if it
+/// is run in checked mode. Unit tests of this method pass [mayRunWithAsserts],
+/// but it should not be used for actual benchmarking.
 ///
 /// Example:
 ///
@@ -152,8 +154,10 @@ void testWidgets(
 ///       });
 ///       exit(0);
 ///     }
-Future<void> benchmarkWidgets(WidgetTesterCallback callback) {
+Future<void> benchmarkWidgets(WidgetTesterCallback callback, {bool mayRunWithAsserts: false}) {
   assert(() {
+    if (mayRunWithAsserts) return true;
+
     print('┏╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍┓');
     print('┇ ⚠ THIS BENCHMARK IS BEING RUN WITH ASSERTS ENABLED ⚠  ┇');
     print('┡╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍┦');


### PR DESCRIPTION
## Description

Currently the benchmarks test prints a scary warning message, even when it passes, that a benchmark is being run with asserts enabled.

Normally we don't want developers to do this, because the performance of code with asserts is not characteristic of what end-users will experience. However, we need to unit-test `benchmarkWidgets`, so I've added a contraindicated option to suppress the warning for the test.

## Related Issues

https://github.com/flutter/flutter/pull/25049#issuecomment-487773196