### PR TITLE
add sample code for AnimatedContainer

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -525,53 +525,48 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_container.mp4}
 ///
-/// {@tool sample}
+/// {@tool sample --template=stateful_widget_scaffold}
+///
+/// ```dart preamble
+/// enum BoxState { small, large }
+/// ```
 ///
 /// ```dart
-/// enum BoxState { small, large }
+/// BoxState state = BoxState.small;
 ///
-/// class GrowingBox extends StatefulWidget {
-///   @override
-///   createState() => GrowingBoxState();
+/// void _changeSize() {
+///   setState(() {
+///     state = state == BoxState.small ? BoxState.large : BoxState.small;
+///   });
 /// }
 ///
-/// class GrowingBoxState extends State<GrowingBox> {
-///   BoxState state = BoxState.small;
-///
-///   void _changeSize() {
-///     setState(() {
-///       state = state == BoxState.small ? BoxState.large : BoxState.small;
-///     });
-///   }
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return Column(
-///       mainAxisAlignment: MainAxisAlignment.center,
-///       children: [
-///         AnimatedContainer(
-///           duration: Duration(seconds: 1),
-///           width: state == BoxState.small ? 192 : 256,
-///           height: state == BoxState.small ? 192 : 256,
-///           color: state == BoxState.small ? Colors.blue : Colors.indigo,
-///           transform: Matrix4.rotationZ(state == BoxState.small ? 0.0 : 0.1),
-///           child: Center(
-///             child: Text(
-///               "Hello, World!",
-///               style: Theme.of(context)
-///                   .textTheme
-///                   .display1
-///                   .copyWith(color: Colors.white),
-///             ),
+/// @override
+/// Widget build(BuildContext context) {
+///   return Column(
+///     mainAxisAlignment: MainAxisAlignment.center,
+///     children: [
+///       AnimatedContainer(
+///         duration: Duration(seconds: 1),
+///         width: state == BoxState.small ? 192 : 256,
+///         height: state == BoxState.small ? 192 : 256,
+///         color: state == BoxState.small ? Colors.blue : Colors.indigo,
+///         transform: Matrix4.rotationZ(state == BoxState.small ? 0.0 : 0.1),
+///         child: Center(
+///           child: Text(
+///             "Hello, World!",
+///             style: Theme.of(context)
+///                 .textTheme
+///                 .display1
+///                 .copyWith(color: Colors.white),
 ///           ),
 ///         ),
-///         RaisedButton(
-///           child: Text('Animate'),
-///           onPressed: _changeSize,
-///         ),
-///       ],
-///     );
-///   }
+///       ),
+///       RaisedButton(
+///         child: Text('Animate'),
+///         onPressed: _changeSize,
+///       ),
+///     ],
+///   );
 /// }
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -528,9 +528,9 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}
 ///
-/// The following example transitions an AnimatedContainer between two states.
-/// It adjusts the [height], [width], [color], and [alignment] properties using
-/// [State.setState].
+/// The following example (depicted above) transitions an AnimatedContainer
+/// between two states. It adjusts the [height], [width], [color], and
+/// [alignment] properties when tapped.
 ///
 /// ```dart
 /// bool selected = false;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -22,6 +22,7 @@ import 'transitions.dart';
 //   @override
 //   MyWidgetState createState() => MyWidgetState();
 // }
+// void setState(VoidCallback fn) { }
 
 /// An interpolation between two [BoxConstraints].
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -526,7 +526,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_container.mp4}
 ///
-/// {@tool sample --template=stateful_widget_scaffold}
+/// {@tool snippet --template=stateful_widget_scaffold}
 ///
 /// The following example transitions an AnimatedContainer between two states.
 /// It adjusts the [height], [width], [color], and [alignment] properties using

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -548,8 +548,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///         width: selected ? 200.0 : 100.0,
 ///         height: selected ? 100.0 : 200.0,
 ///         color: selected ? Colors.red : Colors.blue,
-///         alignment:
-///             selected ? Alignment.center : AlignmentDirectional.topCenter,
+///         alignment: selected ? Alignment.center : AlignmentDirectional.topCenter,
 ///         duration: Duration(seconds: 2),
 ///         curve: Curves.fastOutSlowIn,
 ///         child: FlutterLogo(size: 75),

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -522,8 +522,8 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=yI-8QHpGIP4}
 ///
-/// Here's an illustration of what using this widget looks like, using a [curve]
-/// of [Curves.fastOutSlowIn].
+/// Here's an illustration (implemented below) of what using this widget looks
+/// like, using a [curve] of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_container.mp4}
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -548,7 +548,8 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///         width: selected ? 200.0 : 100.0,
 ///         height: selected ? 100.0 : 200.0,
 ///         color: selected ? Colors.red : Colors.blue,
