### PR TITLE
Remove flutter_tools support for old AOT snapshotting

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -268,13 +268,6 @@ class FlutterPlugin implements Plugin<Project> {
         }
     }
 
-    private static Boolean getBuildShareLibrary(Project project) {
-        if (project.hasProperty('build-shared-library')) {
-            return project.property('build-shared-library').toBoolean()
-        }
-        return false;
-    }
-
     private static Boolean splitPerAbi(Project project) {
         if (project.hasProperty('split-per-abi')) {
             return project.property('split-per-abi').toBoolean()
@@ -645,7 +638,6 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "build", "aot"
                 args "--suppress-analytics"
                 args "--quiet"
-                args "--build-shared-library"
                 args "--target", targetPath
                 args "--output-dir", "${intermediateDir}"
                 args "--target-platform", "${targetPlatform}"

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -28,11 +28,6 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
         allowed: <String>['android-arm', 'android-arm64', 'ios'],
       )
       ..addFlag('quiet', defaultsTo: false)
-      ..addFlag('build-shared-library',
-        negatable: false,
-        defaultsTo: false,
-        help: 'Compile to a *.so file (requires NDK when building for Android).',
-      )
       ..addFlag('report-timings',
         negatable: false,
         defaultsTo: false,
@@ -122,7 +117,6 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
             mainPath: mainPath,
             packagesPath: PackageMap.globalPackagesPath,
             outputPath: outputPath,
-            buildSharedLibrary: false,
             extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
           ).then<int>((int buildExitCode) {
             return buildExitCode;
@@ -152,7 +146,6 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
           mainPath: mainPath,
           packagesPath: PackageMap.globalPackagesPath,
           outputPath: outputPath,
-          buildSharedLibrary: argResults['build-shared-library'],
           extraGenSnapshotOptions: argResults[FlutterOptions.kExtraGenSnapshotOptions],
         );
         if (snapshotExitCode != 0) {

--- a/packages/flutter_tools/test/base/build_test.dart
+++ b/packages/flutter_tools/test/base/build_test.dart
@@ -135,7 +135,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
       ), isNot(equals(0)));
     }, overrides: contextOverrides);
 
@@ -147,7 +146,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
       ), isNot(0));
     }, overrides: contextOverrides);
 
@@ -159,7 +157,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
       ), isNot(0));
     }, overrides: contextOverrides);
 
@@ -183,7 +180,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
         iosArch: IOSArch.armv7,
       );
 
@@ -221,7 +217,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
         iosArch: IOSArch.arm64,
       );
 
@@ -233,90 +228,6 @@ void main() {
         '--deterministic',
         '--snapshot_kind=app-aot-assembly',
         '--assembly=${fs.path.join(outputPath, 'snapshot_assembly.S')}',
-        'main.dill',
-      ]);
-    }, overrides: contextOverrides);
-
-    testUsingContext('builds Android arm profile AOT snapshot', () async {
-      fs.file('main.dill').writeAsStringSync('binary magic');
-
-      final String outputPath = fs.path.join('build', 'foo');
-      fs.directory(outputPath).createSync(recursive: true);
-
-      genSnapshot.outputs = <String, String>{
-        fs.path.join(outputPath, 'vm_snapshot_data'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_data'): '',
-        fs.path.join(outputPath, 'vm_snapshot_instr'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_instr'): '',
-      };
-
-      final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-
-      final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm,
-        buildMode: BuildMode.profile,
-        mainPath: 'main.dill',
-        packagesPath: '.packages',
-        outputPath: outputPath,
-        buildSharedLibrary: false,
-      );
-
-      expect(genSnapshotExitCode, 0);
-      expect(genSnapshot.callCount, 1);
-      expect(genSnapshot.snapshotType.platform, TargetPlatform.android_arm);
-      expect(genSnapshot.snapshotType.mode, BuildMode.profile);
-      expect(genSnapshot.additionalArgs, <String>[
-        '--deterministic',
-        '--snapshot_kind=app-aot-blobs',
-        '--vm_snapshot_data=build/foo/vm_snapshot_data',
-        '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
-        '--vm_snapshot_instructions=build/foo/vm_snapshot_instr',
-        '--isolate_snapshot_instructions=build/foo/isolate_snapshot_instr',
-        '--no-sim-use-hardfp',
-        '--no-use-integer-division',
-        'main.dill',
-      ]);
-    }, overrides: contextOverrides);
-
-    testUsingContext('builds Android arm64 profile AOT snapshot', () async {
-      fs.file('main.dill').writeAsStringSync('binary magic');
-
-      final String outputPath = fs.path.join('build', 'foo');
-      fs.directory(outputPath).createSync(recursive: true);
-
-      genSnapshot.outputs = <String, String>{
-        fs.path.join(outputPath, 'vm_snapshot_data'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_data'): '',
-        fs.path.join(outputPath, 'vm_snapshot_instr'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_instr'): '',
-      };
-
-      final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-
-      final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm64,
-        buildMode: BuildMode.profile,
-        mainPath: 'main.dill',
-        packagesPath: '.packages',
-        outputPath: outputPath,
-        buildSharedLibrary: false,
-      );
-
-      expect(genSnapshotExitCode, 0);
-      expect(genSnapshot.callCount, 1);
-      expect(genSnapshot.snapshotType.platform, TargetPlatform.android_arm64);
-      expect(genSnapshot.snapshotType.mode, BuildMode.profile);
-      expect(genSnapshot.additionalArgs, <String>[
-        '--deterministic',
-        '--snapshot_kind=app-aot-blobs',
-        '--vm_snapshot_data=build/foo/vm_snapshot_data',
-        '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
-        '--vm_snapshot_instructions=build/foo/vm_snapshot_instr',
-        '--isolate_snapshot_instructions=build/foo/isolate_snapshot_instr',
         'main.dill',
       ]);
     }, overrides: contextOverrides);
@@ -341,7 +252,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
         iosArch: IOSArch.armv7,
       );
 
@@ -379,7 +289,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
         iosArch: IOSArch.arm64,
       );
 
