### PR TITLE
Add reference to StrutStyle from TextStyle

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -134,6 +134,8 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 ///
 /// ![Text height comparison diagram](https://flutter.github.io/assets-for-api-docs/assets/painting/text_height_comparison_diagram.png)
 ///
+/// See [StrutStyle] for further control of line height at the paragraph level.
+///
 /// ### Wavy red underline with black text
 ///
 /// {@tool sample}

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -543,6 +543,8 @@ class TextStyle extends Diagnosticable {
   /// ![Text height comparison diagram](https://flutter.github.io/assets-for-api-docs/assets/painting/text_height_comparison_diagram.png)
   ///
   /// {@end-tool}
+  ///
+  /// See [StrutStyle] for further control of line height at the paragraph level.
   final double height;
 
   /// The locale used to select region-specific glyphs.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -536,13 +536,9 @@ class TextStyle extends Diagnosticable {
   ///
   /// ![Text height diagram](https://flutter.github.io/assets-for-api-docs/assets/painting/text_height_diagram.png)
   ///
-  /// {@tool sample}
-  ///
   /// Examples of the resulting line heights from different values of `TextStyle.height`:
   ///
   /// ![Text height comparison diagram](https://flutter.github.io/assets-for-api-docs/assets/painting/text_height_comparison_diagram.png)
-  ///
-  /// {@end-tool}
   ///
   /// See [StrutStyle] for further control of line height at the paragraph level.
   final double height;


### PR DESCRIPTION
Docs change that references `StrutStyle` from `TextStyle`'s height docs to help people find what they need faster.