### PR TITLE
add cmx for complex_layout

### DIFF
--- a/dev/benchmarks/complex_layout/fuchsia/meta/complex_layout.cmx
+++ b/dev/benchmarks/complex_layout/fuchsia/meta/complex_layout.cmx
@@ -1,0 +1,25 @@
+{
+    "program": {
+        "data": "data/complex_layout"
+    },
+    "sandbox": {
+        "services": [
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
+            "fuchsia.cobalt.LoggerFactory",
+            "fuchsia.fonts.Provider",
+            "fuchsia.logger.LogSink",
+            "fuchsia.modular.Clipboard",
+            "fuchsia.modular.ContextWriter",
+            "fuchsia.modular.DeviceMap",
+            "fuchsia.modular.ModuleContext",
+            "fuchsia.sys.Environment",
+            "fuchsia.sys.Launcher",
+            "fuchsia.testing.runner.TestRunner",
+            "fuchsia.ui.input.ImeService",
+            "fuchsia.ui.policy.Presenter",
+            "fuchsia.ui.scenic.Scenic"
+        ]
+    }
+}
+


### PR DESCRIPTION
This adds a basic CMX file that allows complex_layout to be run on a Fuchsia device, with access tot he basic services needed for a Flutter mod.