### PR TITLE
Toggle toolbar exception fix

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -749,7 +749,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         cause: SelectionChangedCause.forcePress,
       );
       if (_shouldShowSelectionToolbar) {
-        _editableTextKey.currentState.toggleToolbar();
+        _editableTextKey.currentState.showToolbar();
       }
     }
   }
@@ -819,7 +819,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
   void _handleSingleLongTapEnd(LongPressEndDetails details) {
     if (widget.selectionEnabled) {
       if (_shouldShowSelectionToolbar)
-        _editableTextKey.currentState.toggleToolbar();
+        _editableTextKey.currentState.showToolbar();
     }
   }
 
@@ -827,7 +827,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     if (widget.selectionEnabled) {
       _renderEditable.selectWord(cause: SelectionChangedCause.doubleTap);
       if (_shouldShowSelectionToolbar) {
-        _editableText.toggleToolbar();
+        _editableText.showToolbar();
       }
     }
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1482,11 +1482,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   /// Shows the selection toolbar at the location of the current cursor.
   ///
-  /// Returns `false` if a toolbar couldn't be shown such as when no text
-  /// selection currently exists.
+  /// Returns `false` if a toolbar couldn't be shown, such as when the toolbar
+  /// is already shown, or when no text selection currently exists.
   bool showToolbar() {
-    if (_selectionOverlay == null)
+    if (_selectionOverlay == null || _selectionOverlay.toolbarIsVisible) {
       return false;
+    }
 
     _selectionOverlay.showToolbar();
     return true;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5221,7 +5221,7 @@ void main() {
   );
 
   testWidgets(
-    'double double tap toggles selection menu',
+    'double double tap just shows the selection menu',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: '',
@@ -5245,17 +5245,17 @@ void main() {
       await tester.pump();
       expect(find.text('PASTE'), findsOneWidget);
 
-      // Double tap again hides the selection menu.
+      // Double tap again keeps the selection menu visible.
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pump();
-      expect(find.text('PASTE'), findsNWidgets(0));
+      expect(find.text('PASTE'), findsOneWidget);
     },
   );
 
   testWidgets(
-    'double long press toggles selection menu',
+    'double long press just shows the selection menu',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: '',
@@ -5277,10 +5277,10 @@ void main() {
       await tester.pump();
       expect(find.text('PASTE'), findsOneWidget);
 
-      // Double tap again hides the selection menu.
+      // Long press again keeps the selection menu visible.
       await tester.longPressAt(textOffsetToPosition(tester, 0));
       await tester.pump();
-      expect(find.text('PASTE'), findsNWidgets(0));
+      expect(find.text('PASTE'), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
## Description
Fixes an error that was logged due to an assertion in `toggleToolbar`.  This is due to a fix of a similar problem from https://github.com/flutter/flutter/pull/33802 that switched calls to `showToolbar` to `toggleToolbar`.

## Related Issues

Closes: https://github.com/flutter/flutter/issues/34021