### PR TITLE
[WIP] place ResidentRunner artifacts in isolated directory

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -257,7 +257,6 @@ class AttachCommand extends FlutterCommand {
         device,
         flutterProject: flutterProject,
         trackWidgetCreation: argResults['track-widget-creation'],
-        dillOutputPath: argResults['output-dill'],
         fileSystemRoots: argResults['filesystem-root'],
         fileSystemScheme: argResults['filesystem-scheme'],
         viewFilter: argResults['isolate-filter'],

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -406,7 +406,6 @@ class AppDomain extends Domain {
       device,
       flutterProject: flutterProject,
       trackWidgetCreation: trackWidgetCreation,
-      dillOutputPath: dillOutputPath,
       viewFilter: isolateFilter,
       target: target,
       buildMode: options.buildInfo.mode,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -397,7 +397,6 @@ class RunCommand extends RunCommandBase {
         device,
         flutterProject: flutterProject,
         trackWidgetCreation: argResults['track-widget-creation'],
-        dillOutputPath: argResults['output-dill'],
         fileSystemRoots: argResults['filesystem-root'],
         fileSystemScheme: argResults['filesystem-scheme'],
         viewFilter: argResults['isolate-filter'],

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -539,7 +539,7 @@ abstract class ResidentRunner {
          useBuildIsolation: useBuildIsolation,
          flutterDevices: flutterDevices,
          projectRootPath: projectRootPath,
-         target: target,
+         target: findMainDartFile(target),
          debuggingOptions: debuggingOptions,
        ) {
           // Create the isolated build directory if it doesn't already exist.

--- a/packages/flutter_tools/lib/src/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_web_runner.dart
@@ -41,6 +41,7 @@ class ResidentWebRunner extends ResidentRunner {
           ipv6: ipv6,
           usesTerminalUi: true,
           stayResident: true,
+          useBuildIsolation: false,
         );
 
   WebAssetServer _server;

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -31,6 +31,7 @@ class ColdRunner extends ResidentRunner {
              hotMode: false,
              usesTerminalUi: usesTerminalUi,
              stayResident: stayResident,
+             useBuildIsolation: false,
              ipv6: ipv6);
 
   final bool traceStartup;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -74,6 +74,7 @@ class HotRunner extends ResidentRunner {
              packagesFilePath: packagesFilePath,
              stayResident: stayResident,
              hotMode: true,
+             useBuildIsolation: dillOutputPath == null,
              ipv6: ipv6);
 
   final bool benchmarkMode;
@@ -302,8 +303,9 @@ class HotRunner extends ResidentRunner {
         bundleDirty: isFirstUpload == false && rebuildBundle,
         fullRestart: fullRestart,
         projectRootPath: projectRootPath,
-        pathToReload: getReloadPath(fullRestart: fullRestart),
         invalidatedFiles: invalidatedFiles,
+        dillOutputPath: dillOutputPath ?? environment.buildDir.childFile('app.dill').path,
+        pathToReload: getReloadPath(fullRestart: fullRestart),
       ));
     }
     return results;

--- a/packages/flutter_tools/test/general.shard/commands/attach_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/attach_test.dart
@@ -168,7 +168,6 @@ void main() {
         // output dill, filesystem scheme, and filesystem root.
         final FlutterDevice flutterDevice = flutterDevices.first;
 
-        expect(flutterDevice.dillOutputPath, outputDill);
         expect(flutterDevice.fileSystemScheme, filesystemScheme);
         expect(flutterDevice.fileSystemRoots, const <String>[filesystemRoot]);
       }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -66,6 +66,7 @@ void main() {
       fullRestart: anyNamed('fullRestart'),
       projectRootPath: anyNamed('projectRootPath'),
       pathToReload: anyNamed('pathToReload'),
+      dillOutputPath: anyNamed('dillOutputPath'),
     )).thenAnswer((Invocation invocation) async {
       return UpdateFSReport(
         success: true,
@@ -156,6 +157,7 @@ void main() {
       projectRootPath: anyNamed('projectRootPath'),
       pathToReload: anyNamed('pathToReload'),
       invalidatedFiles: anyNamed('invalidatedFiles'),
+      dillOutputPath: anyNamed('dillOutputPath'),
     )).thenThrow(RpcException(666, 'something bad happened'));
 
     final OperationResult result = await residentRunner.restart(fullRestart: false);
@@ -200,6 +202,7 @@ void main() {
       projectRootPath: anyNamed('projectRootPath'),
       pathToReload: anyNamed('pathToReload'),
       invalidatedFiles: anyNamed('invalidatedFiles'),
+      dillOutputPath: anyNamed('dillOutputPath'),
     )).thenThrow(RpcException(666, 'something bad happened'));
 
     final OperationResult result = await residentRunner.restart(fullRestart: true);

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -395,7 +395,7 @@ class MockFlutterDevice extends Mock implements FlutterDevice {}
 
 class TestRunner extends ResidentRunner {
   TestRunner(List<FlutterDevice> devices)
-    : super(devices);
+    : super(devices, useBuildIsolation: false);
 
   bool hasHelpBeenPrinted = false;
   String receivedCommand;


### PR DESCRIPTION
## Description

By default, the ResidentRunner will output incremental dill files at the same location regardless of how the build was run or the connected devices. This works when there is a single tool process, but multiple tool process sharing the same directory will all attempt to read and write to the same file. The build system Environment is used to create a unique-ish subdirector where this process would be the only user. The inputs to the name are the identifiers of the connected devices, the mode, and the target file.

This approach is preferable to something like a lockfile, because that doesn't prevent different applications (say, target files) from clobbering each other.

Fixes https://github.com/flutter/flutter/issues/18566