### PR TITLE
Fix coverage collection

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -196,10 +196,10 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool Function(String) libra
 }) async {
   final VMService vmService = await connector(serviceUri);
   await vmService.getVM();
-  final Isolate isolate = vmService.vm.isolates.firstWhere((Isolate isolate) => isolate.name == debugName);
   if (!waitPaused) {
     return _getAllCoverage(vmService, libraryPredicate);
   }
+  final Isolate isolate = vmService.vm.isolates.firstWhere((Isolate isolate) => isolate.name == debugName);
   const int kPollAttempts = 20;
   int i = 0;
   while (i < kPollAttempts) {


### PR DESCRIPTION
## Description

collect calls which don't specify a debug name or pause should not look for an isolate.