### PR TITLE
limit open files on macOS when copying assets

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -228,9 +228,8 @@ Future<void> writeBundle(
     bundleDir.deleteSync(recursive: true);
   bundleDir.createSync(recursive: true);
 
-  // On systems with a limited number of file descriptors, limit number of
-  // open files.
-  final Pool pool = Pool(platform.isMacOS ? 30 : 1000);
+  // Limit number of open files to avoid running out of file descriptors.
+  final Pool pool = Pool(64);
   await Future.wait<void>(
     assetEntries.entries.map<Future<void>>((MapEntry<String, DevFSContent> entry) async {
       final PoolResource resource = await pool.request();

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -12,7 +12,6 @@ import 'asset.dart';
 import 'base/build.dart';
 import 'base/common.dart';
 import 'base/file_system.dart';
-import 'base/platform.dart';
 import 'build_info.dart';
 import 'compile.dart';
 import 'dart/package_map.dart';


### PR DESCRIPTION
## Description

The async File APIs batch their work to be shipped off to a background thread, but in doing so they retain the file descriptors. The fix is to only run on ~30 or so files at a time for macOS so as to not exhaust the open files.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34045