### PR TITLE
Don't crash on invalid .packages file

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -543,7 +543,15 @@ class FlutterCommandRunner extends CommandRunner<void> {
     // Check that the flutter running is that same as the one referenced in the pubspec.
     if (fs.isFileSync(kPackagesFileName)) {
       final PackageMap packageMap = PackageMap(kPackagesFileName);
-      final Uri flutterUri = packageMap.map['flutter'];
+      Uri flutterUri;
+      try {
+        flutterUri = packageMap.map['flutter'];
+      } on FormatException {
+        // We're not quie sure why this can happen, perhaps the user
+        // accidentally edited the .packages file. Re-running pub should
+        // fix the issue, and we definitely shouldn't crash here.
+        return;
+      }
 
       if (flutterUri != null && (flutterUri.scheme == 'file' || flutterUri.scheme == '')) {
         // .../flutter/packages/flutter/lib

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -547,7 +547,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
       try {
         flutterUri = packageMap.map['flutter'];
       } on FormatException {
-        // We're not quie sure why this can happen, perhaps the user
+        // We're not quite sure why this can happen, perhaps the user
         // accidentally edited the .packages file. Re-running pub should
         // fix the issue, and we definitely shouldn't crash here.
         return;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -550,6 +550,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
         // We're not quite sure why this can happen, perhaps the user
         // accidentally edited the .packages file. Re-running pub should
         // fix the issue, and we definitely shouldn't crash here.
+        printTrace('Failed to parse .packages file to check flutter dependency.');
         return;
       }
 

--- a/packages/flutter_tools/test/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/runner/flutter_command_runner_test.dart
@@ -103,6 +103,19 @@ void main() {
       }, initializeFlutterRoot: false);
     });
 
+    testUsingContext('Doesnt crash on invalid .packages file', () async {
+      fs.file('pubspec.yaml').createSync();
+      fs.file('.packages')
+        ..createSync()
+        ..writeAsStringSync('Not a valid package');
+
+      await runner.run(<String>['dummy']);
+
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      Platform: () => platform,
+    }, initializeFlutterRoot: false);
+
     group('version', () {
       testUsingContext('checks that Flutter toJson output reports the flutter framework version', () async {
         final ProcessResult result = ProcessResult(0, 0, 'random', '0');


### PR DESCRIPTION
## Description

Fixes common FormatException error from crash logs. This can happen if there is a user modified .packages file, though it's not quite clear what would do that. Since this is only for a sanity check we shouldn't crash.

