### PR TITLE
Fix unused [applicationIcon] property on [showLicensePage]

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -192,6 +192,7 @@ void showLicensePage({
     builder: (BuildContext context) => LicensePage(
       applicationName: applicationName,
       applicationVersion: applicationVersion,
+      applicationIcon: applicationIcon,
       applicationLegalese: applicationLegalese,
     )
   ));
@@ -275,7 +276,7 @@ class AboutDialog extends StatelessWidget {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                if (icon != null) IconTheme(data: const IconThemeData(size: 48.0), child: icon),
+                if (icon != null) IconTheme(data: Theme.of(context).iconTheme, child: icon),
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -341,6 +342,7 @@ class LicensePage extends StatefulWidget {
     Key key,
     this.applicationName,
     this.applicationVersion,
+    this.applicationIcon,
     this.applicationLegalese,
   }) : super(key: key);
 
@@ -356,6 +358,14 @@ class LicensePage extends StatefulWidget {
   ///
   /// Defaults to the empty string.
   final String applicationVersion;
+
+  /// The icon to show below the application name.
+  ///
+  /// By default no icon is shown.
+  ///
+  /// Typically this will be an [ImageIcon] widget. It should honor the
+  /// [IconTheme]'s [IconThemeData.size].
+  final Widget applicationIcon;
 
   /// A string to show in small print.
   ///
@@ -455,6 +465,7 @@ class _LicensePageState extends State<LicensePage> {
     assert(debugCheckHasMaterialLocalizations(context));
     final String name = widget.applicationName ?? _defaultApplicationName(context);
     final String version = widget.applicationVersion ?? _defaultApplicationVersion(context);
+    final Widget icon = widget.applicationIcon ?? _defaultApplicationIcon(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
@@ -474,6 +485,7 @@ class _LicensePageState extends State<LicensePage> {
                 padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
                 children: <Widget>[
                   Text(name, style: Theme.of(context).textTheme.headline, textAlign: TextAlign.center),
+                  if (icon != null) IconTheme(data: Theme.of(context).iconTheme, child: icon),
                   Text(version, style: Theme.of(context).textTheme.body1, textAlign: TextAlign.center),
                   Container(height: 18.0),
                   Text(widget.applicationLegalese ?? '', style: Theme.of(context).textTheme.caption, textAlign: TextAlign.center),

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -44,8 +44,10 @@ void main() {
     expect(find.text('About Pirate app'), findsNothing);
     expect(find.text('0.1.2'), findsNothing);
     expect(find.byWidget(logo), findsNothing);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsNothing);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsNothing,
+    );
     expect(find.text('About box'), findsNothing);
 
     await tester.tap(find.byType(IconButton));
@@ -54,8 +56,10 @@ void main() {
     expect(find.text('About Pirate app'), findsOneWidget);
     expect(find.text('0.1.2'), findsNothing);
     expect(find.byWidget(logo), findsNothing);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsNothing);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsNothing,
+    );
     expect(find.text('About box'), findsNothing);
 
     await tester.tap(find.text('About Pirate app'));
@@ -64,8 +68,10 @@ void main() {
     expect(find.text('About Pirate app'), findsOneWidget);
     expect(find.text('0.1.2'), findsOneWidget);
     expect(find.byWidget(logo), findsOneWidget);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsOneWidget);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsOneWidget,
+    );
     expect(find.text('About box'), findsOneWidget);
 
     LicenseRegistry.addLicense(() {
@@ -80,8 +86,10 @@ void main() {
     expect(find.text('Pirate app'), findsOneWidget);
     expect(find.text('0.1.2'), findsOneWidget);
     expect(find.byWidget(logo), findsOneWidget);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsOneWidget);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsOneWidget,
+    );
     expect(find.text('Pirate license'), findsOneWidget);
   }, skip: isBrowser);
 
@@ -105,7 +113,9 @@ void main() {
     LicenseRegistry.addLicense(() {
       return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
         const LicenseEntryWithLineBreaks(
-            <String>['Another package'], 'Another license'),
+          <String>['Another package'],
+          'Another license',
+        ),
       ]);
     });
 
