### PR TITLE
Add FlutterProjectFactory so that it can be overridden internally.

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -9,6 +9,7 @@ import 'package:yaml/yaml.dart';
 
 import 'android/gradle.dart' as gradle;
 import 'base/common.dart';
+import 'base/context.dart';
 import 'base/file_system.dart';
 import 'build_info.dart';
 import 'bundle.dart' as bundle;
@@ -21,6 +22,25 @@ import 'ios/xcodeproj.dart' as xcode;
 import 'plugins.dart';
 import 'template.dart';
 import 'web/workflow.dart';
+
+FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? FlutterProjectFactory();
+
+class FlutterProjectFactory {
+  /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
+  /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
+  FlutterProject fromDirectory(Directory directory) {
+    assert(directory != null);
+    final FlutterManifest manifest = FlutterProject._readManifest(
+      directory.childFile(bundle.defaultManifestPath).path,
+    );
+    final FlutterManifest exampleManifest = FlutterProject._readManifest(
+      FlutterProject._exampleDirectory(directory)
+          .childFile(bundle.defaultManifestPath)
+          .path,
+    );
+    return FlutterProject(directory, manifest, exampleManifest);
+  }
+}
 
 /// Represents the contents of a Flutter project at the specified [directory].
 ///
@@ -38,25 +58,16 @@ class FlutterProject {
       assert(manifest != null),
       assert(_exampleManifest != null);
 
-  /// Returns a future that completes with a [FlutterProject] view of the given directory
-  /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
-  static FlutterProject fromDirectory(Directory directory) {
-    assert(directory != null);
-    final FlutterManifest manifest = _readManifest(
-      directory.childFile(bundle.defaultManifestPath).path,
-    );
-    final FlutterManifest exampleManifest = _readManifest(
-      _exampleDirectory(directory).childFile(bundle.defaultManifestPath).path,
-    );
-    return FlutterProject(directory, manifest, exampleManifest);
-  }
+  /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
+  /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
+  static FlutterProject fromDirectory(Directory directory) => projectFactory.fromDirectory(directory);
 
-  /// Returns a future that completes with a [FlutterProject] view of the current directory.
-  /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
+  /// Returns a [FlutterProject] view of the current directory or a ToolExit error,
+  /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   static FlutterProject current() => fromDirectory(fs.currentDirectory);
 
-  /// Returns a future that completes with a [FlutterProject] view of the given directory.
-  /// or a ToolExit error, if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
+  /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
+  /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   static FlutterProject fromPath(String path) => fromDirectory(fs.directory(path));
 
   /// The location of this project.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -23,9 +23,11 @@ import 'plugins.dart';
 import 'template.dart';
 import 'web/workflow.dart';
 
-FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? FlutterProjectFactory();
+FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? const FlutterProjectFactory();
 
 class FlutterProjectFactory {
+  const FlutterProjectFactory();
+
   /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   FlutterProject fromDirectory(Directory directory) {


### PR DESCRIPTION
Also update the comments since we don't return Future<FlutterProject> anymore.