### PR TITLE
Fix bug with CupertinoTextField 

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -402,7 +402,10 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
         );
       // iOS doesn't draw anything for collapsed selections.
       case TextSelectionHandleType.collapsed:
-        return Container();
+        return Container(
+          width: 0.0,
+          height: 0.0,
+        );
     }
     assert(type != null);
     return null;


### PR DESCRIPTION

## Description

Fix when the TextField has focus, clicking on other areas will show the  menu bar.(only appear on iOS)

## Related Issues

No relevant issues has been found yet, same with #36284 .