### PR TITLE
use pub run for create test and remove [INFO] logs

### DIFF
--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -87,6 +87,7 @@ Future<void> runCommand(String executable, List<String> arguments, {
   bool skip = false,
   bool expectFlaky = false,
   Duration timeout = _kLongTimeout,
+  bool Function(String) removeLine,
 }) async {
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
   final String relativeWorkingDir = path.relative(workingDirectory);
@@ -103,13 +104,18 @@ Future<void> runCommand(String executable, List<String> arguments, {
   );
 
   Future<List<List<int>>> savedStdout, savedStderr;
+  final Stream<List<int>> stdoutSource = process.stdout
+    .transform<String>(const Utf8Decoder())
+    .transform(const LineSplitter())
+    .where((String line) => removeLine == null || !removeLine(line))
+    .transform(const Utf8Encoder());
   if (printOutput) {
     await Future.wait<void>(<Future<void>>[
-      stdout.addStream(process.stdout),
+      stdout.addStream(stdoutSource),
       stderr.addStream(process.stderr),
     ]);
   } else {
-    savedStdout = process.stdout.toList();
+    savedStdout = stdoutSource.toList();
     savedStderr = process.stderr.toList();
   }
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -592,6 +592,9 @@ Future<void> _pubRunTest(
     case 'tool':
       args.addAll(<String>['--exclude-tags', 'integration']);
       break;
+    case 'create':
+      args.addAll(<String>[path.join('test', 'commands', 'create_test.dart')]);
+      break;
   }
 
   if (useFlutterTestFormatter) {
@@ -608,7 +611,6 @@ Future<void> _pubRunTest(
       pub,
       args,
       workingDirectory: workingDirectory,
-      removeLine: (String line) => line.contains('[INFO]')
     );
   }
 }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -240,7 +240,8 @@ Future<void> _runToolTests() async {
     File(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.snapshot')).deleteSync();
     File(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.stamp')).deleteSync();
   }
-  if (noUseBuildRunner) {
+  // reduce overhead of build_runner in the create case.
+  if (noUseBuildRunner || Platform.environment['SUBSHARD'] == 'create') {
     await _pubRunTest(
       path.join(flutterRoot, 'packages', 'flutter_tools'),
       tableData: bigqueryApi?.tabledata,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -556,7 +556,6 @@ Future<void> _buildRunnerTest(
       args,
       workingDirectory:workingDirectory,
       environment:pubEnvironment,
-      removeLine: (String line) => line.contains('[INFO]') || line.contains('loading test')
     );
   }
 }
@@ -609,7 +608,7 @@ Future<void> _pubRunTest(
       pub,
       args,
       workingDirectory: workingDirectory,
-      removeLine: (String line) => line.contains('[INFO]') || line.contains('loading test')
+      removeLine: (String line) => line.contains('[INFO]')
     );
   }
 }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -556,6 +556,7 @@ Future<void> _buildRunnerTest(
       args,
       workingDirectory:workingDirectory,
       environment:pubEnvironment,
+      removeLine: (String line) => line.contains('[INFO]') || line.contains('loading test')
     );
   }
 }
@@ -607,7 +608,8 @@ Future<void> _pubRunTest(
     await runCommand(
       pub,
       args,
-      workingDirectory:workingDirectory,
+      workingDirectory: workingDirectory,
+      removeLine: (String line) => line.contains('[INFO]') || line.contains('loading test')
     );
   }
 }

--- a/packages/flutter_tools/dart_test.yaml
+++ b/packages/flutter_tools/dart_test.yaml
@@ -1,0 +1,4 @@
+tags:
+  "no_coverage":
+  "create":
+  "integration":

--- a/packages/flutter_tools/dart_test.yaml
+++ b/packages/flutter_tools/dart_test.yaml
@@ -2,3 +2,4 @@ tags:
   "no_coverage":
   "create":
   "integration":
+ 


### PR DESCRIPTION
## Description

Since we're only running one (or two?) test files the overhead of pre-compilation is not worth it. This will also cut down on the logspam in this particular case.