### PR TITLE
Fix janky scrolls on iPhone X/XS

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -197,7 +197,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// If there is any overscroll, it is reported using [didOverscrollBy].
   double setPixels(double newPixels) {
     assert(_pixels != null);
-    assert(SchedulerBinding.instance.schedulerPhase.index <= SchedulerPhase.transientCallbacks.index);
+    assert(SchedulerBinding.instance.schedulerPhase.index <= SchedulerPhase.transientCallbacks.index
+           || SchedulerBinding.instance.schedulerPhase == SchedulerPhase.postFrameCallbacks);
     if (newPixels != pixels) {
       final double overscroll = applyBoundaryConditions(newPixels);
       assert(() {

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -863,17 +863,21 @@ void main() {
 
       // Now item 1 is closest to the center.
       await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      await tester.pump();
       expect(selectedItems, <int>[1]);
 
       // Now item 1 is still closest to the center for another full itemExtent (100px).
       await scrollGesture.moveBy(const Offset(0.0, -99.0));
+      await tester.pump();
       expect(selectedItems, <int>[1]);
 
       await scrollGesture.moveBy(const Offset(0.0, -1.0));
+      await tester.pump();
       expect(selectedItems, <int>[1, 2]);
 
       // Going back triggers previous item indices.
       await scrollGesture.moveBy(const Offset(0.0, 50.0));
+      await tester.pump();
       expect(selectedItems, <int>[1, 2, 1]);
     });
 

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -659,6 +659,7 @@ void main() {
     await gesture.moveBy(const Offset(0.0, 10.0)); // overscroll
     await gesture.moveBy(const Offset(0.0, 10.0)); // overscroll
     await tester.pump();
+    await tester.pump();
     expect(tester.getRect(find.byKey(key1)), const Rect.fromLTWH(0.0, 0.0, 800.0, 100.0));
     expect(tester.getRect(find.byKey(key2)).top, greaterThan(100.0));
     expect(tester.getRect(find.byKey(key2)).top, lessThan(130.0));

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -298,12 +298,14 @@ void main() {
 
     // We've crossed the halfway mark.
     await gesture.moveBy(const Offset(-40.0, 0.0));
+    await tester.pump();
 
     expect(log, equals(const <int>[1]));
     log.clear();
 
     // Moving a bit more should not generate redundant notifications.
     await gesture.moveBy(const Offset(-40.0, 0.0));
+    await tester.pump();
 
     expect(log, isEmpty);
 

--- a/packages/flutter/test/widgets/scroll_events_test.dart
+++ b/packages/flutter/test/widgets/scroll_events_test.dart
@@ -39,6 +39,120 @@ void main() {
     scrollable.position.jumpTo(newScrollOffset);
   }
 
+
+
+  Future<List<double>> _simulateScrollEvents(
+      WidgetTester tester,
+      int numEvents,
+      Duration deliveryTimestamp(int i),
+      Duration frameTime) async {
+    await tester.pumpWidget(SingleChildScrollView(
+      child: Container(width: 1000.0, height: 1000.0),
+    ));
+    final TestGesture gesture = await tester.startGesture(const Offset(500.0, 500.0));
+
+    double frameOffset() {
+      try {
+        return tester
+            .state<ScrollableState>(find.byType(Scrollable))
+            .position
+            .pixels;
+      } on StateError {
+        return -1;  // fail elegantly when there's no scrollable.
+      }
+    }
+
+    final List<double> frameOffsets = <double>[];
+    int numFrameDrawn = 0, numFramePumped = 0;
+    tester.binding.addPersistentFrameCallback((Duration t) {
+      numFrameDrawn += 1;
+      frameOffsets.add(frameOffset());
+    });
+
+    int dragIndex = 0;
+    for (int frameIndex = 1; dragIndex < numEvents; frameIndex += 1) {
+      final Duration frameTimestamp = frameTime * frameIndex;
+      while (dragIndex < numEvents && deliveryTimestamp(dragIndex) <= frameTimestamp) {
+        await gesture.moveBy(const Offset(0.0, -1.0));
+        dragIndex += 1;
+      }
+      await tester.pump(frameTime);
+      numFramePumped += 1;
+    }
+
+    // We should miss at most 1 frame.
+    // Without the fix (https://github.com/flutter/flutter/pull/36616), we could miss half of the frames.
+    if (numFrameDrawn < numFramePumped - 1) {
+      final List<String> formatted = List<String>.generate(
+          numEvents,
+          (int i) => (deliveryTimestamp(i).inMicroseconds / frameTime.inMicroseconds).toStringAsFixed(3),
+      );
+      print('Test failed with delivery sequence: $formatted');
+      print('Frame offsets: $frameOffsets');
+    }
+    expect(numFrameDrawn, greaterThanOrEqualTo(numFramePumped - 1));
+
+    return frameOffsets;
+  }
+
+  testWidgets('Miss at most one frame for irregular scroll drag events', (WidgetTester tester) async {
+    const Duration kFrameTime = Duration(microseconds: 1e6 ~/ 60);
+    const double kBaseDeliveryDelay = 0.2;  // in kFrameTime
+
+    // Add an additional delay of [0.1, 0.9, 0.1, 0.9, 0.1, 0.9, ...] in kFrameTime
+    Duration deliveryTimestamp(int i) => kFrameTime * (i + kBaseDeliveryDelay + <double>[0.1, 0.9][i % 2]);
+
+    await _simulateScrollEvents(tester, 20, deliveryTimestamp, kFrameTime);
+  });
+
+  testWidgets('Delay at most one event for faster-than-vsync events', (WidgetTester tester) async {
+    const Duration kFrameTime = Duration(microseconds: 1e6 ~/ 60);
+    const double kBaseDeliveryDelay = 0.2;  // in kFrameTime
+
+    // Simulate 120Hz input events delivery.
+    Duration deliveryTimestamp(int i) => kFrameTime * (i * 0.5 + kBaseDeliveryDelay);
+
+    final List<double> offsets = await _simulateScrollEvents(tester, 40, deliveryTimestamp, kFrameTime);
+
+    // Ideal offsets are [2, 4, 6, 8, ...] (i.e., two pixels per frame).
+    final List<double> idealOffsets = List<double>.generate(20, (int i) => ((i + 1) * 2).toDouble());
+
+    expect(offsets.length, equals(idealOffsets.length));
+    for (int i = 0; i < offsets.length; i += 1) {
+      expect(offsets[i], greaterThanOrEqualTo(idealOffsets[i] - 1));
+    }
+  });
+
+  testWidgets('Handles iPhone XS irregular events with different base delays', (WidgetTester tester) async {
+    const Duration kFrameTime = Duration(microseconds: 1e6 ~/ 60);
+
+    final List<double> actualDeliveryTimes = <double>[
+      0.0, 0.9659423828125, 2.1082000732421875, 3.0290679931640625,
+      4.1031341552734375, 5.1513214111328125, 6.2241363525390625, 7.2659454345703125,
+      8.308258056640625, 9.60675048828125, 10.399948120117188, 11.470001220703125,
+      12.5802001953125, 13.535812377929688, 14.885757446289062, 15.564254760742188,
+      16.654876708984375, 17.683822631835938, 18.759628295898438, 20.022262573242188,
+      20.712265014648438, 21.741439819335938, 22.833389282226562, 24.141189575195312,
+      24.9683837890625, 25.973190307617188, 27.008193969726562, 28.006820678710938,
+      29.046951293945312, 30.136886596679688, 31.162567138671875, 32.22850036621094,
+      33.266815185546875, 34.69987487792969, 35.41351318359375, 36.35557556152344,
+      37.485443115234375, 38.55400085449219, 39.57757568359375, 40.678253173828125,
+      41.96244812011719, 42.71376037597656, 43.70013427734375, 44.67982482910156,
+      45.75013732910156, 46.811065673828125, 47.85569763183594
+      // the raw number is in 16ms instead of 16.67ms
+    ].map((double x) => x * 16 / (1000 / 60)).toList();
+
+
+    // Try all kinds of base delay based on real delivery times.
+    for (double baseDeliveryDelay = 0.0; baseDeliveryDelay < 1; baseDeliveryDelay += 0.2) {
+      Duration deliveryTimestamp(int i) =>
+          kFrameTime * (actualDeliveryTimes[i] + baseDeliveryDelay);
+
+      await _simulateScrollEvents(tester, actualDeliveryTimes.length, deliveryTimestamp, kFrameTime);
+    }
+  });
+
+
   testWidgets('Scroll event drag', (WidgetTester tester) async {
     final List<String> log = <String>[];
     await tester.pumpWidget(_buildScroller(log: log));

--- a/packages/flutter/test/widgets/scroll_events_test.dart
+++ b/packages/flutter/test/widgets/scroll_events_test.dart
@@ -39,8 +39,6 @@ void main() {
     scrollable.position.jumpTo(newScrollOffset);
   }
 
-
-
   Future<List<double>> _simulateScrollEvents(
       WidgetTester tester,
       int numEvents,

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -141,10 +141,13 @@ void main() {
     await pumpTest(tester, TargetPlatform.android);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
     await gesture.moveBy(const Offset(0.0, -0.5));
+    await tester.pump();
     expect(getScrollOffset(tester), 0.5);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 10));
+    await tester.pump();
     expect(getScrollOffset(tester), 1.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 20));
+    await tester.pump();
     expect(getScrollOffset(tester), 1.5);
   });
 
@@ -152,18 +155,24 @@ void main() {
     await pumpTest(tester, TargetPlatform.iOS);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
     await gesture.moveBy(const Offset(0.0, -0.5));
+    await tester.pump();
     expect(getScrollOffset(tester), 0.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 10));
+    await tester.pump();
     expect(getScrollOffset(tester), 0.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 20));
+    await tester.pump();
     expect(getScrollOffset(tester), 0.0);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 30));
+    await tester.pump();
     // Now -2.5 in total.
     expect(getScrollOffset(tester), 0.0);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
     // Now -3.5, just reached threshold.
     expect(getScrollOffset(tester), 0.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 50));
