### PR TITLE
Form validateSilent() method

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -380,7 +380,7 @@ class FormFieldState<T> extends State<FormField<T>> {
     if (widget.validator != null)
       _errorText = widget.validator(_value);
   }
-  
+
   /// Calls [FormField.validator] to validate the field. Returns true if there
   /// were no errors. Doesn't set [errorText] and doesn't rebuild the widget.
   bool validateSilent() {

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -203,12 +203,13 @@ class FormState extends State<Form> {
       hasError = !field.validate() || hasError;
     return !hasError;
   }
-  
+
   /// Validates every [FormField] that is a descendant of this [Form] until
   /// the first error. Returns true if there are no errors.
   bool validateSilent() {
     for (FormFieldState<dynamic> field in _fields) {
-      if (!field.validateSilent()) return false;
+      if (!field.validateSilent())
+        return false;
     }
     return true;
   }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -203,6 +203,15 @@ class FormState extends State<Form> {
       hasError = !field.validate() || hasError;
     return !hasError;
   }
+  
+  /// Validates every [FormField] that is a descendant of this [Form] until
+  /// the first error. Returns true if there are no errors.
+  bool validateSilent() {
+    for (FormFieldState<dynamic> field in _fields) {
+      if (!field.validateSilent()) return false;
+    }
+    return true;
+  }
 }
 
 class _FormScope extends InheritedWidget {
@@ -369,6 +378,12 @@ class FormFieldState<T> extends State<FormField<T>> {
   void _validate() {
     if (widget.validator != null)
       _errorText = widget.validator(_value);
+  }
+  
+  /// Calls [FormField.validator] to validate the field. Returns true if there
+  /// were no errors. Doesn't set [errorText] and doesn't rebuild the widget.
+  bool validateSilent() {
+    return widget.validator(_value) != null;
   }
 
   /// Updates this field's state to the new value. Useful for responding to

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -384,7 +384,10 @@ class FormFieldState<T> extends State<FormField<T>> {
   /// Calls [FormField.validator] to validate the field. Returns true if there
   /// were no errors. Doesn't set [errorText] and doesn't rebuild the widget.
   bool validateSilent() {
-    return widget.validator(_value) != null;
+    if (widget.validator != null) {
+      return widget.validator(_value) == null;
+    }
+    return true;
   }
 
   /// Updates this field's state to the new value. Useful for responding to

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -462,6 +462,7 @@ void main() {
 
     expect(fieldValue, isNull);
     expect(formKey.currentState.validate(), isTrue);
+    expect(formKey.currentState.validateSilent(), isTrue);
 
     await tester.enterText(find.byType(TextFormField), 'Test');
     await tester.pumpWidget(builder(false));
@@ -469,12 +470,14 @@ void main() {
     // Form wasn't saved yet.
     expect(fieldValue, null);
     expect(formKey.currentState.validate(), isFalse);
+    expect(formKey.currentState.validateSilent(), isFalse);
 
     formKey.currentState.save();
 
     // Now fieldValue is saved.
     expect(fieldValue, 'Test');
     expect(formKey.currentState.validate(), isFalse);
+    expect(formKey.currentState.validateSilent(), isFalse);
 
     // Now remove the field with an error.
     await tester.pumpWidget(builder(true));
@@ -483,5 +486,6 @@ void main() {
     formKey.currentState.reset();
     formKey.currentState.save();
     expect(formKey.currentState.validate(), isTrue);
+    expect(formKey.currentState.validateSilent(), isTrue);
   });
 }


### PR DESCRIPTION
## Description

The form doesn't have methods to validate without rebuilding and showing error messages. This imposes some restrictions. For example, you can't check is form valid in dispose() or deactivate() method (someone can want to autosave the data, when the page is closing).

To resolve this, i added `validateSilent()` methods to FormState and FormFieldState. These methods validates the fields, but they don't modify view.

## Related Issues

I didn't found related issues.

## Tests

I changed the Form test, now it also tests the new methods.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
