### PR TITLE
Add plumbing for hello world startup test in devicelab

### DIFF
--- a/dev/devicelab/bin/tasks/hello_world__start_up.dart
+++ b/dev/devicelab/bin/tasks/hello_world__start_up.dart
@@ -1,0 +1,14 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createHelloWorldStartupTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -74,6 +74,13 @@ TaskFunction createComplexLayoutStartupTest() {
   ).run;
 }
 
+TaskFunction createHelloWorldStartupTest() {
+  return StartupTest(
+    '${flutterDirectory.path}/examples/hello_world',
+    reportMetrics: false,
+  ).run;
+}
+
 TaskFunction createFlutterGalleryCompileTest() {
   return CompileTest('${flutterDirectory.path}/examples/flutter_gallery').run;
 }

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -277,6 +277,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  # hello_world__start_up:
+  #   description: >
+  #     Verifies that Hello World can start on an array of devices.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android_esoteric"]
+
   microbenchmarks:
     description: >
       Runs benchmarks from dev/benchmarks/microbenchmarks.


### PR DESCRIPTION
## Description

This is the first step in getting esoteric devices wired
up to device lab to ensure that we can at least start Flutter
apps in profile mode on such devices.

## Related Issues

https://github.com/flutter/flutter/issues/35838

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
