### PR TITLE
Add `emulatorID` field to devices in daemon

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -157,7 +157,7 @@ This is sent when an app is stopped or detached from. The `params` field will be
 
 #### device.getDevices
 
-Return a list of all connected devices. The `params` field will be a List; each item is a map with the fields `id`, `name`, `platform`, `category`, `platformType`, `ephemeral`, and `emulator` (a boolean).
+Return a list of all connected devices. The `params` field will be a List; each item is a map with the fields `id`, `name`, `platform`, `category`, `platformType`, `ephemeral`, `emulator` (a boolean) and `emulatorId`.
 
 `category` is string description of the kind of workflow the device supports. The current categories are "mobile", "web" and "desktop", or null if none.
 
@@ -166,6 +166,8 @@ supports. The current catgetories are "android", "ios", "linux", "macos",
 "fuchsia", "windows", and "web". These are kept in sync with the response from `daemon.getSupportedPlatforms`.
 
 `ephemeral` is a boolean which indicates where the device needs to be manually connected to a development machine. For example, a physical Android device is ephemeral, but the "web" device (that is always present) is not.
+
+`emulatorId` is an string ID that matches the ID from `getEmulators` to allow clients to match running devices to the emulators that started them (for example to hide emulators that are already running). This field is not guaranteed to be populated even if a device was spawned from an emulator as it may require a successful connection to the device to retrieve it. In the case of a failed connection or the device is not an emulator, this field will be null.
 
 #### device.enable
 
@@ -258,6 +260,7 @@ See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter
 
 ## Changelog
 
+- 0.5.3: Added `emulatorId` field to device.
 - 0.5.2: Added `platformType` and `category` fields to emulator.
 - 0.5.1: Added `platformType`, `ephemeral`, and `category` fields to device.
 - 0.5.0: Added `daemon.getSupportedPlatforms` command

--- a/packages/flutter_tools/lib/src/android/android_console.dart
+++ b/packages/flutter_tools/lib/src/android/android_console.dart
@@ -1,0 +1,50 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:async/async.dart';
+
+/// Creates a console connection to an Android emulator that can be used to run
+/// commands such as "avd name" which are not available to ADB.
+class AndroidConsole {
+  AndroidConsole._(this.socket):
+    queue = StreamQueue<String>(socket.asyncMap(ascii.decode));
+
+  final Socket socket;
+  final StreamQueue<String> queue;
+
+  static Future<AndroidConsole> connect(String host, int port) async {
+    final Socket socket = await Socket.connect(host, port);
+    final AndroidConsole console = AndroidConsole._(socket);
+    // Discard initial connection text.
+    await console._readResponse();
+    return console;
+  }
+
+  Future<String> getAvdName() async {
+    _write('avd name\n');
+    return _readResponse();
+  }
+
+  void destroy()  => socket.destroy();
+
+  Future<String> _readResponse() async {
+    String text = (await queue.next).trim();
+    if (text.endsWith('\nOK')) {
+      text = text.substring(0, text.length - 3);
+    }
+    return text.trim();
+  }
+
+  void _write(String text) {
+    socket.add(ascii.encode(text));
+  }
+}

--- a/packages/flutter_tools/lib/src/android/android_console.dart
+++ b/packages/flutter_tools/lib/src/android/android_console.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:async/async.dart';
 import '../base/context.dart';
+import '../base/io.dart';
+import '../convert.dart';
 
 /// Default factory that creates a real Android console connection.
 final AndroidConsoleSocketFactory _kAndroidConsoleSocketFactory = (String host, int port) => Socket.connect( host,  port);

--- a/packages/flutter_tools/lib/src/android/android_console.dart
+++ b/packages/flutter_tools/lib/src/android/android_console.dart
@@ -11,7 +11,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:async/async.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import '../base/context.dart';
 
 /// Default factory that creates a real Android console connection.

--- a/packages/flutter_tools/lib/src/android/android_console.dart
+++ b/packages/flutter_tools/lib/src/android/android_console.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -135,10 +135,12 @@ class AndroidDevice extends Device {
     return _isLocalEmulator;
   }
 
