### PR TITLE
Add generated Icon diagram to api docs

### DIFF
--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -29,7 +29,7 @@ import 'icon_theme_data.dart';
 /// This example shows how to use [Icon] to create an addition icon, in the
 /// color pink, and 30 x 30 pixels in size.
 ///
-/// ![A pink plus sign](https://raw.githubusercontent.com/flutter/assets-for-api-docs/master/assets/widgets/icon.png)
+/// ![A pink plus sign](https://flutter.github.io/flutter/assets-for-api-docs/master/assets/widgets/icon.png)
 ///
 /// ```dart
 /// Icon(

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -135,8 +135,7 @@ class Icon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(this.textDirection != null || debugCheckHasDirectionality(context));
-    final TextDirection textDirection =
-        this.textDirection ?? Directionality.of(context);
+    final TextDirection textDirection = this.textDirection ?? Directionality.of(context);
 
     final IconThemeData iconTheme = IconTheme.of(context);
 
@@ -156,8 +155,7 @@ class Icon extends StatelessWidget {
 
     Widget iconWidget = RichText(
       overflow: TextOverflow.visible, // Never clip.
-      textDirection:
-          textDirection, // Since we already fetched it for the assert...
+      textDirection: textDirection, // Since we already fetched it for the assert...
       text: TextSpan(
         text: String.fromCharCode(icon.codePoint),
         style: TextStyle(
@@ -202,8 +200,7 @@ class Icon extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(
-        IconDataProperty('icon', icon, ifNull: '<empty>', showName: false));
+    properties.add(IconDataProperty('icon', icon, ifNull: '<empty>', showName: false));
     properties.add(DoubleProperty('size', size, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
   }

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -29,7 +29,7 @@ import 'icon_theme_data.dart';
 /// This example shows how to use [Icon] to create an addition icon, in the
 /// color pink, and 30 x 30 pixels in size.
 ///
-/// ![A pink plus sign](https://flutter.github.io/flutter/assets-for-api-docs/master/assets/widgets/icon.png)
+/// ![A pink plus sign](https://flutter.github.io/assets-for-api-docs/assets/widgets/icon.png)
 ///
 /// ```dart
 /// Icon(
@@ -135,7 +135,8 @@ class Icon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(this.textDirection != null || debugCheckHasDirectionality(context));
-    final TextDirection textDirection = this.textDirection ?? Directionality.of(context);
+    final TextDirection textDirection =
+        this.textDirection ?? Directionality.of(context);
 
     final IconThemeData iconTheme = IconTheme.of(context);
 
@@ -155,7 +156,8 @@ class Icon extends StatelessWidget {
 
     Widget iconWidget = RichText(
       overflow: TextOverflow.visible, // Never clip.
-      textDirection: textDirection, // Since we already fetched it for the assert...
+      textDirection:
+          textDirection, // Since we already fetched it for the assert...
       text: TextSpan(
         text: String.fromCharCode(icon.codePoint),
         style: TextStyle(
@@ -200,7 +202,8 @@ class Icon extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(IconDataProperty('icon', icon, ifNull: '<empty>', showName: false));
+    properties.add(
+        IconDataProperty('icon', icon, ifNull: '<empty>', showName: false));
     properties.add(DoubleProperty('size', size, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
   }

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -29,6 +29,8 @@ import 'icon_theme_data.dart';
 /// This example shows how to use [Icon] to create an addition icon, in the
 /// color pink, and 30 x 30 pixels in size.
 ///
+/// ![A pink plus sign](https://raw.githubusercontent.com/flutter/assets-for-api-docs/master/assets/widgets/icon.png)
+///
 /// ```dart
 /// Icon(
 ///   Icons.add,


### PR DESCRIPTION
## Description

This PR embeds a new Icon diagram to match the sample code that is in the api docs.

## Related Issues

  - [x] Before merge, the asset must be merged: https://github.com/flutter/assets-for-api-docs/pull/88

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [X] No, this is *not* a breaking change.