### PR TITLE
Use product define for flutter web and remove extra asset server

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
@@ -608,6 +608,7 @@ Future<void> bootstrapDart2Js(BuildStep buildStep) async {
     '-o',
     '$jsOutputPath',
     '--packages="$packageFile"',
+    '-Ddart.vm.product=true',
     dartPath,
   ];
   final Dart2JsBatchWorkerPool dart2js = await buildStep.fetchResource(dart2JsWorkerResource);

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -411,8 +411,7 @@ class RunCommand extends RunCommandBase {
     // in a "hot mode".
     final bool webMode = !FlutterVersion.instance.isStable
       && devices.length == 1
-      && await devices.single.targetPlatform == TargetPlatform.web_javascript
-      && hotMode;
+      && await devices.single.targetPlatform == TargetPlatform.web_javascript;
 
     ResidentRunner runner;
     final String applicationBinaryPath = argResults['use-application-binary'];
@@ -438,6 +437,7 @@ class RunCommand extends RunCommandBase {
         target: targetFile,
         flutterProject: flutterProject,
         ipv6: ipv6,
+        debuggingOptions: _createDebuggingOptions(),
       );
     } else {
       runner = ColdRunner(

--- a/packages/flutter_tools/lib/src/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_web_runner.dart
@@ -32,15 +32,14 @@ class ResidentWebRunner extends ResidentRunner {
     String target,
     @required this.flutterProject,
     @required bool ipv6,
+    @required DebuggingOptions debuggingOptions,
   }) : super(
           flutterDevices,
           target: target,
           usesTerminalUI: true,
           stayResident: true,
           saveCompilationTrace: false,
-          debuggingOptions: DebuggingOptions.enabled(
-            const BuildInfo(BuildMode.debug, ''),
-          ),
+          debuggingOptions: debuggingOptions,
           ipv6: ipv6,
         );
 
@@ -134,8 +133,7 @@ class ResidentWebRunner extends ResidentRunner {
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');
     }
-    await writeBundle(
-        fs.directory(getAssetBuildDirectory()), assetBundle.entries);
+    await writeBundle(fs.directory(getAssetBuildDirectory()), assetBundle.entries);
 
     // Step 2: Start an HTTP server
     _server = WebAssetServer(flutterProject, target, ipv6);

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -115,6 +115,8 @@ class WebDevice extends Device {
     bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
+    // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
+    // for the web initialization and server logic.
     return LaunchResult.succeeded(observatoryUri: null);
   }
 

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -11,9 +11,7 @@ import '../base/platform.dart';
 import '../base/process_manager.dart';
 import '../build_info.dart';
 import '../device.dart';
-import '../globals.dart';
 import '../project.dart';
-import '../web/compile.dart';
 import '../web/workflow.dart';
 import 'chrome.dart';
 
@@ -31,9 +29,6 @@ class WebApplicationPackage extends ApplicationPackage {
 
 class WebDevice extends Device {
   WebDevice() : super('web');
-
-  HttpServer _server;
-  WebApplicationPackage _package;
 
   @override
   bool get supportsHotReload => true;
@@ -120,26 +115,11 @@ class WebDevice extends Device {
     bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
-    await buildWeb(
-      package.flutterProject,
-      fs.path.relative(mainPath, from: package.flutterProject.directory.path),
-      debuggingOptions.buildInfo,
-    );
-    _package = package;
-    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    _server.listen(_basicAssetServer);
-    printStatus('Serving assets from http:localhost:${_server.port}');
-    await chromeLauncher.launch('http://localhost:${_server.port}');
     return LaunchResult.succeeded(observatoryUri: null);
   }
 
-  // Note: we don't currently have a way to track which chrome processes
-  // belong to the flutter tool, so we'll err on the side of caution by
-  // keeping these open.
   @override
   Future<bool> stopApp(ApplicationPackage app) async {
-    await _server?.close();
-    _server = null;
     return true;
   }
 
@@ -148,39 +128,6 @@ class WebDevice extends Device {
 
   @override
   Future<bool> uninstallApp(ApplicationPackage app) async => true;
-
-  Future<void> _basicAssetServer(HttpRequest request) async {
-    if (request.method != 'GET') {
-      request.response.statusCode = HttpStatus.forbidden;
-      await request.response.close();
-      return;
-    }
-    // Resolve all get requests to the build/web/ or build/flutter_assets directory.
-    final Uri uri = request.uri;
-    File file;
-    String contentType;
-    if (uri.path == '/') {
-      file = _package.webSourcePath.childFile('index.html');
-      contentType = 'text/html';
-    } else if (uri.path == '/main.dart.js') {
-      file = fs.file(fs.path.join(getWebBuildDirectory(), 'main.dart.js'));
-      contentType = 'text/javascript';
-    } else {
-      file = fs.file(fs.path.join(getAssetBuildDirectory(), uri.path.replaceFirst('/assets/', '')));
-    }
-
-    if (!file.existsSync()) {
-      request.response.statusCode = HttpStatus.notFound;
-      await request.response.close();
-      return;
-    }
-    request.response.statusCode = HttpStatus.ok;
-    if (contentType != null) {
-      request.response.headers.add(HttpHeaders.contentTypeHeader, contentType);
-    }
-    await request.response.addStream(file.openRead());
-    await request.response.close();
-  }
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {


### PR DESCRIPTION
## Description

The device-based asset server existed before dartdevc and the web runner. Now that the latter work the former is unnecessary.


Add the dart.vm.product define to the compilation.