### PR TITLE
Fix web size test for new world

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -239,7 +239,7 @@ class WebCompileTest {
     rmTree(sampleDir);
 
     await inDirectory<void>(Directory.systemTemp, () async {
-      await flutter('create', options: <String>['--template=app', sampleAppName]);
+      await flutter('create', options: <String>['--template=app', '--web', sampleAppName]);
       await inDirectory(sampleDir, () async {
         await flutter('packages', options: <String>['get']);
         await evalFlutter('build', options: <String>[

--- a/examples/hello_world/web/index.html
+++ b/examples/hello_world/web/index.html
@@ -1,0 +1,12 @@
+<!-- Copyright 2019 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Flutter Gallery</title>
+    </head>
+    <body>
+        <script src="main.dart.js"></script>
+    </body>
+</html>

--- a/examples/hello_world/web/index.html
+++ b/examples/hello_world/web/index.html
@@ -4,7 +4,7 @@ found in the LICENSE file. -->
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Flutter Gallery</title>
+        <title>Hello, World</title>
     </head>
     <body>
         <script src="main.dart.js"></script>


### PR DESCRIPTION
## Description

Adds the required config to compile for web to the hello_world example, and updates the basic material app to pass the `--web` config.

Requires https://github.com/flutter/flutter/pull/34018