### PR TITLE
Refactor: Simplily Mouse Tracking

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -146,8 +146,8 @@ class MouseTracker extends ChangeNotifier {
         collectMousePositions();
       });
     }
-      SchedulerBinding.instance.scheduleFrame();
-    }
+    SchedulerBinding.instance.scheduleFrame();
+  }
 
   // Handler for events coming from the PointerRouter.
   void _handleEvent(PointerEvent event) {

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -145,9 +145,9 @@ class MouseTracker extends ChangeNotifier {
         _postFrameCheckScheduled = false;
         collectMousePositions();
       });
+    }
       SchedulerBinding.instance.scheduleFrame();
     }
-  }
 
   // Handler for events coming from the PointerRouter.
   void _handleEvent(PointerEvent event) {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -146,6 +146,7 @@ void main() {
     try {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
+      await tester.pump();
       await tester.pumpAndSettle();
 
       expect(find.text('Add'), findsOneWidget);

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -146,7 +146,6 @@ void main() {
     try {
       await gesture.addPointer();
       await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
-      await tester.pump();
       await tester.pumpAndSettle();
 
       expect(find.text('Add'), findsOneWidget);

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -282,7 +282,7 @@ void main() {
       expect(enter1, isEmpty);
       expect(exit1, isEmpty);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
       clearLists();
 
       await gesture.removePointer();
@@ -352,7 +352,7 @@ void main() {
       expect(enter2, isEmpty);
       expect(exit2, isEmpty);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
       clearLists();
       await gesture.moveTo(center2);
       await tester.pump();
@@ -365,7 +365,7 @@ void main() {
       expect(enter2, isNotEmpty);
       expect(enter2.last.position, equals(center2));
       expect(exit2, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isFalse);
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
       clearLists();
       await gesture.moveTo(const Offset(400.0, 450.0));
@@ -377,8 +377,8 @@ void main() {
       expect(enter2, isEmpty);
       expect(exit2, isNotEmpty);
       expect(exit2.last.position, equals(const Offset(400.0, 450.0)));
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isFalse);
+      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
       clearLists();
       await tester.pumpWidget(Container());
       expect(move1, isEmpty);


### PR DESCRIPTION
## Description

This PR refactors how `MouseTracker` handles `_TrackedAnnotation`.

Before this PR, every render box with `MouseTrackerAnnotation` will create a `_TrackedAnnotation` in `MouseTracker`, and only destroys it when detached. Every `_TrackedAnnotation` is also traversed in `collectMousePositions` every frame. This causes an `O(n)` memory usage and run time where `n` is the number of `MouseTrackerAnnotation` on screen.

With this PR, render boxes only creates a `_TrackedAnnotation` when a mouse enters it, and destroys it when the mouse leaves. This greatly reduces the number of `_TrackedAnnotation`s to store and to visit every frame.

This PR also addresses the following issues:
- Fixed an unnecessary (probably by mistake) nested for loop in `collectMousePositions`.
- Fixed: frame is not always scheduled in `_scheduleMousePositionCheck`.
  - Calling `SchedulerBinding.instance.scheduleFrame` for multiple times is very cheap since `SchedulerBinding` tracks if a frame has been scheduled internally. Failing to call it, however, can cause flaky tests.

This PR does not change public behavior, but it does change the behavior of some `visibleForTesting` interfaces, since some tests check if the given `MouseTrackerAnnotation` is tracked in `MouseTracker`.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
