### PR TITLE
UIApplicationLaunchOptionsKey -> UIApplication.LaunchOptionsKey

### DIFF
--- a/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.flutterView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Profile;
 		};
@@ -531,7 +531,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.flutterView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -553,7 +553,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.flutterView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/examples/platform_channel_swift/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/platform_channel_swift/ios/Runner.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Profile;
 		};
@@ -464,7 +464,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -489,7 +489,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
+++ b/examples/platform_channel_swift/ios/Runner/AppDelegate.swift
@@ -25,7 +25,7 @@ enum MyFlutterErrorCode {
 
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     guard let controller = window?.rootViewController as? FlutterViewController else {
       fatalError("rootViewController is not type FlutterViewController")

--- a/packages/flutter_tools/templates/app/ios-swift.tmpl/Runner/AppDelegate.swift
+++ b/packages/flutter_tools/templates/app/ios-swift.tmpl/Runner/AppDelegate.swift
@@ -5,7 +5,7 @@ import Flutter
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -245,7 +245,7 @@ void main() {
         final FlutterProject project = await someProject();
 
         when(mockXcodeProjectInterpreter.getBuildSettings(any, any)).thenReturn(<String, String>{
-          'SWIFT_VERSION': '3.0',
+          'SWIFT_VERSION': '4.0',
         });
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {


### PR DESCRIPTION
## Description

- Replace obsoleted UIApplicationLaunchOptionsKey with UIApplication.LaunchOptionsKey 
- Upgrade all example projects to at least Swift 4.0 since Swift 3.0 projects cannot be opened in Xcode 11.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/35760

## Tests

None.
flutter_view_ios__start_up will exercise that example project Swift version bump.
platform_channel_swift doesn't seem to be tested anywhere, and in fact doesn't compile on master.  Will file another issue for that...

I tested this manually by:
```
$ flutter create -i swift test_swift
$ open ios/Runner.xcworkspace 
```
Builds successfully.
Change SWIFT_VERSION build setting to 4.2 and then 5.  Still builds successfully.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
