### PR TITLE
add line-length to `flutter format` command line

### DIFF
--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -28,6 +28,11 @@ class FormatCommand extends FlutterCommand {
       defaultsTo: false,
       negatable: false,
     );
+    argParser.addOption('line-length',
+      abbr: 'l',
+      help: 'Wrap lines longer than this length. Defaults to 80 characters.',
+      defaultsTo: '80',
+    );
   }
 
   @override
@@ -65,6 +70,7 @@ class FormatCommand extends FlutterCommand {
       dartfmt,
       if (argResults['dry-run']) '-n',
       if (argResults['machine']) '-m',
+      if (argResults['line-length'] != null) '-l ${argResults['line-length']}',
       if (!argResults['dry-run'] && !argResults['machine']) '-w',
       if (argResults['set-exit-if-changed']) '--set-exit-if-changed',
       ...argResults.rest,

--- a/packages/flutter_tools/test/general.shard/commands/format_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/format_test.dart
@@ -74,5 +74,30 @@ void main() {
       final String shouldNotFormatted = srcFile.readAsStringSync();
       expect(shouldNotFormatted, nonFormatted);
     });
+
+    testUsingContext('line-length', () async {
+      const int lineLengthShort = 50;
+      const int lineLengthLong = 120;
+      final String projectPath = await createProject(tempDir);
+
+      final File srcFile = fs.file(
+          fs.path.join(projectPath, 'lib', 'main.dart'));
+      final String nonFormatted = srcFile.readAsStringSync();
+      srcFile.writeAsStringSync(
+          nonFormatted.replaceFirst('main()',
+              'main(anArgument1, anArgument2, anArgument3, anArgument4, anArgument5)'));
+
+      final String nonFormattedWithLongLine = srcFile.readAsStringSync();
+      final FormatCommand command = FormatCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      await runner.run(<String>['format', '--line-length', '$lineLengthLong', srcFile.path]);
+      final String notFormatted = srcFile.readAsStringSync();
+      expect(nonFormattedWithLongLine, notFormatted);
+
+      await runner.run(<String>['format', '--line-length', '$lineLengthShort', srcFile.path]);
+      final String shouldFormatted = srcFile.readAsStringSync();
+      expect(nonFormattedWithLongLine, isNot(shouldFormatted));
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR will allow us to pass line length to format command in flutter, therefore, it's possible to pass it over to `dartfmt` and overwrite the default value which is 80.

## Related Issues

I didn't find any open issues. 

## Tests

I added the following tests:

- show format dart file if it's longer than line-length 
-show not format dart file if it's shorter than line-length
