### PR TITLE
Keep LLDB connection to iOS device alive while running from CLI. 

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -183,8 +183,8 @@ Future<int> runCommandAndStreamOutput(
     .listen((String line) {
       if (mapFunction != null)
         line = mapFunction(line);
-        if (line != null)
-      printError('$prefix$line', wrap: false);
+      if (line != null)
+        printError('$prefix$line', wrap: false);
     });
 
   // Wait for stdout to be fully processed before completing with the exit code (non-detached case),

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -181,9 +181,9 @@ Future<int> runCommandAndStreamOutput(
     .transform<String>(const LineSplitter())
     .where((String line) => filter == null || filter.hasMatch(line))
     .listen((String line) {
-      if (mapFunction != null) 
+      if (mapFunction != null)
         line = mapFunction(line);
-        if (line != null) 
+        if (line != null)
       printError('$prefix$line', wrap: false);
     });
 

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -129,6 +129,11 @@ Future<Process> runCommand(
 /// If [filter] is non-null, all lines that do not match it are removed. If
 /// [mapFunction] is present, all lines that match [filter] are also forwarded
 /// to [mapFunction] for further processing.
+///
+/// If [detachFilter] is non-null, the returned future will complete with exit code `0`
+/// when the process outputs something matching [detachFilter] to stderr. The process will
+/// continue in the background, and the final exit code will not be reported. [filter] is
+/// not considered on lines matching [detachFilter].
 Future<int> runCommandAndStreamOutput(
   List<String> cmd, {
   String workingDirectory,
@@ -138,7 +143,9 @@ Future<int> runCommandAndStreamOutput(
   RegExp filter,
   StringConverter mapFunction,
   Map<String, String> environment,
+  RegExp detachFilter,
 }) async {
+  final Completer<int> result = Completer<int>();
   final Process process = await runCommand(
     cmd,
     workingDirectory: workingDirectory,
@@ -148,6 +155,15 @@ Future<int> runCommandAndStreamOutput(
   final StreamSubscription<String> stdoutSubscription = process.stdout
     .transform<String>(utf8.decoder)
     .transform<String>(const LineSplitter())
+    .map((String line) {
+      if (detachFilter != null && detachFilter.hasMatch(line) && !result.isCompleted) {
+        // Detach from the process, assuming it will eventually complete successfully.
+        // Output printed after detaching (incl. stdout and stderr) will still be
+        // processed by [filter] and [mapFunction].
+        result.complete(0);
+      }
+      return line;
+    })
     .where((String line) => filter == null || filter.hasMatch(line))
     .listen((String line) {
       if (mapFunction != null)
@@ -165,25 +181,34 @@ Future<int> runCommandAndStreamOutput(
     .transform<String>(const LineSplitter())
     .where((String line) => filter == null || filter.hasMatch(line))
     .listen((String line) {
-      if (mapFunction != null)
+      if (mapFunction != null) 
         line = mapFunction(line);
-      if (line != null)
-        printError('$prefix$line', wrap: false);
+        if (line != null) 
+      printError('$prefix$line', wrap: false);
     });
 
-  // Wait for stdout to be fully processed
-  // because process.exitCode may complete first causing flaky tests.
-  await waitGroup<void>(<Future<void>>[
-    stdoutSubscription.asFuture<void>(),
-    stderrSubscription.asFuture<void>(),
-  ]);
+  // Wait for stdout to be fully processed before completing with the exit code (non-detached case),
+  // because process.exitCode may complete first causing flaky tests. If the process detached,
+  // we at least have a predictable output for stdout, although (unavoidably) not for stderr.
+  Future<void> readOutput() async {
+    await waitGroup<void>(<Future<void>>[
+      stdoutSubscription.asFuture<void>(),
+      stderrSubscription.asFuture<void>(),
+    ]);
 
-  await waitGroup<void>(<Future<void>>[
-    stdoutSubscription.cancel(),
-    stderrSubscription.cancel(),
-  ]);
+    await waitGroup<void>(<Future<void>>[
+      stdoutSubscription.cancel(),
+      stderrSubscription.cancel(),
+    ]);
 
-  return await process.exitCode;
+    // Complete the future if the we did not detach the process yet.
+    if (!result.isCompleted) {
+      result.complete(process.exitCode);
+    }
+  }
+
+  unawaited(readOutput());
+  return result.future;
 }
 
 /// Runs the [command] interactively, connecting the stdin/stdout/stderr

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -62,11 +62,14 @@ class IOSDeploy {
     final Map<String, String> iosDeployEnv = Map<String, String>.from(platform.environment);
     iosDeployEnv['PATH'] = '/usr/bin:${iosDeployEnv['PATH']}';
 
+    // Detach from the ios-deploy process once it' outputs 'autoexit', signaling that the 
+    // App has been started and LLDB is in "autopilot" mode.
     return await runCommandAndStreamOutput(
       launchCommand,
       mapFunction: _monitorInstallationFailure,
       trace: true,
       environment: iosDeployEnv,
+      detachFilter: RegExp('.*autoexit.*')
     );
   }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -62,7 +62,7 @@ class IOSDeploy {
     final Map<String, String> iosDeployEnv = Map<String, String>.from(platform.environment);
     iosDeployEnv['PATH'] = '/usr/bin:${iosDeployEnv['PATH']}';
 
-    // Detach from the ios-deploy process once it' outputs 'autoexit', signaling that the 
+    // Detach from the ios-deploy process once it' outputs 'autoexit', signaling that the
     // App has been started and LLDB is in "autopilot" mode.
     return await runCommandAndStreamOutput(
       launchCommand,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -45,7 +45,7 @@ class IOSDeploy {
       '--bundle',
       bundlePath,
       '--no-wifi',
-      '--justlaunch',
+      '--noninteractive',
     ];
     if (launchArguments.isNotEmpty) {
       launchCommand.add('--args');

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -200,6 +200,9 @@ class MockStream<T> implements Stream<T> {
   Stream<T> where(bool test(T event)) => MockStream<T>();
 
   @override
+  Stream<S> map<S>(S Function(T) _) => MockStream<S>();
+
+  @override
   StreamSubscription<T> listen(void onData(T event), { Function onError, void onDone(), bool cancelOnError }) {
     return MockStreamSubscription<T>();
   }


### PR DESCRIPTION
## Description

Instead of detaching from the spawned App process on the device immediately, keep the LLDB client connection open (in autopilot mode) until the App quits or the server connection is lost.

This replicates the behavior of Xcode, which also keeps a debugger attached to the App after launching it.

## Tests

This change will be covered by all running benchmarks (which are launched via "flutter run"/"flutter drive"), and probably be covered by all tests as well.

I also tested the workflow locally -- including cases where the App or Flutter CLI is terminated first.

## Breaking Change

I don't believe this should introduce any breaking changes. The LLDB client automatically exits when the app dies or the device is disconnected, so there shouldn't even be any user-visible changes to the behavior of the tool (besides the output of "-v").