### PR TITLE
[Material] FAB refactor - remove unnecessary IconTheme 

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -431,18 +431,7 @@ class FloatingActionButton extends StatelessWidget {
       ?? floatingActionButtonTheme.shape
       ?? (isExtended ? _defaultExtendedShape : _defaultShape);
 
-    Widget result;
-
-    if (child != null) {
-      result = IconTheme.merge(
-        data: IconThemeData(
-          color: foregroundColor,
-        ),
-        child: child,
-      );
-    }
-
-    result = RawMaterialButton(
+    Widget result = RawMaterialButton(
       onPressed: onPressed,
       elevation: elevation,
       focusElevation: focusElevation,
@@ -458,7 +447,7 @@ class FloatingActionButton extends StatelessWidget {
       shape: shape,
       clipBehavior: clipBehavior ?? Clip.none,
       focusNode: focusNode,
-      child: result,
+      child: child,
     );
 
     if (tooltip != null) {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -781,6 +781,23 @@ void main() {
       ),
     );
   }, semanticsEnabled: true);
+
+  testWidgets('Foreground color applies to icon on fab', (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xcafefeed);
+
+    await tester.pumpWidget(MaterialApp(
+      home: FloatingActionButton(
+        onPressed: () {},
+        foregroundColor: foregroundColor,
+        child: Icon(Icons.access_alarm),
+      ),
+    ));
+
+    final RichText iconRichText = tester.widget<RichText>(
+      find.descendant(of: find.byIcon(Icons.access_alarm), matching: find.byType(RichText)),
+    );
+    expect(iconRichText.text.style.color, foregroundColor);
+  });
 }
 
 Offset _rightEdgeOfFab(WidgetTester tester) {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -789,7 +789,7 @@ void main() {
       home: FloatingActionButton(
         onPressed: () {},
         foregroundColor: foregroundColor,
-        child: Icon(Icons.access_alarm),
+        child: const Icon(Icons.access_alarm),
       ),
     ));
 


### PR DESCRIPTION
## Description

This is a minor refactor. Since `RawMaterialButton` applies the `textStyle.color` to the icon in a button, FABs don't need to create their own `IconTheme`.

## Tests

I added the following tests:

* Test to confirm that the `foregroundColor` is applied to the icon in a FAB.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
