### PR TITLE
Handles parsing APK manifests with additional namespaces or attributes

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -490,15 +490,16 @@ class ApkManifestData {
     final List<String> lines = data.split('\n');
     assert(lines.length > 3);
 
-    final _Element manifest = _Element.fromLine(lines[1], null);
+    final int manifestLine = lines.indexWhere((String line) => line.contains('E: manifest'));
+    final _Element manifest = _Element.fromLine(lines[manifestLine], null);
     _Element currentElement = manifest;
 
-    for (String line in lines.skip(2)) {
+    for (String line in lines.skip(manifestLine)) {
       final String trimLine = line.trimLeft();
       final int level = line.length - trimLine.length;
 
       // Handle level out
-      while (level <= currentElement.level) {
+      while (currentElement.parent != null && level <= currentElement.level) {
         currentElement = currentElement.parent;
       }
 

--- a/packages/flutter_tools/test/application_package_test.dart
+++ b/packages/flutter_tools/test/application_package_test.dart
@@ -144,6 +144,12 @@ void main() {
       expect(data.packageName, 'io.flutter.examples.hello_world');
       expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity2');
     }, overrides: noColorTerminalOverride);
+    testUsingContext('Parses manifest with a dist namespace', () {
+      final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithDistNamespace);
+      expect(data, isNotNull);
+      expect(data.packageName, 'io.flutter.examples.hello_world');
+      expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity');
+    }, overrides: noColorTerminalOverride);
     testUsingContext('Error when parsing manifest with no Activity that has enabled set to true nor has no value for its enabled field', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithNoEnabledActivity);
       expect(data, isNull);
@@ -520,6 +526,42 @@ const String _aaptDataWithNoLauncherActivity =
         E: intent-filter (line=42)
           E: action (line=43)
             A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")''';
+
+const String _aaptDataWithDistNamespace =
+'''N: android=http://schemas.android.com/apk/res/android
+  N: dist=http://schemas.android.com/apk/distribution
+    E: manifest (line=7)
+      A: android:versionCode(0x0101021b)=(type 0x10)0x1
+      A: android:versionName(0x0101021c)="1.0" (Raw: "1.0")
+      A: android:compileSdkVersion(0x01010572)=(type 0x10)0x1c
+      A: android:compileSdkVersionCodename(0x01010573)="9" (Raw: "9")
+      A: package="io.flutter.examples.hello_world" (Raw: "io.flutter.examples.hello_world")
+      A: platformBuildVersionCode=(type 0x10)0x1
+      A: platformBuildVersionName=(type 0x4)0x3f800000
+      E: uses-sdk (line=13)
+        A: android:minSdkVersion(0x0101020c)=(type 0x10)0x10
+        A: android:targetSdkVersion(0x01010270)=(type 0x10)0x1c
+      E: dist:module (line=17)
+        A: dist:instant=(type 0x12)0xffffffff
+      E: uses-permission (line=24)
+        A: android:name(0x01010003)="android.permission.INTERNET" (Raw: "android.permission.INTERNET")
+      E: application (line=32)
+        A: android:label(0x01010001)="hello_world" (Raw: "hello_world")
+        A: android:icon(0x01010002)=@0x7f010000
+        A: android:name(0x01010003)="io.flutter.app.FlutterApplication" (Raw: "io.flutter.app.FlutterApplication")
+        E: activity (line=36)
+          A: android:theme(0x01010000)=@0x01030009
+          A: android:name(0x01010003)="io.flutter.examples.hello_world.MainActivity" (Raw: "io.flutter.examples.hello_world.MainActivity")
+          A: android:launchMode(0x0101001d)=(type 0x10)0x1
+          A: android:configChanges(0x0101001f)=(type 0x11)0x400037b4
+          A: android:windowSoftInputMode(0x0101022b)=(type 0x11)0x10
+          A: android:hardwareAccelerated(0x010102d3)=(type 0x12)0xffffffff
+          E: intent-filter (line=43)
+            E: action (line=44)
+              A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")
+            E: category (line=46)
+              A: android:name(0x01010003)="android.intent.category.LAUNCHER" (Raw: "android.intent.category.LAUNCHER")
+''';
 
 
 class MockIosWorkFlow extends Mock implements IOSWorkflow {

--- a/packages/flutter_tools/test/application_package_test.dart
+++ b/packages/flutter_tools/test/application_package_test.dart
@@ -138,18 +138,21 @@ void main() {
       expect(data.packageName, 'io.flutter.examples.hello_world');
       expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity2');
     }, overrides: noColorTerminalOverride);
+
     testUsingContext('Parses manifest with an Activity that has no value for its enabled field, action set to android.intent.action.MAIN and category set to android.intent.category.LAUNCHER', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithDefaultEnabledAndMainLauncherActivity);
       expect(data, isNotNull);
       expect(data.packageName, 'io.flutter.examples.hello_world');
       expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity2');
     }, overrides: noColorTerminalOverride);
