### PR TITLE
Place build outputs under dart tool

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -4,7 +4,6 @@
 
 import '../base/common.dart';
 import '../base/context.dart';
-import '../base/file_system.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../convert.dart';

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -96,7 +96,9 @@ abstract class AssembleBase extends FlutterCommand {
   Environment get environment {
     final FlutterProject flutterProject = FlutterProject.current();
     final Environment result = Environment(
-      buildDir: fs.directory(getBuildDirectory()),
+      buildDir: flutterProject.directory
+          .childDirectory('.dart_tool')
+          .childDirectory('flutter_build'),
       projectDir: flutterProject.directory,
       defines: _parseDefines(argResults['define']),
     );

--- a/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
@@ -39,11 +39,10 @@ void main() {
         defines: <String, String>{
           'BuildMode': 'debug'
         }, projectDir: fs.currentDirectory,
-        buildDir: fs.directory(getBuildDirectory()),
+        buildDir: fs.directory(fs.path.join('.dart_tool', 'flutter_build')).absolute,
       );
 
-      expect(bufferLogger.statusText.trim(),
-          fs.path.relative(environment.buildDir.path, from: fs.currentDirectory.path));
+      expect(bufferLogger.statusText.trim(), environment.buildDir.path);
     }));
 
     test('Can describe a target', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
@@ -5,7 +5,6 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/assemble.dart';


### PR DESCRIPTION
## Description

Since we'll be treating most of the output for assemble as intermediaries for other tools to use, it makes more sense to place it somewhere that stays mostly hidden. This reuses the .dart_tool subdirectory which is already a part of gitignore templates.