### PR TITLE
Don't try to flutterExit if isolate is still paused

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -177,7 +177,15 @@ class FlutterDevice {
     final List<Future<void>> futures = <Future<void>>[];
     for (FlutterView view in flutterViews) {
       if (view != null && view.uiIsolate != null) {
-        futures.add(view.uiIsolate.flutterExit());
+        if (view.uiIsolate.pauseEvent.isPauseEvent) {
+          // Do nothing. while we could resume the isolate, there would be
+          // timing issues in waiting for the uiIsolate to come up and register
+          // the extensions. We could fix this by defining the isolate exit
+          // at the engine level.
+          continue;
+        } else {
+          futures.add(view.uiIsolate.flutterExit());
+        }
       }
     }
     // The flutterExit message only returns if it fails, so just wait a few

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -28,6 +28,7 @@ void main() {
     MockFlutterView mockFlutterView;
     ResidentRunner residentRunner;
     MockDevice mockDevice;
+    MockIsolate mockIsolate;
 
     setUp(() {
       testbed = Testbed(setup: () {
@@ -44,6 +45,7 @@ void main() {
       mockVMService = MockVMService();
       mockDevFS = MockDevFS();
       mockFlutterView = MockFlutterView();
+      mockIsolate = MockIsolate();
       // DevFS Mocks
       when(mockDevFS.lastCompiled).thenReturn(DateTime(2000));
       when(mockDevFS.sources).thenReturn(<Uri>[]);
@@ -73,7 +75,7 @@ void main() {
         mockFlutterView
       ]);
       when(mockFlutterDevice.device).thenReturn(mockDevice);
-      when(mockFlutterView.uiIsolate).thenReturn(MockIsolate());
+      when(mockFlutterView.uiIsolate).thenReturn(mockIsolate);
       when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
       when(mockFlutterDevice.observatoryUris).thenReturn(<Uri>[
         testUri,
@@ -96,6 +98,12 @@ void main() {
       when(mockVMService.done).thenAnswer((Invocation invocation) {
         final Completer<void> result = Completer<void>.sync();
         return result.future;
+      });
+      when(mockIsolate.resume()).thenAnswer((Invocation invocation) {
+        return Future<Map<String, Object>>.value(null);
+      });
+      when(mockIsolate.flutterExit()).thenAnswer((Invocation invocation) {
+        return Future<Map<String, Object>>.value(null);
       });
     });
 
@@ -203,6 +211,39 @@ void main() {
     }, overrides: <Type, Generator>{
       Usage: () => MockUsage(),
     }));
+
+    group('FlutterDevice' , () {
+      test('Will not exit a paused isolate', () => testbed.run(() async {
+        final TestFlutterDevice flutterDevice = TestFlutterDevice(
+          mockDevice,
+          <FlutterView>[ mockFlutterView ],
+        );
+        final MockServiceEvent mockServiceEvent = MockServiceEvent();
+        when(mockServiceEvent.isPauseEvent).thenReturn(true);
+        when(mockIsolate.pauseEvent).thenReturn(mockServiceEvent);
+        when(mockDevice.supportsFlutterExit).thenReturn(true);
+
+        await flutterDevice.exitApps();
+
+        verifyNever(mockIsolate.flutterExit());
+      }));
+
+      test('Will exit an un-paused isolate', () => testbed.run(() async {
+        final TestFlutterDevice flutterDevice = TestFlutterDevice(
+          mockDevice,
+          <FlutterView> [mockFlutterView ],
+        );
+
+        final MockServiceEvent mockServiceEvent = MockServiceEvent();
+        when(mockServiceEvent.isPauseEvent).thenReturn(false);
+        when(mockIsolate.pauseEvent).thenReturn(mockServiceEvent);
+        when(mockDevice.supportsFlutterExit).thenReturn(true);
+
+        await flutterDevice.exitApps();
+
+        verify(mockIsolate.flutterExit()).called(1);
+      }));
+    });
   });
 }
 
@@ -213,3 +254,12 @@ class MockDevFS extends Mock implements DevFS {}
 class MockIsolate extends Mock implements Isolate {}
 class MockDevice extends Mock implements Device {}
 class MockUsage extends Mock implements Usage {}
+class MockServiceEvent extends Mock implements ServiceEvent {}
+class TestFlutterDevice extends FlutterDevice {
+  TestFlutterDevice(Device device, this.views)
+    : super(device, buildMode: BuildMode.debug, trackWidgetCreation: false);
+
+  @override
+  final List<FlutterView> views;
+}
+

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -226,6 +226,7 @@ void main() {
         await flutterDevice.exitApps();
 
         verifyNever(mockIsolate.flutterExit());
+        verify(mockDevice.stopApp(any)).called(1);
       }));
 
       test('Will exit an un-paused isolate', () => testbed.run(() async {


### PR DESCRIPTION
## Description

After a cup of coffee, I'm less certain that this is the actual cause of the json rpc exceptions, but currently it does cause a scary error message to be printed. Currently we have only one reasonable choice about what can be done here:

  - Use device.stopApp instead of flutter exit. This is essentially the same behavior as today, but without the scary message. On device types other than the iOS simulator, this will correctly take down the app instance.

Less reasonable choices:

  - Resume the isolate and wait for it to start up. Then call exit.

A longer term fix might be to move the implementation of the isolate exit callback into the engine or vm_service in such a way that 1) different platfroms could have reasonable platform-specific implementations. 2) it could be called regardless of the isolate pause state.