### PR TITLE
[flutter_tool,fuchsia] Update the install flow for packaging migration.

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -265,7 +265,9 @@ class FuchsiaDevice extends Device {
       }
 
       // Start up a package server.
-      fuchsiaPackageServer = FuchsiaPackageServer(packageRepo.path, host, port);
+      const String packageServerName = 'flutter_tool';
+      fuchsiaPackageServer = FuchsiaPackageServer(
+          packageRepo.path, packageServerName, host, port);
       if (!await fuchsiaPackageServer.start()) {
         printError('Failed to start the Fuchsia package server');
         return LaunchResult.failed();
@@ -277,16 +279,17 @@ class FuchsiaDevice extends Device {
         return LaunchResult.failed();
       }
 
-      // Teach amber about the package server.
-      if (!await fuchsiaDeviceTools.amberCtl.addSrc(this, fuchsiaPackageServer)) {
+      // Teach the package controller about the package server.
+      if (!await fuchsiaDeviceTools.amberCtl.addRepoCfg(this, fuchsiaPackageServer)) {
         printError('Failed to teach amber about the package server');
         return LaunchResult.failed();
       }
       serverRegistered = true;
 
-      // Tell amber to prefetch the app.
-      if (!await fuchsiaDeviceTools.amberCtl.getUp(this, appName)) {
-        printError('Failed to get amber to prefetch the package');
+      // Tell the package controller to prefetch the app.
+      if (!await fuchsiaDeviceTools.amberCtl.pkgCtlResolve(
+          this, fuchsiaPackageServer, appName)) {
+        printError('Failed to get pkgctl to prefetch the package');
         return LaunchResult.failed();
       }
 
@@ -298,15 +301,16 @@ class FuchsiaDevice extends Device {
 
       // Instruct tiles_ctl to start the app.
       final String fuchsiaUrl =
-          'fuchsia-pkg://fuchsia.com/$appName#meta/$appName.cmx';
+          'fuchsia-pkg://$packageServerName/$appName#meta/$appName.cmx';
       if (!await fuchsiaDeviceTools.tilesCtl.add(this, fuchsiaUrl, <String>[])) {
         printError('Failed to add the app to tiles');
         return LaunchResult.failed();
       }
     } finally {
-      // Try to un-teach amber about the package server if needed.
+      // Try to un-teach the package controller about the package server if
+      // needed.
       if (serverRegistered) {
-        await fuchsiaDeviceTools.amberCtl.rmSrc(this, fuchsiaPackageServer);
+        await fuchsiaDeviceTools.amberCtl.pkgCtlRepoRemove(this, fuchsiaPackageServer);
       }
       // Shutdown the package server and delete the package repo;
       fuchsiaPackageServer?.stop();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -166,6 +166,7 @@ class FuchsiaPM {
 /// Example usage:
 /// var server = FuchsiaPackageServer(
 ///     '/path/to/repo',
+///     'server_name',
 ///     await FuchsiaDevFinder.resolve(deviceName),
 ///     await freshPort());
 /// try {
@@ -176,7 +177,7 @@ class FuchsiaPM {
 ///   server.stop();
 /// }
 class FuchsiaPackageServer {
-  FuchsiaPackageServer(this._repo, this._host, this._port);
+  FuchsiaPackageServer(this._repo, this.name, this._host, this._port);
 
   final String _repo;
   final String _host;
@@ -186,6 +187,9 @@ class FuchsiaPackageServer {
 
   /// The url that can be used by the device to access this package server.
   String get url => 'http://$_host:$_port';
+
+  // The name used to reference the server by fuchsia-pkg:// urls.
+  final String name;
 
   /// Usees [FuchiaPM.newrepo] and [FuchsiaPM.serve] to spin up a new Fuchsia
   /// package server.

--- a/packages/flutter_tools/test/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/fuchsia/fuchsia_device_test.dart
@@ -695,6 +695,22 @@ class FakeFuchsiaAmberCtl implements FuchsiaAmberCtl {
   Future<bool> getUp(FuchsiaDevice device, String packageName) async {
     return true;
   }
+
+  @override
+  Future<bool> addRepoCfg(FuchsiaDevice device, FuchsiaPackageServer server) async {
+    return true;
+  }
+
+  @override
+  Future<bool> pkgCtlResolve(FuchsiaDevice device, FuchsiaPackageServer server,
+                             String packageName) async {
+    return true;
+  }
+
+  @override
+  Future<bool> pkgCtlRepoRemove(FuchsiaDevice device, FuchsiaPackageServer server) async {
+    return true;
+  }
 }
 
 class FailingAmberCtl implements FuchsiaAmberCtl {
@@ -710,6 +726,22 @@ class FailingAmberCtl implements FuchsiaAmberCtl {
 
   @override
   Future<bool> getUp(FuchsiaDevice device, String packageName) async {
+    return false;
+  }
+
+  @override
+  Future<bool> addRepoCfg(FuchsiaDevice device, FuchsiaPackageServer server) async {
+    return false;
+  }
+
+  @override
+  Future<bool> pkgCtlResolve(FuchsiaDevice device, FuchsiaPackageServer server,
+                             String packageName) async {
+    return false;
+  }
+
+  @override
+  Future<bool> pkgCtlRepoRemove(FuchsiaDevice device, FuchsiaPackageServer server) async {
     return false;
   }
 }


### PR DESCRIPTION
## Description

The Fuchsia package resolution flow is undergoing a migration. During the migration, some actions use amber_ctl, and others use pkgctl. This PR switches some actions from amber_ctl to pkgctl. During the migration, I'll leave both amber_ctl and pkgctl actions in FuchsiaAmberCtl until the migration ends and a better organization is more clear.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
