### PR TITLE
[flutter_tool] Don't truncate verbose logs from _flutter.listViews

### DIFF
--- a/packages/flutter_tools/test/devfs_test.dart
+++ b/packages/flutter_tools/test/devfs_test.dart
@@ -250,6 +250,7 @@ class MockVM implements VM {
     Map<String, dynamic> params = const <String, dynamic>{},
     Duration timeout,
     bool timeoutFatal = true,
+    bool truncateLogs = true,
   }) async {
     _service.messages.add('$method $params');
     return <String, dynamic>{'success': true};


### PR DESCRIPTION
## Description

When a vm has several Flutter views, only the first couple fit within the 250 character budget for the verbose logging from `listViews`. This PR removes the truncation for the `listViews` response logging to help determine whether a view with the requested name actually exists when it is expected but not found.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
