### PR TITLE
Prepare for Socket implements Stream<Uint8List>

### DIFF
--- a/packages/flutter_tools/test/android/android_device_test.dart
+++ b/packages/flutter_tools/test/android/android_device_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_console.dart';
@@ -574,7 +575,7 @@ class MockWorkingAndroidConsoleSocket extends Mock implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
-  Stream<E> asyncMap<E>(FutureOr<E> convert(List<int> event)) => _controller.stream as Stream<E>;
+  Stream<E> asyncMap<E>(FutureOr<E> convert(Uint8List event)) => _controller.stream as Stream<E>;
 
   @override
   void add(List<int> data) {
@@ -595,7 +596,7 @@ class MockUnresponsiveAndroidConsoleSocket extends Mock implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
-  Stream<E> asyncMap<E>(FutureOr<E> convert(List<int> event)) => _controller.stream as Stream<E>;
+  Stream<E> asyncMap<E>(FutureOr<E> convert(Uint8List event)) => _controller.stream as Stream<E>;
 
   @override
   void add(List<int> data) {}


### PR DESCRIPTION
## Description

An upcoming change in the Dart SDK changes `Socket` from
implementing `Stream<List<int>>` to implementing `Stream<Uint8List>`.
This forwards-compatible change in flutter_tools prepares for that
Dart SDK change.

## Related Issues

https://github.com/dart-lang/sdk/issues/36900

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.