### PR TITLE
pass .packages path to snapshot invocation

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -180,4 +180,4 @@ fi
 
 # FLUTTER_TOOL_ARGS isn't quoted below, because it is meant to be considered as
 # separate space-separated args.
-"$DART" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+"$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -177,7 +177,7 @@ REM
 REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
-"%dart%" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & exit /B !ERRORLEVEL!
+"%dart%" --packages="%flutter_tools_dir%\.packages" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & exit /B !ERRORLEVEL!
 
 :final_exit
 EXIT /B %exit_code%


### PR DESCRIPTION
## Description

While a snapshot can generally run without a .packages, it prevents using some Isolate package resolution APIs we need to use to integrate with webdev