### PR TITLE
Updating MediaQuery with viewPadding

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -35,10 +35,15 @@ enum Orientation {
 ///
 /// ## Insets and Padding
 ///
-/// //TODO(Piinks): Diagram & further elaboration below
+/// ![A diagram of padding, viewInsets, and viewPadding in correlation with each
+/// other](https://flutter.github.io/assets-for-api-docs/assets/widgets/media_query.mp4)
 ///
-/// This diagram illustrates how [padding] is derived from [viewPadding] and
-/// [viewInsets].
+/// This diagram illustrates how [padding] relates to [viewPadding] and
+/// [viewInsets], shown here in its simplest configuration, as the difference
+/// between the two. In cases when the viewInsets exceed the viewPadding, like
+/// when a keyboard is shown below, padding goes to zero rather than a negative
+/// value. Therefore, padding is calculated by taking
+/// `max(0.0, viewPadding - viewInsets)`.
 ///
 /// {@animation 300 300 https://flutter.github.io/assets-for-api-docs/assets/widgets/window_padding.mp4}
 ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -378,8 +378,8 @@ class MediaQueryData {
       textScaleFactor: textScaleFactor,
       platformBrightness: platformBrightness,
       padding: padding,
-      viewPadding: viewInsets,
-      viewInsets: viewPadding.copyWith(
+      viewInsets: viewInsets,
+      viewPadding: viewPadding.copyWith(
         left: removeLeft ? 0.0 : null,
         top: removeTop ? 0.0 : null,
         right: removeRight ? 0.0 : null,

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -32,24 +32,28 @@ enum Orientation {
 /// exception, unless the `nullOk` argument is set to true, in which case it
 /// returns null.
 ///
-/// MediaQueryData includes two [EdgeInsets] values:
-/// [padding] and [viewInsets]. These
-/// values reflect the configuration of the device and are used by
-/// many top level widgets, like [SafeArea] and the Cupertino and
-/// Material scaffold widgets. The padding value defines areas that
-/// might not be completely visible, like the display "notch" on the
-/// iPhone X. The viewInsets value defines areas that aren't visible at
-/// all, typically because they're obscured by the device's keyboard.
+/// MediaQueryData includes three [EdgeInsets] values:
+/// [padding], [viewPadding], and [viewInsets]. These values reflect the
+/// configuration of the device and are used by many top level widgets, like
+/// [SafeArea] and the Cupertino and Material [Scaffold] widgets. The padding
+/// value defines areas that might not be completely visible, like the display
+/// "notch" on the iPhone X. The viewInsets value defines areas that aren't
+/// visible at all, typically because they're obscured by the device's keyboard.
+/// Similar to viewInsets, viewPadding does not differentiate padding in areas
+/// that may be obscured. For example, by using the viewPadding property,
+/// padding would defer to the iPhone "safe area" regardless of whether a
+/// keyboard is showing.
 ///
-/// The viewInsets and padding values are independent, they're both
+/// The viewInsets, viewPadding, and padding values are independent, they're
 /// measured from the edges of the MediaQuery widget's bounds. The
 /// bounds of the top level MediaQuery created by [WidgetsApp] are the
 /// same as the window that contains the app.
 ///
-/// Widgets whose layouts consume space defined by [viewInsets] or
-/// [padding] should enclose their children in secondary MediaQuery
+/// Widgets whose layouts consume space defined by [viewInsets], [viewPadding],
+/// or [padding] should enclose their children in secondary MediaQuery
 /// widgets that reduce those properties by the same amount.
-/// The [removePadding] and [removeInsets] methods are useful for this.
+/// The [removePadding], [removeViewPadding], and [removeInsets] methods are
+/// useful for this.
 @immutable
 class MediaQueryData {
   /// Creates data for a media query with explicit values.
@@ -63,6 +67,7 @@ class MediaQueryData {
     this.platformBrightness = Brightness.light,
     this.padding = EdgeInsets.zero,
     this.viewInsets = EdgeInsets.zero,
+    this.viewPadding = EdgeInsets.zero,
     this.alwaysUse24HourFormat = false,
     this.accessibleNavigation = false,
     this.invertColors = false,
@@ -82,6 +87,7 @@ class MediaQueryData {
       textScaleFactor = window.textScaleFactor,
       platformBrightness = window.platformBrightness,
       padding = EdgeInsets.fromWindowPadding(window.padding, window.devicePixelRatio),
+      viewPadding = EdgeInsets.fromWindowPadding(window.viewPadding, window.devicePixelRatio),
       viewInsets = EdgeInsets.fromWindowPadding(window.viewInsets, window.devicePixelRatio),
       accessibleNavigation = window.accessibilityFeatures.accessibleNavigation,
       invertColors = window.accessibilityFeatures.invertColors,
@@ -128,15 +134,15 @@ class MediaQueryData {
   /// When a mobile device's keyboard is visible `viewInsets.bottom`
   /// corresponds to the top of the keyboard.
   ///
-  /// This value is independent of the [padding]: both values are
-  /// measured from the edges of the [MediaQuery] widget's bounds. The
+  /// This value is independent of the [padding] and [viewPadding]: their values
+  /// are measured from the edges of the [MediaQuery] widget's bounds. The
   /// bounds of the top level MediaQuery created by [WidgetsApp] are the
   /// same as the window (often the mobile device screen) that contains the app.
   ///
   /// See also:
   ///
   /// * [MediaQueryData], which provides some additional detail about this
-  ///   property and how it differs from [padding].
+  ///   property and how it differs from [padding] and [viewPadding].
   final EdgeInsets viewInsets;
 
   /// The parts of the display that are partially obscured by system UI,
@@ -151,10 +157,27 @@ class MediaQueryData {
   /// See also:
   ///
   ///  * [MediaQueryData], which provides some additional detail about this
-  ///    property and how it differs from [viewInsets].
+  ///    property and how it differs from [viewInsets] and [viewPadding].
   ///  * [SafeArea], a widget that consumes this padding with a [Padding] widget
   ///    and automatically removes it from the [MediaQuery] for its child.
   final EdgeInsets padding;
+
+  /// The parts of the display that may be obscured by the system UI, but
+  /// respect the padding established below the obstruction.
+  ///
+  /// When a mobile device's keyboard is visible, `viewPadding.bottom`
+  /// corresponds to the bottom of the view beneath it.
+  ///
+  /// This value is independent of the [padding] and [viewInsets]: their values
+  /// are measured from the edges of the [MediaQuery] widget's bounds. The
+  /// bounds of the top level MediaQuery created by [WidgetsApp] are the
+  /// same as the window (often the mobile device screen) that contains the app.
+  ///
+  /// See also:
+  ///
+  /// * [MediaQueryData], which provides some additional detail about this
+  ///   property and how it differs from [padding] and [viewInsets].
+  final EdgeInsets viewPadding;
 
   /// Whether to use 24-hour format when formatting time.
   ///
@@ -218,6 +241,7 @@ class MediaQueryData {
     double textScaleFactor,
     Brightness platformBrightness,
     EdgeInsets padding,
+    EdgeInsets viewPadding,
     EdgeInsets viewInsets,
     bool alwaysUse24HourFormat,
     bool disableAnimations,
@@ -231,6 +255,7 @@ class MediaQueryData {
       textScaleFactor: textScaleFactor ?? this.textScaleFactor,
       platformBrightness: platformBrightness ?? this.platformBrightness,
       padding: padding ?? this.padding,
+      viewPadding: viewPadding ?? this.viewPadding,
       viewInsets: viewInsets ?? this.viewInsets,
       alwaysUse24HourFormat: alwaysUse24HourFormat ?? this.alwaysUse24HourFormat,
       invertColors: invertColors ?? this.invertColors,
@@ -254,6 +279,7 @@ class MediaQueryData {
   ///  * [SafeArea], which both removes the padding from the [MediaQuery] and
   ///    adds a [Padding] widget.
   ///  * [removeViewInsets], the same thing but for [viewInsets].
+  ///  * [removeViewPadding], the same thing but for [viewPadding].
   MediaQueryData removePadding({
     bool removeLeft = false,
     bool removeTop = false,
@@ -273,6 +299,7 @@ class MediaQueryData {
         right: removeRight ? 0.0 : null,
         bottom: removeBottom ? 0.0 : null,
       ),
+      viewPadding: viewPadding,
       viewInsets: viewInsets,
       alwaysUse24HourFormat: alwaysUse24HourFormat,
       disableAnimations: disableAnimations,
@@ -294,6 +321,7 @@ class MediaQueryData {
   ///  * [new MediaQuery.removeViewInsets], which uses this method to remove
   ///    padding from the ambient [MediaQuery].
   ///  * [removePadding], the same thing but for [padding].
+  ///  * [removeViewPadding], the same thing but for [viewPadding].
   MediaQueryData removeViewInsets({
     bool removeLeft = false,
     bool removeTop = false,
@@ -308,7 +336,50 @@ class MediaQueryData {
       textScaleFactor: textScaleFactor,
       platformBrightness: platformBrightness,
       padding: padding,
+      viewPadding: viewPadding,
       viewInsets: viewInsets.copyWith(
+        left: removeLeft ? 0.0 : null,
+        top: removeTop ? 0.0 : null,
+        right: removeRight ? 0.0 : null,
+        bottom: removeBottom ? 0.0 : null,
+      ),
+      alwaysUse24HourFormat: alwaysUse24HourFormat,
+      disableAnimations: disableAnimations,
+      invertColors: invertColors,
+      accessibleNavigation: accessibleNavigation,
+      boldText: boldText,
+    );
+  }
+
+  /// Creates a copy of this media query data but with the given [viewPadding]
+  /// replaced with zero.
+  ///
+  /// The `removeLeft`, `removeTop`, `removeRight`, and `removeBottom` arguments
+  /// must not be null. If all four are false (the default) then this
+  /// [MediaQueryData] is returned unmodified.
+  ///
+  /// See also:
+  ///
+  ///  * [new MediaQuery.removeViewPadding], which uses this method to remove
+  ///    padding from the ambient [MediaQuery].
+  ///  * [removePadding], the same thing but for [padding].
+  ///  * [removeViewInsets], the same thing but for [viewInsets].
+  MediaQueryData removeViewPadding({
+    bool removeLeft = false,
+    bool removeTop = false,
+    bool removeRight = false,
+    bool removeBottom = false,
+  }) {
+    if (!(removeLeft || removeTop || removeRight || removeBottom))
+      return this;
+    return MediaQueryData(
+      size: size,
+      devicePixelRatio: devicePixelRatio,
+      textScaleFactor: textScaleFactor,
+      platformBrightness: platformBrightness,
+      padding: padding,
+      viewPadding: viewInsets,
+      viewInsets: viewPadding.copyWith(
         left: removeLeft ? 0.0 : null,
         top: removeTop ? 0.0 : null,
         right: removeRight ? 0.0 : null,
@@ -332,6 +403,7 @@ class MediaQueryData {
         && typedOther.textScaleFactor == textScaleFactor
         && typedOther.platformBrightness == platformBrightness
         && typedOther.padding == padding
+        && typedOther.viewPadding == viewPadding
         && typedOther.viewInsets == viewInsets
         && typedOther.alwaysUse24HourFormat == alwaysUse24HourFormat
         && typedOther.disableAnimations == disableAnimations
@@ -348,6 +420,7 @@ class MediaQueryData {
       textScaleFactor,
       platformBrightness,
       padding,
+      viewPadding,
       viewInsets,
       alwaysUse24HourFormat,
       disableAnimations,
@@ -365,6 +438,7 @@ class MediaQueryData {
              'textScaleFactor: ${textScaleFactor.toStringAsFixed(1)}, '
              'platformBrightness: $platformBrightness, '
              'padding: $padding, '
+             'viewPadding: $viewPadding, '
              'viewInsets: $viewInsets, '
              'alwaysUse24HourFormat: $alwaysUse24HourFormat, '
              'accessibleNavigation: $accessibleNavigation, '
@@ -430,6 +504,7 @@ class MediaQuery extends InheritedWidget {
   ///    adds a [Padding] widget.
   ///  * [MediaQueryData.padding], the affected property of the [MediaQueryData].
   ///  * [new removeViewInsets], the same thing but for removing view insets.
+  ///  * [new removeViewPadding], the same thing but for removing view insets.
   factory MediaQuery.removePadding({
     Key key,
     @required BuildContext context,
@@ -472,6 +547,7 @@ class MediaQuery extends InheritedWidget {
   ///
   ///  * [MediaQueryData.viewInsets], the affected property of the [MediaQueryData].
   ///  * [new removePadding], the same thing but for removing paddings.
+  ///  * [new removeViewPadding], the same thing but for removing view insets.
   factory MediaQuery.removeViewInsets({
     Key key,
     @required BuildContext context,
@@ -484,6 +560,50 @@ class MediaQuery extends InheritedWidget {
     return MediaQuery(
       key: key,
       data: MediaQuery.of(context).removeViewInsets(
+        removeLeft: removeLeft,
+        removeTop: removeTop,
+        removeRight: removeRight,
+        removeBottom: removeBottom,
+      ),
+      child: child,
+    );
+  }
+
+  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery] from
+  /// the given context, but removes the specified view padding.
+  ///
+  /// This should be inserted into the widget tree when the [MediaQuery] view
+  /// padding is consumed by a widget in such a way that the view padding is no
+  /// longer exposed to the widget's descendants or siblings.
+  ///
+  /// The [context] argument is required, must not be null, and must have a
+  /// [MediaQuery] in scope.
+  ///
+  /// The `removeLeft`, `removeTop`, `removeRight`, and `removeBottom` arguments
+  /// must not be null. If all four are false (the default) then the returned
+  /// [MediaQuery] reuses the ambient [MediaQueryData] unmodified, which is not
+  /// particularly useful.
+  ///
+  /// The [child] argument is required and must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [MediaQueryData.viewPadding], the affected property of the
+  ///  [MediaQueryData].
+  ///  * [new removePadding], the same thing but for removing paddings.
+  ///  * [new removeViewInsets], the same thing but for removing view insets.
+  factory MediaQuery.removeViewPadding({
+    Key key,
+    @required BuildContext context,
+    bool removeLeft = false,
+    bool removeTop = false,
+    bool removeRight = false,
+    bool removeBottom = false,
+    @required Widget child,
+  }) {
+    return MediaQuery(
+      key: key,
+      data: MediaQuery.of(context).removeViewPadding(
         removeLeft: removeLeft,
         removeTop: removeTop,
         removeRight: removeRight,

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -36,13 +36,13 @@ enum Orientation {
 /// ## Insets and Padding
 ///
 /// ![A diagram of padding, viewInsets, and viewPadding in correlation with each
-/// other](https://flutter.github.io/assets-for-api-docs/assets/widgets/media_query.mp4)
+/// other](https://flutter.github.io/assets-for-api-docs/assets/widgets/media_query.png)
 ///
 /// This diagram illustrates how [padding] relates to [viewPadding] and
 /// [viewInsets], shown here in its simplest configuration, as the difference
 /// between the two. In cases when the viewInsets exceed the viewPadding, like
-/// when a keyboard is shown below, padding goes to zero rather than a negative
-/// value. Therefore, padding is calculated by taking
+/// when a software keyboard is shown below, padding goes to zero rather than a
+/// negative value. Therefore, padding is calculated by taking
 /// `max(0.0, viewPadding - viewInsets)`.
 ///
 /// {@animation 300 300 https://flutter.github.io/assets-for-api-docs/assets/widgets/window_padding.mp4}
@@ -55,17 +55,17 @@ enum Orientation {
 ///
 /// MediaQueryData includes three [EdgeInsets] values:
 /// [padding], [viewPadding], and [viewInsets]. These values reflect the
-/// configuration of the device and are used by many top level widgets, listed
-/// below. The padding value defines areas that might not be completely visible,
-/// like the display "notch" on the iPhone X. The viewInsets value defines areas that
-/// aren't visible at all, typically because they're obscured by the device's
-/// keyboard. Similar to viewInsets, viewPadding does not differentiate padding
-/// in areas that may be obscured. For example, by using the viewPadding
-/// property, padding would defer to the iPhone "safe area" regardless of
-/// whether a keyboard is showing.
+/// configuration of the device and are used and optionally consumed by widgets
+/// that position content within these insets. The padding value defines areas
+/// that might not be completely visible, like the display "notch" on the iPhone
+/// X. The viewInsets value defines areas that aren't visible at all, typically
+/// because they're obscured by the device's keyboard. Similar to viewInsets,
+/// viewPadding does not differentiate padding in areas that may be obscured.
+/// For example, by using the viewPadding property, padding would defer to the
+/// iPhone "safe area" regardless of whether a keyboard is showing.
 ///
 /// The viewInsets and viewPadding are independent values, they're
-/// measured from the edges of the MediaQuery widget's bounds. together they
+/// measured from the edges of the MediaQuery widget's bounds. Together they
 /// inform the [padding] property. The bounds of the top level MediaQuery
 /// created by [WidgetsApp] are the same as the window that contains the app.
 ///
@@ -168,7 +168,7 @@ class MediaQueryData {
   /// See also:
   ///
   /// * [ui.window], which provides some additional detail about this property
-  /// and how it relates to [padding] and [viewPadding].
+  ///   and how it relates to [padding] and [viewPadding].
   final EdgeInsets viewInsets;
 
   /// The parts of the display that are partially obscured by system UI,
@@ -190,16 +190,19 @@ class MediaQueryData {
   ///    and automatically removes it from the [MediaQuery] for its child.
   final EdgeInsets padding;
 
-  /// The parts of the display that may be obscured by the system UI, but
-  /// respect the padding established below the obstruction.
+  /// The parts of the display that are partially obscured by system UI,
+  /// typically by the hardware display "notches" or the system status bar.
   ///
-  /// When a mobile device's keyboard is visible, `viewPadding.bottom`
-  /// corresponds to the bottom of the view beneath it.
+  /// This value remains the same regardless of whether the system is reporting
+  /// other obstructions in the same physical area of the screen. For example, a
+  /// software keyboard on the bottom of the screen that may cover and consume
+  /// the same area that requires bottom padding will not affect this value.
   ///
   /// This value is independent of the [padding] and [viewInsets]: their values
   /// are measured from the edges of the [MediaQuery] widget's bounds. The
   /// bounds of the top level MediaQuery created by [WidgetsApp] are the
-  /// same as the window (often the mobile device screen) that contains the app.
+  /// same as the window that contains the app. On mobile devices, this will
+  /// typically be the full screen.
   ///
   /// See also:
   ///

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -101,7 +101,7 @@ void main() {
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
     const EdgeInsets padding = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
-    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 6.0, right: 8.0, left: 10.0, bottom: 12.0);
     const EdgeInsets viewInsets = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
 
     MediaQueryData unpadded;
@@ -144,7 +144,7 @@ void main() {
     expect(unpadded.devicePixelRatio, devicePixelRatio);
     expect(unpadded.textScaleFactor, textScaleFactor);
     expect(unpadded.padding, EdgeInsets.zero);
-    expect(unpadded.viewPadding, viewPadding);
+    expect(unpadded.viewPadding, viewInsets);
     expect(unpadded.viewInsets, viewInsets);
     expect(unpadded.alwaysUse24HourFormat, true);
     expect(unpadded.accessibleNavigation, true);
@@ -158,7 +158,7 @@ void main() {
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
     const EdgeInsets padding = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
-    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 6.0, right: 8.0, left: 10.0, bottom: 12.0);
     const EdgeInsets viewInsets = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
 
     MediaQueryData unpadded;
@@ -201,7 +201,7 @@ void main() {
     expect(unpadded.devicePixelRatio, devicePixelRatio);
     expect(unpadded.textScaleFactor, textScaleFactor);
     expect(unpadded.padding, padding);
-    expect(unpadded.viewPadding, viewPadding);
+    expect(unpadded.viewPadding, padding);
     expect(unpadded.viewInsets, EdgeInsets.zero);
     expect(unpadded.alwaysUse24HourFormat, true);
     expect(unpadded.accessibleNavigation, true);
@@ -215,7 +215,7 @@ void main() {
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
     const EdgeInsets padding = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
-    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 6.0, right: 8.0, left: 10.0, bottom: 12.0);
     const EdgeInsets viewInsets = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
 
     MediaQueryData unpadded;
@@ -257,7 +257,7 @@ void main() {
     expect(unpadded.size, size);
     expect(unpadded.devicePixelRatio, devicePixelRatio);
     expect(unpadded.textScaleFactor, textScaleFactor);
-    expect(unpadded.padding, padding);
+    expect(unpadded.padding, EdgeInsets.zero);
     expect(unpadded.viewPadding, EdgeInsets.zero);
     expect(unpadded.viewInsets, viewInsets);
     expect(unpadded.alwaysUse24HourFormat, true);

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -56,6 +56,7 @@ void main() {
     expect(copied.devicePixelRatio, data.devicePixelRatio);
     expect(copied.textScaleFactor, data.textScaleFactor);
     expect(copied.padding, data.padding);
+    expect(copied.viewPadding, data.viewPadding);
     expect(copied.viewInsets, data.viewInsets);
     expect(copied.alwaysUse24HourFormat, data.alwaysUse24HourFormat);
     expect(copied.accessibleNavigation, data.accessibleNavigation);
@@ -72,6 +73,7 @@ void main() {
       devicePixelRatio: 1.41,
       textScaleFactor: 1.62,
       padding: const EdgeInsets.all(9.10938),
+      viewPadding: const EdgeInsets.all(11.24031),
       viewInsets: const EdgeInsets.all(1.67262),
       alwaysUse24HourFormat: true,
       accessibleNavigation: true,
@@ -84,6 +86,7 @@ void main() {
     expect(copied.devicePixelRatio, 1.41);
     expect(copied.textScaleFactor, 1.62);
     expect(copied.padding, const EdgeInsets.all(9.10938));
+    expect(copied.viewPadding, const EdgeInsets.all(11.24031));
     expect(copied.viewInsets, const EdgeInsets.all(1.67262));
     expect(copied.alwaysUse24HourFormat, true);
     expect(copied.accessibleNavigation, true);
@@ -98,6 +101,7 @@ void main() {
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
     const EdgeInsets padding = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
     const EdgeInsets viewInsets = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
 
     MediaQueryData unpadded;
@@ -108,6 +112,7 @@ void main() {
           devicePixelRatio: devicePixelRatio,
           textScaleFactor: textScaleFactor,
           padding: padding,
+          viewPadding: viewPadding,
           viewInsets: viewInsets,
           alwaysUse24HourFormat: true,
           accessibleNavigation: true,
@@ -139,6 +144,7 @@ void main() {
     expect(unpadded.devicePixelRatio, devicePixelRatio);
     expect(unpadded.textScaleFactor, textScaleFactor);
     expect(unpadded.padding, EdgeInsets.zero);
+    expect(unpadded.viewPadding, viewPadding);
     expect(unpadded.viewInsets, viewInsets);
     expect(unpadded.alwaysUse24HourFormat, true);
     expect(unpadded.accessibleNavigation, true);
@@ -152,6 +158,7 @@ void main() {
     const double devicePixelRatio = 2.0;
     const double textScaleFactor = 1.2;
     const EdgeInsets padding = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
     const EdgeInsets viewInsets = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
 
     MediaQueryData unpadded;
@@ -162,6 +169,7 @@ void main() {
           devicePixelRatio: devicePixelRatio,
           textScaleFactor: textScaleFactor,
           padding: padding,
+          viewPadding : viewPadding,
           viewInsets: viewInsets,
           alwaysUse24HourFormat: true,
           accessibleNavigation: true,
@@ -193,7 +201,65 @@ void main() {
     expect(unpadded.devicePixelRatio, devicePixelRatio);
     expect(unpadded.textScaleFactor, textScaleFactor);
     expect(unpadded.padding, padding);
+    expect(unpadded.viewPadding, viewPadding);
     expect(unpadded.viewInsets, EdgeInsets.zero);
+    expect(unpadded.alwaysUse24HourFormat, true);
+    expect(unpadded.accessibleNavigation, true);
+    expect(unpadded.invertColors, true);
+    expect(unpadded.disableAnimations, true);
+    expect(unpadded.boldText, true);
+  });
+
+  testWidgets('MediaQuery.removeViewPadding removes specified viewPadding', (WidgetTester tester) async {
+    const Size size = Size(2.0, 4.0);
+    const double devicePixelRatio = 2.0;
+    const double textScaleFactor = 1.2;
+    const EdgeInsets padding = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 2.0, right: 4.0, left: 5.0, bottom: 6.0);
+    const EdgeInsets viewInsets = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
+
+    MediaQueryData unpadded;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: size,
+          devicePixelRatio: devicePixelRatio,
+          textScaleFactor: textScaleFactor,
+          padding: padding,
+          viewPadding : viewPadding,
+          viewInsets: viewInsets,
+          alwaysUse24HourFormat: true,
+          accessibleNavigation: true,
+          invertColors: true,
+          disableAnimations: true,
+          boldText: true,
+        ),
+        child: Builder(
+          builder: (BuildContext context) {
+            return MediaQuery.removeViewPadding(
+              context: context,
+              removeLeft: true,
+              removeTop: true,
+              removeRight: true,
+              removeBottom: true,
+              child: Builder(
+                builder: (BuildContext context) {
+                  unpadded = MediaQuery.of(context);
+                  return Container();
+                }
+              ),
+            );
+          },
+        ),
+      )
+    );
+
+    expect(unpadded.size, size);
+    expect(unpadded.devicePixelRatio, devicePixelRatio);
+    expect(unpadded.textScaleFactor, textScaleFactor);
+    expect(unpadded.padding, padding);
+    expect(unpadded.viewPadding, EdgeInsets.zero);
+    expect(unpadded.viewInsets, viewInsets);
     expect(unpadded.alwaysUse24HourFormat, true);
     expect(unpadded.accessibleNavigation, true);
     expect(unpadded.invertColors, true);


### PR DESCRIPTION
## Description

Updates the `MediaQuery` and `MediaQueryData` classes to include the `viewPadding` property & relevant functionality that was introduced in https://github.com/flutter/engine/pull/8848.  
This is part 1 of 2 on the way to fixing #29941, with implementation in the following classes to be added after this lands:

- `material/Scaffold`
- `widgets/SafeArea`
- `cupertino/CupertinoTabScaffold`
- `cupertino/CupertinoPageScaffold`

## Related Issues

Addresses #29941 

## Tests

Updated Tests:

- MediaQueryData.copyWith defaults to source
- MediaQuery.copyWith copies specified values
- MediaQuery.removePadding removes specified padding
- MediaQuery.removeViewInsets removes specified viewInsets

Added:
- MediaQuery.removeViewPadding removes specified viewPadding


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