+    await tester.pump();
     // -0.5 over threshold transferred.
     expect(getScrollOffset(tester), 0.5);
   });
@@ -181,8 +190,10 @@ void main() {
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
     // This is a typical 'hesitant' iOS scroll start.
     await gesture.moveBy(const Offset(0.0, -10.0));
+    await tester.pump();
     expect(getScrollOffset(tester), moreOrLessEquals(1.1666666666666667));
     await gesture.moveBy(const Offset(0.0, -10.0), timeStamp: const Duration(milliseconds: 20));
+    await tester.pump();
     // Subsequent motions unaffected.
     expect(getScrollOffset(tester), moreOrLessEquals(11.16666666666666673));
   });
@@ -190,13 +201,18 @@ void main() {
   testWidgets('Small continuing motion preserved on iOS', (WidgetTester tester) async {
     await pumpTest(tester, TargetPlatform.iOS);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
+    await tester.pump();
     await gesture.moveBy(const Offset(0.0, -30.0)); // Break threshold.
+    await tester.pump();
     expect(getScrollOffset(tester), 30.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 20));
+    await tester.pump();
     expect(getScrollOffset(tester), 30.5);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
     expect(getScrollOffset(tester), 31.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 60));
+    await tester.pump();
     expect(getScrollOffset(tester), 31.5);
   });
 
