### PR TITLE
Skip web test on crazy import

### DIFF
--- a/packages/flutter/build.yaml
+++ b/packages/flutter/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    sources:
+      exclude:
+        - "test/examples/sector_layout_test.dart"


### PR DESCRIPTION
## Description

build_runner fails when attempt to produce modules for relative imports outside of the project, add a config to skip this test so the web testing doesn't break.