### PR TITLE
Do not use ideographic baseline for RenderPargraph baseline

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -318,7 +318,11 @@ class RenderParagraph extends RenderBox
     assert(constraints != null);
     assert(constraints.debugAssertIsValid());
     _layoutTextWithConstraints(constraints);
-    return _textPainter.computeDistanceToActualBaseline(baseline);
+    // TODO(garyq): Since our metric for ideographic baseline is currently inacurrate
+    // and the non-alphabetic baselines are based off of the alphabetic baseline, we
+    // use the alphabetic for now to produce correct layouts. We should eventually change
+    // this back to pass the `baseline` property in.
+    return _textPainter.computeDistanceToActualBaseline(TextBaseline.alphabetic);
   }
 
   // Intrinsics cannot be calculated without a full layout for

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -321,7 +321,8 @@ class RenderParagraph extends RenderBox
     // TODO(garyq): Since our metric for ideographic baseline is currently inacurrate
     // and the non-alphabetic baselines are based off of the alphabetic baseline, we
     // use the alphabetic for now to produce correct layouts. We should eventually change
-    // this back to pass the `baseline` property in.
+    // this back to pass the `baseline` property when the ideographic baseline is properly
+    // implemented (https://github.com/flutter/flutter/issues/22625).
     return _textPainter.computeDistanceToActualBaseline(TextBaseline.alphabetic);
   }
 

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -1,0 +1,183 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Text baseline with CJK locale', (WidgetTester tester) async {
+    // This test in combination with 'Text baseline with EN locale' verify the baselines
+    // used to align text with ideographic baselines is reasonable. We are currently
+    // using the alphabetic baseline to lay out as the ideographic baseline is not yet
+    // properly implemented. When the ideographic baseline is better defined and implemented,
+    // the values of this test should change very slightly.
+    final Key targetKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: <String, WidgetBuilder>{
+          '/next': (BuildContext context) {
+            return const Text('Next');
+          },
+        },
+        localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+          GlobalMaterialLocalizations.delegate,
+        ],
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('es', 'ES'),
+          Locale('zh', 'CN'),
+        ],
+        locale: const Locale('zh', 'CN'),
+        home: Material(
+          child: Center(
+            child: Builder(
+              key: targetKey,
+              builder: (BuildContext context) {
+                return PopupMenuButton<int>(
+                  onSelected: (int value) {
+                    Navigator.pushNamed(context, '/next');
+                  },
+                  itemBuilder: (BuildContext context) {
+                    return [
+                      PopupMenuItem(
+                        value: 1,
+                        child: Text(
+                          'hello, world',
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: 2,
+                        child: Text(
+                          '你好，世界',
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                      ),
+                    ];
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(targetKey));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+    expect(find.text('hello, world'), findsOneWidget);
+    expect(find.text('你好，世界'), findsOneWidget);
+
+    Offset topLeft = tester.getTopLeft(find.text('hello, world'));
+    Offset topRight = tester.getTopRight(find.text('hello, world'));
+    Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
+    Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
+
+    expect(topLeft, Offset(392.0, 298.3999996185303));
+    expect(topRight, Offset(596.0, 298.3999996185303));
+    expect(bottomLeft, Offset(392.0, 315.3999996185303));
+    expect(bottomRight, Offset(596.0, 315.3999996185303));
+
+    topLeft = tester.getTopLeft(find.text('你好，世界'));
+    topRight = tester.getTopRight(find.text('你好，世界'));
+    bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
+    bottomRight = tester.getBottomRight(find.text('你好，世界'));
+
+    expect(topLeft, Offset(392.0, 346.3999996185303));
+    expect(topRight, Offset(477.0, 346.3999996185303));
+    expect(bottomLeft, Offset(392.0, 363.3999996185303));
+    expect(bottomRight, Offset(477.0, 363.3999996185303));
+  });
+
+  testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
+    // This test in combination with 'Text baseline with CJK locale' verify the baselines
+    // used to align text with ideographic baselines is reasonable. We are currently
+    // using the alphabetic baseline to lay out as the ideographic baseline is not yet
+    // properly implemented. When the ideographic baseline is better defined and implemented,
+    // the values of this test should change very slightly.
+    final Key targetKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: <String, WidgetBuilder>{
+          '/next': (BuildContext context) {
+            return const Text('Next');
+          },
+        },
+        localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+          GlobalMaterialLocalizations.delegate,
+        ],
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('es', 'ES'),
+          Locale('zh', 'CN'),
+        ],
+        locale: const Locale('en', 'US'),
+        home: Material(
+          child: Center(
+            child: Builder(
+              key: targetKey,
+              builder: (BuildContext context) {
+                return PopupMenuButton<int>(
+                  onSelected: (int value) {
+                    Navigator.pushNamed(context, '/next');
+                  },
+                  itemBuilder: (BuildContext context) {
+                    return [
+                      PopupMenuItem(
+                        value: 1,
+                        child: Text(
+                          'hello, world',
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: 2,
+                        child: Text(
+                          '你好，世界',
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                      ),
+                    ];
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(targetKey));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+
+    expect(find.text('hello, world'), findsOneWidget);
+    expect(find.text('你好，世界'), findsOneWidget);
+
+    Offset topLeft = tester.getTopLeft(find.text('hello, world'));
+    Offset topRight = tester.getTopRight(find.text('hello, world'));
+    Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
+    Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
+
+
+    expect(topLeft, Offset(392.0, 299.19999980926514));
+    expect(topRight, Offset(584.0, 299.19999980926514));
+    expect(bottomLeft, Offset(392.0, 315.19999980926514));
+    expect(bottomRight, Offset(584.0, 315.19999980926514));
+
+    topLeft = tester.getTopLeft(find.text('你好，世界'));
+    topRight = tester.getTopRight(find.text('你好，世界'));
+    bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
+    bottomRight = tester.getBottomRight(find.text('你好，世界'));
+
+    expect(topLeft, Offset(392.0, 347.19999980926514));
+    expect(topRight, Offset(472.0, 347.19999980926514));
+    expect(bottomLeft, Offset(392.0, 363.19999980926514));
+    expect(bottomRight, Offset(472.0, 363.19999980926514));
+  });
+}

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -42,15 +42,15 @@ void main() {
                     Navigator.pushNamed(context, '/next');
                   },
                   itemBuilder: (BuildContext context) {
-                    return [
-                      PopupMenuItem(
+                    return <PopupMenuItem<int>>[
+                      PopupMenuItem<int>(
                         value: 1,
                         child: Text(
                           'hello, world',
                           style: TextStyle(color: Colors.blue),
                         ),
                       ),
-                      PopupMenuItem(
+                      PopupMenuItem<int>(
                         value: 2,
                         child: Text(
                           '你好，世界',
@@ -79,20 +79,20 @@ void main() {
     Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
-    expect(topLeft, Offset(392.0, 298.3999996185303));
-    expect(topRight, Offset(596.0, 298.3999996185303));
-    expect(bottomLeft, Offset(392.0, 315.3999996185303));
-    expect(bottomRight, Offset(596.0, 315.3999996185303));
+    expect(topLeft, const Offset(392.0, 298.3999996185303));
+    expect(topRight, const Offset(596.0, 298.3999996185303));
+    expect(bottomLeft, const Offset(392.0, 315.3999996185303));
+    expect(bottomRight, const Offset(596.0, 315.3999996185303));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, Offset(392.0, 346.3999996185303));
-    expect(topRight, Offset(477.0, 346.3999996185303));
-    expect(bottomLeft, Offset(392.0, 363.3999996185303));
-    expect(bottomRight, Offset(477.0, 363.3999996185303));
+    expect(topLeft, const Offset(392.0, 346.3999996185303));
+    expect(topRight, const Offset(477.0, 346.3999996185303));
+    expect(bottomLeft, const Offset(392.0, 363.3999996185303));
+    expect(bottomRight, const Offset(477.0, 363.3999996185303));
   });
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
@@ -129,15 +129,15 @@ void main() {
                     Navigator.pushNamed(context, '/next');
                   },
                   itemBuilder: (BuildContext context) {
-                    return [
-                      PopupMenuItem(
+                    return <PopupMenuItem<int>>[
+                      PopupMenuItem<int>(
                         value: 1,
                         child: Text(
                           'hello, world',
                           style: TextStyle(color: Colors.blue),
                         ),
                       ),
-                      PopupMenuItem(
+                      PopupMenuItem<int>(
                         value: 2,
                         child: Text(
                           '你好，世界',
@@ -167,19 +167,19 @@ void main() {
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
 
-    expect(topLeft, Offset(392.0, 299.19999980926514));
-    expect(topRight, Offset(584.0, 299.19999980926514));
-    expect(bottomLeft, Offset(392.0, 315.19999980926514));
-    expect(bottomRight, Offset(584.0, 315.19999980926514));
+    expect(topLeft, const Offset(392.0, 299.19999980926514));
+    expect(topRight, const Offset(584.0, 299.19999980926514));
+    expect(bottomLeft, const Offset(392.0, 315.19999980926514));
+    expect(bottomRight, const Offset(584.0, 315.19999980926514));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, Offset(392.0, 347.19999980926514));
-    expect(topRight, Offset(472.0, 347.19999980926514));
-    expect(bottomLeft, Offset(392.0, 363.19999980926514));
-    expect(bottomRight, Offset(472.0, 363.19999980926514));
+    expect(topLeft, const Offset(392.0, 347.19999980926514));
+    expect(topRight, const Offset(472.0, 347.19999980926514));
+    expect(bottomLeft, const Offset(392.0, 363.19999980926514));
+    expect(bottomRight, const Offset(472.0, 363.19999980926514));
   });
 }

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -13,7 +13,8 @@ void main() {
     // used to align text with ideographic baselines is reasonable. We are currently
     // using the alphabetic baseline to lay out as the ideographic baseline is not yet
     // properly implemented. When the ideographic baseline is better defined and implemented,
-    // the values of this test should change very slightly.
+    // the values of this test should change very slightly. See the issue this is based off
+    // of: https://github.com/flutter/flutter/issues/25782.
     final Key targetKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
@@ -99,7 +100,8 @@ void main() {
     // used to align text with ideographic baselines is reasonable. We are currently
     // using the alphabetic baseline to lay out as the ideographic baseline is not yet
     // properly implemented. When the ideographic baseline is better defined and implemented,
-    // the values of this test should change very slightly.
+    // the values of this test should change very slightly. See the issue this is based off
+    // of: https://github.com/flutter/flutter/issues/25782.
     final Key targetKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Text baseline with CJK locale', (WidgetTester tester) async {
     // This test in combination with 'Text baseline with EN locale' verify the baselines
-    // used to align text with ideographic baselines is reasonable. We are currently
+    // used to align text with ideographic baselines are reasonable. We are currently
     // using the alphabetic baseline to lay out as the ideographic baseline is not yet
     // properly implemented. When the ideographic baseline is better defined and implemented,
     // the values of this test should change very slightly. See the issue this is based off
@@ -68,8 +68,7 @@ void main() {
     );
 
     await tester.tap(find.byKey(targetKey));
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+    await tester.pumpAndSettle();
 
     expect(find.text('hello, world'), findsOneWidget);
     expect(find.text('你好，世界'), findsOneWidget);
@@ -97,7 +96,7 @@ void main() {
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
     // This test in combination with 'Text baseline with CJK locale' verify the baselines
-    // used to align text with ideographic baselines is reasonable. We are currently
+    // used to align text with ideographic baselines are reasonable. We are currently
     // using the alphabetic baseline to lay out as the ideographic baseline is not yet
     // properly implemented. When the ideographic baseline is better defined and implemented,
     // the values of this test should change very slightly. See the issue this is based off
@@ -155,8 +154,7 @@ void main() {
     );
 
     await tester.tap(find.byKey(targetKey));
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1)); // finish the menu animation
+    await tester.pumpAndSettle();
 
     expect(find.text('hello, world'), findsOneWidget);
     expect(find.text('你好，世界'), findsOneWidget);

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(topRight, const Offset(477.0, 346.3999996185303));
     expect(bottomLeft, const Offset(392.0, 363.3999996185303));
     expect(bottomRight, const Offset(477.0, 363.3999996185303));
-  });
+  }, skip: !isLinux);
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
     // This test in combination with 'Text baseline with CJK locale' verify the baselines
@@ -179,5 +179,5 @@ void main() {
     expect(topRight, const Offset(472.0, 347.19999980926514));
     expect(bottomLeft, const Offset(392.0, 363.19999980926514));
     expect(bottomRight, const Offset(472.0, 363.19999980926514));
-  });
+  }, skip: !isLinux);
 }


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/issues/25782 Has found that using the ideographic baseline for CJK results in improper vertical centering of text. The root cause of this is that the ideographic baseline implementation in LibTxt is currently only an approximation (an existing TODO specifies fixing this), and should not be used for sensitive purposes.

Here, we override the baseline parameter and always use TextBaseline.alphabtic since it produces a much more accurate and reasonable baseline for most CJK fonts.

The long term solution is to fully support other baselines and provide accurate values for them.

## Related Issues

https://github.com/flutter/flutter/issues/25782

## Tests

Verify that the position of the text is as expected in a popupmenu.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.