### PR TITLE
Attempt to re-enable integration_tests-macos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -498,12 +498,18 @@ task:
         - dart --enable-asserts dev/bots/test.dart
     - name: build_tests-macos
       env:
-        SHARD: build_tests # we should also enable integration_tests at some point, but it's too flaky right now
+        SHARD: build_tests
         COCOAPODS_DISABLE_STATS: true
         FLUTTER_FRAMEWORK_DIR: "/tmp/flutter sdk/bin/cache/artifacts/engine/ios/"
       osx_instance:
         image: mojave-flutter
       remove_preinstalled_flutter_script: rm -rf $FLUTTER_HOME
+      test_all_script:
+        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+        - dart --enable-asserts dev/bots/test.dart
+    - name: integration_tests-macos
+      env:
+        SHARD: integration_tests
       test_all_script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts dev/bots/test.dart


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/36120

I doubt we'll still be able to find the old cirrus logs. Only way is to try this in pre-submit again. 