### PR TITLE
Add flag to use root navigator for showModalBottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -427,6 +427,7 @@ Future<T> showModalBottomSheet<T>({
   assert(context != null);
   assert(builder != null);
   assert(isScrollControlled != null);
+  assert(useRootNavigator != null);
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
 

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -400,6 +400,11 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// a [GridView] and have the bottom sheet be draggable, you should set this
 /// parameter to true.
 ///
+/// The `useRootNavigator` parameter ensures that the root navigator is used to
+/// display the [BottomSheet] when set to `true`. This is useful in the case
+/// that a modal [BottomSheet] needs to be displayed above all other content
+/// but the caller is inside another [Navigator].
+///
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -417,6 +417,7 @@ Future<T> showModalBottomSheet<T>({
   double elevation,
   ShapeBorder shape,
   bool isScrollControlled = false,
+  bool useRootNavigator = false,
 }) {
   assert(context != null);
   assert(builder != null);
@@ -424,7 +425,7 @@ Future<T> showModalBottomSheet<T>({
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
 
-  return Navigator.push(context, _ModalBottomSheetRoute<T>(
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(_ModalBottomSheetRoute<T>(
     builder: builder,
     theme: Theme.of(context, shadowThemeOnly: true),
     isScrollControlled: isScrollControlled,

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -384,8 +384,7 @@ void main() {
     ));
 
     await tester.tap(find.text('Show bottom sheet'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
 
     // Bottom sheet is displayed in correct position.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 544.0);
@@ -413,8 +412,7 @@ void main() {
     ));
 
     await tester.tap(find.text('Show bottom sheet'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
 
     // Bottom sheet is displayed in correct position.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 600.0);

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -361,4 +361,91 @@ void main() {
     ), ignoreTransform: true, ignoreRect: true, ignoreId: true));
     semantics.dispose();
   });
+
+  testWidgets('showModalBottomSheet does not use root Navigator by default', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Navigator(onGenerateRoute: (RouteSettings settings) => MaterialPageRoute<void>(builder: (_) {
+          return const TestPage();
+        })),
+        bottomNavigationBar: BottomNavigationBar(
+          items: <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              icon: Icon(Icons.ac_unit),
+              title: const Text('Item 1'),
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.style),
+              title: const Text('Item 2'),
+            )
+          ],
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Show bottom sheet'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Bottom sheet is in displayed in correct position
+    expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 544.0);
+  });
+
+  testWidgets('showModalBottomSheet uses root Navigator when specified', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Navigator(onGenerateRoute: (RouteSettings settings) => MaterialPageRoute<void>(builder: (_) {
+          return const TestPage(useRootNavigator: true);
+        })),
+        bottomNavigationBar: BottomNavigationBar(
+          items: <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              icon: Icon(Icons.ac_unit),
+              title: const Text('Item 1'),
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.style),
+              title: const Text('Item 2'),
+            )
+          ],
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Show bottom sheet'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Bottom sheet is in displayed in correct position
+    expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 600.0);
+  });
+}
+
+class TestPage extends StatelessWidget {
+  const TestPage({Key key, this.useRootNavigator}) : super(key: key);
+
+  final bool useRootNavigator;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: FlatButton(
+        child: const Text('Show bottom sheet'),
+        onPressed: () {
+          if (useRootNavigator != null) {
+            showModalBottomSheet<void>(
+              useRootNavigator: useRootNavigator,
+              context: context,
+              builder: (_) => const Text('Modal bottom sheet'),
+            );
+          } else {
+            showModalBottomSheet<void>(
+              context: context,
+              builder: (_) => const Text('Modal bottom sheet'),
+            );
+          }
+        }
+      ),
+    );
+  }
 }

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -366,17 +366,17 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Navigator(onGenerateRoute: (RouteSettings settings) => MaterialPageRoute<void>(builder: (_) {
-          return const TestPage();
+          return const _TestPage();
         })),
         bottomNavigationBar: BottomNavigationBar(
-          items: <BottomNavigationBarItem>[
+          items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(
               icon: Icon(Icons.ac_unit),
-              title: const Text('Item 1'),
+              title: Text('Item 1'),
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.style),
-              title: const Text('Item 2'),
+              title: Text('Item 2'),
             )
           ],
         ),
@@ -387,7 +387,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    // Bottom sheet is in displayed in correct position
+    // Bottom sheet is displayed in correct position.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 544.0);
   });
 
@@ -395,17 +395,17 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Navigator(onGenerateRoute: (RouteSettings settings) => MaterialPageRoute<void>(builder: (_) {
-          return const TestPage(useRootNavigator: true);
+          return const _TestPage(useRootNavigator: true);
         })),
         bottomNavigationBar: BottomNavigationBar(
-          items: <BottomNavigationBarItem>[
+          items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(
               icon: Icon(Icons.ac_unit),
-              title: const Text('Item 1'),
+              title: Text('Item 1'),
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.style),
-              title: const Text('Item 2'),
+              title: Text('Item 2'),
             )
           ],
         ),
@@ -416,13 +416,13 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    // Bottom sheet is in displayed in correct position
+    // Bottom sheet is displayed in correct position.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 600.0);
   });
 }
 
-class TestPage extends StatelessWidget {
-  const TestPage({Key key, this.useRootNavigator}) : super(key: key);
+class _TestPage extends StatelessWidget {
+  const _TestPage({Key key, this.useRootNavigator}) : super(key: key);
 
   final bool useRootNavigator;
 

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -386,7 +386,8 @@ void main() {
     await tester.tap(find.text('Show bottom sheet'));
     await tester.pumpAndSettle();
 
-    // Bottom sheet is displayed in correct position.
+    // Bottom sheet is displayed in correct position within the inner navigator
+    // and above the BottomNavigationBar.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 544.0);
   });
 
@@ -414,7 +415,8 @@ void main() {
     await tester.tap(find.text('Show bottom sheet'));
     await tester.pumpAndSettle();
 
-    // Bottom sheet is displayed in correct position.
+    // Bottom sheet is displayed in correct position above all content including
+    // the BottomNavigationBar.
     expect(tester.getBottomLeft(find.byType(BottomSheet)).dy, 600.0);
   });
 }


### PR DESCRIPTION
## Description

Allow the use of the root navigator for showModalBottomSheet for cases where it is called from another Navigator. This ensures that the bottom sheet can always cover the entire screen if necessary.

## Related Issues

Closes #35204

## Tests

I added the following tests:

* Ensure the existing behavior is maintained
* Check that it uses the root navigator when specified

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