-  /// If the device is an emulator, returns the ID shown in the output of
-  /// `flutter emulators` that matches this device. Fetching this name may require
-  /// connecting to the device and if an error occurs null will be returned.
-  /// If this devices is not an emulator, null will be returned.
+  /// The unique identifier for the emulator that corresponds to this device, or
+  /// null if it is not an emulator.
+  ///
+  /// The ID returned matches that in the output of `flutter emulators`. Fetching
+  /// this name may require connecting to the device and if an error occurs null
+  /// will be returned.
   @override
   Future<String> get emulatorId async {
     // Emulators always have IDs in the format emulator-(port) where port is the
@@ -162,8 +164,7 @@ class AndroidDevice extends Device {
       } finally {
         console.destroy();
       }
-    }
-    catch (e) {
+    } catch (e) {
       printTrace('Failed to fetch avd name for emulator $name: $e');
       // If we fail to connect to the device, we should not fail so just return
       // an empty name. This data is best-effort.

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -26,6 +26,7 @@ import '../protocol_discovery.dart';
 
 import 'adb.dart';
 import 'android.dart';
+import 'android_console.dart';
 import 'android_sdk.dart';
 
 enum _HardwareType { emulator, physical }
@@ -132,6 +133,42 @@ class AndroidDevice extends Device {
       }
     }
     return _isLocalEmulator;
