### PR TITLE
fix debug paint crash when axis direction inverted

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1425,6 +1425,10 @@ abstract class RenderSliver extends RenderObject {
   /// This means that the dimensions may be negative.
   ///
   /// This is only valid after [layout] has completed.
+  ///
+  /// See also:
+  ///
+  ///  * [getAbsoluteSize], which returns absolute size.
   @protected
   Size getAbsoluteSizeRelativeToOrigin() {
     assert(geometry != null);
@@ -1438,6 +1442,30 @@ abstract class RenderSliver extends RenderObject {
         return Size(constraints.crossAxisExtent, geometry.paintExtent);
       case AxisDirection.left:
         return Size(-geometry.paintExtent, constraints.crossAxisExtent);
+    }
+    return null;
+  }
+
+  /// This returns the absolute [Size] of the sliver.
+  ///
+  /// The dimensions are always positive and calling this is only valid after
+  /// [layout] has completed.
+  ///
+  /// See also:
+  ///
+  ///  * [getAbsoluteSizeRelativeToOrigin], which returns the size relative to
+  ///    the leading edge of the sliver.
+  @protected
+  Size getAbsoluteSize() {
+    assert(geometry != null);
+    assert(!debugNeedsLayout);
+    switch (constraints.axisDirection) {
+      case AxisDirection.up:
+      case AxisDirection.down:
+        return Size(constraints.crossAxisExtent, geometry.paintExtent);
+      case AxisDirection.right:
+      case AxisDirection.left:
+        return Size(geometry.paintExtent, constraints.crossAxisExtent);
     }
     return null;
   }

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -328,12 +328,12 @@ class RenderSliverPadding extends RenderSliver with RenderObjectWithChildMixin<R
     super.debugPaint(context, offset);
     assert(() {
       if (debugPaintSizeEnabled) {
-        final Size parentSize = getAbsoluteSizeRelativeToOrigin();
+        final Size parentSize = getAbsoluteSize();
         final Rect outerRect = offset & parentSize;
         Size childSize;
         Rect innerRect;
         if (child != null) {
-          childSize = child.getAbsoluteSizeRelativeToOrigin();
+          childSize = child.getAbsoluteSize();
           final SliverPhysicalParentData childParentData = child.parentData;
           innerRect = (offset + childParentData.paintOffset) & childSize;
           assert(innerRect.top >= outerRect.top);

--- a/packages/flutter/test/rendering/debug_test.dart
+++ b/packages/flutter/test/rendering/debug_test.dart
@@ -124,4 +124,70 @@ void main() {
     expect(b.debugPaint, isNot(paints..rect(color: const Color(0x90909090))));
     debugPaintSizeEnabled = false;
   });
+
+  test('debugPaintPadding from render objects with inverted direction vertical', () {
+    debugPaintSizeEnabled = true;
+    RenderSliver s;
+    final RenderViewport root = RenderViewport(
+      axisDirection: AxisDirection.up,
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      children: <RenderSliver>[
+        s = RenderSliverPadding(
+          padding: const EdgeInsets.all(10.0),
+          child: RenderSliverToBoxAdapter(
+            child: RenderPadding(
+              padding: const EdgeInsets.all(10.0),
+            ),
+          ),
+        ),
+      ],
+    );
+    layout(root);
+    dynamic error;
+    try {
+      s.debugPaint(
+        PaintingContext(
+          ContainerLayer(), const Rect.fromLTRB(0.0, 0.0, 800.0, 600.0)),
+        const Offset(0.0, 500)
+      );
+    } catch(e) {
+      error = e;
+    }
+    expect(error, isNull);
+    debugPaintSizeEnabled = false;
+  });
+
+  test('debugPaintPadding from render objects with inverted direction horizontal', () {
+    debugPaintSizeEnabled = true;
+    RenderSliver s;
+    final RenderViewport root = RenderViewport(
+      axisDirection: AxisDirection.left,
+      crossAxisDirection: AxisDirection.down,
+      offset: ViewportOffset.zero(),
+      children: <RenderSliver>[
+        s = RenderSliverPadding(
+          padding: const EdgeInsets.all(10.0),
+          child: RenderSliverToBoxAdapter(
+            child: RenderPadding(
+              padding: const EdgeInsets.all(10.0),
+            ),
+          ),
+        ),
+      ],
+    );
+    layout(root);
+    dynamic error;
+    try {
+      s.debugPaint(
+        PaintingContext(
+          ContainerLayer(), const Rect.fromLTRB(0.0, 0.0, 800.0, 600.0)),
+        const Offset(0.0, 500)
+      );
+    } catch(e) {
+      error = e;
+    }
+    expect(error, isNull);
+    debugPaintSizeEnabled = false;
+  });
 }


### PR DESCRIPTION
## Description

debugPaint of RenderSliverPadding verifies the children paint rectangle is within parent paint rectangle. The logic however only consider the case where axis direction is down or right.
In the case of up or left, it doesn't calculate the rectangle correctly. This is due to it tries to combine an absolute offset with a relative size.

This pr fixes it.

## Related Issues

https://github.com/flutter/flutter/issues/28406

## Tests

I added the following tests:

"debugPaintPadding from render objects with inverted direction"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
