### PR TITLE
Add currentSystemFrameTimeStamp to SchedulerBinding

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -842,6 +842,17 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   }
   Duration _currentFrameTimeStamp;
 
+  /// The raw time stamp as provided by the engine to [Window.onBeginFrame]
+  /// for the frame currently being processed.
+  ///
+  /// Unlike [currentFrameTimeStamp], this time stamp is neither adjusted to
+  /// offset when the epoch started nor scaled to reflect the [timeDilation] in
+  /// the current epoch.
+  Duration get currentSystemFrameTimeStamp {
+    assert(_lastRawTimeStamp != null);
+    return _lastRawTimeStamp;
+  }
+
   int _profileFrameNumber = 0;
   final Stopwatch _profileFrameStopwatch = Stopwatch();
   String _debugBanner;

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -848,6 +848,11 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   /// Unlike [currentFrameTimeStamp], this time stamp is neither adjusted to
   /// offset when the epoch started nor scaled to reflect the [timeDilation] in
   /// the current epoch.
+  ///
+  /// On most platforms, this is a more or less arbitrary value, and should
+  /// generally be ignored. On Fuchsia, this corresponds to the system-provided
+  /// presentation time, and can be used to ensure that animations running in
+  /// different processes are synchronized.
   Duration get currentSystemFrameTimeStamp {
     assert(_lastRawTimeStamp != null);
     return _lastRawTimeStamp;

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -145,7 +145,7 @@ void main() {
 
     scheduler.scheduleFrameCallback(frameCallback);
     tick(const Duration(seconds: 8));
-    expect(lastTimeStamp, Duration(seconds: 3)); // 2s + (8 - 6)s / 2
+    expect(lastTimeStamp, const Duration(seconds: 3)); // 2s + (8 - 6)s / 2
     expect(lastSystemTimeStamp, const Duration(seconds: 8));
   });
 }

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import '../flutter_test_alternative.dart';
+import 'scheduler_tester.dart';
 
 class TestSchedulerBinding extends BindingBase with ServicesBinding, SchedulerBinding { }
 
@@ -114,5 +115,37 @@ void main() {
     // events are locked.
     expect(timerQueueTasks.length, 2);
     expect(taskExecuted, false);
+  });
+
+  test('currentSystemFrameTimeStamp is the raw timestamp', () {
+    Duration lastTimeStamp;
+    Duration lastSystemTimeStamp;
+
+    void frameCallback(Duration timeStamp) {
+      expect(timeStamp, scheduler.currentFrameTimeStamp);
+      lastTimeStamp = scheduler.currentFrameTimeStamp;
+      lastSystemTimeStamp = scheduler.currentSystemFrameTimeStamp;
+    }
+
+    scheduler.scheduleFrameCallback(frameCallback);
+    tick(const Duration(seconds: 2));
+    expect(lastTimeStamp, Duration.zero);
+    expect(lastSystemTimeStamp, const Duration(seconds: 2));
+
+    scheduler.scheduleFrameCallback(frameCallback);
+    tick(const Duration(seconds: 4));
+    expect(lastTimeStamp, const Duration(seconds: 2));
+    expect(lastSystemTimeStamp, const Duration(seconds: 4));
+
+    timeDilation = 2;
+    scheduler.scheduleFrameCallback(frameCallback);
+    tick(const Duration(seconds: 6));
+    expect(lastTimeStamp, const Duration(seconds: 2)); // timeDilation calls SchedulerBinding.resetEpoch
+    expect(lastSystemTimeStamp, const Duration(seconds: 6));
+
+    scheduler.scheduleFrameCallback(frameCallback);
+    tick(const Duration(seconds: 8));
+    expect(lastTimeStamp, Duration(seconds: 3)); // 2s + (8-6)s / 2
+    expect(lastSystemTimeStamp, const Duration(seconds: 8));
   });
 }

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -145,7 +145,7 @@ void main() {
 
     scheduler.scheduleFrameCallback(frameCallback);
     tick(const Duration(seconds: 8));
-    expect(lastTimeStamp, Duration(seconds: 3)); // 2s + (8-6)s / 2
+    expect(lastTimeStamp, Duration(seconds: 3)); // 2s + (8 - 6)s / 2
     expect(lastSystemTimeStamp, const Duration(seconds: 8));
   });
 }


### PR DESCRIPTION
## Description

Provides access to the raw (unadjusted) time stamp that was passed from the engine to the framework.

## Related Issues

https://github.com/flutter/flutter/issues/33216

## Tests

I added the following tests:

* currentSystemFrameTimeStamp is the raw timestamp

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
