### PR TITLE
[Material] Add support for hovered, pressed, focused, and selected text color on Chips.

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -16,6 +16,7 @@ import 'icons.dart';
 import 'ink_well.dart';
 import 'material.dart';
 import 'material_localizations.dart';
+import 'material_state.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip.dart';
@@ -77,6 +78,15 @@ abstract class ChipAttributes {
   ///
   /// This only has an effect on widgets that respect the [DefaultTextStyle],
   /// such as [Text].
+  ///
+  /// If [labelStyle.color] is a [MaterialStateProperty<Color>], [MaterialStateProperty.resolve]
+  /// is used for the following [MaterialState]s:
+  ///
+  ///  * [MaterialState.disabled].
+  ///  * [MaterialState.selected].
+  ///  * [MaterialState.hovered].
+  ///  * [MaterialState.focused].
+  ///  * [MaterialState.pressed].
   TextStyle get labelStyle;
 
   /// The [ShapeBorder] to draw around the chip.
@@ -1400,6 +1410,8 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   Animation<double> enableAnimation;
   Animation<double> selectionFade;
 
+  final Set<MaterialState> _states = <MaterialState>{};
+
   bool get hasDeleteButton => widget.onDeleted != null;
   bool get hasAvatar => widget.avatar != null;
 
@@ -1416,6 +1428,8 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   void initState() {
     assert(widget.onSelected == null || widget.onPressed == null);
     super.initState();
+    _updateState(MaterialState.disabled, !widget.isEnabled ?? false);
+    _updateState(MaterialState.selected, widget.selected ?? false);
     selectController = AnimationController(
       duration: _kSelectDuration,
       value: widget.selected == true ? 1.0 : 0.0,
@@ -1486,12 +1500,17 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     super.dispose();
   }
 
+  void _updateState(MaterialState state, bool value) {
+    value ? _states.add(state) : _states.remove(state);
+  }
+
   void _handleTapDown(TapDownDetails details) {
     if (!canTap) {
       return;
     }
     setState(() {
       _isTapping = true;
+      _updateState(MaterialState.pressed, true);
     });
   }
 
@@ -1501,6 +1520,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     }
     setState(() {
       _isTapping = false;
+      _updateState(MaterialState.pressed, false);
     });
   }
 
@@ -1510,10 +1530,23 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     }
     setState(() {
       _isTapping = false;
+      _updateState(MaterialState.pressed, false);
     });
     // Only one of these can be set, so only one will be called.
     widget.onSelected?.call(!widget.selected);
     widget.onPressed?.call();
+  }
+
+  void _handleFocus(bool isFocused) {
+    setState(() {
+      _updateState(MaterialState.focused, isFocused);
+    });
+  }
+
+  void _handleHover(bool isHovered) {
+    setState(() {
+      _updateState(MaterialState.hovered, isHovered);
+    });
   }
 
   /// Picks between three different colors, depending upon the state of two
