### PR TITLE
Add handling of 'TextInput.clearClient' message from platform to framework (#35054).

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -753,6 +753,9 @@ class _TextInputClientHandler {
       case 'TextInputClient.updateFloatingCursor':
         _currentConnection._client.updateFloatingCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
         break;
+      case 'TextInput.clearClient':
+        _currentConnection.close();
+        break;
       default:
         throw MissingPluginException();
     }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -632,7 +632,7 @@ abstract class TextInputClient {
 /// See also:
 ///
 ///  * [TextInput.attach]
-class TextInputConnection {
+class TextInputConnection with ChangeNotifier {
   TextInputConnection._(this._client)
     : assert(_client != null),
       _id = _nextId++;
@@ -667,11 +667,18 @@ class TextInputConnection {
   void close() {
     if (attached) {
       SystemChannels.textInput.invokeMethod<void>('TextInput.clearClient');
-      _clientHandler
-        .._currentConnection = null
-        .._scheduleHide();
+      _onConnectionClosed();
+      _clientHandler._scheduleHide();
     }
     assert(!attached);
+  }
+
+  /// Clear out the current text input connection.
+  ///
+  /// Call this method when the current text input connection has cleared.
+  void _onConnectionClosed() {
+    _clientHandler._currentConnection = null;
+    notifyListeners();
   }
 }
 
@@ -753,8 +760,8 @@ class _TextInputClientHandler {
       case 'TextInputClient.updateFloatingCursor':
         _currentConnection._client.updateFloatingCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
         break;
-      case 'TextInput.clearClient':
-        _currentConnection.close();
+      case 'TextInputClient.onConnectionClosed':
+        _currentConnection._onConnectionClosed();
         break;
       default:
         throw MissingPluginException();

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1327,7 +1327,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               textCapitalization: widget.textCapitalization,
               keyboardAppearance: widget.keyboardAppearance,
           ),
-      )..setEditingState(localValue);
+      )
+      ..setEditingState(localValue)
+      ..addListener(() {
+        if (!_textInputConnection.attached) {
+          widget.focusNode.unfocus();
+        }
+      });
     }
     _textInputConnection.show();
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1327,8 +1327,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               textCapitalization: widget.textCapitalization,
               keyboardAppearance: widget.keyboardAppearance,
           ),
-      )
-      ..setEditingState(localValue);
+      )..setEditingState(localValue);
     }
     _textInputConnection.show();
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1328,12 +1328,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               keyboardAppearance: widget.keyboardAppearance,
           ),
       )
-      ..setEditingState(localValue)
-      ..addListener(() {
-        if (!_textInputConnection.attached) {
-          widget.focusNode.unfocus();
-        }
-      });
+      ..setEditingState(localValue);
     }
     _textInputConnection.show();
   }

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -85,5 +85,44 @@ void main() {
       expect(signed.hashCode == signedDecimal.hashCode, false);
       expect(decimal.hashCode == signedDecimal.hashCode, false);
     });
+
+    test('The framework TextInputConnection closes when the platform loses its input connection', () async {
+      // Assemble a TextInputConnection so we can verify its change in state.
+      final TextInputClient client = NoOpTextInputClient();
+      const TextInputConfiguration configuration = TextInputConfiguration();
+      final TextInputConnection textInputConnection = TextInput.attach(client, configuration);
+
+      // Verify that TextInputConnection think its attached to a client. This is
+      // an intermediate verification of expected state.
+      expect(textInputConnection.attached, true);
+
+      // Pretend that the platform has lost its input connection.
+      final ByteData messageBytes = const JSONMessageCodec().encodeMessage(
+          <String, dynamic>{
+            'args': <dynamic>[1],
+            'method': 'TextInputClient.onConnectionClosed',
+          }
+      );
+      defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData _) {},
+      );
+
+      // Verify that textInputConnection no longer think its attached to an input
+      // connection. This is the critical verification of this test.
+      expect(textInputConnection.attached, false);
+    });
   });
+}
+
+class NoOpTextInputClient extends TextInputClient {
+  @override
+  void performAction(TextInputAction action) {}
+
+  @override
+  void updateEditingValue(TextEditingValue value) {}
+
+  @override
+  void updateFloatingCursor(RawFloatingCursorPoint point) {}
 }


### PR DESCRIPTION
Problem:
Flutter is not setup to handle backgrounding and then foregrounding an app when an input control has focus. The issue is visible in the new embedding because the new embedding loosens platform restrictions around `FlutterActivity` continuity.

Repro Steps:

- Run an app with a TextField
- Give focus to the TextField
- Press Android's home button
- Switch back to the app
- Tap the TextField to give it focus again
- An error appears in the logs.

The issue is that Flutter is unaware that the app was backgrounded and therefore expects the same input connection to exist when re-foregrounded. But on the Android side, the input connection was lost when the app was backgrounded and therefore needs to be recreated when foregrounded again.

Solution:
When `FlutterActivity` goes to the background and detaches from the `FlutterEngine` instance, instruct the framework to clear the input client. By clearing it, when the user taps on the control after being re-foregrounded, Flutter will request a new input connection and things should continue as expected.

Corresponding Engine PR:
https://github.com/flutter/engine/pull/9498