### PR TITLE
use FlutterError in MultiChildRenderObjectWidget

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1688,8 +1688,9 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
       assert(() {
         final int index = children.indexOf(null);
         if (index >= 0) {
-          throw AssertionError(
-            "The widget's children must not contain any null values, but a null value was found at index $index"
+          throw FlutterError(
+            "$runtimeType's children must not contain any null values, "
+            'but a null value was found at index $index'
           );
         }
         return true;

--- a/packages/flutter/test/widgets/multichild_test.dart
+++ b/packages/flutter/test/widgets/multichild_test.dart
@@ -32,7 +32,7 @@ void checkTree(WidgetTester tester, List<BoxDecoration> expectedDecorations) {
 }
 
 class MockMultiChildRenderObjectWidget extends MultiChildRenderObjectWidget {
-  MockMultiChildRenderObjectWidget({Key key, List<Widget> children}) : super(key: key, children: children);
+  MockMultiChildRenderObjectWidget({ Key key, List<Widget> children }) : super(key: key, children: children);
 
   @override
   RenderObject createRenderObject(BuildContext context) => null;

--- a/packages/flutter/test/widgets/multichild_test.dart
+++ b/packages/flutter/test/widgets/multichild_test.dart
@@ -31,6 +31,13 @@ void checkTree(WidgetTester tester, List<BoxDecoration> expectedDecorations) {
   }
 }
 
+class MockMultiChildRenderObjectWidget extends MultiChildRenderObjectWidget {
+  MockMultiChildRenderObjectWidget({Key key, List<Widget> children}) : super(key: key, children: children);
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => null;
+}
+
 void main() {
   testWidgets('MultiChildRenderObjectElement control test', (WidgetTester tester) async {
 
@@ -344,5 +351,18 @@ void main() {
     );
 
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC]);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/37136.
+  test('provides useful assertion message when one of the children is null', () {
+    bool assertionTriggered = false;
+    try {
+      MockMultiChildRenderObjectWidget(children: const <Widget>[null]);
+    } catch (e) {
+      expect(e.toString(), contains("MockMultiChildRenderObjectWidget's children must not contain any null values,"));
+      assertionTriggered = true;
+    }
+
+    expect(assertionTriggered, isTrue);
   });
 }


### PR DESCRIPTION
## Description

Throw `FlutterError` instead of `AssertionError` whose `toString()` doesn't provide any insight of what caused the framework to assert.

Now the error message should read:
> I/flutter ( 4170): ══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
I/flutter ( 4170): The following assertion was thrown building TestPage(dirty, state: _TestPageState#a4aee):
I/flutter ( 4170): Column's children must not contain any null values, but a null value was found at index 0
I/flutter ( 4170):
I/flutter ( 4170): User-created ancestor of the error-causing widget was:
I/flutter ( 4170):   MaterialApp org-dartlang-app:/main.dart:55:12

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37136
Fixes https://github.com/flutter/flutter/issues/37056
and many others

## Tests

I added the following tests:

- provides useful assertion message when one of the children is null

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
