### PR TITLE
[flutter_tool] Add missing toString()

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -664,7 +664,7 @@ class DeviceDomain extends Domain {
           final Map<String, Object> response = await _deviceToMap(device);
           sendEvent(eventName, response);
         } catch (err) {
-          printError(err);
+          printError('$err');
         }
       });
     };


### PR DESCRIPTION
## Description

Prior to this PR, a non-String exception caught here would lead to an unhandled runtime type error.

## Related Issues

Saw in crash logging.

## Tests

I added the following tests:

I'm open to suggestions. I don't immediately see a good way to inject an error into the Daemon's `sendEvent()` call.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
