### PR TITLE
Remove Chain terse parsing

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -115,6 +115,7 @@ Future<int> _handleToolError(
         error: error,
         stackTrace: stackTrace,
         getFlutterVersion: getFlutterVersion,
+        command: args.join(' '),
       );
 
       if (error is String)

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -84,6 +84,7 @@ class CrashReportSender {
     @required dynamic error,
     @required StackTrace stackTrace,
     @required String getFlutterVersion(),
+    @required String command,
   }) async {
     try {
       final String flutterVersion = getFlutterVersion();
@@ -111,6 +112,7 @@ class CrashReportSender {
       req.fields['type'] = _kDartTypeId;
       req.fields['error_runtime_type'] = '${error.runtimeType}';
       req.fields['error_message'] = '$error';
+      req.fields['comments'] = command;
 
       req.files.add(http.MultipartFile.fromString(
         _kStackTraceFileField,

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import '../base/io.dart';
 import '../base/os.dart';
@@ -113,10 +112,9 @@ class CrashReportSender {
       req.fields['error_runtime_type'] = '${error.runtimeType}';
       req.fields['error_message'] = '$error';
 
-      final String stackTraceWithRelativePaths = Chain.parse(stackTrace.toString()).terse.toString();
       req.files.add(http.MultipartFile.fromString(
         _kStackTraceFileField,
-        stackTraceWithRelativePaths,
+        stackTrace.toString(),
         filename: _kStackTraceFilename,
       ));
 

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -181,6 +181,7 @@ Future<void> verifyCrashReportSent(RequestInfo crashInfo) async {
   expect(crashInfo.fields['type'], 'DartError');
   expect(crashInfo.fields['error_runtime_type'], 'StateError');
   expect(crashInfo.fields['error_message'], 'Bad state: Test bad state error');
+  expect(crashInfo.fields['comments'], 'crash');
 
   final BufferLogger logger = context.get<Logger>();
   expect(logger.statusText, 'Sending crash report to Google.\n'


### PR DESCRIPTION
## Description

We've been receiving a burst of error reports with "unparsed" in the stack traces. To resolve this, we can switch to the native toString of stack traces for error reporting.