### PR TITLE
SliverLayoutBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -14,9 +14,18 @@ typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstrain
 /// The signature of the [SliverLayoutBuilder] builder function.
 typedef SliverLayoutWidgetBuilder = Widget Function(BuildContext context, SliverConstraints constraints);
 
-// A widget that defers its building until layout.
+/// An abstract superclass for widgets that defer their building until layout.
+///
+/// Similar to the [Builder] widget except that the framework calls the [builder]
+/// function at layout time and provides the constraints that this widget should
+/// adhere to. This is useful when the parent constrains the child's size and layout,
+/// and doesn't depend on the child's intrinsic size.
 abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> extends RenderObjectWidget {
-  const ConstrainedLayoutBuilder._({
+  /// Creates a widget that defers its building until layout.
+  ///
+  /// The [builder] argument must not be null, and the returned widget should not
+  /// be null.
+  const ConstrainedLayoutBuilder({
     Key key,
     @required this.builder,
   }) : assert(builder != null),
@@ -25,7 +34,9 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
   @override
   _LayoutBuilderElement<ConstraintType> createElement() => _LayoutBuilderElement<ConstraintType>(this);
 
-  final Widget Function(BuildContext context, ConstraintType constraints) builder;
+  /// Called at layout time to construct the widget tree. The builder must not
+  /// return null.
+  final Widget Function(BuildContext, ConstraintType) builder;
 
   // updateRenderObject is redundant with the logic in the LayoutBuilderElement below.
 }
@@ -168,10 +179,8 @@ class LayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {
   const LayoutBuilder({
     Key key,
     LayoutWidgetBuilder builder,
-  }) : super._(key: key, builder: builder);
+  }) : super(key: key, builder: builder);
 
-  /// Called at layout time to construct the widget tree. The builder must not
-  /// return null.
   @override
   LayoutWidgetBuilder get builder;
 
@@ -261,7 +270,7 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   const SliverLayoutBuilder({
     Key key,
     SliverLayoutWidgetBuilder builder,
-  }) : super._(key: key, builder: builder);
+  }) : super(key: key, builder: builder);
 
   /// Called at layout time to construct the widget tree. The builder must return
   /// a non-null sliver widget.

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -137,7 +137,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   }
 }
 
-/// Generic mixin for render objects created by [ConstrainedLayoutBuilder].
+/// Generic mixin for [RenderObject]s created by [ConstrainedLayoutBuilder].
 ///
 /// Provides a callback that should be called at layout time, typically in
 /// [RenderObject.performLayout].

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -48,7 +48,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   ConstrainedLayoutBuilder<ConstraintType> get widget => super.widget;
 
   @override
-  _GenericRenderLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject;
+  RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject;
 
   Element _child;
 
@@ -130,15 +130,20 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
 
   @override
   void removeChildRenderObject(RenderObject child) {
-    final _GenericRenderLayoutBuilder<ConstraintType, RenderObject> renderObject = this.renderObject;
+    final RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> renderObject = this.renderObject;
     assert(renderObject.child == child);
     renderObject.child = null;
     assert(renderObject == this.renderObject);
   }
 }
 
