### PR TITLE
Improve Material RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -267,9 +267,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
-    if (notification.depth != 0 || !notification.leading)
-      return false;
-    if (_mode == _RefreshIndicatorMode.drag) {
+    if (notification.depth != 0) return false;
+    if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
       notification.disallowGlow();
       return true;
     }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -427,7 +427,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     assert(_isIndicatorAtTop != null);
 
     final bool showIndeterminateIndicator =
-        _mode == _RefreshIndicatorMode.refresh || _mode == _RefreshIndicatorMode.done;
+      _mode == _RefreshIndicatorMode.refresh || _mode == _RefreshIndicatorMode.done;
 
     return Stack(
       children: <Widget>[
@@ -445,8 +445,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                 ? EdgeInsets.only(top: widget.displacement)
                 : EdgeInsets.only(bottom: widget.displacement),
               alignment: _isIndicatorAtTop
-                  ? Alignment.topCenter
-                  : Alignment.bottomCenter,
+                ? Alignment.topCenter
+                : Alignment.bottomCenter,
               child: ScaleTransition(
                 scale: _scaleFactor,
                 child: AnimatedBuilder(

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -103,9 +103,9 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsLabel,
     this.semanticsValue,
   }) : assert(child != null),
-        assert(onRefresh != null),
-        assert(notificationPredicate != null),
-        super(key: key);
+       assert(onRefresh != null),
+       assert(notificationPredicate != null),
+       super(key: key);
 
   /// The widget below this widget in the tree.
   ///
@@ -191,7 +191,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
         begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
         end: (widget.color ?? theme.accentColor).withOpacity(1.0),
       ).chain(CurveTween(
-          curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
+        curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
       )),
     );
     super.didChangeDependencies();

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
@@ -303,7 +302,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
 
   void _checkDragOffset(double containerExtent) {
     assert(_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed);
-    double newValue = _dragOffset / (containerExtent * _kDragContainerExtentPercentage);
+    final double newValue = _dragOffset / (containerExtent * _kDragContainerExtentPercentage);
     _positionController.value = newValue.clamp(0.0, 1.0); // this triggers various rebuilds
     if (_mode == _RefreshIndicatorMode.drag && _valueColor.value.alpha == 0xFF)
       _mode = _RefreshIndicatorMode.armed;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -267,7 +267,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
-    if (notification.depth != 0) return false;
+    if (notification.depth != 0)
+      return false;
     if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
       notification.disallowGlow();
       return true;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -103,9 +103,9 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsLabel,
     this.semanticsValue,
   }) : assert(child != null),
-       assert(onRefresh != null),
-       assert(notificationPredicate != null),
-       super(key: key);
+        assert(onRefresh != null),
+        assert(notificationPredicate != null),
+        super(key: key);
 
   /// The widget below this widget in the tree.
   ///
@@ -191,7 +191,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
         begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
         end: (widget.color ?? theme.accentColor).withOpacity(1.0),
       ).chain(CurveTween(
-        curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
+          curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
       )),
     );
     super.didChangeDependencies();
@@ -250,6 +250,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
         _dragOffset -= notification.overscroll / 2.0;
         _checkDragOffset(notification.metrics.viewportDimension);
       }
+      if (_mode == _RefreshIndicatorMode.armed && notification.dragDetails.primaryDelta < 0 && _valueColor.value.alpha != 0xFF)
+        _mode = _RefreshIndicatorMode.drag;
     } else if (notification is ScrollEndNotification) {
       switch (_mode) {
         case _RefreshIndicatorMode.armed:
@@ -302,8 +304,6 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   void _checkDragOffset(double containerExtent) {
     assert(_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed);
     double newValue = _dragOffset / (containerExtent * _kDragContainerExtentPercentage);
-    if (_mode == _RefreshIndicatorMode.armed)
-      newValue = math.max(newValue, 1.0 / _kDragSizeFactorLimit);
     _positionController.value = newValue.clamp(0.0, 1.0); // this triggers various rebuilds
     if (_mode == _RefreshIndicatorMode.drag && _valueColor.value.alpha == 0xFF)
       _mode = _RefreshIndicatorMode.armed;
@@ -427,7 +427,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     assert(_isIndicatorAtTop != null);
 
     final bool showIndeterminateIndicator =
-      _mode == _RefreshIndicatorMode.refresh || _mode == _RefreshIndicatorMode.done;
+        _mode == _RefreshIndicatorMode.refresh || _mode == _RefreshIndicatorMode.done;
 
     return Stack(
       children: <Widget>[
@@ -445,8 +445,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                 ? EdgeInsets.only(top: widget.displacement)
                 : EdgeInsets.only(bottom: widget.displacement),
               alignment: _isIndicatorAtTop
-                ? Alignment.topCenter
-                : Alignment.bottomCenter,
+                  ? Alignment.topCenter
+                  : Alignment.bottomCenter,
               child: ScaleTransition(
                 scale: _scaleFactor,
                 child: AnimatedBuilder(


### PR DESCRIPTION
## Description

When finished, this should resolve #36158.

## Progress

The first change I made should fix the issue that disallowed pushing the refresh indicator up, i.e. canceling, however, it might break some other behavior that I am unaware of.

### Before

![](https://camo.githubusercontent.com/49ce6136aa3ceee76895126b9c003baa271071f4/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f5158564c6f69384e4e456e4d4e685945636d2f67697068792e676966)

### After

![](https://media.giphy.com/media/iIkd4Dcm021bazoLLO/giphy.gif)

There are some test failures on iOS, however, I am currently unable to test on iOS.

## Question

I tried to figure out how to prevent the behavior shown in #36158. Now, I am wondering if it is even easily possible to prevent the scrolling from happening as returning true to `onNotification` is too late because `RefreshIndicator` is already an ancestor of the scroll view, i.e. the scrolling in the scroll view happens before `RefreshIndicator` is notified.