### PR TITLE
Respond to AndroidView focus events.

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -583,6 +583,14 @@ class AndroidViewController {
     });
   }
 
+  /// Clears the focus from the Android View if it is focused.
+  Future<void> clearFocus() {
+    if (_state != _AndroidViewState.created) {
+      return null;
+    }
+    return SystemChannels.platform_views.invokeMethod<void>('clearFocus', id);
+  }
+
   static int _getAndroidDirection(TextDirection direction) {
     assert(direction != null);
     switch (direction) {

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -28,6 +28,8 @@ class FakeAndroidPlatformViewsController {
 
   Completer<void> createCompleter;
 
+  int lastClearedFocusViewId;
+
   void registerViewType(String viewType) {
     _registeredViewTypes.add(viewType);
   }
@@ -50,6 +52,8 @@ class FakeAndroidPlatformViewsController {
         return _touch(call);
       case 'setDirection':
         return _setDirection(call);
+      case 'clearFocus':
+        return _clearFocus(call);
     }
     return Future<dynamic>.sync(() => null);
   }
@@ -152,6 +156,19 @@ class FakeAndroidPlatformViewsController {
 
     _views[id].layoutDirection = layoutDirection;
 
+    return Future<dynamic>.sync(() => null);
+  }
+
+  Future<dynamic> _clearFocus(MethodCall call) {
+    final int id = call.arguments;
+
+    if (!_views.containsKey(id))
+      throw PlatformException(
+        code: 'error',
+        message: 'Trying to dispose a platform view with unknown id: $id',
+      );
+
+    lastClearedFocusViewId = id;
     return Future<dynamic>.sync(() => null);
   }
 }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -165,7 +165,7 @@ class FakeAndroidPlatformViewsController {
     if (!_views.containsKey(id))
       throw PlatformException(
         code: 'error',
-        message: 'Trying to dispose a platform view with unknown id: $id',
+        message: 'Trying to clear the focus on a platform view with unknown id: $id',
       );
 
     lastClearedFocusViewId = id;

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -908,6 +908,100 @@ void main() {
       expect(containerFocusNode.hasFocus, isFalse);
       expect(androidViewFocusNode.hasFocus, isTrue);
     });
+
+    testWidgets('AndroidView sets a platform view text input client when focused', (WidgetTester tester) async {
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      viewsController.createCompleter = Completer<void>();
+
+      final GlobalKey containerKey = GlobalKey();
+      await tester.pumpWidget(
+        Center(
+          child: Column(
+            children: <Widget>[
+              const SizedBox(
+                width: 200.0,
+                height: 100.0,
+                child: AndroidView(viewType: 'webview', layoutDirection: TextDirection.ltr),
+              ),
+              Focus(
+                debugLabel: 'container',
+                child: Container(key: containerKey),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      viewsController.createCompleter.complete();
+
+
+      final Element containerElement = tester.element(find.byKey(containerKey));
+      final FocusNode containerFocusNode = Focus.of(containerElement);
+
+      containerFocusNode.requestFocus();
+      await tester.pump();
+
+      int lastPlatformViewTextClient;
+      SystemChannels.textInput.setMockMethodCallHandler((MethodCall call) {
+        if (call.method == 'TextInput.setPlatformViewClient') {
+          lastPlatformViewTextClient = call.arguments;
+        }
+        return null;
+      });
+
+      viewsController.invokeViewFocused(currentViewId + 1);
+      await tester.pump();
+
+      expect(lastPlatformViewTextClient, currentViewId + 1);
+    });
+
+    testWidgets('AndroidView clears platform focus when unfocused', (WidgetTester tester) async {
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      viewsController.createCompleter = Completer<void>();
+
+      final GlobalKey containerKey = GlobalKey();
+      await tester.pumpWidget(
+        Center(
+          child: Column(
+            children: <Widget>[
+              const SizedBox(
+                width: 200.0,
+                height: 100.0,
+                child: AndroidView(viewType: 'webview', layoutDirection: TextDirection.ltr),
+              ),
+              Focus(
+                debugLabel: 'container',
+                child: Container(key: containerKey),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      viewsController.createCompleter.complete();
+
+      final Element containerElement = tester.element(find.byKey(containerKey));
+      final FocusNode containerFocusNode = Focus.of(containerElement);
+
+      containerFocusNode.requestFocus();
+      await tester.pump();
+
+      viewsController.invokeViewFocused(currentViewId + 1);
+      await tester.pump();
+
+      viewsController.lastClearedFocusViewId = null;
+
+      containerFocusNode.requestFocus();
+      await tester.pump();
+
+      expect(viewsController.lastClearedFocusViewId, currentViewId + 1);
+    });
   });
 
   group('UiKitView', () {


### PR DESCRIPTION
## Description

When an AndroidView gains focus we invoke the(newly introduced)
'TextInput.setPlatformViewClient' text_input system channel method
which sets the platform view as the text input target.

When the AndroidView loses focus we send a `clearFocus` message to
platform views system channel(so the engine can clear the focus from
the platform view).

This PR is going to land before the engine implementation is rolled to
the framework, we swallow MissingPluginException for the newly
introduced method channel methods so this is a no-op before the engine
is ready(after the engine is rolled with the corresponding change I'll
remove the logic to swallow the exceptions).

The engine counterpart is in: https://github.com/flutter/engine/pull/9203

## Related Issues

#19718

## Tests

I added the following tests:

* AndroidView sets a platform view text input client when focused
* AndroidView clears platform focus when unfocused

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.