### PR TITLE
Fix selection menu not showing after clear

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1121,7 +1121,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       return;
     }
     if (value.text != _value.text) {
-      _hideSelectionOverlayIfNeeded();
+      hideToolbar();
       _showCaretOnScreen();
       if (widget.obscureText && value.text.length == _value.text.length + 1) {
         _obscureShowCharTicksPending = _kObscureShowLatestCharCursorTicks;
@@ -1360,11 +1360,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
   }
 
-  void _hideSelectionOverlayIfNeeded() {
-    _selectionOverlay?.hide();
-    _selectionOverlay = null;
-  }
-
   void _updateOrDisposeSelectionOverlayIfNeeded() {
     if (_selectionOverlay != null) {
       if (_hasFocus) {
@@ -1383,7 +1378,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // EditableWidget, not just changes triggered by user gestures.
     requestKeyboard();
 
-    _hideSelectionOverlayIfNeeded();
+    _selectionOverlay?.hide();
+    _selectionOverlay = null;
 
     if (widget.selectionControls != null) {
       _selectionOverlay = TextSelectionOverlay(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -33,6 +33,7 @@ void main() {
   });
 
   tearDown(() {
+    controller.dispose();
     controller = null;
   });
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter/foundation.dart';
 import 'editable_text_utils.dart';
 import 'semantics_tester.dart';
 
-final TextEditingController controller = TextEditingController();
+TextEditingController controller;
 final FocusNode focusNode = FocusNode(debugLabel: 'EditableText Node');
 final FocusScopeNode focusScopeNode = FocusScopeNode(debugLabel: 'EditableText Scope Node');
 const TextStyle textStyle = TextStyle();
@@ -29,6 +29,11 @@ enum HandlePositionInViewport {
 void main() {
   setUp(() {
     debugResetSemanticsIdCounter();
+    controller = TextEditingController();
+  });
+
+  tearDown(() {
+    controller = null;
   });
 
   // Tests that the desired keyboard action button is requested.
@@ -528,6 +533,21 @@ void main() {
       cause: SelectionChangedCause.tap,
     );
     await tester.pump();
+    expect(state.showToolbar(), true);
+    await tester.pump();
+    expect(find.text('PASTE'), findsOneWidget);
+
+    // Hide the toolbar and clear the text and selection.
+    state.hideToolbar();
+    await tester.pump();
+    expect(find.text('PASTE'), findsNothing);
+    state.updateEditingValue(const TextEditingValue(
+      text: '',
+    ));
+    await tester.pump();
+    expect(find.text('PASTE'), findsNothing);
+
+    // Should be able to show the toolbar.
     expect(state.showToolbar(), true);
     await tester.pump();
     expect(find.text('PASTE'), findsOneWidget);


### PR DESCRIPTION
## Description

If you long press an empty text field, then the selection menu shows, but if you type some content and then delete it all so it's empty again, the menu doesn't show.  This PR fixes that.

## Related Issues

Closes https://github.com/flutter/flutter/issues/35998

## Tests

Tested adding text, deleting it, and then showing the menu in editable_text_test.dart.