### PR TITLE
Remove paused check for tooling tests

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -47,7 +47,7 @@ class CoverageCollector extends TestWatcher {
   /// has been run to completion so that all coverage data has been recorded.
   ///
   /// The returned [Future] completes when the coverage is collected.
-  Future<void> collectCoverageIsolate(Uri observatoryUri, String debugName) async {
+  Future<void> collectCoverageIsolate(Uri observatoryUri) async {
     assert(observatoryUri != null);
     print('collecting coverage data from $observatoryUri...');
     final Map<String, dynamic> data = await collect(observatoryUri, (String libraryName) {
@@ -56,7 +56,7 @@ class CoverageCollector extends TestWatcher {
       return (coverageDirectory != null)
           || (flutterProject == null)
           || libraryName.contains(flutterProject.manifest.appName);
-    }, waitPaused: true, debugName: debugName);
+    });
     if (data == null) {
       throw Exception('Failed to collect coverage.');
     }
@@ -196,28 +196,6 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool Function(String) libra
 }) async {
   final VMService vmService = await connector(serviceUri);
   await vmService.getVM();
-  if (!waitPaused) {
-    return _getAllCoverage(vmService, libraryPredicate);
-  }
-  final Isolate isolate = vmService.vm.isolates.firstWhere((Isolate isolate) => isolate.name == debugName);
-  const int kPollAttempts = 20;
-  int i = 0;
-  while (i < kPollAttempts) {
-    await isolate.load();
-    if (isolate.pauseEvent?.kind == ServiceEvent.kPauseStart) {
-      break;
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    i += 1;
-  }
-  if (i == kPollAttempts) {
-    print('Isolate $debugName was never paused, refusing to collect coverage');
-    return const <String, dynamic>{
-      'type': 'CodeCoverage',
-      'coverage': <Object>[]
-    };
-  }
-  print('isolate is paused, collecting coverage...');
   return _getAllCoverage(vmService, libraryPredicate);
 }
 

--- a/packages/flutter_tools/tool/tool_coverage.dart
+++ b/packages/flutter_tools/tool/tool_coverage.dart
@@ -77,10 +77,8 @@ class VMPlatform extends PlatformPlugin {
     final dynamic channel = IsolateChannel<Object>.connectReceive(receivePort)
         .transformStream(StreamTransformer<Object, Object>.fromHandlers(handleDone: (EventSink<Object> sink) async {
       try {
-        // Pause the isolate so it is ready for coverage collection.
-        isolate.pause();
         // this will throw if collection fails.
-        await coverageCollector.collectCoverageIsolate(info.serverUri, path);
+        await coverageCollector.collectCoverageIsolate(info.serverUri);
       } finally {
         isolate.kill(priority: Isolate.immediate);
         isolate = null;
@@ -117,14 +115,13 @@ class VMPlatform extends PlatformPlugin {
     return await Isolate.spawnUri(p.toUri(testPath), <String>[], message,
       packageConfig: p.toUri('.packages'),
       checked: true,
-      debugName: path,
     );
   }
 
   @override
   Future<void> close() async {
     try {
-      await Future.wait(_pending.values).timeout(const Duration(seconds: 10));
+      await Future.wait(_pending.values).timeout(const Duration(minutes: 1));
     } on TimeoutException {
       // TODO(jonahwilliams): resolve whether there are any specific tests that
       // get stuck or if it is a general infra issue with how we are collecting


### PR DESCRIPTION
## Description

Isolate.pause is not causing the test isolates to pause. They don't appear to be trapped in a loop.

see: https://github.com/flutter/flutter/pull/35377#discussion_r300817207

for more context