### PR TITLE
[WIP adding tests] Prompt rect for autocorrection (and multistage text input)  

### DIFF
--- a/dev/devicelab/lib/tasks/integration_ui.dart
+++ b/dev/devicelab/lib/tasks/integration_ui.dart
@@ -21,11 +21,12 @@ Future<TaskResult> runEndToEndTests() async {
     if (deviceOperatingSystem == DeviceOperatingSystem.ios)
       await prepareProvisioningCertificates(testDirectory.path);
 
-    const List<String> entryPoints = <String>[
+    final List<String> entryPoints = <String>[
       'lib/keyboard_resize.dart',
       'lib/driver.dart',
       'lib/screenshot.dart',
       'lib/keyboard_textfield.dart',
+      if (deviceOperatingSystem == DeviceOperatingSystem.ios) 'lib/input_ios.dart',
     ];
 
     for (final String entryPoint in entryPoints) {

--- a/dev/integration_tests/ui/lib/input_ios.dart
+++ b/dev/integration_tests/ui/lib/input_ios.dart
@@ -1,0 +1,30 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_driver/driver_extension.dart';
+
+void main() {
+  enableFlutterDriverExtension();
+  runApp(DriverTestApp());
+}
+
+class DriverTestApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      home: CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(
+          middle: const Text('FlutterDriver test'),
+        ),
+        child: const Center(
+          child: CupertinoTextField(
+            key: ValueKey<String>('enter-text-field'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -105,47 +105,5 @@ void main() {
       await driver.enterText('World!');
       await driver.waitFor(find.text('World!'));
     });
-
-    test('Autocorrection highlight rect appear and disappear as expected.', () async {
-      final SerializableFinder textFieldFinder = find.byValueKey('enter-text-field');
-      final Matcher promptRectVisible = contains(getColor(0x00, 0x7A, 0xFF, 47));
-
-      Future<void> verifyScreenshot(bool hasPromptRect) async {
-        final Image image = decodePng(await driver.screenshot());
-        expect(
-          image.data,
-          hasPromptRect ? promptRectVisible : isNot(promptRectVisible),
-        );
-      }
-
-      await driver.waitFor(textFieldFinder);
-      await driver.tap(textFieldFinder);
-
-      driver.enterText('a');
-      await driver.waitFor(find.text('a'));
-      // Wait for the prompt rect to show up.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      await verifyScreenshot(false);
-
-      driver.enterText('asd');
-      // Wait for the prompt rect to show up.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      await driver.waitFor(find.text('asd'));
-      await verifyScreenshot(Platform.isIOS);
-
-      driver.enterText('asdf');
-      // Wait for the prompt rect to show up.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      await driver.waitFor(find.text('asdf'));
-      await verifyScreenshot(Platform.isIOS);
-
-      driver.enterText('asd');
-      // Wait for the prompt rect to show up.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      await driver.waitFor(find.text('asd'));
-      // Should not show up since we deleted the last character.
-      await verifyScreenshot(false);
-    });
-
   });
 }

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter_driver/flutter_driver.dart';
+import 'package:image/image.dart';
 
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
@@ -103,5 +105,47 @@ void main() {
       await driver.enterText('World!');
       await driver.waitFor(find.text('World!'));
     });
+
+    test('Autocorrection highlight rect appear and disappear as expected.', () async {
+      final SerializableFinder textFieldFinder = find.byValueKey('enter-text-field');
+      final Matcher promptRectVisible = contains(getColor(0x00, 0x7A, 0xFF, 47));
+
+      Future<void> verifyScreenshot(bool hasPromptRect) async {
+        final Image image = decodePng(await driver.screenshot());
+        expect(
+          image.data,
+          hasPromptRect ? promptRectVisible : isNot(promptRectVisible),
+        );
+      }
+
+      await driver.waitFor(textFieldFinder);
+      await driver.tap(textFieldFinder);
+
+      driver.enterText('a');
+      await driver.waitFor(find.text('a'));
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await verifyScreenshot(false);
+
+      driver.enterText('asd');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asd'));
+      await verifyScreenshot(Platform.isIOS);
+
+      driver.enterText('asdf');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asdf'));
+      await verifyScreenshot(Platform.isIOS);
+
+      driver.enterText('asd');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asd'));
+      // Should not show up since we deleted the last character.
+      await verifyScreenshot(false);
+    });
+
   });
 }

--- a/dev/integration_tests/ui/test_driver/input_ios_test.dart
+++ b/dev/integration_tests/ui/test_driver/input_ios_test.dart
@@ -1,0 +1,65 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:image/image.dart';
+
+import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
+
+void main() {
+  group('FlutterDriver', () {
+    FlutterDriver driver;
+
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDownAll(() async {
+      await driver.close();
+    });
+
+    test('Autocorrection highlight rect appear and disappear as expected.', () async {
+      final SerializableFinder textFieldFinder = find.byValueKey('enter-text-field');
+      final Matcher promptRectVisible = contains(getColor(0x00, 0x7A, 0xFF, 47));
+
+      Future<void> verifyScreenshot(bool hasPromptRect) async {
+        final Image image = decodePng(await driver.screenshot());
+        expect(
+          image.data,
+          hasPromptRect ? promptRectVisible : isNot(promptRectVisible),
+        );
+      }
+
+      await driver.waitFor(textFieldFinder);
+      await driver.tap(textFieldFinder);
+
+      driver.enterText('a');
+      await driver.waitFor(find.text('a'));
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await verifyScreenshot(false);
+
+      driver.enterText('asd');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asd'));
+      await verifyScreenshot(true);
+
+      driver.enterText('asdz');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asdz'));
+      await verifyScreenshot(true);
+
+      driver.enterText('asd');
+      // Wait for the prompt rect to show up.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await driver.waitFor(find.text('asd'));
+      // Should not show up since we deleted the last character.
+      await verifyScreenshot(false);
+    });
+  });
+}

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -926,7 +926,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
   }
 }
 
