### PR TITLE
Prepare for Uint8List SDK breaking changes

### DIFF
--- a/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
+++ b/dev/devicelab/lib/tasks/save_catalog_screenshots.dart
@@ -65,7 +65,7 @@ class Upload {
       } else {
         // TODO(hansmuller): only retry on 5xx and 429 responses
         logMessage('Request to save "$name" (length ${content.length}) failed with status ${response.statusCode}, will retry');
-        logMessage(await response.transform<String>(utf8.decoder).join());
+        logMessage(await response.cast<List<int>>().transform<String>(utf8.decoder).join());
       }
       return response.statusCode == HttpStatus.ok;
     } on TimeoutException catch (_) {

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -299,7 +299,7 @@ Future<void> precacheLanguageAndRegionTags() async {
   final HttpClient client = HttpClient();
   final HttpClientRequest request = await client.getUrl(Uri.parse(registry));
   final HttpClientResponse response = await request.close();
-  final String body = (await response.transform<String>(utf8.decoder).toList()).join('');
+  final String body = (await response.cast<List<int>>().transform<String>(utf8.decoder).toList()).join('');
   client.close(force: true);
   final List<Map<String, List<String>>> sections = body.split('%%').skip(1).map<Map<String, List<String>>>(_parseSection).toList();
   for (Map<String, List<String>> section in sections) {

--- a/packages/flutter_tools/test/base/net_test.dart
+++ b/packages/flutter_tools/test/base/net_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/base/net.dart';
@@ -216,13 +217,13 @@ class MockHttpClientResponse extends Stream<List<int>> implements io.HttpClientR
   String get reasonPhrase => '<reason phrase>';
 
   @override
-  StreamSubscription<List<int>> listen(
-    void onData(List<int> event), {
+  StreamSubscription<Uint8List> listen(
+    void onData(Uint8List event), {
     Function onError,
     void onDone(),
     bool cancelOnError,
   }) {
-    return Stream<List<int>>.fromFuture(Future<List<int>>.error(const io.SocketException('test')))
+    return Stream<Uint8List>.fromFuture(Future<Uint8List>.error(const io.SocketException('test')))
       .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -1303,13 +1304,13 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
   */
 
   @override
-  StreamSubscription<List<int>> listen(
-    void onData(List<int> event), {
+  StreamSubscription<Uint8List> listen(
+    void onData(Uint8List event), {
     Function onError,
     void onDone(),
     bool cancelOnError,
   }) {
-    return Stream<List<int>>.fromIterable(<List<int>>[result.codeUnits])
+    return Stream<Uint8List>.fromIterable(<Uint8List>[Uint8List.fromList(result.codeUnits)])
       .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 


### PR DESCRIPTION
## Description

As part of https://github.com/dart-lang/sdk/issues/36900, certain classes and methods that currently deal in `List<int>` will be changing to deal in `Uint8List`.  This forwards-compatible change gets us closer to supporting that code when it lands, while being a no-op for existing usages.

## Related Issues

https://github.com/dart-lang/sdk/issues/36900

## Tests

n/a - relying on Dart analysis

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
