### PR TITLE
Disable widgets and material web tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -348,9 +348,11 @@ Future<void> _runWebTests() async {
     'test/services/',
     'test/painting/',
     'test/scheduler/',
-    'test/widgets/',
     'test/semantics/',
-    'test/material/',
+    // TODO(flutterweb): re-enable when instabiliy around pumpAndSettle is
+    // resolved.
+    // 'test/widgets/',
+    // 'test/material/',
   ]);
 }
 


### PR DESCRIPTION
## Description

These tests are currently too flaky to run. If enough of them get stuck we'll timeout the shard which is still failing.