### PR TITLE
Make it easier to pass local engine flags when running devicelab tests

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -54,10 +54,17 @@ Future<void> main(List<String> rawArgs) async {
   }
 
   final bool silent = args['silent'];
+  final String localEngine = args['local-engine'];
+  final String localEngineSrcPath = args['local-engine-src-path'];
 
   for (String taskName in _taskNames) {
     section('Running task "$taskName"');
-    final Map<String, dynamic> result = await runTask(taskName, silent: silent);
+    final Map<String, dynamic> result = await runTask(
+      taskName,
+      silent: silent,
+      localEngine: localEngine,
+      localEngineSrcPath: localEngineSrcPath,
+    );
 
     if (!result['success'])
       exitCode = 1;
@@ -123,6 +130,19 @@ final ArgParser _argParser = ArgParser()
     'silent',
     negatable: true,
     defaultsTo: false,
+  )
+  ..addOption(
+    'local-engine',
+    help: 'Name of a build output within the engine out directory, if you are '
+          'building Flutter locally. Use this to select a specific version of '
+          'the engine if you have built multiple engine targets. This path is '
+          'relative to --local-engine-src-path/out.',
+  )
+  ..addOption(
+    'local-engine-src-path',
+    help: 'Path to your engine src directory, if you are building Flutter '
+          'locally. Defaults to \$FLUTTER_ENGINE if set, or tries to guess at '
+          'the location based on the value of the --flutter-root option.',
   );
 
 bool _listsEqual(List<dynamic> a, List<dynamic> b) {

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -23,7 +23,12 @@ const Duration taskTimeoutWithGracePeriod = Duration(minutes: 26);
 ///
 /// Running the task in [silent] mode will suppress standard output from task
 /// processes and only print standard errors.
-Future<Map<String, dynamic>> runTask(String taskName, { bool silent = false }) async {
+Future<Map<String, dynamic>> runTask(
+  String taskName, {
+  bool silent = false,
+  String localEngine,
+  String localEngineSrcPath,
+}) async {
   final String taskExecutable = 'bin/tasks/$taskName.dart';
 
   if (!file(taskExecutable).existsSync())
@@ -32,6 +37,8 @@ Future<Map<String, dynamic>> runTask(String taskName, { bool silent = false }) a
   final Process runner = await startProcess(dartBin, <String>[
     '--enable-vm-service=0', // zero causes the system to choose a free port
     '--no-pause-isolates-on-exit',
+    if (localEngine != null) '-DlocalEngine=$localEngine',
+    if (localEngineSrcPath != null) '-DlocalEngineSrcPath=$localEngineSrcPath',
     taskExecutable,
   ]);
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -346,14 +346,12 @@ Future<int> flutter(String command, {
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String> environment,
 }) {
-  final List<String> args = <String>[command];
-  if (localEngine != null) {
-    args.addAll(<String>['--local-engine', localEngine]);
-    if (localEngineSrcPath != null) {
-      args.addAll(<String>['--local-engine-src-path', localEngineSrcPath]);
-    }
-  }
-  args.addAll(options);
+  final List<String> args = <String>[
+    command,
+    if (localEngine != null) ...<String>['--local-engine', localEngine],
+    if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],
+    ...options,
+  ];
   return exec(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
       canFail: canFail, environment: environment);
 }
@@ -365,14 +363,12 @@ Future<String> evalFlutter(String command, {
   Map<String, String> environment,
   StringBuffer stderr, // if not null, the stderr will be written here.
 }) {
-  final List<String> args = <String>[command];
-  if (localEngine != null) {
-    args.addAll(<String>['--local-engine', localEngine]);
-    if (localEngineSrcPath != null) {
-      args.addAll(<String>['--local-engine-src-path', localEngineSrcPath]);
-    }
-  }
-  args.addAll(options);
+  final List<String> args = <String>[
+    command,
+    if (localEngine != null) ...<String>['--local-engine', localEngine],
+    if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],
+    ...options,
+  ];
   return eval(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
       canFail: canFail, environment: environment, stderr: stderr);
 }

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -18,6 +18,13 @@ import 'adb.dart';
 /// Virtual current working directory, which affect functions, such as [exec].
 String cwd = Directory.current.path;
 
+/// The local engine to use for [flutter] and [evalFlutter], if any.
+String get localEngine => const String.fromEnvironment('localEngine');
+
+/// The local engine source path to use if a local engine is used for [flutter]
+/// and [evalFlutter].
+String get localEngineSrcPath => const String.fromEnvironment('localEngineSrcPath');
+
 List<ProcessInfo> _runningProcesses = <ProcessInfo>[];
 ProcessManager _processManager = const LocalProcessManager();
 
@@ -339,7 +346,14 @@ Future<int> flutter(String command, {
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String> environment,
 }) {
-  final List<String> args = <String>[command]..addAll(options);
+  final List<String> args = <String>[command];
+  if (localEngine != null) {
+    args.addAll(<String>['--local-engine', localEngine]);
+    if (localEngineSrcPath != null) {
+      args.addAll(<String>['--local-engine-src-path', localEngineSrcPath]);
+    }
+  }
+  args.addAll(options);
   return exec(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
       canFail: canFail, environment: environment);
 }
@@ -351,7 +365,14 @@ Future<String> evalFlutter(String command, {
   Map<String, String> environment,
   StringBuffer stderr, // if not null, the stderr will be written here.
 }) {
-  final List<String> args = <String>[command]..addAll(options);
+  final List<String> args = <String>[command];
+  if (localEngine != null) {
+    args.addAll(<String>['--local-engine', localEngine]);
+    if (localEngineSrcPath != null) {
+      args.addAll(<String>['--local-engine-src-path', localEngineSrcPath]);
+    }
+  }
+  args.addAll(options);
   return eval(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
       canFail: canFail, environment: environment, stderr: stderr);
 }

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/flutter
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   args: 1.5.2


### PR DESCRIPTION
Make dev/devicelab/bin/run.dart take a `--local-engine` and `--local-engine-src-path` parameter.


Fixes #34047 
