### PR TITLE
Parameterize CoverageCollector with a library name predicate

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -117,9 +117,14 @@ Future<void> run(List<String> args) async {
     CoverageCollector collector;
     if (argResults['coverage']) {
       collector = CoverageCollector(
-        flutterProject: FlutterProject.current(),
-        coverageDirectory: coverageDirectory,
-      );
+        libraryPredicate: (String libraryName) {
+          // If we have a specified coverage directory then accept all libraries.
+          if (coverageDirectory != null) {
+            return true;
+          }
+          final String projectName = FlutterProject.current().manifest.appName;
+          return libraryName.contains(projectName);
+        });
       if (!argResults.options.contains(_kOptionTestDirectory)) {
         throwToolExit('Use of --coverage requires setting --test-directory');
       }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -190,8 +190,9 @@ class TestCommand extends FastFlutterCommand {
 
     CoverageCollector collector;
     if (argResults['coverage'] || argResults['merge-coverage']) {
+      final String projectName = FlutterProject.current().manifest.appName;
       collector = CoverageCollector(
-        flutterProject: FlutterProject.current(),
+        libraryPredicate: (String libraryName) => libraryName.contains(projectName),
       );
     }
 

--- a/packages/flutter_tools/tool/tool_coverage.dart
+++ b/packages/flutter_tools/tool/tool_coverage.dart
@@ -47,7 +47,7 @@ Future<void> main(List<String> arguments) async {
 /// A platform that loads tests in isolates spawned within this Dart process.
 class VMPlatform extends PlatformPlugin {
   final CoverageCollector coverageCollector = CoverageCollector(
-    flutterProject: FlutterProject.current(),
+    libraryPredicate: (String libraryName) => libraryName.contains(FlutterProject.current().manifest.appName),
   );
   final Map<String, Future<void>> _pending = <String, Future<void>>{};
   final String precompiledPath = path.join('.dart_tool', 'build', 'generated', 'flutter_tools');


### PR DESCRIPTION
An optimization to the coverage collection speed was added in #30811. This commit further expands on it to parameterize the CoverageCollector with a custom predicate, allowing internal use cases to filter the RPC calls to the Dart VM based on scripts of interest to coverage collection.