### PR TITLE
Revert "update the Flutter.Frame event to use new engine APIs"

### DIFF
--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' show window, FrameTiming;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
@@ -11,18 +10,7 @@ import 'package:flutter/services.dart';
 
 import '../flutter_test_alternative.dart';
 
-class TestSchedulerBinding extends BindingBase with ServicesBinding, SchedulerBinding {
-  final Map<String, List<Map<String, dynamic>>> eventsDispatched = <String, List<Map<String, dynamic>>>{};
-
-  @override
-  void postEvent(String eventKind, Map<dynamic, dynamic> eventData) {
-    getEventsDispatched(eventKind).add(eventData);
-  }
-
-  List<Map<String, dynamic>> getEventsDispatched(String eventKind) {
-    return eventsDispatched.putIfAbsent(eventKind, () => <Map<String, dynamic>>[]);
-  }
-}
+class TestSchedulerBinding extends BindingBase with ServicesBinding, SchedulerBinding { }
 
 class TestStrategy {
   int allowedPriority = 10000;
@@ -33,8 +21,7 @@ class TestStrategy {
 }
 
 void main() {
-  TestSchedulerBinding scheduler;
-
+  SchedulerBinding scheduler;
   setUpAll(() {
     scheduler = TestSchedulerBinding();
   });
@@ -128,24 +115,5 @@ void main() {
     // events are locked.
     expect(timerQueueTasks.length, 2);
     expect(taskExecuted, false);
-  });
-
-  test('Flutter.Frame event fired', () async {
-    window.onReportTimings(<FrameTiming>[FrameTiming(<int>[
-      // build start, build finish
-      10000, 15000,
-      // raster start, raster finish
-      16000, 20000,
-    ])]);
-
-    final List<Map<String, dynamic>> events = scheduler.getEventsDispatched('Flutter.Frame');
-    expect(events, hasLength(1));
-
-    final Map<String, dynamic> event = events.first;
-    expect(event['number'], isNonNegative);
-    expect(event['startTime'], 10000);
-    expect(event['elapsed'], 10000);
-    expect(event['build'], 5000);
-    expect(event['raster'], 4000);
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#34243 due to a failure on the device lab:

```
run:stdout: [        ] -> +file:///Users/flutter/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.5/lib/src/backend/runtime.dart
2019-06-12T12:18:00.657191: Task failed: JSON-RPC error 103: Stream already subscribed2019-06-12T12:18:00.657325: 

Stack trace:
2019-06-12T12:18:00.692196: package:json_rpc_2/src/client.dart 110:64                  Client.sendRequest
package:json_rpc_2/src/peer.dart 79:15                     Peer.sendRequest
package:vm_service_client/src/stream_manager.dart 115:17   StreamManager._controller.
dart:async                                                 Stream.first
bin/tasks/service_extensions_test.dart 82:74               main..
===== asynchronous gap ===========================
dart:async                                                 _asyncThenWrapperHelper
bin/tasks/service_extensions_test.dart                     main..
package:flutter_devicelab/framework/utils.dart 399:24      inDirectory
===== asynchronous gap ===========================
dart:async                                                 _asyncThenWrapperHelper
bin/tasks/service_extensions_test.dart                     main.
package:flutter_devicelab/framework/framework.dart 157:32  _TaskRunner._performTask.
```

I'll re-do the PR once I've had time to track down the failure.
