### PR TITLE
Build all example projects in CI build smoke test

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -258,22 +258,27 @@ Future<void> _runToolTests() async {
   print('${bold}DONE: All tests successful.$reset');
 }
 
-/// Verifies that AOT, APK, and IPA (if on macOS) builds of some
-/// examples apps finish without crashing. It does not actually
+/// Verifies that AOT, APK, and IPA (if on macOS) builds the
+/// examples apps without crashing. It does not actually
 /// launch the apps. That happens later in the devicelab. This is
 /// just a smoke-test. In particular, this will verify we can build
 /// when there are spaces in the path name for the Flutter SDK and
 /// target app.
 Future<void> _runBuildTests() async {
-  final List<String> paths = <String>[
-    path.join('examples', 'hello_world'),
-    path.join('examples', 'flutter_gallery'),
-    path.join('examples', 'flutter_view'),
-  ];
-  for (String path in paths) {
-    await _flutterBuildAot(path);
-    await _flutterBuildApk(path);
-    await _flutterBuildIpa(path);
+  final Stream<FileSystemEntity> exampleDirectories = Directory(path.join(flutterRoot, 'examples')).list();
+  await for (FileSystemEntity fileEntity in exampleDirectories) {
+    if (fileEntity is! Directory) {
+      continue;
+    }
+    final String examplePath = fileEntity.path;
+    final String basename = path.basename(examplePath);
+    final bool expectIpaBuildFailure = basename == 'layers' || // Remove when https://github.com/flutter/flutter/issues/35771 is fixed.
+                                       basename == 'platform_channel_swift'; // Remove when https://github.com/flutter/flutter/issues/35773 is fixed.
+    final bool expectPodInstallBuildFailure = basename == 'layers'; // Remove when https://github.com/flutter/flutter/issues/35771 is fixed.
+
+    await _flutterBuildAot(examplePath);
+    await _flutterBuildApk(examplePath);
+    await _flutterBuildIpa(examplePath, expectPodInstallBuildFailure: expectPodInstallBuildFailure, expectIpaBuildFailure: expectIpaBuildFailure);
   }
   await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'));
 
@@ -318,7 +323,7 @@ Future<void> _flutterBuildApk(String relativePathToApplication) async {
   print('Done.');
 }
 
-Future<void> _flutterBuildIpa(String relativePathToApplication) async {
+Future<void> _flutterBuildIpa(String relativePathToApplication, {bool expectPodInstallBuildFailure = false, bool expectIpaBuildFailure = false}) async {
   if (!Platform.isMacOS) {
     return;
   }
@@ -330,14 +335,14 @@ Future<void> _flutterBuildIpa(String relativePathToApplication) async {
     await runCommand('pod',
       <String>['install'],
       workingDirectory: podfile.parent.path,
-      expectNonZeroExit: false,
+      expectNonZeroExit: expectPodInstallBuildFailure,
       timeout: _kShortTimeout,
     );
   }
   await runCommand(flutter,
     <String>['build', 'ios', '--no-codesign', '--debug', '-v'],
     workingDirectory: path.join(flutterRoot, relativePathToApplication),
-    expectNonZeroExit: false,
+    expectNonZeroExit: expectIpaBuildFailure,
     timeout: _kShortTimeout,
   );
   print('Done.');

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -272,13 +272,11 @@ Future<void> _runBuildTests() async {
     }
     final String examplePath = fileEntity.path;
     final String basename = path.basename(examplePath);
-    final bool expectIpaBuildFailure = basename == 'layers' || // Remove when https://github.com/flutter/flutter/issues/35771 is fixed.
-                                       basename == 'platform_channel_swift'; // Remove when https://github.com/flutter/flutter/issues/35773 is fixed.
-    final bool expectPodInstallBuildFailure = basename == 'layers'; // Remove when https://github.com/flutter/flutter/issues/35771 is fixed.
+    final bool expectIpaBuildFailure = basename == 'platform_channel_swift'; // Remove when https://github.com/flutter/flutter/issues/35773 is fixed.
 
     await _flutterBuildAot(examplePath);
     await _flutterBuildApk(examplePath);
-    await _flutterBuildIpa(examplePath, expectPodInstallBuildFailure: expectPodInstallBuildFailure, expectIpaBuildFailure: expectIpaBuildFailure);
+    await _flutterBuildIpa(examplePath, expectIpaBuildFailure: expectIpaBuildFailure);
   }
   await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'));
 
@@ -323,7 +321,7 @@ Future<void> _flutterBuildApk(String relativePathToApplication) async {
   print('Done.');
 }
 
-Future<void> _flutterBuildIpa(String relativePathToApplication, {bool expectPodInstallBuildFailure = false, bool expectIpaBuildFailure = false}) async {
+Future<void> _flutterBuildIpa(String relativePathToApplication, {bool expectIpaBuildFailure = false}) async {
   if (!Platform.isMacOS) {
     return;
   }
@@ -335,7 +333,7 @@ Future<void> _flutterBuildIpa(String relativePathToApplication, {bool expectPodI
     await runCommand('pod',
       <String>['install'],
       workingDirectory: podfile.parent.path,
-      expectNonZeroExit: expectPodInstallBuildFailure,
+      expectNonZeroExit: false,
       timeout: _kShortTimeout,
     );
   }

--- a/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		26D36078B4738B64685A0B6F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		2D9222431EC1E1BA007564B0 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		2D9222441EC1E1BA007564B0 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -55,6 +56,8 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C77CA0BBC4B57129484236F4 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC01738FBE39EADD5AC4BF42 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		ECF490DDAB8ABCEEFB1780BE /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +141,9 @@
 		E54E8B7296D73DD9B2385312 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				ECF490DDAB8ABCEEFB1780BE /* Pods-Runner.debug.xcconfig */,
+				26D36078B4738B64685A0B6F /* Pods-Runner.release.xcconfig */,
+				DC01738FBE39EADD5AC4BF42 /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -273,7 +279,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter_view/ios/Runner.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		2DE332E81E55C6F100393FD5 /* MainViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainViewController.h; sourceTree = "<group>"; };
 		3B3967011E83382E004F5970 /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		3B3967041E83383D004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		63EC5EC13E843CD861057871 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -60,6 +61,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C50B4FE91C29B0DE9DD62DD3 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		EADA814501F2EF49C9E6C636 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +82,9 @@
 		840012C8B5EDBCF56B0E4AC1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				63EC5EC13E843CD861057871 /* Pods-Runner.debug.xcconfig */,
+				C50B4FE91C29B0DE9DD62DD3 /* Pods-Runner.release.xcconfig */,
+				EADA814501F2EF49C9E6C636 /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -165,7 +171,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				D7EBAA0AD2D4385BA6FA83BA /* [CP] Embed Pods Frameworks */,
-				0273455D92E89802918C824F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -226,21 +231,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0273455D92E89802918C824F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -275,13 +265,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D7EBAA0AD2D4385BA6FA83BA /* [CP] Embed Pods Frameworks */ = {
@@ -296,7 +289,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/platform_channel_swift/android/app/build.gradle
+++ b/examples/platform_channel_swift/android/app/build.gradle
@@ -1,0 +1,60 @@
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+def flutterRoot = localProperties.getProperty('flutter.sdk')
+if (flutterRoot == null) {
+    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+}
+
+def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+if (flutterVersionCode == null) {
+    flutterVersionCode = '1'
+}
+
+def flutterVersionName = localProperties.getProperty('flutter.versionName')
+if (flutterVersionName == null) {
+    flutterVersionName = '1.0'
+}
+
+apply plugin: 'com.android.application'
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
+android {
+    compileSdkVersion 28
+
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+
+    defaultConfig {
+        applicationId "io.flutter.examples.platform_channel_swift"
+        minSdkVersion 16
+        targetSdkVersion 28
+        versionCode flutterVersionCode.toInteger()
+        versionName flutterVersionName
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig signingConfigs.debug
+        }
+    }
+}
+
+flutter {
+    source '../..'
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}

--- a/examples/platform_channel_swift/android/app/src/androidTest/java/com/example/platformchannel/ExampleInstrumentedTest.java
+++ b/examples/platform_channel_swift/android/app/src/androidTest/java/com/example/platformchannel/ExampleInstrumentedTest.java
@@ -1,0 +1,94 @@
+package com.example.platformchannel;
+
+import android.graphics.Bitmap;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import io.flutter.view.FlutterView;
+
+import android.app.Instrumentation;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+    @Rule
+    public ActivityTestRule<MainActivity> activityRule =
+        new ActivityTestRule<>(MainActivity.class);
+
+
+    @Test
+    public void testBitmap() {
+        final Instrumentation instr = InstrumentationRegistry.getInstrumentation();
+        final BitmapPoller poller = new BitmapPoller(5);
+        instr.runOnMainSync(new Runnable() {
+            public void run() {
+                final FlutterView flutterView = activityRule.getActivity().getFlutterView();
+
+                // Call onPostResume to start the engine's renderer even if the activity
+                // is paused in the test environment.
+                flutterView.onPostResume();
+
+                poller.start(flutterView);
+            }
+        });
+
+        Bitmap bitmap = null;
+        try {
+            bitmap = poller.waitForBitmap();
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+
+        assertNotNull(bitmap);
+        assertTrue(bitmap.getWidth() > 0);
+        assertTrue(bitmap.getHeight() > 0);
+
+        // Check that a pixel matches the default Material background color.
+        assertTrue(bitmap.getPixel(bitmap.getWidth() - 1, bitmap.getHeight() - 1) == 0xFFFAFAFA);
+    }
+
+    // Waits on a FlutterView until it is able to produce a bitmap.
+    private class BitmapPoller {
+        private int triesPending;
+        private int waitMsec;
+        private FlutterView flutterView;
+        private Bitmap bitmap;
+        private CountDownLatch latch = new CountDownLatch(1);
+
+        private final int delayMsec = 1000;
+
+        BitmapPoller(int tries) {
+            triesPending = tries;
+            waitMsec = delayMsec * tries + 100;
+        }
+
+        void start(FlutterView flutterView) {
+            this.flutterView = flutterView;
+            flutterView.postDelayed(checkBitmap, delayMsec);
+        }
+
+        Bitmap waitForBitmap() throws InterruptedException {
+            latch.await(waitMsec, TimeUnit.MILLISECONDS);
+            return bitmap;
+        }
+
+        private Runnable checkBitmap = new Runnable() {
+            public void run() {
+                bitmap = flutterView.getBitmap();
+                triesPending--;
+                if (bitmap != null || triesPending == 0) {
+                    latch.countDown();
+                } else {
+                    flutterView.postDelayed(checkBitmap, delayMsec);
+                }
+            }
+        };
+    }
+}

--- a/examples/platform_channel_swift/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel_swift/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.platformchannel">
+
+    <!-- The INTERNET permission is required for development. Specifically,
+         flutter needs it to communicate with the running application
+         to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
+    <application android:name="io.flutter.app.FlutterApplication" android:label="@string/app_name">
+        <activity android:name=".MainActivity"
+                  android:launchMode="singleTop"
+                  android:theme="@android:style/Theme.Black.NoTitleBar"
+                  android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+                  android:hardwareAccelerated="true"
+                  android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
+++ b/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
@@ -1,0 +1,101 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.example.platformchannel;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.os.Bundle;
+
+import io.flutter.app.FlutterActivity;
+import io.flutter.plugin.common.EventChannel;
+import io.flutter.plugin.common.EventChannel.EventSink;
+import io.flutter.plugin.common.EventChannel.StreamHandler;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugins.GeneratedPluginRegistrant;
+
+public class MainActivity extends FlutterActivity {
+  private static final String BATTERY_CHANNEL = "samples.flutter.io/battery";
+  private static final String CHARGING_CHANNEL = "samples.flutter.io/charging";
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    GeneratedPluginRegistrant.registerWith(this);
+    new EventChannel(getFlutterView(), CHARGING_CHANNEL).setStreamHandler(
+        new StreamHandler() {
+          private BroadcastReceiver chargingStateChangeReceiver;
+          @Override
+          public void onListen(Object arguments, EventSink events) {
+            chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
+            registerReceiver(
+                chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+          }
+
+          @Override
+          public void onCancel(Object arguments) {
+            unregisterReceiver(chargingStateChangeReceiver);
+            chargingStateChangeReceiver = null;
+          }
+        }
+    );
+
+    new MethodChannel(getFlutterView(), BATTERY_CHANNEL).setMethodCallHandler(
+        new MethodCallHandler() {
+          @Override
+          public void onMethodCall(MethodCall call, Result result) {
+            if (call.method.equals("getBatteryLevel")) {
+              int batteryLevel = getBatteryLevel();
+
+              if (batteryLevel != -1) {
+                result.success(batteryLevel);
+              } else {
+                result.error("UNAVAILABLE", "Battery level not available.", null);
+              }
+            } else {
+              result.notImplemented();
+            }
+          }
+        }
+    );
+  }
+
+  private BroadcastReceiver createChargingStateChangeReceiver(final EventSink events) {
+    return new BroadcastReceiver() {
+      @Override
+      public void onReceive(Context context, Intent intent) {
+        int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+
+        if (status == BatteryManager.BATTERY_STATUS_UNKNOWN) {
+          events.error("UNAVAILABLE", "Charging status unavailable", null);
+        } else {
+          boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                               status == BatteryManager.BATTERY_STATUS_FULL;
+          events.success(isCharging ? "charging" : "discharging");
+        }
+      }
+    };
+  }
+
+  private int getBatteryLevel() {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      BatteryManager batteryManager = (BatteryManager) getSystemService(BATTERY_SERVICE);
+      return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+    } else {
+      Intent intent = new ContextWrapper(getApplicationContext()).
+          registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+      return (intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100) /
+          intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+    }
+  }
+}

--- a/examples/platform_channel_swift/android/app/src/main/res/values/strings.xml
+++ b/examples/platform_channel_swift/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Platform Channel</string>
+    <string name="title">Flutter Application</string>
+</resources>

--- a/examples/platform_channel_swift/android/build.gradle
+++ b/examples/platform_channel_swift/android/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
+    project.evaluationDependsOn(':app')
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/examples/platform_channel_swift/android/gradle.properties
+++ b/examples/platform_channel_swift/android/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx1536M

--- a/examples/platform_channel_swift/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/platform_channel_swift/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 23 08:50:38 CEST 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/examples/platform_channel_swift/android/settings.gradle
+++ b/examples/platform_channel_swift/android/settings.gradle
@@ -1,0 +1,15 @@
+include ':app'
+
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withInputStream { stream -> plugins.load(stream) }
+}
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/examples/platform_view/ios/Podfile.lock
+++ b/examples/platform_view/ios/Podfile.lock
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 9d0fac939486c9aba2809b7982dfdbb47a7b0296
+  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
   MaterialControls: 1c6b29e78d3a13d8dd6a67ed31b6d26eb5de8f72
 
-PODFILE CHECKSUM: 4a320bf98e7f7e414d7d7f5079edf1b2d6679c9b
+PODFILE CHECKSUM: 80af51c01ee3f0969ddbf2d1f0dcd6f44fad2c52
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.7.1

--- a/examples/platform_view/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/platform_view/ios/Runner.xcodeproj/project.pbxproj
@@ -40,11 +40,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0F803D4F4B1DB3E426346AD7 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		2DAF064A1ED38C2300716BEE /* PlatformViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformViewController.h; sourceTree = "<group>"; };
 		2DAF064B1ED38C3E00716BEE /* PlatformViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlatformViewController.m; sourceTree = "<group>"; };
 		2DAF064D1ED4224F00716BEE /* ic_add.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_add.png; sourceTree = "<group>"; };
+		3036634A71F5F09C1B6453EC /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		6E6555FD3971FC12A9802782 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -60,6 +62,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9D6BF03EDD3895D7B4DA4D7D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +82,9 @@
 		5A56E2F315C4CB64895375DA /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				3036634A71F5F09C1B6453EC /* Pods-Runner.debug.xcconfig */,
+				9D6BF03EDD3895D7B4DA4D7D /* Pods-Runner.release.xcconfig */,
+				0F803D4F4B1DB3E426346AD7 /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -236,7 +242,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {


### PR DESCRIPTION
## Description

Prevent the example apps from atrophying when integration tests do not build all platforms.
Catch unintentional breaking platform API changes.
- Build aot, apk, and ipa for all example projects.
- Let newer version of CoocaPods touch the tracked project files.

To run:
```
SHARD=build_tests dart dev/bots/test.dart
```
This adds ~2 minutes to that shard on my machine.

## Related Issues
Accounts for build failures from issues:
https://github.com/flutter/flutter/issues/35771
https://github.com/flutter/flutter/issues/35773

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.