### PR TITLE
Increase timeout duration on text contrast reorderable_list_demo

### DIFF
--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -664,7 +664,7 @@ void main() {
       });
 
       testWidgets('reorderable_list_demo $themeName', (WidgetTester tester) async {
-        tester.binding.addTime(const Duration(seconds: 3));
+        tester.binding.addTime(const Duration(seconds: 6);
         final SemanticsHandle handle = tester.ensureSemantics();
         await tester.pumpWidget(MaterialApp(theme: theme, home: const ReorderableListDemo()));
         await expectLater(tester, meetsGuideline(textContrastGuideline));

--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -664,7 +664,7 @@ void main() {
       });
 
       testWidgets('reorderable_list_demo $themeName', (WidgetTester tester) async {
-        tester.binding.addTime(const Duration(seconds: 6);
+        tester.binding.addTime(const Duration(seconds: 6));
         final SemanticsHandle handle = tester.ensureSemantics();
         await tester.pumpWidget(MaterialApp(theme: theme, home: const ReorderableListDemo()));
         await expectLater(tester, meetsGuideline(textContrastGuideline));

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -354,12 +354,16 @@ class TextPainter {
   /// Sets the dimensions of each placeholder in [text].
   ///
   /// The number of [PlaceholderDimensions] provided should be the same as the
-  /// number of [PlaceholderSpan]s in text.
+  /// number of [PlaceholderSpan]s in text. Passing in an empty or null `value`
+  /// will do nothing.
   ///
   /// If [layout] is attempted without setting the placeholder dimensions, the
   /// placeholders will be ignored in the text layout and no valid
   /// [inlinePlaceholderBoxes] will be returned.
   void setPlaceholderDimensions(List<PlaceholderDimensions> value) {
+    if (value == null || value.length == 0 || listEquals(value, _placeholderDimensions)) {
+      return;
+    }
     assert(() {
       int placeholderCount = 0;
       text.visitChildren((InlineSpan span) {


### PR DESCRIPTION
`flutter_gallery/test/accessibility_test.dart: All material demos meet text contrast guidelines reorderable_list_demo ThemeData.light()` seems to time out on mac flakily.

This increases the timeout duration.