### PR TITLE
Tweak the display name of emulators

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -32,14 +32,13 @@ class AndroidEmulator extends Emulator {
 
   Map<String, String> _properties;
 
+  // Android Studio uses the ID with underscores replaced with spaces
+  // for the name if displayname is not set so we do the same.
   @override
-  String get name => _prop('hw.device.name');
+  String get name => _prop('avd.ini.displayname') ?? id.replaceAll('_', ' ').trim();
 
   @override
   String get manufacturer => _prop('hw.device.manufacturer');
-
-  @override
-  String get label => _prop('avd.ini.displayname');
 
   @override
   Category get category => Category.mobile;

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -218,7 +218,6 @@ abstract class Emulator {
   final bool hasConfig;
   String get name;
   String get manufacturer;
-  String get label;
   Category get category;
   PlatformType get platformType;
 
@@ -250,7 +249,7 @@ abstract class Emulator {
         emulator.id ?? '',
         emulator.name ?? '',
         emulator.manufacturer ?? '',
-        emulator.label ?? '',
+        emulator.platformType?.toString() ?? '',
       ]);
     }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -33,9 +33,6 @@ class IOSEmulator extends Emulator {
   String get manufacturer => 'Apple';
 
   @override
-  String get label => null;
-
-  @override
   Category get category => Category.mobile;
 
   @override

--- a/packages/flutter_tools/test/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/android/android_emulator_test.dart
@@ -23,24 +23,42 @@ void main() {
       expect(emulator.id, emulatorID);
       expect(emulator.hasConfig, true);
     });
-    testUsingContext('stores expected metadata', () {
+    testUsingContext('reads expected metadata', () {
       const String emulatorID = '1234';
-      const String name = 'My Test Name';
       const String manufacturer = 'Me';
-      const String label = 'The best one';
+      const String displayName = 'The best one';
       final Map<String, String> properties = <String, String>{
-        'hw.device.name': name,
         'hw.device.manufacturer': manufacturer,
-        'avd.ini.displayname': label,
+        'avd.ini.displayname': displayName,
       };
       final AndroidEmulator emulator =
           AndroidEmulator(emulatorID, properties);
       expect(emulator.id, emulatorID);
-      expect(emulator.name, name);
+      expect(emulator.name, displayName);
       expect(emulator.manufacturer, manufacturer);
-      expect(emulator.label, label);
       expect(emulator.category, Category.mobile);
       expect(emulator.platformType, PlatformType.android);
+    });
+    testUsingContext('prefers displayname for name', () {
+      const String emulatorID = '1234';
+      const String displayName = 'The best one';
+      final Map<String, String> properties = <String, String>{
+        'avd.ini.displayname': displayName,
+      };
+      final AndroidEmulator emulator =
+          AndroidEmulator(emulatorID, properties);
+      expect(emulator.name, displayName);
+    });
+    testUsingContext('uses cleaned up ID if no displayname is set', () {
+      // Android Studio uses the ID with underscores replaced with spaces
+      // for the name if displayname is not set so we do the same.
+      const String emulatorID = 'This_is_my_ID';
+      final Map<String, String> properties = <String, String>{
+        'avd.ini.notadisplayname': 'this is not a display name',
+      };
+      final AndroidEmulator emulator =
+          AndroidEmulator(emulatorID, properties);
+      expect(emulator.name, 'This is my ID');
     });
     testUsingContext('parses ini files', () {
       const String iniFile = '''

--- a/packages/flutter_tools/test/emulator_test.dart
+++ b/packages/flutter_tools/test/emulator_test.dart
@@ -46,11 +46,11 @@ void main() {
 
     testUsingContext('getEmulatorsById', () async {
       final _MockEmulator emulator1 =
-          _MockEmulator('Nexus_5', 'Nexus 5', 'Google', '');
+          _MockEmulator('Nexus_5', 'Nexus 5', 'Google');
       final _MockEmulator emulator2 =
-          _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google', '');
+          _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google');
       final _MockEmulator emulator3 =
-          _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple', '');
+          _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple');
       final List<Emulator> emulators = <Emulator>[
         emulator1,
         emulator2,
@@ -160,7 +160,7 @@ class TestEmulatorManager extends EmulatorManager {
 }
 
 class _MockEmulator extends Emulator {
-  _MockEmulator(String id, this.name, this.manufacturer, this.label)
+  _MockEmulator(String id, this.name, this.manufacturer)
     : super(id, true);
 
   @override
@@ -168,9 +168,6 @@ class _MockEmulator extends Emulator {
 
   @override
   final String manufacturer;
-
-  @override
-  final String label;
 
   @override
   Category get category => Category.mobile;


### PR DESCRIPTION
## Description

This tweaks the display name for emulators, as the "name" we are currently displaying is the "hardware device name" (eg. phone name) which doesn't match what the user sees as the "name" in Android Studio and looked inconsistent against other devices.

Previously:

<img width="554" alt="Screenshot 2019-06-20 at 11 25 47 am" src="https://user-images.githubusercontent.com/1078012/59843545-ad8ee280-9350-11e9-9543-3051c09afac9.png">

The second column here (which is the "name", which we also send to daemon clients) is not very good. Here's how Android Studio shows the same devices:

![Screenshot 2019-06-20 at 11 29 41 am](https://user-images.githubusercontent.com/1078012/59843594-cb5c4780-9350-11e9-9eaa-23a70dd41ab2.png)

It appears to show the "displayname" in preference (which we have in the last column), falling back to what we consider the ID (but with underscores swapped for spaces).

Doing the same thing for us (removing the old label flag, and making name match `displayname ?? id.replaceAll('_', ' ')` we end up with (I also added platformType since we have it now):

<img width="500" alt="Screenshot 2019-06-20 at 11 45 55 am" src="https://user-images.githubusercontent.com/1078012/59843686-fc3c7c80-9350-11e9-8467-10b47e5fae99.png">

The second column now matches Android Studio and looks better in the clients.

@devoncarew @pq  FYI - since this changes the value sent over the daemon, this will change what's seen in IntelliJ if you use `getEmulators` (for the better, hopefully). I don't expect names are being persisted anywhere so it shouldn't be breaking, but it'd be good to have confirmation of that. If you were previously displaying both name and ID, you might want to drop ID from the display because they're generally very similar strings.

(cc @jonahwilliams)
