### PR TITLE
[flutter_tool] Catch a yaml parse failure during project creation

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -16,6 +16,7 @@ import 'bundle.dart' as bundle;
 import 'cache.dart';
 import 'desktop.dart';
 import 'flutter_manifest.dart';
+import 'globals.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_utils.dart' as plist;
 import 'ios/xcodeproj.dart' as xcode;
@@ -177,9 +178,16 @@ class FlutterProject {
   /// Completes with an empty [FlutterManifest], if the file does not exist.
   /// Completes with a ToolExit on validation error.
   static FlutterManifest _readManifest(String path) {
-    final FlutterManifest manifest = FlutterManifest.createFromPath(path);
-    if (manifest == null)
+    FlutterManifest manifest;
+    try {
+      manifest = FlutterManifest.createFromPath(path);
+    } on YamlException catch (e) {
+      printStatus('Error detected in pubspec.yaml:', emphasis: true);
+      printError('$e');
+    }
+    if (manifest == null) {
       throwToolExit('Please correct the pubspec.yaml file at $path');
+    }
     return manifest;
   }
 

--- a/packages/flutter_tools/test/project_test.dart
+++ b/packages/flutter_tools/test/project_test.dart
@@ -40,7 +40,19 @@ void main() {
 
         expect(
           () => FlutterProject.fromDirectory(directory),
-          throwsA(isInstanceOf<Exception>()),
+          throwsA(isInstanceOf<ToolExit>()),
+        );
+      });
+
+      testInMemory('fails on pubspec.yaml parse failure', () async {
+        final Directory directory = fs.directory('myproject');
+        directory.childFile('pubspec.yaml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(parseErrorPubspec);
+
+        expect(
+          () => FlutterProject.fromDirectory(directory),
+          throwsA(isInstanceOf<ToolExit>()),
         );
       });
 
@@ -52,7 +64,7 @@ void main() {
 
         expect(
           () => FlutterProject.fromDirectory(directory),
-          throwsA(isInstanceOf<Exception>()),
+          throwsA(isInstanceOf<ToolExit>()),
         );
       });
 
@@ -573,6 +585,14 @@ String get invalidPubspec => '''
 name: hello
 flutter:
   invalid:
+''';
+
+String get parseErrorPubspec => '''
+name: hello
+# Whitespace is important.
+flutter:
+    something:
+  something_else:
 ''';
 
 String projectFileWithBundleId(String id, {String qualifier}) {


### PR DESCRIPTION
## Description

Previously, this resulted in an unhandled exception. Now this will throwToolExit and propagate the parse error from the yaml parser.

## Related Issues

https://github.com/flutter/flutter/issues/35915

## Tests

I added the following tests:

Test in test/project_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
