### PR TITLE
Add Container fallback to Ink build method

### DIFF
--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -259,7 +259,7 @@ class _InkState extends State<Ink> {
       _ink.decoration = widget.decoration;
       _ink.configuration = createLocalImageConfiguration(context);
     }
-    Widget current = widget.child;
+    Widget current = widget.child ?? Container();
     final EdgeInsetsGeometry effectivePadding = widget._paddingIncludingDecoration;
     if (effectivePadding != null)
       current = Padding(padding: effectivePadding, child: current);

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -259,11 +259,11 @@ class _InkState extends State<Ink> {
       _ink.decoration = widget.decoration;
       _ink.configuration = createLocalImageConfiguration(context);
     }
-    Widget current = widget.child ?? Container();
+    Widget current = widget.child;
     final EdgeInsetsGeometry effectivePadding = widget._paddingIncludingDecoration;
     if (effectivePadding != null)
       current = Padding(padding: effectivePadding, child: current);
-    return current;
+    return current ?? Container();
   }
 
   @override

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -10,12 +10,20 @@ import '../rendering/mock_canvas.dart';
 
 void main() {
   testWidgets('The Ink widget renders a Container by default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Material(
+        child: Ink(),
+      ),
+    );
+    RenderBox container = tester.renderObject(find.byType(Container));
+    expect(container.size.height, 600.0);
+    expect(container.size.width, 800.0);
+
     const double height = 150.0;
     const double width = 200.0;
     await tester.pumpWidget(
-      Align(
-        alignment: Alignment.topLeft,
-        child: Material(
+      Material(
+        child: Center( // used to constrain to child's size
           child: Ink(
             height: height,
             width: width,
@@ -23,8 +31,9 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
-    final RenderBox container = tester.renderObject(find.byType(Container));
+    container = tester.renderObject(find.byType(Container));
     expect(container.size.height, height);
     expect(container.size.width, width);
   });

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -9,6 +9,26 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+  testWidgets('The Ink widget renders a Container by default', (WidgetTester tester) async {
+    const double height = 150.0;
+    const double width = 200.0;
+    await tester.pumpWidget(
+      Align(
+        alignment: Alignment.topLeft,
+        child: Material(
+          child: Ink(
+            height: height,
+            width: width,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox container = tester.renderObject(find.byType(Container));
+    expect(container.size.height, height);
+    expect(container.size.width, width);
+  });
+
   testWidgets('The InkWell widget renders an ink splash', (WidgetTester tester) async {
     const Color highlightColor = Color(0xAAFF0000);
     const Color splashColor = Color(0xAA0000FF);

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -31,7 +31,6 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-
     expect(tester.getSize(find.byType(Container)).height, height);
     expect(tester.getSize(find.byType(Container)).width, width);
   });

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -15,9 +15,8 @@ void main() {
         child: Ink(),
       ),
     );
-    RenderBox container = tester.renderObject(find.byType(Container));
-    expect(container.size.height, 600.0);
-    expect(container.size.width, 800.0);
+    expect(tester.getSize(find.byType(Container)).height, 600.0);
+    expect(tester.getSize(find.byType(Container)).width, 800.0);
 
     const double height = 150.0;
     const double width = 200.0;
@@ -33,9 +32,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    container = tester.renderObject(find.byType(Container));
-    expect(container.size.height, height);
-    expect(container.size.width, width);
+    expect(tester.getSize(find.byType(Container)).height, height);
+    expect(tester.getSize(find.byType(Container)).width, width);
   });
 
   testWidgets('The InkWell widget renders an ink splash', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Adds a fallback for `Ink` so that when a `child` is not provided, a `Container` is used instead. 

## Related Issues

Related to PR https://github.com/flutter/flutter/pull/35211

## Tests

I added the following tests:

- Test to verify that a Container is built by default when no child is specified.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
