### PR TITLE
Fix Textfields in Semantics Debugger

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -228,7 +228,8 @@ class _SemanticsDebuggerPainter extends CustomPainter {
         || pointerPosition != oldDelegate.pointerPosition;
   }
 
-  String _getMessage(SemanticsNode node) {
+  @visibleForTesting
+  String getMessage(SemanticsNode node) {
     final SemanticsData data = node.getSemanticsData();
     final List<String> annotations = <String>[];
 
@@ -296,14 +297,8 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     return message.trim();
   }
 
-  static const TextStyle _messageStyle = TextStyle(
-    color: Color(0xFF000000),
-    fontSize: 10.0,
-    height: 0.8,
-  );
-
   void _paintMessage(Canvas canvas, SemanticsNode node) {
-    final String message = _getMessage(node);
+    final String message = getMessage(node);
     if (message.isEmpty)
       return;
     final Rect rect = node.rect;
@@ -311,7 +306,11 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     canvas.clipRect(rect);
     final TextPainter textPainter = TextPainter()
       ..text = TextSpan(
-        style: _messageStyle,
+        style: const TextStyle(
+          color: Color(0xFF000000),
+          fontSize: 10.0,
+          height: 0.8,
+        ),
         text: message,
       )
       ..textDirection = TextDirection.ltr // _getMessage always returns LTR text, even if node.label is RTL

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -194,147 +194,6 @@ class _SemanticsClient extends ChangeNotifier {
   }
 }
 
-String _getMessage(SemanticsNode node) {
-  final SemanticsData data = node.getSemanticsData();
-  final List<String> annotations = <String>[];
-
-  bool wantsTap = false;
-  if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
-    annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
-    wantsTap = true;
-  }
-  if (data.hasFlag(SemanticsFlag.isTextField)) {
-    annotations.add('textfield');
-    wantsTap = true;
-  }
-
-  if (data.hasAction(SemanticsAction.tap)) {
-    if (!wantsTap)
-      annotations.add('button');
-  } else {
-    if (wantsTap)
-      annotations.add('disabled');
-  }
-
-  if (data.hasAction(SemanticsAction.longPress))
-    annotations.add('long-pressable');
-
-  final bool isScrollable = data.hasAction(SemanticsAction.scrollLeft)
-                         || data.hasAction(SemanticsAction.scrollRight)
-                         || data.hasAction(SemanticsAction.scrollUp)
-                         || data.hasAction(SemanticsAction.scrollDown);
-
-  final bool isAdjustable = data.hasAction(SemanticsAction.increase)
-                         || data.hasAction(SemanticsAction.decrease);
-
-  if (isScrollable)
-    annotations.add('scrollable');
-
-  if (isAdjustable)
-    annotations.add('adjustable');
-
-  assert(data.label != null);
-  String message;
-  if (data.label.isEmpty) {
-    message = annotations.join('; ');
-  } else {
-    String label;
-    if (data.textDirection == null) {
-      label = '${Unicode.FSI}${data.label}${Unicode.PDI}';
-      annotations.insert(0, 'MISSING TEXT DIRECTION');
-    } else {
-      switch (data.textDirection) {
-        case TextDirection.rtl:
-          label = '${Unicode.RLI}${data.label}${Unicode.PDF}';
-          break;
-        case TextDirection.ltr:
-          label = data.label;
-          break;
-      }
-    }
-    if (annotations.isEmpty) {
-      message = label;
-    } else {
-      message = '$label (${annotations.join('; ')})';
-    }
-  }
-
-  return message.trim();
-}
-
-const TextStyle _messageStyle = TextStyle(
-  color: Color(0xFF000000),
-  fontSize: 10.0,
-  height: 0.8,
-);
-
-void _paintMessage(Canvas canvas, SemanticsNode node) {
-  final String message = _getMessage(node);
-  if (message.isEmpty)
-    return;
-  final Rect rect = node.rect;
-  canvas.save();
-  canvas.clipRect(rect);
-  final TextPainter textPainter = TextPainter()
-    ..text = TextSpan(
-      style: _messageStyle,
-      text: message,
-    )
-    ..textDirection = TextDirection.ltr // _getMessage always returns LTR text, even if node.label is RTL
-    ..textAlign = TextAlign.center
-    ..layout(maxWidth: rect.width);
-
-  textPainter.paint(canvas, Alignment.center.inscribe(textPainter.size, rect).topLeft);
-  canvas.restore();
-}
-
-int _findDepth(SemanticsNode node) {
-  if (!node.hasChildren || node.mergeAllDescendantsIntoThisNode)
-    return 1;
-  int childrenDepth = 0;
-  node.visitChildren((SemanticsNode child) {
-    childrenDepth = math.max(childrenDepth, _findDepth(child));
-    return true;
-  });
-  return childrenDepth + 1;
-}
-
-void _paint(Canvas canvas, SemanticsNode node, int rank) {
-  canvas.save();
-  if (node.transform != null)
-    canvas.transform(node.transform.storage);
-  final Rect rect = node.rect;
-  if (!rect.isEmpty) {
-    final Color lineColor = Color(0xFF000000 + math.Random(node.id).nextInt(0xFFFFFF));
-    final Rect innerRect = rect.deflate(rank * 1.0);
-    if (innerRect.isEmpty) {
-      final Paint fill = Paint()
-       ..color = lineColor
-       ..style = PaintingStyle.fill;
-      canvas.drawRect(rect, fill);
-    } else {
-      final Paint fill = Paint()
-       ..color = const Color(0xFFFFFFFF)
-       ..style = PaintingStyle.fill;
-      canvas.drawRect(rect, fill);
-      final Paint line = Paint()
-       ..strokeWidth = rank * 2.0
-       ..color = lineColor
-       ..style = PaintingStyle.stroke;
-      canvas.drawRect(innerRect, line);
-    }
-    _paintMessage(canvas, node);
-  }
-  if (!node.mergeAllDescendantsIntoThisNode) {
-    final int childRank = rank - 1;
-    node.visitChildren((SemanticsNode child) {
-      _paint(canvas, child, childRank);
-      return true;
-    });
-  }
-  canvas.restore();
-}
-
 class _SemanticsDebuggerPainter extends CustomPainter {
   const _SemanticsDebuggerPainter(this.owner, this.generation, this.pointerPosition, this.devicePixelRatio);
 
@@ -367,5 +226,146 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     return owner != oldDelegate.owner
         || generation != oldDelegate.generation
         || pointerPosition != oldDelegate.pointerPosition;
+  }
+
+  String _getMessage(SemanticsNode node) {
+    final SemanticsData data = node.getSemanticsData();
+    final List<String> annotations = <String>[];
+
+    bool wantsTap = false;
+    if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
+      annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
+      wantsTap = true;
+    }
+    if (data.hasFlag(SemanticsFlag.isTextField)) {
+      annotations.add('textfield');
+      wantsTap = true;
+    }
+
+    if (data.hasAction(SemanticsAction.tap)) {
+      if (!wantsTap)
+        annotations.add('button');
+    } else {
+      if (wantsTap)
+        annotations.add('disabled');
+    }
+
+    if (data.hasAction(SemanticsAction.longPress))
+      annotations.add('long-pressable');
+
+    final bool isScrollable = data.hasAction(SemanticsAction.scrollLeft)
+        || data.hasAction(SemanticsAction.scrollRight)
+        || data.hasAction(SemanticsAction.scrollUp)
+        || data.hasAction(SemanticsAction.scrollDown);
+
+    final bool isAdjustable = data.hasAction(SemanticsAction.increase)
+        || data.hasAction(SemanticsAction.decrease);
+
+    if (isScrollable)
+      annotations.add('scrollable');
+
+    if (isAdjustable)
+      annotations.add('adjustable');
+
+    assert(data.label != null);
+    String message;
+    if (data.label.isEmpty) {
+      message = annotations.join('; ');
+    } else {
+      String label;
+      if (data.textDirection == null) {
+        label = '${Unicode.FSI}${data.label}${Unicode.PDI}';
+        annotations.insert(0, 'MISSING TEXT DIRECTION');
+      } else {
+        switch (data.textDirection) {
+          case TextDirection.rtl:
+            label = '${Unicode.RLI}${data.label}${Unicode.PDF}';
+            break;
+          case TextDirection.ltr:
+            label = data.label;
+            break;
+        }
+      }
+      if (annotations.isEmpty) {
+        message = label;
+      } else {
+        message = '$label (${annotations.join('; ')})';
+      }
+    }
+
+    return message.trim();
+  }
+
+  static const TextStyle _messageStyle = TextStyle(
+    color: Color(0xFF000000),
+    fontSize: 10.0,
+    height: 0.8,
+  );
+
+  void _paintMessage(Canvas canvas, SemanticsNode node) {
+    final String message = _getMessage(node);
+    if (message.isEmpty)
+      return;
+    final Rect rect = node.rect;
+    canvas.save();
+    canvas.clipRect(rect);
+    final TextPainter textPainter = TextPainter()
+      ..text = TextSpan(
+        style: _messageStyle,
+        text: message,
+      )
+      ..textDirection = TextDirection.ltr // _getMessage always returns LTR text, even if node.label is RTL
+      ..textAlign = TextAlign.center
+      ..layout(maxWidth: rect.width);
+
+    textPainter.paint(canvas, Alignment.center.inscribe(textPainter.size, rect).topLeft);
+    canvas.restore();
+  }
+
+  int _findDepth(SemanticsNode node) {
+    if (!node.hasChildren || node.mergeAllDescendantsIntoThisNode)
+      return 1;
+    int childrenDepth = 0;
+    node.visitChildren((SemanticsNode child) {
+      childrenDepth = math.max(childrenDepth, _findDepth(child));
+      return true;
+    });
+    return childrenDepth + 1;
+  }
+
+  void _paint(Canvas canvas, SemanticsNode node, int rank) {
+    canvas.save();
+    if (node.transform != null)
+      canvas.transform(node.transform.storage);
+    final Rect rect = node.rect;
+    if (!rect.isEmpty) {
+      final Color lineColor = Color(0xFF000000 + math.Random(node.id).nextInt(0xFFFFFF));
+      final Rect innerRect = rect.deflate(rank * 1.0);
+      if (innerRect.isEmpty) {
+        final Paint fill = Paint()
+          ..color = lineColor
+          ..style = PaintingStyle.fill;
+        canvas.drawRect(rect, fill);
+      } else {
+        final Paint fill = Paint()
+          ..color = const Color(0xFFFFFFFF)
+          ..style = PaintingStyle.fill;
+        canvas.drawRect(rect, fill);
+        final Paint line = Paint()
+          ..strokeWidth = rank * 2.0
+          ..color = lineColor
+          ..style = PaintingStyle.stroke;
+        canvas.drawRect(innerRect, line);
+      }
+      _paintMessage(canvas, node);
+    }
+    if (!node.mergeAllDescendantsIntoThisNode) {
+      final int childRank = rank - 1;
+      node.visitChildren((SemanticsNode child) {
+        _paint(canvas, child, childRank);
+        return true;
+      });
+    }
+    canvas.restore();
   }
 }

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -203,6 +203,10 @@ String _getMessage(SemanticsNode node) {
     annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
     wantsTap = true;
   }