@@ -204,22 +220,31 @@ void main() {
     await pumpTest(tester, TargetPlatform.iOS);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
     await gesture.moveBy(const Offset(0.0, -30.0)); // Break threshold.
+    await tester.pump();
     expect(getScrollOffset(tester), 30.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 20));
+    await tester.pump();
     expect(getScrollOffset(tester), 30.5);
     await gesture.moveBy(Offset.zero);
+    await tester.pump();
     // Stationary too long, threshold reset.
     await gesture.moveBy(Offset.zero, timeStamp: const Duration(milliseconds: 120));
+    await tester.pump();
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 140));
+    await tester.pump();
     expect(getScrollOffset(tester), 30.5);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 150));
+    await tester.pump();
     expect(getScrollOffset(tester), 30.5);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 160));
+    await tester.pump();
     expect(getScrollOffset(tester), 30.5);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 170));
+    await tester.pump();
     // New threshold broken.
     expect(getScrollOffset(tester), 31.5);
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 180));
+    await tester.pump();
     expect(getScrollOffset(tester), 32.5);
   });
 


### PR DESCRIPTION
Fix janky scrolls on iPhone X/XS

Fixes https://github.com/flutter/flutter/issues/31086

Tests added:
* Miss at most one frame for irregular scroll drag events
* Delay at most one event for faster-than-vsync events
* Handles iPhone XS irregular events with different base delays

Many `await tester.pump()` are added to existing unit tests that use `gesture.moveBy` to declare that those input events aren't faster than VSYNC (and the tests shall pass).