### PR TITLE
When ndk.abiFilters does not contain arm64-v8a, we use android-arm

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -294,6 +294,14 @@ class FlutterPlugin implements Plugin<Project> {
      * Unfortunately, the engine artifacts include the .class and libflutter.so files.
      */
     private static String getBasePlatform(Project project) {
+        // When ndk.abiFilters does not contain arm64-v8a, we use android-arm platform.
+        if (project.android.defaultConfig.ndk.hasProperty("abiFilters")) {
+            def abiFilters = project.android.defaultConfig.ndk.abiFilters
+            if (!(ARCH_ARM64 in abiFilters)) {
+                return PLATFORM_ARM32;
+            }
+        }
+
         if (PLATFORM_ARM64 in getTargetPlatforms(project)) {
             return PLATFORM_ARM64;
         }


### PR DESCRIPTION
## Description

When my project set ndk.abiFilters but does not contain `arm64-v8a`, use `android-arm` target-platform.

```diff
android {
    defaultConfig {
        ...
+        ndk {
+            abiFilters "armeabi-v7a"
+        }
    }
}
```

## Related Issues

#35098

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
