### PR TITLE
Add GitHub CODEOWNERS file to auto-add reviewers by path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Below is a list of Flutter team members who are suggested reviewers
+# for contributions to this repository.
+#
+# These names are just suggestions. It is fine to have your changes
+# reviewed by someone else.
+#
+# Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
+
+/CODEOWNERS @magder
+/packages/flutter_tools/templates/module/ios/ @magder
+/packages/flutter_tools/templates/**/Podfile* @magder


### PR DESCRIPTION
## Description

New CODEOWNERS file for team members to be auto-added as reviewers based on changed path pattern.  This will hopefully cut down on frustration from contributors when PRs languish for months without being brought to the right person's attention.

The plugins team has set this precedent and has found it to be working well for them:
https://github.com/flutter/plugins/blob/master/CODEOWNERS

See https://help.github.com/en/articles/about-code-owners.

## Tests

None.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.