### PR TITLE
Fix some tests now that the isMultiline flag is added to values

### DIFF
--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -419,8 +419,7 @@ void _defineTests() {
             inMutuallyExclusiveGroup: true,
             header: true,
             obscured: true,
-            // TODO(mdebbar): Uncomment after https://github.com/flutter/engine/pull/9894
-            //multiline: true,
+            multiline: true,
             scopesRoute: true,
             namesRoute: true,
             image: true,
@@ -433,10 +432,7 @@ void _defineTests() {
     List<SemanticsFlag> flags = SemanticsFlag.values.values.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.
-    flags
-      // TODO(mdebbar): Remove this line after https://github.com/flutter/engine/pull/9894
-      ..remove(SemanticsFlag.isMultiline)
-      ..remove(SemanticsFlag.hasImplicitScrolling);
+    flags.remove(SemanticsFlag.hasImplicitScrolling);
     TestSemantics expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
@@ -471,8 +467,7 @@ void _defineTests() {
             inMutuallyExclusiveGroup: true,
             header: true,
             obscured: true,
-            // TODO(mdebbar): Uncomment after https://github.com/flutter/engine/pull/9894
-            //multiline: true,
+            multiline: true,
             scopesRoute: true,
             namesRoute: true,
             image: true,
@@ -484,10 +479,7 @@ void _defineTests() {
     flags = SemanticsFlag.values.values.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.
-    flags
-      // TODO(mdebbar): Remove this line after https://github.com/flutter/engine/pull/9894
-      ..remove(SemanticsFlag.isMultiline)
-      ..remove(SemanticsFlag.hasImplicitScrolling);
+    flags.remove(SemanticsFlag.hasImplicitScrolling);
 
     expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -479,8 +479,7 @@ void main() {
           inMutuallyExclusiveGroup: true,
           header: true,
           obscured: true,
-          // TODO(mdebbar): Uncomment after https://github.com/flutter/engine/pull/9894
-          //multiline: true,
+          multiline: true,
           scopesRoute: true,
           namesRoute: true,
           image: true,
@@ -489,8 +488,6 @@ void main() {
     );
     final List<SemanticsFlag> flags = SemanticsFlag.values.values.toList();
     flags
-      // TODO(mdebbar): Remove this line after https://github.com/flutter/engine/pull/9894
-      ..remove(SemanticsFlag.isMultiline)
       ..remove(SemanticsFlag.hasToggledState)
       ..remove(SemanticsFlag.isToggled)
       ..remove(SemanticsFlag.hasImplicitScrolling);


### PR DESCRIPTION
## Description

Taking over from https://github.com/flutter/flutter/pull/36487 by @mdebbar.

This is a follow-up to https://github.com/flutter/engine/pull/9894. This re-enables testing of some semantics flags that were previously excluded.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34265

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
