### PR TITLE
Fixed LicensePage to close page before loaded the License causes an error

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -401,6 +401,9 @@ class _LicensePageState extends State<LicensePage> {
           Priority.animation,
           debugLabel: 'License',
         );
+      if (!mounted) {
+        return;
+      }
       setState(() {
         _licenses.add(const Padding(
           padding: EdgeInsets.symmetric(vertical: 18.0),


### PR DESCRIPTION
## Description
Closing the page when the LicensePage does not load the full license will result in the following error:

```
E/flutter : [ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: setState() called after dispose(): _LicensePageState#f9c4f(lifecycle state: defunct, not mounted)
E/flutter : This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback. The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter : This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
E/flutter : #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1090:9)
E/flutter : #1      State.setState (package:flutter/src/widgets/framework.dart:1116:6)
E/flutter : #2      _LicensePageState._initLicenses (package:flutter/src/material/about.dart:404:7)
```
https://github.com/flutter/flutter/blob/c1562c99582945784ee87d90c83716bcf6d1e3df/packages/flutter/lib/src/material/about.dart#L390-L406

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
