### PR TITLE
[flutter_tool] Catch ProcessException from 'adb devices'

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -678,8 +678,11 @@ List<AndroidDevice> getAdbDevices() {
   try {
     text = runSync(<String>[adbPath, 'devices', '-l']);
   } on ArgumentError catch (exception) {
-    throwToolExit('Unable to run "adb", check your Android SDK installation and '
+    throwToolExit('Unable to find "adb", check your Android SDK installation and '
       'ANDROID_HOME environment variable: ${exception.message}');
+  } on ProcessException catch (exception) {
+    throwToolExit('Unable to run "adb", check your Android SDK installation and '
+      'ANDROID_HOME environment variable: ${exception.executable}');
   }
   final List<AndroidDevice> devices = <AndroidDevice>[];
   parseADBDeviceOutput(text, devices: devices);


### PR DESCRIPTION
## Description

This PR catches a `ProcessException` in addition to an `ArgumentError` on a call out to `adb devices`. We get the `ArgumentError` when adb is not found, and we get a `ProcessException` when it is found but running it results in a `ProcessException` from `dart:io`.

## Related Issues

https://github.com/flutter/flutter/issues/36074

## Tests

I added the following tests:

Added test to android_device_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.