### PR TITLE
Disable flaky tests on Windows

### DIFF
--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -16,11 +16,7 @@ import 'feedback_tester.dart';
 void main() {
   group('showDatePicker', () {
     _tests();
-  },
-    // Skip on Windows because this test is quite flaky when run on Windows,
-    // until https://github.com/flutter/flutter/issues/19696 is fixed.
-    skip: isWindows || isBrowser,
-  );
+  });
 }
 
 void _tests() {
@@ -106,7 +102,7 @@ void _tests() {
     await tester.tap(find.text('17'));
     await tester.pumpAndSettle();
     expect(_selectedDate, equals(DateTime(2016, DateTime.august, 17)));
-  });
+  }, skip: isWindows); // TODO(dnfield): these are flaky on Windows https://github.com/flutter/flutter#19696
 
   testWidgets('render picker with intrinsic dimensions', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -132,7 +128,7 @@ void _tests() {
       ),
     );
     await tester.pump(const Duration(seconds: 5));
-  });
+  }, skip: isWindows); // TODO(dnfield): these are flaky on Windows https://github.com/flutter/flutter#19696
 
   Future<void> preparePicker(WidgetTester tester, Future<void> callback(Future<DateTime> date)) async {
     BuildContext buttonContext;


### PR DESCRIPTION
Skip flaky tests on Windows.  The skip on the group wasn't working.

TBR @gspencergoog @jonahwilliams 