### PR TITLE
Expose build-dir config option

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import '../android/android_sdk.dart';
 import '../android/android_studio.dart';
+import '../base/common.dart';
+import '../base/file_system.dart';
 import '../convert.dart';
 import '../features.dart';
 import '../globals.dart';
@@ -25,7 +27,7 @@ class ConfigCommand extends FlutterCommand {
     argParser.addOption('android-sdk', help: 'The Android SDK directory.');
     argParser.addOption('android-studio-dir', help: 'The Android Studio install directory.');
     argParser.addOption('build-dir', help: 'The relative path to override a projects build directory',
-        valueHelp: '/out');
+        valueHelp: 'out/');
     argParser.addFlag('machine',
       negatable: false,
       hide: !verboseHelp,
@@ -129,9 +131,14 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('clear-ios-signing-cert'))
       _updateConfig('ios-signing-cert', '');
-    
-    if (argResults.wasParsed('build-dir'))
-      _updateConfig('build-dir', argResults['build-dir']);
+
+    if (argResults.wasParsed('build-dir')) {
+      final String buildDir = argResults['build-dir'];
+      if (fs.path.isAbsolute(buildDir)) {
+        throwToolExit('build-dir should be a relative path');
+      }
+      _updateConfig('build-dir', buildDir);
+    }
 
     for (Feature feature in allFeatures) {
       if (feature.configSetting == null) {

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -24,6 +24,8 @@ class ConfigCommand extends FlutterCommand {
     argParser.addOption('gradle-dir', help: 'The gradle install directory.');
     argParser.addOption('android-sdk', help: 'The Android SDK directory.');
     argParser.addOption('android-studio-dir', help: 'The Android Studio install directory.');
+    argParser.addOption('build-dir', help: 'The relative path to override a projects build directory',
+        valueHelp: '/out');
     argParser.addFlag('machine',
       negatable: false,
       hide: !verboseHelp,
@@ -127,6 +129,9 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('clear-ios-signing-cert'))
       _updateConfig('ios-signing-cert', '');
+    
+    if (argResults.wasParsed('build-dir'))
+      _updateConfig('build-dir', argResults['build-dir']);
 
     for (Feature feature in allFeatures) {
       if (feature.configSetting == null) {

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -129,7 +129,7 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('clear-ios-signing-cert'))
       _updateConfig('ios-signing-cert', '');
-    
+
     if (argResults.wasParsed('build-dir'))
       _updateConfig('build-dir', argResults['build-dir']);
 

--- a/packages/flutter_tools/test/general.shard/commands/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/config_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/config.dart';
 import 'package:flutter_tools/src/version.dart';
@@ -51,6 +52,18 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidStudio: () => mockAndroidStudio,
       AndroidSdk: () => mockAndroidSdk,
+    });
+
+    testUsingContext('Can set build-dir', () async {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      await commandRunner.run(<String>[
+        'config',
+        '--build-dir=foo'
+      ]);
+
+      expect(getBuildDirectory(), 'foo');
     });
 
     testUsingContext('allows setting and removing feature flags', () async {

--- a/packages/flutter_tools/test/general.shard/commands/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/config_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -64,6 +65,16 @@ void main() {
       ]);
 
       expect(getBuildDirectory(), 'foo');
+    });
+
+    testUsingContext('throws error on absolute path to build-dir', () async {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      expect(() => commandRunner.run(<String>[
+        'config',
+        '--build-dir=/foo'
+      ]), throwsA(isInstanceOf<ToolExit>()));
     });
 
     testUsingContext('allows setting and removing feature flags', () async {


### PR DESCRIPTION
## Description

This config value is used to determine the relative dir that the build artifacts are output to. It should be exposed as a config option for ease of use.