### PR TITLE
Unmark flutter_gallery__back_button_memory as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -526,7 +526,6 @@ tasks:
       Measures memory usage after Android app suspend and resume.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   analyzer_benchmark:
     description: >


### PR DESCRIPTION
This test is no longer particularly flaky.