### PR TITLE
'the the' doc fix

### DIFF
--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -803,9 +803,9 @@ class _EmptySliderTickMarkShape extends SliderTickMarkShape {
 ///
 /// See also:
 ///
-///  * [RoundSliderThumbShape], which is the the default thumb shape.
-///  * [RoundSliderOverlayShape], which is the the default overlay shape.
-///  * [PaddleSliderValueIndicatorShape], which is the the default value
+///  * [RoundSliderThumbShape], which is the default thumb shape.
+///  * [RoundSliderOverlayShape], which is the default overlay shape.
+///  * [PaddleSliderValueIndicatorShape], which is the default value
 ///    indicator shape.
 abstract class SliderComponentShape {
   /// Abstract const constructor. This constructor enables subclasses to provide

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -156,7 +156,7 @@ class Typography extends Diagnosticable {
   /// on the overall [ThemeData.brightness], when the current locale's
   /// [MaterialLocalizations.scriptCategory] is [ScriptCategory.englishLike].
   ///
-  /// To look up a localized [TextTheme], use the the overall [Theme], for
+  /// To look up a localized [TextTheme], use the overall [Theme], for
   /// example: `Theme.of(context).textTheme`.
   final TextTheme englishLike;
 
@@ -167,7 +167,7 @@ class Typography extends Diagnosticable {
   /// on the overall [ThemeData.brightness], when the current locale's
   /// [MaterialLocalizations.scriptCategory] is [ScriptCategory.dense].
   ///
-  /// To look up a localized [TextTheme], use the the overall [Theme], for
+  /// To look up a localized [TextTheme], use the overall [Theme], for
   /// example: `Theme.of(context).textTheme`.
   final TextTheme dense;
 
@@ -177,7 +177,7 @@ class Typography extends Diagnosticable {
   /// on the overall [ThemeData.brightness], when the current locale's
   /// [MaterialLocalizations.scriptCategory] is [ScriptCategory.tall].
   ///
-  /// To look up a localized [TextTheme], use the the overall [Theme], for
+  /// To look up a localized [TextTheme], use the overall [Theme], for
   /// example: `Theme.of(context).textTheme`.
   final TextTheme tall;
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1507,7 +1507,7 @@ class RenderEditable extends RenderBox {
   // should rework this properly to once again match the platform. The constant
   // _kCaretHeightOffset scales poorly for small font sizes.
   //
-  /// On iOS, the cursor is taller than the the cursor on Android. The height
+  /// On iOS, the cursor is taller than the cursor on Android. The height
   /// of the cursor for iOS is approximate and obtained through an eyeball
   /// comparison.
   Rect get _getCaretPrototype {

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -220,7 +220,7 @@ class Actions extends InheritedWidget {
     return inherited?.dispatcher;
   }
 
-  /// Invokes the action associated with the given [Intent] using the the
+  /// Invokes the action associated with the given [Intent] using the
   /// [Actions] widget that most tightly encloses the given [BuildContext].
   ///
   /// The `context`, `intent` and `nullOk` arguments must not be null.
@@ -230,7 +230,7 @@ class Actions extends InheritedWidget {
   /// reaches the root.
   ///
   /// Will throw if no ambient [Actions] widget is found, or if the given
-  /// `intent` doesn't map to an action in any of the the [Actions.actions] maps
+  /// `intent` doesn't map to an action in any of the [Actions.actions] maps
   /// that are found.
   ///
   /// Setting `nullOk` to true means that if no ambient [Actions] widget is


### PR DESCRIPTION
## Description

Removes redundant 'the's from documentation

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
