### PR TITLE
Fix `flutter pub -v`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -249,7 +249,12 @@ class UpdatePackagesCommand extends FlutterCommand {
         fakePackage.createSync();
         fakePackage.writeAsStringSync(_generateFakePubspec(dependencies.values));
         // First we run "pub upgrade" on this generated package:
-        await pubGet(context: PubContext.updatePackages, directory: tempDir.path, upgrade: true, checkLastModified: false);
+        await pubGet(
+          context: PubContext.updatePackages,
+          directory: tempDir.path,
+          upgrade: true,
+          checkLastModified: false,
+        );
         // Then we run "pub deps --style=compact" on the result. We pipe all the
         // output to tree.fill(), which parses it so that it can create a graph
         // of all the dependencies so that we can figure out the transitive

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -96,9 +96,9 @@ Future<void> pubGet({
       'Running "flutter pub $command" in ${fs.path.basename(directory)}...',
       timeout: timeoutConfiguration.slowOperation,
     );
+    final bool verbose = FlutterCommand.current != null && FlutterCommand.current.globalResults['verbose'];
     final List<String> args = <String>[
-      '--verbosity=warning',
-      if (FlutterCommand.current != null && FlutterCommand.current.globalResults['verbose']) '--verbose',
+      if (verbose) '--verbose' else '--verbosity=warning',
       ...<String>[command, '--no-precompile'],
       if (offline) '--offline',
     ];


### PR DESCRIPTION
## Description

When we were running `pub` within `flutter pub`, we were
unconditionally including the `--verbosity=warning` argument.
Then we were conditionally including `--verbose` if we were
running in verbose mode.  However, the former argument
supersedes the latter, and we were never able to run `pub`
in verbose mode.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.