### PR TITLE
Text selection handle color respects Theme.textSelectionHandleColor

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -32,6 +32,7 @@ const BoxDecoration _kDefaultRoundedBorderDecoration = BoxDecoration(
 );
 
 // Value extracted via color reader from iOS simulator.
+const Color _kHandlesColor = Color(0xFF136FE0);
 const Color _kSelectionHighlightColor = Color(0x667FAACF);
 const Color _kInactiveTextColor = Color(0xFFC2C2C2);
 const Color _kDisabledBackground = Color(0xFFFAFAFA);
@@ -820,6 +821,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
           minLines: widget.minLines,
           expands: widget.expands,
           selectionColor: _kSelectionHighlightColor,
+          textSelectionHandleColor: _kHandlesColor,
           selectionControls: widget.selectionEnabled
             ? cupertinoTextSelectionControls : null,
           onChanged: widget.onChanged,

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -14,7 +14,6 @@ import 'localizations.dart';
 
 // Read off from the output on iOS 12. This color does not vary with the
 // application's theme color.
-const Color _kHandlesColor = Color(0xFF136FE0);
 const double _kSelectionHandleOverlap = 1.5;
 const double _kSelectionHandleRadius = 5.5;
 
@@ -249,12 +248,13 @@ class _ToolbarRenderBox extends RenderShiftedBox {
 
 /// Draws a single text selection handle with a bar and a ball.
 class _TextSelectionHandlePainter extends CustomPainter {
-  const _TextSelectionHandlePainter();
+  const _TextSelectionHandlePainter(this.color);
+  final Color color;
 
   @override
   void paint(Canvas canvas, Size size) {
     final Paint paint = Paint()
-        ..color = _kHandlesColor
+        ..color = color
         ..strokeWidth = 2.0;
     canvas.drawCircle(
       const Offset(_kSelectionHandleRadius, _kSelectionHandleRadius),
@@ -280,6 +280,7 @@ class _TextSelectionHandlePainter extends CustomPainter {
 }
 
 class _CupertinoTextSelectionControls extends TextSelectionControls {
+
   /// Returns the size of the Cupertino handle.
   @override
   Size getHandleSize(double textLineHeight) {
@@ -373,15 +374,15 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
 
   /// Builder for iOS text selection edges.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, Color color, double textLineHeight) {
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
     final Size desiredSize = getHandleSize(textLineHeight);
 
     final Widget handle = SizedBox.fromSize(
       size: desiredSize,
-      child: const CustomPaint(
-        painter: _TextSelectionHandlePainter(),
+      child: CustomPaint(
+        painter: _TextSelectionHandlePainter(color),
       ),
     );
 

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -280,7 +280,6 @@ class _TextSelectionHandlePainter extends CustomPainter {
 }
 
 class _CupertinoTextSelectionControls extends TextSelectionControls {
-
   /// Returns the size of the Cupertino handle.
   @override
   Size getHandleSize(double textLineHeight) {

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -248,7 +248,8 @@ class _ToolbarRenderBox extends RenderShiftedBox {
 
 /// Draws a single text selection handle with a bar and a ball.
 class _TextSelectionHandlePainter extends CustomPainter {
-  const _TextSelectionHandlePainter(this.color);
+  const _TextSelectionHandlePainter({ @required this.color }) : assert(color != null);
+
   final Color color;
 
   @override
@@ -276,7 +277,7 @@ class _TextSelectionHandlePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_TextSelectionHandlePainter oldPainter) => false;
+  bool shouldRepaint(_TextSelectionHandlePainter oldPainter) => color != oldPainter.color;
 }
 
 class _CupertinoTextSelectionControls extends TextSelectionControls {
@@ -381,7 +382,7 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
     final Widget handle = SizedBox.fromSize(
       size: desiredSize,
       child: CustomPaint(
-        painter: _TextSelectionHandlePainter(color),
+        painter: _TextSelectionHandlePainter(color: color),
       ),
     );
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -974,6 +974,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         minLines: widget.minLines,
         expands: widget.expands,
         selectionColor: themeData.textSelectionColor,
+        textSelectionHandleColor: themeData.textSelectionHandleColor,
         selectionControls: widget.selectionEnabled ? textSelectionControls : null,
         onChanged: widget.onChanged,
         onSelectionChanged: _handleSelectionChanged,

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -112,7 +112,7 @@ class _TextSelectionToolbarLayout extends SingleChildLayoutDelegate {
 
 /// Draws a single text selection handle which points up and to the left.
 class _TextSelectionHandlePainter extends CustomPainter {
-  _TextSelectionHandlePainter({ this.color });
+  const _TextSelectionHandlePainter({ @required this.color }) : assert(color != null);
 
   final Color color;
 

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -11,7 +11,6 @@ import 'debug.dart';
 import 'flat_button.dart';
 import 'material.dart';
 import 'material_localizations.dart';
-import 'theme.dart';
 
 const double _kHandleSize = 22.0;
 
@@ -185,14 +184,12 @@ class _MaterialTextSelectionControls extends TextSelectionControls {
 
   /// Builder for material-style text selection handles.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, Color color, double textHeight) {
     final Widget handle = SizedBox(
       width: _kHandleSize,
       height: _kHandleSize,
       child: CustomPaint(
-        painter: _TextSelectionHandlePainter(
-          color: Theme.of(context).textSelectionHandleColor
-        ),
+        painter: _TextSelectionHandlePainter(color: color),
       ),
     );
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -292,6 +292,7 @@ class EditableText extends StatefulWidget {
     bool showCursor,
     this.showSelectionHandles = false,
     this.selectionColor,
+    @required this.textSelectionHandleColor,
     this.selectionControls,
     TextInputType keyboardType,
     this.textInputAction,
@@ -322,6 +323,7 @@ class EditableText extends StatefulWidget {
        assert(readOnly != null),
        assert(style != null),
        assert(cursorColor != null),
+       assert(textSelectionHandleColor != null),
        assert(cursorOpacityAnimates != null),
        assert(paintCursorAboveText != null),
        assert(backgroundCursorColor != null),
@@ -614,6 +616,11 @@ class EditableText extends StatefulWidget {
 
   /// The color to use when painting the selection.
   final Color selectionColor;
+
+  /// The color to use when painting the selection handle.
+  ///
+  /// Must not be null.
+  final Color textSelectionHandleColor;
 
   /// Optional delegate for building the text selection handles and toolbar.
   ///
@@ -1290,6 +1297,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         startHandleLayerLink: _startHandleLayerLink,
         endHandleLayerLink: _endHandleLayerLink,
         renderObject: renderObject,
+        textSelectionHandleColor: widget.textSelectionHandleColor,
         selectionControls: widget.selectionControls,
         selectionDelegate: this,
         dragStartBehavior: widget.dragStartBehavior,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -94,7 +94,7 @@ abstract class TextSelectionControls {
   ///
   /// The top left corner of this widget is positioned at the bottom of the
   /// selection position.
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight);
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, Color color, double textLineHeight);
 
   /// Get the anchor point of the handle relative to itself. The anchor point is
   /// the point that is aligned with a specific point in the text. A handle
@@ -274,6 +274,7 @@ class TextSelectionOverlay {
     @required this.endHandleLayerLink,
     @required this.renderObject,
     this.selectionControls,
+    @required this.textSelectionHandleColor,
     bool handlesVisible = false,
     this.selectionDelegate,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -281,6 +282,7 @@ class TextSelectionOverlay {
   }) : assert(value != null),
        assert(context != null),
        assert(handlesVisible != null),
+       assert(textSelectionHandleColor != null),
        _handlesVisible = handlesVisible,
        _value = value {
     final OverlayState overlay = Overlay.of(context);
@@ -316,6 +318,11 @@ class TextSelectionOverlay {
   // moves? Not sure what cases I need to handle, or how to handle them.
   /// The editable line in which the selected text is being displayed.
   final RenderEditable renderObject;
+
+  /// The color used to paint the text selection handle.
+  ///
+  /// Must not be null.
+  final Color textSelectionHandleColor;
 
   /// Builds text selection handles and toolbar.
   final TextSelectionControls selectionControls;
@@ -513,6 +520,7 @@ class TextSelectionOverlay {
         endHandleLayerLink: endHandleLayerLink,
         renderObject: renderObject,
         selection: _selection,
+        selectionHandleColor: textSelectionHandleColor,
         selectionControls: selectionControls,
         position: position,
         dragStartBehavior: dragStartBehavior,
@@ -591,6 +599,7 @@ class _TextSelectionHandleOverlay extends StatefulWidget {
     @required this.renderObject,
     @required this.onSelectionHandleChanged,
     @required this.onSelectionHandleTapped,
+    @required this.selectionHandleColor,
     @required this.selectionControls,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : super(key: key);
@@ -602,6 +611,7 @@ class _TextSelectionHandleOverlay extends StatefulWidget {
   final RenderEditable renderObject;
   final ValueChanged<TextSelection> onSelectionHandleChanged;
   final VoidCallback onSelectionHandleTapped;
+  final Color selectionHandleColor;
   final TextSelectionControls selectionControls;
   final DragStartBehavior dragStartBehavior;
 
@@ -785,6 +795,7 @@ class _TextSelectionHandleOverlayState
               child: widget.selectionControls.buildHandle(
                 context,
                 type,
+                widget.selectionHandleColor,
                 widget.renderObject.preferredLineHeight,
               ),
             ),

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -18,6 +18,7 @@ void main() {
       return CupertinoApp(
         home: EditableText(
           key: key,
+          textSelectionHandleColor: CupertinoColors.activeBlue,
           controller: controller,
           focusNode: FocusNode(),
           style: const TextStyle(),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6669,7 +6669,7 @@ void main() {
       expect(box, paints..rect(color: expectedSelectionHandleColor));
     }
 
-    // Currently this does not reflect theme changes.
+    // Currently visible handles do not reflect theme changes.
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -23,6 +23,7 @@ void main() {
           style: const TextStyle(),
           cursorColor: Colors.black,
           backgroundCursorColor: Colors.black,
+          textSelectionHandleColor: Colors.blue,
         )
       );
     }

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -30,6 +30,7 @@ void main() {
           focusNode: focusNode,
           style: textStyle,
           cursorColor: cursorColor,
+          textSelectionHandleColor: Colors.blue,
           cursorWidth: 10.0,
           cursorRadius: const Radius.circular(2.0),
         ))));
@@ -54,6 +55,7 @@ void main() {
           focusNode: FocusNode(),
           style: Typography(platform: TargetPlatform.android).black.subhead,
           cursorColor: Colors.blue,
+          textSelectionHandleColor: Colors.blue,
           selectionControls: materialTextSelectionControls,
           keyboardType: TextInputType.text,
           onChanged: (String value) {
@@ -112,6 +114,7 @@ void main() {
           style: Typography(platform: TargetPlatform.android).black.subhead,
           cursorColor: Colors.blue,
           selectionControls: materialTextSelectionControls,
+          textSelectionHandleColor: Colors.blue,
           keyboardType: TextInputType.text,
           onChanged: (String value) {
             changedValue = value;
@@ -384,6 +387,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               style: textStyle,
@@ -471,6 +475,7 @@ void main() {
               controller: controller,
               focusNode: focusNode,
               style: textStyle,
+              textSelectionHandleColor: Colors.blue,
               cursorColor: cursorColor,
             ),
           ),
@@ -525,6 +530,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               style: textStyle,
@@ -591,6 +597,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               autofocus: true,
@@ -710,6 +717,7 @@ void main() {
             const SizedBox(width: 10, height: 10),
             EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               key: editableTextKey,
               controller: TextEditingController(),
               focusNode: FocusNode(),

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -27,6 +27,7 @@ void main() {
             children: <Widget>[
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -69,6 +70,7 @@ void main() {
               ),
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 scrollPadding: const EdgeInsets.all(50.0),
                 controller: controller,
                 focusNode: focusNode,
@@ -115,6 +117,7 @@ void main() {
               ),
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -165,6 +168,7 @@ void main() {
               ),
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 controller: controller,
                 focusNode: focusNode,
                 style: textStyle,
@@ -259,6 +263,7 @@ void main() {
             children: <Widget>[
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 maxLines: null, // multi-line
                 controller: controller,
                 focusNode: focusNode,
@@ -315,6 +320,7 @@ void main() {
               ),
               EditableText(
                 backgroundCursorColor: Colors.grey,
+                textSelectionHandleColor: Colors.blue,
                 scrollPadding: const EdgeInsets.only(bottom: 300.0),
                 controller: controller,
                 focusNode: focusNode,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -51,6 +51,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               textInputAction: action,
@@ -80,6 +81,7 @@ void main() {
           child: EditableText(
             controller: controller,
             backgroundCursorColor: Colors.grey,
+            textSelectionHandleColor: Colors.blue,
             focusNode: focusNode,
             style: textStyle,
             cursorColor: cursorColor,
@@ -109,6 +111,7 @@ void main() {
             child: EditableText(
               controller: controller,
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               focusNode: focusNode,
               style: textStyle,
               cursorColor: cursorColor,
@@ -247,6 +250,7 @@ void main() {
             child: EditableText(
               controller: controller,
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               focusNode: focusNode,
               keyboardType: TextInputType.multiline,
               style: textStyle,
@@ -279,6 +283,7 @@ void main() {
         MaterialApp(
           home: EditableText(
             backgroundCursorColor: Colors.grey,
+            textSelectionHandleColor: Colors.blue,
             controller: controller,
             focusNode: focusNode,
             style: style,
@@ -340,6 +345,7 @@ void main() {
             child: EditableText(
               controller: controller,
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               focusNode: focusNode,
               maxLines: null,
               style: textStyle,
@@ -372,6 +378,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               maxLines: null,
@@ -406,6 +413,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               keyboardType: TextInputType.phone,
@@ -440,6 +448,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               maxLines: 3, // Sets multiline keyboard implicitly.
@@ -473,6 +482,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               maxLines: 1, // Sets text keyboard implicitly.
@@ -500,6 +510,7 @@ void main() {
       MaterialApp(
         home: EditableText(
           backgroundCursorColor: Colors.grey,
+          textSelectionHandleColor: Colors.blue,
           controller: controller,
           focusNode: focusNode,
           style: textStyle,
@@ -538,6 +549,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: FocusNode(),
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -578,6 +590,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -608,6 +621,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -645,6 +659,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -685,6 +700,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -725,6 +741,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -765,6 +782,7 @@ void main() {
     final Widget widget = MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: TextEditingController(),
         focusNode: focusNode,
         style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -818,6 +836,7 @@ void main() {
                   child: Material(
                     child: EditableText(
                       backgroundCursorColor: Colors.grey,
+                      textSelectionHandleColor: Colors.blue,
                       controller: currentController,
                       focusNode: focusNode,
                       style: Typography(platform: TargetPlatform.android)
@@ -883,6 +902,7 @@ void main() {
             autofocus: true,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               style: textStyle,
@@ -926,6 +946,7 @@ void main() {
             node: focusScopeNode,
             child: EditableText(
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               controller: controller,
               focusNode: focusNode,
               style: textStyle,
@@ -968,6 +989,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1051,6 +1073,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1144,6 +1167,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1246,6 +1270,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1347,6 +1372,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1445,6 +1471,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         obscureText: true,
         controller: controller,
         focusNode: focusNode,
@@ -1497,6 +1524,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1541,6 +1569,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: EditableText(
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         obscureText: true,
         focusNode: focusNode,
@@ -1590,6 +1619,7 @@ void main() {
       return tester.pumpWidget(MaterialApp(
         home: EditableText(
           backgroundCursorColor: Colors.grey,
+          textSelectionHandleColor: Colors.blue,
           controller: controller,
           focusNode: focusNode,
           style: textStyle,
@@ -1607,7 +1637,7 @@ void main() {
           TextSelection.collapsed(offset: controller.text.length);
 
       controls = MockTextSelectionControls();
-      when(controls.buildHandle(any, any, any)).thenReturn(Container());
+      when(controls.buildHandle(any, any, any, any)).thenReturn(Container());
       when(controls.buildToolbar(any, any, any, any, any, any))
           .thenReturn(Container());
     });
@@ -1802,6 +1832,7 @@ void main() {
       child: EditableText(
         controller: controller,
         backgroundCursorColor: Colors.red,
+        textSelectionHandleColor: Colors.blue,
         cursorColor: Colors.red,
         focusNode: FocusNode(),
         style: textStyle,
@@ -1851,6 +1882,7 @@ void main() {
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: EditableText(
+            textSelectionHandleColor: Colors.blue,
             controller: controller,
             focusNode: FocusNode(),
             style: Typography(platform: TargetPlatform.android).black.subhead,
@@ -1889,6 +1921,7 @@ void main() {
             style: Typography(platform: TargetPlatform.android).black.subhead,
             cursorColor: Colors.blue,
             backgroundCursorColor: Colors.grey,
+            textSelectionHandleColor: Colors.blue,
             keyboardAppearance: Brightness.dark,
           ),
         ),
@@ -1915,6 +1948,7 @@ void main() {
       home: EditableText(
         autofocus: true,
         backgroundCursorColor: Colors.grey,
+        textSelectionHandleColor: Colors.blue,
         controller: controller,
         focusNode: focusNode,
         style: textStyle,
@@ -1962,6 +1996,7 @@ void main() {
             style: Typography(platform: TargetPlatform.android).black.subhead,
             cursorColor: Colors.blue,
             backgroundCursorColor: Colors.grey,
+            textSelectionHandleColor: Colors.blue,
             selectionControls: materialTextSelectionControls,
             keyboardType: TextInputType.text,
           ),
@@ -2129,6 +2164,7 @@ void main() {
             style: Typography(platform: TargetPlatform.android).black.subhead,
             cursorColor: Colors.blue,
             backgroundCursorColor: Colors.grey,
+            textSelectionHandleColor: Colors.blue,
             selectionControls: materialTextSelectionControls,
             keyboardType: TextInputType.text,
             textAlign: TextAlign.right,
@@ -2192,6 +2228,7 @@ void main() {
               style: Typography(platform: TargetPlatform.iOS).black.subhead,
               cursorColor: Colors.blue,
               backgroundCursorColor: Colors.grey,
+              textSelectionHandleColor: Colors.blue,
               selectionControls: cupertinoTextSelectionControls,
               keyboardType: TextInputType.text,
             ),
@@ -2366,6 +2403,7 @@ class CustomStyleEditableText extends EditableText {
           controller: controller,
           cursorColor: cursorColor,
           backgroundCursorColor: Colors.grey,
+          textSelectionHandleColor: Colors.blue,
           focusNode: focusNode,
           style: style,
         );

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17,6 +17,16 @@ import '../rendering/mock_canvas.dart';
 import 'editable_text_utils.dart';
 import 'semantics_tester.dart';
 
+final TextEditingController controller = TextEditingController();
+final FocusNode focusNode = FocusNode(debugLabel: 'EditableText Node');
+final FocusScopeNode focusScopeNode = FocusScopeNode(debugLabel: 'EditableText Scope Node');
+const TextStyle textStyle = TextStyle();
+const Color cursorColor = Color.fromARGB(0xFF, 0xFF, 0x00, 0x00);
+
+enum HandlePositionInViewport {
+  leftEdge, rightEdge, within,
+}
+
 void main() {
   setUp(() {
     debugResetSemanticsIdCounter();
@@ -2415,12 +2425,18 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   }, skip: isBrowser);
 }
-const Color cursorColor = Color.fromARGB(0xFF, 0xFF, 0x00, 0x00);
-const TextStyle textStyle = TextStyle();
-final TextEditingController controller = TextEditingController();
-final FocusNode focusNode = FocusNode(debugLabel: 'EditableText Node');
 
-final FocusScopeNode focusScopeNode = FocusScopeNode(debugLabel: 'EditableText Scope Node');
+class MockTextSelectionControls extends Mock implements TextSelectionControls {
+  @override
+  Size getHandleSize(double textLineHeight) {
+    return Size.zero;
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return Offset.zero;
+  }
+}
 
 class CustomStyleEditableText extends EditableText {
   CustomStyleEditableText({
@@ -2448,21 +2464,5 @@ class CustomStyleEditableTextState extends EditableTextState {
       style: const TextStyle(fontStyle: FontStyle.italic),
       text: widget.controller.value.text,
     );
-  }
-}
-
-enum HandlePositionInViewport {
-  leftEdge, rightEdge, within,
-}
-
-class MockTextSelectionControls extends Mock implements TextSelectionControls {
-  @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
-    return Offset.zero;
-  }
-
-  @override
-  Size getHandleSize(double textLineHeight) {
-    return Size.zero;
   }
 }

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -541,6 +541,7 @@ class FakeEditableText extends EditableText {
     controller: TextEditingController(),
     focusNode: FocusNode(),
     backgroundCursorColor: Colors.white,
+    textSelectionHandleColor: Colors.blue,
     cursorColor: Colors.white,
     style: const TextStyle(),
   );


### PR DESCRIPTION
## Description

Added a new parameter to `EditableText`'s constructor, as well as `TextSelectionControls.buildHandle`. 

Note that even with this fix, if the selection handles are currently visible, `ThemeData.textSelectionHandleColor` change won't immediately affect the color of the handles, until the handles are rebuilt. This is because selection handles might be higher up in the tree than the `Theme` it is depending on (which happens to `selectionColor` as well). See https://github.com/flutter/flutter/issues/36220.

## Related Issues

Fixes #34640

## Tests

I added the following tests:

- selection handles respect Theme
- text selection handle color

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). Will send out the link after initial review.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
