### PR TITLE
Removing Leftover Golden Test Skips

### DIFF
--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -546,7 +546,6 @@ void main() {
         'switch.tap.off.png',
         version: 0,
       ),
-      skip: !isLinux,
     );
 
     await tester.tap(find.byKey(switchKey));
@@ -561,7 +560,6 @@ void main() {
         'switch.tap.turningOn.png',
         version: 0,
       ),
-      skip: !isLinux,
     );
 
     await tester.pumpAndSettle();
@@ -571,7 +569,6 @@ void main() {
         'switch.tap.on.png',
         version: 0,
       ),
-      skip: !isLinux,
     );
   });
 


### PR DESCRIPTION
## Description

These skips are no longer necessary with #36103 having now landed. Updated the wiki as well to reflect this: [Writing a golden file test for package:flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
