### PR TITLE
fix devicelab test for chrome reload worklow

### DIFF
--- a/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
@@ -17,7 +17,7 @@ final Directory flutterGalleryDir = dir(path.join(flutterDirectory.path, 'exampl
 TaskFunction createWebDevModeTest() {
   return () async {
     final List<String> options = <String>[
-      '--hot', '-d', 'web', '--verbose', '--resident', '--target=lib/main_web.dart',
+      '--hot', '-d', 'web', '--verbose', '--resident', '--target=lib/main.dart',
     ];
     setLocalEngineOptionIfNecessary(options);
     int hotRestartCount = 0;


### PR DESCRIPTION
## Description

The main_web.dart entrypoint was removed since it was no longer needed
