### PR TITLE
Improve Windows build failure message

### DIFF
--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -19,11 +19,13 @@ import 'msbuild_utils.dart';
 import 'visual_studio.dart';
 
 /// Builds the Windows project using msbuild.
-Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {String target}) async {
+Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo,
+    {String target}) async {
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': Cache.flutterRoot,
     'PROJECT_DIR': windowsProject.project.directory.path,
-    'TRACK_WIDGET_CREATION': (buildInfo?.trackWidgetCreation == true).toString(),
+    'TRACK_WIDGET_CREATION':
+        (buildInfo?.trackWidgetCreation == true).toString(),
   };
   if (target != null) {
     environment['FLUTTER_TARGET'] = target;
@@ -31,7 +33,8 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;
     final String engineOutPath = localEngineArtifacts.engineOutPath;
-    environment['FLUTTER_ENGINE'] = fs.path.dirname(fs.path.dirname(engineOutPath));
+    environment['FLUTTER_ENGINE'] =
+        fs.path.dirname(fs.path.dirname(engineOutPath));
     environment['LOCAL_ENGINE'] = fs.path.basename(engineOutPath);
   }
   writePropertySheet(windowsProject.generatedPropertySheetFile, environment);
@@ -69,19 +72,20 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
   int result;
   try {
     process.stderr
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen(printError);
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(printError);
     process.stdout
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen(printTrace);
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(printTrace);
     result = await process.exitCode;
   } finally {
     status.cancel();
   }
   if (result != 0) {
-    throwToolExit('Build process failed');
+    throwToolExit('Build process failed. To view the stack trace, please run `flutter run -d windows -v`. If this does not help you resolve your build failure, please file an issue at https://github.com/flutter/flutter/issues/new/choose');
   }
-  flutterUsage.sendTiming('build', 'vs_build', Duration(milliseconds: sw.elapsedMilliseconds));
+  flutterUsage.sendTiming(
+      'build', 'vs_build', Duration(milliseconds: sw.elapsedMilliseconds));
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -81,7 +81,7 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
     status.cancel();
   }
   if (result != 0) {
-    throwToolExit('Build process failed. To view the stack trace, please run `flutter run -d windows -v`. If this does not help you resolve your build failure, please file an issue at https://github.com/flutter/flutter/issues/new/choose');
+    throwToolExit('Build process failed. To view the stack trace, please run `flutter run -d windows -v`.');
   }
   flutterUsage.sendTiming('build', 'vs_build', Duration(milliseconds: sw.elapsedMilliseconds));
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -19,13 +19,11 @@ import 'msbuild_utils.dart';
 import 'visual_studio.dart';
 
 /// Builds the Windows project using msbuild.
-Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo,
-    {String target}) async {
+Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {String target}) async {
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': Cache.flutterRoot,
     'PROJECT_DIR': windowsProject.project.directory.path,
-    'TRACK_WIDGET_CREATION':
-        (buildInfo?.trackWidgetCreation == true).toString(),
+    'TRACK_WIDGET_CREATION': (buildInfo?.trackWidgetCreation == true).toString(),
   };
   if (target != null) {
     environment['FLUTTER_TARGET'] = target;
@@ -33,8 +31,7 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo,
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;
     final String engineOutPath = localEngineArtifacts.engineOutPath;
-    environment['FLUTTER_ENGINE'] =
-        fs.path.dirname(fs.path.dirname(engineOutPath));
+    environment['FLUTTER_ENGINE'] = fs.path.dirname(fs.path.dirname(engineOutPath));
     environment['LOCAL_ENGINE'] = fs.path.basename(engineOutPath);
   }
   writePropertySheet(windowsProject.generatedPropertySheetFile, environment);
@@ -72,13 +69,13 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo,
   int result;
   try {
     process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen(printError);
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(printError);
     process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen(printTrace);
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(printTrace);
     result = await process.exitCode;
   } finally {
     status.cancel();
@@ -86,6 +83,5 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo,
   if (result != 0) {
     throwToolExit('Build process failed. To view the stack trace, please run `flutter run -d windows -v`. If this does not help you resolve your build failure, please file an issue at https://github.com/flutter/flutter/issues/new/choose');
   }
-  flutterUsage.sendTiming(
-      'build', 'vs_build', Duration(milliseconds: sw.elapsedMilliseconds));
+  flutterUsage.sendTiming('build', 'vs_build', Duration(milliseconds: sw.elapsedMilliseconds));
 }


### PR DESCRIPTION
## Description

This PR improves the build failure message for Windows build targets. It suggests that the user run `flutter run -d windows -v` to see a stack trace, and if that does not help the user solve the build failure it prompts the user to open an issue.

## Related Issues

Contributes to, but does not fully address, #33583

## Tests

This PR does not change any behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
