### PR TITLE
More HttpClientResponse Uint8List fixes

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1900,7 +1900,9 @@ class _MockHttpResponse implements HttpClientResponse {
     bool Function(Uint8List element) test, {
     List<int> Function() orElse,
   }) {
-    return _delegate.firstWhere(test, orElse: orElse);
+    return _delegate.firstWhere(test, orElse: () {
+      return Uint8List.fromList(orElse());
+    });
   }
 
   @override
@@ -1940,7 +1942,9 @@ class _MockHttpResponse implements HttpClientResponse {
     bool Function(Uint8List element) test, {
     List<int> Function() orElse,
   }) {
-    return _delegate.lastWhere(test, orElse: orElse);
+    return _delegate.lastWhere(test, orElse: () {
+      return Uint8List.fromList(orElse());
+    });
   }
 
   @override
@@ -1953,12 +1957,14 @@ class _MockHttpResponse implements HttpClientResponse {
 
   @override
   Future<dynamic> pipe(StreamConsumer<List<int>> streamConsumer) {
-    return _delegate.pipe(streamConsumer);
+    return _delegate.cast<List<int>>().pipe(streamConsumer);
   }
 
   @override
   Future<Uint8List> reduce(List<int> Function(Uint8List previous, Uint8List element) combine) {
-    return _delegate.reduce(combine);
+    return _delegate.reduce((Uint8List previous, Uint8List element) {
+      return Uint8List.fromList(combine(previous, element));
+    });
   }
 
   @override
@@ -1966,7 +1972,9 @@ class _MockHttpResponse implements HttpClientResponse {
 
   @override
   Future<Uint8List> singleWhere(bool Function(Uint8List element) test, {List<int> Function() orElse}) {
-    return _delegate.singleWhere(test, orElse: orElse);
+    return _delegate.singleWhere(test, orElse: () {
+      return Uint8List.fromList(orElse());
+    });
   }
 
   @override
@@ -2009,7 +2017,7 @@ class _MockHttpResponse implements HttpClientResponse {
 
   @override
   Stream<S> transform<S>(StreamTransformer<List<int>, S> streamTransformer) {
-    return _delegate.transform<S>(streamTransformer);
+    return _delegate.cast<List<int>>().transform<S>(streamTransformer);
   }
 
   @override


### PR DESCRIPTION
## Description

Follow-on change to https://github.com/flutter/flutter/pull/34863 (see that change
for context), whereby we ensure that we're properly dealing in `Uint8List`.

These necessary changes would have been caught by disabling implicit casts
in our analysis options.

## Related Issues

dart-lang/sdk#36900
https://github.com/flutter/flutter/issues/13815

## Tests

n/a - this is low-level testing code already

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
