### PR TITLE
Adjust how web tests are run to prevent timeouts

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -88,7 +88,7 @@ Future<void> _runSmokeTests() async {
     script: path.join('test_smoke_test', 'fail_test.dart'),
     expectFailure: true,
     printOutput: false,
-    timeout: _kShort
+    timeout: _kShortTimeout
                         ,
   );
   // We run the timeout tests individually because they are timing-sensitive.

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -472,7 +472,9 @@ Future<void> _runWebTests() async {
       // 'test/widgets/',
       // 'test/material/',
     ]).timeout(const Duration(minutes: 30)); // prevent tests that get stuck from causing the shard to fail.
-  } on TimeoutException { // Do nothing for now }
+  } on TimeoutException {
+    // Do nothing for now
+  }
 }
 
 Future<void> _runCoverage() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -457,7 +457,7 @@ Future<void> _runTests() async {
 }
 
 Future<void> _runWebTests() async {
-  _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
+  await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
     'test/foundation/',
     'test/physics/',
     'test/rendering/',

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -88,8 +88,7 @@ Future<void> _runSmokeTests() async {
     script: path.join('test_smoke_test', 'fail_test.dart'),
     expectFailure: true,
     printOutput: false,
-    timeout: _kShortTimeout
-                        ,
+    timeout: _kShortTimeout,
   );
   // We run the timeout tests individually because they are timing-sensitive.
   await _runFlutterTest(automatedTests,
@@ -458,23 +457,19 @@ Future<void> _runTests() async {
 }
 
 Future<void> _runWebTests() async {
-  try {
-    await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
-      'test/foundation/',
-      'test/physics/',
-      'test/rendering/',
-      'test/services/',
-      'test/painting/',
-      'test/scheduler/',
-      'test/semantics/',
-      // TODO(flutterweb): re-enable when instabiliy around pumpAndSettle is
-      // resolved.
-      // 'test/widgets/',
-      // 'test/material/',
-    ]).timeout(const Duration(minutes: 30)); // prevent tests that get stuck from causing the shard to fail.
-  } on TimeoutException {
-    // Do nothing for now
-  }
+  _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
+    'test/foundation/',
+    'test/physics/',
+    'test/rendering/',
+    'test/services/',
+    'test/painting/',
+    'test/scheduler/',
+    'test/semantics/',
+    // TODO(flutterweb): re-enable when instabiliy around pumpAndSettle is
+    // resolved.
+    // 'test/widgets/',
+    // 'test/material/',
+  ]);
 }
 
 Future<void> _runCoverage() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -469,7 +469,7 @@ Future<void> _runWebTests() async {
     // resolved.
     // 'test/widgets/',
     // 'test/material/',
-  ]);
+  ]).timeout(const Duration(minutes: 30)); // prevent tests that get stuck from causing the shard to fail.
 }
 
 Future<void> _runCoverage() async {
@@ -759,24 +759,25 @@ Future<void> _runFlutterWebTest(String workingDirectory, {
     '-v',
     '--platform=chrome',
     ...?flutterTestArgs,
-    ...tests,
   ];
 
   // TODO(jonahwilliams): fix relative path issues to make this unecessary.
   final Directory oldCurrent = Directory.current;
   Directory.current = Directory(path.join(flutterRoot, 'packages', 'flutter'));
   try {
-    await runCommand(
-      flutter,
-      args,
-      workingDirectory: workingDirectory,
-      expectFlaky: true,
-      timeout: timeout,
-      environment: <String, String>{
-        'FLUTTER_WEB': 'true',
-        'FLUTTER_LOW_RESOURCE_MODE': 'true',
-      },
-    );
+    for (String testGroup in tests) {
+      await runCommand(
+        flutter,
+        <String>[...args, testGroup],
+        workingDirectory: workingDirectory,
+        expectFlaky: true,
+        timeout: timeout,
+        environment: <String, String>{
+          'FLUTTER_WEB': 'true',
+          'FLUTTER_LOW_RESOURCE_MODE': 'true',
+        },
+      );
+    }
   } finally {
     Directory.current = oldCurrent;
   }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -88,7 +88,8 @@ Future<void> _runSmokeTests() async {
     script: path.join('test_smoke_test', 'fail_test.dart'),
     expectFailure: true,
     printOutput: false,
-    timeout: _kShortTimeout,
+    timeout: _kShort
+                        ,
   );
   // We run the timeout tests individually because they are timing-sensitive.
   await _runFlutterTest(automatedTests,
@@ -457,19 +458,21 @@ Future<void> _runTests() async {
 }
 
 Future<void> _runWebTests() async {
-  await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
-    'test/foundation/',
-    'test/physics/',
-    'test/rendering/',
-    'test/services/',
-    'test/painting/',
-    'test/scheduler/',
-    'test/semantics/',
-    // TODO(flutterweb): re-enable when instabiliy around pumpAndSettle is
-    // resolved.
-    // 'test/widgets/',
-    // 'test/material/',
-  ]).timeout(const Duration(minutes: 30)); // prevent tests that get stuck from causing the shard to fail.
+  try {
+    await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
+      'test/foundation/',
+      'test/physics/',
+      'test/rendering/',
+      'test/services/',
+      'test/painting/',
+      'test/scheduler/',
+      'test/semantics/',
+      // TODO(flutterweb): re-enable when instabiliy around pumpAndSettle is
+      // resolved.
+      // 'test/widgets/',
+      // 'test/material/',
+    ]).timeout(const Duration(minutes: 30)); // prevent tests that get stuck from causing the shard to fail.
+  } on TimeoutException { // Do nothing for now }
 }
 
 Future<void> _runCoverage() async {


### PR DESCRIPTION
## Description

While the web tests failing doesn't mark the shard as red, timeouts still do. Prevent this from happening by running the tests with their own timeout.

Separately, as an attempt to reduce flakiness run these tests through separate flutter test invocations so the chrome instance is torn down between tests.
