### PR TITLE
Fix DefaultTabController created with no Tabs

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -313,7 +313,7 @@ class DefaultTabController extends StatefulWidget {
     @required this.child,
   }) : assert(initialIndex != null),
        assert(length >= 0),
-       assert(initialIndex >= 0 && initialIndex < length),
+       assert(initialIndex >= 0 && initialIndex <= length),
        super(key: key);
 
   /// The total number of tabs.

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -313,7 +313,7 @@ class DefaultTabController extends StatefulWidget {
     @required this.child,
   }) : assert(initialIndex != null),
        assert(length >= 0),
-       assert(initialIndex >= 0 && initialIndex <= length),
+       assert(length == 0 || (initialIndex >= 0 && initialIndex < length)),
        super(key: key);
 
   /// The total number of tabs.

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2350,4 +2350,94 @@ void main() {
     expect(find.text('Tab1'), findsOneWidget);
     expect(find.text('Tab2'), findsOneWidget);
   });
+  
+    testWidgets('DefaultTabController with zero tabs',
+          (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/32428
+        int noOfTabs = 0;
+        List<Widget> tabList;
+        List<Widget> tabViewList;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return DefaultTabController(
+                    length: noOfTabs,
+                    child: Scaffold(
+                      appBar: AppBar(
+                        title: const Text('Default TabBar Preview'),
+                        bottom: (noOfTabs > 0)
+                            ? TabBar(isScrollable: true, tabs: tabList)
+                            : null,
+                      ),
+                      body: (noOfTabs > 0)
+                          ? TabBarView(children: tabViewList)
+                          : const Center(
+                        child: Text('No tabs'),
+                      ),
+                      bottomNavigationBar: BottomAppBar(
+                        child: Row(
+                          mainAxisSize: MainAxisSize.max,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: <Widget>[
+                            IconButton(
+                              key: const Key('Add tab'),
+                              icon: const Icon(Icons.add),
+                              onPressed: () {
+                                setState(() {
+                                  noOfTabs++;
+                                });
+
+                                tabList = <Widget>[];
+                                tabViewList = <Widget>[];
+
+                                for (int i = 0; i < noOfTabs; i++) {
+                                  tabList
+                                      .add(
+                                      Tab(text: 'Tab ' + (i + 1).toString()));
+                                  tabViewList.add(Center(
+                                      child: Text(
+                                          'Tab ' + (i + 1).toString())));
+                                }
+                              },
+                            ),
+                            IconButton(
+                              key: const Key('Del tab'),
+                              icon: Icon(Icons.delete),
+                              onPressed: () {
+                                setState(() {
+                                  noOfTabs--;
+                                });
+
+                                tabList = <Widget>[];
+                                tabViewList = <Widget>[];
+
+                                for (int i = 0; i < noOfTabs; i++) {
+                                  tabList
+                                      .add(
+                                      Tab(text: 'Tab ' + (i + 1).toString()));
+                                  tabViewList.add(Center(
+                                      child: Text(
+                                          'Tab ' + (i + 1).toString())));
+                                }
+                              },
+                            )
+                          ],
+                        ),
+                      ),
+                    ));
+              },
+            ),
+          ),
+        );
+        expect(find.text('No tabs'), findsOneWidget);
+        await tester.tap(find.byKey(const Key('Add tab')));
+        await tester.pumpAndSettle();
+        expect(find.text('Tab 1'), findsNWidgets(2));
+        await tester.tap(find.byKey(const Key('Del tab')));
+        await tester.pumpAndSettle();
+        expect(find.text('Tab 1'), findsNothing);
+        expect(find.text('No tabs'), findsOneWidget);
+      });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2350,7 +2350,7 @@ void main() {
     expect(find.text('Tab1'), findsOneWidget);
     expect(find.text('Tab2'), findsOneWidget);
   });
