### PR TITLE
Keep LLDB connection to iOS device alive while running from CLI.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -45,7 +45,7 @@ class IOSDeploy {
       '--bundle',
       bundlePath,
       '--no-wifi',
-      '--justlaunch',
+      '--no-interactive',
     ];
     if (launchArguments.isNotEmpty) {
       launchCommand.add('--args');


### PR DESCRIPTION
## Description

Instead of detaching from the spawned App process on the device immediately, keep the LLDB client connection open (in autopilot mode) until the App quits or the server connection is lost.

This replicates the behavior of Xcode, which also keeps a debugger attached to the App after launching it.

## Tests

This change will be covered by all running benchmarks (which are launched via "flutter run"/"flutter drive"), and probably be covered by all tests as well. 

## Breaking Change

I don't believe this should introduce any breaking changes. The LLDB client automatically exits when the app dies or the device is disconnected, so there shouldn't even be any user-visible changes to the behavior of the tool (besides the output of "-v").