### PR TITLE
Update constructor APIs TooltipTheme, ToggleButtonsTheme, PopupMenuTheme

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -656,7 +656,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 
     Widget menu = _PopupMenu<T>(route: this, semanticLabel: semanticLabel);
     if (popupMenuTheme != null)
-      menu = PopupMenuTheme(textStyle: popupMenuTheme.textStyle, child: menu);
+      menu = PopupMenuTheme(data: PopupMenuThemeData(textStyle: popupMenuTheme.textStyle), child: menu);
     if (theme != null)
       menu = Theme(data: theme, child: menu);
 

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -124,20 +124,11 @@ class PopupMenuThemeData extends Diagnosticable {
 class PopupMenuTheme extends InheritedWidget {
   /// Creates a popup menu theme that controls the configurations for
   /// popup menus in its widget subtree.
-  PopupMenuTheme({
+  const PopupMenuTheme({
     Key key,
-    Color color,
-    ShapeBorder shape,
-    double elevation,
-    TextStyle textStyle,
+    @required this.data,
     Widget child,
-  }) : data = PopupMenuThemeData(
-         color: color,
-         shape: shape,
-         elevation: elevation,
-         textStyle: textStyle,
-       ),
-       super(key: key, child: child);
+  }) : assert(data != null), super(key: key, child: child);
 
   /// The properties for descendant popup menu widgets.
   final PopupMenuThemeData data;

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -124,6 +124,8 @@ class PopupMenuThemeData extends Diagnosticable {
 class PopupMenuTheme extends InheritedWidget {
   /// Creates a popup menu theme that controls the configurations for
   /// popup menus in its widget subtree.
+  ///
+  /// The data argument must not be null.
   const PopupMenuTheme({
     Key key,
     @required this.data,

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -216,6 +216,8 @@ class ToggleButtonsThemeData extends Diagnosticable {
 class ToggleButtonsTheme extends InheritedWidget {
   /// Creates a toggle buttons theme that controls the color and border
   /// parameters for [ToggleButtons].
+  ///
+  /// The data argument must not be null.
   const ToggleButtonsTheme({
     Key key,
     @required this.data,

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -216,38 +216,11 @@ class ToggleButtonsThemeData extends Diagnosticable {
 class ToggleButtonsTheme extends InheritedWidget {
   /// Creates a toggle buttons theme that controls the color and border
   /// parameters for [ToggleButtons].
-  ToggleButtonsTheme({
+  const ToggleButtonsTheme({
     Key key,
-    Color color,
-    Color selectedColor,
-    Color disabledColor,
-    Color fillColor,
-    Color focusColor,
-    Color highlightColor,
-    Color hoverColor,
-    Color splashColor,
-    Color borderColor,
-    Color selectedBorderColor,
-    Color disabledBorderColor,
-    BorderRadius borderRadius,
-    double borderWidth,
+    @required this.data,
     Widget child,
-  }) :  data = ToggleButtonsThemeData(
-          color: color,
-          selectedColor: selectedColor,
-          disabledColor: disabledColor,
-          fillColor: fillColor,
-          focusColor: focusColor,
-          highlightColor: highlightColor,
-          hoverColor: hoverColor,
-          splashColor: splashColor,
-          borderColor: borderColor,
-          selectedBorderColor: selectedBorderColor,
-          disabledBorderColor: disabledBorderColor,
-          borderRadius: borderRadius,
-          borderWidth: borderWidth,
-        ),
-        super(key: key, child: child);
+  }) : assert(data != null), super(key: key, child: child);
 
   /// Specifies the color and border values for descendant [ToggleButtons] widgets.
   final ToggleButtonsThemeData data;

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -214,6 +214,8 @@ class TooltipThemeData extends Diagnosticable {
 class TooltipTheme extends InheritedWidget {
   /// Creates a tooltip theme that controls the configurations for
   /// [Tooltip].
+  ///
+  /// The data argument must not be null.
   const TooltipTheme({
     Key key,
     @required this.data,

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -214,32 +214,11 @@ class TooltipThemeData extends Diagnosticable {
 class TooltipTheme extends InheritedWidget {
   /// Creates a tooltip theme that controls the configurations for
   /// [Tooltip].
-  TooltipTheme({
+  const TooltipTheme({
     Key key,
-    double height,
-    EdgeInsetsGeometry padding,
-    EdgeInsetsGeometry margin,
-    double verticalOffset,
-    bool preferBelow,
-    bool excludeFromSemantics,
-    Decoration decoration,
-    TextStyle textStyle,
-    Duration waitDuration,
-    Duration showDuration,
+    @required this.data,
     Widget child,
-  }) : data = TooltipThemeData(
-         height: height,
-         padding: padding,
-         margin: margin,
-         verticalOffset: verticalOffset,
-         preferBelow: preferBelow,
-         excludeFromSemantics: excludeFromSemantics,
-         decoration: decoration,
-         textStyle: textStyle,
-         waitDuration: waitDuration,
-         showDuration: showDuration,
-       ),
-       super(key: key, child: child);
+  }) : assert(data != null), super(key: key, child: child);
 
   /// The properties for descendant [Tooltip] widgets.
   final TooltipThemeData data;

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -196,9 +196,11 @@ class TooltipThemeData extends Diagnosticable {
 ///
 /// ```dart
 /// TooltipTheme(
-///   decoration: BoxDecoration(
-///     color: Colors.blue.withOpacity(0.9),
-///     borderRadius: BorderRadius.zero,
+///   data: TooltipThemeData(
+///     decoration: BoxDecoration(
+///       color: Colors.blue.withOpacity(0.9),
+///       borderRadius: BorderRadius.zero,
+///     ),
 ///   ),
 ///   child: Tooltip(
 ///     message: 'Example tooltip',

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -261,10 +261,12 @@ void main() {
         child: Column(
           children: <Widget>[
             PopupMenuTheme(
-              color: Colors.pink,
-              shape: BeveledRectangleBorder(borderRadius: BorderRadius.circular(10)),
-              elevation: 6.0,
-              textStyle: const TextStyle(color: Color(0xfffff000), textBaseline: TextBaseline.alphabetic),
+              data: PopupMenuThemeData(
+                color: Colors.pink,
+                shape: BeveledRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                elevation: 6.0,
+                textStyle: const TextStyle(color: Color(0xfffff000), textBaseline: TextBaseline.alphabetic),
+              ),
               child: PopupMenuButton<void>(
                 key: popupButtonKey,
                 itemBuilder: (BuildContext context) {

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -22,7 +22,7 @@ void main() {
     expect(const ToggleButtonsThemeData().hashCode, const ToggleButtonsThemeData().copyWith().hashCode);
   });
 
-   test('ToggleButtonsThemeData defaults', () {
+  test('ToggleButtonsThemeData defaults', () {
     const ToggleButtonsThemeData themeData = ToggleButtonsThemeData();
     expect(themeData.color, null);
     expect(themeData.selectedColor, null);
@@ -38,7 +38,7 @@ void main() {
     expect(themeData.borderRadius, null);
     expect(themeData.borderWidth, null);
 
-    final ToggleButtonsTheme theme = ToggleButtonsTheme();
+    const ToggleButtonsTheme theme = ToggleButtonsTheme(data: ToggleButtonsThemeData());
     expect(theme.data.color, null);
     expect(theme.data.selectedColor, null);
     expect(theme.data.disabledColor, null);
@@ -118,6 +118,7 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
+              data: const ToggleButtonsThemeData(),
               child: ToggleButtons(
                 color: enabledColor,
                 isSelected: const <bool>[false],
@@ -154,7 +155,9 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
-              selectedColor: selectedColor,
+              data: const ToggleButtonsThemeData(
+                selectedColor: selectedColor,
+              ),
               child: ToggleButtons(
                 color: enabledColor,
                 isSelected: const <bool>[true],
@@ -186,7 +189,9 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
-              disabledColor: disabledColor,
+              data: const ToggleButtonsThemeData(
+                disabledColor: disabledColor,
+              ),
               child: ToggleButtons(
                 color: enabledColor,
                 isSelected: const <bool>[false],
@@ -221,7 +226,7 @@ void main() {
       Material(
         child: boilerplate(
           child: ToggleButtonsTheme(
-            fillColor: customFillColor,
+            data: const ToggleButtonsThemeData(fillColor: customFillColor),
             child: ToggleButtons(
               isSelected: const <bool>[true],
               onPressed: (int index) {},
@@ -257,10 +262,12 @@ void main() {
       Material(
         child: boilerplate(
           child: ToggleButtonsTheme(
-            splashColor: splashColor,
-            highlightColor: highlightColor,
-            hoverColor: hoverColor,
-            focusColor: focusColor,
+            data: const ToggleButtonsThemeData(
+              splashColor: splashColor,
+              highlightColor: highlightColor,
+              hoverColor: hoverColor,
+              focusColor: focusColor,
+            ),
             child: ToggleButtons(
               isSelected: const <bool>[true],
               onPressed: (int index) {},
@@ -332,8 +339,10 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
-              borderColor: borderColor,
-              borderWidth: customWidth,
+              data: const ToggleButtonsThemeData(
+                borderColor: borderColor,
+                borderWidth: customWidth,
+              ),
               child: ToggleButtons(
                 isSelected: const <bool>[false],
                 onPressed: (int index) {},
@@ -371,8 +380,10 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
-              selectedBorderColor: selectedBorderColor,
-              borderWidth: customWidth,
+              data: const ToggleButtonsThemeData(
+                selectedBorderColor: selectedBorderColor,
+                borderWidth: customWidth,
+              ),
               child: ToggleButtons(
                 isSelected: const <bool>[true],
                 onPressed: (int index) {},
@@ -409,8 +420,10 @@ void main() {
         Material(
           child: boilerplate(
             child: ToggleButtonsTheme(
-              disabledBorderColor: disabledBorderColor,
-              borderWidth: customWidth,
+              data: const ToggleButtonsThemeData(
+                disabledBorderColor: disabledBorderColor,
+                borderWidth: customWidth,
+              ),
               child: ToggleButtons(
                 isSelected: const <bool>[false],
                 children: const <Widget>[

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -159,10 +159,12 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: TooltipTheme(
-          height: 100.0,
-          padding: const EdgeInsets.all(0.0),
-          verticalOffset: 100.0,
-          preferBelow: false,
+          data: const TooltipThemeData(
+            height: 100.0,
+            padding: EdgeInsets.all(0.0),
+            verticalOffset: 100.0,
+            preferBelow: false,
+          ),
           child: Overlay(
             initialEntries: <OverlayEntry>[
               OverlayEntry(
@@ -286,10 +288,12 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: TooltipTheme(
-          height: 190.0,
-          padding: const EdgeInsets.all(0.0),
-          verticalOffset: 100.0,
-          preferBelow: false,
+          data: const TooltipThemeData(
+            height: 190.0,
+            padding: EdgeInsets.all(0.0),
+            verticalOffset: 100.0,
+            preferBelow: false,
+          ),
           child: Overlay(
             initialEntries: <OverlayEntry>[
               OverlayEntry(
@@ -412,10 +416,12 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: TooltipTheme(
-          height: 190.0,
-          padding: const EdgeInsets.all(0.0),
-          verticalOffset: 100.0,
-          preferBelow: true,
+          data: const TooltipThemeData(
+            height: 190.0,
+            padding: EdgeInsets.all(0.0),
+            verticalOffset: 100.0,
+            preferBelow: true,
+          ),
           child: Overlay(
             initialEntries: <OverlayEntry>[
               OverlayEntry(
@@ -529,8 +535,10 @@ void main() {
             OverlayEntry(
               builder: (BuildContext context) {
                 return TooltipTheme(
-                  padding: const EdgeInsets.all(0.0),
-                  margin: const EdgeInsets.all(_customPaddingValue),
+                  data: const TooltipThemeData(
+                    padding: EdgeInsets.all(0.0),
+                    margin: EdgeInsets.all(_customPaddingValue),
+                  ),
                   child: Tooltip(
                     key: key,
                     message: tooltipText,
@@ -607,6 +615,7 @@ void main() {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(MaterialApp(
       home: TooltipTheme(
+        data: const TooltipThemeData(),
         child: Tooltip(
           textStyle: const TextStyle(
             color: Colors.orange,
@@ -687,7 +696,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: TooltipTheme(
-          decoration: customDecoration,
+          data: const TooltipThemeData(decoration: customDecoration),
           child: Overlay(
             initialEntries: <OverlayEntry>[
               OverlayEntry(
@@ -769,14 +778,16 @@ void main() {
   testWidgets('Tooltip height and padding - TooltipTheme', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     const double customTooltipHeight = 100.0;
-    const double customPaddingVal = 20.0;
+    const double customPaddingValue = 20.0;
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: TooltipTheme(
-          height: customTooltipHeight,
-          padding: const EdgeInsets.all(customPaddingVal),
+          data: const TooltipThemeData(
+            height: customTooltipHeight,
+            padding: EdgeInsets.all(customPaddingValue),
+          ),
           child: Overlay(
             initialEntries: <OverlayEntry>[
               OverlayEntry(
@@ -805,8 +816,8 @@ void main() {
     ));
 
     expect(tip.size.height, equals(customTooltipHeight));
-    expect(content.size.height, equals(customTooltipHeight - 2 * customPaddingVal));
-    expect(content.size.width, equals(tip.size.width - 2 * customPaddingVal));
+    expect(content.size.height, equals(customTooltipHeight - 2 * customPaddingValue));
+    expect(content.size.width, equals(tip.size.width - 2 * customPaddingValue));
   }, skip: isBrowser);
 
   testWidgets('Tooltip waitDuration - ThemeData.tooltipTheme', (WidgetTester tester) async {
@@ -868,7 +879,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: TooltipTheme(
-          waitDuration: customWaitDuration,
+          data: const TooltipThemeData(waitDuration: customWaitDuration),
           child: Center(
             child: Tooltip(
               message: tooltipText,
@@ -943,7 +954,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: TooltipTheme(
-          showDuration: customShowDuration,
+          data: const TooltipThemeData(showDuration: customShowDuration),
           child: Center(
             child: Tooltip(
               message: tooltipText,
@@ -1012,8 +1023,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        home: TooltipTheme(
-          child: const Center(
+        home: const TooltipTheme(
+          data: TooltipThemeData(),
+          child: Center(
             child: Tooltip(
               message: 'Foo',
               child: Text('Bar'),
@@ -1089,9 +1101,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        home: TooltipTheme(
-          excludeFromSemantics: true,
-          child: const Center(
+        home: const TooltipTheme(
+          data: TooltipThemeData(excludeFromSemantics: true),
+          child: Center(
             child: Tooltip(
               message: 'Foo',
               child: Text('Bar'),
@@ -1175,6 +1187,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: TooltipTheme(
+          data: const TooltipThemeData(),
           child: Center(
             child: Tooltip(
               message: 'Foo',

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -1022,8 +1022,8 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: const TooltipTheme(
+      const MaterialApp(
+        home: TooltipTheme(
           data: TooltipThemeData(),
           child: Center(
             child: Tooltip(
@@ -1100,8 +1100,8 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: const TooltipTheme(
+      const MaterialApp(
+        home: TooltipTheme(
           data: TooltipThemeData(excludeFromSemantics: true),
           child: Center(
             child: Tooltip(


### PR DESCRIPTION
The constructor signatures for TooltipTheme, ToggleButtonsTheme, PopupMenuTheme have been incompatibly changed. They require just one theme `data` parameter.

For example the `TooltipTheme` constructor was defined like this:
```
const PopupMenuTheme({
  Key key,
  Color color,
  ShapeBorder shape,
  double elevation,
  TextStyle textStyle,
  Widget child,
}) : data = PopupMenuThemeData(
       color: color,
       shape: shape,
       elevation: elevation,
       textStyle: textStyle,
     ),
     super(key: key, child: child);
}) : assert(data != null), super(key: key, child: child);

final PopupMenuThemeData data;
```

It's now defined like this:
```
const PopupMenuTheme({
  Key key,
  @required this.data,
  Widget child,
}) : assert(data != null), super(key: key, child: child);

final PopupMenuThemeData data;
```

Not having a theme data parameter makes it difficult to override an inherited theme’s configuration. For example to override the inherited PopupMenuTheme one would have to write:
```
PopupMenuThemeData inheritedTheme = PopupMenuTheme.of(context);
PopupMenuTheme(
  color: Colors.green, // the only property to be changed
  shape: inheritedTheme.shape,
  elevation: inheritedTheme.elevation,
  textStyle: inheritedTheme.textStyle,
  child: myWidgetSubtree,
)
```

This is tedious, error prone, and likely to rot when TooltipThemeData is extended. It's also inconsistent with `Theme` and `ThemeData`. Better to just have a TooltipThemeData valued data constructor parameter, since copyWith can be applied to ToolTipThemeData.
```
TooltipTheme(
  data: TooltipTheme.of(context).copyWith(
    height: myNewTooltipHeight, // the only property to be changed
  ),
  child: myWidgetSubtree,
)
```

These APIs were added just last week: PopupMenuTheme https://github.com/flutter/flutter/pull/36088 TooltipTheme https://github.com/flutter/flutter/pull/36030 ToggleButtonsTheme https://github.com/flutter/flutter/pull/34599

Code that had already adopted the new APIs can easily be updated as shown in the example above.