-mixin _GenericRenderLayoutBuilder<ConstraintType extends Constraints, ChildType extends RenderObject> on RenderObjectWithChildMixin<ChildType> {
+/// Generic mixin for render objects created by [ConstrainedLayoutBuilder].
+///
+/// Provides a callback that should be called at layout time, typically in
+/// [RenderObject.performLayout].
+mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildType extends RenderObject> on RenderObjectWithChildMixin<ChildType> {
   LayoutCallback<ConstraintType> _callback;
+  /// Change the layout callback.
   set callback(LayoutCallback<ConstraintType> value) {
     if (value == _callback)
       return;
@@ -146,6 +151,7 @@ mixin _GenericRenderLayoutBuilder<ConstraintType extends Constraints, ChildType 
     markNeedsLayout();
   }
 
+  /// Invoke the layout callback.
   void layoutAndBuildChild() {
     assert(_callback != null);
     invokeLayoutCallback(_callback);
@@ -188,7 +194,7 @@ class LayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {
   _RenderLayoutBuilder createRenderObject(BuildContext context) => _RenderLayoutBuilder();
 }
 
-class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<RenderBox>, _GenericRenderLayoutBuilder<BoxConstraints, RenderBox> {
+class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<RenderBox>, RenderConstrainedLayoutBuilder<BoxConstraints, RenderBox> {
   @override
   double computeMinIntrinsicWidth(double height) {
     assert(_debugThrowIfNotCheckingIntrinsics());
@@ -281,7 +287,7 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   _RenderSliverLayoutBuilder createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
 }
 
-class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, _GenericRenderLayoutBuilder<SliverConstraints, RenderSliver> {
+class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> {
   @override
   double childMainAxisPosition(RenderObject child) {
     assert(child != null);

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -20,7 +20,7 @@ abstract class _GenericLayoutBuilder<ConstraintType extends Constraints> extends
     Key key,
     @required this.builder,
   }) : assert(builder != null),
-  super(key: key);
+       super(key: key);
 
   @override
   _LayoutBuilderElement<ConstraintType> createElement() => _LayoutBuilderElement<ConstraintType>(this);

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -8,8 +8,6 @@ import 'package:flutter/rendering.dart';
 import 'debug.dart';
 import 'framework.dart';
 
-export 'sliver_layout_builder.dart';
-
 /// The signature of the [LayoutBuilder] builder function.
 typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstraints constraints);
 
@@ -33,8 +31,9 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
   @override
   _LayoutBuilderElement<ConstraintType> createElement() => _LayoutBuilderElement<ConstraintType>(this);
 
-  /// Called at layout time to construct the widget tree. The builder must not
-  /// return null.
+  /// Called at layout time to construct the widget tree.
+  ///
+  /// The builder must not return null.
   final Widget Function(BuildContext, ConstraintType) builder;
 
   // updateRenderObject is redundant with the logic in the LayoutBuilderElement below.

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -15,8 +15,8 @@ typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstrain
 typedef SliverLayoutWidgetBuilder = Widget Function(BuildContext context, SliverConstraints constraints);
 
 // A widget that defers its building until layout.
-abstract class _GenericLayoutBuilder<ConstraintType extends Constraints> extends RenderObjectWidget {
-  const _GenericLayoutBuilder({
+abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> extends RenderObjectWidget {
+  const ConstrainedLayoutBuilder._({
     Key key,
     @required this.builder,
   }) : assert(builder != null),
@@ -31,10 +31,10 @@ abstract class _GenericLayoutBuilder<ConstraintType extends Constraints> extends
 }
 
 class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderObjectElement {
-  _LayoutBuilderElement(_GenericLayoutBuilder<ConstraintType> widget) : super(widget);
+  _LayoutBuilderElement(ConstrainedLayoutBuilder<ConstraintType> widget) : super(widget);
 
   @override
-  _GenericLayoutBuilder<ConstraintType> get widget => super.widget;
+  ConstrainedLayoutBuilder<ConstraintType> get widget => super.widget;
 
   @override
   _GenericRenderLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject;
@@ -60,7 +60,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   }
 
   @override
-  void update(_GenericLayoutBuilder<ConstraintType> newWidget) {
+  void update(ConstrainedLayoutBuilder<ConstraintType> newWidget) {
     assert(widget != newWidget);
     super.update(newWidget);
     assert(widget == newWidget);
@@ -161,14 +161,14 @@ mixin _GenericRenderLayoutBuilder<ConstraintType extends Constraints, ChildType 
 ///  * [Builder], which calls a `builder` function at build time.
 ///  * [StatefulBuilder], which passes its `builder` function a `setState` callback.
 ///  * [CustomSingleChildLayout], which positions its child during layout.
-class LayoutBuilder extends _GenericLayoutBuilder<BoxConstraints> {
+class LayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {
   /// Creates a widget that defers its building until layout.
   ///
   /// The [builder] argument must not be null.
   const LayoutBuilder({
     Key key,
     LayoutWidgetBuilder builder,
-  }) : super(key: key, builder: builder);
+  }) : super._(key: key, builder: builder);
 
   /// Called at layout time to construct the widget tree. The builder must not
   /// return null.
@@ -254,14 +254,14 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
 /// See also:
 ///
 ///  * [LayoutBuilder], the non-sliver version of this widget.
-class SliverLayoutBuilder extends _GenericLayoutBuilder<SliverConstraints> {
+class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   /// Creates a sliver widget that defers its building until layout.
   ///
   /// The [builder] argument must not be null.
   const SliverLayoutBuilder({
     Key key,
     SliverLayoutWidgetBuilder builder,
-  }) : super(key: key, builder: builder);
+  }) : super._(key: key, builder: builder);
 
   /// Called at layout time to construct the widget tree. The builder must return
   /// a non-null sliver widget.
@@ -291,8 +291,7 @@ class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChild
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     assert(child != null);
     assert(child == this.child);
-    // No-op because child's offset is always (0, 0),
-    // transform.translate(0, 0) doesn't do anything.
+    // child's offset is always (0, 0), transform.translate(0, 0) does not mutate the transform.
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -276,10 +276,40 @@ class SliverLayoutBuilder extends _GenericLayoutBuilder<SliverConstraints> {
   _RenderSliverLayoutBuilder createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
 }
 
-class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, _GenericRenderLayoutBuilder<BoxConstraints, RenderSliver> {
+class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, _GenericRenderLayoutBuilder<SliverConstraints, RenderSliver> {
+
+  @override
+  double childMainAxisPosition(RenderObject child) {
+    assert(child != null);
+    assert(child == this.child);
+    return calculatePaintOffset(constraints, from: 0, to: 0);
+  }
+
   @override
   void performLayout() {
-    // TODO: implement performLayout
+    assert(callback != null);
+    invokeLayoutCallback(callback);
+    if (child == null) {
+      geometry = SliverGeometry.zero;
+      return;
+    }
+
+    child.layout(constraints, parentUsesSize: true);
+    final SliverGeometry childGeometry= child.geometry;
+    geometry = childGeometry;
+  }
+
+  @override
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child != null);
+    assert(child == this.child);
+    // No-op because transform.translate(0, 0) doesn't do anything.
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child?.geometry?.visible == true)
+      context.paintChild(child, offset);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -1,0 +1,79 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import 'framework.dart';
+import 'layout_builder.dart';
+
+/// The signature of the [SliverLayoutBuilder] builder function.
+typedef SliverLayoutWidgetBuilder = Widget Function(BuildContext context, SliverConstraints constraints);
+
+/// Builds a sliver widget tree that can depend on its own [SliverConstraints].
+///
+/// Similar to the [LayoutBuilder] widget except its builder should return a sliver
+/// widget, and [SliverLayoutBuilder] is itself a sliver. The framework calls the
+/// [builder] function at layout time and provides the current [SliverConstraints].
+/// The [SliverLayoutBuilder]'s final [SliverGeometry] will match the [SliverGeometry]
+/// of its child.
+///
+///
+/// See also:
+///
+///  * [LayoutBuilder], the non-sliver version of this widget.
+class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
+  /// Creates a sliver widget that defers its building until layout.
+  ///
+  /// The [builder] argument must not be null.
+  const SliverLayoutBuilder({
+    Key key,
+    SliverLayoutWidgetBuilder builder,
+  }) : super(key: key, builder: builder);
+
+  /// Called at layout time to construct the widget tree. The builder must return
+  /// a non-null sliver widget.
+  @override
+  SliverLayoutWidgetBuilder get builder => super.builder;
+
+  @override
+  _RenderSliverLayoutBuilder createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+}
+
+class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> {
+  @override
+  double childMainAxisPosition(RenderObject child) {
+    assert(child != null);
+    assert(child == this.child);
+    return 0;
+  }
+
+  @override
+  void performLayout() {
+    layoutAndBuildChild();
+    child?.layout(constraints, parentUsesSize: true);
+    geometry = child?.geometry ?? SliverGeometry.zero;
+  }
+
+  @override
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child != null);
+    assert(child == this.child);
+    // child's offset is always (0, 0), transform.translate(0, 0) does not mutate the transform.
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    // This renderObject does not introduce additional offset to child's position.
+    if (child?.geometry?.visible == true)
+      context.paintChild(child, offset);
+  }
+
+  @override
+  bool hitTestChildren(SliverHitTestResult result, {double mainAxisPosition, double crossAxisPosition}) {
+    return child != null
+        && child.geometry.hitTestExtent > 0
+        && child.hitTest(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+  }
+}

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -32,8 +32,9 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
     SliverLayoutWidgetBuilder builder,
   }) : super(key: key, builder: builder);
 
-  /// Called at layout time to construct the widget tree. The builder must return
-  /// a non-null sliver widget.
+  /// Called at layout time to construct the widget tree.
+  ///
+  /// The builder must return a non-null sliver widget.
   @override
   SliverLayoutWidgetBuilder get builder => super.builder;
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -92,6 +92,7 @@ export 'src/widgets/shortcuts.dart';
 export 'src/widgets/single_child_scroll_view.dart';
 export 'src/widgets/size_changed_layout_notifier.dart';
 export 'src/widgets/sliver.dart';
+export 'src/widgets/sliver_layout_builder.dart';
 export 'src/widgets/sliver_persistent_header.dart';
 export 'src/widgets/sliver_prototype_extent_list.dart';
 export 'src/widgets/spacer.dart';

--- a/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
@@ -56,6 +56,8 @@ void main() {
         return StatefulWrapper(key: key, child: Container(height: 100.0));
       }),
     );
+
+    expect(tester.takeException(), null);
   });
 
   testWidgets('Moving global key inside a SliverLayoutBuilder', (WidgetTester tester) async {
@@ -95,5 +97,7 @@ void main() {
         ),
       ),
     );
+
+    expect(tester.takeException(), null);
   });
 }

