### PR TITLE
Added onChanged property to TextFormField

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -98,6 +98,7 @@ class TextFormField extends FormField<String> {
     int minLines,
     bool expands = false,
     int maxLength,
+    ValueChanged<String> onChanged,
     VoidCallback onEditingComplete,
     ValueChanged<String> onFieldSubmitted,
     FormFieldSetter<String> onSaved,
@@ -144,6 +145,12 @@ class TextFormField extends FormField<String> {
       final _TextFormFieldState state = field;
       final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
         .applyDefaults(Theme.of(field.context).inputDecorationTheme);
+      void onChangedHandler(String value) {
+        if (onChanged != null) {
+          onChanged(value);
+        }
+        field.didChange(value);
+      }
       return TextField(
         controller: state._effectiveController,
         focusNode: focusNode,
@@ -165,7 +172,8 @@ class TextFormField extends FormField<String> {
         minLines: minLines,
         expands: expands,
         maxLength: maxLength,
-        onChanged: field.didChange,
+        // onChanged: field.didChange,
+        onChanged: onChangedHandler,
         onEditingComplete: onEditingComplete,
         onSubmitted: onFieldSubmitted,
         inputFormatters: inputFormatters,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -172,7 +172,6 @@ class TextFormField extends FormField<String> {
         minLines: minLines,
         expands: expands,
         maxLength: maxLength,
-        // onChanged: field.didChange,
         onChanged: onChangedHandler,
         onEditingComplete: onEditingComplete,
         onSubmitted: onFieldSubmitted,

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -123,6 +123,28 @@ void main() {
     expect(_called, true);
   });
 
+  testWidgets('onChanged callbacks are called', (WidgetTester tester) async {
+    bool _called = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              onChanged: (String value) {
+                _called = true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'Soup');
+    await tester.pump();
+    expect(_called, true);
+  });
+
   testWidgets('autovalidate is passed to super', (WidgetTester tester) async {
     int _validateCalled = 0;
 

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -124,7 +124,7 @@ void main() {
   });
 
   testWidgets('onChanged callbacks are called', (WidgetTester tester) async {
-    bool _called = false;
+    String _value;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -132,7 +132,7 @@ void main() {
           child: Center(
             child: TextFormField(
               onChanged: (String value) {
-                _called = true;
+                _value = value;
               },
             ),
           ),
@@ -142,7 +142,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField), 'Soup');
     await tester.pump();
-    expect(_called, true);
+    expect(_value, 'Soup');
   });
 
   testWidgets('autovalidate is passed to super', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Adds `onChanged` property to the `TextFormField` material widget.

## Related Issues

Resolves #28914

## Tests

I added the following tests:

- `onChanged callbacks are called` in `text_form_field_test.dart`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

*No documentation changes were needed as it's already covered.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.