### PR TITLE
[flutter_tool] Improve Windows flutter clean error message

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/platform.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../project.dart';
@@ -34,7 +35,10 @@ class CleanCommand extends FlutterCommand {
     if (buildDir.existsSync()) {
       try {
         buildDir.deleteSync(recursive: true);
-      } catch (error) {
+      } on FileSystemException catch (error) {
+        if (platform.isWindows) {
+          _windowsDeleteFailure(buildDir.path);
+        }
         throwToolExit(error.toString());
       }
     }
@@ -43,11 +47,22 @@ class CleanCommand extends FlutterCommand {
     if (flutterProject.dartTool.existsSync()) {
       try {
         flutterProject.dartTool.deleteSync(recursive: true);
-      } catch (error) {
+      } on FileSystemException catch (error) {
+        if (platform.isWindows) {
+          _windowsDeleteFailure(flutterProject.dartTool.path);
+        }
         throwToolExit(error.toString());
       }
     }
     return const FlutterCommandResult(ExitStatus.success);
+  }
+
+  void _windowsDeleteFailure(String path) {
+    printError(
+      'Failed to remove $path. '
+      'A program may still be using a file in the directory or the directory itself. '
+      'To find and stop such a program, see: '
+      'https://superuser.com/questions/1333118/cant-delete-empty-folder-because-it-is-used');
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/commands/clean_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/clean_test.dart
@@ -2,46 +2,74 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/commands/clean.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 
-
 void main() {
-  final MockFileSystem mockFileSystem = MockFileSystem();
-  final MockDirectory currentDirectory = MockDirectory();
-  final MockDirectory exampleDirectory = MockDirectory();
-  final MockDirectory buildDirectory = MockDirectory();
-  final MockDirectory dartToolDirectory = MockDirectory();
-  final MockFile pubspec = MockFile();
-  final MockFile examplePubspec = MockFile();
+  MockFileSystem mockFileSystem;
+  MockDirectory currentDirectory;
+  MockDirectory exampleDirectory;
+  MockDirectory buildDirectory;
+  MockDirectory dartToolDirectory;
+  MockFile pubspec;
+  MockFile examplePubspec;
+  MockPlatform windowsPlatform;
 
-  when(mockFileSystem.currentDirectory).thenReturn(currentDirectory);
-  when(currentDirectory.childDirectory('example')).thenReturn(exampleDirectory);
-  when(currentDirectory.childFile('pubspec.yaml')).thenReturn(pubspec);
-  when(pubspec.path).thenReturn('/test/pubspec.yaml');
-  when(exampleDirectory.childFile('pubspec.yaml')).thenReturn(examplePubspec);
-  when(currentDirectory.childDirectory('.dart_tool')).thenReturn(dartToolDirectory);
-  when(examplePubspec.path).thenReturn('/test/example/pubspec.yaml');
-  when(mockFileSystem.isFileSync('/test/pubspec.yaml')).thenReturn(false);
-  when(mockFileSystem.isFileSync('/test/example/pubspec.yaml')).thenReturn(false);
-  when(mockFileSystem.directory('build')).thenReturn(buildDirectory);
-  when(mockFileSystem.path).thenReturn(fs.path);
-  when(buildDirectory.existsSync()).thenReturn(true);
-  when(dartToolDirectory.existsSync()).thenReturn(true);
+  setUp(() {
+    mockFileSystem = MockFileSystem();
+    currentDirectory = MockDirectory();
+    exampleDirectory = MockDirectory();
+    buildDirectory = MockDirectory();
+    dartToolDirectory = MockDirectory();
+    pubspec = MockFile();
+    examplePubspec = MockFile();
+    windowsPlatform = MockPlatform();
+    when(mockFileSystem.currentDirectory).thenReturn(currentDirectory);
+    when(currentDirectory.childDirectory('example')).thenReturn(exampleDirectory);
+    when(currentDirectory.childFile('pubspec.yaml')).thenReturn(pubspec);
+    when(pubspec.path).thenReturn('/test/pubspec.yaml');
+    when(exampleDirectory.childFile('pubspec.yaml')).thenReturn(examplePubspec);
+    when(currentDirectory.childDirectory('.dart_tool')).thenReturn(dartToolDirectory);
+    when(examplePubspec.path).thenReturn('/test/example/pubspec.yaml');
+    when(mockFileSystem.isFileSync('/test/pubspec.yaml')).thenReturn(false);
+    when(mockFileSystem.isFileSync('/test/example/pubspec.yaml')).thenReturn(false);
+    when(mockFileSystem.directory('build')).thenReturn(buildDirectory);
+    when(mockFileSystem.path).thenReturn(fs.path);
+    when(buildDirectory.existsSync()).thenReturn(true);
+    when(dartToolDirectory.existsSync()).thenReturn(true);
+    when(windowsPlatform.isWindows).thenReturn(true);
+  });
+
   group(CleanCommand, () {
     testUsingContext('removes build and .dart_tool directories', () async {
       await CleanCommand().runCommand();
       verify(buildDirectory.deleteSync(recursive: true)).called(1);
       verify(dartToolDirectory.deleteSync(recursive: true)).called(1);
     }, overrides: <Type, Generator>{
-      FileSystem: () => mockFileSystem,
       Config: () => null,
+      FileSystem: () => mockFileSystem,
+    });
+
+    testUsingContext('prints a helpful error message on Windows', () async {
+      final BufferLogger logger = context.get<Logger>();
+      when(buildDirectory.deleteSync(recursive: true)).thenThrow(
+          const FileSystemException('Deletion failed'));
+      expect(() async => await CleanCommand().runCommand(), throwsA(isInstanceOf<ToolExit>()));
+      expect(logger.errorText, contains('A program may still be using a file'));
+    }, overrides: <Type, Generator>{
+      Config: () => null,
+      FileSystem: () => mockFileSystem,
+      Platform: () => windowsPlatform,
+      Logger: () => BufferLogger(),
     });
   });
 }
@@ -49,3 +77,4 @@ void main() {
 class MockFileSystem extends Mock implements FileSystem {}
 class MockFile extends Mock implements File {}
 class MockDirectory extends Mock implements Directory {}
+class MockPlatform extends Mock implements Platform {}


### PR DESCRIPTION
## Description

This PR improves the error message on Windows with flutter clean fails to delete a directory.

## Related Issues

https://github.com/flutter/flutter/issues/36763

## Tests

I added the following tests:

Added a test in clean_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