-
 /// Builds a [Paint] that paints an iOS style prompt rectangle.
 ///
 /// More specifically, when the prompt rectangle is an autocorrection indicator,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
@@ -990,6 +991,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         onEditingComplete: widget.onEditingComplete,
         onSubmitted: widget.onSubmitted,
         onSelectionHandleTapped: _handleSelectionHandleTapped,
+        promptRectPaintBuilder: Platform.isIOS ? cupertinoPromptPaintBuilder : null,
         inputFormatters: formatters,
         rendererIgnoresPointer: true,
         cursorWidth: widget.cursorWidth,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1791,12 +1791,12 @@ class RenderEditable extends RenderBox {
     final List<TextBox> boxes = _textPainter.getBoxesForSelection(
       TextSelection(
         baseOffset: _currentPromptRectRange.start,
-        extentOffset: _currentPromptRectRange.end
-      )
+        extentOffset: _currentPromptRectRange.end,
+      ),
     );
 
-    for(Rect rect in boxes.map((TextBox box) => box.toRect())) {
-      canvas.drawRect(rect.shift(effectiveOffset), paint);
+    for (TextBox box in boxes) {
+      canvas.drawRect(box.toRect().shift(effectiveOffset), paint);
     }
   }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -349,9 +349,6 @@ enum TextCapitalization {
 
 /// Indicates what caused the text input prompt rectangle to appear.
 enum TextInputPromptRectAppearCause {
-  /// The prompt rectangle appeared because of a unknown reason.
-  unspecified,
-
   /// The prompt rectangle appeared to indicate the range of text that will be
   /// affected by autocorrection.
   autocorrection,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -314,6 +314,7 @@ class EditableText extends StatefulWidget {
     this.enableInteractiveSelection,
     this.scrollController,
     this.scrollPhysics,
+    this.promptRectPaintBuilder,
   }) : assert(controller != null),
        assert(focusNode != null),
        assert(obscureText != null),
@@ -809,6 +810,9 @@ class EditableText extends StatefulWidget {
     return enableInteractiveSelection ?? !obscureText;
   }
 
+  /// {@macro flutter.rendering.editable.promptRectPaintBuilder}
+  final PromptRectPaintBuilder promptRectPaintBuilder;
+
   @override
   EditableTextState createState() => EditableTextState();
 
@@ -998,6 +1002,15 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _finalizeEditing(false);
         break;
     }
+  }
+
+  @override
+  void showPromptRect(int start, int end, TextInputPromptRectAppearCause cause) {
+    if (cause == TextInputPromptRectAppearCause.autocorrection && !widget.autocorrect) {
+      return;
+    }
+
+    renderEditable.showPromptRectIfNeeded(TextRange(start: start, end: end), cause);
   }
 
   // The original position of the caret on FloatingCursorDragState.start.
@@ -1578,6 +1591,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               enableInteractiveSelection: widget.enableInteractiveSelection,
               textSelectionDelegate: this,
               devicePixelRatio: _devicePixelRatio,
+              promptRectPaintBuilder: widget.promptRectPaintBuilder,
             ),
           ),
         );
@@ -1650,6 +1664,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.textSelectionDelegate,
     this.paintCursorAboveText,
     this.devicePixelRatio,
+    this.promptRectPaintBuilder,
   }) : assert(textDirection != null),
        assert(rendererIgnoresPointer != null),
        super(key: key);
@@ -1682,6 +1697,7 @@ class _Editable extends LeafRenderObjectWidget {
   final TextSelectionDelegate textSelectionDelegate;
   final double devicePixelRatio;
   final bool paintCursorAboveText;
+  final PromptRectPaintBuilder promptRectPaintBuilder;
 
   @override
   RenderEditable createRenderObject(BuildContext context) {
@@ -1713,6 +1729,7 @@ class _Editable extends LeafRenderObjectWidget {
       enableInteractiveSelection: enableInteractiveSelection,
       textSelectionDelegate: textSelectionDelegate,
       devicePixelRatio: devicePixelRatio,
+      promptRectPaintBuilder: promptRectPaintBuilder,
     );
   }
 


### PR DESCRIPTION
## Description
Engine counterpart: https://github.com/flutter/engine/pull/9539

Display prompt rectangles when `UIKit` decides it's appropriate to do so (because of autocorrection/multistage text input, etc.).

Use `-[UITextInput firstRectForRange:]` as an indicator of when and where the prompt rectangle should show up, and dismiss the prompt rectangle eagerly in `renderEditable.performLayout`, since there doesn't seem to be a good way to tell when the rectangle should be dismissed.

## Known Fidelity Issues

- If one types "f" after "asd" , the autocorrection prompt rectangle for "asd" will go away then reappear for "asdf", instead of just extending the old rectangle to cover the new word.

A gif showcasing the difference between autocorrection & multistage text input:
![ezgif-4-6e01122435eb](https://user-images.githubusercontent.com/31859944/60290126-e426a900-98cc-11e9-80e1-7dd2a1b49511.gif)


## Related Issues

Fixes #12920

## Tests

To Be Added.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
