### PR TITLE
Optimization: do not allocate temporary objects in MatrixUtils.transformRect

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
@@ -1,0 +1,42 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:flutter/painting.dart';
+import 'package:flutter/rendering.dart';
+
+import '../common.dart';
+
+const int _kNumIters = 10000;
+
+void main() {
+  assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
+  print('MatrixUtils.transformRect benchmark...');
+
+  final Matrix4 transform = Matrix4.zero()
+    ..scale(1.2, 1.3, 1.0)
+    ..rotateZ(0.1);
+
+  final List<Rect> _rects = List.generate(_kNumIters, (int i ) {
+    return Rect.fromLTRB(i * 1.1, i * 1.2, i * 1.5, i * 1.8);
+  });
+
+  final Stopwatch watch = Stopwatch();
+  watch.start();
+  for (int i = 0; i < _kNumIters; i += 1) {
+    final Rect rect = _rects[i];
+    MatrixUtils.transformRect(transform, rect);
+  }
+  watch.stop();
+
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  printer.addResult(
+    description: 'MatrixUtils.transformRect',
+    value: watch.elapsedMicroseconds / _kNumIters,
+    unit: 'µs per iteration',
+    name: 'MatrixUtils_transformRect_iteration',
+  );
+  printer.printToStdout();
+}

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -51,6 +51,7 @@ TaskFunction createMicrobenchmarkTask() {
     final Map<String, double> allResults = <String, double>{};
     allResults.addAll(await _runMicrobench('lib/stocks/layout_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/stocks/build_bench.dart'));
+    allResults.addAll(await _runMicrobench('lib/geometry/matrix_utils_transform_rect_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/geometry/rrect_contains_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/gestures/velocity_tracker_bench.dart'));
     allResults.addAll(await _runMicrobench('lib/stocks/animation_bench.dart'));

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -160,13 +160,13 @@ class MatrixUtils {
     //
     // Semantically we transform each corner of the input rect and then pick
     // the min/max values to get the bounding rect. However, doing that
-    // directly would require that we allocate four vectors (one for each)
-    // corner, and perform four perspective transforms. Each vector allocates
-    // a Float64List(3).
+    // directly would require that we allocate four vectors (one for each
+    // corner), four Offset objects, and perform four perspective vector
+    // transforms. Additionally each vector allocates a Float64List(3).
     //
-    // This implementation constructs does not allocate any objects at all.
-    // It uses a temporary matrix (allocated statically once) to store all
-    // point data. The transformation is a single matrix multiplication.
+    // This implementation does not allocate any objects at all. It uses a
+    // temporary matrix (allocated statically once) to store all point
+    // data. The transformation is a single matrix multiplication.
     // Row-major order and transpose multiplication are used to avoid temporary
     // matrices during multiplication (see [Matrix4.multiplyTranspose]).
     // Otherwise, we would have to copy the `transform` matrix to avoid

--- a/packages/flutter/test/painting/matrix_utils_test.dart
+++ b/packages/flutter/test/painting/matrix_utils_test.dart
@@ -121,4 +121,66 @@ void main() {
       forcedOffset,
     );
   });
+
+  test('transformRect with no perspective (w = 1)', () {
+    const Rect l10t20r30b40 = Rect.fromLTRB(10, 20, 30, 40);
+    const Rect l20t40r60b80 = Rect.fromLTRB(20, 40, 60, 80);
+
+    // Identity
+    expect(
+      MatrixUtils.transformRect(Matrix4.identity(), l10t20r30b40),
+      l10t20r30b40,
+    );
+
+    // 2D Scaling
+    expect(
+      MatrixUtils.transformRect(Matrix4.diagonal3Values(2, 2, 2), l10t20r30b40),
+      l20t40r60b80,
+    );
+
+    // Rotation
+    expect(
+      MatrixUtils.transformRect(Matrix4.rotationZ(pi / 2.0), l10t20r30b40),
+      within<Rect>(distance: 0.00001, from: const Rect.fromLTRB(-40.0, 10.0, -20.0, 30.0)),
+    );
+  });
+
+  test('transformRect with perspective (w != 1)', () {
+    final Matrix4 transform = MatrixUtils.createCylindricalProjectionTransform(
+      radius: 10.0,
+      angle: pi / 8.0,
+      perspective: 0.3,
+    );
+
+    for (int i = 1; i < 10000; i++) {
+      final Rect rect = Rect.fromLTRB(11.0 * i, 12.0 * i, 15.0 * i, 18.0 * i);
+      final Rect golden = _vectorWiseTransformRect(transform, rect);
+      expect(MatrixUtils.transformRect(transform, rect), golden);
+    }
+  });
+}
+
+// Produces the same computation as `MatrixUtils.transformRect` but it does this
+// one point at a time. This function is used as the golden implementation of the
+// optimized `MatrixUtils.transformRect` to make sure optimizations do not contain
+// bugs.
+Rect _vectorWiseTransformRect(Matrix4 transform, Rect rect) {
+  final Offset point1 = MatrixUtils.transformPoint(transform, rect.topLeft);
+  final Offset point2 = MatrixUtils.transformPoint(transform, rect.topRight);
+  final Offset point3 = MatrixUtils.transformPoint(transform, rect.bottomLeft);
+  final Offset point4 = MatrixUtils.transformPoint(transform, rect.bottomRight);
+  return Rect.fromLTRB(
+      _min4(point1.dx, point2.dx, point3.dx, point4.dx),
+      _min4(point1.dy, point2.dy, point3.dy, point4.dy),
+      _max4(point1.dx, point2.dx, point3.dx, point4.dx),
+      _max4(point1.dy, point2.dy, point3.dy, point4.dy),
+  );
+}
+
+double _min4(double a, double b, double c, double d) {
+  return min(a, min(b, min(c, d)));
+}
+
+double _max4(double a, double b, double c, double d) {
+  return max(a, max(b, max(c, d)));
 }


### PR DESCRIPTION
## Description

Optimize the performance of `MatrixUtils.transformRect`. This function is called 200-300 times per frame when accessibility is enabled in the material demo page in Flutter Gallery. On Nexus 5X each call costs 2.7 microseconds, which is ~0.8ms of frame time.

The optimization performs the transformation as a single matrix multiplication, and it uses a statically allocated temporary matrix to store intermediate results. This removes 4 `Offset` objects, 4 `Vector3` objects, 4 `Float64List` objects. It replaces 4 separate Matrix x Vector multiplications with one Matrix x Matrix multiplication.

Results:

- Dart AOT (Nexus 5X): 1.42x speed-up (2.7µs => 1.89µs average)
- dart2js (Nexus 5X):  3.09x speed-up (1.52µs => 0.49µs average)
- dart2js (Xeon): 3.84x speed-up (0.62µs => 0.16µs average)

## Related Issues

No issues have been filed for this, but we do observe slowness in Flutter for web when accessibility is enabled. `MatrixUtils.transformRect` shows up in our performance profiles.

## Tests

I added the following tests:

- Added new tests in `matrix_utils_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.
