### PR TITLE
Fix invocations of ideviceinstaller not passing DYLD_LIBRARY_PATH

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -191,20 +191,18 @@ class IOSDevice extends Device {
 
   @override
   Future<bool> isAppInstalled(ApplicationPackage app) async {
+    RunResult apps;
     try {
-      final RunResult apps = await runCheckedAsync(
+      apps = await runCheckedAsync(
         <String>[_installerPath, '--list-apps'],
         environment: Map<String, String>.fromEntries(
           <MapEntry<String, String>>[cache.dyLdLibEntry],
         ),
       );
-      if (RegExp(app.id, multiLine: true).hasMatch(apps.stdout)) {
-        return true;
-      }
-    } catch (e) {
+    } on ProcessException {
       return false;
     }
-    return false;
+    return RegExp(app.id, multiLine: true).hasMatch(apps.stdout);
   }
 
   @override
@@ -227,7 +225,7 @@ class IOSDevice extends Device {
         ),
       );
       return true;
-    } catch (e) {
+    } on ProcessException {
       return false;
     }
   }
@@ -242,7 +240,7 @@ class IOSDevice extends Device {
         ),
       );
       return true;
-    } catch (e) {
+    } on ProcessException {
       return false;
     }
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -192,7 +192,12 @@ class IOSDevice extends Device {
   @override
   Future<bool> isAppInstalled(ApplicationPackage app) async {
     try {
-      final RunResult apps = await runCheckedAsync(<String>[_installerPath, '--list-apps']);
+      final RunResult apps = await runCheckedAsync(
+        <String>[_installerPath, '--list-apps'],
+        environment: Map<String, String>.fromEntries(
+          <MapEntry<String, String>>[cache.dyLdLibEntry],
+        ),
+      );
       if (RegExp(app.id, multiLine: true).hasMatch(apps.stdout)) {
         return true;
       }
@@ -215,7 +220,12 @@ class IOSDevice extends Device {
     }
 
     try {
-      await runCheckedAsync(<String>[_installerPath, '-i', iosApp.deviceBundlePath]);
+      await runCheckedAsync(
+        <String>[_installerPath, '-i', iosApp.deviceBundlePath],
+        environment: Map<String, String>.fromEntries(
+          <MapEntry<String, String>>[cache.dyLdLibEntry],
+        ),
+      );
       return true;
     } catch (e) {
       return false;
@@ -225,7 +235,12 @@ class IOSDevice extends Device {
   @override
   Future<bool> uninstallApp(ApplicationPackage app) async {
     try {
-      await runCheckedAsync(<String>[_installerPath, '-U', app.id]);
+      await runCheckedAsync(
+        <String>[_installerPath, '-U', app.id],
+        environment: Map<String, String>.fromEntries(
+          <MapEntry<String, String>>[cache.dyLdLibEntry],
+        ),
+      );
       return true;
     } catch (e) {
       return false;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
@@ -46,6 +47,7 @@ void main() {
     MockFileSystem mockFileSystem;
     MockProcessManager mockProcessManager;
     const String installerPath = '/path/to/ideviceinstaller';
+    const String appId = '789';
     const MapEntry<String, String> libraryEntry = MapEntry<String, String>(
       'DYLD_LIBRARY_PATH',
       '/path/to/libraries'
@@ -72,15 +74,17 @@ void main() {
     testUsingContext('installApp() invokes process with correct environment', () async {
       final IOSDevice device = IOSDevice('123');
       const String bundlePath = '/path/to/bundle';
+      final List<String> args = <String>[installerPath, '-i', bundlePath];
       when(mockApp.deviceBundlePath).thenReturn(bundlePath);
       final MockDirectory directory = MockDirectory();
       when(mockFileSystem.directory(bundlePath)).thenReturn(directory);
       when(directory.existsSync()).thenReturn(true);
+      when(mockProcessManager.run(args, environment: env))
+        .thenAnswer(
+          (_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', ''))
+        );
       await device.installApp(mockApp);
-      verify(mockProcessManager.run(
-          <String>[installerPath, '-i', bundlePath],
-          environment: env,
-      ));
+      verify(mockProcessManager.run(args, environment: env));
     }, overrides: <Type, Generator>{
       Artifacts: () => mockArtifacts,
       Cache: () => mockCache,
@@ -91,11 +95,14 @@ void main() {
 
     testUsingContext('isAppInstalled() invokes process with correct environment', () async {
       final IOSDevice device = IOSDevice('123');
+      final List<String> args = <String>[installerPath, '--list-apps'];
+      when(mockProcessManager.run(args, environment: env))
+        .thenAnswer(
+          (_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', ''))
+        );
+      when(mockApp.id).thenReturn(appId);
       await device.isAppInstalled(mockApp);
-      verify(mockProcessManager.run(
-          <String>[installerPath, '--list-apps'],
-          environment: env,
-      ));
+      verify(mockProcessManager.run(args, environment: env));
     }, overrides: <Type, Generator>{
       Artifacts: () => mockArtifacts,
       Cache: () => mockCache,
@@ -104,14 +111,15 @@ void main() {
     });
 
     testUsingContext('uninstallApp() invokes process with correct environment', () async {
-      const String appId = '789';
       final IOSDevice device = IOSDevice('123');
+      final List<String> args = <String>[installerPath, '-U', appId];
       when(mockApp.id).thenReturn(appId);
+      when(mockProcessManager.run(args, environment: env))
+        .thenAnswer(
+          (_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', ''))
+        );
       await device.uninstallApp(mockApp);
-      verify(mockProcessManager.run(
-          <String>[installerPath, '-U', appId],
-          environment: env,
-      ));
+      verify(mockProcessManager.run(args, environment: env));
     }, overrides: <Type, Generator>{
       Artifacts: () => mockArtifacts,
       Cache: () => mockCache,

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -7,8 +7,10 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -22,6 +24,11 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 
+class MockIOSApp extends Mock implements IOSApp {}
+class MockArtifacts extends Mock implements Artifacts {}
+class MockCache extends Mock implements Cache {}
+class MockDirectory extends Mock implements Directory {}
+class MockFileSystem extends Mock implements FileSystem {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcode extends Mock implements Xcode {}
@@ -29,8 +36,89 @@ class MockFile extends Mock implements File {}
 class MockProcess extends Mock implements Process {}
 
 void main() {
-  final FakePlatform osx = FakePlatform.fromPlatform(const LocalPlatform());
-  osx.operatingSystem = 'macos';
+  final FakePlatform macPlatform = FakePlatform.fromPlatform(const LocalPlatform());
+  macPlatform.operatingSystem = 'macos';
+
+  group('Process calls', () {
+    MockIOSApp mockApp;
+    MockArtifacts mockArtifacts;
+    MockCache mockCache;
+    MockFileSystem mockFileSystem;
+    MockProcessManager mockProcessManager;
+    const String installerPath = '/path/to/ideviceinstaller';
+    const MapEntry<String, String> libraryEntry = MapEntry<String, String>(
+      'DYLD_LIBRARY_PATH',
+      '/path/to/libraries'
+    );
+    final Map<String, String> env = Map<String, String>.fromEntries(
+      <MapEntry<String, String>>[libraryEntry]
+    );
+
+    setUp(() {
+      mockApp = MockIOSApp();
+      mockArtifacts = MockArtifacts();
+      mockCache = MockCache();
+      when(mockCache.dyLdLibEntry).thenReturn(libraryEntry);
+      mockFileSystem = MockFileSystem();
+      mockProcessManager = MockProcessManager();
+      when(
+        mockArtifacts.getArtifactPath(
+          Artifact.ideviceinstaller,
+          platform: anyNamed('platform'),
+        )
+      ).thenReturn(installerPath);
+    });
+
+    testUsingContext('installApp() invokes process with correct environment', () async {
+      final IOSDevice device = IOSDevice('123');
+      const String bundlePath = '/path/to/bundle';
+      when(mockApp.deviceBundlePath).thenReturn(bundlePath);
+      final MockDirectory directory = MockDirectory();
+      when(mockFileSystem.directory(bundlePath)).thenReturn(directory);
+      when(directory.existsSync()).thenReturn(true);
+      await device.installApp(mockApp);
+      verify(mockProcessManager.run(
+          <String>[installerPath, '-i', bundlePath],
+          environment: env,
+      ));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      Cache: () => mockCache,
+      FileSystem: () => mockFileSystem,
+      Platform: () => macPlatform,
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('isAppInstalled() invokes process with correct environment', () async {
+      final IOSDevice device = IOSDevice('123');
+      await device.isAppInstalled(mockApp);
+      verify(mockProcessManager.run(
+          <String>[installerPath, '--list-apps'],
+          environment: env,
+      ));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      Cache: () => mockCache,
+      Platform: () => macPlatform,
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('uninstallApp() invokes process with correct environment', () async {
+      const String appId = '789';
+      final IOSDevice device = IOSDevice('123');
+      when(mockApp.id).thenReturn(appId);
+      await device.uninstallApp(mockApp);
+      verify(mockProcessManager.run(
+          <String>[installerPath, '-U', appId],
+          environment: env,
+      ));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      Cache: () => mockCache,
+      Platform: () => macPlatform,
+      ProcessManager: () => mockProcessManager,
+    });
+  });
 
   group('getAttachedDevices', () {
     MockIMobileDevice mockIMobileDevice;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -15,7 +15,6 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
-import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';


### PR DESCRIPTION
## Description

Forgetting to add DYLD_LIBRARY_PATH to these invocations didn't break the devicelab or my ad hoc testing. Added unit tests to verify its working.

## Tests

Added new tests for `IOSDevice.isAppInstalled()`, `.installApp()`, and `.uninstallApp()`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.