@@ -1535,6 +1568,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     super.didUpdateWidget(oldWidget);
     if (oldWidget.isEnabled != widget.isEnabled) {
       setState(() {
+        _updateState(MaterialState.disabled, !widget.isEnabled ?? false);
         if (widget.isEnabled) {
           enableController.forward();
         } else {
@@ -1553,6 +1587,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     }
     if (oldWidget.selected != widget.selected) {
       setState(() {
+        _updateState(MaterialState.selected, widget.selected ?? false);
         if (widget.selected == true) {
           selectController.forward();
         } else {
@@ -1621,65 +1656,73 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     final Color selectedShadowColor = widget.selectedShadowColor ?? chipTheme.selectedShadowColor ?? _defaultShadowColor;
     final bool selected = widget.selected ?? false;
 
-    Widget result = Material(
-      elevation: isTapping ? pressElevation : elevation,
-      shadowColor: selected ? selectedShadowColor : shadowColor,
-      animationDuration: pressedAnimationDuration,
-      shape: shape,
-      clipBehavior: widget.clipBehavior,
-      child: InkWell(
-        onTap: canTap ? _handleTap : null,
-        onTapDown: canTap ? _handleTapDown : null,
-        onTapCancel: canTap ? _handleTapCancel : null,
-        customBorder: shape,
-        child: AnimatedBuilder(
-          animation: Listenable.merge(<Listenable>[selectController, enableController]),
-          builder: (BuildContext context, Widget child) {
-            return Container(
-              decoration: ShapeDecoration(
-                shape: shape,
-                color: getBackgroundColor(chipTheme),
+    final TextStyle effectiveLabelStyle = widget.labelStyle ?? chipTheme.labelStyle;
+    final Color resolvedLabelColor =  MaterialStateProperty.resolveAs<Color>(effectiveLabelStyle?.color, _states);
+    final TextStyle resolvedLabelStyle = effectiveLabelStyle?.copyWith(color: resolvedLabelColor);
+
+    Widget result = Focus(
+      onFocusChange: _handleFocus,
+      child: Material(
+        elevation: isTapping ? pressElevation : elevation,
+        shadowColor: selected ? selectedShadowColor : shadowColor,
+        animationDuration: pressedAnimationDuration,
+        shape: shape,
+        clipBehavior: widget.clipBehavior,
+        child: InkWell(
+          onTap: canTap ? _handleTap : null,
+          onTapDown: canTap ? _handleTapDown : null,
+          onTapCancel: canTap ? _handleTapCancel : null,
+          onHover: canTap ? _handleHover : null,
+          customBorder: shape,
+          child: AnimatedBuilder(
+            animation: Listenable.merge(<Listenable>[selectController, enableController]),
+            builder: (BuildContext context, Widget child) {
+              return Container(
+                decoration: ShapeDecoration(
+                  shape: shape,
+                  color: getBackgroundColor(chipTheme),
+                ),
+                child: child,
+              );
+            },
+            child: _wrapWithTooltip(
+              widget.tooltip,
+              widget.onPressed,
+              _ChipRenderWidget(
+                theme: _ChipRenderTheme(
+                  label: DefaultTextStyle(
+                    overflow: TextOverflow.fade,
+                    textAlign: TextAlign.start,
+                    maxLines: 1,
+                    softWrap: false,
+                    style: resolvedLabelStyle,
+                    child: widget.label,
+                  ),
+                  avatar: AnimatedSwitcher(
+                    child: widget.avatar,
+                    duration: _kDrawerDuration,
+                    switchInCurve: Curves.fastOutSlowIn,
+                  ),
+                  deleteIcon: AnimatedSwitcher(
+                    child: _buildDeleteIcon(context, theme, chipTheme),
+                    duration: _kDrawerDuration,
+                    switchInCurve: Curves.fastOutSlowIn,
+                  ),
+                  brightness: chipTheme.brightness,
+                  padding: (widget.padding ?? chipTheme.padding).resolve(textDirection),
+                  labelPadding: (widget.labelPadding ?? chipTheme.labelPadding).resolve(textDirection),
+                  showAvatar: hasAvatar,
+                  showCheckmark: widget.showCheckmark,
+                  canTapBody: canTap,
+                ),
+                value: widget.selected,
+                checkmarkAnimation: checkmarkAnimation,
+                enableAnimation: enableAnimation,
+                avatarDrawerAnimation: avatarDrawerAnimation,
+                deleteDrawerAnimation: deleteDrawerAnimation,
+                isEnabled: widget.isEnabled,
+                avatarBorder: widget.avatarBorder,
               ),
-              child: child,
-            );
-          },
-          child: _wrapWithTooltip(
-            widget.tooltip,
-            widget.onPressed,
-            _ChipRenderWidget(
-              theme: _ChipRenderTheme(
-                label: DefaultTextStyle(
-                  overflow: TextOverflow.fade,
-                  textAlign: TextAlign.start,
-                  maxLines: 1,
-                  softWrap: false,
-                  style: widget.labelStyle ?? chipTheme.labelStyle,
-                  child: widget.label,
-                ),
-                avatar: AnimatedSwitcher(
-                  child: widget.avatar,
-                  duration: _kDrawerDuration,
-                  switchInCurve: Curves.fastOutSlowIn,
-                ),
-                deleteIcon: AnimatedSwitcher(
-                  child: _buildDeleteIcon(context, theme, chipTheme),
-                  duration: _kDrawerDuration,
-                  switchInCurve: Curves.fastOutSlowIn,
-                ),
-                brightness: chipTheme.brightness,
-                padding: (widget.padding ?? chipTheme.padding).resolve(textDirection),
-                labelPadding: (widget.labelPadding ?? chipTheme.labelPadding).resolve(textDirection),
-                showAvatar: hasAvatar,
-                showCheckmark: widget.showCheckmark,
-                canTapBody: canTap,
-              ),
-              value: widget.selected,
-              checkmarkAnimation: checkmarkAnimation,
-              enableAnimation: enableAnimation,
-              avatarDrawerAnimation: avatarDrawerAnimation,
-              deleteDrawerAnimation: deleteDrawerAnimation,
-              isEnabled: widget.isEnabled,
-              avatarBorder: widget.avatarBorder,
             ),
           ),
         ),

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1428,7 +1428,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
   void initState() {
     assert(widget.onSelected == null || widget.onPressed == null);
     super.initState();
-    _updateState(MaterialState.disabled, !widget.isEnabled ?? false);
+    _updateState(MaterialState.disabled, !widget.isEnabled);
     _updateState(MaterialState.selected, widget.selected ?? false);
     selectController = AnimationController(
       duration: _kSelectDuration,
@@ -1568,7 +1568,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
     super.didUpdateWidget(oldWidget);
     if (oldWidget.isEnabled != widget.isEnabled) {
       setState(() {
-        _updateState(MaterialState.disabled, !widget.isEnabled ?? false);
+        _updateState(MaterialState.disabled, !widget.isEnabled);
         if (widget.isEnabled) {
           enableController.forward();
         } else {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' show window;
 
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -47,12 +49,10 @@ IconThemeData getIconData(WidgetTester tester) {
 
 DefaultTextStyle getLabelStyle(WidgetTester tester) {
   return tester.widget(
-    find
-        .descendant(
+    find.descendant(
       of: find.byType(RawChip),
       matching: find.byType(DefaultTextStyle),
-    )
-        .last,
+    ).last,
   );
 }
 
@@ -1736,5 +1736,93 @@ void main() {
       ),
     );
     expect(find.byType(InkWell), findsOneWidget);
+  });
+
+  testWidgets('Chip uses stateful color for text color in different states', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+
+    const Color pressedColor = Color(0x00000001);
+    const Color hoverColor = Color(0x00000002);
+    const Color focusedColor = Color(0x00000003);
+    const Color defaultColor = Color(0x00000004);
+    const Color selectedColor = Color(0x00000005);
+    const Color disabledColor = Color(0x00000006);
+
+    Color getTextColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return disabledColor;
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return pressedColor;
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return hoverColor;
+      }
+      if (states.contains(MaterialState.focused)) {
+        return focusedColor;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return selectedColor;
+      }
+      return defaultColor;
+    }
+
+    Widget chipWidget({ bool enabled = true, bool selected = false }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Focus(
+              focusNode: focusNode,
+              child: ChoiceChip(
+                label: const Text('Chip'),
+                selected: selected,
+                onSelected: enabled ? (_) {} : null,
+                labelStyle: TextStyle(color: MaterialStateColor.resolveWith(getTextColor)),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    Color textColor() {
+      return tester.renderObject<RenderParagraph>(find.text('Chip')).text.style.color;
+    }
+
+    // Default, not disabled.
+    await tester.pumpWidget(chipWidget());
+    expect(textColor(), equals(defaultColor));
+
+    // Selected.
+    await tester.pumpWidget(chipWidget(selected: true));
+    expect(textColor(), selectedColor);
+
+    // Focused.
+    final FocusNode chipFocusNode = focusNode.children.first;
+    chipFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(textColor(), focusedColor);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(ChoiceChip));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(textColor(), hoverColor);
+
+    // Pressed.
+    await gesture.down(center);
+    await tester.pumpAndSettle();
+    expect(textColor(), pressedColor);
+
+    // Disabled.
+    await tester.pumpWidget(chipWidget(enabled: false));
+    await tester.pumpAndSettle();
+    expect(textColor(), disabledColor);
+
+    // Teardown.
+    await gesture.removePointer();
   });
 }

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1749,21 +1749,21 @@ void main() {
     const Color disabledColor = Color(0x00000006);
 
     Color getTextColor(Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+      if (states.contains(MaterialState.disabled))
         return disabledColor;
-      }
-      if (states.contains(MaterialState.pressed)) {
+
+      if (states.contains(MaterialState.pressed))
         return pressedColor;
-      }
-      if (states.contains(MaterialState.hovered)) {
+
+      if (states.contains(MaterialState.hovered))
         return hoverColor;
-      }
-      if (states.contains(MaterialState.focused)) {
+
+      if (states.contains(MaterialState.focused))
         return focusedColor;
-      }
-      if (states.contains(MaterialState.selected)) {
+
+      if (states.contains(MaterialState.selected))
         return selectedColor;
-      }
+
       return defaultColor;
     }
 

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1770,15 +1770,13 @@ void main() {
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
         home: Scaffold(
-          body: Center(
-            child: Focus(
-              focusNode: focusNode,
-              child: ChoiceChip(
-                label: const Text('Chip'),
-                selected: selected,
-                onSelected: enabled ? (_) {} : null,
-                labelStyle: TextStyle(color: MaterialStateColor.resolveWith(getTextColor)),
-              ),
+          body: Focus(
+            focusNode: focusNode,
+            child: ChoiceChip(
+              label: const Text('Chip'),
+              selected: selected,
+              onSelected: enabled ? (_) {} : null,
+              labelStyle: TextStyle(color: MaterialStateColor.resolveWith(getTextColor)),
             ),
           ),
         ),

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' show window;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -337,5 +338,101 @@ void main() {
     expect(lerpBNull75.brightness, equals(Brightness.light));
     expect(lerpBNull75.elevation, 0.25);
     expect(lerpBNull75.pressElevation, 1.0);
+  });
+
+  testWidgets('Chip uses stateful color from chip theme', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+
+    const Color pressedColor = Color(0x00000001);
+    const Color hoverColor = Color(0x00000002);
+    const Color focusedColor = Color(0x00000003);
+    const Color defaultColor = Color(0x00000004);
+    const Color selectedColor = Color(0x00000005);
+    const Color disabledColor = Color(0x00000006);
+
+    Color getTextColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return disabledColor;
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return pressedColor;
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return hoverColor;
+      }
+      if (states.contains(MaterialState.focused)) {
+        return focusedColor;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return selectedColor;
+      }
+      return defaultColor;
+    }
+
+    final TextStyle labelStyle =  TextStyle(
+      color: MaterialStateColor.resolveWith(getTextColor),
+    );
+    Widget chipWidget({ bool enabled = true, bool selected = false }) {
+      return MaterialApp(
+        theme: ThemeData(
+          chipTheme: ThemeData.light().chipTheme.copyWith(
+            labelStyle: labelStyle,
+            secondaryLabelStyle: labelStyle,
+          ),
+        ),
+        home: Scaffold(
+          body: Center(
+            child: Focus(
+              focusNode: focusNode,
+              child: ChoiceChip(
+                label: const Text('Chip'),
+                selected: selected,
+                onSelected: enabled ? (_) {} : null,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    Color textColor() {
+      return tester.renderObject<RenderParagraph>(find.text('Chip')).text.style.color;
+    }
+
+    // Default, not disabled.
+    await tester.pumpWidget(chipWidget());
+    expect(textColor(), equals(defaultColor));
+
+    // Selected.
+    await tester.pumpWidget(chipWidget(selected: true));
+    expect(textColor(), selectedColor);
+
+    // Focused.
+    final FocusNode chipFocusNode = focusNode.children.first;
+    chipFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(textColor(), focusedColor);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(ChoiceChip));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(textColor(), hoverColor);
+
+    // Pressed.
+    await gesture.down(center);
+    await tester.pumpAndSettle();
+    expect(textColor(), pressedColor);
+
+    // Disabled.
+    await tester.pumpWidget(chipWidget(enabled: false));
+    await tester.pumpAndSettle();
+    expect(textColor(), disabledColor);
+
+    // Teardown.
+    await gesture.removePointer();
   });
 }

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -351,21 +351,21 @@ void main() {
     const Color disabledColor = Color(0x00000006);
 
     Color getTextColor(Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+      if (states.contains(MaterialState.disabled))
         return disabledColor;
-      }
-      if (states.contains(MaterialState.pressed)) {
+
+      if (states.contains(MaterialState.pressed))
         return pressedColor;
-      }
-      if (states.contains(MaterialState.hovered)) {
+
+      if (states.contains(MaterialState.hovered))
         return hoverColor;
-      }
-      if (states.contains(MaterialState.focused)) {
+
+      if (states.contains(MaterialState.focused))
         return focusedColor;
-      }
-      if (states.contains(MaterialState.selected)) {
+
+      if (states.contains(MaterialState.selected))
         return selectedColor;
-      }
+
       return defaultColor;
     }
 

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -381,14 +381,12 @@ void main() {
           ),
         ),
         home: Scaffold(
-          body: Center(
-            child: Focus(
-              focusNode: focusNode,
-              child: ChoiceChip(
-                label: const Text('Chip'),
-                selected: selected,
-                onSelected: enabled ? (_) {} : null,
-              ),
+          body: Focus(
+            focusNode: focusNode,
+            child: ChoiceChip(
+              label: const Text('Chip'),
+              selected: selected,
+              onSelected: enabled ? (_) {} : null,
             ),
           ),
         ),


### PR DESCRIPTION
## Description

This change updates Chips to support `MaterialStateProperty<Color>` for text color on chips. This allows for fully customizable text colors for every state that a chip can be in.

For example, you can accomplish the following customized chip

![giphy](https://user-images.githubusercontent.com/4229329/62159272-4b29ea00-b2df-11e9-873b-b9d5480dc3ec.gif)

Using the following code snippet:
```dart
final textColor = MaterialStateColor.resolveWith((states) {
  if (states.contains(MaterialState.selected)) {
    if (states.contains(MaterialState.pressed)) {
      return Colors.blue[900];
    }
    return Colors.blue[600];
  }
  if (states.contains(MaterialState.pressed)) {
    return Colors.black;
  }
  return Colors.grey[700];
});


ChoiceChip(
  ...
  labelStyle: TextStyle(color: textColor),
);
```

## Tests

I added the following tests:

* Test a chip with a stateful color in all of the states to make sure that states are properly tracked, and colors is used correctly.
* Test that the above can also be accomplished using only the theme.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