@@ -407,7 +316,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: true,
       );
 
       expect(genSnapshotExitCode, 0);
@@ -437,7 +345,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: true,
       );
 
       expect(genSnapshotExitCode, 0);
@@ -453,90 +360,6 @@ void main() {
       ]);
     }, overrides: contextOverrides);
 
-    testUsingContext('builds Android arm release AOT snapshot', () async {
-      fs.file('main.dill').writeAsStringSync('binary magic');
-
-      final String outputPath = fs.path.join('build', 'foo');
-      fs.directory(outputPath).createSync(recursive: true);
-
-      genSnapshot.outputs = <String, String>{
-        fs.path.join(outputPath, 'vm_snapshot_data'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_data'): '',
-        fs.path.join(outputPath, 'vm_snapshot_instr'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_instr'): '',
-      };
-
-      final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-
-      final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm,
-        buildMode: BuildMode.release,
-        mainPath: 'main.dill',
-        packagesPath: '.packages',
-        outputPath: outputPath,
-        buildSharedLibrary: false,
-      );
-
-      expect(genSnapshotExitCode, 0);
-      expect(genSnapshot.callCount, 1);
-      expect(genSnapshot.snapshotType.platform, TargetPlatform.android_arm);
-      expect(genSnapshot.snapshotType.mode, BuildMode.release);
-      expect(genSnapshot.additionalArgs, <String>[
-        '--deterministic',
-        '--snapshot_kind=app-aot-blobs',
-        '--vm_snapshot_data=build/foo/vm_snapshot_data',
-        '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
-        '--vm_snapshot_instructions=build/foo/vm_snapshot_instr',
-        '--isolate_snapshot_instructions=build/foo/isolate_snapshot_instr',
-        '--no-sim-use-hardfp',
-        '--no-use-integer-division',
-        'main.dill',
-      ]);
-    }, overrides: contextOverrides);
-
-    testUsingContext('builds Android arm64 release AOT snapshot', () async {
-      fs.file('main.dill').writeAsStringSync('binary magic');
-
-      final String outputPath = fs.path.join('build', 'foo');
-      fs.directory(outputPath).createSync(recursive: true);
-
-      genSnapshot.outputs = <String, String>{
-        fs.path.join(outputPath, 'vm_snapshot_data'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_data'): '',
-        fs.path.join(outputPath, 'vm_snapshot_instr'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_instr'): '',
-      };
-
-      final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-
-      final int genSnapshotExitCode = await snapshotter.build(
-        platform: TargetPlatform.android_arm64,
-        buildMode: BuildMode.release,
-        mainPath: 'main.dill',
-        packagesPath: '.packages',
-        outputPath: outputPath,
-        buildSharedLibrary: false,
-      );
-
-      expect(genSnapshotExitCode, 0);
-      expect(genSnapshot.callCount, 1);
-      expect(genSnapshot.snapshotType.platform, TargetPlatform.android_arm64);
-      expect(genSnapshot.snapshotType.mode, BuildMode.release);
-      expect(genSnapshot.additionalArgs, <String>[
-        '--deterministic',
-        '--snapshot_kind=app-aot-blobs',
-        '--vm_snapshot_data=build/foo/vm_snapshot_data',
-        '--isolate_snapshot_data=build/foo/isolate_snapshot_data',
-        '--vm_snapshot_instructions=build/foo/vm_snapshot_instr',
-        '--isolate_snapshot_instructions=build/foo/isolate_snapshot_instr',
-        'main.dill',
-      ]);
-    }, overrides: contextOverrides);
-
     testUsingContext('reports timing', () async {
       fs.file('main.dill').writeAsStringSync('binary magic');
 
@@ -544,10 +367,7 @@ void main() {
       fs.directory(outputPath).createSync(recursive: true);
 
       genSnapshot.outputs = <String, String>{
-        fs.path.join(outputPath, 'vm_snapshot_data'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_data'): '',
-        fs.path.join(outputPath, 'vm_snapshot_instr'): '',
-        fs.path.join(outputPath, 'isolate_snapshot_instr'): '',
+        fs.path.join(outputPath, 'app.so'): '',
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
@@ -560,7 +380,6 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        buildSharedLibrary: false,
       );
 
       expect(genSnapshotExitCode, 0);


### PR DESCRIPTION
Android now exclusively uses ELF shared libraries, and
iOS uses assembly.