### PR TITLE
Kill compiler process when test does not exit cleanly

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -738,6 +738,7 @@ class ResidentCompiler {
     if (_server == null) {
       return 0;
     }
+    printTrace('killing pid ${_server.pid}');
     _server.kill();
     return _server.exitCode;
   }

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -85,6 +85,7 @@ class TestCompiler {
 
   Future<void> dispose() async {
     await compilerController.close();
+    await _shutdown();
   }
 
   /// Create the resident compiler used to compile the test.

--- a/packages/flutter_tools/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/test_compiler_test.dart
@@ -59,6 +59,15 @@ void main() {
 
       expect(await testCompiler.compile('test/foo.dart'), null);
       expect(fs.file('test/foo.dart.dill').existsSync(), false);
+      verify(residentCompiler.shutdown()).called(1);
+    }));
+
+    test('Disposing test compiler shuts down backing compiler', () => testbed.run(() async {
+      testCompiler.compiler = residentCompiler;
+      expect(testCompiler.compilerController.isClosed, false);
+      await testCompiler.dispose();
+      expect(testCompiler.compilerController.isClosed, true);
+      verify(residentCompiler.shutdown()).called(1);
     }));
   });
 }


### PR DESCRIPTION
## Description
Disposing of the test_compiler should also kill the underlying compiler process.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34613.

## Tests

Confirmed repro steps in https://github.com/flutter/flutter/issues/34613 no longer leaks process.
I added the following tests:
- New `test_compiler_test` test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