+  }
+
+  /// If the device is an emulator, returns the ID shown in the output of
+  /// `flutter emulators` that matches this device. Fetching this name may require
+  /// connecting to the device and if an error occurs null will be returned.
+  /// If this devices is not an emulator, null will be returned.
+  @override
+  Future<String> get emulatorId async {
+    // Emulators always have IDs in the format emulator-(port) where port is the
+    // Android Console port number.
+    final RegExp emulatorPortRegex = RegExp(r'emulator-(\d+)');
+    if (!(await isLocalEmulator))
+      return null;
+
+    try {
+      final Match portMatch = emulatorPortRegex.firstMatch(id);
+      if (portMatch == null || portMatch.groupCount < 1) {
+        return null;
+      }
+
+      const String host = 'localhost';
+      final int port = int.parse(portMatch.group(1));
+      printTrace('Connecting to $host:$port to get avd name');
+      final AndroidConsole console = await AndroidConsole.connect('localhost', port);
+      try {
+        return await console.getAvdName();
+      } finally {
+        console.destroy();
+      }
+    }
+    catch (e) {
+      printTrace('Failed to fetch avd name for emulator $name: $e');
+      // If we fail to connect to the device, we should not fail so just return
+      // an empty name. This data is best-effort.
+      return null;
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -777,6 +777,7 @@ Future<Map<String, dynamic>> _deviceToMap(Device device) async {
     'category': device.category?.toString(),
     'platformType': device.platformType?.toString(),
     'ephemeral': device.ephemeral,
+    'emulatorId': await device.emulatorId,
   };
 }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -26,7 +26,7 @@ import '../run_hot.dart';
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 
-const String protocolVersion = '0.5.2';
+const String protocolVersion = '0.5.3';
 
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -262,6 +262,12 @@ abstract class Device {
   /// Whether it is an emulated device running on localhost.
   Future<bool> get isLocalEmulator;
 
+  /// If the device is an emulator, returns the ID shown in the output of
+  /// `flutter emulators` that matches this device. Fetching this name may require
+  /// connecting to the device and if an error occurs null will be returned.
+  /// If this devices is not an emulator, null will be returned.
+  Future<String> get emulatorId;
+
   /// Whether the device is a simulator on a platform which supports hardware rendering.
   Future<bool> get supportsHardwareRendering async {
     assert(await isLocalEmulator);

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -262,10 +262,12 @@ abstract class Device {
   /// Whether it is an emulated device running on localhost.
   Future<bool> get isLocalEmulator;
 
-  /// If the device is an emulator, returns the ID shown in the output of
-  /// `flutter emulators` that matches this device. Fetching this name may require
-  /// connecting to the device and if an error occurs null will be returned.
-  /// If this devices is not an emulator, null will be returned.
+  /// The unique identifier for the emulator that corresponds to this device, or
+  /// null if it is not an emulator.
+  ///
+  /// The ID returned matches that in the output of `flutter emulators`. Fetching
+  /// this name may require connecting to the device and if an error occurs null
+  /// will be returned.
   Future<String> get emulatorId;
 
   /// Whether the device is a simulator on a platform which supports hardware rendering.

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -198,6 +198,9 @@ class FuchsiaDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool get supportsStartPaused => false;
 
   @override

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -146,6 +146,9 @@ class IOSDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool get supportsStartPaused => false;
 
   static Future<List<IOSDevice>> getAttachedDevices() async {

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -11,6 +11,7 @@ import '../emulator.dart';
 import '../globals.dart';
 import '../macos/xcode.dart';
 import 'ios_workflow.dart';
+import 'simulators.dart';
 
 class IOSEmulators extends EmulatorDiscovery {
   @override
@@ -74,5 +75,5 @@ List<IOSEmulator> getEmulators() {
     return <IOSEmulator>[];
   }
 
-  return <IOSEmulator>[IOSEmulator('apple_ios_simulator')];
+  return <IOSEmulator>[IOSEmulator(iosSimulatorId)];
 }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -27,6 +27,7 @@ import 'mac.dart';
 import 'plist_utils.dart';
 
 const String _xcrunPath = '/usr/bin/xcrun';
+const String iosSimulatorId = 'apple_ios_simulator';
 
 class IOSSimulators extends PollingDeviceDiscovery {
   IOSSimulators() : super('iOS simulators');
@@ -229,6 +230,9 @@ class IOSSimulator extends Device {
 
   @override
   Future<bool> get isLocalEmulator async => true;
+
+  @override
+  Future<String> get emulatorId async => iosSimulatorId;
 
   @override
   bool get supportsHotReload => true;

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -54,6 +54,9 @@ class LinuxDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool isSupported() => true;
 
   @override

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -55,6 +55,9 @@ class MacOSDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool isSupported() => true;
 
   @override

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -56,6 +56,9 @@ class FlutterTesterDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   String get name => 'Flutter test device';
 
   @override

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -71,6 +71,9 @@ class WebDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool isSupported() => flutterWebEnabled && canFindChrome();
 
   @override

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -56,6 +56,9 @@ class WindowsDevice extends Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  Future<String> get emulatorId async => null;
+
+  @override
   bool isSupported() => true;
 
   @override

--- a/packages/flutter_tools/test/android/android_device_test.dart
+++ b/packages/flutter_tools/test/android/android_device_test.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_console.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
@@ -278,6 +280,83 @@ flutter:
     FileSystem: () => MemoryFileSystem(),
   });
 
+  group('emulatorId', () {
+    final ProcessManager mockProcessManager = MockProcessManager();
+    const String dummyEmulatorId = 'dummyEmulatorId';
+    final Future<Socket> Function(String host, int port) unresponsiveSocket =
+        (String host, int port) async => MockUnresponsiveAndroidConsoleSocket();
+    final Future<Socket> Function(String host, int port) workingSocket =
+        (String host, int port) async => MockWorkingAndroidConsoleSocket(dummyEmulatorId);
+    String hardware;
+    bool socketWasCreated;
+
+    setUp(() {
+      hardware = 'goldfish'; // Known emulator
+      socketWasCreated = false;
+      when(mockProcessManager.run(argThat(contains('getprop')),
+          stderrEncoding: anyNamed('stderrEncoding'),
+          stdoutEncoding: anyNamed('stdoutEncoding'))).thenAnswer((_) {
+        final StringBuffer buf = StringBuffer()
+          ..writeln('[ro.hardware]: [$hardware]');
+        final ProcessResult result = ProcessResult(1, 0, buf.toString(), '');
+        return Future<ProcessResult>.value(result);
+      });
+    });
+
+    testUsingContext('returns correct ID for responsive emulator', () async {
+      final AndroidDevice device = AndroidDevice('emulator-5555');
+      expect(await device.emulatorId, equals(dummyEmulatorId));
+    }, overrides: <Type, Generator>{
+      AndroidConsoleSocketFactory: () => workingSocket,
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('does not create socket for non-emulator devices', () async {
+      hardware = 'samsungexynos7420';
+
+      // Still use an emulator-looking ID so we can be sure the failure is due
+      // to the isLocalEmulator field and not because the ID doesn't contain a
+      // port.
+      final AndroidDevice device = AndroidDevice('emulator-5555');
+      expect(await device.emulatorId, isNull);
+      expect(socketWasCreated, isFalse);
+    }, overrides: <Type, Generator>{
+      AndroidConsoleSocketFactory: () => (String host, int port) async {
+        socketWasCreated = true;
+        throw 'Socket was created for non-emulator';
+      },
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('does not create socket for emulators with no port', () async {
+      final AndroidDevice device = AndroidDevice('emulator-noport');
+      expect(await device.emulatorId, isNull);
+      expect(socketWasCreated, isFalse);
+    }, overrides: <Type, Generator>{
+      AndroidConsoleSocketFactory: () => (String host, int port) async {
+        socketWasCreated = true;
+        throw 'Socket was created for emulator without port in ID';
+      },
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('returns null for connection error', () async {
+      final AndroidDevice device = AndroidDevice('emulator-5555');
+      expect(await device.emulatorId, isNull);
+    }, overrides: <Type, Generator>{
+      AndroidConsoleSocketFactory: () => (String host, int port) => throw 'Fake socket error',
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('returns null for unresponsive device', () async {
+      final AndroidDevice device = AndroidDevice('emulator-5555');
+      expect(await device.emulatorId, isNull);
+    }, overrides: <Type, Generator>{
+      AndroidConsoleSocketFactory: () => unresponsiveSocket,
+      ProcessManager: () => mockProcessManager,
+    });
+  });
+
   group('portForwarder', () {
     final ProcessManager mockProcessManager = MockProcessManager();
     final AndroidDevice device = AndroidDevice('1234');
@@ -480,3 +559,44 @@ const String kAdbShellGetprop = '''
 [wlan.driver.status]: [unloaded]
 [xmpp.auto-presence]: [true]
 ''';
+
+/// A mock Android Console that presents a connection banner and responds to
+/// "avd name" requests with the supplied name.
+class MockWorkingAndroidConsoleSocket extends Mock implements Socket {
+  MockWorkingAndroidConsoleSocket(this.avdName) {
+    _controller.add('Android Console: Welcome!\n');
+    // Include OK in the same packet here. In the response to "avd name"
+    // it's sent alone to ensure both are handled.
+    _controller.add('Android Console: Some intro text\nOK\n');
+  }
+
+  final String avdName;
+  final StreamController<String> _controller = StreamController<String>();
+
+  @override
+  Stream<E> asyncMap<E>(FutureOr<E> convert(List<int> event)) => _controller.stream as Stream<E>;
+
+  @override
+  void add(List<int> data) {
+    final String text = ascii.decode(data);
+    if (text == 'avd name\n') {
+      _controller.add('$avdName\n');
+      // Include OK in its own packet here. In welcome banner it's included
+      // as part of the previous text to ensure both are handled.
+      _controller.add('OK\n');
+    } else {
+      throw 'Unexpected command $text';
+    }
+  }
+}
+
+/// An Android console socket that drops all input and returns no output.
+class MockUnresponsiveAndroidConsoleSocket extends Mock implements Socket {
+  final StreamController<String> _controller = StreamController<String>();
+
+  @override
+  Stream<E> asyncMap<E>(FutureOr<E> convert(List<int> event)) => _controller.stream as Stream<E>;
+
+  @override
+  void add(List<int> data) {}
+}


### PR DESCRIPTION
## Description

This adds an additional `emulatorId` to devices so allow clients to match them up (and hide already-running emulators from the "Launch Emulator" list). It's currently only exposed in the daemon, though we may also want to expose this in `flutter devices` (@mit-mit FYI).

@devoncarew @jonahwilliams 

For Android this requires creating a connection to the device and running "avd name" (it doesn't work via adb) - see original investigations at https://github.com/flutter/flutter/pull/16705#issuecomment-382742079. It's more important now for VS Code, as the device selector is showing both devices and emulators, and the dupes are weird.

Here's how the Android Console works on a real emulator for reference:

```
dantup-macbookpro:inetutils-1.9 dantup$ telnet/telnet localhost 5554
Connected to localhost.
Escape character is '^]'.
Android Console: Authentication required
Android Console: type 'auth <auth_token>' to authenticate
Android Console: you can find your <auth_token> in 
'/Users/dantup/.emulator_console_auth_token'
OK
avd name
Danny_Nexus
OK
```

## Tests

This still needs tests - I want to be sure we're happy with this before proceeding (and I'm also open to ideas on how best to test this, the only significant code is in connecting to running emulators, and I'm not sure if we have much infrastructure for testing something like that.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