+  if (data.hasFlag(SemanticsFlag.isTextField)) {
+    annotations.add('textfield');
+    wantsTap = true;
+  }
 
   if (data.hasAction(SemanticsAction.tap)) {
     if (!wantsTap)

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -397,7 +397,7 @@ void main() {
                 Semantics(
                   container: true,
                   key: checkboxDisabled,
-                  child: Checkbox(
+                  child: const Checkbox(
                     value: true,
                     onChanged: null,
                   ),
@@ -405,7 +405,7 @@ void main() {
                 Semantics(
                   container: true,
                   key: checkboxDisabledUnchecked,
-                  child: Checkbox(
+                  child: const Checkbox(
                     value: false,
                     onChanged: null,
                   ),

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -362,4 +362,113 @@ void main() {
     expect(valueTop, isFalse);
     expect(valueTop, isFalse);
   });
+
+  testWidgets('SemanticsDebugger checkbox message', (WidgetTester tester) async {
+    final Key checkbox = UniqueKey();
+    final Key checkboxUnchecked = UniqueKey();
+    final Key checkboxDisabled = UniqueKey();
+    final Key checkboxDisabledUnchecked = UniqueKey();
+    final Key debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: ListView(
+              children: <Widget>[
+                Semantics(
+                  container: true,
+                  key: checkbox,
+                  child: Checkbox(
+                    value: true,
+                    onChanged: (bool _) { },
+                  ),
+                ),
+                Semantics(
+                  container: true,
+                  key: checkboxUnchecked,
+                  child: Checkbox(
+                    value: false,
+                    onChanged: (bool _) { },
+                  ),
+                ),
+                Semantics(
+                  container: true,
+                  key: checkboxDisabled,
+                  child: Checkbox(
+                    value: true,
+                    onChanged: null,
+                  ),
+                ),
+                Semantics(
+                  container: true,
+                  key: checkboxDisabledUnchecked,
+                  child: Checkbox(
+                    value: false,
+                    onChanged: null,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      _getMessageShownInSemanticsDebugger(widgetKey: checkbox, debuggerKey: debugger, tester: tester),
+      'checked',
+    );
+    expect(
+      _getMessageShownInSemanticsDebugger(widgetKey: checkboxUnchecked, debuggerKey: debugger, tester: tester),
+      'unchecked',
+    );
+    expect(
+      _getMessageShownInSemanticsDebugger(widgetKey: checkboxDisabled, debuggerKey: debugger, tester: tester),
+      'checked; disabled',
+    );
+    expect(
+      _getMessageShownInSemanticsDebugger(widgetKey: checkboxDisabledUnchecked, debuggerKey: debugger, tester: tester),
+      'unchecked; disabled',
+    );
+  });
+
+  testWidgets('SemanticsDebugger textfield', (WidgetTester tester) async {
+    final UniqueKey textField = UniqueKey();
+    final UniqueKey debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: TextField(
+              key: textField,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      _getMessageShownInSemanticsDebugger(widgetKey: textField, debuggerKey: debugger, tester: tester),
+      'textfield',
+    );
+  });
+}
+
+String _getMessageShownInSemanticsDebugger({
+  @required Key widgetKey,
+  @required Key debuggerKey,
+  @required WidgetTester tester,
+}) {
+  final CustomPaint customPaint = tester.widgetList(find.descendant(
+    of: find.byKey(debuggerKey),
+    matching: find.byType(CustomPaint),
+  )).first;
+  final dynamic semanticsDebuggerPainter = customPaint.foregroundPainter;
+  expect(semanticsDebuggerPainter.runtimeType.toString(), '_SemanticsDebuggerPainter');
+  return semanticsDebuggerPainter.getMessage(tester.renderObject(find.byKey(widgetKey)).debugSemantics);
 }


### PR DESCRIPTION
## Description

Identifies textfields as Textfields in the semantics debugger. (Previously they were labeled as buttons, which is technically correct since they are tap-able, but it's also misleading.)

## Related Issues

None

## Tests

Unclear how to test that a custom paint writes the correct text on the canvas.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
