### PR TITLE
disable a test case in xcode_backend.sh

### DIFF
--- a/packages/flutter_tools/test/ios/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/ios/xcode_backend_test.dart
@@ -64,5 +64,5 @@ void main() {
 
     await expectXcodeBackendFails(localEngineDebugBuildModeRelease);
     await expectXcodeBackendFails(localEngineProfileBuildeModeRelease);
-  }, skip: !platform.isMacOS);
+  }, skip: true); // #35707 non-hermetic test requires precache to have run.
 }

--- a/packages/flutter_tools/test/ios/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/ios/xcode_backend_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 
 import '../src/common.dart';
 


### PR DESCRIPTION
## Description

This test case relies on `flutter precache` having run as it uses the real cache.

See https://github.com/flutter/flutter/issues/35707
