### PR TITLE
flutter_test fix: restore the omitted solo flag for test and group

### DIFF
--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -166,6 +166,7 @@ void test(
   dynamic tags,
   Map<String, dynamic> onPlatform,
   int retry,
+  @deprecated bool solo = false,
 }) {
   _declarer.test(
     description.toString(), body,
@@ -175,6 +176,7 @@ void test(
     onPlatform: onPlatform,
     tags: tags,
     retry: retry,
+    solo: solo
   );
 }
 
@@ -232,8 +234,11 @@ void test(
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void group(Object description, Function body, { dynamic skip }) {
-  _declarer.group(description.toString(), body, skip: skip);
+void group(Object description, Function body, {
+  dynamic skip,
+  @deprecated bool solo = false,
+}) {
+  _declarer.group(description.toString(), body, skip: skip, solo: solo);
 }
 
 /// Registers a function to be run before tests.

--- a/packages/flutter_test/test/solo_test.dart
+++ b/packages/flutter_test/test/solo_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
+// This test does not guarantee that the solo tests/groups are called, this is
+// extensively tested in the test package. It however tests that non-solo
+// tests are skipped
+void main() {
+  test('not_solo_test', () {
+    fail('not_solo');
+  });
+
+  test('solo_test', () {
+    expect(true, isTrue);
+  }, solo: true);
+
+  group('solo_group', () {
+    test('test', () {
+      expect(true, isTrue);
+    });
+  }, solo: true);
+}


### PR DESCRIPTION
as done in the regular test package.

## Description

this flag is deprecated on purpose to only use it temporarily during development. It allows running a quickly a single test without using special launch arguments.

## Related Issues

https://github.com/flutter/flutter/issues/35768

## Tests

I added the following tests: solo_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
