### PR TITLE
Remove @protected annotation on ImageProvider.obtainKey

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -375,7 +375,6 @@ abstract class ImageProvider<T> {
   /// arguments and [ImageConfiguration] objects should return keys that are
   /// '==' to each other (possibly by using a class for the key that itself
   /// implements [==]).
-  @protected
   Future<T> obtainKey(ImageConfiguration configuration);
 
   /// Converts a key into an [ImageStreamCompleter], and begins fetching the


### PR DESCRIPTION
## Description

Most ImageProvider sub-types already override obtainKey without another `@protected` annotation, making them effectively un-protected. Since the behavior of this annotation changes depending on the type signature, it doesn't seem very stable - it is also an ignorable hint that provides no additional safety