### PR TITLE
Ensure user-thrown errors have ErrorSummary nodes

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -411,7 +411,7 @@ class FlutterErrorDetails extends Diagnosticable {
         String message = exceptionAsString();
         if (message.startsWith(prefix))
           message = message.substring(prefix.length);
-        properties.add(ErrorDescription('$message'));
+        properties.add(ErrorSummary('$message'));
       }
     }
 

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -328,4 +328,28 @@ void main() {
       );
     }
   });
+
+  test('User-thrown exceptions have ErrorSummary properties', () {
+    {
+      DiagnosticsNode node;
+      try {
+        throw 'User thrown string';
+      } catch (e) {
+        node = FlutterErrorDetails(exception: e).toDiagnosticsNode();
+      }
+      final ErrorSummary summary = node.getProperties().whereType<ErrorSummary>().single;
+      expect(summary.value, equals(<String>['User thrown string']));
+    }
+
+    {
+      DiagnosticsNode node;
+      try {
+        throw ArgumentError.notNull('myArgument');
+      } catch (e) {
+        node = FlutterErrorDetails(exception: e).toDiagnosticsNode();
+      }
+      final ErrorSummary summary = node.getProperties().whereType<ErrorSummary>().single;
+      expect(summary.value, equals(<String>['Invalid argument(s) (myArgument): Must not be null']));
+    }
+  });
 }


### PR DESCRIPTION
This changes user-thrown errors to have `ErrorSummary` nodes instead of just `ErrorDescriptions`. This is used in the editors for highlighting the error message.

Before:

![white](https://user-images.githubusercontent.com/1078012/61813210-18927400-ae3d-11e9-81cd-f2e19b5fa47b.png)

After:

![red](https://user-images.githubusercontent.com/1078012/61813219-1c25fb00-ae3d-11e9-8b5e-23074701d0b7.png)
