### PR TITLE
Add endIndent property to Divider and VerticalDivider

### DIFF
--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -10,7 +10,7 @@ import 'theme.dart';
 // Examples can assume:
 // BuildContext context;
 
-/// A one physical pixel thick horizontal line, with padding on either
+/// A one device pixel thick horizontal line, with padding on either
 /// side.
 ///
 /// In the material design language, this represents a divider. Dividers can be
@@ -43,11 +43,11 @@ class Divider extends StatelessWidget {
 
   /// The divider's height extent.
   ///
-  /// The divider itself is always drawn as one physical pixel thick horizontal
+  /// The divider itself is always drawn as one device pixel thick horizontal
   /// line that is centered within the height specified by this value.
   ///
   /// A divider with a [height] of 0.0 is always drawn as a line with a height
-  /// of exactly one physical pixel, without any padding around it.
+  /// of exactly one device pixel, without any padding around it.
   final double height;
 
   /// The amount of empty space to the left of the divider.
@@ -123,7 +123,7 @@ class Divider extends StatelessWidget {
   }
 }
 
-/// A one physical pixel thick horizontal line, with padding on either
+/// A one device pixel thick horizontal line, with padding on either
 /// side.
 ///
 /// In the material design language, this represents a divider. Vertical
@@ -152,11 +152,11 @@ class VerticalDivider extends StatelessWidget {
 
   /// The divider's width.
   ///
-  /// The divider itself is always drawn as one physical pixel thick
+  /// The divider itself is always drawn as one device pixel thick
   /// line that is centered within the width specified by this value.
   ///
   /// A divider with a [width] of 0.0 is always drawn as a line with a width
-  /// of exactly one physical pixel, without any padding around it.
+  /// of exactly one device pixel, without any padding around it.
   final double width;
 
   /// The amount of empty space on top of the divider.

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -191,7 +191,7 @@ class VerticalDivider extends StatelessWidget {
       child: Center(
         child: Container(
           width: 0.0,
-          margin: EdgeInsetsDirectional.only(start: indent),
+          margin: EdgeInsetsDirectional.only(start: indent, end: endIndent),
           decoration: BoxDecoration(
             border: Border(
               left: Divider.createBorderSide(context, color: color),

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -10,18 +10,17 @@ import 'theme.dart';
 // Examples can assume:
 // BuildContext context;
 
-/// A one device pixel thick horizontal line, with padding on either
+/// A one physical pixel thick horizontal line, with padding on either
 /// side.
 ///
-/// In the material design language, this represents a divider.
+/// In the material design language, this represents a divider. Dividers can be
+/// used in lists, [Drawer]s, and elsewhere to separate content.
 ///
-/// Dividers can be used in lists, [Drawer]s, and elsewhere to separate content
-/// vertically or horizontally depending on the value of the [axis] enum.
-/// To create a one-pixel divider between items in a list, consider using
+/// To create a one-pixel divider between [ListTile] items, consider using
 /// [ListTile.divideTiles], which is optimized for this case.
 ///
 /// The box's total height is controlled by [height]. The appropriate
-/// padding is automatically computed from the width or height.
+/// padding is automatically computed from the height.
 ///
 /// See also:
 ///
@@ -44,11 +43,11 @@ class Divider extends StatelessWidget {
 
   /// The divider's height extent.
   ///
-  /// The divider itself is always drawn as one device pixel thick horizontal
+  /// The divider itself is always drawn as one physical pixel thick horizontal
   /// line that is centered within the height specified by this value.
   ///
   /// A divider with a [height] of 0.0 is always drawn as a line with a height
-  /// of exactly one device pixel, without any padding around it.
+  /// of exactly one physical pixel, without any padding around it.
   final double height;
 
   /// The amount of empty space to the left of the divider.
@@ -124,22 +123,19 @@ class Divider extends StatelessWidget {
   }
 }
 
-/// A one device pixel thick vertical line, with padding on either
+/// A one physical pixel thick horizontal line, with padding on either
 /// side.
 ///
-/// In the material design language, this represents a divider.
-///
-/// Dividers can be used in lists, [Drawer]s, and elsewhere to separate content
-/// horizontally. To create a one-pixel divider between items in a list,
-/// consider using [ListTile.divideTiles], which is optimized for this case.
+/// In the material design language, this represents a divider. Vertical
+/// dividers can be used in horizontally scrolling lists, such as a
+/// [ListView] with [ListView.scrollDirection] set to [Axis.horizontal].
 ///
 /// The box's total width is controlled by [width]. The appropriate
 /// padding is automatically computed from the width.
 ///
 /// See also:
 ///
-///  * [PopupMenuDivider], which is the equivalent but for popup menus.
-///  * [ListTile.divideTiles], another approach to dividing widgets in a list.
+///  * [ListView.separated], which can be used to generate vertical dividers.
 ///  * <https://material.io/design/components/dividers.html>
 class VerticalDivider extends StatelessWidget {
   /// Creates a material design divider.
@@ -156,17 +152,17 @@ class VerticalDivider extends StatelessWidget {
 
   /// The divider's width.
   ///
-  /// The divider itself is always drawn as one device pixel thick
+  /// The divider itself is always drawn as one physical pixel thick
   /// line that is centered within the width specified by this value.
   ///
   /// A divider with a [width] of 0.0 is always drawn as a line with a width
-  /// of exactly one device pixel, without any padding around it.
+  /// of exactly one physical pixel, without any padding around it.
   final double width;
 
-  /// The amount of empty space to the left of the divider.
+  /// The amount of empty space on top of the divider.
   final double indent;
 
-  /// The amount of empty space to the right of the divider.
+  /// The amount of empty space under the divider.
   final double endIndent;
 
   /// The color to use when painting the line.
@@ -191,7 +187,7 @@ class VerticalDivider extends StatelessWidget {
       child: Center(
         child: Container(
           width: 0.0,
-          margin: EdgeInsetsDirectional.only(start: indent, end: endIndent),
+          margin: EdgeInsetsDirectional.only(top: indent, bottom: endIndent),
           decoration: BoxDecoration(
             border: Border(
               left: Divider.createBorderSide(context, color: color),

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -36,6 +36,7 @@ class Divider extends StatelessWidget {
     Key key,
     this.height = 16.0,
     this.indent = 0.0,
+    this.rightIndent = 0.0,
     this.color,
   }) : assert(height >= 0.0),
        super(key: key);
@@ -52,6 +53,9 @@ class Divider extends StatelessWidget {
 
   /// The amount of empty space to the left of the divider.
   final double indent;
+
+  /// The amount of empty space to the right of the divider.
+  final double endIndent;
 
   /// The color to use when painting the line.
   ///
@@ -108,7 +112,7 @@ class Divider extends StatelessWidget {
       child: Center(
         child: Container(
           height: 0.0,
-          margin: EdgeInsetsDirectional.only(start: indent),
+          margin: EdgeInsetsDirectional.only(start: indent, end: endIndent),
           decoration: BoxDecoration(
             border: Border(
               bottom: createBorderSide(context, color: color),
@@ -145,6 +149,7 @@ class VerticalDivider extends StatelessWidget {
     Key key,
     this.width = 16.0,
     this.indent = 0.0,
+    this.endIndent = 0.0,
     this.color,
   }) : assert(width >= 0.0),
        super(key: key);
@@ -160,6 +165,9 @@ class VerticalDivider extends StatelessWidget {
 
   /// The amount of empty space to the left of the divider.
   final double indent;
+
+  /// The amount of empty space to the right of the divider.
+  final double endIndent;
 
   /// The color to use when painting the line.
   ///

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -36,7 +36,7 @@ class Divider extends StatelessWidget {
     Key key,
     this.height = 16.0,
     this.indent = 0.0,
-    this.rightIndent = 0.0,
+    this.endIndent = 0.0,
     this.color,
   }) : assert(height >= 0.0),
        super(key: key);

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -123,7 +123,7 @@ class Divider extends StatelessWidget {
   }
 }
 
-/// A one device pixel thick horizontal line, with padding on either
+/// A one device pixel thick vertical line, with padding on either
 /// side.
 ///
 /// In the material design language, this represents a divider. Vertical

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -23,8 +23,8 @@ void main() {
   });
 
   testWidgets('Horizontal divider custom indentation', (WidgetTester tester) async {
-    RenderBox divider;
-    RenderBox decoratedBox;
+    Rect dividerRect;
+    Rect lineRect;
 
     await tester.pumpWidget(
       const Directionality(
@@ -38,12 +38,13 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
-    divider = tester.firstRenderObject(find.byType(Divider));
     // Container widgets wrap its child in an DecoratedBox widget, which in turn
     // is wrapped by a Padding widget. The Padding widget provides these
     // indentations.
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.width, 10.0 + decoratedBox.size.width);
+    dividerRect = tester.getRect(find.byType(Divider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.left, dividerRect.left + 10.0);
+    expect(lineRect.right, dividerRect.right);
 
     await tester.pumpWidget(
       const Directionality(
@@ -57,9 +58,10 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
-    divider = tester.firstRenderObject(find.byType(Divider));
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.width, decoratedBox.size.width + 10.0);
+    dividerRect = tester.getRect(find.byType(Divider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.left, dividerRect.left);
+    expect(lineRect.right, dividerRect.right - 10.0);
 
     await tester.pumpWidget(
       const Directionality(
@@ -74,9 +76,10 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 20.0);
-    divider = tester.firstRenderObject(find.byType(Divider));
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.width, 10.0 + decoratedBox.size.width + 10.0);
+    dividerRect = tester.getRect(find.byType(Divider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.left, dividerRect.left + 10.0);
+    expect(lineRect.right, dividerRect.right - 10.0);
   });
 
   testWidgets('Vertical Divider Test', (WidgetTester tester) async {
@@ -118,8 +121,8 @@ void main() {
   });
 
   testWidgets('Vertical divider custom indentation', (WidgetTester tester) async {
-    RenderBox divider;
-    RenderBox decoratedBox;
+    Rect dividerRect;
+    Rect lineRect;
 
     await tester.pumpWidget(
       const Directionality(
@@ -133,12 +136,13 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
-    divider = tester.firstRenderObject(find.byType(VerticalDivider));
     // Container widgets wrap its child in an DecoratedBox widget, which in turn
     // is wrapped by a Padding widget. The Padding widget provides these
     // indentations.
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.height, 10.0 + decoratedBox.size.height);
+    dividerRect = tester.getRect(find.byType(VerticalDivider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.top, dividerRect.top + 10.0);
+    expect(lineRect.bottom, dividerRect.bottom);
 
     await tester.pumpWidget(
       const Directionality(
@@ -152,9 +156,10 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
-    divider = tester.firstRenderObject(find.byType(VerticalDivider));
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.height, decoratedBox.size.height + 10.0);
+    dividerRect = tester.getRect(find.byType(VerticalDivider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.top, dividerRect.top);
+    expect(lineRect.bottom, dividerRect.bottom - 10.0);
 
     await tester.pumpWidget(
       const Directionality(
@@ -169,8 +174,9 @@ void main() {
     );
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 20.0);
-    divider = tester.firstRenderObject(find.byType(VerticalDivider));
-    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
-    expect(divider.size.height, 10.0 + decoratedBox.size.height + 10.0);
+    dividerRect = tester.getRect(find.byType(VerticalDivider));
+    lineRect = tester.getRect(find.byType(DecoratedBox));
+    expect(lineRect.top, dividerRect.top + 10.0);
+    expect(lineRect.bottom, dividerRect.bottom - 10.0);
   });
 }

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -22,7 +22,7 @@ void main() {
     expect(find.byType(Divider), paints..path(strokeWidth: 0.0));
   });
 
-  testWidgets('Divider custom indentation', (WidgetTester tester) async {
+  testWidgets('Horizontal divider custom indentation', (WidgetTester tester) async {
     RenderBox divider;
     RenderBox decoratedBox;
 
@@ -58,9 +58,6 @@ void main() {
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
     divider = tester.firstRenderObject(find.byType(Divider));
-    // Container widgets wrap its child in an DecoratedBox widget, which in turn
-    // is wrapped by a Padding widget. The Padding widget provides these
-    // indentations.
     decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
     expect(divider.size.width, decoratedBox.size.width + 10.0);
 
@@ -78,9 +75,6 @@ void main() {
 
     expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 20.0);
     divider = tester.firstRenderObject(find.byType(Divider));
-    // Container widgets wrap its child in an DecoratedBox widget, which in turn
-    // is wrapped by a Padding widget. The Padding widget provides these
-    // indentations.
     decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
     expect(divider.size.width, 10.0 + decoratedBox.size.width + 10.0);
   });
@@ -121,5 +115,62 @@ void main() {
     expect(box.size.width, 16.0);
     expect(containerBox.size.height, 600.0);
     expect(find.byType(VerticalDivider), paints..path(strokeWidth: 0.0));
+  });
+
+  testWidgets('Vertical divider custom indentation', (WidgetTester tester) async {
+    RenderBox divider;
+    RenderBox decoratedBox;
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: VerticalDivider(
+            indent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
+    divider = tester.firstRenderObject(find.byType(VerticalDivider));
+    // Container widgets wrap its child in an DecoratedBox widget, which in turn
+    // is wrapped by a Padding widget. The Padding widget provides these
+    // indentations.
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.height, 10.0 + decoratedBox.size.height);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: VerticalDivider(
+            endIndent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
+    divider = tester.firstRenderObject(find.byType(VerticalDivider));
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.height, decoratedBox.size.height + 10.0);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: VerticalDivider(
+            indent: 10.0,
+            endIndent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 20.0);
+    divider = tester.firstRenderObject(find.byType(VerticalDivider));
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.height, 10.0 + decoratedBox.size.height + 10.0);
   });
 }

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -22,6 +22,69 @@ void main() {
     expect(find.byType(Divider), paints..path(strokeWidth: 0.0));
   });
 
+  testWidgets('Divider custom indentation', (WidgetTester tester) async {
+    RenderBox divider;
+    RenderBox decoratedBox;
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Divider(
+            indent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
+    divider = tester.firstRenderObject(find.byType(Divider));
+    // Container widgets wrap its child in an DecoratedBox widget, which in turn
+    // is wrapped by a Padding widget. The Padding widget provides these
+    // indentations.
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.width, 10.0 + decoratedBox.size.width);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Divider(
+            endIndent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
+    divider = tester.firstRenderObject(find.byType(Divider));
+    // Container widgets wrap its child in an DecoratedBox widget, which in turn
+    // is wrapped by a Padding widget. The Padding widget provides these
+    // indentations.
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.width, decoratedBox.size.width + 10.0);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Divider(
+            indent: 10.0,
+            endIndent: 10.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 20.0);
+    divider = tester.firstRenderObject(find.byType(Divider));
+    // Container widgets wrap its child in an DecoratedBox widget, which in turn
+    // is wrapped by a Padding widget. The Padding widget provides these
+    // indentations.
+    decoratedBox = tester.firstRenderObject(find.byType(DecoratedBox));
+    expect(divider.size.width, 10.0 + decoratedBox.size.width + 10.0);
+  });
+
   testWidgets('Vertical Divider Test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/painting.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+
   testWidgets('Divider control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
@@ -23,6 +24,7 @@ void main() {
   });
 
   testWidgets('Horizontal divider custom indentation', (WidgetTester tester) async {
+    const double customIndent = 10.0;
     Rect dividerRect;
     Rect lineRect;
 
@@ -31,7 +33,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Divider(
-            indent: 10.0,
+            indent: customIndent,
           ),
         ),
       ),
@@ -40,7 +42,7 @@ void main() {
     // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
-    expect(lineRect.left, dividerRect.left + 10.0);
+    expect(lineRect.left, dividerRect.left + customIndent);
     expect(lineRect.right, dividerRect.right);
 
     await tester.pumpWidget(
@@ -48,7 +50,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Divider(
-            endIndent: 10.0,
+            endIndent: customIndent,
           ),
         ),
       ),
@@ -57,15 +59,15 @@ void main() {
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left);
-    expect(lineRect.right, dividerRect.right - 10.0);
+    expect(lineRect.right, dividerRect.right - customIndent);
 
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Divider(
-            indent: 10.0,
-            endIndent: 10.0,
+            indent: customIndent,
+            endIndent: customIndent,
           ),
         ),
       ),
@@ -73,8 +75,8 @@ void main() {
 
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
-    expect(lineRect.left, dividerRect.left + 10.0);
-    expect(lineRect.right, dividerRect.right - 10.0);
+    expect(lineRect.left, dividerRect.left + customIndent);
+    expect(lineRect.right, dividerRect.right - customIndent);
   });
 
   testWidgets('Vertical Divider Test', (WidgetTester tester) async {
@@ -116,6 +118,7 @@ void main() {
   });
 
   testWidgets('Vertical divider custom indentation', (WidgetTester tester) async {
+    const double customIndent = 10.0;
     Rect dividerRect;
     Rect lineRect;
 
@@ -124,7 +127,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: VerticalDivider(
-            indent: 10.0,
+            indent: customIndent,
           ),
         ),
       ),
@@ -133,7 +136,7 @@ void main() {
     // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
-    expect(lineRect.top, dividerRect.top + 10.0);
+    expect(lineRect.top, dividerRect.top + customIndent);
     expect(lineRect.bottom, dividerRect.bottom);
 
     await tester.pumpWidget(
@@ -141,7 +144,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: VerticalDivider(
-            endIndent: 10.0,
+            endIndent: customIndent,
           ),
         ),
       ),
@@ -150,15 +153,15 @@ void main() {
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top);
-    expect(lineRect.bottom, dividerRect.bottom - 10.0);
+    expect(lineRect.bottom, dividerRect.bottom - customIndent);
 
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: VerticalDivider(
-            indent: 10.0,
-            endIndent: 10.0,
+            indent: customIndent,
+            endIndent: customIndent,
           ),
         ),
       ),
@@ -166,7 +169,7 @@ void main() {
 
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
-    expect(lineRect.top, dividerRect.top + 10.0);
-    expect(lineRect.bottom, dividerRect.bottom - 10.0);
+    expect(lineRect.top, dividerRect.top + customIndent);
+    expect(lineRect.bottom, dividerRect.bottom - customIndent);
   });
 }

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -37,10 +37,7 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
-    // Container widgets wrap its child in an DecoratedBox widget, which in turn
-    // is wrapped by a Padding widget. The Padding widget provides these
-    // indentations.
+    // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left + 10.0);
@@ -57,7 +54,6 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 10.0);
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left);
@@ -75,7 +71,6 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.horizontal, 20.0);
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left + 10.0);
@@ -135,10 +130,7 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
-    // Container widgets wrap its child in an DecoratedBox widget, which in turn
-    // is wrapped by a Padding widget. The Padding widget provides these
-    // indentations.
+    // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top + 10.0);
@@ -155,7 +147,6 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 10.0);
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top);
@@ -173,7 +164,6 @@ void main() {
       ),
     );
 
-    expect(tester.firstWidget<Padding>(find.byType(Padding)).padding.vertical, 20.0);
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top + 10.0);

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/painting.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
-
   testWidgets('Divider control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
@@ -38,7 +37,6 @@ void main() {
         ),
       ),
     );
-
     // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
@@ -55,7 +53,6 @@ void main() {
         ),
       ),
     );
-
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left);
@@ -72,7 +69,6 @@ void main() {
         ),
       ),
     );
-
     dividerRect = tester.getRect(find.byType(Divider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.left, dividerRect.left + customIndent);
@@ -132,7 +128,6 @@ void main() {
         ),
       ),
     );
-
     // The divider line is drawn with a DecoratedBox with a border
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
@@ -149,7 +144,6 @@ void main() {
         ),
       ),
     );
-
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top);
@@ -166,7 +160,6 @@ void main() {
         ),
       ),
     );
-
     dividerRect = tester.getRect(find.byType(VerticalDivider));
     lineRect = tester.getRect(find.byType(DecoratedBox));
     expect(lineRect.top, dividerRect.top + customIndent);


### PR DESCRIPTION
## Description

Adds a new `endIndent` parameter to adjust the the dividers from the end as well. I decided to not update `indent` to `startIndent`, as that would be a breaking change. Edit: I would appreciate some feedback on this, since `startIndent` is much clearer, but changing the API would also result a breaking change. 

I also took this opportunity to update the Divider docs, since I tried to create vertical lines with it and do not think it can actually be used that way.

Edit: This also fixes `VerticalDivider` to now properly add indents at the `top`, not at the `start`

## Related Issues

https://github.com/flutter/flutter/issues/21244

## Tests

I added the following tests:
- Test for Divider's indent and endIndent 
- Test for VerticalDivider's indent and endIndent 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
