### PR TITLE
add a kIsWeb constant to foundation

### DIFF
--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -41,7 +41,7 @@ const double precisionErrorTolerance = 1e-10;
 
 /// A constant that is true if the application was compiled to run on the web.
 ///
-/// This implementation takes advantage of the fact that avaScript does not
+/// This implementation takes advantage of the fact that JavaScript does not
 /// support integers. In this environment, Dart's doubles and ints are
 /// backed by the same kind of object. Thus a double `0.0` is identical
 /// to an integer `0`. This is not true for Dart code running in AOT or on the

--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -38,3 +38,12 @@ const bool kDebugMode = !kReleaseMode && !kProfileMode;
 /// precision loss in calculations. Differences below this threshold are safe to
 /// disregard.
 const double precisionErrorTolerance = 1e-10;
+
+/// A constant that is true if the application was compiled to run on the web.
+///
+/// This implementation takes advantage of the fact that avaScript does not
+/// support integers. In this environment, Dart's doubles and ints are
+/// backed by the same kind of object. Thus a double `0.0` is identical
+/// to an integer `0`. This is not true for Dart code running in AOT or on the
+/// VM.
+const bool kIsWeb = identical(0, 0.0);

--- a/packages/flutter/test/foundation/constants_test.dart
+++ b/packages/flutter/test/foundation/constants_test.dart
@@ -1,0 +1,13 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('!chrome') // This test is not intended to run on the web.
+import 'package:flutter/foundation.dart';
+import '../flutter_test_alternative.dart';
+
+void main() {
+  test('isWeb is false for flutter tester', () {
+    expect(kIsWeb, false);
+  });
+}


### PR DESCRIPTION
## Description

This constant can be used to detect whether the flutter app is running on the VM/AOT or compiled to JavaScript. This is important for certain feature detection, like whether or not dart:io methods are safe to call.