### PR TITLE
Test that modules built as AAR contain the right assets and artifacts

### DIFF
--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
@@ -134,6 +135,33 @@ Future<void> main() async {
         'package_info_release-1.0.pom',
       ));
 
+      section('Check assets in release AAR');
+
+      final Iterable<String> releaseAar = await getFilesInAar(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'devicelab',
+        'hello',
+        'flutter_release',
+        '1.0',
+        'flutter_release-1.0.aar',
+      ));
+
+      checkItContains<String>(<String>[
+        'assets/flutter_assets/FontManifest.json',
+        'assets/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf',
+      ], releaseAar);
+
+      section('Check AOT blobs in release AAR');
+
+      checkItContains<String>(<String>[
+        'jni/arm64-v8a/libapp.so',
+        'jni/arm64-v8a/libflutter.so',
+        'jni/armeabi-v7a/libapp.so',
+        'jni/armeabi-v7a/libflutter.so',
+      ], releaseAar);
+
       section('Build debug AAR');
 
       await inDirectory(projectDir, () async {
@@ -149,9 +177,9 @@ Future<void> main() async {
         'flutter',
         'devicelab',
         'hello',
-        'flutter_release',
+        'flutter_debug',
         '1.0',
-        'flutter_release-1.0.aar',
+        'flutter_debug-1.0.aar',
       ));
 
       checkFileExists(path.join(
@@ -209,7 +237,41 @@ Future<void> main() async {
         'package_info_debug-1.0.pom',
       ));
 
+
+      section('Check assets in debug AAR');
+
+      final Iterable<String> debugAar = await getFilesInAar(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'devicelab',
+        'hello',
+        'flutter_debug',
+        '1.0',
+        'flutter_debug-1.0.aar',
+      ));
+
+      checkItContains<String>(<String>[
+        'assets/flutter_assets/FontManifest.json',
+        'assets/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf',
+        // JIT snapshots.
+        'assets/flutter_assets/isolate_snapshot_data',
+        'assets/flutter_assets/kernel_blob.bin',
+        'assets/flutter_assets/vm_snapshot_data',
+      ], debugAar);
+
+      section('Check AOT blobs in debug AAR');
+
+      checkItContains<String>(<String>[
+        'jni/arm64-v8a/libflutter.so',
+        'jni/armeabi-v7a/libflutter.so',
+        'jni/x86/libflutter.so',
+        'jni/x86_64/libflutter.so',
+      ], debugAar);
+
       return TaskResult.success(null);
+    } on TaskResult catch (taskResult) {
+      return taskResult;
     } catch (e) {
       return TaskResult.failure(e.toString());
     } finally {

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -34,6 +34,7 @@ Future<void> runPluginProjectTest(Future<void> testFunction(FlutterPluginProject
   }
 }
 
+/// Returns the list of files inside an Android Package Kit.
 Future<Iterable<String>> getFilesInApk(String apk) async {
   if (!File(apk).existsSync())
     throw TaskResult.failure(
@@ -50,9 +51,14 @@ Future<Iterable<String>> getFilesInApk(String apk) async {
       .map((String line) => line.split(' ').last)
       .toList();
 }
-
+/// Returns the list of files inside an Android App Bundle.
 Future<Iterable<String>> getFilesInAppBundle(String bundle) {
   return getFilesInApk(bundle);
+}
+
+/// Returns the list of files inside an Android Archive.
+Future<Iterable<String>> getFilesInAar(String aar) {
+  return getFilesInApk(aar);
 }
 
 void checkItContains<T>(Iterable<T> values, Iterable<T> collection) {


### PR DESCRIPTION
## Description

Test that modules built as AAR contain the assets and snapshots.


## Related Issues

https://github.com/flutter/flutter/issues/36831

## Tests

This is a test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
