### PR TITLE
[flutter_tool] Usage refactor cleanup

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -334,6 +334,15 @@ class GroupedValidator extends DoctorValidator {
 
   final List<DoctorValidator> subValidators;
 
+  List<ValidationResult> _subResults;
+
+  /// Subvalidator results.
+  ///
+  /// To avoid losing information when results are merged, the subresults are
+  /// cached on this field when they are available. The results are in the same
+  /// order as the subvalidator list.
+  List<ValidationResult> get subResults => _subResults;
+
   @override
   String get slowWarning => _currentSlowWarning;
   String _currentSlowWarning = 'Initializing...';
@@ -356,6 +365,7 @@ class GroupedValidator extends DoctorValidator {
 
   ValidationResult _mergeValidationResults(List<ValidationResult> results) {
     assert(results.isNotEmpty, 'Validation results should not be empty');
+    _subResults = results;
     ValidationType mergedType = results[0].type;
     final List<ValidationMessage> mergedMessages = <ValidationMessage>[];
     String statusInfo;

--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -276,6 +276,22 @@ void main() {
       Platform: _kNoColorOutputPlatform,
       Usage: () => mockUsage,
     });
+
+    testUsingContext('events for grouped validators are properly decomposed', () async {
+      await FakeGroupedDoctor().diagnose(verbose: false);
+
+      expect(
+        verify(mockUsage.sendEvent('doctorResult.PassingGroupedValidator', captureAny)).captured,
+        <dynamic>['installed', 'installed', 'installed'],
+      );
+      expect(
+        verify(mockUsage.sendEvent('doctorResult.MissingGroupedValidator', captureAny)).captured,
+        <dynamic>['missing'],
+      );
+    }, overrides: <Type, Generator>{
+      Platform: _kNoColorOutputPlatform,
+      Usage: () => mockUsage,
+    });
   });
 
   group('doctor with fake validators', () {


### PR DESCRIPTION
## Description

This PR has two missing cleanups from the `Usage` refactor PR:
* It adds a test that full restart sends the target platform in the usage event
* It decomposes GroupedValidators when sending their events.

## Tests

I added the following tests:

Tests in resident_runner_test.dart and doctor_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