@@ -142,7 +152,9 @@ void main() {
     LicenseRegistry.addLicense(() {
       return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
         const LicenseEntryWithLineBreaks(
-            <String>['Another package'], 'Another license'),
+          <String>['Another package'],
+          'Another license',
+        ),
       ]);
     });
 
@@ -154,8 +166,7 @@ void main() {
             applicationName: 'LicensePage test app',
             applicationVersion: '0.1.2',
             applicationIcon: logo,
-            applicationLegalese:
-                'I am the very model of a modern major general.',
+            applicationLegalese: 'I am the very model of a modern major general.',
           ),
         ),
       ),
@@ -165,8 +176,10 @@ void main() {
     expect(find.text('LicensePage test app'), findsOneWidget);
     expect(find.text('0.1.2'), findsOneWidget);
     expect(find.byWidget(logo), findsOneWidget);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsOneWidget);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsOneWidget,
+    );
     expect(find.text('AAA'), findsNothing);
     expect(find.text('BBB'), findsNothing);
     expect(find.text('Another package'), findsNothing);
@@ -178,8 +191,10 @@ void main() {
     expect(find.text('LicensePage test app'), findsOneWidget);
     expect(find.text('0.1.2'), findsOneWidget);
     expect(find.byWidget(logo), findsOneWidget);
-    expect(find.text('I am the very model of a modern major general.'),
-        findsOneWidget);
+    expect(
+      find.text('I am the very model of a modern major general.'),
+      findsOneWidget,
+    );
     expect(find.text('AAA'), findsOneWidget);
     expect(find.text('BBB'), findsOneWidget);
     expect(find.text('Another package'), findsOneWidget);

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -14,6 +14,8 @@ void main() {
   });
 
   testWidgets('AboutListTile control test', (WidgetTester tester) async {
+    const FlutterLogo logo = FlutterLogo();
+
     await tester.pumpWidget(
       MaterialApp(
         title: 'Pirate app',
@@ -26,7 +28,7 @@ void main() {
               children: const <Widget>[
                 AboutListTile(
                   applicationVersion: '0.1.2',
-                  applicationIcon: FlutterLogo(),
+                  applicationIcon: logo,
                   applicationLegalese: 'I am the very model of a modern major general.',
                   aboutBoxChildren: <Widget>[
                     Text('About box'),
@@ -41,6 +43,9 @@ void main() {
 
     expect(find.text('About Pirate app'), findsNothing);
     expect(find.text('0.1.2'), findsNothing);
+    expect(find.byWidget(logo), findsNothing);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsNothing);
     expect(find.text('About box'), findsNothing);
 
     await tester.tap(find.byType(IconButton));
@@ -48,6 +53,9 @@ void main() {
 
     expect(find.text('About Pirate app'), findsOneWidget);
     expect(find.text('0.1.2'), findsNothing);
+    expect(find.byWidget(logo), findsNothing);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsNothing);
     expect(find.text('About box'), findsNothing);
 
     await tester.tap(find.text('About Pirate app'));
@@ -55,17 +63,25 @@ void main() {
 
     expect(find.text('About Pirate app'), findsOneWidget);
     expect(find.text('0.1.2'), findsOneWidget);
+    expect(find.byWidget(logo), findsOneWidget);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsOneWidget);
     expect(find.text('About box'), findsOneWidget);
 
     LicenseRegistry.addLicense(() {
       return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
-        const LicenseEntryWithLineBreaks(<String>[ 'Pirate package '], 'Pirate license'),
+        const LicenseEntryWithLineBreaks(<String>['Pirate package '], 'Pirate license'),
       ]);
     });
 
     await tester.tap(find.text('VIEW LICENSES'));
     await tester.pumpAndSettle(const Duration(milliseconds: 100));
 
+    expect(find.text('Pirate app'), findsOneWidget);
+    expect(find.text('0.1.2'), findsOneWidget);
+    expect(find.byWidget(logo), findsOneWidget);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsOneWidget);
     expect(find.text('Pirate license'), findsOneWidget);
   }, skip: isBrowser);
 
@@ -79,7 +95,7 @@ void main() {
     expect(find.text('About flutter_tester'), findsOneWidget);
   });
 
-  testWidgets('AboutListTile control test', (WidgetTester tester) async {
+  testWidgets('LicensePage control test', (WidgetTester tester) async {
     LicenseRegistry.addLicense(() {
       return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
         const LicenseEntryWithLineBreaks(<String>['AAA'], 'BBB'),
@@ -88,7 +104,8 @@ void main() {
 
     LicenseRegistry.addLicense(() {
       return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
-        const LicenseEntryWithLineBreaks(<String>['Another package'], 'Another license'),
+        const LicenseEntryWithLineBreaks(
+            <String>['Another package'], 'Another license'),
       ]);
     });
 
@@ -107,6 +124,62 @@ void main() {
 
     await tester.pumpAndSettle();
 
+    expect(find.text('AAA'), findsOneWidget);
+    expect(find.text('BBB'), findsOneWidget);
+    expect(find.text('Another package'), findsOneWidget);
+    expect(find.text('Another license'), findsOneWidget);
+  }, skip: isBrowser);
+
+  testWidgets('LicensePage control test with all properties', (WidgetTester tester) async {
+    const FlutterLogo logo = FlutterLogo();
+
+    LicenseRegistry.addLicense(() {
+      return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
+        const LicenseEntryWithLineBreaks(<String>['AAA'], 'BBB'),
+      ]);
+    });
+
+    LicenseRegistry.addLicense(() {
+      return Stream<LicenseEntry>.fromIterable(<LicenseEntry>[
+        const LicenseEntryWithLineBreaks(
+            <String>['Another package'], 'Another license'),
+      ]);
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        title: 'Pirate app',
+        home: Center(
+          child: LicensePage(
+            applicationName: 'LicensePage test app',
+            applicationVersion: '0.1.2',
+            applicationIcon: logo,
+            applicationLegalese:
+                'I am the very model of a modern major general.',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Pirate app'), findsNothing);
+    expect(find.text('LicensePage test app'), findsOneWidget);
+    expect(find.text('0.1.2'), findsOneWidget);
+    expect(find.byWidget(logo), findsOneWidget);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsOneWidget);
+    expect(find.text('AAA'), findsNothing);
+    expect(find.text('BBB'), findsNothing);
+    expect(find.text('Another package'), findsNothing);
+    expect(find.text('Another license'), findsNothing);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pirate app'), findsNothing);
+    expect(find.text('LicensePage test app'), findsOneWidget);
+    expect(find.text('0.1.2'), findsOneWidget);
+    expect(find.byWidget(logo), findsOneWidget);
+    expect(find.text('I am the very model of a modern major general.'),
+        findsOneWidget);
     expect(find.text('AAA'), findsOneWidget);
     expect(find.text('BBB'), findsOneWidget);
     expect(find.text('Another package'), findsOneWidget);
@@ -187,6 +260,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(licenseEntry.paragraphsCalled, true);
   }, skip: isBrowser);
+
+  testWidgets('LicensePage logic defaults to executable name for app name', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        title: 'flutter_tester',
+        home: Material(child: LicensePage()),
+      ),
+    );
+    expect(find.text('flutter_tester'), findsOneWidget);
+  });
 }
 
 class FakeLicenseEntry extends LicenseEntry {


### PR DESCRIPTION
## Description

Currently `showLicensePage` function taking `applicationIcon` property but `applicationIcon` is not used for layout of `LicensePage` widget now. So, this PR remove that property to avoid misleading.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

NOTE: If developers are passing `applicationIcon` property to  `showLicensePage` function, their build will be failed after merge this PR. At that case, their `applicationIcon` property does not making any meaning now, and removing `applicationIcon` property is no UI effects for their application.