### PR TITLE
Clean up host_app_ephemeral Profile build settings

### DIFF
--- a/dev/integration_tests/ios_add2app/build_and_test.sh
+++ b/dev/integration_tests/ios_add2app/build_and_test.sh
@@ -6,6 +6,12 @@ cd "$(dirname "$0")"
 
 pushd flutterapp
 ../../../../bin/flutter build ios --debug --no-codesign -v
+
+pushd .ios
+xcodebuild -workspace Runner.xcworkspace -scheme Runner -destination generic/platform=iOS -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGNING_IDENTITY="" CODE_SIGNING_ALLOWED=NO
+xcodebuild -workspace Runner.xcworkspace -scheme Runner -destination generic/platform=iOS -configuration Profile CODE_SIGNING_REQUIRED=NO CODE_SIGNING_IDENTITY="" CODE_SIGNING_ALLOWED=NO
+xcodebuild -workspace Runner.xcworkspace -scheme Runner -destination generic/platform=iOS -configuration Release CODE_SIGNING_REQUIRED=NO CODE_SIGNING_IDENTITY="" CODE_SIGNING_ALLOWED=NO
+popd
 popd
 
 pod install

--- a/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/xcshareddata/xcschemes/ios_add2app.xcscheme
+++ b/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/xcshareddata/xcschemes/ios_add2app.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24E221B421A28A0B008ADF09"
+               BuildableName = "ios_add2app.app"
+               BlueprintName = "ios_add2app"
+               ReferencedContainer = "container:ios_add2app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "24E221B421A28A0B008ADF09"
+            BuildableName = "ios_add2app.app"
+            BlueprintName = "ios_add2app"
+            ReferencedContainer = "container:ios_add2app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "24E221B421A28A0B008ADF09"
+            BuildableName = "ios_add2app.app"
+            BlueprintName = "ios_add2app"
+            ReferencedContainer = "container:ios_add2app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -76,7 +76,7 @@ BuildApp() {
       EchoError "If that is not set, the CONFIGURATION environment variable is used."
       EchoError ""
       EchoError "You can fix this by either adding an appropriately named build"
-      EchoError "configuration, or adding an appriate value for FLUTTER_BUILD_MODE to the"
+      EchoError "configuration, or adding an appropriate value for FLUTTER_BUILD_MODE to the"
       EchoError ".xcconfig file for the current build configuration (${CONFIGURATION})."
       EchoError "========================================================================"
       exit -1;;

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Config.tmpl/Release.xcconfig
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Config.tmpl/Release.xcconfig
@@ -1,2 +1,1 @@
 #include "Flutter.xcconfig"
-FLUTTER_BUILD_MODE=release

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.xcodeproj.tmpl/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.xcodeproj.tmpl/project.pbxproj.tmpl
@@ -312,11 +312,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
+					"$(PROJECT_DIR)/Flutter/engine",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
## Description

* Remove FLUTTER_BUILD_MODE from the Release xcconfig since the Profile build config uses it as a base, and it's no longer needed as of https://github.com/flutter/flutter/pull/23387/files#diff-0d00f38df3883291f23cee8074ac075d.
* Remove the Profile build config DEVELOPMENT_TEAM and add the "$(PROJECT_DIR)/Flutter/engine" framework search path so it builds.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/35302.

## Tests

I added the following tests:

Expanded ios_add2app integration test to run xcodebuild for Flutter subproject.  This required adding an app scheme to that project.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
