### PR TITLE
Defer reassemble until reload is finished

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -127,7 +127,10 @@ abstract class BindingBase {
     assert(() {
       registerSignalServiceExtension(
         name: 'reassemble',
-        callback: reassembleApplication,
+        callback: () {
+          developer.debugger();
+          return reassembleApplication();
+        },
       );
       return true;
     }());

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -65,6 +65,15 @@ abstract class BindingBase {
     developer.Timeline.finishSync();
   }
 
+  /// Used by ext.flutter.reassemble to set a breakpoint before reloading.
+  ///
+  /// Test bindings may override this to avoid actually setting a breakpoint.
+  @protected
+  @visibleForTesting
+  void setBreakpoint() {
+    developer.debugger();
+  }
+
   static bool _debugInitialized = false;
   static bool _debugServiceExtensionsRegistered = false;
 
@@ -128,7 +137,7 @@ abstract class BindingBase {
       registerSignalServiceExtension(
         name: 'reassemble',
         callback: () {
-          developer.debugger();
+          setBreakpoint();
           return reassembleApplication();
         },
       );

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2666,16 +2666,6 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// the `ext.flutter.reassemble` hook is not available, and so this code will
   /// never execute.
   ///
-  /// Implementers should not rely on any ordering for hot reload source update,
-  /// reassemble, and build methods after a hot reload has been initiated. It is
-  /// possible that a [Timer] (e.g. an [Animation]) or a debugging session
-  /// attached to the isolate could trigger a build with reloaded code _before_
-  /// reassemble is called. Code that expects preconditions to be set by
-  /// reassemble after a hot reload must be resilient to being called out of
-  /// order, e.g. by fizzling instead of throwing. That said, once reassemble is
-  /// called, build will be called after it at least once.
-  /// {@endtemplate}
-  ///
   /// See also:
   ///
   ///  * [State.reassemble]

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -30,6 +30,12 @@ class TestServiceExtensionsBinding extends BindingBase
 
   final Map<String, List<Map<String, dynamic>>> eventsDispatched = <String, List<Map<String, dynamic>>>{};
 
+  bool inBreakpoint = false;
+  @override
+  void setBreakpoint() {
+    inBreakpoint = true;
+  }
+
   @override
   void registerServiceExtension({
     @required String name,
@@ -559,7 +565,8 @@ void main() {
     completed = false;
     expect(binding.reassembled, 0);
     pendingResult = binding.testExtension('reassemble', <String, String>{});
-    pendingResult.whenComplete(() { completed = true; });
+    expect(binding.inBreakpoint, true);
+    pendingResult.whenComplete(() { completed = true; binding.inBreakpoint = false; });
     await binding.flushMicrotasks();
     expect(binding.frameScheduled, isTrue);
     expect(completed, false);

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -564,6 +564,7 @@ void main() {
 
     completed = false;
     expect(binding.reassembled, 0);
+    expect(binding.inBreakpoint, false);
     pendingResult = binding.testExtension('reassemble', <String, String>{});
     expect(binding.inBreakpoint, true);
     pendingResult.whenComplete(() { completed = true; binding.inBreakpoint = false; });

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -619,6 +619,7 @@ class HotRunner extends ResidentRunner {
     final List<FlutterView> reassembleViews = <FlutterView>[];
     String serviceEventKind;
     int pausedIsolatesFound = 0;
+    final List<Future<void>> futures = <Future<void>>[];
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         // Check if the isolate is paused, and if so, don't reassemble. Ignore the
@@ -632,7 +633,7 @@ class HotRunner extends ResidentRunner {
             serviceEventKind = ''; // many kinds
           }
         } else {
-          unawaited(view.uiIsolate.flutterReassemble());
+          futures.add(view.uiIsolate.flutterReassemble());
           reassembleViews.add(view);
         }
       }
@@ -757,7 +758,6 @@ class HotRunner extends ResidentRunner {
     assert(reassembleViews.isNotEmpty);
     printTrace('Reassembling application');
     bool failedReassemble = false;
-    final List<Future<void>> futures = <Future<void>>[];
     // Resume the isolates we paused earlier.
     for (FlutterView view in reassembleViews) {
       futures.add(() async {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1239,7 +1239,12 @@ class Isolate extends ServiceObjectOwner {
 
   /// Resumes the isolate.
   Future<Map<String, dynamic>> resume() {
-    return invokeRpcRaw('resume');
+    return invokeRpcRaw('resume').then((Map<String, dynamic> result) {
+      if (result['type'] == 'Success') {
+        pauseEvent = ServiceEvent._empty(this).._kind = ServiceEvent.kResume;
+      }
+      return result;
+    });
   }
 
   // Flutter extension methods.


### PR DESCRIPTION
## Description

Instead of reassembling after we're done reloading, call reassemble first and set a breakpoint.

Then, do the reload, and resume.

## Related Issues

Fixes #26503 

## Tests

I added the following tests:

Updated the reassemble service extension test.

__TODO__: Test the original problem.  Will have to think about how to do that in a non-flaky way.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
