### PR TITLE
Fix a type error?

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -534,7 +534,7 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
       observer.didHaveMemoryPressure();
   }
 
-  Future<void> _handleSystemMessage(Object systemMessage) async {
+  Future<dynamic> _handleSystemMessage(dynamic systemMessage) async {
     final Map<String, dynamic> message = systemMessage;
     final String type = message['type'];
     switch (type) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -534,7 +534,7 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
       observer.didHaveMemoryPressure();
   }
 
-  Future<dynamic> _handleSystemMessage(dynamic systemMessage) async {
+  Future<dynamic> _handleSystemMessage(Object systemMessage) async {
     final Map<String, dynamic> message = systemMessage;
     final String type = message['type'];
     switch (type) {


### PR DESCRIPTION
## Description

The error is `Future<void> Function(Object)` is not assignable to `Future<dynamic> Function(dynamic)`

- Analyzer does not flag this as an error.
- The CFE flutter target (via the frontend_server) does not flag this as an error.
- dart2js does not flag this as an error.
- ddc flags this as an error, but _only_ on hot restart.

This _seems_ like an error, because in this case we're returning a `Future` of a less specific type `void`. This was landed as a part of a "prefer void to null" refactor and was previous a `Future<Null>` which makes sense would have been assignable in this case

