### PR TITLE
Don't show scrollbar if there isn't enough content

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -103,6 +103,11 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    final ScrollMetrics metrics = notification.metrics;
+    if (metrics.maxScrollExtent <= metrics.minScrollExtent) {
+      return false;
+    }
+
     if (notification is ScrollUpdateNotification ||
         notification is OverscrollNotification) {
       // Any movements always makes the scrollbar start showing up.

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -109,6 +109,11 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    final ScrollMetrics metrics = notification.metrics;
+    if (metrics.maxScrollExtent <= metrics.minScrollExtent) {
+      return false;
+    }
+
     // iOS sub-delegates to the CupertinoScrollbar instead and doesn't handle
     // scroll notifications here.
     if (_currentPlatform != TargetPlatform.iOS

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -256,13 +256,8 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     // The size of the scrollable area.
     final double trackExtent = _lastMetrics.viewportDimension - 2 * mainAxisMargin - mainAxisPadding;
 
-    final bool shouldPaint =
-      // Skip painting if there's not enough space.
-      (_lastMetrics.viewportDimension > mainAxisPadding && trackExtent > 0)
-      // Skip painting if there's not enough content to scroll.
-      && (_lastMetrics.maxScrollExtent > _lastMetrics.minScrollExtent);
-
-    if (!shouldPaint) {
+    // Skip painting if there's not enough space.
+    if (_lastMetrics.viewportDimension <= mainAxisPadding || trackExtent <= 0) {
       return;
     }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -256,8 +256,13 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     // The size of the scrollable area.
     final double trackExtent = _lastMetrics.viewportDimension - 2 * mainAxisMargin - mainAxisPadding;
 
-    // Skip painting if there's not enough space.
-    if (_lastMetrics.viewportDimension <= mainAxisPadding || trackExtent <= 0) {
+    final bool shouldPaint =
+      // Skip painting if there's not enough space.
+      (_lastMetrics.viewportDimension > mainAxisPadding && trackExtent > 0)
+      // Skip painting if there's not enough content to scroll.
+      && (_lastMetrics.maxScrollExtent > _lastMetrics.minScrollExtent);
+
+    if (!shouldPaint) {
       return;
     }
 

--- a/packages/flutter/test/cupertino/scrollbar_paint_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_paint_test.dart
@@ -77,7 +77,7 @@ void main() {
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
     await gesture.moveBy(_kGestureOffset);
     // Move back to original position.
-    await gesture.moveBy(Offset.zero.translate(-_kGestureOffset.dx, -_kGestureOffset.dy));
+    await gesture.moveBy(Offset(-_kGestureOffset.dx, -_kGestureOffset.dy));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
@@ -95,5 +95,45 @@ void main() {
         const Radius.circular(1.25),
       ),
     ));
+  });
+
+  testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.fromLTRB(0, 20, 0, 34),
+          ),
+          child: CupertinoPageScaffold(
+            navigationBar: const CupertinoNavigationBar(
+              middle: Text('Title'),
+              backgroundColor: Color(0x11111111),
+            ),
+            child: CupertinoScrollbar(
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                children: const <Widget> [SizedBox(width: 10, height: 10)],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+    await gesture.moveBy(_kGestureOffset);
+    // Move back to original position.
+    await gesture.moveBy(Offset(-_kGestureOffset.dx, -_kGestureOffset.dy));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byType(CupertinoScrollbar), isNot(paints..rrect()));
+
+    // The scrollbar should not appear even when overscrolled.
+    final TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+    await overscrollGesture.moveBy(_kGestureOffset);
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.byType(CupertinoScrollbar), isNot(paints..rrect()));
   });
 }

--- a/packages/flutter/test/material/scrollbar_paint_test.dart
+++ b/packages/flutter/test/material/scrollbar_paint_test.dart
@@ -77,4 +77,32 @@ void main() {
       ),
     ));
   });
+
+  testWidgets("should not paint when there isn't enough space", (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.fromLTRB(0, 20, 0, 34)
+        ),
+        child: Scaffold(
+          appBar: AppBar(title: const Text('Title')),
+          body: Scrollbar(
+            child: ListView(
+              children: const <Widget>[SizedBox(width: 40, height: 40)]
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+    // On Android it should not overscroll.
+    await gesture.moveBy(const Offset(0, 100));
+    // Trigger fade in animation.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byType(Scrollbar), isNot(paints..rect()));
+  });
+
 }

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -115,8 +115,9 @@ void main() {
     final List<Invocation> invocations = <Invocation>[];
     final TestCanvas canvas = TestCanvas(invocations);
     scrollPainter.paint(canvas, const Size(10.0, 100.0));
-    final Rect thumbRect = invocations.single.positionalArguments[0];
-    expect(thumbRect.isFinite, isTrue);
+
+    // Scrollbar is not supposed to draw anything if there isn't enough content.
+    expect(invocations.isEmpty, isTrue);
   });
 
   testWidgets('Adaptive scrollbar', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Don't show scrollbar if there isn't enough content for both material and cupertino.

## Related Issues

Fixes #33635

## Tests

I added the following tests:

- should not paint when there isn't enough space (material)
- should not paint when there isn't enough space (cupertino)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
