### PR TITLE
add analytics fields for attached device os version & run mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -208,9 +208,15 @@ class RunCommand extends RunCommandBase {
   @override
   Future<Map<String, String>> get usageValues async {
     final bool isEmulator = await devices[0].isLocalEmulator;
-    final String deviceType = devices.length == 1
-            ? getNameForTargetPlatform(await devices[0].targetPlatform)
-            : 'multiple';
+    String deviceType, deviceOsVersion;
+    if (devices.length == 1) {
+      deviceType = getNameForTargetPlatform(await devices[0].targetPlatform);
+      deviceOsVersion = await devices[0].sdkNameAndVersion;
+    } else {
+      deviceType = 'multiple';
+      deviceOsVersion = 'multiple';
+    }
+    final String modeName = getBuildInfo().modeName;
     final AndroidProject androidProject = FlutterProject.current().android;
     final IosProject iosProject = FlutterProject.current().ios;
     final List<String> hostLanguage = <String>[];
@@ -225,6 +231,8 @@ class RunCommand extends RunCommandBase {
     return <String, String>{
       kCommandRunIsEmulator: '$isEmulator',
       kCommandRunTargetName: deviceType,
+      kCommandRunTargetOsVersion: deviceOsVersion,
+      kCommandRunModeName: modeName,
       kCommandRunProjectModule: '${FlutterProject.current().isModule}',
       kCommandRunProjectHostLanguage: hostLanguage.join(','),
     };

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -16,6 +16,10 @@ import 'globals.dart';
 import 'version.dart';
 
 const String _kFlutterUA = 'UA-67589403-6';
+
+const String kSessionHostOsDetails = 'cd1';
+const String kSessionChannelName = 'cd2';
+
 const String kEventReloadReasonParameterName = 'cd5';
 const String kEventReloadFinalLibraryCount = 'cd6';
 const String kEventReloadSyncedLibraryCount = 'cd7';
@@ -31,6 +35,8 @@ const String kCommandRunTargetName = 'cd4';
 const String kCommandRunProjectType = 'cd14';
 const String kCommandRunProjectHostLanguage = 'cd15';
 const String kCommandRunProjectModule = 'cd18';
+const String kCommandRunTargetOsVersion = 'cd22';
+const String kCommandRunModeName = 'cd23';
 
 const String kCommandCreateAndroidLanguage = 'cd16';
 const String kCommandCreateIosLanguage = 'cd17';
@@ -51,9 +57,9 @@ class Usage {
         documentDirectory: configDirOverride != null ? fs.directory(configDirOverride) : null);
 
     // Report a more detailed OS version string than package:usage does by default.
-    _analytics.setSessionValue('cd1', os.name);
+    _analytics.setSessionValue(kSessionHostOsDetails, os.name);
     // Send the branch name as the "channel".
-    _analytics.setSessionValue('cd2', flutterVersion.getBranchName(redactUnknownBranches: true));
+    _analytics.setSessionValue(kSessionChannelName, flutterVersion.getBranchName(redactUnknownBranches: true));
     // Record the host as the application installer ID - the context that flutter_tools is running in.
     if (platform.environment.containsKey('FLUTTER_HOST')) {
       _analytics.setSessionValue('aiid', platform.environment['FLUTTER_HOST']);
@@ -96,11 +102,13 @@ class Usage {
   String get clientId => _analytics.clientId;
 
   void sendCommand(String command, { Map<String, String> parameters }) {
+    print('YOLO DAWG!!!! -> $suppressAnalytics');
     if (suppressAnalytics)
       return;
 
     parameters ??= const <String, String>{};
 
+    parameters.forEach((k, v) => print('$k: $v')); // TODO remove
     _analytics.sendScreenView(command, parameters: parameters);
   }
 

--- a/packages/flutter_tools/lib/src/usage.dart
+++ b/packages/flutter_tools/lib/src/usage.dart
@@ -102,13 +102,11 @@ class Usage {
   String get clientId => _analytics.clientId;
 
   void sendCommand(String command, { Map<String, String> parameters }) {
-    print('YOLO DAWG!!!! -> $suppressAnalytics');
     if (suppressAnalytics)
       return;
 
     parameters ??= const <String, String>{};
 
-    parameters.forEach((k, v) => print('$k: $v')); // TODO remove
     _analytics.sendScreenView(command, parameters: parameters);
   }
 


### PR DESCRIPTION
## Description

Adds two new custom analytics dimensions: `run_target_os_version` and `run_target_mode_name` that are sent with each invocation of `flutter run` and show up in Google Analytics as "screens".

## Related Issues

Fixes [33844](https://github.com/flutter/flutter/issues/33844).
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
