### PR TITLE
Re-enable docs with new container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,15 +24,14 @@ task:
     fingerprint_script: echo $OS; cat bin/internal/engine.version
   setup_script: ./dev/bots/cirrus_setup.sh
   matrix:
-    # TODO(flutter/flutter#34435): re-enable the docs shard
-    # - name: docs
-    #   env:
-    #     SHARD: docs
-    #     # For uploading master docs to Firebase master branch staging site
-    #     FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
-    #     # For uploading beta docs to Firebase public live site
-    #     FIREBASE_PUBLIC_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
-    #   docs_script: ./dev/bots/docs.sh
+    - name: docs
+      env:
+        SHARD: docs
+        # For uploading master docs to Firebase master branch staging site
+        FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
+        # For uploading beta docs to Firebase public live site
+        FIREBASE_PUBLIC_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
+      docs_script: ./dev/bots/docs.sh
     - name: deploy_gallery
       depends_on:
         - docs

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -103,6 +103,10 @@ RUN dpkg-query -L nodejs
 # Install Firebase
 # This is why we need nodejs installed.
 RUN /usr/bin/npm --verbose install -g firebase-tools
+# TODO(dnfield): Remove this once Firebase has a fix upstream for
+# https://github.com/flutter/flutter/issues/34435
+COPY patch_firebase.sh /root/patch_firebase.sh
+RUN /root/patch_firebase.sh
 
 # Install dashing
 # This is why we need golang installed.

--- a/dev/ci/docker_linux/patch_firebase.sh
+++ b/dev/ci/docker_linux/patch_firebase.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+FIREBASE_CMD_LOC=$(which firebase)
+NODE_DIR=$(dirname $(dirname $FIREBASE_CMD_LOC))
+echo "Node directory is located at $NODE_DIR"
+
+UPLOADER_FILE="$NODE_DIR""/lib/node_modules/firebase-tools/lib/deploy/hosting/uploader.js"
+echo "File to modify is $UPLOADER_FILE"
+
+REPLACE='s#populateBatchSize || 1000;#populateBatchSize || 100;#'
+echo "Going to replace with $REPLACE"
+sed -i "$REPLACE" "$UPLOADER_FILE"


### PR DESCRIPTION
I intend to land this once the docs shard on presubmit completes, so we can try to test the docs post submit more quickly.  If it fixes things I'll mark flutter/flutter#34435 as not being TODAY, and leave open until we get a more robust fix upstream.  If it doesn't, I'll retag the docker image and revert this patch.