### PR TITLE
[flutter_tool] Include the local timezone in analytics timestamp

### DIFF
--- a/packages/flutter_tools/lib/src/base/time.dart
+++ b/packages/flutter_tools/lib/src/base/time.dart
@@ -32,3 +32,18 @@ class _FixedTimeClock extends SystemClock {
   @override
   DateTime now() => _fixedTime;
 }
+
+/// Format time as 'yyyy-MM-dd HH:mm:ss Z' where Z is the difference between the
+/// timezone of t and UTC formatted according to RFC 822.
+String formatDateTime(DateTime t) {
+  final String sign = t.timeZoneOffset.isNegative ? '-' : '+';
+  final Duration tzOffset = t.timeZoneOffset.abs();
+  final int hoursOffset = tzOffset.inHours;
+  final int minutesOffset =
+      tzOffset.inMinutes - (Duration.minutesPerHour * hoursOffset);
+  assert(hoursOffset < 24);
+  assert(minutesOffset < 60);
+
+  String twoDigits(int n) => (n >= 10) ? '$n' : '0$n';
+  return '$t $sign${twoDigits(hoursOffset)}${twoDigits(minutesOffset)}';
+}

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -223,7 +223,7 @@ class _UsageImpl implements Usage {
 
     final Map<String, String> paramsWithLocalTime = <String, String>{
       ...?parameters,
-      cdKey(CustomDimensions.localTime): systemClock.now().toString(),
+      cdKey(CustomDimensions.localTime): formatDateTime(systemClock.now()),
     };
     _analytics.sendScreenView(command, parameters: paramsWithLocalTime);
   }
@@ -240,7 +240,7 @@ class _UsageImpl implements Usage {
 
     final Map<String, String> paramsWithLocalTime = <String, String>{
       ...?parameters,
-      cdKey(CustomDimensions.localTime): systemClock.now().toString(),
+      cdKey(CustomDimensions.localTime): formatDateTime(systemClock.now()),
     };
 
     _analytics.sendEvent(category, parameter, parameters: paramsWithLocalTime);

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -212,7 +212,7 @@ void main() {
 
       final String log = fs.file('analytics.log').readAsStringSync();
       final DateTime dateTime = DateTime.fromMillisecondsSinceEpoch(kMillis);
-      expect(log.contains(dateTime.toString()), isTrue);
+      expect(log.contains(formatDateTime(dateTime)), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       SystemClock: () => mockClock,
@@ -237,7 +237,7 @@ void main() {
 
       final String log = fs.file('analytics.log').readAsStringSync();
       final DateTime dateTime = DateTime.fromMillisecondsSinceEpoch(kMillis);
-      expect(log.contains(dateTime.toString()), isTrue);
+      expect(log.contains(formatDateTime(dateTime)), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       SystemClock: () => mockClock,

--- a/packages/flutter_tools/test/general.shard/time_test.dart
+++ b/packages/flutter_tools/test/general.shard/time_test.dart
@@ -18,4 +18,22 @@ void main() {
       expect(clock.ago(const Duration(days: 10)), DateTime(1991, 8, 13));
     });
   });
+
+  group('formatting', () {
+    test('can round-trip formatted time', () {
+      final DateTime time = DateTime(1991, 7, 31);
+      expect(time.isUtc, isFalse);
+      // formatDateTime() adds a timezone offset to DateTime.toString().
+      final String formattedTime = formatDateTime(time);
+      // If a date time string has a timezone offset, DateTime.tryParse()
+      // converts the parsed time to UTC.
+      final DateTime parsedTime = DateTime.tryParse(formattedTime);
+      expect(parsedTime, isNotNull);
+      expect(parsedTime.isUtc, isTrue);
+      // Convert the parsed time (which should be utc) to the local timezone and
+      // compare against the original time which is in the local timezone. They
+      // should be the same.
+      expect(parsedTime.toLocal(), equals(time));
+    });
+  });
 }


### PR DESCRIPTION
## Description

Prior to this PR, analytics screens and events include the local time, but no timezone information. This PR adds the timezone information formatted as "yyyy/MM/dd HH:mm:ss (+/-)HHmm".

## Related Issues

https://github.com/flutter/flutter/issues/37334

## Tests

I added the following tests:

Updated existing analytics tests and added a test in time_test.dart of the new formatting code.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
