### PR TITLE
Add widget of the week videos

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1545,6 +1545,8 @@ abstract class ParentDataWidget<T extends RenderObjectWidget> extends ProxyWidge
 /// for that inherited widget using [BuildContext.inheritFromWidgetOfExactType]
 /// and then returns the [ThemeData].
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=1t-8rBCGBYw}
+///
 /// See also:
 ///
 ///  * [StatefulWidget] and [State], for widgets that can build differently

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -510,6 +510,8 @@ class MediaQueryData {
 /// exception, unless the `nullOk` argument is set to true, in which case it
 /// returns null.
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=A3WrA4zAaPw}
+///
 /// See also:
 ///
 ///  * [WidgetsApp] and [MaterialApp], which introduce a [MediaQuery] and keep

--- a/packages/flutter/lib/src/widgets/spacer.dart
+++ b/packages/flutter/lib/src/widgets/spacer.dart
@@ -33,6 +33,8 @@ import 'framework.dart';
 /// ```
 /// {@end-tool}
 ///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=7FJgd7QN1zI}
+///
 /// See also:
 ///
 ///  * [Row] and [Column], which are the most common containers to use a Spacer


### PR DESCRIPTION
## Description

This adds widget of the week video embeddings to the documentation blocks of the following widgets:

* Spacer
* MediaQuery
* InheritedWidget

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.