### PR TITLE
Fix RenderFittedBox when child.size.isEmpty

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3614,7 +3614,7 @@ class _SemanticsGeometry {
     assert(transform != null);
     if (rect == null)
       return null;
-    if (rect.isEmpty)
+    if (rect.isEmpty || transform.isZero())
       return Rect.zero;
     return MatrixUtils.inverseTransformRect(transform, rect);
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2311,7 +2311,7 @@ class RenderFittedBox extends RenderProxyBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    if (size.isEmpty)
+    if (size.isEmpty || child?.size?.isEmpty == true)
       return false;
     _updatePaintData();
     return result.addWithPaintTransform(
@@ -2325,7 +2325,7 @@ class RenderFittedBox extends RenderProxyBox {
 
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
-    if (size.isEmpty) {
+    if (size.isEmpty || child.size.isEmpty) {
       transform.setZero();
     } else {
       _updatePaintData();

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -16,18 +16,13 @@ import 'rendering_tester.dart';
 
 void main() {
   test('RenderFittedBox handles applying paint transform and hit-testing with empty size', () {
-    RenderFittedBox makeFittedBox(Size size) {
-      return RenderFittedBox(
-        child: RenderCustomPaint(
-          preferredSize: size,
-          painter: TestCallbackPainter(onPaint: () {
-          }),
-        ),
-      );
-    }
+    final RenderFittedBox fittedBox = RenderFittedBox(
+      child: RenderCustomPaint(
+        preferredSize: Size.zero,
+        painter: TestCallbackPainter(onPaint: () {}),
+      ),
+    );
 
-    // The RenderFittedBox paints if both its size and its child's size are nonempty.
-    final RenderFittedBox fittedBox = makeFittedBox(Size.zero);
     layout(fittedBox, phase: EnginePhase.flushSemantics);
     final Matrix4 transform = Matrix4.identity();
     fittedBox.applyPaintTransform(fittedBox.child, transform);

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -15,6 +15,28 @@ import '../flutter_test_alternative.dart';
 import 'rendering_tester.dart';
 
 void main() {
+  test('RenderFittedBox handles applying paint transform and hit-testing with empty size', () {
+    RenderFittedBox makeFittedBox(Size size) {
+      return RenderFittedBox(
+        child: RenderCustomPaint(
+          preferredSize: size,
+          painter: TestCallbackPainter(onPaint: () {
+          }),
+        ),
+      );
+    }
+
+    // The RenderFittedBox paints if both its size and its child's size are nonempty.
+    final RenderFittedBox fittedBox = makeFittedBox(Size.zero);
+    layout(fittedBox, phase: EnginePhase.flushSemantics);
+    final Matrix4 transform = Matrix4.identity();
+    fittedBox.applyPaintTransform(fittedBox.child, transform);
+    expect(transform, Matrix4.zero());
+
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    expect(fittedBox.hitTestChildren(hitTestResult), isFalse);
+  });
+
   test('RenderFittedBox does not paint with empty sizes', () {
     bool painted;
     RenderFittedBox makeFittedBox(Size size) {

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -61,6 +61,25 @@ class _UpdateCountedClipPath extends ClipPath {
 }
 
 void main() {
+  testWidgets('ClipRect with a FittedBox child sized to zero works with semantics', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: ClipRect(
+          child: FittedBox(
+            child: SizedBox.fromSize(
+              size: Size.zero,
+              child: Semantics(
+                image: true,
+                label: 'Image',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.byType(FittedBox), findsOneWidget);
+  });
+
   testWidgets('ClipRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(const _UpdateCountedClipRect());
 


### PR DESCRIPTION
## Description

This was discovered on intenral tests after enabling semantics in testing.  We missed this previously.

When a RenderFittedBox's child is size.zero, we shouldn't try to figure out the scale. We guard this correctly on paint, but weren't doing so for applyPaintTransform or hitTestChildren.

## Tests

I added the following tests:

Test that we can properly hit test/apply paint transform when the child is zero sized.
Test that we can properly compute the semantics when a clip rect is surrounding a zero sized fitted box.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
