### PR TITLE
[WIP] Updates to macOS build to support flutter assemble

### DIFF
--- a/packages/flutter_tools/bin/macos_build_flutter_assets.sh
+++ b/packages/flutter_tools/bin/macos_build_flutter_assets.sh
@@ -52,7 +52,8 @@ fi
 # Set the build mode
 build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"
 
-# Select the correc target for the given build mode
+# Select the correct target for the given build mode
+# TODO(jonahwilliams): switch over build mode when macOS supports release + profile.
 target_name="debug_macos_application"
 
 RunCommand "${FLUTTER_ROOT}/bin/flutter"                                    \

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -46,6 +46,8 @@ enum Artifact {
   windowsDesktopPath,
   /// The root of the sky_engine package
   skyEnginePath,
+  /// The path to the macOS podspec.
+  flutterMacOSPodspec,
 }
 
 String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMode mode ]) {
@@ -107,6 +109,8 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return '';
     case Artifact.skyEnginePath:
       return 'sky_engine';
+    case Artifact.flutterMacOSPodspec:
+      return 'FlutterMacOS.podspec';
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;
@@ -244,6 +248,7 @@ class CachedArtifacts extends Artifacts {
       case Artifact.flutterMacOSFramework:
       case Artifact.linuxDesktopPath:
       case Artifact.windowsDesktopPath:
+      case Artifact.flutterMacOSPodspec:
         final String engineArtifactsPath = cache.getArtifactDirectory('engine').path;
         final String platformDirName = getNameForTargetPlatform(platform);
         return fs.path.join(engineArtifactsPath, platformDirName, _artifactToFileName(artifact, platform, mode));
@@ -343,6 +348,8 @@ class LocalEngineArtifacts extends Artifacts {
       case Artifact.linuxDesktopPath:
         return fs.path.join(_hostEngineOutPath, _artifactToFileName(artifact));
       case Artifact.windowsDesktopPath:
+        return fs.path.join(_hostEngineOutPath, _artifactToFileName(artifact));
+      case Artifact.flutterMacOSPodspec:
         return fs.path.join(_hostEngineOutPath, _artifactToFileName(artifact));
       case Artifact.skyEnginePath:
         return fs.path.join(_hostEngineOutPath, 'gen', 'dart-pkg', _artifactToFileName(artifact));

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -496,7 +496,7 @@ class BuildSystem {
   /// All currently registered targets.
   static final Map<String, Target> _defaultTargets = <String, Target>{
     unpackMacos.name: unpackMacos,
-    macosApplication.name: macosApplication,
+    debugMacosApplication.name: debugMacosApplication,
     macoReleaseApplication.name: macoReleaseApplication,
     unpackLinux.name: unpackLinux,
     unpackWindows.name: unpackWindows,
@@ -645,12 +645,12 @@ class _BuildInstance {
       final Map<String, ChangeType> updates = await target.computeChanges(inputs, environment, fileCache);
       if (updates.isEmpty) {
         skipped = true;
-        printStatus('Skipping target: ${target.name}');
+        printTrace('Skipping target: ${target.name}');
       } else {
-        printStatus('${target.name}: Starting');
+        printTrace('${target.name}: Starting');
         // build actions may be null.
         await target?.buildAction(updates, environment);
-        printStatus('${target.name}: Complete');
+        printTrace('${target.name}: Complete');
 
         final List<File> outputs = target.resolveOutputs(environment);
         // Update hashes for output files.

--- a/packages/flutter_tools/lib/src/build_system/exceptions.dart
+++ b/packages/flutter_tools/lib/src/build_system/exceptions.dart
@@ -93,3 +93,16 @@ class MissingDefineException implements Exception {
         'but it was not provided';
   }
 }
+
+class ConflictingDefineException implements Exception {
+  ConflictingDefineException(this.define, this.left, this.right);
+
+  final String define;
+  final String left;
+  final String right;
+
+  @override
+  String toString() {
+    return 'Define $define had conflicting values of $left and $right';
+  }
+}

--- a/packages/flutter_tools/lib/src/build_system/output_formats.dart
+++ b/packages/flutter_tools/lib/src/build_system/output_formats.dart
@@ -1,0 +1,41 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/file_system.dart';
+
+import '../convert.dart';
+import 'build_system.dart';
+
+ /// Generates an .xcfilelist from a previous build for the input and output files.
+void generateXcFileList(String targetName, Environment environment, String path) {
+  final List<File> stamps = buildSystem.stampFilesFor(targetName, environment);
+  final StringBuffer inputFileListBuffer = StringBuffer();
+  final StringBuffer outputFileListBuffer = StringBuffer();
+  // Cannot include plist in the xcfilelist.
+  bool notIntermediate(String path) {
+    return !path.contains('plist') &&
+           !path.contains('.flutter-plugins') &&
+           !path.contains(environment.buildDir.path);
+  }
+  for (File file in stamps) {
+    if (!file.existsSync()) {
+      continue;
+    }
+    final Map<String, Object> data = json.decode(file.readAsStringSync());
+    (data['inputs'] as List<Object>)
+      .cast<String>()
+      .where(notIntermediate)
+      .forEach(inputFileListBuffer.writeln);
+    (data['outputs'] as List<Object>)
+      .cast<String>()
+      .where(notIntermediate)
+      .forEach(outputFileListBuffer.writeln);
+  }
+  fs.file(fs.path.join(path, 'FlutterInputs.xcfilelist'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(inputFileListBuffer.toString());
+  fs.file(fs.path.join(path, 'FlutterOutputs.xcfilelist'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(outputFileListBuffer.toString());
+}

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -54,7 +54,7 @@ Future<void> compileKernel(Map<String, ChangeType> updates, Environment environm
     targetProductVm: buildMode == BuildMode.release,
     outputFilePath: environment
       .buildDir
-      .childFile('main.app.dill')
+      .childFile('app.dill')
       .path,
     depFilePath: null,
     mainPath: targetFile,
@@ -79,7 +79,7 @@ Future<void> compileAotElf(Map<String, ChangeType> updates, Environment environm
   final int snapshotExitCode = await snapshotter.build(
     platform: targetPlatform,
     buildMode: buildMode,
-    mainPath: environment.buildDir.childFile('main.app.dill').path,
+    mainPath: environment.buildDir.childFile('app.dill').path,
     packagesPath: environment.projectDir.childFile('.packages').path,
     outputPath: outputPath,
   );
@@ -132,7 +132,7 @@ Future<void> compileAotAssembly(Map<String, ChangeType> updates, Environment env
     final int snapshotExitCode = await snapshotter.build(
       platform: targetPlatform,
       buildMode: buildMode,
-      mainPath: environment.buildDir.childFile('main.app.dill').path,
+      mainPath: environment.buildDir.childFile('app.dill').path,
       packagesPath: environment.projectDir.childFile('.packages').path,
       outputPath: outputPath,
       iosArch: iosArchs.single,
@@ -148,7 +148,7 @@ Future<void> compileAotAssembly(Map<String, ChangeType> updates, Environment env
       pending.add(snapshotter.build(
         platform: targetPlatform,
         buildMode: buildMode,
-        mainPath: environment.buildDir.childFile('main.app.dill').path,
+        mainPath: environment.buildDir.childFile('app.dill').path,
         packagesPath: environment.projectDir.childFile('.packages').path,
         outputPath: fs.path.join(outputPath, getNameForIOSArch(iosArch)),
         iosArch: iosArch,
@@ -182,7 +182,7 @@ const Target kernelSnapshot = Target(
     Source.artifact(Artifact.frontendServerSnapshotForEngineDartSdk),
   ],
   outputs: <Source>[
-    Source.pattern('{BUILD_DIR}/main.app.dill'),
+    Source.pattern('{BUILD_DIR}/app.dill'),
   ],
   dependencies: <Target>[],
   buildAction: compileKernel,
@@ -192,7 +192,7 @@ const Target kernelSnapshot = Target(
 const Target aotElfProfile = Target(
   name: 'aot_elf_profile',
   inputs: <Source>[
-    Source.pattern('{BUILD_DIR}/main.app.dill'),
+    Source.pattern('{BUILD_DIR}/app.dill'),
     Source.pattern('{PROJECT_DIR}/.packages'),
     Source.artifact(Artifact.engineDartBinary),
     Source.artifact(Artifact.skyEnginePath),
@@ -211,10 +211,10 @@ const Target aotElfProfile = Target(
 );
 
 /// Generate an ELF binary from a dart kernel file in release mode.
-const Target aotElfRelease= Target(
+const Target aotElfRelease = Target(
   name: 'aot_elf_release',
   inputs: <Source>[
-    Source.pattern('{BUILD_DIR}/main.app.dill'),
+    Source.pattern('{BUILD_DIR}/app.dill'),
     Source.pattern('{PROJECT_DIR}/.packages'),
     Source.artifact(Artifact.engineDartBinary),
     Source.artifact(Artifact.skyEnginePath),
@@ -236,7 +236,7 @@ const Target aotElfRelease= Target(
 const Target aotAssemblyProfile = Target(
   name: 'aot_assembly_profile',
   inputs: <Source>[
-    Source.pattern('{BUILD_DIR}/main.app.dill'),
+    Source.pattern('{BUILD_DIR}/app.dill'),
     Source.pattern('{PROJECT_DIR}/.packages'),
     Source.artifact(Artifact.engineDartBinary),
     Source.artifact(Artifact.skyEnginePath),
@@ -246,9 +246,6 @@ const Target aotAssemblyProfile = Target(
     ),
   ],
   outputs: <Source>[
-    // TODO(jonahwilliams): are these used or just a side effect?
-    // Source.pattern('{BUILD_DIR}/snapshot_assembly.S'),
-    // Source.pattern('{BUILD_DIR}/snapshot_assembly.o'),
     Source.pattern('{BUILD_DIR}/App.framework/App'),
   ],
   dependencies: <Target>[
@@ -261,7 +258,7 @@ const Target aotAssemblyProfile = Target(
 const Target aotAssemblyRelease = Target(
   name: 'aot_assembly_release',
   inputs: <Source>[
-    Source.pattern('{BUILD_DIR}/main.app.dill'),
+    Source.pattern('{BUILD_DIR}/app.dill'),
     Source.pattern('{PROJECT_DIR}/.packages'),
     Source.artifact(Artifact.engineDartBinary),
     Source.artifact(Artifact.skyEnginePath),
@@ -271,9 +268,6 @@ const Target aotAssemblyRelease = Target(
     ),
   ],
   outputs: <Source>[
-    // TODO(jonahwilliams): are these used or just a side effect?
-    // Source.pattern('{BUILD_DIR}/snapshot_assembly.S'),
-    // Source.pattern('{BUILD_DIR}/snapshot_assembly.o'),
     Source.pattern('{BUILD_DIR}/App.framework/App'),
   ],
   dependencies: <Target>[

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -45,6 +45,9 @@ Future<void> compileKernel(Map<String, ChangeType> updates, Environment environm
   }
   final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
   final String targetFile = environment.defines[kTargetFile] ?? fs.path.join('lib', 'main.dart');
+  final String packagesPath = environment.projectDir.childFile('.packages').path;
+  final PackageUriMapper packageUriMapper = PackageUriMapper(targetFile,
+      packagesPath, null, null);
 
   final CompilerOutput output = await compiler.compile(
     sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath, mode: buildMode),
@@ -57,7 +60,8 @@ Future<void> compileKernel(Map<String, ChangeType> updates, Environment environm
       .childFile('app.dill')
       .path,
     depFilePath: null,
-    mainPath: targetFile,
+    packagesPath: packagesPath,
+    mainPath: packageUriMapper.map(targetFile)?.toString() ?? targetFile,
   );
   if (output.errorCount != 0) {
     throw Exception('Errors during snapshot creation: $output');
@@ -97,6 +101,9 @@ List<File> listDartSources(Environment environment) {
   final List<File> dartFiles = <File>[];
   for (Uri uri in packageMap.values) {
     final Directory libDirectory = fs.directory(uri.toFilePath(windows: platform.isWindows));
+    if (!libDirectory.existsSync()) {
+      continue;
+    }
     for (FileSystemEntity entity in libDirectory.listSync(recursive: true)) {
       if (entity is File && entity.path.endsWith('.dart')) {
         dartFiles.add(entity);

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -15,7 +15,10 @@ const Target debugIosApplication = Target(
   dependencies: <Target>[
     copyAssets,
     kernelSnapshot,
-  ]
+  ],
+  defines: <String, String>{
+    kBuildMode: 'debug',
+  },
 );
 
 /// Create an iOS profile application.
@@ -27,7 +30,10 @@ const Target profileIosApplication = Target(
   dependencies: <Target>[
     copyAssets,
     aotAssemblyProfile,
-  ]
+  ],
+  defines: <String, String>{
+    kBuildMode: 'profile',
+  },
 );
 
 /// Create an iOS debug application.
@@ -39,5 +45,8 @@ const Target releaseIosApplication = Target(
   dependencies: <Target>[
     copyAssets,
     aotAssemblyRelease,
-  ]
+  ],
+  defines: <String, String>{
+    kBuildMode: 'release',
+  },
 );

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -31,6 +31,7 @@ Future<void> copyFramework(Map<String, ChangeType> updates,
     .projectDir
     .childDirectory('macos')
     .childDirectory('Flutter')
+    .childDirectory('ephemeral')
     .childDirectory('FlutterMacOS.framework');
   if (targetDirectory.existsSync()) {
     targetDirectory.deleteSync(recursive: true);
@@ -46,7 +47,7 @@ Future<void> copyFramework(Map<String, ChangeType> updates,
   }
 }
 
-const String _kOutputPrefix = '{PROJECT_DIR}/macos/Flutter/FlutterMacOS.framework';
+const String _kOutputPrefix = '{PROJECT_DIR}/macos/Flutter/ephemeral/FlutterMacOS.framework';
 
 /// Copies the macOS desktop framework to the copy directory.
 const Target unpackMacos = Target(

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/macos/cocoapods.dart';
-
 import '../../artifacts.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/process_manager.dart';
 import '../../build_info.dart';
 import '../../globals.dart';
+import '../../macos/cocoapods.dart';
 import '../../project.dart';
 import '../build_system.dart';
 import '../exceptions.dart';

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -94,6 +94,7 @@ class AssembleCommand extends FlutterCommand {
     } on ConflictingDefineException catch (err) {
       throwToolExit(err.toString());
     }
+    printStatus('building with defines: ${environment.defines}');
     final BuildResult result = await buildSystem.build(targetName, environment, BuildSystemConfig(
       resourcePoolSize: argResults['resource-pool-size'],
     ));

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -7,7 +7,8 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
-import '../convert.dart';
+import '../build_system/exceptions.dart';
+import '../build_system/output_formats.dart';
 import '../globals.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
@@ -19,69 +20,24 @@ BuildSystem get buildSystem => context.get<BuildSystem>();
 /// system.
 class AssembleCommand extends FlutterCommand {
   AssembleCommand() {
-    addSubcommand(AssembleRun());
-    addSubcommand(AssembleDescribe());
-    addSubcommand(AssembleListInputs());
-    addSubcommand(AssembleBuildDirectory());
-  }
-  @override
-  String get description => 'Assemble and build flutter resources.';
-
-  @override
-  String get name => 'assemble';
-
-  @override
-  bool get isExperimental => true;
-
-  @override
-  Future<FlutterCommandResult> runCommand() {
-    return null;
-  }
-}
-
-abstract class AssembleBase extends FlutterCommand {
-  AssembleBase() {
     argParser.addMultiOption(
       'define',
       abbr: 'd',
       help: 'Allows passing configuration to a target with --define=target=key=value.'
     );
     argParser.addOption(
-      'build-mode',
-      allowed: const <String>[
-        'debug',
-        'profile',
-        'release',
-      ],
+      'project-dir',
+      help: 'The root directory of the project to build.'
     );
     argParser.addOption(
       'resource-pool-size',
       help: 'The maximum number of concurrent tasks the build system will run.'
     );
-  }
-
-  /// Returns the provided target platform.
-  ///
-  /// Throws a [ToolExit] if none is provided. This intentionally has no
-  /// default.
-  TargetPlatform get targetPlatform {
-    final String value = argResults['target-platform'] ?? 'darwin-x64';
-    if (value == null) {
-      throwToolExit('--target-platform is required for flutter assemble.');
-    }
-    return getTargetPlatformForName(value);
-  }
-
-  /// Returns the provided build mode.
-  ///
-  /// Throws a [ToolExit] if none is provided. This intentionally has no
-  /// default.
-  BuildMode get buildMode {
-    final String value = argResults['build-mode'] ?? 'debug';
-    if (value == null) {
-      throwToolExit('--build-mode is required for flutter assemble.');
-    }
-    return getBuildModeForName(value);
+    argParser.addOption(
+      'xcfilelist-path',
+      help: 'The location where a FlutterInputs.xcfilelist and FlutterOutputs.xcfilelist'
+      ' will be generated. If not provided these files are not created.'
+    );
   }
 
   /// The name of the target we are describing or building.
@@ -93,12 +49,16 @@ abstract class AssembleBase extends FlutterCommand {
   }
 
   /// The environmental configuration for a build invocation.
-  Environment get environment {
-    final FlutterProject flutterProject = FlutterProject.current();
+  Environment buildEnvironment() {
+    final Directory projectDirectory = argResults['project-dir'] == null
+        ? fs.currentDirectory
+        : fs.directory(argResults['project-dir']);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(projectDirectory);
+    final Map<String, String> defines = buildSystem.collectDefines(targetName,  _parseDefines(argResults['define']));
     final Environment result = Environment(
-      buildDir: fs.directory(getBuildDirectory()),
+      buildDir: fs.directory(fs.path.join(projectDirectory.path, getBuildDirectory())),
       projectDir: flutterProject.directory,
-      defines: _parseDefines(argResults['define']),
+      defines: defines,
     );
     return result;
   }
@@ -116,21 +76,24 @@ abstract class AssembleBase extends FlutterCommand {
     }
     return results;
   }
-}
-
-/// Execute a build starting from a target action.
-class AssembleRun extends AssembleBase {
-  @override
-  String get description => 'Execute the stages for a specified target.';
 
   @override
-  String get name => 'run';
+  String get description => 'Assemble and build flutter resources.';
+
+  @override
+  String get name => 'assemble';
 
   @override
   bool get isExperimental => true;
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    Environment environment;
+    try {
+      environment = buildEnvironment();
+    } on ConflictingDefineException catch (err) {
+      throwToolExit(err.toString());
+    }
     final BuildResult result = await buildSystem.build(targetName, environment, BuildSystemConfig(
       resourcePoolSize: argResults['resource-pool-size'],
     ));
@@ -142,80 +105,11 @@ class AssembleRun extends AssembleBase {
       throwToolExit('build failed');
     } else {
       printStatus('build succeeded');
-    }
-    return null;
-  }
-}
-
-/// Fully describe a target and its dependencies.
-class AssembleDescribe extends AssembleBase {
-  @override
-  String get description => 'List the stages for a specified target.';
-
-  @override
-  String get name => 'describe';
-
-  @override
-  bool get isExperimental => true;
-
-  @override
-  Future<FlutterCommandResult> runCommand() {
-    try {
-      printStatus(
-        json.encode(buildSystem.describe(targetName, environment))
-      );
-    } on Exception catch (err, stackTrace) {
-      printTrace(stackTrace.toString());
-      throwToolExit(err.toString());
-    }
-    return null;
-  }
-}
-
-/// List input files for a target.
-class AssembleListInputs extends AssembleBase {
-  @override
-  String get description => 'List the inputs for a particular target.';
-
-  @override
-  String get name => 'inputs';
-
-  @override
-  bool get isExperimental => true;
-
-  @override
-  Future<FlutterCommandResult> runCommand() {
-    try {
-      final List<Map<String, Object>> results = buildSystem.describe(targetName, environment);
-      for (Map<String, Object> result in results) {
-        if (result['name'] == targetName) {
-          final List<String> inputs = result['inputs'];
-          inputs.forEach(printStatus);
-        }
+      final String generateXcfileListPath = argResults['xcfilelist-path'];
+      if (generateXcfileListPath != null) {
+        generateXcFileList(targetName, environment, generateXcfileListPath);
       }
-    } on Exception catch (err, stackTrace) {
-      printTrace(stackTrace.toString());
-      throwToolExit(err.toString());
     }
     return null;
   }
 }
-
-/// Return the build directory for a configuiration.
-class AssembleBuildDirectory extends AssembleBase {
-  @override
-  String get description => 'List the inputs for a particular target.';
-
-  @override
-  String get name => 'build-dir';
-
-  @override
-  bool get isExperimental => true;
-
-  @override
-  Future<FlutterCommandResult> runCommand() {
-    printStatus(environment.buildDir.path);
-    return null;
-  }
-}
-

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -8,6 +8,7 @@ import '../base/common.dart';
 import '../base/platform.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../globals.dart';
 import '../macos/build_macos.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
@@ -60,11 +61,12 @@ class BuildMacosCommand extends BuildSubCommand {
     if (!flutterProject.macos.existsSync()) {
       throwToolExit('No macOS desktop project configured.');
     }
-    await buildMacOS(
+    final String executable = await buildMacOS(
       flutterProject: flutterProject,
       buildInfo: buildInfo,
       targetOverride: targetFile,
     );
+    printStatus('build macOS application at $executable');
     return null;
   }
 }

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -47,6 +47,7 @@ Future<void> updateGeneratedXcodeProperties({
   String targetOverride,
   bool useMacOSConfig = false,
   bool setSymroot = true,
+  Directory buildDirOverride,
 }) async {
   final StringBuffer localsBuffer = StringBuffer();
 
@@ -63,7 +64,7 @@ Future<void> updateGeneratedXcodeProperties({
     localsBuffer.writeln('FLUTTER_TARGET=$targetOverride');
 
   // The build outputs directory, relative to FLUTTER_APPLICATION_PATH.
-  localsBuffer.writeln('FLUTTER_BUILD_DIR=${getBuildDirectory()}');
+  localsBuffer.writeln('FLUTTER_BUILD_DIR=${buildDirOverride?.path ?? getBuildDirectory()}');
 
   if (setSymroot) {
     localsBuffer.writeln('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -31,7 +31,7 @@ abstract class MacOSApp extends ApplicationPackage {
   /// which is expected to start the application and send the observatory
   /// port over stdout.
   factory MacOSApp.fromPrebuiltApp(FileSystemEntity applicationBinary) {
-    final _ExecutableAndId executableAndId = _executableFromBundle(applicationBinary);
+    final ExecutableAndId executableAndId = executableFromBundle(applicationBinary);
     final Directory applicationBundle = fs.directory(applicationBinary);
     return PrebuiltMacOSApp(
       bundleDir: applicationBundle,
@@ -41,8 +41,10 @@ abstract class MacOSApp extends ApplicationPackage {
     );
   }
 
+  String hackExecutable;
+
   /// Look up the executable name for a macOS application bundle.
-  static _ExecutableAndId _executableFromBundle(Directory applicationBundle) {
+  static ExecutableAndId executableFromBundle(Directory applicationBundle) {
     final FileSystemEntityType entityType = fs.typeSync(applicationBundle.path);
     if (entityType == FileSystemEntityType.notFound) {
       printError('File "${applicationBundle.path}" does not exist.');
@@ -75,7 +77,7 @@ abstract class MacOSApp extends ApplicationPackage {
     if (!fs.file(executable).existsSync()) {
       printError('Could not find macOS binary at $executable');
     }
-    return _ExecutableAndId(executable, id);
+    return ExecutableAndId(executable, id);
   }
 
   @override
@@ -140,13 +142,13 @@ class BuildableMacOSApp extends MacOSApp {
     if (directory == null) {
       return null;
     }
-    final _ExecutableAndId executableAndId = MacOSApp._executableFromBundle(fs.directory(directory));
+    final ExecutableAndId executableAndId = MacOSApp.executableFromBundle(fs.directory(directory));
     return executableAndId.executable;
   }
 }
 
-class _ExecutableAndId {
-  _ExecutableAndId(this.executable, this.id);
+class ExecutableAndId {
+  ExecutableAndId(this.executable, this.id);
 
   final String executable;
   final String id;

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/file_hash_store.dart';
 import 'package:flutter_tools/src/build_system/filecache.pb.dart' as pb;
+import 'package:flutter_tools/src/build_system/targets/dart.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:mockito/mockito.dart';
@@ -252,6 +253,34 @@ void main() {
 
       expect(secondChanges, <String, ChangeType>{});
     }));
+
+    test('fails if conflicting defines are set', () async {
+      const Target b = Target(
+        name: 'b',
+        buildAction: null,
+        defines: <String, String>{
+          kBuildMode: 'profile',
+        },
+        dependencies: <Target>[],
+        inputs: <Source>[],
+        outputs: <Source>[]
+      );
+      const Target a = Target(
+        name: 'a',
+        buildAction: null,
+        defines: <String, String>{
+          kBuildMode: 'debug',
+        },
+        dependencies: <Target>[
+          b,
+        ],
+        inputs: <Source>[],
+        outputs: <Source>[]
+      );
+      final BuildSystem buildSystem = BuildSystem(<String, Target>{'a': a, 'b': b});
+
+      expect(() => buildSystem.collectDefines('a', <String, String>{}), throwsA(isInstanceOf<ConflictingDefineException>()));
+    });
   });
 
   group('FileCache', () {

--- a/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
@@ -41,6 +41,8 @@ void main() {
       'foobar',
       'example',
     );
+    final ConflictingDefineException conflictingDefineException = ConflictingDefineException(
+        'a', 'b', 'c');
 
     expect(
         missingInputException.toString(),
@@ -67,6 +69,10 @@ void main() {
     expect(
         missingDefineException.toString(),
         'Target example required define foobar but it was not provided'
+    );
+    expect(
+        conflictingDefineException.toString(),
+        'Define a had conflicting values of b and c'
     );
   });
 }

--- a/packages/flutter_tools/test/general.shard/build_system/output_formats_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/output_formats_test.dart
@@ -1,0 +1,46 @@
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/output_formats.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../src/common.dart';
+import '../../src/testbed.dart';
+
+void main() {
+  group('output formats', () {
+    Testbed testbed;
+    MockBuildSystem mockBuildSystem;
+
+    setUp(() {
+      mockBuildSystem = MockBuildSystem();
+      testbed = Testbed(overrides: <Type, Generator>{
+        BuildSystem: () => mockBuildSystem,
+      });
+    });
+
+    test('generates xcfile lists', () => testbed.run(() {
+      final Environment environment = Environment(
+        projectDir: fs.currentDirectory,
+      );
+      fs.file('example.stamp')
+        ..createSync()
+        ..writeAsStringSync('''
+  {"inputs":["c","Info.plist",".flutter-plugins","${fs.path.join(environment.buildDir.path, 'f')}"],
+  "outputs":["a","b"]}
+  ''');
+      when(buildSystem.stampFilesFor('example', environment)).thenReturn(<File>[
+        fs.file('example.stamp'),
+      ]);
+
+      generateXcFileList('example', environment, 'paths');
+      final File inputFile = fs.file(fs.path.join('paths', 'FlutterInputs.xcfilelist'));
+      final File outputFile = fs.file(fs.path.join('paths', 'FlutterOutputs.xcfilelist'));
+
+      expect(inputFile.readAsLinesSync(), <String>['c', '']);
+      expect(outputFile.readAsLinesSync(),  <String>['a', 'b', '']);
+    }));
+  });
+}
+
+class MockBuildSystem extends Mock implements BuildSystem {}

--- a/packages/flutter_tools/test/general.shard/build_system/output_formats_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/output_formats_test.dart
@@ -1,3 +1,6 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';


### PR DESCRIPTION
## Description

Updates the macOS desktop build to use fluter assemble. This also requires the changes in https://github.com/google/flutter-desktop-embedding/pull/459 in order to build.


### build system changes:
- Allow `optional` to be provided to `Source.pattern`. If the file does not exist when the `SourceVisitor` is looking for it, it will ignore the path and continue. This is required to support the pods action, which is not invoked if there is no podfile.

- Allow targets to specify values for certain defines. To avoid the confusion of being able to pass something other that `-dBuildMode=debug` to `debug_macos_application`. I had to change how some wiring was done so that when we calculate the build directory we have all of the define values. Right now I've made it an error if the same define is specified with different values. This would prevent passing `release` to the debug rule.

### build rule changes
- Updated the kernel snapshot rule to use the PackageUriMapper. This prevents the annoying warning about interpreting a file Uri as a lib Uri.
- Added rules for podInstall and plugin file generation.

### assemble command changes
- Removed all commands except for `run`, which was renamed to assemble. While exploring the usage of the xcfilelists to improve the xcode build I found that the other commands were not that useful. I've removed them until I find a way to use them, if ever.
- Added the capability to specify the project directory.
- Added the capability to specify an output path where the xcfilelist's will be written. There are some weird rules about how these are generated. I haven't yet figured out why I'm not allowed to specify the flutter framework directory as an output. Until I get something working there this won't be safe to land, since it seems like deleting the framework may not force it to rerun from xcode.

### macOS build/run
- I've added a bunch of hacks to get it working, still need to figure out a saner way of finding the executable path.

Currently this is not tested as it needs to be, and the executable lookup is still a hack.

### Performance changes

Based on the FDE examples:

This change will _slightly_ regress build timing, but put us on a better path towards safer builds. I attribute a large part of the slowdown from a clean build to always running cocoa pods if the pubspec has changed (or if the build is clean). We do pay a slightly higher price currently for checking output files, but there is likely to be more room for performance improvements. In return we get safety if outputs/intermediates are mutated/removed.

### Build timing with change.

|          | example           | testbed  |
| ------------- |:-------------:| -----:|
| clean      | 17.8 seconds | 27.2 seconds |
| no changes | 6.5 seconds      |    7.4 seconds |
| no changes (w/ inputFileList)      | 3.5 seconds      |   4.5 seconds |

### Prior build timing

|          | example           | testbed  |
| ------------- |:-------------:| -----:|
| clean      | 13.3 seconds | 24 seconds |
| no changes* | 2.5 seconds      |    3.7 seconds |
| no changes w/ removed fingerprint | 6.24 seconds    |    7.45 seconds |

* moving/altering/deleting app.dill will crash the build process
