### PR TITLE
Cleanup widgets/sliver_persistent_header.dart with resolution of dart-lang/sdk#31543

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -309,10 +309,7 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
-    // Not passing this snapConfiguration as a constructor parameter to avoid the
-    // additional layers added due to https://github.com/dart-lang/sdk/issues/31543
-    return _RenderSliverFloatingPersistentHeaderForWidgets()
-      ..snapConfiguration = delegate.snapConfiguration;
+    return _RenderSliverFloatingPersistentHeaderForWidgets(snapConfiguration: delegate.snapConfiguration);
   }
 
   @override
@@ -321,7 +318,12 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
   }
 }
 
-class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin {
+  _RenderSliverFloatingPinnedPersistentHeaderForWidgets({
+    RenderBox child,
+    FloatingHeaderSnapConfiguration snapConfiguration,
+  }) : super(child: child, snapConfiguration: snapConfiguration);
+}
 
 class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverFloatingPinnedPersistentHeader({
@@ -331,10 +333,7 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
-    // Not passing this snapConfiguration as a constructor parameter to avoid the
-    // additional layers added due to https://github.com/dart-lang/sdk/issues/31543
-    return _RenderSliverFloatingPinnedPersistentHeaderForWidgets()
-      ..snapConfiguration = delegate.snapConfiguration;
+    return _RenderSliverFloatingPinnedPersistentHeaderForWidgets(snapConfiguration: delegate.snapConfiguration);
   }
 
   @override
@@ -343,4 +342,9 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
   }
 }
 
-class _RenderSliverFloatingPersistentHeaderForWidgets extends RenderSliverFloatingPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+class _RenderSliverFloatingPersistentHeaderForWidgets extends RenderSliverFloatingPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin {
+  _RenderSliverFloatingPersistentHeaderForWidgets({
+    RenderBox child,
+    FloatingHeaderSnapConfiguration snapConfiguration,
+  }) : super(child: child, snapConfiguration: snapConfiguration);
+}

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -284,10 +284,7 @@ class _SliverScrollingPersistentHeader extends _SliverPersistentHeaderRenderObje
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
-abstract class _RenderSliverScrollingPersistentHeader extends RenderSliverScrollingPersistentHeader { }
-
-class _RenderSliverScrollingPersistentHeaderForWidgets extends _RenderSliverScrollingPersistentHeader
+class _RenderSliverScrollingPersistentHeaderForWidgets extends RenderSliverScrollingPersistentHeader
   with _RenderSliverPersistentHeaderForWidgetsMixin { }
 
 class _SliverPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
@@ -302,10 +299,7 @@ class _SliverPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectW
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
-abstract class _RenderSliverPinnedPersistentHeader extends RenderSliverPinnedPersistentHeader { }
-
-class _RenderSliverPinnedPersistentHeaderForWidgets extends _RenderSliverPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+class _RenderSliverPinnedPersistentHeaderForWidgets extends RenderSliverPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
 
 class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverFloatingPersistentHeader({
@@ -327,10 +321,7 @@ class _SliverFloatingPersistentHeader extends _SliverPersistentHeaderRenderObjec
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
-abstract class _RenderSliverFloatingPinnedPersistentHeader extends RenderSliverFloatingPinnedPersistentHeader { }
-
-class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends _RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+class _RenderSliverFloatingPinnedPersistentHeaderForWidgets extends RenderSliverFloatingPinnedPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
 
 class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectWidget {
   const _SliverFloatingPinnedPersistentHeader({
@@ -352,7 +343,4 @@ class _SliverFloatingPinnedPersistentHeader extends _SliverPersistentHeaderRende
   }
 }
 
-// This class exists to work around https://github.com/dart-lang/sdk/issues/31543
-abstract class _RenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersistentHeader { }
-
-class _RenderSliverFloatingPersistentHeaderForWidgets extends _RenderSliverFloatingPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }
+class _RenderSliverFloatingPersistentHeaderForWidgets extends RenderSliverFloatingPersistentHeader with _RenderSliverPersistentHeaderForWidgetsMixin { }


### PR DESCRIPTION
## Description

Removed classes from widgets/sliver_persistent_header.dart that are
 no longer needed with https://github.com/dart-lang/sdk/issues/31543 being fixed.
Added a snapConfiguration parameter to _RenderSliverFloatingPersistentHeaderForWidgets and  _RenderSliverFloatingPinnedPersistentHeaderForWidgets.

## Related Issues



## Tests

Ran all flutter tests and they passed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ NA] I signed the [CLA].
- [X ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X ] I updated/added relevant documentation (doc comments with `///`).
- [X ] All existing and new tests are passing.
- [ X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ X] No, this is *not* a breaking change.
