### PR TITLE
enable lint avoid_bool_literals_in_conditional_expressions

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -52,7 +52,7 @@ linter:
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_as
-    # - avoid_bool_literals_in_conditional_expressions # not yet tested
+    - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
     - avoid_classes_with_only_static_members

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -430,7 +430,7 @@ class SampleChecker {
             startLine = Line('', filename: relativeFilePath, line: lineNumber + 1, indent: 3);
             inPreamble = true;
           } else if (sampleMatch != null) {
-            inSnippet = sampleMatch != null ? sampleMatch[1] == 'snippet' : false;
+            inSnippet = sampleMatch != null && sampleMatch[1] == 'snippet';
             if (inSnippet) {
               startLine = Line(
                 '',

--- a/examples/flutter_gallery/lib/demo/material/chip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/chip_demo.dart
@@ -247,7 +247,7 @@ class _ChipDemoState extends State<ChipDemo> {
       return FilterChip(
         key: ValueKey<String>(name),
         label: Text(_capitalize(name)),
-        selected: _tools.contains(name) ? _selectedTools.contains(name) : false,
+        selected: _tools.contains(name) && _selectedTools.contains(name),
         onSelected: !_tools.contains(name)
             ? null
             : (bool value) {

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -618,9 +618,9 @@ class _CupertinoBackGestureController<T> {
     // or after mid screen, we should animate the page out. Otherwise, the page
     // should be animated back in.
     if (velocity.abs() >= _kMinFlingVelocity)
-      animateForward = velocity > 0 ? false : true;
+      animateForward = velocity <= 0;
     else
-      animateForward = controller.value > 0.5 ? true : false;
+      animateForward = controller.value > 0.5;
 
     if (animateForward) {
       // The closer the panel is to dismissing, the shorter the animation is.

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1469,7 +1469,7 @@ abstract class DiagnosticsNode {
   ///
   /// If `minLevel` is [DiagnosticLevel.hidden] no diagnostics will be filtered.
   /// If `minLevel` is [DiagnosticLevel.off] all diagnostics will be filtered.
-  bool isFiltered(DiagnosticLevel minLevel) => kReleaseMode ? true : level.index < minLevel.index;
+  bool isFiltered(DiagnosticLevel minLevel) => kReleaseMode || level.index < minLevel.index;
 
   /// Priority level of the diagnostic used to control which diagnostics should
   /// be shown and filtered.

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -197,7 +197,7 @@ class BottomNavigationBar extends StatefulWidget {
        assert(elevation != null && elevation >= 0.0),
        assert(iconSize != null && iconSize >= 0.0),
        assert(
-         selectedItemColor != null ? fixedColor == null : true,
+         selectedItemColor == null || fixedColor == null,
          'Either selectedItemColor or fixedColor can be specified, but not both'
        ),
        assert(selectedFontSize != null && selectedFontSize >= 0.0),

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1410,7 +1410,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   }
 
   bool _isTapping = false;
-  bool get isTapping => !canTap ? false : _isTapping;
+  bool get isTapping => canTap && _isTapping;
 
   @override
   void initState() {

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -616,7 +616,7 @@ class DataTable extends StatelessWidget {
         label: column.label,
         tooltip: column.tooltip,
         numeric: column.numeric,
-        onSort: () => column.onSort != null ? column.onSort(dataColumnIndex, sortColumnIndex == dataColumnIndex ? !sortAscending : true) : null,
+        onSort: () => column.onSort != null ? column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null,
         sorted: dataColumnIndex == sortColumnIndex,
         ascending: sortAscending,
       );

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -346,7 +346,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         break;
     }
 
-    final bool opened = _controller.value > 0.5 ? true : false;
+    final bool opened = _controller.value > 0.5;
     if (opened != _previouslyOpened && widget.drawerCallback != null)
       widget.drawerCallback(opened);
     _previouslyOpened = opened;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2173,7 +2173,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     );
 
     // extendBody locked when keyboard is open
-    final bool _extendBody = minInsets.bottom > 0 ? false : widget.extendBody;
+    final bool _extendBody = minInsets.bottom <= 0 && widget.extendBody;
 
     return _ScaffoldScope(
       hasDrawer: hasDrawer,

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -150,7 +150,7 @@ class TabController extends ChangeNotifier {
   void _changeIndex(int value, { Duration duration, Curve curve }) {
     assert(value != null);
     assert(value >= 0 && (value < length || length == 0));
-    assert(duration == null ? curve == null : true);
+    assert(duration != null || curve == null);
     assert(_indexIsChangingCount >= 0);
     if (value == _index || length < 2)
       return;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2969,7 +2969,7 @@ class RenderIgnorePointer extends RenderProxyBox {
 
   @override
   bool hitTest(BoxHitTestResult result, { Offset position }) {
-    return ignoring ? false : super.hitTest(result, position: position);
+    return !ignoring && super.hitTest(result, position: position);
   }
 
   // TODO(ianh): figure out a way to still include labels and flags in

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -469,7 +469,7 @@ class RawFloatingCursorPoint {
     this.offset,
     @required this.state,
   }) : assert(state != null),
-       assert(state == FloatingCursorDragState.Update ? offset != null : true);
+       assert(state != FloatingCursorDragState.Update || offset != null);
 
   /// The raw position of the floating cursor as determined by the iOS sdk.
   final Offset offset;

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -95,7 +95,7 @@ class Dismissible extends StatefulWidget {
     this.crossAxisEndOffset = 0.0,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : assert(key != null),
-       assert(secondaryBackground != null ? background != null : true),
+       assert(secondaryBackground == null || background != null),
        assert(dragStartBehavior != null),
        super(key: key);
 

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -75,9 +75,11 @@ class WidgetSpan extends PlaceholderSpan {
     TextBaseline baseline,
     TextStyle style,
   }) : assert(child != null),
-       assert((identical(alignment, ui.PlaceholderAlignment.aboveBaseline) ||
-              identical(alignment, ui.PlaceholderAlignment.belowBaseline) ||
-              identical(alignment, ui.PlaceholderAlignment.baseline)) ? baseline != null : true),
+       assert(baseline != null || !(
+         identical(alignment, ui.PlaceholderAlignment.aboveBaseline) ||
+         identical(alignment, ui.PlaceholderAlignment.belowBaseline) ||
+         identical(alignment, ui.PlaceholderAlignment.baseline)
+       )),
        super(
          alignment: alignment,
          baseline: baseline,

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -25,7 +25,7 @@ class FakeMissingSizeRenderBox extends RenderBox {
   }
 
   @override
-  bool get hasSize => fakeMissingSize ? false : super.hasSize;
+  bool get hasSize => !fakeMissingSize && super.hasSize;
 
   bool fakeMissingSize = false;
 }

--- a/packages/flutter_localizations/test/override_test.dart
+++ b/packages/flutter_localizations/test/override_test.dart
@@ -37,7 +37,7 @@ class FooMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLoc
 
   @override
   bool isSupported(Locale locale) {
-    return supportedLanguage == 'allLanguages' ? true : locale.languageCode == supportedLanguage;
+    return supportedLanguage == 'allLanguages' || locale.languageCode == supportedLanguage;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -175,7 +175,7 @@ class AOTSnapshotter {
         'entryPoint': mainPath,
         'extraGenSnapshotOptions': extraGenSnapshotOptions.join(' '),
         'engineHash': Cache.instance.engineRevision,
-        'buildersUsed': '${flutterProject != null ? flutterProject.hasBuilders : false}',
+        'buildersUsed': '${flutterProject != null && flutterProject.hasBuilders}',
       },
       depfilePaths: <String>[],
     );

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -163,7 +163,7 @@ class Stdio {
   bool get hasTerminal => io.stdout.hasTerminal;
   int get terminalColumns => hasTerminal ? io.stdout.terminalColumns : null;
   int get terminalLines => hasTerminal ? io.stdout.terminalLines : null;
-  bool get supportsAnsiEscapes => hasTerminal ? io.stdout.supportsAnsiEscapes : false;
+  bool get supportsAnsiEscapes => hasTerminal && io.stdout.supportsAnsiEscapes;
 }
 
 Stdio get stdio => context.get<Stdio>() ?? const Stdio();

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -148,7 +148,7 @@ Future<int> runCommandAndStreamOutput(
   final StreamSubscription<String> stdoutSubscription = process.stdout
     .transform<String>(utf8.decoder)
     .transform<String>(const LineSplitter())
-    .where((String line) => filter == null ? true : filter.hasMatch(line))
+    .where((String line) => filter == null || filter.hasMatch(line))
     .listen((String line) {
       if (mapFunction != null)
         line = mapFunction(line);
@@ -163,7 +163,7 @@ Future<int> runCommandAndStreamOutput(
   final StreamSubscription<String> stderrSubscription = process.stderr
     .transform<String>(utf8.decoder)
     .transform<String>(const LineSplitter())
-    .where((String line) => filter == null ? true : filter.hasMatch(line))
+    .where((String line) => filter == null || filter.hasMatch(line))
     .listen((String line) {
       if (mapFunction != null)
         line = mapFunction(line);

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -246,7 +246,7 @@ class KernelCompiler {
           'trackWidgetCreation': trackWidgetCreation.toString(),
           'linkPlatformKernelIn': linkPlatformKernelIn.toString(),
           'engineHash': Cache.instance.engineRevision,
-          'buildersUsed': '${flutterProject != null ? flutterProject.hasBuilders : false}',
+          'buildersUsed': '${flutterProject != null && flutterProject.hasBuilders}',
         },
         depfilePaths: <String>[depFilePath],
         pathFilter: (String path) => !path.startsWith('/b/build/slave/'),


### PR DESCRIPTION
## Description

Enables lint [avoid_bool_literals_in_conditional_expressions](https://dart-lang.github.io/linter/lints/avoid_bool_literals_in_conditional_expressions.html)

## Related Issues

None

## Tests

None

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
