### PR TITLE
Catch socketException and throw tool exit instead

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -501,7 +501,7 @@ class MDnsObservatoryDiscovery {
       return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
     } on SocketException catch (error) {
       throwToolExit(
-          'Failed to discovery Flutter observatory: '
+          'Failed to discover Flutter observatory: '
           '$error.'
       );
       return null;

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -499,6 +499,12 @@ class MDnsObservatoryDiscovery {
         }
       }
       return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
+    } on SocketException catch (error) {
+      throwToolExit(
+          'Failed to discovery Flutter observatory: '
+          '$error.'
+      );
+      return null;
     } finally {
       client.stop();
     }

--- a/packages/flutter_tools/test/commands/attach_test.dart
+++ b/packages/flutter_tools/test/commands/attach_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
@@ -547,6 +548,14 @@ void main() {
       final MDnsObservatoryDiscovery portDiscovery = MDnsObservatoryDiscovery(mdnsClient: client);
       final int port = (await portDiscovery.query(applicationId: 'bar'))?.port;
       expect(port, isNull);
+    });
+
+    testUsingContext('SocketException during query throws ToolExit', () async {
+      final MDnsClient client = MockMDnsClient();
+      when(client.lookup(any)).thenThrow(const SocketException('error'));
+
+      final MDnsObservatoryDiscovery portDiscovery = MDnsObservatoryDiscovery(mdnsClient: client);
+      expect(portDiscovery.query(), throwsA(isInstanceOf<ToolExit>()));
     });
   });
 }


### PR DESCRIPTION
## Description

Handles error case from crash logs where we might get a SocketException such as "SocketException: Failed to create datagram socket (OS Error: The requested address is not valid in its context"
