### PR TITLE
prototype ignore semantics actions

### DIFF
--- a/examples/flutter_gallery/ios/Flutter/flutter_export_environment.sh
+++ b/examples/flutter_gallery/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/chtai/git/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/chtai/git/flutter/examples/flutter_gallery"
+export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "FLUTTER_FRAMEWORK_DIR=/Users/chtai/git/flutter/bin/cache/artifacts/engine/ios"

--- a/examples/flutter_gallery/ios/Flutter/flutter_export_environment.sh
+++ b/examples/flutter_gallery/ios/Flutter/flutter_export_environment.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/Users/chtai/git/flutter"
-export "FLUTTER_APPLICATION_PATH=/Users/chtai/git/flutter/examples/flutter_gallery"
-export "FLUTTER_TARGET=lib/main.dart"
-export "FLUTTER_BUILD_DIR=build"
-export "SYMROOT=${SOURCE_ROOT}/../build/ios"
-export "FLUTTER_FRAMEWORK_DIR=/Users/chtai/git/flutter/bin/cache/artifacts/engine/ios"

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -825,7 +825,8 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
         child: EditableText(
           key: editableTextKey,
           controller: controller,
-          readOnly: widget.readOnly || !(widget.enabled ?? true),
+          readOnly: widget.readOnly,
+          enabled: enabled,
           toolbarOptions: widget.toolbarOptions,
           showCursor: widget.showCursor,
           showSelectionHandles: _showSelectionHandles,

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -825,7 +825,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
         child: EditableText(
           key: editableTextKey,
           controller: controller,
-          readOnly: widget.readOnly,
+          readOnly: widget.readOnly || !(widget.enabled ?? true),
           toolbarOptions: widget.toolbarOptions,
           showCursor: widget.showCursor,
           showSelectionHandles: _showSelectionHandles,
@@ -869,12 +869,13 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     );
 
     return Semantics(
-      onTap: () {
-        if (!controller.selection.isValid) {
-          controller.selection = TextSelection.collapsed(offset: controller.text.length);
-        }
-        _requestKeyboard();
-      },
+      onTap: enabled ?
+        () {
+          if (!controller.selection.isValid) {
+            controller.selection = TextSelection.collapsed(offset: controller.text.length);
+          }
+          _requestKeyboard();
+        } : null,
       child: IgnorePointer(
         ignoring: !enabled,
         child: Container(

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -971,7 +971,7 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
     Widget child = RepaintBoundary(
       child: EditableText(
         key: editableTextKey,
-        readOnly: widget.readOnly,
+        readOnly: widget.readOnly || !(widget.enabled ?? true),
         toolbarOptions: widget.toolbarOptions,
         showCursor: widget.showCursor,
         showSelectionHandles: _showSelectionHandles,
@@ -1035,7 +1035,9 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       );
     }
 
+    final bool enabled = widget.enabled ?? widget.decoration?.enabled ?? true;
     return Semantics(
+<<<<<<< HEAD
       onTap: () {
         if (!_effectiveController.selection.isValid)
           _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
@@ -1044,8 +1046,19 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       child: MouseRegion(
         onEnter: _handleMouseEnter,
         onExit: _handleMouseExit,
+=======
+      onTap: enabled ?
+        () {
+          if (!_effectiveController.selection.isValid)
+            _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
+          _requestKeyboard();
+        } : null,
+      child: Listener(
+        onPointerEnter: _handlePointerEnter,
+        onPointerExit: _handlePointerExit,
+>>>>>>> prototype ignore semantics actions
         child: IgnorePointer(
-          ignoring: !(widget.enabled ?? widget.decoration?.enabled ?? true),
+          ignoring: !enabled,
           child: _selectionGestureDetectorBuilder.buildGestureDetector(
             behavior: HitTestBehavior.translucent,
             child: child,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -967,11 +967,13 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
         cursorColor ??= themeData.cursorColor;
         break;
     }
+    final bool enabled = widget.enabled ?? widget.decoration?.enabled ?? true;
 
     Widget child = RepaintBoundary(
       child: EditableText(
         key: editableTextKey,
-        readOnly: widget.readOnly || !(widget.enabled ?? true),
+        readOnly: widget.readOnly,
+        enabled: enabled,
         toolbarOptions: widget.toolbarOptions,
         showCursor: widget.showCursor,
         showSelectionHandles: _showSelectionHandles,
@@ -1035,28 +1037,16 @@ class _TextFieldState extends State<TextField> with AutomaticKeepAliveClientMixi
       );
     }
 
-    final bool enabled = widget.enabled ?? widget.decoration?.enabled ?? true;
     return Semantics(
-<<<<<<< HEAD
-      onTap: () {
-        if (!_effectiveController.selection.isValid)
-          _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
-        _requestKeyboard();
-      },
+    onTap: enabled ?
+      () {
+      if (!_effectiveController.selection.isValid)
+        _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
+      _requestKeyboard();
+    } : null,
       child: MouseRegion(
         onEnter: _handleMouseEnter,
         onExit: _handleMouseExit,
-=======
-      onTap: enabled ?
-        () {
-          if (!_effectiveController.selection.isValid)
-            _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
-          _requestKeyboard();
-        } : null,
-      child: Listener(
-        onPointerEnter: _handlePointerEnter,
-        onPointerExit: _handlePointerExit,
->>>>>>> prototype ignore semantics actions
         child: IgnorePointer(
           ignoring: !enabled,
           child: _selectionGestureDetectorBuilder.buildGestureDetector(

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -158,6 +158,7 @@ class RenderEditable extends RenderBox {
     this.onCaretChanged,
     this.ignorePointer = false,
     bool readOnly = false,
+    bool enabled = true,
     bool forceLine = true,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     bool obscureText = false,
@@ -194,6 +195,7 @@ class RenderEditable extends RenderBox {
        assert(textSelectionDelegate != null),
        assert(cursorWidth != null && cursorWidth >= 0.0),
        assert(readOnly != null),
+       assert(enabled != null),
        assert(forceLine != null),
        assert(devicePixelRatio != null),
        _textPainter = TextPainter(
@@ -225,6 +227,7 @@ class RenderEditable extends RenderBox {
        _endHandleLayerLink = endHandleLayerLink,
        _obscureText = obscureText,
        _readOnly = readOnly,
+       _enabled = enabled,
        _forceLine = forceLine {
     assert(_showCursor != null);
     assert(!_showCursor.value || cursorColor != null);
@@ -792,6 +795,17 @@ class RenderEditable extends RenderBox {
     markNeedsSemanticsUpdate();
   }
 
+  /// Whether this rendering object is enabled.
+  bool get enabled => _enabled;
+  bool _enabled = false;
+  set enabled(bool value) {
+    assert(value != null);
+    if (_enabled == value)
+      return;
+    _enabled = value;
+    markNeedsSemanticsUpdate();
+  }
+
   /// The maximum number of lines for the text to span, wrapping if necessary.
   ///
   /// If this is 1 (the default), the text will not wrap, but will extend
@@ -1040,7 +1054,7 @@ class RenderEditable extends RenderBox {
       ..textDirection = textDirection
       ..isFocused = hasFocus
       ..isTextField = true
-      ..isReadOnly = readOnly;
+      ..isReadOnly = readOnly || !enabled;
 
     if (hasFocus && selectionEnabled)
       config.onSetSelection = _handleSetSelection;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2998,14 +2998,6 @@ class RenderIgnorePointer extends RenderProxyBox {
        super(child) {
     assert(_ignoring != null);
     assert(_ignoringSemantics != null);
-    if (ignoring && !_ignoringSemantics) {
-      updateMutedSemanticsActions(
-        <SemanticsAction>{
-          SemanticsAction.tap,
-          SemanticsAction.longPress,
-        }
-      );
-    }
   }
 
   /// Whether this render object is ignored during hit testing.
@@ -3021,16 +3013,7 @@ class RenderIgnorePointer extends RenderProxyBox {
     _ignoring = value;
     if (_ignoringSemantics)
       return;
-    if (ignoring) {
-      updateMutedSemanticsActions(
-        <SemanticsAction>{
-        SemanticsAction.tap,
-        SemanticsAction.longPress,
-        }
-      );
-    } else {
-      updateMutedSemanticsActions(<SemanticsAction>{});
-    }
+    markNeedsSemanticsUpdate();
   }
 
   bool _wasIgnoring;
@@ -3045,7 +3028,7 @@ class RenderIgnorePointer extends RenderProxyBox {
     assert(ignoringSemantics != null);
     if (value == _ignoringSemantics)
       return;
-    bool wasIgnoringSemantics = _ignoringSemantics;
+    final bool wasIgnoringSemantics = _ignoringSemantics;
     _ignoringSemantics = value;
     if (ignoring != _wasIgnoring && !wasIgnoringSemantics) {
       // Previous update of ignoring does not actually updating muted semantics
@@ -3057,6 +3040,19 @@ class RenderIgnorePointer extends RenderProxyBox {
     }
     _wasIgnoring = _ignoring;
     markNeedsSemanticsUpdate();
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    if (ignoring && !_ignoringSemantics) {
+      config.mutedActions = <SemanticsAction>{
+        SemanticsAction.tap,
+        SemanticsAction.longPress,
+      };
+    } else {
+      config.mutedActions = <SemanticsAction>{};
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2684,6 +2684,9 @@ class SemanticsConfiguration {
   /// create semantic boundaries that are either writable or not for children.
   bool explicitChildNodes = false;
 
+  /// Actions that will not be propagate to semantics action handler
+  Set<SemanticsAction> mutedActions = <SemanticsAction>{};
+
   /// Whether the owning [RenderObject] makes other [RenderObject]s previously
   /// painted within the same semantic boundary unreachable for accessibility
   /// purposes.
@@ -2727,6 +2730,7 @@ class SemanticsConfiguration {
   /// The provided `handler` is called to respond to the user triggered
   /// `action`.
   void _addAction(SemanticsAction action, _SemanticsActionHandler handler) {
+    assert(!mutedActions.contains(action));
     assert(handler != null);
     _actions[action] = handler;
     _actionsAsBits |= action.index;
@@ -2769,6 +2773,8 @@ class SemanticsConfiguration {
   VoidCallback get onTap => _onTap;
   VoidCallback _onTap;
   set onTap(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.tap))
+      return;
     _addArgumentlessAction(SemanticsAction.tap, value);
     _onTap = value;
   }
@@ -2784,6 +2790,8 @@ class SemanticsConfiguration {
   VoidCallback get onLongPress => _onLongPress;
   VoidCallback _onLongPress;
   set onLongPress(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.longPress))
+      return;
     _addArgumentlessAction(SemanticsAction.longPress, value);
     _onLongPress = value;
   }
@@ -2802,6 +2810,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollLeft => _onScrollLeft;
   VoidCallback _onScrollLeft;
   set onScrollLeft(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.scrollLeft))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollLeft, value);
     _onScrollLeft = value;
   }
@@ -2816,6 +2826,8 @@ class SemanticsConfiguration {
   VoidCallback get onDismiss => _onDismiss;
   VoidCallback _onDismiss;
   set onDismiss(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.dismiss))
+      return;
     _addArgumentlessAction(SemanticsAction.dismiss, value);
     _onDismiss = value;
   }
@@ -2834,6 +2846,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollRight => _onScrollRight;
   VoidCallback _onScrollRight;
   set onScrollRight(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.scrollRight))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollRight, value);
     _onScrollRight = value;
   }
@@ -2852,6 +2866,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollUp => _onScrollUp;
   VoidCallback _onScrollUp;
   set onScrollUp(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.scrollUp))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollUp, value);
     _onScrollUp = value;
   }
@@ -2870,6 +2886,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollDown => _onScrollDown;
   VoidCallback _onScrollDown;
   set onScrollDown(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.scrollDown))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollDown, value);
     _onScrollDown = value;
   }
@@ -2888,6 +2906,8 @@ class SemanticsConfiguration {
   VoidCallback get onIncrease => _onIncrease;
   VoidCallback _onIncrease;
   set onIncrease(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.increase))
+      return;
     _addArgumentlessAction(SemanticsAction.increase, value);
     _onIncrease = value;
   }
@@ -2906,6 +2926,8 @@ class SemanticsConfiguration {
   VoidCallback get onDecrease => _onDecrease;
   VoidCallback _onDecrease;
   set onDecrease(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.decrease))
+      return;
     _addArgumentlessAction(SemanticsAction.decrease, value);
     _onDecrease = value;
   }
@@ -2919,6 +2941,8 @@ class SemanticsConfiguration {
   VoidCallback get onCopy => _onCopy;
   VoidCallback _onCopy;
   set onCopy(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.copy))
+      return;
     _addArgumentlessAction(SemanticsAction.copy, value);
     _onCopy = value;
   }
@@ -2933,6 +2957,8 @@ class SemanticsConfiguration {
   VoidCallback get onCut => _onCut;
   VoidCallback _onCut;
   set onCut(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.cut))
+      return;
     _addArgumentlessAction(SemanticsAction.cut, value);
     _onCut = value;
   }
@@ -2946,6 +2972,8 @@ class SemanticsConfiguration {
   VoidCallback get onPaste => _onPaste;
   VoidCallback _onPaste;
   set onPaste(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.paste))
+      return;
     _addArgumentlessAction(SemanticsAction.paste, value);
     _onPaste = value;
   }
@@ -2962,6 +2990,8 @@ class SemanticsConfiguration {
   VoidCallback get onShowOnScreen => _onShowOnScreen;
   VoidCallback _onShowOnScreen;
   set onShowOnScreen(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.showOnScreen))
+      return;
     _addArgumentlessAction(SemanticsAction.showOnScreen, value);
     _onShowOnScreen = value;
   }
@@ -2976,6 +3006,8 @@ class SemanticsConfiguration {
   MoveCursorHandler get onMoveCursorForwardByCharacter => _onMoveCursorForwardByCharacter;
   MoveCursorHandler _onMoveCursorForwardByCharacter;
   set onMoveCursorForwardByCharacter(MoveCursorHandler value) {
+    if (mutedActions.contains(SemanticsAction.moveCursorForwardByCharacter))
+      return;
     assert(value != null);
     _addAction(SemanticsAction.moveCursorForwardByCharacter, (dynamic args) {
       final bool extentSelection = args;
@@ -2995,6 +3027,8 @@ class SemanticsConfiguration {
   MoveCursorHandler get onMoveCursorBackwardByCharacter => _onMoveCursorBackwardByCharacter;
   MoveCursorHandler _onMoveCursorBackwardByCharacter;
   set onMoveCursorBackwardByCharacter(MoveCursorHandler value) {
+    if (mutedActions.contains(SemanticsAction.moveCursorBackwardByCharacter))
+      return;
     assert(value != null);
     _addAction(SemanticsAction.moveCursorBackwardByCharacter, (dynamic args) {
       final bool extentSelection = args;
@@ -3014,6 +3048,8 @@ class SemanticsConfiguration {
   MoveCursorHandler get onMoveCursorForwardByWord => _onMoveCursorForwardByWord;
   MoveCursorHandler _onMoveCursorForwardByWord;
   set onMoveCursorForwardByWord(MoveCursorHandler value) {
+    if (mutedActions.contains(SemanticsAction.moveCursorForwardByWord))
+      return;
     assert(value != null);
     _addAction(SemanticsAction.moveCursorForwardByWord, (dynamic args) {
       final bool extentSelection = args;
@@ -3033,6 +3069,8 @@ class SemanticsConfiguration {
   MoveCursorHandler get onMoveCursorBackwardByWord => _onMoveCursorBackwardByWord;
   MoveCursorHandler _onMoveCursorBackwardByWord;
   set onMoveCursorBackwardByWord(MoveCursorHandler value) {
+    if (mutedActions.contains(SemanticsAction.moveCursorBackwardByWord))
+      return;
     assert(value != null);
     _addAction(SemanticsAction.moveCursorBackwardByWord, (dynamic args) {
       final bool extentSelection = args;
@@ -3052,6 +3090,8 @@ class SemanticsConfiguration {
   SetSelectionHandler get onSetSelection => _onSetSelection;
   SetSelectionHandler _onSetSelection;
   set onSetSelection(SetSelectionHandler value) {
+    if (mutedActions.contains(SemanticsAction.setSelection))
+      return;
     assert(value != null);
     _addAction(SemanticsAction.setSelection, (dynamic args) {
       assert(args != null && args is Map);
@@ -3085,6 +3125,8 @@ class SemanticsConfiguration {
   VoidCallback get onDidGainAccessibilityFocus => _onDidGainAccessibilityFocus;
   VoidCallback _onDidGainAccessibilityFocus;
   set onDidGainAccessibilityFocus(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.didGainAccessibilityFocus))
+      return;
     _addArgumentlessAction(SemanticsAction.didGainAccessibilityFocus, value);
     _onDidGainAccessibilityFocus = value;
   }
@@ -3109,6 +3151,8 @@ class SemanticsConfiguration {
   VoidCallback get onDidLoseAccessibilityFocus => _onDidLoseAccessibilityFocus;
   VoidCallback _onDidLoseAccessibilityFocus;
   set onDidLoseAccessibilityFocus(VoidCallback value) {
+    if (mutedActions.contains(SemanticsAction.didLoseAccessibilityFocus))
+      return;
     _addArgumentlessAction(SemanticsAction.didLoseAccessibilityFocus, value);
     _onDidLoseAccessibilityFocus = value;
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5981,7 +5981,6 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderIgnorePointer renderObject) {
-    print('ignoring = $ignoring');
     renderObject
       ..ignoring = ignoring
       ..ignoringSemantics = ignoringSemantics;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5952,9 +5952,10 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
   const IgnorePointer({
     Key key,
     this.ignoring = true,
-    this.ignoringSemantics,
+    this.ignoringSemantics = false,
     Widget child,
   }) : assert(ignoring != null),
+       assert(ignoringSemantics != null),
        super(key: key, child: child);
 
   /// Whether this widget is ignored during hit testing.
@@ -5980,6 +5981,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderIgnorePointer renderObject) {
+    print('ignoring = $ignoring');
     renderObject
       ..ignoring = ignoring
       ..ignoringSemantics = ignoringSemantics;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -350,6 +350,7 @@ class EditableText extends StatefulWidget {
     @required this.controller,
     @required this.focusNode,
     this.readOnly = false,
+    this.enabled = true,
     this.obscureText = false,
     this.autocorrect = true,
     @required this.style,
@@ -404,6 +405,7 @@ class EditableText extends StatefulWidget {
        assert(showSelectionHandles != null),
        assert(enableInteractiveSelection != null),
        assert(readOnly != null),
+       assert(enabled != null),
        assert(forceLine != null),
        assert(style != null),
        assert(cursorColor != null),
@@ -466,6 +468,14 @@ class EditableText extends StatefulWidget {
   /// Defaults to false. Must not be null.
   /// {@endtemplate}
   final bool readOnly;
+
+  /// Whether the text is enabled.
+  ///
+  /// When this is set to true, the semantics of this widget will be treated as
+  /// Text.
+  ///
+  /// Defaults to true. Must not be null.
+  final bool enabled;
 
   /// Whether the text will take the full width regardless of the text width.
   ///
@@ -1733,6 +1743,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                   : _cursorVisibilityNotifier,
               forceLine: widget.forceLine,
               readOnly: widget.readOnly,
+              enabled: widget.enabled,
               hasFocus: _hasFocus,
               maxLines: widget.maxLines,
               minLines: widget.minLines,
@@ -1798,6 +1809,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.showCursor,
     this.forceLine,
     this.readOnly,
+    this.enabled,
     this.textWidthBasis,
     this.hasFocus,
     this.maxLines,
@@ -1835,6 +1847,7 @@ class _Editable extends LeafRenderObjectWidget {
   final ValueNotifier<bool> showCursor;
   final bool forceLine;
   final bool readOnly;
+  final bool enabled;
   final bool hasFocus;
   final int maxLines;
   final int minLines;
@@ -1871,6 +1884,7 @@ class _Editable extends LeafRenderObjectWidget {
       showCursor: showCursor,
       forceLine: forceLine,
       readOnly: readOnly,
+      enabled: enabled,
       hasFocus: hasFocus,
       maxLines: maxLines,
       minLines: minLines,
@@ -1908,6 +1922,7 @@ class _Editable extends LeafRenderObjectWidget {
       ..showCursor = showCursor
       ..forceLine = forceLine
       ..readOnly = readOnly
+      ..enabled = enabled
       ..hasFocus = hasFocus
       ..maxLines = maxLines
       ..minLines = minLines

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -57,7 +57,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child1',
                   textDirection: TextDirection.ltr,
@@ -99,7 +99,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -153,7 +153,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -195,7 +195,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -35,7 +35,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -89,7 +89,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -131,7 +131,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,


### PR DESCRIPTION
## Description

This is a prototype.


expects behavior as following
```
if ignoringSemantics = true
     no semantics segmantics should be collected from the subtree
else
     if ignoring= true
           collect all the semantics except tap and longpress
    else
           collect all semantics
```
## Related Issues

https://github.com/flutter/flutter/issues/37162

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

Design doc https://docs.google.com/document/d/1WuVBc58_wV6__ZCe1NgYsnvTJtSdOtVcwSzPwM_YT74/edit?usp=sharing