### PR TITLE
Build number (part after +) is documented as optional, use entire app version if not present

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -99,7 +99,7 @@ class FlutterManifest {
   /// Can be null if version isn't set or has a wrong format.
   String get buildName {
     if (appVersion != null && appVersion.contains('+'))
-      return appVersion.contains('+') ? appVersion.split('+')?.elementAt(0) : appVersion;
+      return appVersion.split('+')?.elementAt(0);
     else
       return appVersion;
   }
@@ -107,10 +107,10 @@ class FlutterManifest {
   /// The build version number from the `pubspec.yaml` file.
   /// Can be null if version isn't set or has a wrong format.
   String get buildNumber {
-    if (appVersion != null) {
-      return appVersion.contains('+') ? appVersion.split('+')?.elementAt(1) : appVersion;
+    if (appVersion != null && appVersion.contains('+')) {
+      return appVersion.split('+')?.elementAt(1);
     } else {
-      return null;
+      return appVersion;
     }
   }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -108,9 +108,10 @@ class FlutterManifest {
   /// Can be null if version isn't set or has a wrong format.
   String get buildNumber {
     if (appVersion != null && appVersion.contains('+')) {
-      return appVersion.split('+')?.elementAt(1);
+      final String value = appVersion.split('+')?.elementAt(1);
+      return value;
     } else {
-      return appVersion;
+      return null;
     }
   }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -99,7 +99,7 @@ class FlutterManifest {
   /// Can be null if version isn't set or has a wrong format.
   String get buildName {
     if (appVersion != null && appVersion.contains('+'))
-      return appVersion.split('+')?.elementAt(0);
+      return appVersion.contains('+') ? appVersion.split('+')?.elementAt(0) : appVersion;
     else
       return appVersion;
   }
@@ -107,9 +107,8 @@ class FlutterManifest {
   /// The build version number from the `pubspec.yaml` file.
   /// Can be null if version isn't set or has a wrong format.
   String get buildNumber {
-    if (appVersion != null && appVersion.contains('+')) {
-      final String value = appVersion.split('+')?.elementAt(1);
-      return value;
+    if (appVersion != null) {
+      return appVersion.contains('+') ? appVersion.split('+')?.elementAt(1) : appVersion;
     } else {
       return null;
     }

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -80,12 +80,17 @@ Future<void> updateGeneratedXcodeProperties({
     localsBuffer.writeln('FLUTTER_FRAMEWORK_DIR=$frameworkDir');
   }
 
-  final String buildName = validatedBuildNameForPlatform(TargetPlatform.ios, buildInfo?.buildName ?? project.manifest.buildName);
+  final String buildNameToParse = buildInfo?.buildName ?? project.manifest.buildName;
+  final String buildName = validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse);
   if (buildName != null) {
     localsBuffer.writeln('FLUTTER_BUILD_NAME=$buildName');
   }
 
-  final String buildNumber = validatedBuildNumberForPlatform(TargetPlatform.ios, buildInfo?.buildNumber ?? project.manifest.buildNumber);
+  String buildNumber = validatedBuildNumberForPlatform(TargetPlatform.ios, buildInfo?.buildNumber ?? project.manifest.buildNumber);
+  // Drop back to parsing build name if build number is not present. Build number is optional in the manifest, but
+  // FLUTTER_BUILD_NUMBER is required as the backing value for the required CFBundleVersion.
+  buildNumber ??= validatedBuildNumberForPlatform(TargetPlatform.ios, buildNameToParse);
+
   if (buildNumber != null) {
     localsBuffer.writeln('FLUTTER_BUILD_NUMBER=$buildNumber');
   }

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -17,6 +17,8 @@ void main() {
     testUsingContext('CFBundleVersion for iOS', () async {
       String buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, 'xyz');
       expect(buildName, '0');
+      buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '0.0.1');
+      expect(buildName, '0.0.1');
       buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '123.xyz');
       expect(buildName, '123');
       buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '123.456.xyz');
@@ -37,6 +39,8 @@ void main() {
     testUsingContext('CFBundleShortVersionString for iOS', () async {
       String buildName = validatedBuildNameForPlatform(TargetPlatform.ios, 'xyz');
       expect(buildName, '0.0.0');
+      buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '0.0.1');
+      expect(buildName, '0.0.1');
       buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '123.456.xyz');
       expect(buildName, '123.456.0');
       buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '123.xyz');

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -428,7 +428,7 @@ flutter:
         manifest: manifest,
         expectedAppVersion: '0.0.1',
         expectedBuildName: '0.0.1',
-        expectedBuildNumber: '0.0.1',
+        expectedBuildNumber: null,
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -415,6 +415,23 @@ flutter:
       );
     });
 
+    test('parses major.minor.patch with no build version', () async {
+      const String manifest = '''
+name: test
+version: 0.0.1
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+      await checkManifestVersion(
+        manifest: manifest,
+        expectedAppVersion: '0.0.1',
+        expectedBuildName: '0.0.1',
+        expectedBuildNumber: '0.0.1',
+      );
+    });
+
     test('parses major.minor.patch+build version clause 2', () async {
       const String manifest = '''
 name: test

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -395,6 +395,7 @@ Information about project "Runner":
       final File localPropertiesFile = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
       expect(propertyFor('FLUTTER_BUILD_NAME', localPropertiesFile), expectedBuildName);
       expect(propertyFor('FLUTTER_BUILD_NUMBER', localPropertiesFile), expectedBuildNumber);
+      expect(propertyFor('FLUTTER_BUILD_NUMBER', localPropertiesFile), isNotNull);
     }
 
     testUsingOsxContext('extract build name and number from pubspec.yaml', () async {
@@ -430,7 +431,7 @@ flutter:
         manifestString: manifest,
         buildInfo: buildInfo,
         expectedBuildName: '1.0.0',
-        expectedBuildNumber: null,
+        expectedBuildNumber: '1.0.0',
       );
     });
 
@@ -449,6 +450,24 @@ flutter:
         buildInfo: buildInfo,
         expectedBuildName: '1.0.2',
         expectedBuildNumber: '1',
+      );
+    });
+
+    testUsingOsxContext('allow build info to override build name with build number fallback', () async {
+      const String manifest = '''
+name: test
+version: 1.0.0
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+      const BuildInfo buildInfo = BuildInfo(BuildMode.release, null, buildName: '1.0.2');
+      await checkBuildVersion(
+        manifestString: manifest,
+        buildInfo: buildInfo,
+        expectedBuildName: '1.0.2',
+        expectedBuildNumber: '1.0.2',
       );
     });
 


### PR DESCRIPTION
## Description

Generated pubspec says:
> A version number is three numbers separated by dots, like 1.2.43 followed by an **optional** build number separated by a +.

However build name and number were not being parsed unless it contained a "+"

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34477

See logic introduced in https://github.com/flutter/flutter/pull/27743.

## Tests
- flutter_manifest_test 'parses major.minor.patch with no build version'
- Added 0-prefix case to build_info_test, though that would not have failed before this change

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.