### PR TITLE
Close platform when tests are complete (dispose compiler and delete font files)

### DIFF
--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -105,7 +105,7 @@ Future<int> runTests(
   final InternetAddressType serverType =
       ipv6 ? InternetAddressType.IPv6 : InternetAddressType.IPv4;
 
-  loader.installHook(
+  final loader.FlutterPlatform platform = loader.installHook(
     shellPath: shellPath,
     watcher: watcher,
     enableObservatory: enableObservatory,
@@ -145,5 +145,6 @@ Future<int> runTests(
     return exitCode;
   } finally {
     fs.currentDirectory = saved;
+    await platform.close();
   }
 }

--- a/packages/flutter_tools/test/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/flutter_platform_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/test/flutter_platform.dart';
 
 import 'package:mockito/mockito.dart';
@@ -23,6 +24,58 @@ void main() {
       final FlutterPlatform flutterPlatfrom = FlutterPlatform(shellPath: '/', precompiledDillPath: 'example.dill');
       flutterPlatfrom.loadChannel('test1.dart', MockPlatform());
       expect(() => flutterPlatfrom.loadChannel('test2.dart', MockPlatform()), throwsA(isA<ToolExit>()));
+    });
+
+    testUsingContext('installHook creates a FlutterPlatform', () {
+      expect(() => installHook(
+        shellPath: 'abc',
+        enableObservatory: false,
+        startPaused: true
+      ), throwsA(isA<AssertionError>()));
+
+      expect(() => installHook(
+        shellPath: 'abc',
+        enableObservatory: false,
+        startPaused: false,
+        observatoryPort: 123
+      ), throwsA(isA<AssertionError>()));
+
+      FlutterPlatform capturedPlatform;
+      final Map<String, String> expectedPrecompiledDillFiles = <String, String>{'Key': 'Value'};
+      final FlutterPlatform flutterPlatform = installHook(
+        shellPath: 'abc',
+        enableObservatory: true,
+        machine: true,
+        startPaused: true,
+        disableServiceAuthCodes: true,
+        port: 100,
+        precompiledDillPath: 'def',
+        precompiledDillFiles: expectedPrecompiledDillFiles,
+        trackWidgetCreation: true,
+        updateGoldens: true,
+        buildTestAssets: true,
+        observatoryPort: 200,
+        serverType: InternetAddressType.IPv6,
+        icudtlPath: 'ghi',
+        platformPluginRegistration: (FlutterPlatform platform) {
+          capturedPlatform = platform;
+        });
+
+      expect(identical(capturedPlatform, flutterPlatform), equals(true));
+      expect(flutterPlatform.shellPath, equals('abc'));
+      expect(flutterPlatform.enableObservatory, equals(true));
+      expect(flutterPlatform.machine, equals(true));
+      expect(flutterPlatform.startPaused, equals(true));
+      expect(flutterPlatform.disableServiceAuthCodes, equals(true));
+      expect(flutterPlatform.port, equals(100));
+      expect(flutterPlatform.host, InternetAddress.loopbackIPv6);
+      expect(flutterPlatform.explicitObservatoryPort, equals(200));
+      expect(flutterPlatform.precompiledDillPath, equals('def'));
+      expect(flutterPlatform.precompiledDillFiles, expectedPrecompiledDillFiles);
+      expect(flutterPlatform.trackWidgetCreation, equals(true));
+      expect(flutterPlatform.updateGoldens, equals(true));
+      expect(flutterPlatform.buildTestAssets, equals(true));
+      expect(flutterPlatform.icudtlPath, equals('ghi'));
     });
   });
 }


### PR DESCRIPTION
## Description

Close the FlutterPlatform after tests are complete.  This will dispose the compiler and delete the font files from tmp.

## Related Issues

Sometimes the compiler isn't being disposed when tests do not clean up correctly.  I noticed this when I was investigating https://github.com/flutter/flutter/issues/34613, but I didn't file a separate issue.

## Tests

I added the following tests:
- 'installHook creates a FlutterPlatform'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.