### PR TITLE
Clarify showDuration and waitDuration API docs and test behavior

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -124,10 +124,14 @@ class Tooltip extends StatefulWidget {
   /// The length of time that a pointer must hover over a tooltip's widget
   /// before the tooltip will be shown.
   ///
+  /// Once the pointer leaves the widget, the tooltip will immediately
+  /// disappear.
+  ///
   /// Defaults to 0 milliseconds (tooltips are shown immediately upon hover).
   final Duration waitDuration;
 
-  /// The length of time that the tooltip will be shown once it has appeared.
+  /// The length of time that the tooltip will be shown after a long press
+  /// is released.
   ///
   /// Defaults to 1.5 seconds.
   final Duration showDuration;
@@ -220,7 +224,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       return;
     }
     if (_longPressActivated) {
-      // Tool tips activated by long press should stay around for 1.5s.
+      // Tool tips activated by long press should stay around for the showDuration.
       _hideTimer ??= Timer(showDuration, _controller.reverse);
     } else {
       // Tool tips activated by hover should disappear as soon as the mouse

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -574,7 +574,7 @@ void main() {
     ));
   }, skip: isBrowser);
 
-  testWidgets('Tooltip stays around', (WidgetTester tester) async {
+  testWidgets('Tooltip stays after long press', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
@@ -592,18 +592,27 @@ void main() {
 
     final Finder tooltip = find.byType(Tooltip);
     TestGesture gesture = await tester.startGesture(tester.getCenter(tooltip));
+
+    // long press reveals tooltip
     await tester.pump(kLongPressTimeout);
     await tester.pump(const Duration(milliseconds: 10));
-    await gesture.up();
     expect(find.text(tooltipText), findsOneWidget);
+    await gesture.up();
+
+    // tap (down, up) gesture hides tooltip, since its not
+    // a long press
     await tester.tap(tooltip);
     await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tooltipText), findsNothing);
+
+    // long press once more
     gesture = await tester.startGesture(tester.getCenter(tooltip));
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-    expect(find.text(tooltipText), findsNothing);
     await tester.pump(kLongPressTimeout);
+    await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tooltipText), findsOneWidget);
+
+    // keep holding the long press, should still show tooltip
     await tester.pump(kLongPressTimeout);
     expect(find.text(tooltipText), findsOneWidget);
     gesture.up();
@@ -611,7 +620,6 @@ void main() {
 
   testWidgets('Tooltip shows/hides when hovered', (WidgetTester tester) async {
     const Duration waitDuration = Duration(milliseconds: 0);
-    const Duration showDuration = Duration(milliseconds: 1500);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     await gesture.moveTo(const Offset(1.0, 1.0));
@@ -623,7 +631,6 @@ void main() {
         home: Center(
           child: Tooltip(
             message: tooltipText,
-            showDuration: showDuration,
             waitDuration: waitDuration,
             child: Container(
               width: 100.0,
@@ -653,7 +660,6 @@ void main() {
     await tester.pump();
 
     // Wait for it to disappear.
-    await tester.pump(showDuration);
     await tester.pumpAndSettle();
     await gesture.removePointer();
     expect(find.text(tooltipText), findsNothing);

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -608,6 +608,9 @@ void main() {
     // long press once more
     gesture = await tester.startGesture(tester.getCenter(tooltip));
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text(tooltipText), findsNothing);
+
     await tester.pump(kLongPressTimeout);
     await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tooltipText), findsOneWidget);


### PR DESCRIPTION
## Description

Add some clarification to the API doc and the tests for Tooltip.showDuration and Tooltip.waitDuration.


## Related Issues

Fixes https://github.com/flutter/flutter/issues/36032

## Tests

I added the following tests:

n/a, update test behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
