### PR TITLE
Use DeviceManager instead of device to determine if device supports project.

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -202,7 +202,7 @@ class DeviceManager {
     if (devices.length > 1 && !hasSpecifiedDeviceId) {
       devices = <Device>[
         for (Device device in devices)
-          if (device.isSupportedForProject(flutterProject))
+          if (isDeviceSupportedForProject(device, flutterProject))
             device
       ];
     }
@@ -224,6 +224,8 @@ class DeviceManager {
   }
 
   /// Returns whether the device is supported for the project.
+  ///
+  /// This exists to allow the check to be overriden for google3 clients.
   bool isDeviceSupportedForProject(Device device, FlutterProject flutterProject) {
     return device.isSupportedForProject(flutterProject);
   }

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -116,6 +116,20 @@ void main() {
         nonEphemeralTwo,
       ]);
     });
+
+    testUsingContext('uses DeviceManager.isDeviceSupportedForProject instead of device.isSupportedForProject', () async {
+      final List<Device> devices = <Device>[
+        unsupported,
+      ];
+      final TestDeviceManager deviceManager = TestDeviceManager(devices);
+      deviceManager.isAlwaysSupportedOverride = true;
+
+      final List<Device> filtered = await deviceManager.findTargetDevices(FlutterProject.current());
+
+      expect(filtered, <Device>[
+        unsupported,
+      ]);
+    });
   });
 }
 
@@ -123,10 +137,19 @@ class TestDeviceManager extends DeviceManager {
   TestDeviceManager(this.allDevices);
 
   final List<Device> allDevices;
+  bool isAlwaysSupportedOverride;
 
   @override
   Stream<Device> getAllConnectedDevices() {
     return Stream<Device>.fromIterable(allDevices);
+  }
+
+  @override
+  bool isDeviceSupportedForProject(Device device, FlutterProject flutterProject) {
+    if (isAlwaysSupportedOverride != null) {
+      return isAlwaysSupportedOverride;
+    }
+    return super.isDeviceSupportedForProject(device, flutterProject);
   }
 }
 


### PR DESCRIPTION
## Description

To allow clients to override the behavior.  cc @gspencergoog 