### PR TITLE
enable lint prefer_if_null_operators

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -141,7 +141,7 @@ linter:
     # - prefer_function_declarations_over_variables # not yet tested
     - prefer_generic_function_type_aliases
     # - prefer_if_elements_to_conditional_expressions # not yet tested
-    # - prefer_if_null_operators # not yet tested
+    - prefer_if_null_operators
     - prefer_initializing_formals
     - prefer_inlined_adds
     # - prefer_int_literals # not yet tested

--- a/packages/flutter_tools/test/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/windows/visual_studio_test.dart
@@ -41,18 +41,17 @@ void main() {
 
     final MockProcessResult result = MockProcessResult();
     when(result.exitCode).thenReturn(0);
-    when<String>(result.stdout).thenReturn(response == null
-        ? json.encode(<Map<String, dynamic>>[
-            <String, dynamic>{
-              'installationPath': visualStudioPath,
-              'displayName': 'Visual Studio Community 2017',
-              'installationVersion': '15.9.28307.665',
-              'catalog': <String, String>{
-                'productDisplayVersion': '15.9.12',
-              },
-            }
-          ])
-        : response);
+    when<String>(result.stdout).thenReturn(response ??
+      json.encode(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'installationPath': visualStudioPath,
+          'displayName': 'Visual Studio Community 2017',
+          'installationVersion': '15.9.28307.665',
+          'catalog': <String, String>{
+            'productDisplayVersion': '15.9.12',
+          },
+        },
+      ]));
 
     final List<String> requirementArguments = requiredComponents == null
         ? <String>[]


### PR DESCRIPTION
## Description

Enables lint [prefer_if_null_operators](https://dart-lang.github.io/linter/lints/prefer_if_null_operators.html)

## Related Issues

None

## Tests

None

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
