### PR TITLE
Change focus example to be more canonical (and correct)

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -236,6 +236,7 @@ class FocusAttachment {
 ///
 /// class _ColorfulButtonState extends State<ColorfulButton> {
 ///   FocusNode _node;
+///   bool _focused = false;
 ///   FocusAttachment _nodeAttachment;
 ///   Color _color = Colors.white;
 ///
@@ -243,7 +244,16 @@ class FocusAttachment {
 ///   void initState() {
 ///     super.initState();
 ///     _node = FocusNode(debugLabel: 'Button');
+///     _node.addListener(_handleFocusChange);
 ///     _nodeAttachment = _node.attach(context, onKey: _handleKeyPress);
+///   }
+///
+///   void _handleFocusChange() {
+///     if (_node.hasFocus != _focused) {
+///       setState(() {
+///         _focused = _node.hasFocus;
+///       });
+///     }
 ///   }
 ///
 ///   bool _handleKeyPress(FocusNode node, RawKeyEvent event) {
@@ -274,6 +284,7 @@ class FocusAttachment {
 ///
 ///   @override
 ///   void dispose() {
+///     _node.removeListener(_handleFocusChange);
 ///     // The attachment will automatically be detached in dispose().
 ///     _node.dispose();
 ///     super.dispose();
@@ -284,24 +295,20 @@ class FocusAttachment {
 ///     _nodeAttachment.reparent();
 ///     return GestureDetector(
 ///       onTap: () {
-///         if (_node.hasFocus) {
-///           setState(() {
+///         if (_focused) {
 ///             _node.unfocus();
-///           });
 ///         } else {
-///           setState(() {
-///             _node.requestFocus();
-///           });
+///            _node.requestFocus();
 ///         }
 ///       },
 ///       child: Center(
 ///         child: Container(
 ///           width: 400,
 ///           height: 100,
-///           color: _node.hasFocus ? _color : Colors.white,
+///           color: _focused ? _color : Colors.white,
 ///           alignment: Alignment.center,
 ///           child: Text(
-///               _node.hasFocus ? "I'm in color! Press R,G,B!" : 'Press to focus'),
+///               _focused ? "I'm in color! Press R,G,B!" : 'Press to focus'),
 ///         ),
 ///       ),
 ///     );


### PR DESCRIPTION
## Description

This changes the example for `FocusNode` to be more correct, listening to the focus node for changes, instead of assuming that it is the only one doing the changing.

## Related Issues

Fixes #31697.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
