### PR TITLE
Update a potentially final callback field

### DIFF
--- a/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
@@ -714,7 +714,7 @@ class _TestLayoutPerformer extends SingleChildRenderObjectWidget {
 class _RenderTestLayoutPerformer extends RenderBox {
   _RenderTestLayoutPerformer({VoidCallback performLayout}) : _performLayout = performLayout;
 
-  VoidCallback _performLayout;
+  final VoidCallback _performLayout;
 
   @override
   void performLayout() {


### PR DESCRIPTION
Caught by a newly improved `prefer_final_fields` lint that hasn't made it's way into Flutter just yet.

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8909092515117476256/+/steps/analyze_flutter/0/stdout

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes


/cc @stereotype441 @dnfield 