### PR TITLE
Support for elevation based dark theme overlay color in the Material widget

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -338,8 +338,8 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
   Color _darkThemeOverlayColor(BuildContext context, double elevation) {
     final ThemeData theme = Theme.of(context);
     if (elevation > 0.0 &&
-        theme.brightness == Brightness.dark &&
-        theme.applyDarkThemeElevationOverlay) {
+      theme.brightness == Brightness.dark &&
+      theme.applyDarkThemeElevationOverlay) {
 
       // Compute the opacity for the given elevation according to the spec:
       // https://material.io/design/color/dark-theme.html#properties

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -203,12 +203,12 @@ class Material extends StatefulWidget {
   /// The z-coordinate at which to place this material relative to its parent.
   ///
   /// This controls the size of the shadow below the material and the opacity
-  /// of the dark theme overlay color.
+  /// of the elevation overlay color if it is applied.
   ///
   /// If this is non-zero, the contents of the material are clipped, because the
   /// widget conceptually defines an independent printed piece of material.
   ///
-  /// Defaults to 0. Changing this value will cause the shadow and the dark theme
+  /// Defaults to 0. Changing this value will cause the shadow and the elevation
   /// overlay to animate over [animationDuration].
   ///
   /// The value is non-negative.
@@ -217,7 +217,7 @@ class Material extends StatefulWidget {
   ///
   ///   * [ThemeData.applyElevationOverlay] which controls the whether
   ///     an overlay color will be applied to indicate elevation.
-  ///   * [color] which may have a dark theme overlay applied.
+  ///   * [color] which may have an elevation overlay applied.
   ///
   /// {@endtemplate}
   final double elevation;

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -267,7 +267,7 @@ class Material extends StatefulWidget {
   final Clip clipBehavior;
 
   /// Defines the duration of animated changes for [shape], [elevation],
-  /// [shadowColor] and the dark theme overlay if in a dark theme.
+  /// [shadowColor] and the elevation overlay if it is applied.
   ///
   /// The default value is [kThemeChangeDuration].
   final Duration animationDuration;
@@ -317,7 +317,7 @@ class Material extends StatefulWidget {
 }
 
 // Apply a semi-transparent white on surface colors to
-// indicate the level of elevation..
+// indicate the level of elevation.
 Color _elevationOverlayColor(BuildContext context, Color background, double elevation) {
   final ThemeData theme = Theme.of(context);
   if (elevation > 0.0 &&

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -215,7 +215,7 @@ class Material extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///   * [ThemeData.applyElevationOverlay] which controls the whether
+  ///   * [ThemeData.applyElevationOverlayColor] which controls the whether
   ///     an overlay color will be applied to indicate elevation.
   ///   * [color] which may have an elevation overlay applied.
   ///
@@ -228,7 +228,7 @@ class Material extends StatefulWidget {
   /// [MaterialType.transparency].
   ///
   /// To support dark themes, if the surrounding
-  /// [ThemeData.applyElevationOverlay] is [true] and
+  /// [ThemeData.applyElevationOverlayColor] is [true] and
   /// this color is [ThemeData.colorScheme.surface] then a semi-transparent
   /// white will be composited on top this color to indicate the elevation.
   ///
@@ -321,8 +321,8 @@ class Material extends StatefulWidget {
 Color _elevationOverlayColor(BuildContext context, Color background, double elevation) {
   final ThemeData theme = Theme.of(context);
   if (elevation > 0.0 &&
-    theme.applyElevationOverlay &&
-    background == theme.colorScheme.surface) {
+      theme.applyElevationOverlayColor &&
+      background == theme.colorScheme.surface) {
 
     // Compute the opacity for the given elevation
     // This formula matches the values in the spec:

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -155,9 +155,9 @@ abstract class MaterialInkController {
 class Material extends StatefulWidget {
   /// Creates a piece of material.
   ///
-  /// The [type], [elevation], [darkThemeOverlay], [shadowColor],
-  /// [borderOnForeground] and [animationDuration] arguments must not be null.
-  /// Additionally, [elevation] must be non-negative.
+  /// The [type], [elevation], [shadowColor], [borderOnForeground] and
+  /// [animationDuration] arguments must not be null. Additionally, [elevation]
+  /// must be non-negative.
   ///
   /// If a [shape] is specified, then the [borderRadius] property must be
   /// null and the [type] property must not be [MaterialType.circle]. If the
@@ -169,7 +169,7 @@ class Material extends StatefulWidget {
     this.type = MaterialType.canvas,
     this.elevation = 0.0,
     this.color,
-    this.darkThemeOverlay = true,
+    this.applyDarkThemeElevationOverlay,
     this.shadowColor = const Color(0xFF000000),
     this.textStyle,
     this.borderRadius,
@@ -180,7 +180,6 @@ class Material extends StatefulWidget {
     this.child,
   }) : assert(type != null),
        assert(elevation != null && elevation >= 0.0),
-       assert(darkThemeOverlay != null),
        assert(shadowColor != null),
        assert(!(shape != null && borderRadius != null)),
        assert(animationDuration != null),
@@ -221,8 +220,9 @@ class Material extends StatefulWidget {
   /// Must be opaque. To create a transparent piece of material, use
   /// [MaterialType.transparency].
   ///
-  /// If inside a dark theme and [darkThemeOverlay] is [true], a semi-transparent
-  /// white will be composited on top this color to indicated the elevation.
+  /// If inside a dark theme and [applyDarkThemeElevationOverlay] is [true],
+  /// a semi-transparent white will be composited on top this color to
+  /// indicated the elevation.
   ///
   /// By default, the color is derived from the [type] of material.
   final Color color;
@@ -235,14 +235,15 @@ class Material extends StatefulWidget {
   ///
   /// If [false] the [color] will be used unmodified.
   ///
-  /// Defaults to [true].
+  /// If [null] then it will use the value of the surrounding
+  /// [ThemeData.applyDarkThemeElevationOverlay] which defaults to [false].
   ///
   /// See also:
   ///   * [Material.color]
   ///   * [Material.elevation]
   ///   * [ThemeData.brightness]
   ///   * <https://material.io/design/color/dark-theme.html>
-  final bool darkThemeOverlay;
+  final bool applyDarkThemeElevationOverlay;
 
   /// The color to paint the shadow below the material.
   ///
@@ -314,7 +315,7 @@ class Material extends StatefulWidget {
     properties.add(EnumProperty<MaterialType>('type', type));
     properties.add(DoubleProperty('elevation', elevation, defaultValue: 0.0));
     properties.add(ColorProperty('color', color, defaultValue: null));
-    properties.add(FlagProperty('darkThemeOverlay', value: true, ifFalse: 'no dark overlay'));
+    properties.add(FlagProperty('applyDarkThemeElevationOverlay', value: true, ifFalse: 'no elevation overlay'));
     properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: const Color(0xFF000000)));
     textStyle?.debugFillProperties(properties, prefix: 'textStyle.');
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
@@ -339,10 +340,12 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
       }
     }
 
-    if (color != null &&
-        widget.darkThemeOverlay &&
-        Theme.of(context).brightness == Brightness.dark) {
-      color = _darkThemeOverlayColor(color, widget.elevation);
+    if (color != null && Theme.of(context).brightness == Brightness.dark) {
+      final bool applyOverlay = widget.applyDarkThemeElevationOverlay ??
+        Theme.of(context).applyDarkThemeElevationOverlay;
+      if (applyOverlay) {
+        color = _darkThemeOverlayColor(color, widget.elevation);
+      }
     }
     return color;
   }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -159,7 +159,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
-    bool applyElevationOverlay,
+    bool applyElevationOverlayColor,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -229,7 +229,7 @@ class ThemeData extends Diagnosticable {
     final TextTheme defaultAccentTextTheme = accentIsDark ? typography.white : typography.black;
     accentTextTheme = defaultAccentTextTheme.merge(accentTextTheme);
     materialTapTargetSize ??= MaterialTapTargetSize.padded;
-    applyElevationOverlay ??= false;
+    applyElevationOverlayColor ??= false;
     if (fontFamily != null) {
       textTheme = textTheme.apply(fontFamily: fontFamily);
       primaryTextTheme = primaryTextTheme.apply(fontFamily: fontFamily);
@@ -317,7 +317,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme,
       platform: platform,
       materialTapTargetSize: materialTapTargetSize,
-      applyElevationOverlay: applyElevationOverlay,
+      applyElevationOverlayColor: applyElevationOverlayColor,
       pageTransitionsTheme: pageTransitionsTheme,
       appBarTheme: appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme,
@@ -387,7 +387,7 @@ class ThemeData extends Diagnosticable {
     @required this.chipTheme,
     @required this.platform,
     @required this.materialTapTargetSize,
-    @required this.applyElevationOverlay,
+    @required this.applyElevationOverlayColor,
     @required this.pageTransitionsTheme,
     @required this.appBarTheme,
     @required this.bottomAppBarTheme,
@@ -688,8 +688,8 @@ class ThemeData extends Diagnosticable {
   ///
   /// Material drop shadows can be difficult to see in a dark theme, so the
   /// elevation of a surface should be portrayed with an "overlay" in addition
-  /// to the shadow. As the elevation of the component increases, the bright
-  /// overlay increases in opacity. [applyElevationOverlay] turns the
+  /// to the shadow. As the elevation of the component increases, the white
+  /// overlay increases in opacity. [applyElevationOverlayColor] turns the
   /// application of this overlay on or off.
   ///
   /// If [true] a semi-transparent white overlay will be applied to the color
@@ -703,17 +703,17 @@ class ThemeData extends Diagnosticable {
   ///
   /// Note: this setting is here to maintain backwards compatibility with
   /// apps that were built before the Material Dark theme specification
-  /// was published. New apps should set this to [true] for dark themes
-  /// (where [brightness] is [Brightness.dark].
+  /// was published. New apps should set this to [true] for any themes
+  /// where [brightness] is [Brightness.dark].
   ///
   /// See also:
   ///
-  ///  * [Material.elevation], which effects how transparent the overlay is.
-  ///  * [Material.color], which if it matches [colorScheme.surface] an overlay
-  ///    will be applied.
+  ///  * [Material.elevation], which effects how transparent the white overlay is.
+  ///  * [Material.color], the white color overlay will only be applied of the
+  ///    material's color is [colorScheme.surface].
   ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
   ///    the overlay should be applied.
-  final bool applyElevationOverlay;
+  final bool applyElevationOverlayColor;
 
   /// Default [MaterialPageRoute] transitions per [TargetPlatform].
   ///
@@ -815,7 +815,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
-    bool applyElevationOverlay,
+    bool applyElevationOverlayColor,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -874,7 +874,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme ?? this.chipTheme,
       platform: platform ?? this.platform,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
-      applyElevationOverlay: applyElevationOverlay ?? this.applyElevationOverlay,
+      applyElevationOverlayColor: applyElevationOverlayColor ?? this.applyElevationOverlayColor,
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       appBarTheme: appBarTheme ?? this.appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme ?? this.bottomAppBarTheme,
@@ -1011,7 +1011,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t),
       platform: t < 0.5 ? a.platform : b.platform,
       materialTapTargetSize: t < 0.5 ? a.materialTapTargetSize : b.materialTapTargetSize,
-      applyElevationOverlay: t < 0.5 ? a.applyElevationOverlay : b.applyElevationOverlay,
+      applyElevationOverlayColor: t < 0.5 ? a.applyElevationOverlayColor : b.applyElevationOverlayColor,
       pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
       appBarTheme: AppBarTheme.lerp(a.appBarTheme, b.appBarTheme, t),
       bottomAppBarTheme: BottomAppBarTheme.lerp(a.bottomAppBarTheme, b.bottomAppBarTheme, t),
@@ -1076,7 +1076,7 @@ class ThemeData extends Diagnosticable {
            (otherData.chipTheme == chipTheme) &&
            (otherData.platform == platform) &&
            (otherData.materialTapTargetSize == materialTapTargetSize) &&
-           (otherData.applyElevationOverlay == applyElevationOverlay) &&
+           (otherData.applyElevationOverlayColor == applyElevationOverlayColor) &&
            (otherData.pageTransitionsTheme == pageTransitionsTheme) &&
            (otherData.appBarTheme == appBarTheme) &&
            (otherData.bottomAppBarTheme == bottomAppBarTheme) &&
@@ -1140,7 +1140,7 @@ class ThemeData extends Diagnosticable {
       chipTheme,
       platform,
       materialTapTargetSize,
-      applyElevationOverlay,
+      applyElevationOverlayColor,
       pageTransitionsTheme,
       appBarTheme,
       bottomAppBarTheme,
@@ -1201,7 +1201,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<CardTheme>('cardTheme', cardTheme));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize));
-    properties.add(DiagnosticsProperty<bool>('applyDarkThemeElevationOverlay', applyElevationOverlay));
+    properties.add(DiagnosticsProperty<bool>('applyElevationOverlayColor', applyElevationOverlayColor));
     properties.add(DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
     properties.add(DiagnosticsProperty<AppBarTheme>('appBarTheme', appBarTheme, defaultValue: defaultData.appBarTheme));
     properties.add(DiagnosticsProperty<BottomAppBarTheme>('bottomAppBarTheme', bottomAppBarTheme, defaultValue: defaultData.bottomAppBarTheme));

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -159,7 +159,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
-    bool applyDarkThemeElevationOverlay,
+    bool applyElevationOverlay,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -229,7 +229,7 @@ class ThemeData extends Diagnosticable {
     final TextTheme defaultAccentTextTheme = accentIsDark ? typography.white : typography.black;
     accentTextTheme = defaultAccentTextTheme.merge(accentTextTheme);
     materialTapTargetSize ??= MaterialTapTargetSize.padded;
-    applyDarkThemeElevationOverlay ??= false;
+    applyElevationOverlay ??= false;
     if (fontFamily != null) {
       textTheme = textTheme.apply(fontFamily: fontFamily);
       primaryTextTheme = primaryTextTheme.apply(fontFamily: fontFamily);
@@ -317,7 +317,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme,
       platform: platform,
       materialTapTargetSize: materialTapTargetSize,
-      applyDarkThemeElevationOverlay: applyDarkThemeElevationOverlay,
+      applyElevationOverlay: applyElevationOverlay,
       pageTransitionsTheme: pageTransitionsTheme,
       appBarTheme: appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme,
@@ -387,7 +387,7 @@ class ThemeData extends Diagnosticable {
     @required this.chipTheme,
     @required this.platform,
     @required this.materialTapTargetSize,
-    @required this.applyDarkThemeElevationOverlay,
+    @required this.applyElevationOverlay,
     @required this.pageTransitionsTheme,
     @required this.appBarTheme,
     @required this.bottomAppBarTheme,
@@ -683,20 +683,19 @@ class ThemeData extends Diagnosticable {
   /// Configures the hit test size of certain Material widgets.
   final MaterialTapTargetSize materialTapTargetSize;
 
-  /// Apply a semi-transparent white overlay on Material widgets when in dark
-  /// themes.
+  /// Apply a semi-transparent white overlay on Material surfaces to indicate
+  /// elevation for dark themes.
   ///
-  /// A dark theme (where [brightness] is [Brightness.dark]) usually
-  /// has a dark background for surfaces. This can make the normal Material
-  /// drop shadows hard to see. To help with this, Material widgets should
-  /// lighten the background color by adding a semi-transparent white overlay
-  /// to indicate elevation. [applyDarkThemeElevationOverlay] turns the
+  /// Material drop shadows can be difficult to see in a dark theme, so the
+  /// elevation of a surface should be portrayed with an "overlay" in addition
+  /// to the shadow. As the elevation of the component increases, the bright
+  /// overlay increases in opacity. [applyElevationOverlay] turns the
   /// application of this overlay on or off.
   ///
-  /// If [true] a semi-transparent white overlay will be applied to the surface
-  /// color of [Material] widgets when the surrounding theme's [brightness]
-  /// is [Brightness.dark]. The level of transparency is based off of
-  /// [Material.elevation] as per the Material Dark theme specification.
+  /// If [true] a semi-transparent white overlay will be applied to the color
+  /// of [Material] widgets when their [Material.color] is [colorScheme.surface].
+  /// The level of transparency is based on [Material.elevation] as per the
+  /// Material Dark theme specification.
   ///
   /// If [false] the surface color will be used unmodified.
   ///
@@ -704,15 +703,17 @@ class ThemeData extends Diagnosticable {
   ///
   /// Note: this setting is here to maintain backwards compatibility with
   /// apps that were built before the Material Dark theme specification
-  /// was published. New apps should set this to [true].
+  /// was published. New apps should set this to [true] for dark themes
+  /// (where [brightness] is [Brightness.dark].
   ///
   /// See also:
   ///
   ///  * [Material.elevation], which effects how transparent the overlay is.
-  ///  * [brightness], which determines whether the theme is light or dark.
+  ///  * [Material.color], which if it matches [colorScheme.surface] an overlay
+  ///    will be applied.
   ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
   ///    the overlay should be applied.
-  final bool applyDarkThemeElevationOverlay;
+  final bool applyElevationOverlay;
 
   /// Default [MaterialPageRoute] transitions per [TargetPlatform].
   ///
@@ -814,7 +815,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
-    bool applyDarkThemeElevationOverlay,
+    bool applyElevationOverlay,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -873,7 +874,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme ?? this.chipTheme,
       platform: platform ?? this.platform,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
-      applyDarkThemeElevationOverlay: applyDarkThemeElevationOverlay ?? this.applyDarkThemeElevationOverlay,
+      applyElevationOverlay: applyElevationOverlay ?? this.applyElevationOverlay,
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       appBarTheme: appBarTheme ?? this.appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme ?? this.bottomAppBarTheme,
@@ -1010,7 +1011,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t),
       platform: t < 0.5 ? a.platform : b.platform,
       materialTapTargetSize: t < 0.5 ? a.materialTapTargetSize : b.materialTapTargetSize,
-      applyDarkThemeElevationOverlay: t < 0.5 ? a.applyDarkThemeElevationOverlay : b.applyDarkThemeElevationOverlay,
+      applyElevationOverlay: t < 0.5 ? a.applyElevationOverlay : b.applyElevationOverlay,
       pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
       appBarTheme: AppBarTheme.lerp(a.appBarTheme, b.appBarTheme, t),
       bottomAppBarTheme: BottomAppBarTheme.lerp(a.bottomAppBarTheme, b.bottomAppBarTheme, t),
@@ -1075,7 +1076,7 @@ class ThemeData extends Diagnosticable {
            (otherData.chipTheme == chipTheme) &&
            (otherData.platform == platform) &&
            (otherData.materialTapTargetSize == materialTapTargetSize) &&
-           (otherData.applyDarkThemeElevationOverlay == applyDarkThemeElevationOverlay) &&
+           (otherData.applyElevationOverlay == applyElevationOverlay) &&
            (otherData.pageTransitionsTheme == pageTransitionsTheme) &&
            (otherData.appBarTheme == appBarTheme) &&
            (otherData.bottomAppBarTheme == bottomAppBarTheme) &&
@@ -1139,7 +1140,7 @@ class ThemeData extends Diagnosticable {
       chipTheme,
       platform,
       materialTapTargetSize,
-      applyDarkThemeElevationOverlay,
+      applyElevationOverlay,
       pageTransitionsTheme,
       appBarTheme,
       bottomAppBarTheme,
@@ -1200,7 +1201,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<CardTheme>('cardTheme', cardTheme));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize));
-    properties.add(DiagnosticsProperty<bool>('applyDarkThemeElevationOverlay', applyDarkThemeElevationOverlay));
+    properties.add(DiagnosticsProperty<bool>('applyDarkThemeElevationOverlay', applyElevationOverlay));
     properties.add(DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
     properties.add(DiagnosticsProperty<AppBarTheme>('appBarTheme', appBarTheme, defaultValue: defaultData.appBarTheme));
     properties.add(DiagnosticsProperty<BottomAppBarTheme>('bottomAppBarTheme', bottomAppBarTheme, defaultValue: defaultData.bottomAppBarTheme));

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -683,26 +683,35 @@ class ThemeData extends Diagnosticable {
   /// Configures the hit test size of certain Material widgets.
   final MaterialTapTargetSize materialTapTargetSize;
 
-  /// Apply a semi-transparent white overlay on Material widgets when in dark themes.
+  /// Apply a semi-transparent white overlay on Material widgets when in dark
+  /// themes.
+  ///
+  /// A dark theme (where [brightness] is [Brightness.dark]) usually
+  /// has a dark background for surfaces. This can make the normal Material
+  /// drop shadows hard to see. To help with this, Material widgets should
+  /// lighten the background color by adding a semi-transparent white overlay
+  /// to indicate elevation. [applyDarkThemeElevationOverlay] turns the
+  /// application of this overlay on or off.
   ///
   /// If [true] a semi-transparent white overlay will be applied to the surface
-  /// color of [Material] widgets when the surrounding theme's brightness is dark.
-  /// The transparency is based off of the [elevation] as per the Material Dark
-  /// theme specification.
+  /// color of [Material] widgets when the surrounding theme's [brightness]
+  /// is [Brightness.dark]. The level of transparency is based off of
+  /// [Material.elevation] as per the Material Dark theme specification.
   ///
   /// If [false] the surface color will be used unmodified.
   ///
   /// Defaults to [false].
   ///
-  /// Note: this setting is just here to maintain backwards compatibility with
-  /// applications that were built before the Material Dark theme specification
+  /// Note: this setting is here to maintain backwards compatibility with
+  /// apps that were built before the Material Dark theme specification
   /// was published. New apps should set this to [true].
   ///
   /// See also:
   ///
-  ///  * [Material.applyDarkThemeElevationOverlay], which will override this
-  ///    setting on an individual widget.
-  ///  * <https://material.io/design/color/dark-theme.html>
+  ///  * [Material.elevation], which effects how transparent the overlay is.
+  ///  * [brightness], which determines whether the theme is light or dark.
+  ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
+  ///    the overlay should be applied.
   final bool applyDarkThemeElevationOverlay;
 
   /// Default [MaterialPageRoute] transitions per [TargetPlatform].

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -159,6 +159,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
+    bool applyDarkThemeElevationOverlay,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -228,6 +229,7 @@ class ThemeData extends Diagnosticable {
     final TextTheme defaultAccentTextTheme = accentIsDark ? typography.white : typography.black;
     accentTextTheme = defaultAccentTextTheme.merge(accentTextTheme);
     materialTapTargetSize ??= MaterialTapTargetSize.padded;
+    applyDarkThemeElevationOverlay ??= false;
     if (fontFamily != null) {
       textTheme = textTheme.apply(fontFamily: fontFamily);
       primaryTextTheme = primaryTextTheme.apply(fontFamily: fontFamily);
@@ -315,6 +317,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme,
       platform: platform,
       materialTapTargetSize: materialTapTargetSize,
+      applyDarkThemeElevationOverlay: applyDarkThemeElevationOverlay,
       pageTransitionsTheme: pageTransitionsTheme,
       appBarTheme: appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme,
@@ -384,6 +387,7 @@ class ThemeData extends Diagnosticable {
     @required this.chipTheme,
     @required this.platform,
     @required this.materialTapTargetSize,
+    @required this.applyDarkThemeElevationOverlay,
     @required this.pageTransitionsTheme,
     @required this.appBarTheme,
     @required this.bottomAppBarTheme,
@@ -679,6 +683,28 @@ class ThemeData extends Diagnosticable {
   /// Configures the hit test size of certain Material widgets.
   final MaterialTapTargetSize materialTapTargetSize;
 
+  /// Apply a semi-transparent white overlay on Material widgets when in dark themes.
+  ///
+  /// If [true] a semi-transparent white overlay will be applied to the surface
+  /// color of [Material] widgets when the surrounding theme's brightness is dark.
+  /// The transparency is based off of the [elevation] as per the Material Dark
+  /// theme specification.
+  ///
+  /// If [false] the surface color will be used unmodified.
+  ///
+  /// Defaults to [false].
+  ///
+  /// Note: this setting is just here to maintain backwards compatibility with
+  /// applications that were built before the Material Dark theme specification
+  /// was published. New apps should set this to [true].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.applyDarkThemeElevationOverlay], which will override this
+  ///    setting on an individual widget.
+  ///  * <https://material.io/design/color/dark-theme.html>
+  final bool applyDarkThemeElevationOverlay;
+
   /// Default [MaterialPageRoute] transitions per [TargetPlatform].
   ///
   /// [MaterialPageRoute.buildTransitions] delegates to a [PageTransitionsBuilder]
@@ -779,6 +805,7 @@ class ThemeData extends Diagnosticable {
     ChipThemeData chipTheme,
     TargetPlatform platform,
     MaterialTapTargetSize materialTapTargetSize,
+    bool applyDarkThemeElevationOverlay,
     PageTransitionsTheme pageTransitionsTheme,
     AppBarTheme appBarTheme,
     BottomAppBarTheme bottomAppBarTheme,
@@ -837,6 +864,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: chipTheme ?? this.chipTheme,
       platform: platform ?? this.platform,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
+      applyDarkThemeElevationOverlay: applyDarkThemeElevationOverlay ?? this.applyDarkThemeElevationOverlay,
       pageTransitionsTheme: pageTransitionsTheme ?? this.pageTransitionsTheme,
       appBarTheme: appBarTheme ?? this.appBarTheme,
       bottomAppBarTheme: bottomAppBarTheme ?? this.bottomAppBarTheme,
@@ -973,6 +1001,7 @@ class ThemeData extends Diagnosticable {
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t),
       platform: t < 0.5 ? a.platform : b.platform,
       materialTapTargetSize: t < 0.5 ? a.materialTapTargetSize : b.materialTapTargetSize,
+      applyDarkThemeElevationOverlay: t < 0.5 ? a.applyDarkThemeElevationOverlay : b.applyDarkThemeElevationOverlay,
       pageTransitionsTheme: t < 0.5 ? a.pageTransitionsTheme : b.pageTransitionsTheme,
       appBarTheme: AppBarTheme.lerp(a.appBarTheme, b.appBarTheme, t),
       bottomAppBarTheme: BottomAppBarTheme.lerp(a.bottomAppBarTheme, b.bottomAppBarTheme, t),
@@ -1037,6 +1066,7 @@ class ThemeData extends Diagnosticable {
            (otherData.chipTheme == chipTheme) &&
            (otherData.platform == platform) &&
            (otherData.materialTapTargetSize == materialTapTargetSize) &&
+           (otherData.applyDarkThemeElevationOverlay == applyDarkThemeElevationOverlay) &&
            (otherData.pageTransitionsTheme == pageTransitionsTheme) &&
            (otherData.appBarTheme == appBarTheme) &&
            (otherData.bottomAppBarTheme == bottomAppBarTheme) &&
@@ -1100,6 +1130,7 @@ class ThemeData extends Diagnosticable {
       chipTheme,
       platform,
       materialTapTargetSize,
+      applyDarkThemeElevationOverlay,
       pageTransitionsTheme,
       appBarTheme,
       bottomAppBarTheme,
@@ -1160,6 +1191,7 @@ class ThemeData extends Diagnosticable {
     properties.add(DiagnosticsProperty<CardTheme>('cardTheme', cardTheme));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize));
+    properties.add(DiagnosticsProperty<bool>('applyDarkThemeElevationOverlay', applyDarkThemeElevationOverlay));
     properties.add(DiagnosticsProperty<PageTransitionsTheme>('pageTransitionsTheme', pageTransitionsTheme));
     properties.add(DiagnosticsProperty<AppBarTheme>('appBarTheme', appBarTheme, defaultValue: defaultData.appBarTheme));
     properties.add(DiagnosticsProperty<BottomAppBarTheme>('bottomAppBarTheme', bottomAppBarTheme, defaultValue: defaultData.bottomAppBarTheme));

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -273,8 +273,7 @@ void main() {
           Theme(
             data: ThemeData(
               applyElevationOverlay: true,
-              colorScheme: ColorScheme.dark().copyWith(
-                  surface: const Color(0xFF121212)),
+              colorScheme: ColorScheme.dark().copyWith(surface: const Color(0xFF121212)),
             ),
             child: buildMaterial(
                 color: Colors.cyan,

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -216,14 +216,14 @@ void main() {
     expect(modelE.shadowColor, equals(const Color(0xFFFF0000)));
   });
 
-  group('Dark Theme', () {
+  group('Elevation Overlay', () {
 
     testWidgets('applyElevationOverlay set to false does not change surface color', (WidgetTester tester) async {
       const Color surfaceColor = Color(0xFF121212);
       await tester.pumpWidget(Theme(
           data: ThemeData(
             applyElevationOverlay: false,
-            colorScheme: ColorScheme.dark().copyWith(surface: surfaceColor),
+            colorScheme: const ColorScheme.dark().copyWith(surface: surfaceColor),
           ),
           child: buildMaterial(color: surfaceColor, elevation: 8.0))
       );
@@ -253,7 +253,7 @@ void main() {
             Theme(
               data: ThemeData(
                 applyElevationOverlay: true,
-                colorScheme: ColorScheme.dark().copyWith(surface: surfaceColor),
+                colorScheme: const ColorScheme.dark().copyWith(surface: surfaceColor),
               ),
               child: buildMaterial(
                 color: surfaceColor,
@@ -273,7 +273,7 @@ void main() {
           Theme(
             data: ThemeData(
               applyElevationOverlay: true,
-              colorScheme: ColorScheme.dark().copyWith(surface: const Color(0xFF121212)),
+              colorScheme: const ColorScheme.dark().copyWith(surface: const Color(0xFF121212)),
             ),
             child: buildMaterial(
                 color: Colors.cyan,

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -217,95 +217,73 @@ void main() {
   });
 
   group('Dark Theme', () {
-    testWidgets('Light theme does not change background color', (WidgetTester tester) async {
+
+    testWidgets('applyElevationOverlay set to false does not change surface color', (WidgetTester tester) async {
+      const Color surfaceColor = Color(0xFF121212);
       await tester.pumpWidget(Theme(
-        data: ThemeData(
-          brightness: Brightness.light,
-          applyDarkThemeElevationOverlay: true,
-        ),
-        child: buildMaterial(color: const Color(0xFFFFFFFF), elevation: 8.0))
+          data: ThemeData(
+            applyElevationOverlay: false,
+            colorScheme: ColorScheme.dark().copyWith(surface: surfaceColor),
+          ),
+          child: buildMaterial(color: surfaceColor, elevation: 8.0))
       );
       final RenderPhysicalShape model = getShadow(tester);
-      expect(model.color, equals(const Color(0xFFFFFFFF)));
+      expect(model.color, equals(surfaceColor));
     });
 
-    testWidgets('Dark theme overlays a transparent white on background color', (WidgetTester tester) async {
-      // The colors we should get with a base background of 0xFF121212 for
+    testWidgets('applyElevationOverlay set to true overlays a transparent white on surface color', (WidgetTester tester) async {
+      // The colors we should get with a base surface color of 0xFF121212 for
       // a given elevation
       const List<ElevationColor> elevationColors = <ElevationColor>[
         ElevationColor(0.0, Color(0xFF121212)),
         ElevationColor(1.0, Color(0xFF1E1E1E)),
         ElevationColor(2.0, Color(0xFF222222)),
-        ElevationColor(3.0, Color(0xFF242424)),
-        ElevationColor(4.0, Color(0xFF272727)),
-        ElevationColor(6.0, Color(0xFF2C2C2C)),
-        ElevationColor(8.0, Color(0xFF2E2E2E)),
-        ElevationColor(12.0, Color(0xFF333333)),
+        ElevationColor(3.0, Color(0xFF252525)),
+        ElevationColor(4.0, Color(0xFF282828)),
+        ElevationColor(6.0, Color(0xFF2B2B2B)),
+        ElevationColor(8.0, Color(0xFF2D2D2D)),
+        ElevationColor(12.0, Color(0xFF323232)),
         ElevationColor(16.0, Color(0xFF353535)),
-        ElevationColor(24.0, Color(0xFF383838)),
+        ElevationColor(24.0, Color(0xFF393939)),
       ];
+      const Color surfaceColor = Color(0xFF121212);
 
       for (ElevationColor test in elevationColors) {
         await tester.pumpWidget(
-          Theme(
-            data: ThemeData(
-              brightness: Brightness.dark,
-              applyDarkThemeElevationOverlay: true
-            ),
-            child: buildMaterial(
-              color: const Color(0xFF121212),
-              elevation: test.elevation,
-            ),
-          )
+            Theme(
+              data: ThemeData(
+                applyElevationOverlay: true,
+                colorScheme: ColorScheme.dark().copyWith(surface: surfaceColor),
+              ),
+              child: buildMaterial(
+                color: surfaceColor,
+                elevation: test.elevation,
+              ),
+            )
         );
-        await tester.pumpAndSettle(); // wait for the elevation animation to finish
+        await tester
+            .pumpAndSettle(); // wait for the elevation animation to finish
         final RenderPhysicalShape model = getShadow(tester);
         expect(model.color, equals(test.color));
       }
     });
 
-    testWidgets('applyDarkThemeElevationOverlay set to false will not apply overlay', (WidgetTester tester) async {
+    testWidgets('overlay will only apply to materials using colorScheme.surface', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Theme(
-          data: ThemeData(
-            brightness: Brightness.dark,
-            applyDarkThemeElevationOverlay: false,
-          ),
-          child: buildMaterial(
-            color: const Color(0xFF121212),
-            elevation: 8.0
-          ),
-        )
+          Theme(
+            data: ThemeData(
+              applyElevationOverlay: true,
+              colorScheme: ColorScheme.dark().copyWith(
+                  surface: const Color(0xFF121212)),
+            ),
+            child: buildMaterial(
+                color: Colors.cyan,
+                elevation: 8.0
+            ),
+          )
       );
       final RenderPhysicalShape model = getShadow(tester);
-      expect(model.color, equals(const Color(0xFF121212)));
-    });
-
-    testWidgets('applyDarkThemeElevationOverlay not set will be taken from ThemeData', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Theme(
-          data: ThemeData(brightness: Brightness.dark, applyDarkThemeElevationOverlay: true),
-          child: buildMaterial(
-            color: const Color(0xFF121212),
-            elevation: 8.0,
-          ),
-        )
-      );
-      RenderPhysicalShape model = getShadow(tester);
-      expect(model.color, equals(const Color(0xFF2E2E2E)));
-
-      await tester.pumpWidget(
-        Theme(
-          data: ThemeData(brightness: Brightness.dark, applyDarkThemeElevationOverlay: false),
-          child: buildMaterial(
-            color: const Color(0xFF121212),
-            elevation: 8.0,
-          ),
-        )
-      );
-      await tester.pumpAndSettle();
-      model = getShadow(tester);
-      expect(model.color, equals(const Color(0xFF121212)));
+      expect(model.color, equals(Colors.cyan));
     });
 
   });

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -37,7 +37,7 @@ Widget buildMaterial({
   );
 }
 
-RenderPhysicalShape getShadow(WidgetTester tester) {
+RenderPhysicalShape getModel(WidgetTester tester) {
   return tester.renderObject(find.byType(PhysicalShape));
 }
 
@@ -171,23 +171,23 @@ void main() {
     // a kThemeChangeDuration time interval.
 
     await tester.pumpWidget(buildMaterial(elevation: 0.0));
-    final RenderPhysicalShape modelA = getShadow(tester);
+    final RenderPhysicalShape modelA = getModel(tester);
     expect(modelA.elevation, equals(0.0));
 
     await tester.pumpWidget(buildMaterial(elevation: 9.0));
-    final RenderPhysicalShape modelB = getShadow(tester);
+    final RenderPhysicalShape modelB = getModel(tester);
     expect(modelB.elevation, equals(0.0));
 
     await tester.pump(const Duration(milliseconds: 1));
-    final RenderPhysicalShape modelC = getShadow(tester);
+    final RenderPhysicalShape modelC = getModel(tester);
     expect(modelC.elevation, closeTo(0.0, 0.001));
 
     await tester.pump(kThemeChangeDuration ~/ 2);
-    final RenderPhysicalShape modelD = getShadow(tester);
+    final RenderPhysicalShape modelD = getModel(tester);
     expect(modelD.elevation, isNot(closeTo(0.0, 0.001)));
 
     await tester.pump(kThemeChangeDuration);
-    final RenderPhysicalShape modelE = getShadow(tester);
+    final RenderPhysicalShape modelE = getModel(tester);
     expect(modelE.elevation, equals(9.0));
   });
 
@@ -196,42 +196,42 @@ void main() {
     // a kThemeChangeDuration time interval.
 
     await tester.pumpWidget(buildMaterial(shadowColor: const Color(0xFF00FF00)));
-    final RenderPhysicalShape modelA = getShadow(tester);
+    final RenderPhysicalShape modelA = getModel(tester);
     expect(modelA.shadowColor, equals(const Color(0xFF00FF00)));
 
     await tester.pumpWidget(buildMaterial(shadowColor: const Color(0xFFFF0000)));
-    final RenderPhysicalShape modelB = getShadow(tester);
+    final RenderPhysicalShape modelB = getModel(tester);
     expect(modelB.shadowColor, equals(const Color(0xFF00FF00)));
 
     await tester.pump(const Duration(milliseconds: 1));
-    final RenderPhysicalShape modelC = getShadow(tester);
+    final RenderPhysicalShape modelC = getModel(tester);
     expect(modelC.shadowColor, within<Color>(distance: 1, from: const Color(0xFF00FF00)));
 
     await tester.pump(kThemeChangeDuration ~/ 2);
-    final RenderPhysicalShape modelD = getShadow(tester);
+    final RenderPhysicalShape modelD = getModel(tester);
     expect(modelD.shadowColor, isNot(within<Color>(distance: 1, from: const Color(0xFF00FF00))));
 
     await tester.pump(kThemeChangeDuration);
-    final RenderPhysicalShape modelE = getShadow(tester);
+    final RenderPhysicalShape modelE = getModel(tester);
     expect(modelE.shadowColor, equals(const Color(0xFFFF0000)));
   });
 
   group('Elevation Overlay', () {
 
-    testWidgets('applyElevationOverlay set to false does not change surface color', (WidgetTester tester) async {
+    testWidgets('applyElevationOverlayColor set to false does not change surface color', (WidgetTester tester) async {
       const Color surfaceColor = Color(0xFF121212);
       await tester.pumpWidget(Theme(
           data: ThemeData(
-            applyElevationOverlay: false,
+            applyElevationOverlayColor: false,
             colorScheme: const ColorScheme.dark().copyWith(surface: surfaceColor),
           ),
           child: buildMaterial(color: surfaceColor, elevation: 8.0))
       );
-      final RenderPhysicalShape model = getShadow(tester);
+      final RenderPhysicalShape model = getModel(tester);
       expect(model.color, equals(surfaceColor));
     });
 
-    testWidgets('applyElevationOverlay set to true overlays a transparent white on surface color', (WidgetTester tester) async {
+    testWidgets('applyElevationOverlayColor set to true overlays a transparent white on surface color', (WidgetTester tester) async {
       // The colors we should get with a base surface color of 0xFF121212 for
       // a given elevation
       const List<ElevationColor> elevationColors = <ElevationColor>[
@@ -252,7 +252,7 @@ void main() {
         await tester.pumpWidget(
             Theme(
               data: ThemeData(
-                applyElevationOverlay: true,
+                applyElevationOverlayColor: true,
                 colorScheme: const ColorScheme.dark().copyWith(surface: surfaceColor),
               ),
               child: buildMaterial(
@@ -261,9 +261,8 @@ void main() {
               ),
             )
         );
-        await tester
-            .pumpAndSettle(); // wait for the elevation animation to finish
-        final RenderPhysicalShape model = getShadow(tester);
+        await tester.pumpAndSettle(); // wait for the elevation animation to finish
+        final RenderPhysicalShape model = getModel(tester);
         expect(model.color, equals(test.color));
       }
     });
@@ -272,7 +271,7 @@ void main() {
       await tester.pumpWidget(
           Theme(
             data: ThemeData(
-              applyElevationOverlay: true,
+              applyElevationOverlayColor: true,
               colorScheme: const ColorScheme.dark().copyWith(surface: const Color(0xFF121212)),
             ),
             child: buildMaterial(
@@ -281,7 +280,7 @@ void main() {
             ),
           )
       );
-      final RenderPhysicalShape model = getShadow(tester);
+      final RenderPhysicalShape model = getModel(tester);
       expect(model.color, equals(Colors.cyan));
     });
 

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -22,7 +22,6 @@ Widget buildMaterial({
   double elevation = 0.0,
   Color shadowColor = const Color(0xFF00FF00),
   Color color = const Color(0xFF0000FF),
-  bool applyDarkThemeElevationOverlay,
 }) {
   return Center(
     child: SizedBox(
@@ -30,7 +29,6 @@ Widget buildMaterial({
       width: 100.0,
       child: Material(
         color: color,
-        applyDarkThemeElevationOverlay: applyDarkThemeElevationOverlay,
         shadowColor: shadowColor,
         elevation: elevation,
         shape: const CircleBorder(),
@@ -220,7 +218,13 @@ void main() {
 
   group('Dark Theme', () {
     testWidgets('Light theme does not change background color', (WidgetTester tester) async {
-      await tester.pumpWidget(buildMaterial(color: const Color(0xFFFFFFFF)));
+      await tester.pumpWidget(Theme(
+        data: ThemeData(
+          brightness: Brightness.light,
+          applyDarkThemeElevationOverlay: true,
+        ),
+        child: buildMaterial(color: const Color(0xFFFFFFFF), elevation: 8.0))
+      );
       final RenderPhysicalShape model = getShadow(tester);
       expect(model.color, equals(const Color(0xFFFFFFFF)));
     });
@@ -230,25 +234,27 @@ void main() {
       // a given elevation
       const List<ElevationColor> elevationColors = <ElevationColor>[
         ElevationColor(0.0, Color(0xFF121212)),
-        ElevationColor(1.0, Color(0xFF1D1D1D)),
-        ElevationColor(2.0, Color(0xFF212121)),
+        ElevationColor(1.0, Color(0xFF1E1E1E)),
+        ElevationColor(2.0, Color(0xFF222222)),
         ElevationColor(3.0, Color(0xFF242424)),
-        ElevationColor(4.0, Color(0xFF262626)),
+        ElevationColor(4.0, Color(0xFF272727)),
         ElevationColor(6.0, Color(0xFF2C2C2C)),
-        ElevationColor(8.0, Color(0xFF2D2D2D)),
-        ElevationColor(12.0, Color(0xFF323232)),
+        ElevationColor(8.0, Color(0xFF2E2E2E)),
+        ElevationColor(12.0, Color(0xFF333333)),
         ElevationColor(16.0, Color(0xFF353535)),
-        ElevationColor(24.0, Color(0xFF373737)),
+        ElevationColor(24.0, Color(0xFF383838)),
       ];
 
       for (ElevationColor test in elevationColors) {
         await tester.pumpWidget(
           Theme(
-            data: ThemeData(brightness: Brightness.dark),
+            data: ThemeData(
+              brightness: Brightness.dark,
+              applyDarkThemeElevationOverlay: true
+            ),
             child: buildMaterial(
               color: const Color(0xFF121212),
               elevation: test.elevation,
-              applyDarkThemeElevationOverlay: true,
             ),
           )
         );
@@ -261,10 +267,12 @@ void main() {
     testWidgets('applyDarkThemeElevationOverlay set to false will not apply overlay', (WidgetTester tester) async {
       await tester.pumpWidget(
         Theme(
-          data: ThemeData(brightness: Brightness.dark),
+          data: ThemeData(
+            brightness: Brightness.dark,
+            applyDarkThemeElevationOverlay: false,
+          ),
           child: buildMaterial(
             color: const Color(0xFF121212),
-            applyDarkThemeElevationOverlay: false,
             elevation: 8.0
           ),
         )
@@ -284,7 +292,7 @@ void main() {
         )
       );
       RenderPhysicalShape model = getShadow(tester);
-      expect(model.color, equals(const Color(0xFF2D2D2D)));
+      expect(model.color, equals(const Color(0xFF2E2E2E)));
 
       await tester.pumpWidget(
         Theme(


### PR DESCRIPTION
## Description

In dark themes, drop shadows used to indicate elevation in Material apps can be difficult to see. To help with this, the [Material Dark theme specification](https://material.io/design/color/dark-theme.html#properties), adds a new semi-transparent overlay on surfaces to lighten them according to their elevation. This PR adds support for this feature.

![mio-design_assets_1A1Uf3a9TsbtgSKT-hjIAaEiEIXFDTUfE_darktheme-elevationsystem](https://user-images.githubusercontent.com/19588/60552610-53910400-9ce4-11e9-880d-33c221bf8204.png)

If a `Material` widget is in a theme where the new `ThemeData.applyElevationOverlay` flag is turned on, and the `Material.color` is the theme's surface color (i.e. `ThemeData.colorScheme.surface`), then a semi-transparent white will be composited over the `Material.color` for the background of the widget. The level of the transparency follows the values in the specification.

By default this feature is turned off to maintain backwards compatibility with apps built before the Dark theme spec was published. 

To turn it on for your app, you can adjust your dark themes to have `ThemeData.applyElevationOverlay` set to `true`.

## Related Issues

#35494 - A previous attempt at this PR.

## Tests

I added a group of new tests in material_test.dart to exercise this feature.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is not a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
