### PR TITLE
Re-apply compressionState changes.

### DIFF
--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -43,10 +43,8 @@ typedef BytesReceivedCallback = void Function(int cumulative, int total);
 /// bytes from this method (assuming the response is sending compressed bytes),
 /// set both [HttpClient.autoUncompress] to false and the `autoUncompress`
 /// parameter to false.
-// TODO(tvolkert): Remove the [client] param once https://github.com/dart-lang/sdk/issues/36971 is fixed.
 Future<Uint8List> consolidateHttpClientResponseBytes(
   HttpClientResponse response, {
-  HttpClient client,
   bool autoUncompress = true,
   BytesReceivedCallback onBytesReceived,
 }) {
@@ -58,15 +56,21 @@ Future<Uint8List> consolidateHttpClientResponseBytes(
   int expectedContentLength = response.contentLength;
   if (expectedContentLength == -1)
     expectedContentLength = null;
-  if (response.headers?.value(HttpHeaders.contentEncodingHeader) == 'gzip') {
-    if (client?.autoUncompress ?? true) {
+  switch (response.compressionState) {
+    case HttpClientResponseCompressionState.compressed:
+      if (autoUncompress) {
+        // We need to un-compress the bytes as they come in.
+        sink = gzip.decoder.startChunkedConversion(output);
+      }
+      break;
+    case HttpClientResponseCompressionState.decompressed:
       // response.contentLength will not match our bytes stream, so we declare
       // that we don't know the expected content length.
       expectedContentLength = null;
-    } else if (autoUncompress) {
-      // We need to un-compress the bytes as they come in.
-      sink = gzip.decoder.startChunkedConversion(output);
-    }
+      break;
+    case HttpClientResponseCompressionState.notCompressed:
+      // Fall-through.
+      break;
   }
 
   int bytesReceived = 0;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -552,7 +552,6 @@ class NetworkImage extends ImageProvider<NetworkImage> {
 
       final Uint8List bytes = await consolidateHttpClientResponseBytes(
         response,
-        client: _httpClient,
         onBytesReceived: (int cumulative, int total) {
           chunkEvents.add(ImageChunkEvent(
             cumulativeBytesLoaded: cumulative,

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1770,19 +1770,9 @@ class _MockHttpResponse extends Stream<List<int>> implements HttpClientResponse 
   @override
   int get contentLength => -1;
 
-  // TODO(tvolkert): Update (flutter/flutter#33791)
-  /*
   @override
   HttpClientResponseCompressionState get compressionState {
     return HttpClientResponseCompressionState.decompressed;
-  }
-  */
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #compressionState) {
-      return null;
-    }
-    return super.noSuchMethod(invocation);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -47,8 +47,7 @@ export 'dart:io'
         HttpClient,
         HttpClientRequest,
         HttpClientResponse,
-        // TODO(tvolkert): Uncomment (flutter/flutter#33791)
-        //HttpClientResponseCompressionState,
+        HttpClientResponseCompressionState,
         HttpHeaders,
         HttpRequest,
         HttpServer,

--- a/packages/flutter_tools/test/commands/create_test.dart
+++ b/packages/flutter_tools/test/commands/create_test.dart
@@ -1295,13 +1295,10 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
   @override
   String get reasonPhrase => '<reason phrase>';
 
-  // TODO(tvolkert): Update (flutter/flutter#33791)
-  /*
   @override
   HttpClientResponseCompressionState get compressionState {
     return HttpClientResponseCompressionState.decompressed;
   }
-  */
 
   @override
   StreamSubscription<Uint8List> listen(
@@ -1316,10 +1313,6 @@ class MockHttpClientResponse extends Stream<List<int>> implements HttpClientResp
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
-    // TODO(tvolkert): Update (flutter/flutter#33791)
-    if (invocation.memberName == #compressionState) {
-      return null;
-    }
     throw 'io.HttpClientResponse - $invocation';
   }
 }


### PR DESCRIPTION
## Description

This re-applies the changes that were made in #33697 and #33729,
but which were reverted in #33792 and #33790, respectively due to
the Dart SDK not having received the update within Google yet.
The SDK has now rolled, so these changes can be re-applied.

## Related Issues

https://github.com/flutter/flutter/issues/32374
https://github.com/flutter/flutter/issues/33791

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.