### PR TITLE
ExpansionTile: Add colors transition options

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -40,6 +40,10 @@ class ExpansionTile extends StatefulWidget {
     this.children = const <Widget>[],
     this.trailing,
     this.initiallyExpanded = false,
+    this.headerColorTweenBegin,
+    this.headerColorTweenEnd,
+    this.iconColorTweenBegin,
+    this.iconColorTweenEnd,
   }) : assert(initiallyExpanded != null),
        super(key: key);
 
@@ -73,6 +77,23 @@ class ExpansionTile extends StatefulWidget {
 
   /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
   final bool initiallyExpanded;
+
+  /// The color to display the text in transition begin.
+  /// Default value is theme.textTheme.subhead.color
+  final Color headerColorTweenBegin;
+
+  /// The color to display the text in transition begin.
+  /// Default value is theme.primaryColor
+  final Color headerColorTweenEnd;
+
+  /// The color to display the text in transition begin.
+  /// Default value is theme.unselectedWidgetColor
+  final Color iconColorTweenBegin;
+
+  /// The color to display the text in transition begin.
+  /// Default value is theme.primaryColor;
+  final Color iconColorTweenEnd;
+
 
   @override
   _ExpansionTileState createState() => _ExpansionTileState();
@@ -184,11 +205,11 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     _borderColorTween
       ..end = theme.dividerColor;
     _headerColorTween
-      ..begin = theme.textTheme.subhead.color
-      ..end = theme.accentColor;
+      ..begin = widget.headerColorTweenBegin ?? theme.textTheme.subhead.color
+      ..end = widget.headerColorTweenEnd ?? theme.accentColor;
     _iconColorTween
-      ..begin = theme.unselectedWidgetColor
-      ..end = theme.accentColor;
+      ..begin = widget.iconColorTweenBegin ?? theme.unselectedWidgetColor
+      ..end = widget.iconColorTweenEnd ?? theme.accentColor;
     _backgroundColorTween
       ..end = widget.backgroundColor;
     super.didChangeDependencies();


### PR DESCRIPTION
Add colors transitions options in used Title and Icon,
named 'headerColorTweenBegin', 'headerColorTweenEnd', 'iconColorTweenBegin' and 'iconColorTweenEnd'

## Description

I started adding properties that make it possible to define the colors used in the header animations, leaving what is used today by default
I didn't know the best way to indicate default values, since they need to be set by theme, so at runtime. I couldn't think of better names for the variables too.

I had problems with the theme.accentColors like white, because the color in title is static
The representation of the "problem" can be seen below:
```
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(primarySwatch: Colors.blue, accentColor: Colors.white),
      home: Scaffold(
        appBar: AppBar(
          title: Text('Expansion Tile Demo'),
        ),
        body: ExpansionTile(
          title: Text("Tile"),
          children: <Widget>[Text("Expanded Body")],
        ),
      ),
    );
  }
}
```
<img src="https://i.imgur.com/aH7H6g6.gif" width="250">

```
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(primarySwatch: Colors.blue, accentColor: Colors.white),
      home: Scaffold(
        appBar: AppBar(
          title: Text('Expansion Tile Demo'),
        ),
        body: NewExpansionTile(
          title: Text("Tile"),
          headerColorTweenBegin: Colors.red, //new params
          headerColorTweenEnd: Colors.green,
          iconColorTweenBegin: Colors.blue,
          iconColorTweenEnd: Colors.pink, // end
          children: <Widget>[Text("Expanded Body")],
        ),
      ),
    );
  }
}
```

With the change is possible solve this
<img src="https://i.imgur.com/Yw4oPPH.gif" width="250">



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing. 
I could not install the dependencies, but the change is so simple that I hope I have no problems)
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
The same reason
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
