### PR TITLE
[Material] Properly call onChangeStart and onChangeEnd in Range Slider

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -373,17 +373,17 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     enableController = AnimationController(
       duration: enableAnimationDuration,
       vsync: this,
-      value: widget.onChanged != null ? 1.0 : 0.0,
+      value: widget.onChanged != null ? 1.0 : 0.0
     );
     startPositionController = AnimationController(
       duration: Duration.zero,
       vsync: this,
-      value: _unlerp(widget.values.start),
+      value: _unlerp(widget.values.start)
     );
     endPositionController = AnimationController(
       duration: Duration.zero,
       vsync: this,
-      value: _unlerp(widget.values.end),
+      value: _unlerp(widget.values.end)
     );
   }
 
@@ -464,7 +464,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       Size thumbSize,
       Size trackSize,
       double dx, // drag velocity
-      ) {
+    ) {
     final double touchRadius = math.max(thumbSize.width, RangeSlider._minTouchTargetWidth) / 2;
     final bool inStartTouchTarget = (tapValue - values.start).abs() * trackSize.width < touchRadius;
     final bool inEndTouchTarget = (tapValue - values.end).abs() * trackSize.width < touchRadius;

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -729,6 +729,7 @@ class _RenderRangeSlider extends RenderBox {
   HorizontalDragGestureRecognizer _drag;
   TapGestureRecognizer _tap;
   bool _active = false;
+  RangeValues _newValues;
 
   bool get isEnabled => onChanged != null;
 
@@ -878,12 +879,12 @@ class _RenderRangeSlider extends RenderBox {
   double get _adjustmentUnit {
     switch (_platform) {
       case TargetPlatform.iOS:
-      // Matches iOS implementation of material slider.
+        // Matches iOS implementation of material slider.
         return 0.1;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       default:
-      // Matches Android implementation of material slider.
+        // Matches Android implementation of material slider.
         return 0.05;
     }
   }
@@ -974,8 +975,6 @@ class _RenderRangeSlider extends RenderBox {
   RangeValues _discretizeRangeValues(RangeValues values) {
     return RangeValues(_discretize(values.start), _discretize(values.end));
   }
-
-  RangeValues _newValues;
 
   void _startInteraction(Offset globalPosition) {
     final double tapValue = _getValueFromGlobalPosition(globalPosition).clamp(0.0, 1.0);

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -454,8 +454,8 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
   }
 
   // Finds closest thumb. If the thumbs are close to each other, no thumb is
-  // immediately selected while the drag velocity is zero. If the first
-  // non-zero velocity is negative, then the left thumb is selected, and if its
+  // immediately selected while the drag displacement is zero. If the first
+  // non-zero displacement is negative, then the left thumb is selected, and if its
   // positive, then the right thumb is selected.
   static final RangeThumbSelector _defaultRangeThumbSelector = (
       TextDirection textDirection,
@@ -463,16 +463,16 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       double tapValue,
       Size thumbSize,
       Size trackSize,
-      double dx, // drag velocity
+      double dx, // drag displacement
     ) {
     final double touchRadius = math.max(thumbSize.width, RangeSlider._minTouchTargetWidth) / 2;
     final bool inStartTouchTarget = (tapValue - values.start).abs() * trackSize.width < touchRadius;
     final bool inEndTouchTarget = (tapValue - values.end).abs() * trackSize.width < touchRadius;
 
-    // Use the velocity if the thumb touch targets overlap. If dx is 0 and the
-    // the drag position is in both touch targets, no thumb is selected because
-    // it is ambiguous to which thumb should be selected. Once the drag
-    // velocity is non-zero, the thumb selection can be determined.
+    // Use the displacement if the thumb touch targets overlap. If dx is 0 and
+    // the the drag position is in both touch targets, no thumb is selected
+    // because it is ambiguous to which thumb should be selected. Once the drag
+    // displacement is non-zero, the thumb selection can be determined.
     if (inStartTouchTarget && inEndTouchTarget) {
       bool towardsStart;
       bool towardsEnd;
@@ -1018,7 +1018,7 @@ class _RenderRangeSlider extends RenderBox {
     final double dragValue = _getValueFromGlobalPosition(details.globalPosition);
 
     // If no selection has been made yet, test for thumb selection again now
-    // that the value if dx is non zero. If this is the first selection of the
+    // that the value of dx is non-zero. If this is the first selection of the
     // interaction, then onChangeStart must be called.
     bool shouldCallOnChangeStart = false;
     if (_lastThumbSelection == null) {
@@ -1056,9 +1056,7 @@ class _RenderRangeSlider extends RenderBox {
       _state.valueIndicatorController.reverse();
     }
 
-    if (_active && _state.mounted) {
-      if (_lastThumbSelection == null)
-        return;
+    if (_active && _state.mounted && _lastThumbSelection != null) {
       final RangeValues discreteValues = _discretizeRangeValues(_newValues);
       if (onChangeEnd != null) {
         onChangeEnd(discreteValues);

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -128,14 +128,14 @@ class RangeSlider extends StatefulWidget {
     this.inactiveColor,
     this.semanticFormatterCallback
   }) : assert(values != null),
-        assert(min != null),
-        assert(max != null),
-        assert(min <= max),
-        assert(values.start <= values.end),
-        assert(values.start >= min && values.start <= max),
-        assert(values.end >= min && values.end <= max),
-        assert(divisions == null || divisions > 0),
-        super(key: key);
+       assert(min != null),
+       assert(max != null),
+       assert(min <= max),
+       assert(values.start <= values.end),
+       assert(values.start >= min && values.start <= max),
+       assert(values.end >= min && values.end <= max),
+       assert(divisions == null || divisions > 0),
+       super(key: key);
 
   /// The currently selected values for this range slider.
   ///
@@ -371,19 +371,19 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       vsync: this,
     );
     enableController = AnimationController(
-        duration: enableAnimationDuration,
-        vsync: this,
-        value: widget.onChanged != null ? 1.0 : 0.0
+      duration: enableAnimationDuration,
+      vsync: this,
+      value: widget.onChanged != null ? 1.0 : 0.0,
     );
     startPositionController = AnimationController(
-        duration: Duration.zero,
-        vsync: this,
-        value: _unlerp(widget.values.start)
+      duration: Duration.zero,
+      vsync: this,
+      value: _unlerp(widget.values.start),
     );
     endPositionController = AnimationController(
-        duration: Duration.zero,
-        vsync: this,
-        value: _unlerp(widget.values.end)
+      duration: Duration.zero,
+      vsync: this,
+      value: _unlerp(widget.values.end),
     );
   }
 
@@ -1005,12 +1005,12 @@ class _RenderRangeSlider extends RenderBox {
         _state.valueIndicatorController.forward();
         _state.interactionTimer?.cancel();
         _state.interactionTimer =
-            Timer(_minimumInteractionTime * timeDilation, () {
-              _state.interactionTimer = null;
-              if (!_active && _state.valueIndicatorController.status == AnimationStatus.completed) {
-                _state.valueIndicatorController.reverse();
-              }
-            });
+          Timer(_minimumInteractionTime * timeDilation, () {
+            _state.interactionTimer = null;
+            if (!_active && _state.valueIndicatorController.status == AnimationStatus.completed) {
+              _state.valueIndicatorController.reverse();
+            }
+          });
       }
     }
   }

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -463,16 +463,17 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       double tapValue,
       Size thumbSize,
       Size trackSize,
-      double dx, // drag displacement
+      double dx, // The horizontal delta or displacement of the drag update.
     ) {
     final double touchRadius = math.max(thumbSize.width, RangeSlider._minTouchTargetWidth) / 2;
     final bool inStartTouchTarget = (tapValue - values.start).abs() * trackSize.width < touchRadius;
     final bool inEndTouchTarget = (tapValue - values.end).abs() * trackSize.width < touchRadius;
 
-    // Use the displacement if the thumb touch targets overlap. If dx is 0 and
-    // the the drag position is in both touch targets, no thumb is selected
-    // because it is ambiguous to which thumb should be selected. Once the drag
-    // displacement is non-zero, the thumb selection can be determined.
+    // Use dx if the thumb touch targets overlap. If dx is 0 and the drag
+    // position is in both touch targets, no thumb is selected because it is
+    // ambiguous to which thumb should be selected. If the dx is non-zero, the
+    // thumb selection is determined by the direction of the dx. The left thumb
+    // is chosen for negative dx, and the right thumb is chosen for positive dx.
     if (inStartTouchTarget && inEndTouchTarget) {
       bool towardsStart;
       bool towardsEnd;
@@ -1018,8 +1019,8 @@ class _RenderRangeSlider extends RenderBox {
     final double dragValue = _getValueFromGlobalPosition(details.globalPosition);
 
     // If no selection has been made yet, test for thumb selection again now
-    // that the value of dx is non-zero. If this is the first selection of the
-    // interaction, then onChangeStart must be called.
+    // that the value of dx can be non-zero. If this is the first selection of
+    // the interaction, then onChangeStart must be called.
     bool shouldCallOnChangeStart = false;
     if (_lastThumbSelection == null) {
       _lastThumbSelection = sliderTheme.thumbSelector(textDirection, values, dragValue, _thumbSize, size, details.delta.dx);

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -49,7 +49,8 @@ void main() {
     await tester.pump();
     expect(values, equals(const RangeValues(0.3, 0.7)));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -103,7 +104,8 @@ void main() {
     await tester.pump();
     expect(values, equals(const RangeValues(0.3, 0.7)));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -160,7 +162,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(values, equals(const RangeValues(30, 70)));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -219,7 +222,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(values, equals(const RangeValues(30, 70)));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -267,7 +271,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -311,7 +316,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -358,7 +364,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -405,7 +412,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -449,7 +457,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -499,7 +508,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -552,7 +562,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -605,7 +616,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -655,7 +667,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -705,7 +718,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -758,7 +772,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -811,7 +826,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -871,7 +887,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -926,7 +943,8 @@ void main() {
       ),
     );
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
 
@@ -1343,7 +1361,8 @@ void main() {
 
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;
@@ -1412,7 +1431,8 @@ void main() {
 
     final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
 
-    // Get the bounds of the track by shifting by the the overlay radius.
+    // Get the bounds of the track by finding the slider edges and translating
+    // inwards by the overlay radius.
     final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
     final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
     final Offset middle = topLeft + bottomRight / 2;

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -833,6 +833,123 @@ void main() {
     expect(values.end, closeTo(80, 0.01));
   });
 
+  testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by tap', (WidgetTester tester) async {
+    RangeValues values = const RangeValues(30, 70);
+    RangeValues startValues;
+    RangeValues endValues;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MediaQuery(
+              data: MediaQueryData.fromWindow(window),
+              child: Material(
+                child: Center(
+                  child: RangeSlider(
+                    values: values,
+                    min: 0,
+                    max: 100,
+                    onChanged: (RangeValues newValues) {
+                      setState(() {
+                        values = newValues;
+                      });
+                    },
+                    onChangeStart: (RangeValues newValues) {
+                      startValues = newValues;
+                    },
+                    onChangeEnd: (RangeValues newValues) {
+                      endValues = newValues;
+                    },
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Get the bounds of the track by shifting by the the overlay radius.
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
+    final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
+
+    // Drag the start thumb towards the center.
+    final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
+    expect(startValues, null);
+    expect(endValues, null);
+    await tester.dragFrom(leftTarget, (bottomRight - topLeft) * 0.2);
+    expect(startValues.start, closeTo(30, 1));
+    expect(startValues.end, closeTo(70, 1));
+    expect(values.start, closeTo(50, 1));
+    expect(values.end, closeTo(70, 1));
+    expect(endValues.start, closeTo(50, 1));
+    expect(endValues.end, closeTo(70, 1));
+  });
+
+  testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by drag', (WidgetTester tester) async {
+    RangeValues values = const RangeValues(30, 70);
+    RangeValues startValues;
+    RangeValues endValues;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MediaQuery(
+              data: MediaQueryData.fromWindow(window),
+              child: Material(
+                child: Center(
+                  child: RangeSlider(
+                    values: values,
+                    min: 0,
+                    max: 100,
+                    onChanged: (RangeValues newValues) {
+                      setState(() {
+                        values = newValues;
+                      });
+                    },
+                    onChangeStart: (RangeValues newValues) {
+                      startValues = newValues;
+                    },
+                    onChangeEnd: (RangeValues newValues) {
+                      endValues = newValues;
+                    },
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Get the bounds of the track by shifting by the the overlay radius.
+    final Offset topLeft = tester.getTopLeft(find.byType(RangeSlider)).translate(24, 0);
+    final Offset bottomRight = tester.getBottomRight(find.byType(RangeSlider)).translate(-24, 0);
+
+    // Drag the thumbs together.
+    final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
+    await tester.dragFrom(leftTarget, (bottomRight - topLeft) * 0.2);
+    await tester.pumpAndSettle();
+    final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
+    await tester.dragFrom(rightTarget, (bottomRight - topLeft) * -0.2);
+    await tester.pumpAndSettle();
+    expect(values.start, closeTo(50, 1));
+    expect(values.end, closeTo(51, 1));
+
+    // Drag the end thumb to the right.
+    final Offset middleTarget = topLeft + (bottomRight - topLeft) * 0.5;
+    await tester.dragFrom(middleTarget, (bottomRight - topLeft) * 0.4);
+    await tester.pumpAndSettle();
+    expect(startValues.start, closeTo(50, 1));
+    expect(startValues.end, closeTo(51, 1));
+    expect(endValues.start, closeTo(50, 1));
+    expect(endValues.end, closeTo(90, 1));
+  });
+
   ThemeData _buildTheme() {
     return ThemeData(
         platform: TargetPlatform.android,


### PR DESCRIPTION
## Description

This PR fixes a bug in the Range Sider where the onChangeStart and onChangeEnd were not being called if the initial thumb selection came from a drag (rather than a tap). This only happens when the thumbs are very close together. This was caused due to the onChangeStart and onChangeEnd logic only being in startInteraction and endInteraction. Special cases are now in the dragUpdate method.

## Related Issues

https://github.com/flutter/flutter/issues/34854

## Tests

I added the following tests:

 testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by tap')

 testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by drag')

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
