### PR TITLE
Fix windows, exclude widgets from others

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -391,7 +391,8 @@ Future<void> _runTests() async {
     final List<String> tests = Directory(path.join(flutterRoot, 'packages', 'flutter', 'test'))
       .listSync(followLinks: false, recursive: false)
       .whereType<Directory>()
-      .map((Directory dir) => 'test/${path.basename(dir.path)}/')
+      .where((Directory dir) => dir.path.endsWith('widgets') == false)
+      .map((Directory dir) => path.join('test', path.basename(dir.path)))
       .toList();
 
     print('Running tests for: ${tests.join(';')}');

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -392,7 +392,7 @@ Future<void> _runTests() async {
       .listSync(followLinks: false, recursive: false)
       .whereType<Directory>()
       .where((Directory dir) => dir.path.endsWith('widgets') == false)
-      .map((Directory dir) => path.join('test', path.basename(dir.path)))
+      .map((Directory dir) => path.join('test', path.basename(dir.path)) + path.separator)
       .toList();
 
     print('Running tests for: ${tests.join(';')}');


### PR DESCRIPTION
/cc @Piinks @jonahwilliams 

I believe a hard coded path separator was causing these tests to do nothing on Windows :(

I also wasn't excluding the widgets from these tests, which was the whole point!