### PR TITLE
don't warn on CHROME_EXECUTABLE missing if we've already located it.

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -463,6 +463,19 @@ class ValidationMessage {
 
   @override
   String toString() => message;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    final ValidationMessage typedOther = other;
+    return typedOther.message == message
+      && typedOther.type == type;
+  }
+
+  @override
+  int get hashCode => type.hashCode ^ message.hashCode;
 }
 
 class FlutterValidator extends DoctorValidator {

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -71,7 +71,7 @@ class WebDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
-  bool isSupported() => flutterWebEnabled;
+  bool isSupported() => flutterWebEnabled && canFindChrome();
 
   @override
   String get name => 'web';
@@ -81,6 +81,9 @@ class WebDevice extends Device {
 
   @override
   Future<String> get sdkNameAndVersion async {
+    if (!isSupported()) {
+      return 'unknown';
+    }
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
     String version = 'unknown';
     if (platform.isWindows) {

--- a/packages/flutter_tools/lib/src/web/web_validator.dart
+++ b/packages/flutter_tools/lib/src/web/web_validator.dart
@@ -17,7 +17,11 @@ class WebValidator extends DoctorValidator {
     final bool canRunChrome = canFindChrome();
     final List<ValidationMessage> messages = <ValidationMessage>[];
     if (platform.environment.containsKey(kChromeEnvironment)) {
-      messages.add(ValidationMessage('$kChromeEnvironment = $chrome'));
+      if (!canRunChrome) {
+        messages.add(ValidationMessage.hint('$chrome is not executable.'));
+      } else {
+        messages.add(ValidationMessage('$kChromeEnvironment = $chrome'));
+      }
     } else {
       if (!canRunChrome) {
         messages.add(ValidationMessage.hint('$kChromeEnvironment not set'));

--- a/packages/flutter_tools/lib/src/web/web_validator.dart
+++ b/packages/flutter_tools/lib/src/web/web_validator.dart
@@ -19,8 +19,11 @@ class WebValidator extends DoctorValidator {
     if (platform.environment.containsKey(kChromeEnvironment)) {
       messages.add(ValidationMessage('$kChromeEnvironment = $chrome'));
     } else {
-      messages.add(ValidationMessage('Chrome at $chrome'));
-      messages.add(ValidationMessage.hint('$kChromeEnvironment not set'));
+      if (!canRunChrome) {
+        messages.add(ValidationMessage.hint('$kChromeEnvironment not set'));
+      } else {
+        messages.add(ValidationMessage('Chrome at $chrome'));
+      }
     }
     if (!canRunChrome) {
       return ValidationResult(

--- a/packages/flutter_tools/lib/src/web/workflow.dart
+++ b/packages/flutter_tools/lib/src/web/workflow.dart
@@ -39,5 +39,9 @@ class WebWorkflow extends Workflow {
 /// Whether we can locate the chrome executable.
 bool canFindChrome() {
   final String chrome = findChromeExecutable();
-  return processManager.canRun(chrome);
+  try {
+    return processManager.canRun(chrome);
+  } on ArgumentError {
+    return false;
+  }
 }

--- a/packages/flutter_tools/lib/src/web/workflow.dart
+++ b/packages/flutter_tools/lib/src/web/workflow.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../base/context.dart';
-import '../base/file_system.dart';
 import '../base/platform.dart';
 import '../base/process_manager.dart';
 import '../doctor.dart';
@@ -40,12 +39,5 @@ class WebWorkflow extends Workflow {
 /// Whether we can locate the chrome executable.
 bool canFindChrome() {
   final String chrome = findChromeExecutable();
-  if (platform.isLinux) {
-    return processManager.canRun(chrome);
-  } else if (platform.isMacOS) {
-    return fs.file(chrome).existsSync();
-  } else if (platform.isWindows) {
-    return fs.file(chrome).existsSync();
-  }
-  return false;
+  return processManager.canRun(chrome);
 }

--- a/packages/flutter_tools/test/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/web/web_validator_test.dart
@@ -43,6 +43,15 @@ void main() {
       final ValidationResult result = await webValidator.validate();
       expect(result.type, ValidationType.missing);
     }));
+
+    test('Doesn\'t warn about CHROME_EXECUTABLE unless it cant find chrome ', () => testbed.run(() async {
+      fs.file(kMacOSExecutable).deleteSync();
+      final ValidationResult result = await webValidator.validate();
+      expect(result.messages, <ValidationMessage>[
+        ValidationMessage.hint('CHROME_EXECUTABLE not set')
+      ]);
+      expect(result.type, ValidationType.missing);
+    }));
   });
 }
 

--- a/packages/flutter_tools/test/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/web/web_validator_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/web/chrome.dart';

--- a/packages/flutter_tools/test/web/workflow_test.dart
+++ b/packages/flutter_tools/test/web/workflow_test.dart
@@ -83,6 +83,7 @@ void main() {
     }));
 
     test('does not apply on other platforms', () => testbed.run(() {
+      when(mockProcessManager.canRun('chrome')).thenReturn(false);
       expect(workflow.appliesToHostPlatform, false);
       expect(workflow.canLaunchDevices, false);
       expect(workflow.canListDevices, false);


### PR DESCRIPTION
## Description

No need to warn if the executable is otherwise located. Make sure we catch invalid argument errors when attempting to check if chrome exists.

Fixes https://github.com/flutter/flutter/issues/34078
Fixes https://github.com/flutter/flutter/issues/34080