### PR TITLE
retry on HttpException during cache download

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -48,6 +48,7 @@ export 'dart:io'
         HttpClientRequest,
         HttpClientResponse,
         HttpClientResponseCompressionState,
+        HttpException,
         HttpHeaders,
         HttpRequest,
         HttpServer,

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -64,6 +64,9 @@ Future<List<int>> _attempt(Uri url, { bool onlyHeaders = false }) async {
   } on SocketException catch (error) {
     printTrace('Download error: $error');
     return null;
+  } on HttpException catch (error) {
+    printTrace('Download error: $error');
+    return null;
   }
   final HttpClientResponse response = await request.close();
   // If we're making a HEAD request, we're only checking to see if the URL is


### PR DESCRIPTION
## Description

HttpException seems to be thrown if anything goes wrong during the download - we should probably not crash the tool in this case. (see crash logs for multiple occurrences)

https://github.com/dart-lang/sdk/blob/ee4acdef7eb3a1939481c299c6eb79799d472f8f/sdk/lib/_http/http_impl.dart#L160
