### PR TITLE
[flutter_tool] Fix 'q' for Fuchsia profile/debug mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -863,7 +863,7 @@ class AppInstance {
     return runner.restart(fullRestart: fullRestart, pauseAfterRestart: pauseAfterRestart, reason: reason);
   }
 
-  Future<void> stop() => runner.stop();
+  Future<void> stop() => runner.exit();
   Future<void> detach() => runner.detach();
 
   void closeLogger() {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -307,7 +307,7 @@ abstract class Device {
 
   /// Whether flutter applications running on this device can be terminated
   /// from the vmservice.
-  bool get supportsStopApp => true;
+  bool get supportsFlutterExit => true;
 
   /// Whether the device supports taking screenshots of a running flutter
   /// application.

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -184,7 +184,7 @@ class FuchsiaDevice extends Device {
   bool get supportsHotRestart => false;
 
   @override
-  bool get supportsStopApp => false;
+  bool get supportsFlutterExit => false;
 
   @override
   final String name;

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -160,10 +160,8 @@ class ColdRunner extends ResidentRunner {
     await stopEchoingDeviceLog();
     if (_didAttach) {
       appFinished();
-    } else {
-      await stopApp();
     }
-    await stopApp();
+    await exitApp();
   }
 
   @override
@@ -207,7 +205,7 @@ class ColdRunner extends ResidentRunner {
   }
 
   @override
-  Future<void> preStop() async {
+  Future<void> preExit() async {
     for (FlutterDevice device in flutterDevices) {
       // If we're running in release mode, stop the app using the device logic.
       if (device.vmServices == null || device.vmServices.isEmpty)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -218,7 +218,7 @@ class HotRunner extends ResidentRunner {
         printStatus('Benchmark completed. Exiting application.');
         await _cleanupDevFS();
         await stopEchoingDeviceLog();
-        await stopApp();
+        await exitApp();
       }
       final File benchmarkOutput = fs.file('hot_benchmark.json');
       benchmarkOutput.writeAsStringSync(toPrettyJson(benchmarkData));
@@ -922,12 +922,12 @@ class HotRunner extends ResidentRunner {
     if (_didAttach) {
       appFinished();
     } else {
-      await stopApp();
+      await exitApp();
     }
   }
 
   @override
-  Future<void> preStop() async {
+  Future<void> preExit() async {
     await _cleanupDevFS();
     await hotRunnerConfig.runPreShutdownOperations();
   }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -46,7 +46,7 @@ class WebDevice extends Device {
   bool get supportsStartPaused => true;
 
   @override
-  bool get supportsStopApp => true;
+  bool get supportsFlutterExit => true;
 
   @override
   bool get supportsScreenshot => false;

--- a/packages/flutter_tools/test/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsia_device_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       expect(device.supportsHotReload, true);
       expect(device.supportsHotRestart, false);
-      expect(device.supportsStopApp, false);
+      expect(device.supportsFlutterExit, false);
       expect(device.isSupportedForProject(FlutterProject.current()), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,

--- a/packages/flutter_tools/test/hot_test.dart
+++ b/packages/flutter_tools/test/hot_test.dart
@@ -232,7 +232,7 @@ void main() {
         final MockDevice mockDevice = MockDevice();
         when(mockDevice.supportsHotReload).thenReturn(true);
         when(mockDevice.supportsHotRestart).thenReturn(true);
-        when(mockDevice.supportsStopApp).thenReturn(false);
+        when(mockDevice.supportsFlutterExit).thenReturn(false);
         final List<FlutterDevice> devices = <FlutterDevice>[
           FlutterDevice(mockDevice, generator: residentCompiler, trackWidgetCreation: false, buildMode: BuildMode.debug),
         ];
@@ -247,11 +247,11 @@ void main() {
         final MockDevice mockDevice = MockDevice();
         when(mockDevice.supportsHotReload).thenReturn(true);
         when(mockDevice.supportsHotRestart).thenReturn(true);
-        when(mockDevice.supportsStopApp).thenReturn(false);
+        when(mockDevice.supportsFlutterExit).thenReturn(false);
         final List<FlutterDevice> devices = <FlutterDevice>[
           FlutterDevice(mockDevice, generator: residentCompiler, trackWidgetCreation: false, buildMode: BuildMode.debug),
         ];
-        await HotRunner(devices).preStop();
+        await HotRunner(devices).preExit();
         expect(shutdownTestingConfig.shutdownHookCalled, true);
       }, overrides: <Type, Generator>{
         Artifacts: () => mockArtifacts,


### PR DESCRIPTION
## Description

This PR implements 'q' for Fuchsia in debug and profile runs by using the Device's `stopApp` implementation. To make this more readable, I've also distinguished between exiting an app with the FlutterExit vmservice command, and stopping an app with the device's `stopApp`.

## Related Issues

#33689

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
