### PR TITLE
Mark update-packages as non-experimental

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -78,9 +78,6 @@ class UpdatePackagesCommand extends FlutterCommand {
   }
 
   @override
-  bool get isExperimental => true;
-
-  @override
   final String name = 'update-packages';
 
   @override

--- a/packages/flutter_tools/test/commands/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands/update_packages_test.dart
@@ -1,0 +1,18 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/commands/update_packages.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+void main() {
+  group('UpdatePackagesCommand', () {
+    // Marking it as experimental breaks bots tests and packaging scripts on stable branches.
+    testUsingContext('is not marked as experimental', () async {
+      final UpdatePackagesCommand command = UpdatePackagesCommand();
+      expect(command.isExperimental, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Mark update-packages as non-experimental.

Marking it as experimental was breaking tests and packaging
scripts on stable branches.

## Tests

 I added the following tests:

* A test that ensures the command remains non-experimental.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.