--- a/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_and_global_keys_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/src/rendering/sliver.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -54,6 +55,45 @@ void main() {
         key.currentState.trigger();
         return StatefulWrapper(key: key, child: Container(height: 100.0));
       }),
+    );
+  });
+
+  testWidgets('Moving global key inside a SliverLayoutBuilder', (WidgetTester tester) async {
+    final GlobalKey<StatefulWrapperState> key = GlobalKey<StatefulWrapperState>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return SliverToBoxAdapter(
+                  child: Wrapper(child: StatefulWrapper(key: key, child: Container(height: 100.0))),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                key.currentState.trigger();
+                return SliverToBoxAdapter(
+                  child: StatefulWrapper(key: key, child: Container(height: 100.0)),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
     );
   });
 }

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -65,6 +65,8 @@ void main() {
         ),
       ],
     ));
+
+    expect(tester.takeException(), null);
   });
 
   testWidgets('Moving a global key from another SliverLayoutBuilder at layout time', (WidgetTester tester) async {
@@ -121,5 +123,6 @@ void main() {
       ),
     );
 
+    expect(tester.takeException(), null);
   });
 }

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/src/rendering/sliver.dart';
 import 'package:flutter/src/widgets/basic.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/layout_builder.dart';
+import 'package:flutter/src/widgets/sliver_layout_builder.dart';
 import 'package:flutter/src/widgets/scroll_view.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/src/rendering/sliver.dart';
 import 'package:flutter/src/widgets/basic.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/layout_builder.dart';
