### PR TITLE
Minor fixes to precache help text (attempt #2)

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -26,7 +26,7 @@ class DevelopmentArtifact {
   /// This should match the flag name in precache.dart
   final String name;
 
-  /// Whether this artifact should not be usable on stable branches.
+  /// Whether this artifact should be unavailable on stable branches.
   final bool unstable;
 
   /// Artifacts required for Android development.
@@ -35,7 +35,7 @@ class DevelopmentArtifact {
   /// Artifacts required for iOS development.
   static const DevelopmentArtifact iOS = DevelopmentArtifact._('ios');
 
-  /// Artifacts required for web development,
+  /// Artifacts required for web development.
   static const DevelopmentArtifact web = DevelopmentArtifact._('web', unstable: true);
 
   /// Artifacts required for desktop macOS.
@@ -44,13 +44,13 @@ class DevelopmentArtifact {
   /// Artifacts required for desktop Windows.
   static const DevelopmentArtifact windows = DevelopmentArtifact._('windows', unstable: true);
 
-  /// Artifacts required for desktop linux.
+  /// Artifacts required for desktop Linux.
   static const DevelopmentArtifact linux = DevelopmentArtifact._('linux', unstable: true);
 
   /// Artifacts required for Fuchsia.
   static const DevelopmentArtifact fuchsia = DevelopmentArtifact._('fuchsia', unstable: true);
 
-  /// Artifacts required by all developments.
+  /// Artifacts required for any development platform.
   static const DevelopmentArtifact universal = DevelopmentArtifact._('universal');
 
   /// The values of DevelopmentArtifacts.

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -16,21 +16,21 @@ class PrecacheCommand extends FlutterCommand {
     argParser.addFlag('force', abbr: 'f', negatable: false,
         help: 'Force downloading of artifacts.');
     argParser.addFlag('android', negatable: true, defaultsTo: true,
-        help: 'Precache artifacts for Android development');
+        help: 'Precache artifacts for Android development.');
     argParser.addFlag('ios', negatable: true, defaultsTo: true,
-        help: 'Precache artifacts for iOS developemnt');
+        help: 'Precache artifacts for iOS development.');
     argParser.addFlag('web', negatable: true, defaultsTo: false,
-        help: 'Precache artifacts for web development');
+        help: 'Precache artifacts for web development.');
     argParser.addFlag('linux', negatable: true, defaultsTo: false,
-        help: 'Precache artifacts for linux desktop development');
+        help: 'Precache artifacts for Linux desktop development.');
     argParser.addFlag('windows', negatable: true, defaultsTo: false,
-        help: 'Precache artifacts for windows desktop development');
+        help: 'Precache artifacts for Windows desktop development.');
     argParser.addFlag('macos', negatable: true, defaultsTo: false,
-        help: 'Precache artifacts for macOS desktop development');
+        help: 'Precache artifacts for macOS desktop development.');
     argParser.addFlag('fuchsia', negatable: true, defaultsTo: false,
-        help: 'Precache artifacts for Fuchsia development');
+        help: 'Precache artifacts for Fuchsia development.');
     argParser.addFlag('universal', negatable: true, defaultsTo: true,
-        help: 'Precache artifacts required for all developments');
+        help: 'Precache artifacts required for any development platform.');
   }
 
   @override


### PR DESCRIPTION
## Description

Noticed a spelling error on the `flutter precache` command help text, and took the opportunity to tidy up the capitalization and trailing periods to be consistent with `flutter help`. Finally, clarified the difference between `--all-platforms` and `--universal`

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.