### PR TITLE
Update dartdoc to 28.4

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -104,7 +104,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.28.3+2
+"$PUB" global activate dartdoc 0.28.4
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -123,6 +123,8 @@ Future<void> main(List<String> arguments) async {
   );
   print('\n${result.stdout}flutter version: $version\n');
 
+  dartdocBaseArgs.add('--allow-tools');
+
   if (args['json']) {
     dartdocBaseArgs.add('--json');
   }


### PR DESCRIPTION
Update dartdoc to v28.4. This version no longer allows running of tools, so add flag `--allow-tools` to command line arguments.