+import 'package:flutter/src/widgets/scroll_view.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class Wrapper extends StatelessWidget {
@@ -63,5 +65,61 @@ void main() {
         ),
       ],
     ));
+  });
+
+  testWidgets('Moving a global key from another SliverLayoutBuilder at layout time', (WidgetTester tester) async {
+    final GlobalKey victimKey1 = GlobalKey();
+    final GlobalKey victimKey2 = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return SliverPadding(key: victimKey1, padding: const EdgeInsets.fromLTRB(1, 2, 3, 4));
+              },
+            ),
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return SliverPadding(key: victimKey2, padding: const EdgeInsets.fromLTRB(5, 7, 11, 13));
+              },
+            ),
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return const SliverPadding(padding: EdgeInsets.fromLTRB(5, 7, 11, 13));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return SliverPadding(key: victimKey2, padding: const EdgeInsets.fromLTRB(1, 2, 3, 4));
+              },
+            ),
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return const SliverPadding(padding: EdgeInsets.fromLTRB(5, 7, 11, 13));
+              },
+            ),
+            SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraint) {
+                return SliverPadding(key: victimKey1, padding: const EdgeInsets.fromLTRB(5, 7, 11, 13));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
   });
 }

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -77,6 +77,7 @@ void main() {
     expect(parentConstraints2.remainingPaintExtent, 600 - 2 - 4);
     final RenderSliver parentSliver1 = tester.renderObject(find.byKey(parentKey1));
     final RenderSliver parentSliver2 = tester.renderObject(find.byKey(parentKey2));
+
     // scrollExtent == top + bottom.
     expect(parentSliver1.geometry.scrollExtent, 2 + 4);
     expect(parentSliver2.geometry.scrollExtent, 7 + 13);
@@ -187,6 +188,7 @@ void main() {
     expect(parentSliver.geometry.scrollExtent, childHeight);
     expect(parentSliver.geometry.paintExtent, childHeight);
 
+    // When child is over-sized.
     setState(() {
         childWidth = 900.0;
         childHeight = 900.0;
@@ -200,7 +202,6 @@ void main() {
     expect(parentSliver.geometry.scrollExtent, childHeight);
     expect(parentSliver.geometry.paintExtent, 600);
   });
-
 
   testWidgets('LayoutBuilder stateful parent', (WidgetTester tester) async {
     Size layoutBuilderSize;
@@ -507,7 +508,7 @@ void main() {
     // Tap item 2.
     await tester.tapAt(const Offset(300, 50.0 + 100 + 200));
     await tester.pump();
-    //expect(hitCounts, const <int> [1, 1, 0]);
+    expect(hitCounts, const <int> [1, 1, 0]);
 
     // Tap item 3. Shift the touch point up to ensure the touch lands within the viewport.
     await tester.tapAt(const Offset(300, 50.0 + 200 + 200 + 10));
@@ -534,7 +535,6 @@ void main() {
     await tester.pump();
     expect(hitCounts, const <int> [1, 1, 1]);
 
-
     // Tapping outside of the viewport shouldn't do anything.
     await tester.tapAt(const Offset(300, 1));
     await tester.pump();
@@ -551,7 +551,6 @@ void main() {
     await tester.tapAt(const Offset(799, 100));
     await tester.pump();
     expect(hitCounts, const <int> [1, 1, 1]);
-
 
     // Tap the no-content area in the viewport shouldn't do anything
     hitCounts = <int> [0, 0, 0];

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -188,7 +188,7 @@ void main() {
     expect(parentSliver.geometry.scrollExtent, childHeight);
     expect(parentSliver.geometry.paintExtent, childHeight);
 
-    // When child is over-sized.
+    // Make child wider and higher than the viewport.
     setState(() {
         childWidth = 900.0;
         childHeight = 900.0;

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -436,7 +436,7 @@ void main() {
     final RenderBox renderChild1 = tester.renderObject(find.byKey(childKey1));
     final RenderBox renderChild2 = tester.renderObject(find.byKey(childKey2));
 
-    // scrollController.scrollOffset = 0:
+    // Test with scrollController.scrollOffset = 0.
     expect(
       renderChild1.localToGlobal(const Offset(100, 100)),
       const Offset(100, 300.0 + 100),

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -38,6 +38,38 @@ void main() {
     expect(childBox.size, equals(const Size(50.0, 100.0)));
   });
 
+  testWidgets('SliverLayoutBuilder parent geometry', (WidgetTester tester) async {
+    SliverConstraints parentConstraints;
+    final Key childKey = UniqueKey();
+    final Key parentKey = UniqueKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverLayoutBuilder(
+              key: parentKey,
+              builder: (BuildContext context, SliverConstraints constraint) {
+                parentConstraints = constraint;
+                return SliverPadding(key:childKey, padding: const EdgeInsets.fromLTRB(1, 2, 3, 4));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(parentConstraints.crossAxisExtent, 800);
+    expect(parentConstraints.remainingPaintExtent, 600);
+    final RenderSliver parentSliver = tester.renderObject(find.byKey(parentKey));
+    print(parentSliver.geometry);
+    // scrollExtent == top + bottom.
+    expect(parentSliver.geometry.scrollExtent, 2 + 4);
+    final RenderSliver childSliver = tester.renderObject(find.byKey(childKey));
+    expect(childSliver.geometry, parentSliver.geometry);
+  });
+
   testWidgets('LayoutBuilder stateful child', (WidgetTester tester) async {
     Size layoutBuilderSize;
     StateSetter setState;
@@ -64,7 +96,7 @@ void main() {
             );
           },
         ),
-      )
+      ),
     );
 
     expect(layoutBuilderSize, equals(const Size(800.0, 600.0)));


### PR DESCRIPTION
## Description

- Introduce `SliverLayoutBuilder`.

## Related Issues

Closes #35927

## Tests

I added the following tests:

`SliverLayoutBuilder` versions of most `LayoutBuilder` tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
