### PR TITLE
make sure this test doesn't run for real

### DIFF
--- a/packages/flutter/test/scheduler/benchmarks_test.dart
+++ b/packages/flutter/test/scheduler/benchmarks_test.dart
@@ -35,7 +35,11 @@ class TestBinding extends LiveTestWidgetsFlutterBinding {
 }
 
 void main() {
-  final TestBinding binding = TestBinding();
+  TestBinding binding;
+
+  setUp(() {
+    binding = TestBinding();
+  });
 
   test('test pumpBenchmark() only runs one frame', () async {
     await benchmarkWidgets((WidgetTester tester) async {


### PR DESCRIPTION
## Description

Because `main` is invoked whether or not we are running any of the tests, we end up hitting asserts from code that we know does not work on the web yet.

Fixes https://github.com/flutter/flutter/issues/34192 (because making it work is separate issue)