### PR TITLE
Reduce allocations by reusing a matrix for transient transforms in _transformRect

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3599,15 +3599,24 @@ class _SemanticsGeometry {
     }
   }
 
+  // A matrix used to store transient transform data.
+  //
+  // Reusing this matrix avoids allocating a new matrix every time a temporary
+  // matrix is needed.
+  //
+  // This instance should never be returned to the caller. Otherwise, the data
+  // stored in it will be overwritten unpredictably by subsequent reuses.
+  static final Matrix4 _temporaryTransformHolder = Matrix4.zero();
+
   /// From parent to child coordinate system.
   static Rect _transformRect(Rect rect, RenderObject parent, RenderObject child) {
     if (rect == null)
       return null;
     if (rect.isEmpty)
       return Rect.zero;
-    final Matrix4 transform = Matrix4.identity();
-    parent.applyPaintTransform(child, transform);
-    return MatrixUtils.inverseTransformRect(transform, rect);
+    _temporaryTransformHolder.setIdentity();  // clears data from a previous call
+    parent.applyPaintTransform(child, _temporaryTransformHolder);
+    return MatrixUtils.inverseTransformRect(_temporaryTransformHolder, rect);
   }
 
   static Rect _intersectRects(Rect a, Rect b) {


### PR DESCRIPTION
## Description

`_transformRect` is called frequently when accessibility is enabled. For example, when scrolling the material demo list it is called ~240 times on every frame. This allocates a minimum of 240 extra `Matrix4` objects, 240 extra `Float64List` objects, and 30KB worth of matrix data stored inside the lists.

This hits Flutter for web even harder due to https://bugs.chromium.org/p/v8/issues/detail?id=9199. This change improves the performance of `flushSemantics` by 1.77x ([data](https://docs.google.com/spreadsheets/d/1asrG62Ey02B-PFH13ug052DSerdCRUHA2sNPok4UFWw)).

This change allocates one static matrix that's reused by `_transformRect`, removing all of the above-mentioned allocations.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34348

## Tests

I did not add any tests. This is purely an optimization. However, some of our benchmarks might show an improvement.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.
