### PR TITLE
Fix nested scroll view can rebuild without layout

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -498,8 +498,15 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
 
   bool get hasScrolledBody {
     for (_NestedScrollPosition position in _innerPositions) {
-      if (position.pixels > position.minScrollExtent)
+      // TODO(chunhtai): Replace null check with assert once
+      // https://github.com/flutter/flutter/issues/31195 is fixed.
+      if (
+        position.minScrollExtent != null &&
+        position.pixels != null &&
+        position.pixels > position.minScrollExtent
+      ) {
         return true;
+      }
     }
     return false;
   }

--- a/packages/flutter/test/widgets/nested_scroll_view_async_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_async_test.dart
@@ -1,0 +1,72 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart' show DragStartBehavior;
+import 'package:quiver/testing/async.dart';
+
+void main() {
+  setUp(() {
+    WidgetsFlutterBinding.ensureInitialized();
+    WidgetsBinding.instance.resetEpoch();
+  });
+
+  test('NestedScrollView can build sccessfully if mark dirty during warm up frame', () {
+    final FakeAsync fakeAsync = FakeAsync();
+    fakeAsync.run((FakeAsync async) {
+      runApp(
+        MaterialApp(
+          home: Material(
+            child: DefaultTabController(
+              length: 1,
+              child: NestedScrollView(
+                dragStartBehavior: DragStartBehavior.down,
+                headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+                  return <Widget>[
+                    const SliverPersistentHeader(
+                      delegate: TestHeader(),
+                    ),
+                  ];
+                },
+                body: SingleChildScrollView(
+                  dragStartBehavior: DragStartBehavior.down,
+                  child: Container(
+                    height: 1000.0,
+                    child: const Placeholder(),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      // Marks element as dirty right before the first draw frame is called.
+      // This can happen when engine flush user setting.
+      final Element element = find.byType(NestedScrollView, skipOffstage: false).evaluate().single;
+      element.markNeedsBuild();
+      // Triggers draw frame timer scheduled in scheduleWarmUpFrame.
+      fakeAsync.flushTimers();
+    });
+    // Make sure widget is rebuilt correctly.
+    expect(
+      find.byType(NestedScrollView, skipOffstage: false).evaluate().single.widget is NestedScrollView,
+      isTrue
+    );
+  });
+}
+
+class TestHeader extends SliverPersistentHeaderDelegate {
+  const TestHeader();
+  @override
+  double get minExtent => 100.0;
+  @override
+  double get maxExtent => 100.0;
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return const Placeholder();
+  }
+  @override
+  bool shouldRebuild(TestHeader oldDelegate) => false;
+}


### PR DESCRIPTION
## Description

Nestedscrollview cannot be rebuilt if it hasn't been layout. This can happen during schedule warm up frame engine can dirty the element.

## Related Issues

https://github.com/flutter/flutter/issues/31195

## Tests

I added the following tests:

"NestedScrollView can rebuild without layout"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
