### PR TITLE
[Reland] Keep LLDB connection to iOS device alive while running from CLI.

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -112,7 +112,7 @@ Future<Process> runCommand(
   String workingDirectory,
   bool allowReentrantFlutter = false,
   Map<String, String> environment,
-  ProcessStartMode mode,
+  ProcessStartMode mode = ProcessStartMode.normal,
 }) {
   _traceCommand(cmd, workingDirectory: workingDirectory);
   return processManager.start(
@@ -181,11 +181,7 @@ Future<int> runCommandAndStreamOutput(
         await detachResult;
       }
 
-      // Result might have been completed while awaiting onExit.
-      if (!result.isCompleted) {
-        result.complete(0);
-      }
-
+      result.complete(0);
       return line;
     })
     .where((String line) => filter == null || filter.hasMatch(line))

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -43,13 +43,19 @@ class IOSDeploy {
   /// Checks /tmp/<app id>.ios_deploy.pid for an `ios-deploy` processe already running
   /// the app and terminates it.
   Future<void> _killOther(ApplicationPackage package) async {
-    File x;
     final io.File temp = _tempFile(package);
     if (!temp.existsSync())
       return;
 
-    // No need to wait for the process to die, since the launch will block anyway.
     final String pid = await temp.readAsString();
+
+    // Sanity check that we're kill ios-deploy, and not some other process!
+    final RunResult check = await runAsync(<String>['ps', '-p', pid]);
+    if (!check.stdout.contains('ios-deploy'))
+      // Nothing to do.
+      return;
+
+    // No need to wait for the process to die, since the launch will block anyway.
     await runCommand(<String>['kill', pid]);
   }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -48,7 +48,7 @@ class IOSDeploy {
       '--bundle',
       bundlePath,
       '--no-wifi',
-      '--justlaunch',
+      '--noninteractive',
     ];
     if (launchArguments.isNotEmpty) {
       launchCommand.add('--args');
@@ -66,11 +66,14 @@ class IOSDeploy {
     iosDeployEnv['PATH'] = '/usr/bin:${iosDeployEnv['PATH']}';
     iosDeployEnv.addEntries(<MapEntry<String, String>>[cache.dyLdLibEntry]);
 
+    // Detach from the ios-deploy process once it' outputs 'autoexit', signaling that the
+    // App has been started and LLDB is in "autopilot" mode.
     return await runCommandAndStreamOutput(
       launchCommand,
       mapFunction: _monitorInstallationFailure,
       trace: true,
       environment: iosDeployEnv,
+      detachFilter: RegExp('.*autoexit.*')
     );
   }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -44,19 +44,26 @@ class IOSDeploy {
   Future<void> _killOther(ApplicationPackage package) async {
     final File temp = _tempFile(package);
 
-    if (!temp.existsSync())
+    if (!temp.existsSync()) {
       return;
+    }
 
     final String pid = await temp.readAsString();
 
     // Sanity check that we're kill ios-deploy, and not some other process!
     final RunResult check = await runAsync(<String>['ps', '-p', pid]);
-    if (!check.stdout.contains('ios-deploy'))
+    if (!check.stdout.contains('ios-deploy')) {
       // Nothing to do.
       return;
+    }
+
+    try {
+      processManager.killPid(int.parse(pid));
+    } catch (_) {
+      // If we couldn't parse the file's contents, conservatively do nothing.
+    }
 
     // No need to wait for the process to die, since the launch will block anyway.
-    await runCommand(<String>['kill', pid]);
   }
 
   /// We have detached from `ios-deploy`: save its PID in case we need to kill it later.

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 
@@ -34,16 +33,17 @@ import 'mac.dart';
 /// If this (Flutter tools) process terminates before `ios-deploy` or the app, `ios-deploy`
 /// will be suspended. This is problematic because it will keep the app process on the phone
 /// alive via LLDB. Therefore we kill any previously created `ios-deploy` process which
-/// has launched an app before trying to run it again.
+/// has launched an app before trying to run that app again.
 class IOSDeploy {
   const IOSDeploy();
 
-  io.File _tempFile(ApplicationPackage package) => io.File('/tmp/${package.id}.ios_deploy.pid');
+  File _tempFile(ApplicationPackage package) => fs.file('/tmp/${package.id}.ios_deploy.pid');
 
-  /// Checks /tmp/<app id>.ios_deploy.pid for an `ios-deploy` processe already running
+  /// Checks /tmp/<app id>.ios_deploy.pid for an `ios-deploy` process already running
   /// the app and terminates it.
   Future<void> _killOther(ApplicationPackage package) async {
-    final io.File temp = _tempFile(package);
+    final File temp = _tempFile(package);
+
     if (!temp.existsSync())
       return;
 

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -51,6 +51,7 @@ void main() {
         postProcessRecording = i++;
       }, ShutdownStage.POST_PROCESS_RECORDING);
 
+
       addShutdownHook(() async {
         serializeRecording2 = i++;
       }, ShutdownStage.SERIALIZE_RECORDING);
@@ -111,7 +112,7 @@ void main() {
           <String>['foo\n', 'bar\n', 'baz\n'].map(utf8.convert)),
         stderr: const Stream<List<int>>.empty());
 
-      when(mockProcessManager.start(<String>['test1'])).thenAnswer((_) => Future<Process>.value(fake));
+      when(mockProcessManager.start(<String>['test1'], mode: anyNamed('mode'))).thenAnswer((_) => Future<Process>.value(fake));
 
       // Detach when we see "bar", and check that:
       //  - mapFunction still gets run on "baz",

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -200,6 +200,9 @@ class MockStream<T> implements Stream<T> {
   Stream<T> where(bool test(T event)) => MockStream<T>();
 
   @override
+  Stream<S> map<S>(S Function(T) _) => MockStream<S>();
+
+  @override
   StreamSubscription<T> listen(void onData(T event), { Function onError, void onDone(), bool cancelOnError }) {
     return MockStreamSubscription<T>();
   }

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -25,7 +25,8 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
+import '../../src/mocks.dart' hide MockProcessManager;
+import '../../src/mocks.dart' as mocks show MockProcessManager;
 
 class MockIOSApp extends Mock implements IOSApp {}
 class MockArtifacts extends Mock implements Artifacts {}
@@ -33,6 +34,7 @@ class MockCache extends Mock implements Cache {}
 class MockDirectory extends Mock implements Directory {}
 class MockFileSystem extends Mock implements FileSystem {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
+class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcode extends Mock implements Xcode {}
 class MockFile extends Mock implements File {}
 class MockProcess extends Mock implements Process {}
@@ -325,7 +327,7 @@ flutter:
   });
 
   group('IOSDeploy.runApp', () {
-    MockProcessManager mockProcessManager;
+    mocks.MockProcessManager mockProcessManager;
     MemoryFileSystem fileSystem;
     const Utf8Encoder utf8 = Utf8Encoder();
     const String packageName = 'com.example.test';
@@ -334,7 +336,7 @@ flutter:
     when(package.id).thenReturn(packageName);
 
     setUp(() {
-      mockProcessManager = MockProcessManager();
+      mockProcessManager = mocks.MockProcessManager();
       fileSystem = MemoryFileSystem();
       fileSystem.directory('/tmp').createSync();
     });


### PR DESCRIPTION
## Description

The original revision is in the first commit.

If the Flutter tools process is killed before `ios-deploy` has terminated, it will be suspended and prevent us from launching the same app again via `ios-deploy` (the App can still be closed as usual).

To fix this, we record the PID of the last detached `ios-deploy` process and kill it before spawning another.

## Tests

I've added new tests to `process_test.dart` and `devices_test.dart` and checked that the iOS integration tests pass (which were broken by the original commit).