### PR TITLE
Strip debug symbols from ELF library snapshots

### DIFF
--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -418,6 +418,7 @@ void main() {
         '--deterministic',
         '--snapshot_kind=app-aot-elf',
         '--elf=build/foo/app.so',
+        '--strip',
         '--no-sim-use-hardfp',
         '--no-use-integer-division',
         'main.dill',
@@ -447,6 +448,7 @@ void main() {
         '--deterministic',
         '--snapshot_kind=app-aot-elf',
         '--elf=build/foo/app.so',
+        '--strip',
         'main.dill',
       ]);
     }, overrides: contextOverrides);


### PR DESCRIPTION
AOT compiled code is now packaged as an ELF library for Android targets.
By default gen_snapshot's output contains debug symbols.  The symbols could
be stripped as a separate step, but that requires NDK tools that the user
may not have available.

This change passes a gen_snapshot flag that omits the symbols, and it filters
out a warning printed when that flag is used.