### PR TITLE
Docs clarification in TextPainter

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -169,8 +169,8 @@ class TextPainter {
   /// The [InlineSpan] this provides is in the form of a tree that may contain
   /// multiple instances of [TextSpan]s and [WidgetSpan]s. To obtain a plaintext
   /// representation of the contents of this [TextPainter], use [InlineSpan.toPlainText]
-  /// get the full contents of all nodes. [TextSpan.text] will only provide the
-  /// contents of the first node in the tree.
+  /// to get the full contents of all nodes in the tree. [TextSpan.text] will
+  /// only provide the contents of the first node in the tree.
   InlineSpan get text => _text;
   InlineSpan _text;
   set text(InlineSpan value) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -164,8 +164,13 @@ class TextPainter {
   /// The (potentially styled) text to paint.
   ///
   /// After this is set, you must call [layout] before the next call to [paint].
-  ///
   /// This and [textDirection] must be non-null before you call [layout].
+  ///
+  /// The [InlineSpan] this provides is in the form of a tree that may contain
+  /// multiple instances of [TextSpan]s and [WidgetSpan]s. To obtain a plaintext
+  /// representation of the contents of this [TextPainter], use [InlineSpan.toPlainText]
+  /// get the full contents of all nodes. [TextSpan.text] will only provide the
+  /// contents of the first node in the tree.
   InlineSpan get text => _text;
   InlineSpan _text;
   set text(InlineSpan value) {


### PR DESCRIPTION
This clarifies the use of `TextPainter.text` and encourages using `TextSpan.toPlainText` over `TextSpan.text`