-  
+
     testWidgets('DefaultTabController with zero tabs',
           (WidgetTester tester) async {
         // Regression test for https://github.com/flutter/flutter/issues/32428

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2404,7 +2404,7 @@ void main() {
                             ),
                             IconButton(
                               key: const Key('Del tab'),
-                              icon: Icon(Icons.delete),
+                              icon: const Icon(Icons.delete),
                               onPressed: () {
                                 setState(() {
                                   noOfTabs--;

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2350,94 +2350,72 @@ void main() {
     expect(find.text('Tab1'), findsOneWidget);
     expect(find.text('Tab2'), findsOneWidget);
   });
+  testWidgets('DefaultTabController should allow for a length of zero', (
+      WidgetTester tester) async {
+    // Test for https://github.com/flutter/flutter/issues/37139
+    final List<Widget> tabList = <Widget>[];
+    final List<Widget> tabViewList = <Widget>[];
 
-    testWidgets('DefaultTabController with zero tabs',
-          (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/32428
-        int noOfTabs = 0;
-        List<Widget> tabList;
-        List<Widget> tabViewList;
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return DefaultTabController(
-                    length: noOfTabs,
-                    child: Scaffold(
-                      appBar: AppBar(
-                        title: const Text('Default TabBar Preview'),
-                        bottom: (noOfTabs > 0)
-                            ? TabBar(isScrollable: true, tabs: tabList)
-                            : null,
-                      ),
-                      body: (noOfTabs > 0)
-                          ? TabBarView(children: tabViewList)
-                          : const Center(
-                        child: Text('No tabs'),
-                      ),
-                      bottomNavigationBar: BottomAppBar(
-                        child: Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: <Widget>[
-                            IconButton(
-                              key: const Key('Add tab'),
-                              icon: const Icon(Icons.add),
-                              onPressed: () {
-                                setState(() {
-                                  noOfTabs++;
-                                });
-
-                                tabList = <Widget>[];
-                                tabViewList = <Widget>[];
-
-                                for (int i = 0; i < noOfTabs; i++) {
-                                  tabList
-                                      .add(
-                                      Tab(text: 'Tab ' + (i + 1).toString()));
-                                  tabViewList.add(Center(
-                                      child: Text(
-                                          'Tab ' + (i + 1).toString())));
-                                }
-                              },
-                            ),
-                            IconButton(
-                              key: const Key('Del tab'),
-                              icon: const Icon(Icons.delete),
-                              onPressed: () {
-                                setState(() {
-                                  noOfTabs--;
-                                });
-
-                                tabList = <Widget>[];
-                                tabViewList = <Widget>[];
-
-                                for (int i = 0; i < noOfTabs; i++) {
-                                  tabList
-                                      .add(
-                                      Tab(text: 'Tab ' + (i + 1).toString()));
-                                  tabViewList.add(Center(
-                                      child: Text(
-                                          'Tab ' + (i + 1).toString())));
-                                }
-                              },
-                            )
-                          ],
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return DefaultTabController(
+                length: tabList.length,
+                child: Scaffold(
+                  appBar: AppBar(
+                    title: const Text('Default TabBar Preview'),
+                    bottom: (tabList.length > 0)
+                        ? TabBar(isScrollable: true, tabs: tabList)
+                        : null,
+                  ),
+                  body: (tabList.length > 0)
+                      ? TabBarView(children: tabViewList)
+                      : const Center(
+                    child: Text('No tabs'),
+                  ),
+                  bottomNavigationBar: BottomAppBar(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        IconButton(
+                          key: const Key('Add tab'),
+                          icon: const Icon(Icons.add),
+                          onPressed: () {
+                            setState(() {
+                              tabList.add(
+                                  Tab(text: 'Tab ${tabList.length + 1}'));
+                              tabViewList.add(Center(child: Text(
+                                  'Tab ${tabViewList.length + 1}')));
+                            });
+                          },
                         ),
-                      ),
-                    ));
-              },
-            ),
-          ),
-        );
-        expect(find.text('No tabs'), findsOneWidget);
-        await tester.tap(find.byKey(const Key('Add tab')));
-        await tester.pumpAndSettle();
-        expect(find.text('Tab 1'), findsNWidgets(2));
-        await tester.tap(find.byKey(const Key('Del tab')));
-        await tester.pumpAndSettle();
-        expect(find.text('Tab 1'), findsNothing);
-        expect(find.text('No tabs'), findsOneWidget);
-      });
+                        IconButton(
+                          key: const Key('Del tab'),
+                          icon: const Icon(Icons.delete),
+                          onPressed: () {
+                            setState(() {
+                              tabList.removeLast();
+                              tabViewList.removeLast();
+                            });
+                          },
+                        )
+                      ],
+                    ),
+                  ),
+                ));
+          },
+        ),
+      ),
+    );
+    expect(find.text('No tabs'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('Add tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('Tab 1'), findsNWidgets(2));
+    await tester.tap(find.byKey(const Key('Del tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('Tab 1'), findsNothing);
+    expect(find.text('No tabs'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2365,11 +2365,11 @@ void main() {
                 child: Scaffold(
                   appBar: AppBar(
                     title: const Text('Default TabBar Preview'),
-                    bottom: (tabList.length > 0)
+                    bottom: (tabList.isNotEmpty)
                         ? TabBar(isScrollable: true, tabs: tabList)
                         : null,
                   ),
-                  body: (tabList.length > 0)
+                  body: (tabList.isNotEmpty)
                       ? TabBarView(children: tabViewList)
                       : const Center(
                     child: Text('No tabs'),


### PR DESCRIPTION
Prevents an assert error when the DefaultTabController is created and contains no tabs.

## Description

This PR fixes a problem when a DefaultTabController is created with no tabs.

## Related Issues

https://github.com/flutter/flutter/issues/37139

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
