### PR TITLE
Adjust phrasing of features

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -73,7 +73,7 @@ const List<Feature> allFeatures = <Feature>[
 
 /// The [Feature] for flutter web.
 const Feature flutterWebFeature = Feature(
-  name: 'Flutter Web',
+  name: 'Flutter for Web',
   configSetting: 'enable-web',
   environmentOverride: 'FLUTTER_WEB',
   master: FeatureChannelSetting(
@@ -88,7 +88,7 @@ const Feature flutterWebFeature = Feature(
 
 /// The [Feature] for macOS desktop.
 const Feature flutterMacOSDesktopFeature = Feature(
-  name: 'Flutter Desktop for macOS',
+  name: 'Flutter for macOS Desktop',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -99,7 +99,7 @@ const Feature flutterMacOSDesktopFeature = Feature(
 
 /// The [Feature] for Linux desktop.
 const Feature flutterLinuxDesktopFeature = Feature(
-  name: 'Flutter Desktop for Linux',
+  name: 'Flutter for Linux Desktop',
   configSetting: 'enable-linux-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -110,7 +110,7 @@ const Feature flutterLinuxDesktopFeature = Feature(
 
 /// The [Feature] for Windows desktop.
 const Feature flutterWindowsDesktopFeature = Feature(
-  name: 'Flutter Desktop for Windows',
+  name: 'Flutter for Windows Desktop',
   configSetting: 'enable-windows-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -187,7 +187,8 @@ class Feature {
     if (configSetting == null) {
       return null;
     }
-    final StringBuffer buffer = StringBuffer('Enable or disable $name on ');
+    final StringBuffer buffer = StringBuffer('Enable or disable $name. '
+        'This setting will take effect on ');
     final List<String> channels = <String>[
       if (master.available) 'master',
       if (dev.available) 'dev',

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -88,7 +88,7 @@ const Feature flutterWebFeature = Feature(
 
 /// The [Feature] for macOS desktop.
 const Feature flutterMacOSDesktopFeature = Feature(
-  name: 'Flutter for macOS desktop',
+  name: 'Flutter for desktop on macOS',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -99,7 +99,7 @@ const Feature flutterMacOSDesktopFeature = Feature(
 
 /// The [Feature] for Linux desktop.
 const Feature flutterLinuxDesktopFeature = Feature(
-  name: 'Flutter for Linux desktop',
+  name: 'Flutter for desktop on Linux',
   configSetting: 'enable-linux-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -110,7 +110,7 @@ const Feature flutterLinuxDesktopFeature = Feature(
 
 /// The [Feature] for Windows desktop.
 const Feature flutterWindowsDesktopFeature = Feature(
-  name: 'Flutter for Windows desktop',
+  name: 'Flutter for desktop on Windows',
   configSetting: 'enable-windows-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -73,7 +73,7 @@ const List<Feature> allFeatures = <Feature>[
 
 /// The [Feature] for flutter web.
 const Feature flutterWebFeature = Feature(
-  name: 'Flutter for Web',
+  name: 'Flutter for web',
   configSetting: 'enable-web',
   environmentOverride: 'FLUTTER_WEB',
   master: FeatureChannelSetting(
@@ -88,7 +88,7 @@ const Feature flutterWebFeature = Feature(
 
 /// The [Feature] for macOS desktop.
 const Feature flutterMacOSDesktopFeature = Feature(
-  name: 'Flutter for macOS Desktop',
+  name: 'Flutter for macOS desktop',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -99,7 +99,7 @@ const Feature flutterMacOSDesktopFeature = Feature(
 
 /// The [Feature] for Linux desktop.
 const Feature flutterLinuxDesktopFeature = Feature(
-  name: 'Flutter for Linux Desktop',
+  name: 'Flutter for Linux desktop',
   configSetting: 'enable-linux-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -110,7 +110,7 @@ const Feature flutterLinuxDesktopFeature = Feature(
 
 /// The [Feature] for Windows desktop.
 const Feature flutterWindowsDesktopFeature = Feature(
-  name: 'Flutter for Windows Desktop',
+  name: 'Flutter for Windows desktop',
   configSetting: 'enable-windows-desktop',
   environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
   master: FeatureChannelSetting(
@@ -139,7 +139,7 @@ const Feature flutterBuildPluginAsAarFeature = Feature(
 /// a "safe" value, such as being off.
 ///
 /// The top level feature settings can be provided to apply to all channels.
-/// Otherwise, more specific settings take precidence over higher level
+/// Otherwise, more specific settings take precedence over higher level
 /// settings.
 class Feature {
   /// Creates a [Feature].
@@ -197,8 +197,12 @@ class Feature {
     ];
     if (channels.length == 1) {
       buffer.write('the ${channels.single} channel.');
+    } else if (channels.length == 2) {
+      buffer.write('the ${channels.join(' and ')} channels.');
     } else {
-      buffer.write('${channels.join(', ')} channels.');
+      final String prefix = (channels.toList()
+        ..removeLast()).join(', ');
+      buffer.write('the $prefix, and ${channels.last} channels.');
     }
     return buffer.toString();
   }

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -78,19 +78,33 @@ void main() {
     }));
 
     test('flutter web help string', () {
-      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter for Web. This setting will take effect on master, dev channels.');
+      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter for web. This setting will take effect on the master and dev channels.');
     });
 
     test('flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for macOS Desktop. This setting will take effect on the master channel.');
+      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for macOS desktop. This setting will take effect on the master channel.');
     });
 
     test('flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Linux Desktop. This setting will take effect on the master channel.');
+      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Linux desktop. This setting will take effect on the master channel.');
     });
 
     test('flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Windows Desktop. This setting will take effect on the master channel.');
+      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Windows desktop. This setting will take effect on the master channel.');
+    });
+
+    test('help string on multiple channels', () {
+      const Feature testFeature = Feature(
+        name: 'example',
+        master: FeatureChannelSetting(available: true),
+        dev: FeatureChannelSetting(available: true),
+        beta: FeatureChannelSetting(available: true),
+        stable: FeatureChannelSetting(available: true),
+        configSetting: 'foo',
+      );
+
+      expect(testFeature.generateHelpMessage(), 'Enable or disable example. '
+          'This setting will take effect on the master, dev, beta, and stable channels.');
     });
 
     /// Flutter Web

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -82,15 +82,15 @@ void main() {
     });
 
     test('flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for macOS desktop. This setting will take effect on the master channel.');
+      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on macOS. This setting will take effect on the master channel.');
     });
 
     test('flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Linux desktop. This setting will take effect on the master channel.');
+      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Linux. This setting will take effect on the master channel.');
     });
 
     test('flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Windows desktop. This setting will take effect on the master channel.');
+      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Windows. This setting will take effect on the master channel.');
     });
 
     test('help string on multiple channels', () {

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -78,19 +78,19 @@ void main() {
     }));
 
     test('flutter web help string', () {
-      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter Web on master, dev channels.');
+      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter for Web. This setting will take effect on master, dev channels.');
     });
 
     test('flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter Desktop for macOS on the master channel.');
+      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for macOS Desktop. This setting will take effect on the master channel.');
     });
 
     test('flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter Desktop for Linux on the master channel.');
+      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Linux Desktop. This setting will take effect on the master channel.');
     });
 
     test('flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter Desktop for Windows on the master channel.');
+      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for Windows Desktop. This setting will take effect on the master channel.');
     });
 
     /// Flutter Web


### PR DESCRIPTION
## Description

Separate feature description and where it is enabled into two sentences, following suggestion by @devoncarew . Adjust names of features to better match brand guidelines.


```
Usage: flutter config [arguments]
-h, --help                               Print this usage information.
    --[no-]analytics                     Enable or disable reporting anonymously tool usage statistics and crash reports.
    --clear-ios-signing-cert             Clear the saved development certificate choice used to sign apps for iOS device
                                         deployment.

    --gradle-dir                         The gradle install directory.
    --android-sdk                        The Android SDK directory.
    --android-studio-dir                 The Android Studio install directory.
    --[no-]enable-web                    Enable or disable Flutter for Web. This setting will take effect on master, dev
                                         channels.

    --[no-]enable-linux-desktop          Enable or disable Flutter for Linux Desktop. This setting will take effect on the
                                         master channel.

    --[no-]enable-macos-desktop          Enable or disable Flutter for macOS Desktop. This setting will take effect on the
                                         master channel.

    --[no-]enable-windows-desktop        Enable or disable Flutter for Windows Desktop. This setting will take effect on the
                                         master channel.

    --[no-]enable-build-plugin-as-aar    Enable or disable Build plugins independently as AARs in app projects. This setting
                                         will take effect on master, dev channels.

    --clear-features                     Remove all configured features and restore them to the default values.
```