### PR TITLE
don't use regular expressions to measure test time

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -15,7 +15,6 @@
 // Before the fourth time, a change is made to the interface in that same file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -104,6 +104,11 @@ class TestCommand extends FastFlutterCommand {
         allowed: const <String>['tester', 'chrome'],
         defaultsTo: 'tester',
         help: 'The platform to run the unit tests on. Defaults to "tester".'
+      )
+      ..addFlag('benchmark',
+        hide: true,
+        defaultsTo: false,
+        help: 'Run the tester in benchmark mode.'
       );
   }
 
@@ -222,6 +227,11 @@ class TestCommand extends FastFlutterCommand {
     final bool disableServiceAuthCodes =
       argResults['disable-service-auth-codes'];
 
+    Stopwatch stopwatch;
+    if (argResults['benchmark']) {
+      stopwatch = Stopwatch()..start();
+    }
+
     final int result = await runTests(
       files,
       workDir: workDir,
@@ -245,6 +255,13 @@ class TestCommand extends FastFlutterCommand {
       if (!await collector.collectCoverageData(
           argResults['coverage-path'], mergeCoverageData: argResults['merge-coverage']))
         throwToolExit(null);
+    }
+
+    if (argResults['benchmark']) {
+      fs.file('.benchmark_time')
+        ..createSync()
+        ..writeAsStringSync(stopwatch.elapsedMilliseconds.toString());
+      stopwatch.stop();
     }
 
     if (result != 0)


### PR DESCRIPTION
## Description

The flutter_test_performance benchmark is easy to make flaky if the output for test or the flutter tool changes in anyway, because it is running a complicated regular/expression + state machine over stdout from test. 

Instead we should use a similar approach to how we handle hot reload benchmarks, and run a StopWatch + write an output file instead