### PR TITLE
don't crash tool on null from fe server

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -98,6 +98,10 @@ class StdoutHandler {
 
   void handler(String message) {
     printTrace('-> $message');
+    // See https://github.com/flutter/flutter/issues/35924.
+    if (message == null) {
+      return;
+    }
     const String kResultPrefix = 'result ';
     if (boundaryKey == null && message.startsWith(kResultPrefix)) {
       boundaryKey = message.substring(kResultPrefix.length);

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -506,10 +506,10 @@ example:org-dartlang-app:/
     });
   });
 
-  test('StdoutHandler can handle null values', () {
+  testUsingContext('StdoutHandler can handle null values', () {
     final StdoutHandler handler = StdoutHandler();
 
-    expect(() => handler.handler(null), isNot(throwsA(isInstanceOf<NoSuchMethodError>())));
+    expect(() => handler.handler(null), returnsNormally);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -505,6 +505,12 @@ example:org-dartlang-app:/
       Platform: _kNoColorTerminalPlatform,
     });
   });
+
+  test('StdoutHandler can handle null values', () {
+    final StdoutHandler handler = StdoutHandler();
+
+    expect(() => handler.handler(null), isNot(throwsA(isInstanceOf<NoSuchMethodError>())));
+  });
 }
 
 Future<void> _recompile(


### PR DESCRIPTION
## Description

To address https://github.com/flutter/flutter/issues/35924. We believe these null values should be ignored, as they are otherwise appearing during error reporting.