### PR TITLE
Clamp Scaffold's max body height when extendBody is true

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -432,6 +432,7 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
 
       if (extendBody) {
         bodyMaxHeight += bottomWidgetsHeight;
+        bodyMaxHeight = bodyMaxHeight.clamp(0.0, looseConstraints.maxHeight - contentTop).toDouble();
         assert(bodyMaxHeight <= math.max(0.0, looseConstraints.maxHeight - contentTop));
       }
 


### PR DESCRIPTION
## Description

Currently, when `Scaffold` is created with extendBody set to true, a rounding error can occur during layout with lower-spec devices. This results in occurrences like the following: 
```
Calculated allowable body max height during layout: 426.66666666666674
Constraint provided by parent widget: 426.6666666666667
```

Simulating this with an emulator, it results in the following error message: 
```
I/flutter ( 3989): ══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════
I/flutter ( 3989): The following assertion was thrown during performLayout():
I/flutter ( 3989): 'package:flutter/src/material/scaffold.dart': Failed assertion: line 439 pos 16: 'bodyMaxHeight <=
I/flutter ( 3989): math.max(0.0, looseConstraints.maxHeight - contentTop)': is not true.
```

This change clamps the `maxBodyHeight` such that its maximum height can only be the maximum height constraint provided by the parent. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34326

## Tests

n/a - The assert safeguards against incorrect layout height, which is how this exception was originally triggered. It is difficult to reproduce this in a test reliably, since it triggers more frequently with weaker devices and is triggered by swiping up and down rapidly and randomly (see https://github.com/flutter/flutter/issues/34326 for more details)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
