### PR TITLE
Deflake ImageProvider.evict test

### DIFF
--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -44,11 +44,20 @@ void main() {
         final ImageCache otherCache = ImageCache();
         final Uint8List bytes = Uint8List.fromList(kTransparentImage);
         final MemoryImage imageProvider = MemoryImage(bytes);
-        otherCache.putIfAbsent(imageProvider, () => imageProvider.load(imageProvider));
+        final ImageStreamCompleter cacheStream = otherCache.putIfAbsent(
+          imageProvider, () => imageProvider.load(imageProvider),
+        );
+
         final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
         final Completer<void> completer = Completer<void>();
-        stream.addListener(ImageStreamListener((ImageInfo info, bool syncCall) => completer.complete()));
-        await completer.future;
+        final Completer<void> cacheCompleter = Completer<void>();
+        stream.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
+          completer.complete();
+        }));
+        cacheStream.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
+          cacheCompleter.complete();
+        }));
+        await Future.wait(<Future<void>>[completer.future, cacheCompleter.future]);
 
         expect(otherCache.currentSize, 1);
         expect(imageCache.currentSize, 1);

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -47,7 +47,6 @@ void main() {
         final ImageStreamCompleter cacheStream = otherCache.putIfAbsent(
           imageProvider, () => imageProvider.load(imageProvider),
         );
-
         final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
         final Completer<void> completer = Completer<void>();
         final Completer<void> cacheCompleter = Completer<void>();


### PR DESCRIPTION
This test became flaky after flutter/engine#9486, which changed the way that image stream resolution happens.  The test was probably flaky before that, but just harder to reproduce the flakiness.

fixes https://github.com/flutter/flutter/issues/35993 by waiting for the stream to complete on both the cache and the image provider.

/cc @chinmaygarde 