### PR TITLE
Add category/platformType to emulators

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -199,7 +199,7 @@ This is sent when a device is disconnected (and polling has been enabled via `en
 
 #### emulator.getEmulators
 
-Return a list of all available emulators. The `params` field will be a List; each item is a map with the fields `id` and `name`.
+Return a list of all available emulators. The `params` field will be a List; each item is a map with the fields `id`, `name`, `category` and `platformType`. `category` and `platformType` values match the values described in `device.getDevices`.
 
 #### emulator.launch
 
@@ -258,6 +258,7 @@ See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter
 
 ## Changelog
 
+- 0.5.2: Added `platformType` and `category` field to emulator.
 - 0.5.1: Added `platformType`, `ephemeral`, and `category` field to device.
 - 0.5.0: Added `daemon.getSupportedPlatforms` command
 - 0.4.2: Added `app.detach` command

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -258,8 +258,8 @@ See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter
 
 ## Changelog
 
-- 0.5.2: Added `platformType` and `category` field to emulator.
-- 0.5.1: Added `platformType`, `ephemeral`, and `category` field to device.
+- 0.5.2: Added `platformType` and `category` fields to emulator.
+- 0.5.1: Added `platformType`, `ephemeral`, and `category` fields to device.
 - 0.5.0: Added `daemon.getSupportedPlatforms` command
 - 0.4.2: Added `app.detach` command
 - 0.4.1: Added `flutter attach --machine`

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -11,6 +11,7 @@ import '../android/android_workflow.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process_manager.dart';
+import '../device.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
 
@@ -39,6 +40,12 @@ class AndroidEmulator extends Emulator {
 
   @override
   String get label => _prop('avd.ini.displayname');
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  PlatformType get platformType => PlatformType.android;
 
   String _prop(String name) => _properties != null ? _properties[name] : null;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -26,7 +26,7 @@ import '../run_hot.dart';
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 
-const String protocolVersion = '0.5.1';
+const String protocolVersion = '0.5.2';
 
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns
@@ -783,6 +783,8 @@ Map<String, dynamic> _emulatorToMap(Emulator emulator) {
   return <String, dynamic>{
     'id': emulator.id,
     'name': emulator.name,
+    'category': emulator.category?.toString(),
+    'platformType': emulator.platformType?.toString(),
   };
 }
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -10,6 +10,7 @@ import 'android/android_sdk.dart';
 import 'base/context.dart';
 import 'base/io.dart' show ProcessResult;
 import 'base/process_manager.dart';
+import 'device.dart';
 import 'globals.dart';
 import 'ios/ios_emulators.dart';
 
@@ -218,6 +219,8 @@ abstract class Emulator {
   String get name;
   String get manufacturer;
   String get label;
+  Category get category;
+  PlatformType get platformType;
 
   @override
   int get hashCode => id.hashCode;

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../device.dart';
 import '../emulator.dart';
 import '../globals.dart';
 import '../macos/xcode.dart';
@@ -33,6 +34,12 @@ class IOSEmulator extends Emulator {
 
   @override
   String get label => null;
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  PlatformType get platformType => PlatformType.ios;
 
   @override
   Future<void> launch() async {

--- a/packages/flutter_tools/test/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/android/android_emulator_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/android/android_emulator.dart';
+import 'package:flutter_tools/src/device.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -38,6 +39,8 @@ void main() {
       expect(emulator.name, name);
       expect(emulator.manufacturer, manufacturer);
       expect(emulator.label, label);
+      expect(emulator.category, Category.mobile);
+      expect(emulator.platformType, PlatformType.android);
     });
     testUsingContext('parses ini files', () {
       const String iniFile = '''

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart' show ListEquality;
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -170,6 +171,12 @@ class _MockEmulator extends Emulator {
 
   @override
   final String label;
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  PlatformType get platformType => PlatformType.android;
 
   @override
   Future<void> launch() {


### PR DESCRIPTION
@devoncarew @jonahwilliams does this seem like a reasonable change? I started showing emulators in my "device picker" but noticed that for a macOS project it would list emulators. For now I've made it assume that emulators are only useful if supported platforms contain ios or android, but it'd be nicer to not have assumptions like that (and if in future we ever have emulators for non-mobile platforms, it'd fall down without this).

## Description

Adds category/platformTypes to emulator results from the device daemon.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.