### PR TITLE
`child` param doc update in Ink and Ink.image

### DIFF
--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -116,9 +116,8 @@ class Ink extends StatefulWidget {
   /// `color` and a `decoration`, you can pass the color as the `color`
   /// argument to the `BoxDecoration`.
   ///
-  /// The `child` argument must not be null. If there is no
-  /// intention to render anything on this decoration, consider using a
-  /// [Container] with a [BoxDecoration] instead.
+  /// If there is no intention to render anything on this decoration, consider
+  /// using a [Container] with a [BoxDecoration] instead.
   Ink({
     Key key,
     this.padding,
@@ -126,14 +125,13 @@ class Ink extends StatefulWidget {
     Decoration decoration,
     this.width,
     this.height,
-    @required this.child,
+    this.child,
   }) : assert(padding == null || padding.isNonNegative),
        assert(decoration == null || decoration.debugAssertIsValid()),
        assert(color == null || decoration == null,
          'Cannot provide both a color and a decoration\n'
          'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".'
        ),
-       assert(child != null),
        decoration = decoration ?? (color != null ? BoxDecoration(color: color) : null),
        super(key: key);
 
@@ -145,7 +143,7 @@ class Ink extends StatefulWidget {
   /// properties of the [DecorationImage] of that [BoxDecoration] are set
   /// according to the arguments passed to this method.
   ///
-  /// The `image` and `child` argument must not be null. If there is no
+  /// The `image` argument must not be null. If there is no
   /// intention to render anything on this image, consider using a
   /// [Container] with a [BoxDecoration.image] instead.
   ///
@@ -165,13 +163,12 @@ class Ink extends StatefulWidget {
     bool matchTextDirection = false,
     this.width,
     this.height,
-    @required this.child,
+    this.child,
   }) : assert(padding == null || padding.isNonNegative),
        assert(image != null),
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       assert(child != null),
        decoration = BoxDecoration(
          image: DecorationImage(
            image: image,

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -110,11 +110,15 @@ class Ink extends StatefulWidget {
   ///
   /// The [height] and [width] values include the [padding].
   ///
-  /// The `color` argument is a shorthand for `decoration: new
-  /// BoxDecoration(color: color)`, which means you cannot supply both a `color`
-  /// and a `decoration` argument. If you want to have both a `color` and a
-  /// `decoration`, you can pass the color as the `color` argument to the
-  /// `BoxDecoration`.
+  /// The `color` argument is a shorthand for
+  /// `decoration: BoxDecoration(color: color)`, which means you cannot supply
+  /// both a `color` and a `decoration` argument. If you want to have both a
+  /// `color` and a `decoration`, you can pass the color as the `color`
+  /// argument to the `BoxDecoration`.
+  ///
+  /// The `child` argument must not be null. If there is no
+  /// intention to render anything on this decoration, consider using a
+  /// [Container] with a [BoxDecoration] instead.
   Ink({
     Key key,
     this.padding,
@@ -122,13 +126,14 @@ class Ink extends StatefulWidget {
     Decoration decoration,
     this.width,
     this.height,
-    this.child,
+    @required this.child,
   }) : assert(padding == null || padding.isNonNegative),
        assert(decoration == null || decoration.debugAssertIsValid()),
        assert(color == null || decoration == null,
          'Cannot provide both a color and a decoration\n'
-         'The color argument is just a shorthand for "decoration: new BoxDecoration(color: color)".'
+         'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".'
        ),
+       assert(child != null),
        decoration = decoration ?? (color != null ? BoxDecoration(color: color) : null),
        super(key: key);
 
@@ -136,13 +141,16 @@ class Ink extends StatefulWidget {
   /// a [Material].
   ///
   /// This argument is a shorthand for passing a [BoxDecoration] that has only
-  /// its [BoxDecoration.image] property set to the [new Ink] constructor. The
+  /// its [BoxDecoration.image] property set to the [Ink] constructor. The
   /// properties of the [DecorationImage] of that [BoxDecoration] are set
   /// according to the arguments passed to this method.
   ///
-  /// The `image` argument must not be null. The `alignment`, `repeat`, and
-  /// `matchTextDirection` arguments must not be null either, but they have
-  /// default values.
+  /// The `image` and `child` argument must not be null. If there is no
+  /// intention to render anything on this image, consider using a
+  /// [Container] with a [BoxDecoration.image] instead.
+  ///
+  /// The `alignment`, `repeat`, and `matchTextDirection` arguments must not
+  /// be null either, but they have default values.
   ///
   /// See [paintImage] for a description of the meaning of these arguments.
   Ink.image({
@@ -157,12 +165,13 @@ class Ink extends StatefulWidget {
     bool matchTextDirection = false,
     this.width,
     this.height,
-    this.child,
+    @required this.child,
   }) : assert(padding == null || padding.isNonNegative),
        assert(image != null),
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
+       assert(child != null),
        decoration = BoxDecoration(
          image: DecorationImage(
            image: image,
@@ -194,8 +203,8 @@ class Ink extends StatefulWidget {
   /// constructor: set the `color` argument instead of the `decoration`
   /// argument.
   ///
-  /// A shorthand for specifying just an image is also available using the [new
-  /// Ink.image] constructor.
+  /// A shorthand for specifying just an image is also available using the
+  /// [Ink.image] constructor.
   final Decoration decoration;
 
   /// A width to apply to the [decoration] and the [child]. The width includes


### PR DESCRIPTION
## Description

~This change requires the child param for both Ink and Ink.image constructors.~ 
Appropriate doc updates were made to reflect this requirement, as well as additional suggestions to use a Container if the Ink widget is not truly needed.

Since Ink creates a piece of Material, it makes more sense that a `child` Widget be ~required~ suggested, since it'd mainly enable other widgets like InkResponse and InkWell to paint on it. Otherwise, a Container with a BoxDecoration would suffice.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/35191

## Tests

I added the following tests:

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
