### PR TITLE
Backup docs to GCS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,6 +31,8 @@ task:
         FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
         # For uploading beta docs to Firebase public live site
         FIREBASE_PUBLIC_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
+        # For Uploading to GCS
+        GCS_SERVICE_ACCOUNT: ENCRYPTED[ca271fed014bfd5e4207c350e6567413574390b9d4152893e64231d9c09613e5c68e66ec8cb4b6025161c85efa057d65]
       docs_script: ./dev/bots/docs.sh
     - name: deploy_gallery
       depends_on:

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+function upload_gcs() {
+  echo $GCS_SERVICE_ACCOUNT > ${HOME}/gcloud-service-key.json
+  gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+  gcloud --quiet config set project flutter-infra
+
+  gsutil cp -r "$FLUTTER_ROOT/dev/docs" gs://flutter_docs_backup/${CIRRUS_CHANGE_IN_REPO}/
+}
+
 function deploy {
   local total_tries="$1"
   local remaining_tries=$(($total_tries - 1))
@@ -125,6 +133,9 @@ cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/
 if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"
   if [[ "$CIRRUS_BRANCH" == "master" ]]; then
+    echo "Uploading docs to GCS..."
+    upload_gcs
+
     echo "Updating $CIRRUS_BRANCH docs: https://master-api.flutter.dev/"
     # Disable search indexing on the master staging site so searches get only
     # the stable site.


### PR DESCRIPTION
This could help in the case where firebase times out on us - we'd have a copy of what gets uploaded that could be attempted locally with different parameters.

It also could help prove out whether moving to GCS for some of this is viable/more reliable for CI.

/cc @jonahwilliams @tvolkert 