### PR TITLE
Removed hardcoded .app extension to add support for frameworks

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -365,7 +365,7 @@ EmbedFlutterFrameworks() {
 
   # Embed App.framework from Flutter into the app (after creating the Frameworks directory
   # if it doesn't already exist).
-  local xcode_frameworks_dir=${BUILT_PRODUCTS_DIR}"/"${PRODUCT_NAME}".app/Frameworks"
+  local xcode_frameworks_dir=${BUILT_PRODUCTS_DIR}"/"${PRODUCT_NAME}".${WRAPPER_EXTENSION}/Frameworks"
   RunCommand mkdir -p -- "${xcode_frameworks_dir}"
   RunCommand cp -Rv -- "${flutter_ios_out_folder}/App.framework" "${xcode_frameworks_dir}"
 


### PR DESCRIPTION
## Description

The current `xcode_backend` script assumes that Flutter will be embedded in an app target. This change uses  WRAPPER_EXTENSION setting to allow embedding Flutter into any target like other frameworks too. 

I'm also open to provide more documentation on how to do it. This is specially important for teams that would like to create native SDKs on top of Flutter.

## Related Issues

None that I'm aware of.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
