### PR TITLE
Change the value of kMaxUnsignedSMI for the Web

### DIFF
--- a/packages/flutter/lib/src/foundation/_bitfield_web.dart
+++ b/packages/flutter/lib/src/foundation/_bitfield_web.dart
@@ -5,7 +5,13 @@
 import 'bitfield.dart' as bitfield;
 
 /// The dart:html implementation of [bitfield.kMaxUnsignedSMI].
-const int kMaxUnsignedSMI = 0;
+///
+/// This value is used as an optimization to coerse some numbers to be within
+/// the SMI range and avoid heap allocations. Because number encoding is
+/// VM-specific, there's no guarantee that this optimization will be effective
+/// on all JavaScript engines. The value picked here should be correct, but it
+/// does not have to guarantee efficiency.
+const int kMaxUnsignedSMI = -1;
 
 /// The dart:html implementation of [bitfield.Bitfield].
 class BitField<T extends dynamic> implements bitfield.BitField<T> {

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -116,7 +116,8 @@ const int kTouchContact = kPrimaryButton;
 
 /// The bit of [PointerEvent.buttons] that corresponds to the nth mouse button.
 ///
-/// The `number` argument can be at most 62.
+/// The `number` argument can be at most 62 in Flutter for mobile and desktop,
+/// and at most 32 on Flutter for web.
 ///
 /// See [kPrimaryMouseButton], [kSecondaryMouseButton], [kMiddleMouseButton],
 /// [kBackMouseButton], and [kForwardMouseButton] for semantic names for some
@@ -125,7 +126,8 @@ int nthMouseButton(int number) => (kPrimaryMouseButton << (number - 1)) & kMaxUn
 
 /// The bit of [PointerEvent.buttons] that corresponds to the nth stylus button.
 ///
-/// The `number` argument can be at most 62.
+/// The `number` argument can be at most 62 in Flutter for mobile and desktop,
+/// and at most 32 on Flutter for web.
 ///
 /// See [kPrimaryStylusButton] and [kSecondaryStylusButton] for semantic names
 /// for some stylus buttons.


### PR DESCRIPTION
## Description

Change the value of `kMaxUnsignedSMI` to -1, which is what we use on the Web.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/32234

## Tests

No tests are affected. We currently do not run Web tests.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