-///         alignment: selected ? Alignment.center : AlignmentDirectional.topCenter,
+///         alignment:
+///             selected ? Alignment.center : AlignmentDirectional.topCenter,
 ///         duration: Duration(seconds: 2),
 ///         curve: Curves.fastOutSlowIn,
 ///         child: FlutterLogo(size: 75),

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -532,45 +532,30 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// It adjusts the [height], [width], [color], and [alignment] properties using
 /// [State.setState].
 ///
-/// ```dart preamble
-/// enum BoxState { small, large }
-/// ```
-///
 /// ```dart
-/// BoxState state = BoxState.small;
-///
-/// void _changeSize() {
-///   setState(() {
-///     state = state == BoxState.small ? BoxState.large : BoxState.small;
-///   });
-/// }
+/// static const Curve curve = Curves.fastOutSlowIn;
+/// bool selected = false;
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return Column(
-///     mainAxisAlignment: MainAxisAlignment.center,
-///     children: [
-///       AnimatedContainer(
-///         duration: Duration(seconds: 1),
-///         width: state == BoxState.small ? 192 : 256,
-///         height: state == BoxState.small ? 192 : 256,
-///         color: state == BoxState.small ? Colors.blue : Colors.indigo,
-///         transform: Matrix4.rotationZ(state == BoxState.small ? 0.0 : 0.1),
-///         child: Center(
-///           child: Text(
-///             "Hello, World!",
-///             style: Theme.of(context)
-///                 .textTheme
-///                 .display1
-///                 .copyWith(color: Colors.white),
-///           ),
-///         ),
+///   return GestureDetector(
+///     onTap: () {
+///       setState(() {
+///         selected = !selected;
+///       });
+///     },
+///     child: Center(
+///       child: AnimatedContainer(
+///         width: selected ? 200.0 : 100.0,
+///         height: selected ? 100.0 : 200.0,
+///         color: selected ? Colors.red : Colors.blue,
+///         alignment:
+///             selected ? Alignment.center : AlignmentDirectional.topCenter,
+///         duration: Duration(seconds: 2),
+///         curve: curve,
+///         child: FlutterLogo(size: 75),
 ///       ),
-///       RaisedButton(
-///         child: Text('Animate'),
-///         onPressed: _changeSize,
-///       ),
-///     ],
+///     ),
 ///   );
 /// }
 /// ```

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -528,8 +528,8 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@tool sample --template=stateful_widget_scaffold}
 ///
-/// The following example transitions an AnimatedContainer between two states
-/// with different [height], [width], [color], and transform properties using
+/// The following example transitions an AnimatedContainer between two states.
+/// It adjusts the [height], [width], [color], and [alignment] properties using
 /// [State.setState].
 ///
 /// ```dart preamble

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -533,7 +533,6 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// [State.setState].
 ///
 /// ```dart
-/// static const Curve curve = Curves.fastOutSlowIn;
 /// bool selected = false;
 ///
 /// @override
@@ -552,7 +551,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///         alignment:
 ///             selected ? Alignment.center : AlignmentDirectional.topCenter,
 ///         duration: Duration(seconds: 2),
-///         curve: curve,
+///         curve: Curves.fastOutSlowIn,
 ///         child: FlutterLogo(size: 75),
 ///       ),
 ///     ),

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -525,6 +525,57 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_container.mp4}
 ///
+/// {@tool sample}
+///
+/// ```dart
+/// enum BoxState { small, large }
+///
+/// class GrowingBox extends StatefulWidget {
+///   @override
+///   createState() => GrowingBoxState();
+/// }
+///
+/// class GrowingBoxState extends State<GrowingBox> {
+///   BoxState state = BoxState.small;
+///
+///   void _changeSize() {
+///     setState(() {
+///       state = state == BoxState.small ? BoxState.large : BoxState.small;
+///     });
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Column(
+///       mainAxisAlignment: MainAxisAlignment.center,
+///       children: [
+///         AnimatedContainer(
+///           duration: Duration(seconds: 1),
+///           width: state == BoxState.small ? 192 : 256,
+///           height: state == BoxState.small ? 192 : 256,
+///           color: state == BoxState.small ? Colors.blue : Colors.indigo,
+///           transform: Matrix4.rotationZ(state == BoxState.small ? 0.0 : 0.1),
+///           child: Center(
+///             child: Text(
+///               "Hello, World!",
+///               style: Theme.of(context)
+///                   .textTheme
+///                   .display1
+///                   .copyWith(color: Colors.white),
+///             ),
+///           ),
+///         ),
+///         RaisedButton(
+///           child: Text('Animate'),
+///           onPressed: _changeSize,
+///         ),
+///       ],
+///     );
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [AnimatedPadding], which is a subset of this widget that only

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -527,6 +527,10 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@tool sample --template=stateful_widget_scaffold}
 ///
+/// The following example transitions an AnimatedContainer between two states
+/// with different [height], [width], [color], and transform properties using
+/// [State.setState].
+///
 /// ```dart preamble
 /// enum BoxState { small, large }
 /// ```


### PR DESCRIPTION
This adds sample code for AnimatedContainer, loosely off of the AnimatedOpacity docs. This is part of an effort to improve our Animations documentation.
