### PR TITLE
resizeToAvoidBottomInset Cupertino without NavBar

### DIFF
--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -137,6 +137,16 @@ class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {
           ),
         );
       }
+    } else {
+      // If there is no navigation bar, still may need to add padding in order
+      // to support resizeToAvoidBottomInset.
+      final double bottomPadding = widget.resizeToAvoidBottomInset
+          ? existingMediaQuery.viewInsets.bottom
+          : 0.0;
+      paddedContent = Padding(
+        padding: EdgeInsets.only(bottom: bottomPadding),
+        child: paddedContent,
+      );
     }
 
     // The main content being at the bottom is added to the stack first.

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -441,15 +441,15 @@ void main() {
         home: MediaQuery(
           data: MediaQueryData(
             padding: EdgeInsets.zero,
-            viewPadding: EdgeInsets.only(bottom: 20),
+            viewPadding: const EdgeInsets.only(bottom: 20),
             viewInsets: EdgeInsets.only(bottom: showKeyboard ? 300 : 20),
           ),
           child: CupertinoPageScaffold(
             resizeToAvoidBottomInset: true,
-            navigationBar: showNavigationBar ? CupertinoNavigationBar(
+            navigationBar: showNavigationBar ? const CupertinoNavigationBar(
               middle: Text('Title'),
             ) : null,
-            child: Center(
+            child: const Center(
               child: CupertinoTextField(),
             ),
           ),

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -25,7 +25,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(Center)), const Offset(0.0, 0.0));
   });
 
-testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
+  testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -433,5 +433,52 @@ testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
     expect(tester.getTopLeft(find.text('0')).dy, 64);
     expect(tester.getTopLeft(find.text('6')).dy, 364);
     expect(find.text('12'), findsNothing);
+  });
+
+  testWidgets('resizeToAvoidBottomInset is supported even when no navigationBar', (WidgetTester tester) async {
+    Widget buildFrame(bool showNavigationBar, bool showKeyboard) {
+      return CupertinoApp(
+        home: MediaQuery(
+          data: MediaQueryData(
+            padding: EdgeInsets.zero,
+            viewPadding: EdgeInsets.only(bottom: 20),
+            viewInsets: EdgeInsets.only(bottom: showKeyboard ? 300 : 20),
+          ),
+          child: CupertinoPageScaffold(
+            resizeToAvoidBottomInset: true,
+            navigationBar: showNavigationBar ? CupertinoNavigationBar(
+              middle: Text('Title'),
+            ) : null,
+            child: Center(
+              child: CupertinoTextField(),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When there is a nav bar and no keyboard.
+    await tester.pumpWidget(buildFrame(true, false));
+    final Offset positionNoInsetWithNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
+
+    // When there is a nav bar and keyboard, the CupertinoTextField moves up.
+    await tester.pumpWidget(buildFrame(true, true));
+    await tester.pumpAndSettle();
+    final Offset positionWithInsetWithNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
+    expect(positionWithInsetWithNavBar.dy, lessThan(positionNoInsetWithNavBar.dy));
+
+    // When there is no nav bar and no keyboard, the CupertinoTextField is still
+    // centered.
+    await tester.pumpWidget(buildFrame(false, false));
+    final Offset positionNoInsetNoNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
+    expect(positionNoInsetNoNavBar, equals(positionNoInsetWithNavBar));
+
+    // When there is a keyboard but no nav bar, the CupertinoTextField also
+    // moves up to the same position as when there is a keyboard and nav bar.
+    await tester.pumpWidget(buildFrame(false, true));
+    await tester.pumpAndSettle();
+    final Offset positionWithInsetNoNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
+    expect(positionWithInsetNoNavBar.dy, lessThan(positionNoInsetNoNavBar.dy));
+    expect(positionWithInsetNoNavBar, equals(positionWithInsetWithNavBar));
   });
 }


### PR DESCRIPTION
## Description

CupertinoPageScaffold was ignoring `resizeToAvoidBottomInset` when there was no `navigationBar`.  This PR makes it respect the parameter in either case.

The before and after with `resizeToAvoidBottomInset: true` looks like this:

| Before | After |
| --------- | ------ |
| ![flutter_02](https://user-images.githubusercontent.com/389558/62234295-487ed180-b37f-11e9-8be4-a778fc7d3ddd.png) | ![flutter_01](https://user-images.githubusercontent.com/389558/62234296-487ed180-b37f-11e9-8f05-dea33fa2fb64.png) |


## Related Issues

Closes https://github.com/flutter/flutter/issues/34946

## Tests

Added a test to verify that a CupertinoTextField moves up when `resizeToAvoidBottomInset` is true, even without a navbar.