+
     testUsingContext('Parses manifest with a dist namespace', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithDistNamespace);
       expect(data, isNotNull);
       expect(data.packageName, 'io.flutter.examples.hello_world');
       expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity');
     }, overrides: noColorTerminalOverride);
+
     testUsingContext('Error when parsing manifest with no Activity that has enabled set to true nor has no value for its enabled field', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithNoEnabledActivity);
       expect(data, isNull);
@@ -157,6 +160,7 @@ void main() {
       expect(
           logger.errorText, 'Error running io.flutter.examples.hello_world. Default activity not found\n');
     }, overrides: noColorTerminalOverride);
+
     testUsingContext('Error when parsing manifest with no Activity that has action set to android.intent.action.MAIN', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithNoMainActivity);
       expect(data, isNull);
@@ -164,6 +168,7 @@ void main() {
       expect(
           logger.errorText, 'Error running io.flutter.examples.hello_world. Default activity not found\n');
     }, overrides: noColorTerminalOverride);
+
     testUsingContext('Error when parsing manifest with no Activity that has category set to android.intent.category.LAUNCHER', () {
       final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithNoLauncherActivity);
       expect(data, isNull);
@@ -180,6 +185,7 @@ void main() {
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
     };
+
     testUsingContext('Error on non-existing file', () {
       final PrebuiltIOSApp iosApp =
           IOSApp.fromPrebuiltApp(fs.file('not_existing.ipa'));
@@ -190,6 +196,7 @@ void main() {
         'File "not_existing.ipa" does not exist. Use an app bundle or an ipa.\n',
       );
     }, overrides: overrides);
+
     testUsingContext('Error on non-app-bundle folder', () {
       fs.directory('regular_folder').createSync();
       final PrebuiltIOSApp iosApp =
@@ -199,6 +206,7 @@ void main() {
       expect(
           logger.errorText, 'Folder "regular_folder" is not an app bundle.\n');
     }, overrides: overrides);
+
     testUsingContext('Error on no info.plist', () {
       fs.directory('bundle.app').createSync();
       final PrebuiltIOSApp iosApp = IOSApp.fromPrebuiltApp(fs.file('bundle.app'));
@@ -209,6 +217,7 @@ void main() {
         'Invalid prebuilt iOS app. Does not contain Info.plist.\n',
       );
     }, overrides: overrides);
+
     testUsingContext('Error on bad info.plist', () {
       fs.directory('bundle.app').createSync();
       fs.file('bundle.app/Info.plist').writeAsStringSync(badPlistData);
@@ -221,6 +230,7 @@ void main() {
             'Invalid prebuilt iOS app. Info.plist does not contain bundle identifier\n'),
       );
     }, overrides: overrides);
+
     testUsingContext('Success with app bundle', () {
       fs.directory('bundle.app').createSync();
       fs.file('bundle.app/Info.plist').writeAsStringSync(plistData);
@@ -231,6 +241,7 @@ void main() {
       expect(iosApp.id, 'fooBundleId');
       expect(iosApp.bundleName, 'bundle.app');
     }, overrides: overrides);
+
     testUsingContext('Bad ipa zip-file, no payload dir', () {
       fs.file('app.ipa').createSync();
       when(os.unzip(fs.file('app.ipa'), any)).thenAnswer((Invocation _) { });
@@ -242,6 +253,7 @@ void main() {
         'Invalid prebuilt iOS ipa. Does not contain a "Payload" directory.\n',
       );
     }, overrides: overrides);
+
     testUsingContext('Bad ipa zip-file, two app bundles', () {
       fs.file('app.ipa').createSync();
       when(os.unzip(any, any)).thenAnswer((Invocation invocation) {
@@ -263,6 +275,7 @@ void main() {
       expect(logger.errorText,
           'Invalid prebuilt iOS ipa. Does not contain a single app bundle.\n');
     }, overrides: overrides);
+
     testUsingContext('Success with ipa', () {
       fs.file('app.ipa').createSync();
       when(os.unzip(any, any)).thenAnswer((Invocation invocation) {
@@ -319,6 +332,7 @@ void main() {
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
     };
+
     testUsingContext('Error on non-existing file', () {
       final PrebuiltFuchsiaApp fuchsiaApp =
           FuchsiaApp.fromPrebuiltApp(fs.file('not_existing.far'));


### PR DESCRIPTION
## Description

The current parsing of an APK manifest is hardcoded to look for the manifest element on line 1. This isn’t the case where extra namespaces or elements exist within the manifest element.

## Related Issues

#34534 

## Tests

I added the following tests:

application_package_test: Parses manifest with a dist namespace

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.