### PR TITLE
Fixes sliver list does not layout firstchild when child reordered

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -103,6 +103,10 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
         childParentData.layoutOffset = 0.0;
 
         if (scrollOffset == 0.0) {
+          // insertAndLayoutLeadingChild only lays out the children before
+          // firstChild. In this case, nothing has been laid out. We have
+          // to lay out firstChild manually.
+          firstChild.layout(childConstraints, parentUsesSize: true);
           earliestUsefulChild = firstChild;
           leadingChildWithLayout = earliestUsefulChild;
           trailingChildWithLayout ??= earliestUsefulChild;

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   testWidgets('SliverList reverse children (with keys)', (WidgetTester tester) async {
@@ -144,6 +145,52 @@ void main() {
     expect(find.text('Tile 18'), findsOneWidget);
     expect(find.text('Tile 19'), findsNothing);
   });
+
+  testWidgets('SliverList should layout first child in case of child reordering', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/35904.
+    List<String> items = <String>['1', '2'];
+
+    await tester.pumpWidget(_buildSliverListRenderWidgetChild(items));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tile 1'), findsOneWidget);
+    expect(find.text('Tile 2'), findsOneWidget);
+
+    items = items.reversed.toList();
+    await tester.pumpWidget(_buildSliverListRenderWidgetChild(items));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tile 1'), findsOneWidget);
+    expect(find.text('Tile 2'), findsOneWidget);
+  });
+}
+
+Widget _buildSliverListRenderWidgetChild(List<String> items) {
+  return MaterialApp(
+    home: Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: Container(
+          height: 500,
+          child: CustomScrollView(
+            controller: ScrollController(),
+            slivers: <Widget>[
+              SliverList(
+                delegate: SliverChildListDelegate(
+                  items.map<Widget>((String item) {
+                    return Chip(
+                      key: Key(item),
+                      label: Text('Tile $item'),
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
 }
 
 Widget _buildSliverList({


### PR DESCRIPTION
## Description

Sliver does not correctly lay out firstchild if the child list is reordered.
In general case, reordering of children will result in calling childElement.update with itself, and most of the case it doesn't require a relayout or rebuild so it does not cause issue most of the time. However, this is not the case in some widgets. Chip for example will sometimes mark itself as need layout even if it is updating with itself. That happen because it is doing a Widget to widget comparison. for example Text('text1) == Text('text1) will be false as Text widget doesn't have a comparing function, it will end up comparing the reference address. This corner case surface the bug that sliver does not layout the firstchild.

## Related Issues

https://github.com/flutter/flutter/issues/35904

## Tests

I added the following tests:

"SliverList should layout first child in case of child reordering"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
