### PR TITLE
Re-enable `flutter test` expression evaluation tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
@@ -111,6 +111,7 @@ void main() {
       );
       await _flutter.waitForPause();
       await evaluateTrivialExpressions(_flutter);
+      await _flutter.resume();
     });
 
     test('can evaluate complex expressions in a test', () async {
@@ -120,6 +121,7 @@ void main() {
       );
       await _flutter.waitForPause();
       await evaluateComplexExpressions(_flutter);
+      await _flutter.resume();
     });
 
     test('can evaluate expressions returning complex objects in a test', () async {
@@ -129,9 +131,9 @@ void main() {
       );
       await _flutter.waitForPause();
       await evaluateComplexReturningExpressions(_flutter);
+      await _flutter.resume();
     });
-    // Skipped due to https://github.com/flutter/flutter/issues/26518
-  }, timeout: const Timeout.factor(10), skip: true, tags: <String>['integration']); // The DevFS sync takes a really long time, so these tests can be slow.
+  }, timeout: const Timeout.factor(10), tags: <String>['integration']); // The DevFS sync takes a really long time, so these tests can be slow.
 }
 
 Future<void> evaluateTrivialExpressions(FlutterTestDriver flutter) async {

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -653,10 +653,11 @@ class FlutterTestTestDriver extends FlutterTestDriver {
   }
 
   Future<Map<String, dynamic>> _waitForJson({
-    Duration timeout,
+    Duration timeout = defaultTimeout,
   }) async {
     return _timeoutWithMessages<Map<String, dynamic>>(
-      () => _stdout.stream.map<Map<String, dynamic>>(_parseJsonResponse).first,
+      () => _stdout.stream.map<Map<String, dynamic>>(_parseJsonResponse)
+          .firstWhere((Map<String, dynamic> output) => output != null),
       timeout: timeout,
       task: 'Waiting for JSON',
     );


### PR DESCRIPTION
Plus:

- Resume the app being run after expression has been evaluated to prevent the test run being forcefully terminated because it didn't end
- Skip non-JSON when waiting for JSON (eg. when running in verbose mode for debugging locally)
- Pass defaultTimeout in waitForJson (otherwise the assert in _timeoutWithMessages fails when it's not provided)

Closes https://github.com/flutter/flutter/issues/26518 (the original reason for skip was fixed in https://github.com/dart-lang/sdk/issues/34224).