### PR TITLE
Fix semantics_tester

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -438,6 +438,7 @@ class DayPicker extends StatelessWidget {
               // formatted full date.
               label: '${localizations.formatDecimal(day)}, ${localizations.formatFullDate(dayToBuild)}',
               selected: isSelectedDay,
+              sortKey: OrdinalSortKey(day.toDouble()),
               child: ExcludeSemantics(
                 child: Text(localizations.formatDecimal(day), style: itemStyle),
               ),

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -762,7 +762,7 @@ class RenderParagraph extends RenderBox
     TextDirection currentDirection = textDirection;
     Rect currentRect;
 
-    SemanticsConfiguration buildSemanticsConfig(int start, int end, { bool includeText = true }) {
+    SemanticsConfiguration buildSemanticsConfig(int start, int end) {
       final TextDirection initialDirection = currentDirection;
       final TextSelection selection = TextSelection(baseOffset: start, extentOffset: end);
       final List<ui.TextBox> rects = getBoxesForSelection(selection);
@@ -784,10 +784,8 @@ class RenderParagraph extends RenderBox
       order += 1;
       final SemanticsConfiguration configuration = SemanticsConfiguration()
         ..sortKey = OrdinalSortKey(order)
-        ..textDirection = initialDirection;
-      if (includeText) {
-        configuration.label = rawLabel.substring(start, end);
-      }
+        ..textDirection = initialDirection
+        ..label = rawLabel.substring(start, end);
       return configuration;
     }
 
@@ -805,7 +803,7 @@ class RenderParagraph extends RenderBox
         newChildren.add(node);
       }
       final dynamic inlineElement = _inlineSemanticsElements[j];
-      final SemanticsConfiguration configuration = buildSemanticsConfig(start, end, includeText: false);
+      final SemanticsConfiguration configuration = buildSemanticsConfig(start, end);
       if (inlineElement != null) {
         // Add semantics for this recognizer.
         final SemanticsNode node = SemanticsNode();
@@ -824,6 +822,9 @@ class RenderParagraph extends RenderBox
       } else if (childIndex < children.length) {
         // Add semantics for this placeholder. Semantics are precomputed in the children
         // argument.
+        // Placeholders should not get a label, which would come through as an
+        // object replacement character.
+        configuration.label = '';
         final SemanticsNode childNode = children.elementAt(childIndex);
         final TextParentData parentData = child.parentData;
         childNode.rect = Rect.fromLTWH(

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2098,7 +2098,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     properties.add(DoubleProperty('scrollPosition', scrollPosition, defaultValue: null));
     properties.add(DoubleProperty('scrollExtentMax', scrollExtentMax, defaultValue: null));
     properties.add(DoubleProperty('elevation', elevation, defaultValue: 0.0));
-    properties.add(DoubleProperty('thicknes', thickness, defaultValue: 0.0));
+    properties.add(DoubleProperty('thickness', thickness, defaultValue: 0.0));
   }
 
   /// Returns a string representation of this node and its descendants.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2230,7 +2230,7 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
     final List<_BoxEdge> edges = <_BoxEdge>[];
     for (SemanticsNode child in nodes) {
       // Using a small delta to shrink child rects removes overlapping cases.
-      final Rect childRect = child.rect.deflate(0.1);
+      final Rect childRect = child.rect.deflate(1e-15);
       edges.add(_BoxEdge(
         isLeadingEdge: true,
         offset: _pointInParentCoordinates(child, childRect.topLeft).dx,
@@ -2376,7 +2376,7 @@ List<SemanticsNode> _childrenInDefaultOrder(List<SemanticsNode> children, TextDi
   final List<_BoxEdge> edges = <_BoxEdge>[];
   for (SemanticsNode child in children) {
     // Using a small delta to shrink child rects removes overlapping cases.
-    final Rect childRect = child.rect.deflate(0.1);
+    final Rect childRect = child.rect.deflate(1e-15);
     edges.add(_BoxEdge(
       isLeadingEdge: true,
       offset: _pointInParentCoordinates(child, childRect.topLeft).dy,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2230,7 +2230,7 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
     final List<_BoxEdge> edges = <_BoxEdge>[];
     for (SemanticsNode child in nodes) {
       // Using a small delta to shrink child rects removes overlapping cases.
-      final Rect childRect = child.rect.deflate(1e-15);
+      final Rect childRect = child.rect.deflate(0.1);
       edges.add(_BoxEdge(
         isLeadingEdge: true,
         offset: _pointInParentCoordinates(child, childRect.topLeft).dx,
@@ -2376,7 +2376,7 @@ List<SemanticsNode> _childrenInDefaultOrder(List<SemanticsNode> children, TextDi
   final List<_BoxEdge> edges = <_BoxEdge>[];
   for (SemanticsNode child in children) {
     // Using a small delta to shrink child rects removes overlapping cases.
-    final Rect childRect = child.rect.deflate(1e-15);
+    final Rect childRect = child.rect.deflate(0.1);
     edges.add(_BoxEdge(
       isLeadingEdge: true,
       offset: _pointInParentCoordinates(child, childRect.topLeft).dy,

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://flutter.dev
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -449,6 +449,7 @@ void _tests() {
               TestSemantics(
                 children: <TestSemantics>[
                   TestSemantics(
+                    id: 55,
                     actions: <SemanticsAction>[SemanticsAction.scrollLeft, SemanticsAction.scrollRight],
                     children: <TestSemantics>[
                       TestSemantics(
@@ -456,7 +457,21 @@ void _tests() {
                           TestSemantics(
                             children: <TestSemantics>[
                               TestSemantics(
+                                id: 11,
+                                flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                                 children: <TestSemantics>[
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
+                                  TestSemantics(),
                                   TestSemantics(
                                     actions: <SemanticsAction>[SemanticsAction.tap],
                                     label: '1, Friday, January 1, 2016',

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -460,6 +460,7 @@ void _tests() {
                                 id: 11,
                                 flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                                 children: <TestSemantics>[
+                                  // TODO(dnfield): These shouldn't be here. https://github.com/flutter/flutter/issues/34431
                                   TestSemantics(),
                                   TestSemantics(),
                                   TestSemantics(),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -516,7 +516,7 @@ void main() {
                           SemanticsFlag.isTextField,
                           SemanticsFlag.isFocused,
                           SemanticsFlag.isHeader,
-                          SemanticsFlag.namesRoute,
+                          if (debugDefaultTargetPlatformOverride != TargetPlatform.iOS) SemanticsFlag.namesRoute,
                         ],
                         actions: <SemanticsAction>[
                           SemanticsAction.tap,
@@ -525,6 +525,7 @@ void main() {
                         ],
                         label: 'Search',
                         textDirection: TextDirection.ltr,
+                        textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
                   ),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -497,6 +497,17 @@ void main() {
                 textDirection: TextDirection.ltr,
                 children: <TestSemantics>[
                   TestSemantics(
+                    id: 8,
+                    flags: <SemanticsFlag>[
+                      SemanticsFlag.isButton,
+                      SemanticsFlag.hasEnabledState,
+                      SemanticsFlag.isEnabled,
+                    ],
+                    actions: <SemanticsAction>[SemanticsAction.tap],
+                    label: 'Suggestions',
+                    textDirection: TextDirection.ltr,
+                  ),
+                  TestSemantics(
                     id: 9,
                     children: <TestSemantics>[
                       TestSemantics(
@@ -528,17 +539,6 @@ void main() {
                         textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
-                  ),
-                  TestSemantics(
-                    id: 8,
-                    flags: <SemanticsFlag>[
-                      SemanticsFlag.isButton,
-                      SemanticsFlag.hasEnabledState,
-                      SemanticsFlag.isEnabled,
-                    ],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Suggestions',
-                    textDirection: TextDirection.ltr,
                   ),
                 ],
               ),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -496,19 +496,6 @@ void main() {
                 label: routeName,
                 textDirection: TextDirection.ltr,
                 children: <TestSemantics>[
-                  // TODO(dnfield): This is almost certainly wrong. Suggestions
-                  // should come after Back and Search. https://github.com/flutter/flutter/issues/34432
-                  TestSemantics(
-                    id: 8,
-                    flags: <SemanticsFlag>[
-                      SemanticsFlag.isButton,
-                      SemanticsFlag.hasEnabledState,
-                      SemanticsFlag.isEnabled,
-                    ],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Suggestions',
-                    textDirection: TextDirection.ltr,
-                  ),
                   TestSemantics(
                     id: 9,
                     children: <TestSemantics>[
@@ -541,6 +528,17 @@ void main() {
                         textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
+                  ),
+                  TestSemantics(
+                    id: 8,
+                    flags: <SemanticsFlag>[
+                      SemanticsFlag.isButton,
+                      SemanticsFlag.hasEnabledState,
+                      SemanticsFlag.isEnabled,
+                    ],
+                    actions: <SemanticsAction>[SemanticsAction.tap],
+                    label: 'Suggestions',
+                    textDirection: TextDirection.ltr,
                   ),
                 ],
               ),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -496,6 +496,8 @@ void main() {
                 label: routeName,
                 textDirection: TextDirection.ltr,
                 children: <TestSemantics>[
+                  // TODO(dnfield): This is almost certainly wrong. Suggestions
+                  // should come after Back and Search. https://github.com/flutter/flutter/issues/34432
                   TestSemantics(
                     id: 8,
                     flags: <SemanticsFlag>[

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -353,7 +353,7 @@ void main() {
       '   scrollPosition: null\n'
       '   scrollExtentMax: null\n'
       '   elevation: 0.0\n'
-      '   thicknes: 0.0\n',
+      '   thickness: 0.0\n',
     );
 
     final SemanticsConfiguration config = SemanticsConfiguration()
@@ -448,7 +448,7 @@ void main() {
       '   scrollPosition: null\n'
       '   scrollExtentMax: null\n'
       '   elevation: 0.0\n'
-      '   thicknes: 0.0\n',
+      '   thickness: 0.0\n',
     );
 
   });

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -605,8 +605,6 @@ class SemanticsTester {
       buf.writeln('  hint: \'${node.hint}\',');
     if (node.textDirection != null)
       buf.writeln('  textDirection: ${node.textDirection},');
-    if (node.rect != null)
-      buf.writeln('  rect: ${node.rect},');
     if (node.hasChildren) {
       buf.writeln('  children: <TestSemantics>[');
       for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -335,7 +335,9 @@ class TestSemantics {
         result = false;
         return false;
       }
-      return true;
+    }
+    if (it.moveNext()) {
+      return false;
     }
     return result;
   }
@@ -603,7 +605,8 @@ class SemanticsTester {
       buf.writeln('  hint: \'${node.hint}\',');
     if (node.textDirection != null)
       buf.writeln('  textDirection: ${node.textDirection},');
-
+    if (node.rect != null)
+      buf.writeln('  rect: ${node.rect},');
     if (node.hasChildren) {
       buf.writeln('  children: <TestSemantics>[');
       for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -1,0 +1,42 @@
+
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('Semantics tester visits last child', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    const TextStyle textStyle = TextStyle(fontFamily: 'Ahem');
+    await tester.pumpWidget(
+      Text.rich(
+        TextSpan(
+          children: <TextSpan>[
+            const TextSpan(text: 'hello'),
+            TextSpan(text: 'world', recognizer: TapGestureRecognizer()..onTap = () { }),
+          ],
+          style: textStyle,
+        ),
+        textDirection: TextDirection.ltr,
+        maxLines: 1,
+      ),
+    );
+    final TestSemantics expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          children: <TestSemantics>[
+            TestSemantics(
+              label: 'hello',
+              textDirection: TextDirection.ltr,
+            ),
+            TestSemantics(),
+          ],
+        ),
+      ],
+    );
+    expect(semantics, isNot(hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true)));
+    semantics.dispose();
+  });
+}

--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -1,4 +1,6 @@
-
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -152,11 +152,11 @@ void main() {
   //   ┌─────────────────┘
   //   V
   // ┌───┐ ┌─────────┐ ┌───┐
-  // │ E │ │         │>│ H │
-  // └───┘ │    G    │ └───┘
-  //   V   │         │   V
+  // │ E │>│         │>│ G │
+  // └───┘ │    F    │ └───┘
+  //   ┌───|─────────|───┘
   // ┌───┐ │         │ ┌───┐
-  // │ F │>│         │ │ I │
+  // │ H │─|─────────|>│ I │
   // └───┘ └─────────┘ └───┘
   //   ┌─────────────────┘
   //   V
@@ -171,11 +171,11 @@ void main() {
   //   └─────────────────┐
   //                     V
   // ┌───┐ ┌─────────┐ ┌───┐
-  // │ E │<│         │ │ H │
-  // └───┘ │    G    │ └───┘
-  //   V   │         │   V
+  // │ E │<│         │<│ G │
+  // └───┘ │    F    │ └───┘
+  //    └──|─────────|────┐
   // ┌───┐ │         │ ┌───┐
-  // │ F │ │         │<│ I │
+  // │ H │<|─────────|─│ I │
   // └───┘ └─────────┘ └───┘
   //   └─────────────────┐
   //                     V
@@ -189,9 +189,9 @@ void main() {
       'C': const Offset(40.0, 0.0) & tenByTen,
       'D': const Offset(60.0, 0.0) & tenByTen,
       'E': const Offset(0.0, 20.0) & tenByTen,
-      'F': const Offset(0.0, 40.0) & tenByTen,
-      'G': const Offset(20.0, 20.0) & (tenByTen * 2.0),
-      'H': const Offset(60.0, 20.0) & tenByTen,
+      'F': const Offset(20.0, 20.0) & (tenByTen * 2.0),
+      'G': const Offset(60.0, 20.0) & tenByTen,
+      'H': const Offset(0.0, 40.0) & tenByTen,
       'I': const Offset(60.0, 40.0) & tenByTen,
       'J': const Offset(0.0, 60.0) & tenByTen,
       'K': const Offset(20.0, 60.0) & tenByTen,
@@ -208,7 +208,7 @@ void main() {
     await tester.test(
       textDirection: TextDirection.rtl,
       children: children,
-      expectedTraversal: 'D C B A H I G E F M L K J',
+      expectedTraversal: 'D C B A G F E I H M L K J',
     );
   });
 

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -202,13 +202,13 @@ void main() {
     await tester.test(
       textDirection: TextDirection.ltr,
       children: children,
-      expectedTraversal: 'A B C D E F G H I J K L M',
+      expectedTraversal: 'A B C D E G H F I J K L M',
     );
 
     await tester.test(
       textDirection: TextDirection.rtl,
       children: children,
-      expectedTraversal: 'D C B A H I G E F M L K J',
+      expectedTraversal: 'D C B A H G E I F M L K J',
     );
   });
 

--- a/packages/flutter/test/widgets/semantics_traversal_test.dart
+++ b/packages/flutter/test/widgets/semantics_traversal_test.dart
@@ -202,13 +202,13 @@ void main() {
     await tester.test(
       textDirection: TextDirection.ltr,
       children: children,
-      expectedTraversal: 'A B C D E G H F I J K L M',
+      expectedTraversal: 'A B C D E F G H I J K L M',
     );
 
     await tester.test(
       textDirection: TextDirection.rtl,
       children: children,
-      expectedTraversal: 'D C B A H G E I F M L K J',
+      expectedTraversal: 'D C B A H I G E F M L K J',
     );
   });
 

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -168,6 +168,7 @@ void _tests() {
                       SemanticsAction.scrollUp,
                       SemanticsAction.scrollDown,
                     ],
+                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                     children: <TestSemantics>[
                       TestSemantics(
                         id: 3,
@@ -521,6 +522,7 @@ void _tests() {
                       SemanticsAction.scrollUp,
                       SemanticsAction.scrollDown,
                     ],
+                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                     children: <TestSemantics>[
                       TestSemantics(
                         flags: <SemanticsFlag>[SemanticsFlag.isHidden],
@@ -630,6 +632,7 @@ void _tests() {
                       SemanticsAction.scrollUp,
                       SemanticsAction.scrollDown,
                     ],
+                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                     children: <TestSemantics>[
                       TestSemantics(
                         flags: <SemanticsFlag>[SemanticsFlag.isHidden],
@@ -994,6 +997,7 @@ void _tests() {
                       SemanticsAction.scrollUp,
                       SemanticsAction.scrollDown,
                     ],
+                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                     children: <TestSemantics>[
                       TestSemantics(
                         flags: <SemanticsFlag>[SemanticsFlag.isHidden],

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -218,7 +218,7 @@ void main() {
               ],
             ),
             TestSemantics(
-              label: ' regrettable event',
+              label: ' this is a regrettable event',
               textDirection: TextDirection.ltr,
             ),
           ],
@@ -414,7 +414,7 @@ void main() {
             TestSemantics(
               label: 'INTERRUPTION',
               textDirection: TextDirection.rtl,
-              rect: const Rect.fromLTRB(448.0, 0.0, 488.0, 80.0),
+              rect: const Rect.fromLTRB(0.0, 0.0, 40.0, 80.0),
             ),
             TestSemantics(
               label: 'sky',


### PR DESCRIPTION
## Description

Semantics_tester was broken.  If a node had multiple children, it was checking the first and then bailing.

Fixing that has revealed other bugs.

I talked with @GaryQian and I think the test_text tests now have the correct fixes applied in paragraph.dart.  Gary to review.

I'm not as confident on the other changes - DatePicker seems like it may be right now, ~~but not sure why we get all those empty nodes. /cc @goderbauer and/or @darrenaustin~~ we get them because there are empty container placeholders there.

Sliver tests I think are right - they were just missing implicit scrolling flags and not caught previously due to this bug.

Semantics traversal test seems like it may be a different bug.  It's possible the 64 bit rect stuff impacted this and we didn't catch it because of the brokeness of the tester.

This regression was introduced in #16253, where a `return true` that used to live in a closure was moved to a `for` loop.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34363

## Tests

I added the following tests:

Added a sanity check for the tester.  This test fails without these changes.  This is similar to a test I was trying to write, and I was confused about why it was passing when it was so clearly wrong.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
