### PR TITLE
benchmarkWidgets.semanticsEnabled default false.

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -173,7 +173,7 @@ void testWidgets(
 Future<void> benchmarkWidgets(
   WidgetTesterCallback callback, {
   bool mayRunWithAsserts = false,
-  bool semanticsEnabled = true,
+  bool semanticsEnabled = false,
 }) {
   assert(() {
     if (mayRunWithAsserts)


### PR DESCRIPTION
In my previous https://github.com/flutter/flutter/pull/35232 which added `semanticsEnabled` to `benchmarkWidgets`, I meant to let it defaults to false in order not to break existing tests. However I set it to true by mistake, and caused benchmark regression warning (which are expected and does not represent real performance change). 

This PR set its default value to false, so that we can evaluate changing the default behavior later.