### PR TITLE
do not strip symbols when building profile

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -59,6 +59,13 @@ Future<void> main() async {
         );
       }
 
+      if (await _hasDebugSymbols(ephemeralReleaseHostApp)) {
+        return TaskResult.failure(
+          "Ephemeral host app ${ephemeralReleaseHostApp.path}'s App.framework's "
+          "debug symbols weren't stripped in release mode"
+        );
+      }
+
       section('Clean build');
 
       await inDirectory(projectDir, () async {
@@ -89,6 +96,12 @@ Future<void> main() async {
       if (!await _isAppAotBuild(ephemeralProfileHostApp)) {
         return TaskResult.failure(
           'Ephemeral host app ${ephemeralProfileHostApp.path} was not a profile build as expected'
+        );
+      }
+
+      if (!await _hasDebugSymbols(ephemeralProfileHostApp)) {
+        return TaskResult.failure(
+          "Ephemeral host app ${ephemeralProfileHostApp.path}'s App.framework does not contain debug symbols"
         );
       }
 
@@ -289,4 +302,27 @@ Future<bool> _isAppAotBuild(Directory app) async {
   );
 
   return symbolTable.contains('kDartIsolateSnapshotInstructions');
+}
+
+Future<bool> _hasDebugSymbols(Directory app) async {
+  final String binary = path.join(
+    app.path,
+    'Frameworks',
+    'App.framework',
+    'App'
+  );
+
+  final String symbolTable = await eval(
+    'dsymutil',
+    <String> [
+      '--dump-debug-map',
+      binary,
+    ],
+    // The output is huge.
+    printStdout: false,
+  );
+
+  // Search for some random Flutter framework Dart function which should always
+  // be in App.framework.
+  return symbolTable.contains('BuildOwner_reassemble');
 }

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -201,27 +201,29 @@ BuildApp() {
 
     RunCommand cp -r -- "${app_framework}" "${derived_dir}"
 
-    StreamOutput " ├─Generating dSYM file..."
-    # Xcode calls `symbols` during app store upload, which uses Spotlight to
-    # find dSYM files for embedded frameworks. When it finds the dSYM file for
-    # `App.framework` it throws an error, which aborts the app store upload.
-    # To avoid this, we place the dSYM files in a folder ending with ".noindex",
-    # which hides it from Spotlight, https://github.com/flutter/flutter/issues/22560.
-    RunCommand mkdir -p -- "${build_dir}/dSYMs.noindex"
-    RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"
-    if [[ $? -ne 0 ]]; then
-      EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."
-      exit -1
-    fi
-    StreamOutput "done"
+    if [[ "${build_mode}" == "release" ]]; then
+      StreamOutput " ├─Generating dSYM file..."
+      # Xcode calls `symbols` during app store upload, which uses Spotlight to
+      # find dSYM files for embedded frameworks. When it finds the dSYM file for
+      # `App.framework` it throws an error, which aborts the app store upload.
+      # To avoid this, we place the dSYM files in a folder ending with ".noindex",
+      # which hides it from Spotlight, https://github.com/flutter/flutter/issues/22560.
+      RunCommand mkdir -p -- "${build_dir}/dSYMs.noindex"
+      RunCommand xcrun dsymutil -o "${build_dir}/dSYMs.noindex/App.framework.dSYM" "${app_framework}/App"
+      if [[ $? -ne 0 ]]; then
+        EchoError "Failed to generate debug symbols (dSYM) file for ${app_framework}/App."
+        exit -1
+      fi
+      StreamOutput "done"
 
-    StreamOutput " ├─Stripping debug symbols..."
-    RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
-    if [[ $? -ne 0 ]]; then
-      EchoError "Failed to strip ${derived_dir}/App.framework/App."
-      exit -1
+      StreamOutput " ├─Stripping debug symbols..."
+      RunCommand xcrun strip -x -S "${derived_dir}/App.framework/App"
+      if [[ $? -ne 0 ]]; then
+        EchoError "Failed to strip ${derived_dir}/App.framework/App."
+        exit -1
+      fi
+      StreamOutput "done"
     fi
-    StreamOutput "done"
 
   else
     RunCommand mkdir -p -- "${derived_dir}/App.framework"


### PR DESCRIPTION
## Description

Leave them in since people aren't shipping profile builds and they're useful for instrumentations

## Related Issues

Closes #37065

## Tests

I added the following tests:

Module build test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
