### PR TITLE
add the transformPoint and transformRect benchmarks

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
@@ -15,7 +15,7 @@ const int _kNumWarmUp = 10000;
 
 void main() {
   assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
-  print('MatrixUtils.transformRect benchmark...');
+  print('MatrixUtils.transformRect and .transformPoint benchmark...');
 
   Matrix4 _makePerspective(double radius, double angle, double perspective) {
     return MatrixUtils.createCylindricalProjectionTransform(
@@ -124,13 +124,13 @@ void main() {
     name: 'MatrixUtils_affine_transformRect_iteration',
   );
   printer.addResult(
-    description: 'MatrixUtils.TransformPointPerspective',
+    description: 'MatrixUtils.transformPointPerspective',
     value: pointMicrosecondsPerspective * scale,
     unit: 'ns per iteration',
     name: 'MatrixUtils_persp_transformPoint_iteration',
   );
   printer.addResult(
-    description: 'MatrixUtils.TransformPointAffine',
+    description: 'MatrixUtils.transformPointAffine',
     value: pointMicrosecondsAffine * scale,
     unit: 'ns per iteration',
     name: 'MatrixUtils_affine_transformPoint_iteration',

--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
@@ -25,6 +25,14 @@ void main() {
     );
   }
 
+  // The number of transforms (and perspective transforms) provided as data
+  // should be relatively prime to the number of rectangles or points provided
+  // so that the benchmark loops end up applying each transform to each point
+  // or rect. Benchmarks don't have asserts enabled, but essentially:
+  //  assert(_rects.length.gcd(_transforms.length) == 1);
+  //  assert(_rects.length.gcd(_perspectiveTransforms.length) == 1);
+  //  assert(_offsets.length.gcd(_perspectiveTransforms.length) == 1);
+  //  assert(_offsets.length.gcd(_transforms.length) == 1);
   final List<Matrix4> _transforms = <Matrix4>[
     Matrix4.identity()..scale(1.2, 1.3, 1.0)..rotateZ(0.1),
     Matrix4.identity()..translate(12.0, 13.0, 10.0),
@@ -49,10 +57,6 @@ void main() {
     const Offset(-1.1, -1.2),
     const Offset(-1.5, -1.8),
   ];
-  assert(_rects.length.gcd(_transforms.length) == 1);
-  assert(_rects.length.gcd(_perspectiveTransforms.length) == 1);
-  assert(_offsets.length.gcd(_perspectiveTransforms.length) == 1);
-  assert(_offsets.length.gcd(_transforms.length) == 1);
 
   // Warm up lap
   for (int i = 0; i < _kNumWarmUp; i += 1) {

--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_rect_bench.dart
@@ -1,0 +1,135 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/painting.dart';
+import 'package:flutter/rendering.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import '../common.dart';
+
+const int _kNumIterations = 1000000;
+const int _kNumWarmUp = 10000;
+
+void main() {
+  assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
+  print('MatrixUtils.transformRect benchmark...');
+
+  Matrix4 _makePerspective(double radius, double angle, double perspective) {
+    return MatrixUtils.createCylindricalProjectionTransform(
+      radius: radius,
+      angle: angle,
+      perspective: perspective,
+    );
+  }
+
+  final List<Matrix4> _transforms = <Matrix4>[
+    Matrix4.identity()..scale(1.2, 1.3, 1.0)..rotateZ(0.1),
+    Matrix4.identity()..translate(12.0, 13.0, 10.0),
+    Matrix4.identity()..scale(1.2, 1.3, 1.0)..translate(12.0, 13.0, 10.0),
+  ];
+  final List<Matrix4> _perspectiveTransforms = <Matrix4>[
+    _makePerspective(10.0, math.pi / 8.0, 0.3),
+    _makePerspective( 8.0, math.pi / 8.0, 0.2),
+    _makePerspective( 1.0, math.pi / 4.0, 0.1)..rotateX(0.1),
+  ];
+  final List<Rect> _rects = <Rect>[
+    const Rect.fromLTRB(1.1, 1.2, 1.5, 1.8),
+    const Rect.fromLTRB(1.1, 1.2, 0.0, 1.0),
+    const Rect.fromLTRB(1.1, 1.2, 1.3, 1.0),
+    const Rect.fromLTRB(-1.1, -1.2, 0.0, 1.0),
+    const Rect.fromLTRB(-1.1, -1.2, -1.5, -1.8),
+  ];
+  final List<Offset> _offsets = <Offset>[
+    const Offset(1.1, 1.2),
+    const Offset(1.5, 1.8),
+    const Offset(0.0, 0.0),
+    const Offset(-1.1, -1.2),
+    const Offset(-1.5, -1.8),
+  ];
+  assert(_rects.length.gcd(_transforms.length) == 1);
+  assert(_rects.length.gcd(_perspectiveTransforms.length) == 1);
+  assert(_offsets.length.gcd(_perspectiveTransforms.length) == 1);
+  assert(_offsets.length.gcd(_transforms.length) == 1);
+
+  // Warm up lap
+  for (int i = 0; i < _kNumWarmUp; i += 1) {
+    final Rect rect = _rects[i % _rects.length];
+    final Offset offset = _offsets[i % _offsets.length];
+    final Matrix4 transform = (i > _kNumWarmUp / 2)
+        ? _perspectiveTransforms[i % _perspectiveTransforms.length]
+        : _transforms[i % _transforms.length];
+    MatrixUtils.transformRect(transform, rect);
+    MatrixUtils.transformPoint(transform, offset);
+  }
+
+  final Stopwatch watch = Stopwatch();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    final Rect rect = _rects[i % _rects.length];
+    final Matrix4 transform = _perspectiveTransforms[i % _perspectiveTransforms.length];
+    MatrixUtils.transformRect(transform, rect);
+  }
+  watch.stop();
+  final int rectMicrosecondsPerspective = watch.elapsedMicroseconds;
+
+  watch.reset();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    final Rect rect = _rects[i % _rects.length];
+    final Matrix4 transform = _transforms[i % _transforms.length];
+    MatrixUtils.transformRect(transform, rect);
+  }
+  watch.stop();
+  final int rectMicrosecondsAffine = watch.elapsedMicroseconds;
+
+  watch.reset();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    final Offset offset = _offsets[i % _offsets.length];
+    final Matrix4 transform = _perspectiveTransforms[i % _perspectiveTransforms.length];
+    MatrixUtils.transformPoint(transform, offset);
+  }
+  watch.stop();
+  final int pointMicrosecondsPerspective = watch.elapsedMicroseconds;
+
+  watch.reset();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    final Offset offset = _offsets[i % _offsets.length];
+    final Matrix4 transform = _transforms[i % _transforms.length];
+    MatrixUtils.transformPoint(transform, offset);
+  }
+  watch.stop();
+  final int pointMicrosecondsAffine = watch.elapsedMicroseconds;
+
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  const double scale = 1000.0 / _kNumIterations;
+  printer.addResult(
+    description: 'MatrixUtils.transformRectPerspective',
+    value: rectMicrosecondsPerspective * scale,
+    unit: 'ns per iteration',
+    name: 'MatrixUtils_persp_transformRect_iteration',
+  );
+  printer.addResult(
+    description: 'MatrixUtils.transformRectAffine',
+    value: rectMicrosecondsAffine * scale,
+    unit: 'ns per iteration',
+    name: 'MatrixUtils_affine_transformRect_iteration',
+  );
+  printer.addResult(
+    description: 'MatrixUtils.TransformPointPerspective',
+    value: pointMicrosecondsPerspective * scale,
+    unit: 'ns per iteration',
+    name: 'MatrixUtils_persp_transformPoint_iteration',
+  );
+  printer.addResult(
+    description: 'MatrixUtils.TransformPointAffine',
+    value: pointMicrosecondsAffine * scale,
+    unit: 'ns per iteration',
+    name: 'MatrixUtils_affine_transformPoint_iteration',
+  );
+  printer.printToStdout();
+}

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -51,6 +51,7 @@ TaskFunction createMicrobenchmarkTask() {
     final Map<String, double> allResults = <String, double>{
       ...await _runMicrobench('lib/stocks/layout_bench.dart'),
       ...await _runMicrobench('lib/stocks/build_bench.dart'),
+      ...await _runMicrobench('lib/geometry/matrix_utils_transform_rect_bench.dart'),
       ...await _runMicrobench('lib/geometry/rrect_contains_bench.dart'),
       ...await _runMicrobench('lib/gestures/velocity_tracker_bench.dart'),
       ...await _runMicrobench('lib/gestures/gesture_detector_bench.dart'),

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -51,7 +51,7 @@ TaskFunction createMicrobenchmarkTask() {
     final Map<String, double> allResults = <String, double>{
       ...await _runMicrobench('lib/stocks/layout_bench.dart'),
       ...await _runMicrobench('lib/stocks/build_bench.dart'),
-      ...await _runMicrobench('lib/geometry/matrix_utils_transform_rect_bench.dart'),
+      ...await _runMicrobench('lib/geometry/matrix_utils_transform_bench.dart'),
       ...await _runMicrobench('lib/geometry/rrect_contains_bench.dart'),
       ...await _runMicrobench('lib/gestures/velocity_tracker_bench.dart'),
       ...await _runMicrobench('lib/gestures/gesture_detector_bench.dart'),


### PR DESCRIPTION
## Description

These benchmarks expand upon the benchmarks that Yegor originally proposed for measuring MatrixUtils.transformRect optimizations and include additional benchmarks for both affine and perspective matrices and benchmarks for MatrixUtils.transformPoint as well.

There are 2 pending solutions to improve these operations, but this PR will get the benchmarks into the system so we can track the improvement when we actually decide and implement one of the solutions.

Current performance on 2 android devices:

Moto E2:
```
I/flutter (12908): MatrixUtils.transformRectPerspective: 3167.3 ns per iteration
I/flutter (12908): MatrixUtils.transformRectAffine: 3098.9 ns per iteration
I/flutter (12908): MatrixUtils.TransformPointPerspective: 640.2 ns per iteration
I/flutter (12908): MatrixUtils.TransformPointAffine: 633.0 ns per iteration
```

Galaxy Note 9:
```
I/flutter ( 8633): MatrixUtils.transformRectPerspective: 425.5 ns per iteration
I/flutter ( 8633): MatrixUtils.transformRectAffine: 329.2 ns per iteration
I/flutter ( 8633): MatrixUtils.TransformPointPerspective: 41.3 ns per iteration
I/flutter ( 8633): MatrixUtils.TransformPointAffine: 41.2 ns per iteration
```

## Related PR

Original PR from @yjbanov  :

https://github.com/flutter/flutter/pull/35228