### PR TITLE
Fix semantics labeling for paragraphs

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -762,7 +762,7 @@ class RenderParagraph extends RenderBox
     TextDirection currentDirection = textDirection;
     Rect currentRect;
 
-    SemanticsConfiguration buildSemanticsConfig(int start, int end, { bool includeText = true }) {
+    SemanticsConfiguration buildSemanticsConfig(int start, int end) {
       final TextDirection initialDirection = currentDirection;
       final TextSelection selection = TextSelection(baseOffset: start, extentOffset: end);
       final List<ui.TextBox> rects = getBoxesForSelection(selection);
@@ -784,10 +784,8 @@ class RenderParagraph extends RenderBox
       order += 1;
       final SemanticsConfiguration configuration = SemanticsConfiguration()
         ..sortKey = OrdinalSortKey(order)
-        ..textDirection = initialDirection;
-      if (includeText) {
-        configuration.label = rawLabel.substring(start, end);
-      }
+        ..textDirection = initialDirection
+        ..label = rawLabel.substring(start, end);
       return configuration;
     }
 
@@ -805,7 +803,7 @@ class RenderParagraph extends RenderBox
         newChildren.add(node);
       }
       final dynamic inlineElement = _inlineSemanticsElements[j];
-      final SemanticsConfiguration configuration = buildSemanticsConfig(start, end, includeText: false);
+      final SemanticsConfiguration configuration = buildSemanticsConfig(start, end);
       if (inlineElement != null) {
         // Add semantics for this recognizer.
         final SemanticsNode node = SemanticsNode();
@@ -824,6 +822,9 @@ class RenderParagraph extends RenderBox
       } else if (childIndex < children.length) {
         // Add semantics for this placeholder. Semantics are precomputed in the children
         // argument.
+        // Placeholders should not get a label, which would come through as an
+        // object replacement character.
+        configuration.label = '';
         final SemanticsNode childNode = children.elementAt(childIndex);
         final TextParentData parentData = child.parentData;
         childNode.rect = Rect.fromLTWH(

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -414,7 +414,7 @@ void main() {
             TestSemantics(
               label: 'INTERRUPTION',
               textDirection: TextDirection.rtl,
-              rect: const Rect.fromLTRB(448.0, 0.0, 488.0, 80.0),
+              rect: const Rect.fromLTRB(0.0, 0.0, 40.0, 80.0),
             ),
             TestSemantics(
               label: 'sky',


### PR DESCRIPTION
This is cherrypicked out of https://github.com/flutter/flutter/pull/34368.

Fixes the labeling strategy for paragraph when dealing with inline widgets/placeholders

If https://github.com/flutter/flutter/pull/34368 lands, then this can be abandoned.