### PR TITLE
move reload and restart handling into terminal

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -559,6 +559,9 @@ abstract class ResidentRunner {
     });
   }
 
+  /// Whether this runner can hot reload.
+  bool get canHotReload => hotMode;
+
   /// Start the app and keep the process running during its lifetime.
   ///
   /// Returns the exit code that we should use for the flutter tool process; 0
@@ -838,35 +841,6 @@ abstract class ResidentRunner {
 
   /// Called right before we exit.
   Future<void> cleanupAtFinish();
-
-  /// Called when the runner should handle a terminal command.
-  Future<void> handleTerminalCommand(String code) async {
-    switch (code) {
-      case 'r':
-        final OperationResult result = await restart(fullRestart: false);
-        if (!result.isOk) {
-          printStatus('Try again after fixing the above error(s).', emphasis: true);
-        }
-        return;
-      case 'R':
-        // If hot restart is not supported for all devices, ignore the command.
-        if (!canHotRestart) {
-          return;
-        }
-        final OperationResult result = await restart(fullRestart: true);
-        if (!result.isOk) {
-          printStatus('Try again after fixing the above error(s).', emphasis: true);
-        }
-        return;
-      case 'l':
-      case 'L':
-        final List<FlutterView> views = flutterDevices.expand((FlutterDevice d) => d.views).toList();
-        printStatus('Connected ${pluralize('view', views.length)}:');
-        for (FlutterView v in views) {
-          printStatus('${v.uiIsolate.name} (${v.uiIsolate.id})', indent: 2);
-        }
-    }
-  }
 }
 
 class OperationResult {
@@ -918,6 +892,9 @@ class TerminalHandler {
   bool _processingUserRequest = false;
   StreamSubscription<void> subscription;
 
+  @visibleForTesting
+  String lastReceivedCommand;
+
   void setupTerminal() {
     if (!logger.quiet) {
       printStatus('');
@@ -964,6 +941,14 @@ class TerminalHandler {
           return true;
         }
         return false;
+      case 'l':
+        final List<FlutterView> views = residentRunner.flutterDevices
+            .expand((FlutterDevice d) => d.views).toList();
+        printStatus('Connected ${pluralize('view', views.length)}:');
+        for (FlutterView v in views) {
+          printStatus('${v.uiIsolate.name} (${v.uiIsolate.id})', indent: 2);
+        }
+        return true;
       case 'L':
         if (residentRunner.supportsServiceProtocol) {
           await residentRunner.debugDumpLayerTree();
@@ -1000,6 +985,25 @@ class TerminalHandler {
             await residentRunner.screenshot(device);
         }
         return true;
+      case 'r':
+        if (!residentRunner.canHotReload) {
+          return false;
+        }
+        final OperationResult result = await residentRunner.restart(fullRestart: false);
+        if (!result.isOk) {
+          printStatus('Try again after fixing the above error(s).', emphasis: true);
+        }
+        return true;
+      case 'R':
+        // If hot restart is not supported for all devices, ignore the command.
+        if (!residentRunner.canHotRestart || !residentRunner.hotMode) {
+          return false;
+        }
+        final OperationResult result = await residentRunner.restart(fullRestart: true);
+        if (!result.isOk) {
+          printStatus('Try again after fixing the above error(s).', emphasis: true);
+        }
+        return true;
       case 'S':
         if (residentRunner.supportsServiceProtocol) {
           await residentRunner.debugDumpSemanticsTreeInTraversalOrder();
@@ -1031,10 +1035,8 @@ class TerminalHandler {
         await residentRunner.debugToggleDebugCheckElevationsEnabled();
         return true;
     }
-
     return false;
   }
-
 
   Future<void> processTerminalInput(String command) async {
     // When terminal doesn't support line mode, '\n' can sneak into the input.
@@ -1045,9 +1047,8 @@ class TerminalHandler {
     }
     _processingUserRequest = true;
     try {
-      final bool handled = await _commonTerminalInputHandler(command);
-      if (!handled)
-        await residentRunner.handleTerminalCommand(command);
+      lastReceivedCommand = command;
+      await _commonTerminalInputHandler(command);
     } catch (error, st) {
       printError('$error\n$st');
       await _cleanUpAndExit(null);

--- a/packages/flutter_tools/lib/src/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_web_runner.dart
@@ -50,6 +50,9 @@ class ResidentWebRunner extends ResidentRunner {
   final FlutterProject flutterProject;
 
   @override
+  bool get canHotReload => false;
+
+  @override
   Future<int> attach(
       {Completer<DebugConnectionInfo> connectionInfoCompleter,
       Completer<void> appStartedCompleter}) async {
@@ -71,17 +74,6 @@ class ResidentWebRunner extends ResidentRunner {
     await _connection?.sendCommand('Browser.close');
     _connection = null;
     await _server?.dispose();
-  }
-
-  @override
-  Future<void> handleTerminalCommand(String code) async {
-    if (code == 'R') {
-      // If hot restart is not supported for all devices, ignore the command.
-      if (!canHotRestart) {
-        return;
-      }
-      await restart(fullRestart: true);
-    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -39,6 +39,12 @@ class ColdRunner extends ResidentRunner {
   bool _didAttach = false;
 
   @override
+  bool get canHotReload => false;
+
+  @override
+  bool get canHotRestart => false;
+
+  @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,


### PR DESCRIPTION
## Description

No sense in having multiple switch statements across keycodes. This makes testing easier and moves more code out of resident runner, which is a prerequisite for https://github.com/flutter/flutter/issues/34552