### PR TITLE
add an error count field to the Flutter.Error event

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2338,55 +2338,55 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       final FlutterExceptionHandler oldHandler = FlutterError.onError;
 
       try {
-        // enable
+        // Enable structured errors.
         expect(await service.testBoolExtension(
             'structuredErrors', <String, String>{'enabled': 'true'}),
             equals('true'));
 
-        // create an error
+        // Create an error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
           exception: StackTrace.current,
         ));
 
-        // validate that we received an error
+        // Validate that we received an error.
         flutterErrorEvents = service.getEventsDispatched('Flutter.Error');
         expect(flutterErrorEvents, hasLength(1));
 
-        // validate the error contents
+        // Validate the error contents.
         Map<Object, Object> error = flutterErrorEvents.first;
         expect(error['description'], 'Exception caught by rendering library');
         expect(error['children'], isEmpty);
 
-        // validate that we received an error count
+        // Validate that we received an error count.
         expect(error['errorsSinceReload'], 0);
 
-        // send a second error
+        // Send a second error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
           library: 'rendering library',
           context: ErrorDescription('also during layout'),
           exception: StackTrace.current,
         ));
 
-        // validate that the error count increased
+        // Validate that the error count increased.
         flutterErrorEvents = service.getEventsDispatched('Flutter.Error');
         expect(flutterErrorEvents, hasLength(2));
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 1);
 
-        // reload the app
+        // Reload the app.
         tester.binding.reassembleApplication();
         await tester.pump();
 
-        // send another error
+        // Send another error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
           exception: StackTrace.current,
         ));
 
-        // and validate that the error count has been reset
+        // And, validate that the error count has been reset.
         flutterErrorEvents = service.getEventsDispatched('Flutter.Error');
         expect(flutterErrorEvents, hasLength(3));
         error = flutterErrorEvents.last;


### PR DESCRIPTION
## Description

- add an error count field to the Flutter.Error event; this will be used by clients to display errors after an initial error differently (with reduced emphasis, or collapsed by default)

## Related Issues

none

## Tests

I added the following tests:

- `widgets/widget_inspector_test.dart` : `ext.flutter.inspector.structuredErrors`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
