### PR TITLE
Prevent duplicate golden file test names

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1941,7 +1941,10 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       // Verify that taking a screenshot did not change the number of children
       // of the layer.
       expect(getChildLayerCount(layer), equals(expectedChildLayerCount));
-
+      // Remove test name to avoid duplicate test exception.
+      // Check if it is present first in cases of skipped test.
+      if (goldenTestNames.contains('inspector.repaint_boundary_margin.png'))
+        goldenTestNames.remove('inspector.repaint_boundary_margin.png');
       await expectLater(
         service.screenshot(
           repaintBoundary,
@@ -1976,7 +1979,10 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       // Verify that taking a screenshot with debug paint on did not change
       // the number of children the layer has.
       expect(getChildLayerCount(layer), equals(expectedChildLayerCount));
-
+      // Remove test name to avoid duplicate test exception.
+      // Check if it is present first in cases of skipped test.
+      if (goldenTestNames.contains('inspector.repaint_boundary.png'))
+        goldenTestNames.remove('inspector.repaint_boundary.png');
       // Ensure that creating screenshots including ones with debug paint
       // hasn't changed the regular render of the widget.
       await expectLater(
@@ -2019,7 +2025,10 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
           ..markNeedsLayout()
           ..markNeedsPaint();
         expect(container.debugNeedsLayout, isTrue);
-
+        // Remove test name to avoid duplicate test exception.
+        // Check if it is present first in cases of skipped test.
+        if (goldenTestNames.contains('inspector.container_debugPaint.png'))
+          goldenTestNames.remove('inspector.container_debugPaint.png');
         await expectLater(
           service.screenshot(
             find.byKey(outerContainerKey).evaluate().single,

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -97,6 +97,21 @@ set goldenFileComparator(GoldenFileComparator value) {
 ///   * [goldenFileComparator]
 bool autoUpdateGoldenFiles = false;
 
+/// A set for keeping track of golden file test names to prevent duplication.
+///
+/// As calls to [matchesGoldenFile] are executed, it is updated with file names
+/// to prevent conflicts.
+///
+/// The Flutter tool will automatically initialize this to an empty set, so
+/// callers should generally never have to explicitly modify this value. If you
+/// are intentionally testing a golden file multiple times, call [remove] before
+/// executing [matchesGoldenFile] again.
+///
+/// See also:
+///
+///   * [goldenFileComparator]
+Set<String> goldenTestNames = <String>{};
+
 /// Placeholder comparator that is set as the value of [goldenFileComparator]
 /// when the initialization that happens in the test bootstrap either has not
 /// yet happened or has been bypassed.

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1701,6 +1701,12 @@ class _MatchesGoldenFile extends AsyncMatcher {
       imageFuture = _captureImage(elements.single);
     }
 
+    if(goldenTestNames.contains(key.toString()) ){
+      return 'Duplicate file name detected for golden file test: "$key"';
+    } else {
+      goldenTestNames.add(key.toString());
+    }
+
     final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
     return binding.runAsync<String>(() async {
       final ui.Image image = await imageFuture;

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -342,7 +342,7 @@ void main() {
         await tester.pumpWidget(boilerplate(const Text('hello')));
         final Finder finder = find.byType(Text);
         try {
-          await expectLater(finder, matchesGoldenFile('foo.png'));
+          await expectLater(finder, matchesGoldenFile('bar.png'));
           fail('TestFailure expected but not thrown');
         } on TestFailure catch (error) {
           expect(comparator.invocation, _ComparatorInvocation.compare);
@@ -355,7 +355,7 @@ void main() {
         await tester.pumpWidget(boilerplate(const Text('hello')));
         final Finder finder = find.byType(Text);
         try {
-          await expectLater(finder, matchesGoldenFile('foo.png'));
+          await expectLater(finder, matchesGoldenFile('baz.png'));
           fail('TestFailure expected but not thrown');
         } on TestFailure catch (error) {
           expect(comparator.invocation, _ComparatorInvocation.compare);
@@ -367,7 +367,7 @@ void main() {
         await tester.pumpWidget(boilerplate(Container()));
         final Finder finder = find.byType(Text);
         try {
-          await expectLater(finder, matchesGoldenFile('foo.png'));
+          await expectLater(finder, matchesGoldenFile('flop.png'));
           fail('TestFailure expected but not thrown');
         } on TestFailure catch (error) {
           expect(comparator.invocation, isNull);
@@ -381,7 +381,7 @@ void main() {
         )));
         final Finder finder = find.byType(Text);
         try {
-          await expectLater(finder, matchesGoldenFile('foo.png'));
+          await expectLater(finder, matchesGoldenFile('top.png'));
           fail('TestFailure expected but not thrown');
         } on TestFailure catch (error) {
           expect(comparator.invocation, isNull);
@@ -394,11 +394,32 @@ void main() {
       autoUpdateGoldenFiles = true;
       await tester.pumpWidget(boilerplate(const Text('hello')));
       final Finder finder = find.byType(Text);
-      await expectLater(finder, matchesGoldenFile('foo.png'));
+      await expectLater(finder, matchesGoldenFile('pop.png'));
       expect(comparator.invocation, _ComparatorInvocation.update);
       expect(comparator.imageBytes, hasLength(greaterThan(0)));
-      expect(comparator.golden, Uri.parse('foo.png'));
+      expect(comparator.golden, Uri.parse('pop.png'));
       autoUpdateGoldenFiles = false;
+    });
+
+    testWidgets('updates goldenTestNames', (WidgetTester tester) async {
+      expect(goldenTestNames, containsAll(<String>[
+        'foo.png',
+        'bar.png',
+        'baz.png',
+        'pop.png',
+      ]));
+    });
+
+    testWidgets('notifies for duplicate test name', (WidgetTester tester) async {
+      await tester.pumpWidget(boilerplate(const Text('hello')));
+      final Finder finder = find.byType(Text);
+      try {
+        await expectLater(finder, matchesGoldenFile('foo.png'));
+        fail('TestFailure expected but not thrown');
+      } on TestFailure catch (error) {
+        expect(comparator.invocation, isNull);
+        expect(error.message, contains('Duplicate file name detected'));
+      }
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds a check to prevent the creation of duplicate file names for golden file testing. If a duplicate name is found, the test will fail and notify the user of the collision.
When #33688 lands and golden testing moves to Skia Gold, images will not be siloed into library specific folders like [flutter/goldens](https://github.com/flutter/goldens), making it easier to run into naming collisions, and messy if not prevented. One such issue was already corrected through #33804.

- [ ] Update wiki

## Related Issues

Fixes #33806

## Tests

Updated in `flutter/test/widgets/widget_inspector_test.dart`:
- ext.flutter.inspector.screenshot
  - This was the only test in the framework that broke with this change due to the intentional re-use of 3 golden file names.

Updated in `flutter_test/test/matchers_test.dart`:
- Does not match if comparator returns false
- Does not match if comparator throws
- Does not match if finder finds no widgets
- Does not match if finder finds multiple widgets
- Calls update on comparator if autoUpdateGoldenFiles is true
  - These 'tests for the tests' were making use of the same golden name, 'foo.png', and so were updated to use unique names.

Added in `flutter_test/test/matchers_test.dart`:
- Updates goldenTestNames
- Notifies for duplicate test name

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). 
  - [Link to breaking change announcement](https://groups.google.com/forum/#!topic/flutter-announce/uVYVcxyqoCg)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
