### PR TITLE
Pass --enable-asserts down to Dart CFE in debug BuildMode.

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -93,6 +93,7 @@ class BundleBuilder {
         fileSystemRoots: fileSystemRoots,
         fileSystemScheme: fileSystemScheme,
         packagesPath: packagesPath,
+        enableAsserts: buildMode == BuildMode.debug,
       );
       if (compilerOutput?.outputFilename == null) {
         throwToolExit('Compiler failed on $mainPath');

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -101,6 +101,7 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
     List<String> extraFrontEndOptions,
     String incrementalCompilerByteStorePath,
     bool targetProductVm = false,
+    bool enableAsserts = false,
     // These arguments are currently unused.
     String sdkRoot,
     String packagesPath,
@@ -137,6 +138,7 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
       extraFrontEndOptions: extraFrontEndOptions,
       incrementalCompilerByteStorePath: incrementalCompilerByteStorePath,
       targetProductVm: targetProductVm,
+      enableAsserts: enableAsserts,
       sdkRoot: sdkRoot,
       packagesPath: PackageMap.globalGeneratedPackagesPath,
       fileSystemRoots: <String>[

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -223,6 +223,7 @@ class KernelCompiler {
     List<String> fileSystemRoots,
     String fileSystemScheme,
     bool targetProductVm = false,
+    bool enableAsserts = false,
     String initializeFromDill,
   }) async {
     final String frontendServer = artifacts.getArtifactPath(
@@ -287,6 +288,10 @@ class KernelCompiler {
       command.add('-Ddart.vm.product=true');
     } else if (aot) {
       command.add('-Ddart.vm.profile=true');
+    }
+    if (enableAsserts) {
+      // Tell front-end to check assertions during constant evaluation.
+      command.add('--enable-asserts');
     }
     if (incrementalCompilerByteStorePath != null) {
       command.add('--incremental');


### PR DESCRIPTION
Once constant-update-2018 is enabled CFE would become responsible for checking
and reporting assert failures in constant constructors.