### PR TITLE
Fix semantics for floating pinned sliver app bar

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -476,7 +476,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     } else {
       _effectiveScrollOffset = constraints.scrollOffset;
     }
-    final bool overlapsContent = _effectiveScrollOffset < constraints.scrollOffset;
+    final bool overlapsContent = _effectiveScrollOffset <= constraints.scrollOffset;
     excludeFromSemanticsScrolling = overlapsContent;
     layoutChild(_effectiveScrollOffset, maxExtent, overlapsContent: overlapsContent);
     _childPosition = updateGeometry();

--- a/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
@@ -32,7 +32,7 @@ void main() {
                 SliverFixedExtentList(
                   itemExtent: 100.0,
                   delegate: SliverChildBuilderDelegate(
-                    (BuildContext c, int index) {
+                    (BuildContext _, int index) {
                       return Container(
                         height: 100.0,
                         color: index % 2 == 0 ? Colors.red : Colors.yellow,

--- a/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
@@ -6,7 +6,203 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
+import 'semantics_tester.dart';
+
 void main() {
+  testWidgets('Sliver appbars - floating and pinned - correct semantics', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        locale: const Locale('en', 'us'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultWidgetsLocalizations.delegate,
+          DefaultMaterialLocalizations.delegate,
+        ],
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: CustomScrollView(
+              slivers: <Widget>[
+                const SliverAppBar(
+                  title: Text('Hello'),
+                  pinned: true,
+                  floating: true,
+                  expandedHeight: 200.0,
+                ),
+                SliverFixedExtentList(
+                  itemExtent: 100.0,
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext c, int index) {
+                      return Container(
+                        height: 100.0,
+                        color: index % 2 == 0 ? Colors.red : Colors.yellow,
+                        child: Text('Tile $index'),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    TestSemantics expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          textDirection: TextDirection.ltr,
+          children: <TestSemantics>[
+            TestSemantics(
+              children: <TestSemantics>[
+                TestSemantics(
+                  thickness: 4,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      label: 'Hello',
+                      elevation: 4,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHeader, SemanticsFlag.namesRoute],
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ],
+                ),
+                TestSemantics(
+                  actions: <SemanticsAction>[SemanticsAction.scrollUp],
+                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                  scrollIndex: 0,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      label: 'Tile 0',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 1',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 2',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 3',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 4',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 5',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 6',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                  ],
+                )
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+
+    await tester.fling(find.text('Tile 2'), const Offset(0, -600), 2000);
+    await tester.pumpAndSettle();
+
+    expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          textDirection: TextDirection.ltr,
+          children: <TestSemantics>[
+            TestSemantics(
+              children: <TestSemantics>[
+                TestSemantics(
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      label: 'Hello',
+                      flags: <SemanticsFlag>[SemanticsFlag.isHeader, SemanticsFlag.namesRoute],
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ],
+                ),
+                TestSemantics(
+                  actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
+                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                  scrollIndex: 10,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      label: 'Tile 7',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 8',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 9',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 10',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 11',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 12',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 13',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 14',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 15',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 16',
+                      textDirection: TextDirection.ltr,
+                    ),
+                    TestSemantics(
+                      label: 'Tile 17',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                    TestSemantics(
+                      label: 'Tile 18',
+                      textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                    ),
+                  ],
+                )
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true));
+  });
+
   testWidgets('Sliver appbars - floating and pinned - second app bar stacks below', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

SliverAppBars that are floating and pinned without a bottom aren't doing semantics traversal correctly. This is because when there is no bottom, the effective scroll offset can be equal to the constraints.scrollOffset when overlapping children.

The bug was introduced by https://github.com/flutter/flutter/pull/11996, which first allowed such app bars to not have a bottom.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/35488

## Tests

I added the following tests:

Test to check the semantics tree is good after scrolling such a sliver app bar.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
