### PR TITLE
use SizedBox instead of Container for building collapsed selection

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -402,7 +402,7 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
         );
       // iOS doesn't draw anything for collapsed selections.
       case TextSelectionHandleType.collapsed:
-        return Container();
+        return const SizedBox();
     }
     assert(type != null);
     return null;

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -535,18 +535,23 @@ void main() {
       ),
     );
 
-    await tester.pump();
     await tester.pumpAndSettle();
 
     final Finder gestureDetector = find.descendant(
-      of: find.byType(FadeTransition),
-      matching: find.byType(GestureDetector),
+      of: find.byType(Visibility),
+      matching: find.descendant(
+        of: find.byType(FadeTransition),
+        matching: find.byType(GestureDetector),
+      ),
     );
 
     expect(gestureDetector, findsOneWidget);
-    // The size of the GestureDetector should be reasonably small.
-    expect(tester.renderObject<RenderBox>(gestureDetector).size.width, lessThan(100));
-    expect(tester.renderObject<RenderBox>(gestureDetector).size.height, lessThan(100));
+    // The GestureDetector's size should not exceed that of the TextField.
+    final Rect hitRect = tester.getRect(gestureDetector);
+    final Rect textFieldRect = tester.getRect(find.byType(TextField));
+
+    expect(hitRect.size.width, lessThan(textFieldRect.size.width));
+    expect(hitRect.size.height, lessThan(textFieldRect.size.height));
 
     debugDefaultTargetPlatformOverride = null;
   });


### PR DESCRIPTION
## Description

Related PR: #36757

## Related Issues

Fixes https://github.com/flutter/flutter/issues/36996
Fixes https://github.com/flutter/flutter/issues/37032

## Tests

I added the following tests:

selection handle's GestureDetector should not cover the entire screen

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
