### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![Flutter logo][]][flutter.dev]
+ # [![Flutter logo][]][flutter.dev]
 
 [![Build Status - Cirrus][]][Build status]
 [![Gitter Channel][]][Gitter badge]


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
