### PR TITLE
Fix FocusTraversalPolicy makes focus lost

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -312,7 +312,11 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     final _DirectionalPolicyData policyData = _policyData[nearestScope];
     if (policyData != null && policyData.history.isNotEmpty && policyData.history.first.direction != direction) {
       if (policyData.history.last.node.parent == null) {
-        // Reset the policy data if history node is unavailable.
+        // If a node has been removed from the tree, then we should stop
+        // referencing it and reset the scope data so that we don't try and
+        // request focus on it. This can happen in slivers where the rendered node
+        // has been unmounted. This has the side effect that hysteresis might not
+        // be avoided when items that go off screen get unmounted.
         invalidateScopeData(nearestScope);
         return false;
       }

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -312,7 +312,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     final _DirectionalPolicyData policyData = _policyData[nearestScope];
     if (policyData != null && policyData.history.isNotEmpty && policyData.history.first.direction != direction) {
       if (policyData.history.last.node.parent == null) {
-        //Reset the policy data if history node is unavailable
+        // Reset the policy data if history node is unavailable.
         invalidateScopeData(nearestScope);
         return false;
       }

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -311,6 +311,11 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
   bool _popPolicyDataIfNeeded(TraversalDirection direction, FocusScopeNode nearestScope, FocusNode focusedChild) {
     final _DirectionalPolicyData policyData = _policyData[nearestScope];
     if (policyData != null && policyData.history.isNotEmpty && policyData.history.first.direction != direction) {
+      if (policyData.history.last.node.parent == null) {
+        //Reset the policy data if history node is unavailable
+        invalidateScopeData(nearestScope);
+        return false;
+      }
       switch (direction) {
         case TraversalDirection.down:
         case TraversalDirection.up:

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -834,7 +834,7 @@ void main() {
       await tester.pump();
       expect(focusBottom.hasFocus, isTrue);
 
-      //remove center focus node
+      // Remove center focus node.
       await tester.pumpWidget(DefaultFocusTraversal(
         policy: policy,
         child: FocusScope(

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -799,5 +799,65 @@ void main() {
       expect(policy.findFirstFocusInDirection(scope, TraversalDirection.left), equals(upperRightNode));
       expect(policy.findFirstFocusInDirection(scope, TraversalDirection.right), equals(upperLeftNode));
     });
+    testWidgets('Can find focus when policy data dirty', (WidgetTester tester) async {
+      final FocusNode focusTop = FocusNode(debugLabel: 'top');
+      final FocusNode focusCenter = FocusNode(debugLabel: 'center');
+      final FocusNode focusBottom = FocusNode(debugLabel: 'bottom');
+
+      final FocusTraversalPolicy policy = ReadingOrderTraversalPolicy();
+      await tester.pumpWidget(DefaultFocusTraversal(
+        policy: policy,
+        child: FocusScope(
+          debugLabel: 'Scope',
+          child: Column(
+            children: <Widget>[
+              Focus(
+                  focusNode: focusTop,
+                  child: Container(width: 100, height: 100)),
+              Focus(
+                  focusNode: focusCenter,
+                  child: Container(width: 100, height: 100)),
+              Focus(
+                  focusNode: focusBottom,
+                  child: Container(width: 100, height: 100)),
+            ],
+          ),
+        ),
+      ));
+
+      focusTop.requestFocus();
+      final FocusNode scope = focusTop.enclosingScope;
+
+      scope.focusInDirection(TraversalDirection.down);
+      scope.focusInDirection(TraversalDirection.down);
+
+      await tester.pump();
+      expect(focusBottom.hasFocus, isTrue);
+
+      //remove center focus node
+      await tester.pumpWidget(DefaultFocusTraversal(
+        policy: policy,
+        child: FocusScope(
+          debugLabel: 'Scope',
+          child: Column(
+            children: <Widget>[
+              Focus(
+                  focusNode: focusTop,
+                  child: Container(width: 100, height: 100)),
+              Focus(
+                  focusNode: focusBottom,
+                  child: Container(width: 100, height: 100)),
+            ],
+          ),
+        ),
+      ));
+
+      expect(focusBottom.hasFocus, isTrue);
+      scope.focusInDirection(TraversalDirection.up);
+      await tester.pump();
+
+      expect(focusCenter.hasFocus, isFalse);
+      expect(focusTop.hasFocus, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Description

FocusTraversalPolicy keep the previously visited node to avoid hysteresis. But even if the visited focus has been disposed, FocusTraversalPolicy will still use it to requestFocus, which will cause FocusManger to get an abandoned node to get the focus.

## Related Issues

Fixes #34153
Fixes #33435

## Tests

I added the following tests:

* A test to see that focus can be correctly found when visited focus has been disposed. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
