### PR TITLE
[Material] Support for hovered, focused, and pressed border color on `OutlineButton`s

### DIFF
--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -325,8 +325,8 @@ class _RawMaterialButtonState extends State<RawMaterialButton> {
 
   @override
   Widget build(BuildContext context) {
-    final Color effectiveTextColor = MaterialStateProperty.resolveOrReturn(widget.textStyle?.color, _states);
-    final ShapeBorder effectiveShape =  MaterialStateProperty.resolveOrReturn(widget.shape, _states);
+    final Color effectiveTextColor = MaterialStateProperty.resolveAs<Color>(widget.textStyle?.color, _states);
+    final ShapeBorder effectiveShape =  MaterialStateProperty.resolveAs<ShapeBorder>(widget.shape, _states);
 
     final Widget result = Focus(
       focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -325,9 +325,8 @@ class _RawMaterialButtonState extends State<RawMaterialButton> {
 
   ShapeBorder get _effectiveShape {
     final dynamic widgetShape = widget.shape;
-    if (widgetShape is MaterialStateProperty<ShapeBorder>) {
+    if (widgetShape is MaterialStateProperty<ShapeBorder>)
       return widgetShape.resolve(_states);
-    }
     return widget.shape;
   }
 

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -87,7 +87,7 @@ class RawMaterialButton extends StatefulWidget {
   /// Defines the default text style, with [Material.textStyle], for the
   /// button's [child].
   ///
-  /// If [textStyle.color] is a [MaterialStateProperty], [MaterialStateProperty.resolve]
+  /// If [textStyle.color] is a [MaterialStateProperty<Color>], [MaterialStateProperty.resolve]
   /// is used for the following [MaterialState]s:
   ///
   ///  * [MaterialState.pressed].
@@ -200,7 +200,7 @@ class RawMaterialButton extends StatefulWidget {
   /// The button's highlight and splash are clipped to this shape. If the
   /// button has an elevation, then its drop shadow is defined by this shape.
   ///
-  /// If [shape] is a [MaterialStateProperty], [MaterialStateProperty.resolve]
+  /// If [shape] is a [MaterialStateProperty<ShapeBorder>], [MaterialStateProperty.resolve]
   /// is used for the following [MaterialState]s:
   ///
   /// * [MaterialState.pressed].
@@ -323,17 +323,10 @@ class _RawMaterialButtonState extends State<RawMaterialButton> {
     return widget.elevation;
   }
 
-  ShapeBorder get _effectiveShape {
-    final dynamic widgetShape = widget.shape;
-    if (widgetShape is MaterialStateProperty<ShapeBorder>)
-      return widgetShape.resolve(_states);
-    return widget.shape;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final Color effectiveTextColor = MaterialStateColor.resolveColor(widget.textStyle?.color, _states);
-    final ShapeBorder effectiveShape = _effectiveShape;
+    final Color effectiveTextColor = MaterialStateProperty.resolveOrReturn(widget.textStyle?.color, _states);
+    final ShapeBorder effectiveShape =  MaterialStateProperty.resolveOrReturn(widget.shape, _states);
 
     final Widget result = Focus(
       focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/outline_button.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button_theme.dart';
@@ -318,6 +319,16 @@ class _RawMaterialButtonState extends State<RawMaterialButton> {
   @override
   Widget build(BuildContext context) {
     final Color effectiveTextColor = MaterialStateColor.resolveColor(widget.textStyle?.color, _states);
+
+    ShapeBorder effectiveShape = widget.shape;
+    if (effectiveShape is OutlineBorder) {
+      final OutlineBorder typedShape = effectiveShape;
+      final Color resolvedBorderColor = MaterialStateColor.resolveColor(typedShape.side.color, _states);
+      effectiveShape = OutlineBorder(
+        shape: typedShape.shape,
+        side: typedShape.side.copyWith(color: resolvedBorderColor),
+      );
+    }
 
     final Widget result = Focus(
       focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -481,11 +481,10 @@ class ButtonThemeData extends Diagnosticable {
   /// Otherwise the color scheme's [ColorScheme.onSurface] color is returned
   /// with its opacity set to 0.30 if [getBrightness] is dark, 0.38 otherwise.
   ///
-  /// If [MaterialButton.textColor] is a [MaterialStateColor], it will be used
-  /// as the `disabledTextColor`. It will be resolved in the
-  /// [MaterialState.disabled] state.
+  /// If [MaterialButton.textColor] is a [MaterialStateProperty], it will be
+  /// used as the `disabledTextColor`. It will be resolved in the [MaterialState.disabled] state.
   Color getDisabledTextColor(MaterialButton button) {
-    if (button.textColor is MaterialStateColor)
+    if (button.textColor is MaterialStateProperty<Color>)
       return button.textColor;
     if (button.disabledTextColor != null)
       return button.disabledTextColor;

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -481,7 +481,7 @@ class ButtonThemeData extends Diagnosticable {
   /// Otherwise the color scheme's [ColorScheme.onSurface] color is returned
   /// with its opacity set to 0.30 if [getBrightness] is dark, 0.38 otherwise.
   ///
-  /// If [MaterialButton.textColor] is a [MaterialStateProperty], it will be
+  /// If [MaterialButton.textColor] is a [MaterialStateProperty<Color>], it will be
   /// used as the `disabledTextColor`. It will be resolved in the [MaterialState.disabled] state.
   Color getDisabledTextColor(MaterialButton button) {
     if (button.textColor is MaterialStateProperty<Color>)

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -100,8 +100,8 @@ class MaterialButton extends StatelessWidget {
   /// The default text color depends on the button theme's text theme,
   /// [ButtonThemeData.textTheme].
   ///
-  /// If [textColor] is a [MaterialStateProperty], [disabledTextColor] will be
-  /// ignored.
+  /// If [textColor] is a [MaterialStateProperty<Color>], [disabledTextColor]
+  /// will be ignored.
   ///
   /// See also:
   ///
@@ -117,8 +117,8 @@ class MaterialButton extends StatelessWidget {
   /// The default value is the theme's disabled color,
   /// [ThemeData.disabledColor].
   ///
-  /// If [textColor] is a [MaterialStateProperty], [disabledTextColor] will be
-  /// ignored.
+  /// If [textColor] is a [MaterialStateProperty<Color>], [disabledTextColor]
+  /// will be ignored.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -100,7 +100,7 @@ class MaterialButton extends StatelessWidget {
   /// The default text color depends on the button theme's text theme,
   /// [ButtonThemeData.textTheme].
   ///
-  /// If [textColor] is a [MaterialStateColor], [disabledTextColor] will be
+  /// If [textColor] is a [MaterialStateProperty], [disabledTextColor] will be
   /// ignored.
   ///
   /// See also:
@@ -117,7 +117,7 @@ class MaterialButton extends StatelessWidget {
   /// The default value is the theme's disabled color,
   /// [ThemeData.disabledColor].
   ///
-  /// If [textColor] is a [MaterialStateColor], [disabledTextColor] will be
+  /// If [textColor] is a [MaterialStateProperty], [disabledTextColor] will be
   /// ignored.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -195,7 +195,7 @@ abstract class MaterialStateProperty<T> {
   /// This is useful for widgets that have parameters which can optionally be a
   /// [MaterialStateProperty]. For example, [RaisedButton.textColor] can be a
   /// [Color] or a [MaterialStateProperty<Color>].
-  static T resolveOrReturn<T>(T value, Set<MaterialState> states) {
+  static T resolveAs<T>(T value, Set<MaterialState> states) {
     if (value is MaterialStateProperty<T>) {
       final MaterialStateProperty<T> property = value;
       return property.resolve(states);

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -4,8 +4,6 @@
 
 import 'dart:ui' show Color;
 
-import 'package:flutter/painting.dart';
-
 /// Interactive states that some of the Material widgets can take on when
 /// receiving input from the user.
 ///

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' show Color;
 
+import 'package:flutter/painting.dart';
+
 /// Interactive states that some of the Material widgets can take on when
 /// receiving input from the user.
 ///
@@ -109,7 +111,7 @@ typedef MaterialStateColorResolver = Color Function(Set<MaterialState> states);
 /// ),
 /// ```
 /// {@end-tool}
-abstract class MaterialStateColor extends Color {
+abstract class MaterialStateColor extends Color implements MaterialStateProperty<Color> {
   /// Creates a [MaterialStateColor].
   ///
   /// If you want a `const` [MaterialStateColor], you'll need to extend
@@ -152,6 +154,7 @@ abstract class MaterialStateColor extends Color {
 
   /// Returns a [Color] that's to be used when a Material component is in the
   /// specified state.
+  @override
   Color resolve(Set<MaterialState> states);
 
   /// Returns the color for the given set of states if `color` is a
@@ -183,4 +186,17 @@ class _MaterialStateColor extends MaterialStateColor {
 
   @override
   Color resolve(Set<MaterialState> states) => _resolve(states);
+}
+
+/// Interface for classes that can return a value of type `T` based on a set of [MaterialState]s.
+///
+/// For example, [MaterialStateColor] implements `MaterialStateProperty<Color>` because it has a `resolve` method that
+/// returns a different color depending on the given set of [MaterialState]s.
+abstract class MaterialStateProperty<T> {
+
+  /// Returns a different value of type `T` depending on the given `states`.
+  ///
+  /// Some components (such as [RawMaterialButton]s) keep track of their set of [MaterialState]s, and will call
+  /// `resolve` with the current states at build time for specified properties (such as [RawMaterialButton.textStyle]'s color).
+  T resolve(Set<MaterialState> states);
 }

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -154,19 +154,6 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
   /// specified state.
   @override
   Color resolve(Set<MaterialState> states);
-
-  /// Returns the color for the given set of states if `color` is a
-  /// [MaterialStateProperty], otherwise returns the color itself.
-  ///
-  /// This is useful for widgets that have parameters which can be [Color] or
-  /// `MaterialStateProperty<Color>` values.
-  static Color resolveColor(Color color, Set<MaterialState> states) {
-    final dynamic dynamicColor = color;
-    if (dynamicColor is MaterialStateProperty<Color>) {
-      return dynamicColor.resolve(states);
-    }
-    return color;
-  }
 }
 
 /// A [MaterialStateColor] created from a [MaterialStateColorResolver] callback alone.
@@ -201,4 +188,18 @@ abstract class MaterialStateProperty<T> {
   /// [MaterialState]s, and will call `resolve` with the current states at build
   /// time for specified properties (such as [RawMaterialButton.textStyle]'s color).
   T resolve(Set<MaterialState> states);
+
+  /// Returns the value resolved in the given set of states if `value` is a
+  /// [MaterialStateProperty], otherwise returns the value itself.
+  ///
+  /// This is useful for widgets that have parameters which can optionally be a
+  /// [MaterialStateProperty]. For example, [RaisedButton.textColor] can be a
+  /// [Color] or a [MaterialStateProperty<Color>].
+  static T resolveOrReturn<T>(T value, Set<MaterialState> states) {
+    if (value is MaterialStateProperty<T>) {
+      final MaterialStateProperty<T> property = value;
+      return property.resolve(states);
+    }
+    return value;
+  }
 }

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -62,8 +62,9 @@ enum MaterialState {
   error,
 }
 
-/// Signature for the function that returns a color based on a given set of states.
-typedef MaterialStateColorResolver = Color Function(Set<MaterialState> states);
+/// Signature for the function that returns a value of type `T` based on a given
+/// set of states.
+typedef MaterialPropertyResolver<T> = T Function(Set<MaterialState> states);
 
 /// Defines a [Color] whose value depends on a set of [MaterialState]s which
 /// represent the interactive state of a component.
@@ -141,14 +142,15 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
   /// {@end-tool}
   const MaterialStateColor(int defaultValue) : super(defaultValue);
 
-  /// Creates a [MaterialStateColor] from a [MaterialStateColorResolver] callback function.
+  /// Creates a [MaterialStateColor] from a [MaterialPropertyResolver<Color>]
+  /// callback function.
   ///
   /// If used as a regular color, the color resolved in the default state (the
   /// empty set of states) will be used.
   ///
   /// The given callback parameter must return a non-null color in the default
   /// state.
-  factory MaterialStateColor.resolveWith(MaterialStateColorResolver callback) => _MaterialStateColor(callback);
+  static MaterialStateColor resolveWith(MaterialPropertyResolver<Color> callback) => _MaterialStateColor(callback);
 
   /// Returns a [Color] that's to be used when a Material component is in the
   /// specified state.
@@ -156,7 +158,8 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
   Color resolve(Set<MaterialState> states);
 }
 
-/// A [MaterialStateColor] created from a [MaterialStateColorResolver] callback alone.
+/// A [MaterialStateColor] created from a [MaterialPropertyResolver<Color>]
+/// callback alone.
 ///
 /// If used as a regular color, the color resolved in the default state will
 /// be used.
@@ -165,7 +168,7 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
 class _MaterialStateColor extends MaterialStateColor {
   _MaterialStateColor(this._resolve) : super(_resolve(_defaultStates).value);
 
-  final MaterialStateColorResolver _resolve;
+  final MaterialPropertyResolver<Color> _resolve;
 
   /// The default state for a Material component, the empty set of interaction states.
   static const Set<MaterialState> _defaultStates = <MaterialState>{};
@@ -202,4 +205,17 @@ abstract class MaterialStateProperty<T> {
     }
     return value;
   }
+
+  /// Convenience method for creating a [MaterialStateProperty] from a
+  /// [MaterialPropertyResolver] function alone.
+  static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) => _MaterialStateProperty<T>(callback);
+}
+
+class _MaterialStateProperty<T> implements MaterialStateProperty<T> {
+  _MaterialStateProperty(this._resolve);
+
+  final MaterialPropertyResolver<T> _resolve;
+
+  @override
+  T resolve(Set<MaterialState> states) => _resolve(states);
 }

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -193,13 +193,13 @@ class _MaterialStateColor extends MaterialStateColor {
 /// [MaterialState]s.
 ///
 /// For example, [MaterialStateColor] implements `MaterialStateProperty<Color>`
-/// because it has a `resolve` method that returns a different color depending
+/// because it has a `resolve` method that returns a different [Color] depending
 /// on the given set of [MaterialState]s.
 abstract class MaterialStateProperty<T> {
 
   /// Returns a different value of type `T` depending on the given `states`.
   ///
-  /// Some components (such as [RawMaterialButton]s) keep track of their set of
+  /// Some widgets (such as [RawMaterialButton]) keep track of their set of
   /// [MaterialState]s, and will call `resolve` with the current states at build
   /// time for specified properties (such as [RawMaterialButton.textStyle]'s color).
   T resolve(Set<MaterialState> states);

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -158,13 +158,14 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
   Color resolve(Set<MaterialState> states);
 
   /// Returns the color for the given set of states if `color` is a
-  /// [MaterialStateColor], otherwise returns the color itself.
+  /// [MaterialStateProperty], otherwise returns the color itself.
   ///
   /// This is useful for widgets that have parameters which can be [Color] or
-  /// [MaterialStateColor] values.
+  /// `MaterialStateProperty<Color>` values.
   static Color resolveColor(Color color, Set<MaterialState> states) {
-    if (color is MaterialStateColor) {
-      return color.resolve(states);
+    final dynamic dynamicColor = color;
+    if (dynamicColor is MaterialStateProperty<Color>) {
+      return dynamicColor.resolve(states);
     }
     return color;
   }
@@ -188,15 +189,18 @@ class _MaterialStateColor extends MaterialStateColor {
   Color resolve(Set<MaterialState> states) => _resolve(states);
 }
 
-/// Interface for classes that can return a value of type `T` based on a set of [MaterialState]s.
+/// Interface for classes that can return a value of type `T` based on a set of
+/// [MaterialState]s.
 ///
-/// For example, [MaterialStateColor] implements `MaterialStateProperty<Color>` because it has a `resolve` method that
-/// returns a different color depending on the given set of [MaterialState]s.
+/// For example, [MaterialStateColor] implements `MaterialStateProperty<Color>`
+/// because it has a `resolve` method that returns a different color depending
+/// on the given set of [MaterialState]s.
 abstract class MaterialStateProperty<T> {
 
   /// Returns a different value of type `T` depending on the given `states`.
   ///
-  /// Some components (such as [RawMaterialButton]s) keep track of their set of [MaterialState]s, and will call
-  /// `resolve` with the current states at build time for specified properties (such as [RawMaterialButton.textStyle]'s color).
+  /// Some components (such as [RawMaterialButton]s) keep track of their set of
+  /// [MaterialState]s, and will call `resolve` with the current states at build
+  /// time for specified properties (such as [RawMaterialButton.textStyle]'s color).
   T resolve(Set<MaterialState> states);
 }

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -387,7 +387,6 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
       return widget.highlightedBorderColor;
     }
     return widget.borderSide?.color;
-
   }
 
   BorderSide _getOutline() {

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -134,7 +134,7 @@ class OutlineButton extends MaterialButton {
   /// By default the border's color does not change when the button
   /// is pressed.
   ///
-  /// This field is ignored if [borderSide.color] is a [MaterialStateProperty].
+  /// This field is ignored if [borderSide.color] is a [MaterialStateProperty<Color>].
   final Color highlightedBorderColor;
 
   /// The outline border's color when the button is not [enabled].
@@ -142,7 +142,7 @@ class OutlineButton extends MaterialButton {
   /// By default the outline border's color does not change when the
   /// button is disabled.
   ///
-  /// This field is ignored if [borderSide.color] is a [MaterialStateProperty].
+  /// This field is ignored if [borderSide.color] is a [MaterialStateProperty<Color>].
   final Color disabledBorderColor;
 
   /// Defines the color of the border when the button is enabled but not
@@ -154,7 +154,7 @@ class OutlineButton extends MaterialButton {
   /// If null the default border's style is [BorderStyle.solid], its
   /// [BorderSide.width] is 1.0, and its color is a light shade of grey.
   ///
-  /// If [borderSide.color] is a [MaterialStateProperty], [MaterialStateProperty.resolve]
+  /// If [borderSide.color] is a [MaterialStateProperty<Color>], [MaterialStateProperty.resolve]
   /// is used in all states and both [highlightedBorderColor] and [disabledBorderColor]
   /// are ignored.
   final BorderSide borderSide;
@@ -534,7 +534,7 @@ class _OutlineBorder extends ShapeBorder implements MaterialStateProperty<ShapeB
   ShapeBorder resolve(Set<MaterialState> states) {
     return _OutlineBorder(
       shape: shape,
-      side: side.copyWith(color: MaterialStateColor.resolveColor(side.color, states),
+      side: side.copyWith(color: MaterialStateProperty.resolveOrReturn(side.color, states),
     ));
   }
 }

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -380,12 +380,10 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
   }
 
   Color get _currentOutlineColor {
-    if (!widget.enabled) {
+    if (!widget.enabled)
       return widget.disabledBorderColor;
-    }
-    if (_pressed) {
+    if (_pressed)
       return widget.highlightedBorderColor;
-    }
     return widget.borderSide?.color;
   }
 

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -534,7 +534,7 @@ class _OutlineBorder extends ShapeBorder implements MaterialStateProperty<ShapeB
   ShapeBorder resolve(Set<MaterialState> states) {
     return _OutlineBorder(
       shape: shape,
-      side: side.copyWith(color: MaterialStateProperty.resolveOrReturn(side.color, states),
+      side: side.copyWith(color: MaterialStateProperty.resolveAs<Color>(side.color, states),
     ));
   }
 }

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -379,7 +379,11 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
     return colorTween.evaluate(_fillAnimation);
   }
 
-  Color get _currentOutlineColor {
+  Color get _outlineColor {
+    // If outline color is a `MaterialStateProperty`, it will be used in all
+    // states, otherwise we determine the outline color in the current state.
+    if (widget.borderSide?.color is MaterialStateProperty<Color>)
+      return widget.borderSide.color;
     if (!widget.enabled)
       return widget.disabledBorderColor;
     if (_pressed)
@@ -391,18 +395,10 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
     if (widget.borderSide?.style == BorderStyle.none)
       return widget.borderSide;
 
-    Color specifiedColor;
-    // If outline color is a `MaterialStateProperty`, it will be used in all
-    // states, otherwise we determine the outline color in the current state.
-    if (widget.borderSide?.color is MaterialStateProperty<Color>) {
-      specifiedColor = widget.borderSide?.color;
-    } else {
-      specifiedColor = _currentOutlineColor;
-    }
     final Color themeColor = Theme.of(context).colorScheme.onSurface.withOpacity(0.12);
 
     return BorderSide(
-      color: specifiedColor ?? themeColor,
+      color: _outlineColor ?? themeColor,
       width: widget.borderSide?.width ?? 1.0,
     );
   }

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import 'button.dart';
 import 'button_theme.dart';
 import 'colors.dart';
 import 'material_button.dart';
@@ -417,7 +418,7 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
           highlightElevation: _getHighlightElevation(),
           onHighlightChanged: _handleHighlightChanged,
           padding: widget.padding,
-          shape: _OutlineBorder(
+          shape: OutlineBorder(
             shape: widget.shape,
             side: _getOutline(),
           ),
@@ -433,8 +434,8 @@ class _OutlineButtonState extends State<_OutlineButton> with SingleTickerProvide
 
 // Render the button's outline border using using the OutlineButton's
 // border parameters and the button or buttonTheme's shape.
-class _OutlineBorder extends ShapeBorder {
-  const _OutlineBorder({
+class OutlineBorder extends ShapeBorder {
+  const OutlineBorder({
     @required this.shape,
     @required this.side,
   }) : assert(shape != null),
@@ -450,7 +451,7 @@ class _OutlineBorder extends ShapeBorder {
 
   @override
   ShapeBorder scale(double t) {
-    return _OutlineBorder(
+    return OutlineBorder(
       shape: shape.scale(t),
       side: side.scale(t),
     );
@@ -459,8 +460,8 @@ class _OutlineBorder extends ShapeBorder {
   @override
   ShapeBorder lerpFrom(ShapeBorder a, double t) {
     assert(t != null);
-    if (a is _OutlineBorder) {
-      return _OutlineBorder(
+    if (a is OutlineBorder) {
+      return OutlineBorder(
         side: BorderSide.lerp(a.side, side, t),
         shape: ShapeBorder.lerp(a.shape, shape, t),
       );
@@ -471,8 +472,8 @@ class _OutlineBorder extends ShapeBorder {
   @override
   ShapeBorder lerpTo(ShapeBorder b, double t) {
     assert(t != null);
-    if (b is _OutlineBorder) {
-      return _OutlineBorder(
+    if (b is OutlineBorder) {
+      return OutlineBorder(
         side: BorderSide.lerp(side, b.side, t),
         shape: ShapeBorder.lerp(shape, b.shape, t),
       );
@@ -506,7 +507,7 @@ class _OutlineBorder extends ShapeBorder {
       return true;
     if (runtimeType != other.runtimeType)
       return false;
-    final _OutlineBorder typedOther = other;
+    final OutlineBorder typedOther = other;
     return side == typedOther.side && shape == typedOther.shape;
   }
 

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -318,6 +318,139 @@ void main() {
     expect(textColor(), isNot(unusedDisabledTextColor));
   });
 
+  testWidgets('OutlineButton uses stateful color for border color in different states', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+
+    const Color pressedColor = Color(1);
+    const Color hoverColor = Color(2);
+    const Color focusedColor = Color(3);
+    const Color defaultColor = Color(4);
+
+    Color getBorderColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.pressed)) {
+        return pressedColor;
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return hoverColor;
+      }
+      if (states.contains(MaterialState.focused)) {
+        return focusedColor;
+      }
+      return defaultColor;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: OutlineButton(
+              child: const Text('OutlineButton'),
+              onPressed: () {},
+              focusNode: focusNode,
+              borderSide: BorderSide(color: MaterialStateColor.resolveWith(getBorderColor)),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder outlineButton = find.byType(OutlineButton);
+
+    // Default, not disabled.
+    expect(outlineButton, paints..path(color: defaultColor));
+
+    // Focused.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(outlineButton, paints..path(color: focusedColor));
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(OutlineButton));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(outlineButton, paints..path(color: hoverColor));
+
+    // Highlighted (pressed).
+    await gesture.down(center);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(outlineButton, paints..path(color: pressedColor));
+    await gesture.removePointer();
+  });
+
+  testWidgets('OutlineButton ignores highlightBorderColor if border color is stateful', (WidgetTester tester) async {
+    const Color pressedColor = Color(1);
+    const Color defaultColor = Color(2);
+    const Color ignoredPressedColor = Color(3);
+
+    Color getBorderColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.pressed)) {
+        return pressedColor;
+      }
+      return defaultColor;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: OutlineButton(
+              child: const Text('OutlineButton'),
+              onPressed: () {},
+              borderSide: BorderSide(color: MaterialStateColor.resolveWith(getBorderColor)),
+              highlightedBorderColor: ignoredPressedColor,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder outlineButton = find.byType(OutlineButton);
+
+    // Default, not disabled.
+    expect(outlineButton, paints..path(color: defaultColor));
+
+    // Highlighted (pressed).
+    await tester.press(outlineButton);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(outlineButton, paints..path(color: pressedColor));
+  });
+
+  testWidgets('OutlineButton ignores disabledBorderColor if border color is stateful', (WidgetTester tester) async {
+    const Color disabledColor = Color(1);
+    const Color defaultColor = Color(2);
+    const Color ignoredDisabledColor = Color(3);
+
+    Color getBorderColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return disabledColor;
+      }
+      return defaultColor;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: OutlineButton(
+              child: const Text('OutlineButton'),
+              borderSide: BorderSide(color: MaterialStateColor.resolveWith(getBorderColor)),
+              highlightedBorderColor: ignoredDisabledColor,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Disabled.
+    expect(find.byType(OutlineButton), paints..path(color: disabledColor));
+  });
+
   testWidgets('Outline button responds to tap when enabled', (WidgetTester tester) async {
     int pressedCount = 0;
 

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -376,8 +376,7 @@ void main() {
 
     // Highlighted (pressed).
     await gesture.down(center);
-    await tester.pump(); // Start the splash and highlight animations.
-    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    await tester.pumpAndSettle();
     expect(outlineButton, paints..path(color: pressedColor));
     await gesture.removePointer();
   });
@@ -416,8 +415,7 @@ void main() {
 
     // Highlighted (pressed).
     await tester.press(outlineButton);
-    await tester.pump(); // Start the splash and highlight animations.
-    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    await tester.pumpAndSettle();
     expect(outlineButton, paints..path(color: pressedColor));
   });
 

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -439,6 +439,7 @@ void main() {
           body: Center(
             child: OutlineButton(
               child: const Text('OutlineButton'),
+              onPressed: null,
               borderSide: BorderSide(color: MaterialStateColor.resolveWith(getBorderColor)),
               highlightedBorderColor: ignoredDisabledColor,
             ),


### PR DESCRIPTION
## Description

This PR adds support for defining the border color of outline buttons when the button is in the hovered, focused, pressed, or disabled states.

For example, here we use a custom `OutlineButton.borderSide` to get the border to change color to light blue on hover, and then dark blue on press. 

![border](https://user-images.githubusercontent.com/4229329/59945249-0637ab80-9435-11e9-9739-cccd5e4affb5.gif)

## Tests

I added the following tests:

* `OutlineButton` border color can be customized in `pressed`, `hovered`, `focused`, and `disabled` states.
* `OutlineButton` border color ignores `highlightedBorderColor` and `disabledBorderColor` if `borderSide.color` is a stateful color, instead, it uses `borderSide.color` in all states.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
