### PR TITLE
Update the help message on precache command for less confusion

### DIFF
--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -12,7 +12,7 @@ import '../version.dart';
 class PrecacheCommand extends FlutterCommand {
   PrecacheCommand() {
     argParser.addFlag('all-platforms', abbr: 'a', negatable: false,
-        help: 'Precache artifacts for all platforms.');
+        help: 'Precache artifacts for all host platforms.');
     argParser.addFlag('force', abbr: 'f', negatable: false,
         help: 'Force downloading of artifacts.');
     argParser.addFlag('android', negatable: true, defaultsTo: true,


### PR DESCRIPTION
I got confused by the "all platforms" here, apparently it means host platform and target platforms are controlled by separate flags.