### PR TITLE
[flutter_tool] Send analytics command before the command runs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -32,11 +32,12 @@ class LogsCommand extends FlutterCommand {
   Device device;
 
   @override
-  Future<FlutterCommandResult> verifyThenRunCommand() async {
+  Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
     device = await findTargetDevice();
-    if (device == null)
+    if (device == null) {
       throwToolExit(null);
-    return super.verifyThenRunCommand();
+    }
+    return super.verifyThenRunCommand(commandPath);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -64,15 +64,18 @@ class ScreenshotCommand extends FlutterCommand {
   Device device;
 
   @override
-  Future<FlutterCommandResult> verifyThenRunCommand() async {
+  Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
     device = await findTargetDevice();
-    if (device == null)
+    if (device == null) {
       throwToolExit('Must have a connected device');
-    if (argResults[_kType] == _kDeviceType && !device.supportsScreenshot)
+    }
+    if (argResults[_kType] == _kDeviceType && !device.supportsScreenshot) {
       throwToolExit('Screenshot not supported for ${device.name}.');
-    if (argResults[_kType] != _kDeviceType && argResults[_kObservatoryUri] == null)
+    }
+    if (argResults[_kType] != _kDeviceType && argResults[_kObservatoryUri] == null) {
       throwToolExit('Observatory URI must be specified for screenshot type ${argResults[_kType]}');
-    return super.verifyThenRunCommand();
+    }
+    return super.verifyThenRunCommand(commandPath);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -60,11 +60,8 @@ void main() {
       );
       await flutterCommand.run();
 
-      expect(
-        verify(usage.sendCommand(captureAny,
-                parameters: captureAnyNamed('parameters'))).captured[1]['cd26'],
-        equals('success'),
-      );
+      verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
+      verify(usage.sendEvent(captureAny, 'success'));
     },
     overrides: <Type, Generator>{
       SystemClock: () => clock,
@@ -82,11 +79,8 @@ void main() {
       );
       await flutterCommand.run();
 
-      expect(
-        verify(usage.sendCommand(captureAny,
-                parameters: captureAnyNamed('parameters'))).captured[1]['cd26'],
-        equals('warning'),
-      );
+      verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
+      verify(usage.sendEvent(captureAny, 'warning'));
     },
     overrides: <Type, Generator>{
       SystemClock: () => clock,
@@ -106,11 +100,8 @@ void main() {
       try {
         await flutterCommand.run();
       } on ToolExit {
-        expect(
-          verify(usage.sendCommand(captureAny,
-                  parameters: captureAnyNamed('parameters'))).captured[1]['cd26'],
-          equals('fail'),
-        );
+        verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
+        verify(usage.sendEvent(captureAny, 'fail'));
       }
     },
     overrides: <Type, Generator>{
@@ -133,11 +124,8 @@ void main() {
         await flutterCommand.run();
         fail('Mock should make this fail');
       } on ToolExit {
-        expect(
-          verify(usage.sendCommand(captureAny,
-                  parameters: captureAnyNamed('parameters'))).captured[1]['cd26'],
-          equals('fail'),
-        );
+        verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
+        verify(usage.sendEvent(captureAny, 'fail'));
       }
     },
     overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Analytics commands are getting dropped when the tool is terminated with SIGTERM and SIGINT. This change restores sending analytics commands to before the command runs, and sends 'success', 'fail', 'warning' events when they can be detected after a command finishes.

## Tests

I added the following tests:

Fixed related tests in flutter_command_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.