### PR TITLE
Handle compilation errors in frontend server and cleanup error cases

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -81,7 +81,7 @@ class CompilerOutput {
   final List<Uri> sources;
 }
 
-enum StdoutState { CollectDiagnostic, CollectDependencies, RejectCompile }
+enum StdoutState { CollectDiagnostic, CollectDependencies }
 
 /// Handles stdin/stdout communication with the frontend server.
 class StdoutHandler {
@@ -110,11 +110,6 @@ class StdoutHandler {
       if (_expectSources) {
         if (state == StdoutState.CollectDiagnostic) {
           state = StdoutState.CollectDependencies;
-          return;
-        }
-        if (state == StdoutState.RejectCompile) {
-          state = StdoutState.CollectDiagnostic;
-          compilerOutput.complete(null);
           return;
         }
       }
@@ -658,8 +653,7 @@ class ResidentCompiler {
     if (!_compileRequestNeedsConfirmation) {
       return Future<CompilerOutput>.value(null);
     }
-    _stdoutHandler.reset();
-    _stdoutHandler.state = StdoutState.RejectCompile;
+    _stdoutHandler.reset(expectSources: false);
     _server.stdin.writeln('reject');
     printTrace('<- reject');
     _compileRequestNeedsConfirmation = false;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -592,11 +592,7 @@ abstract class ResidentRunner {
 
   bool get supportsRestart => false;
 
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) {
-    final String mode = isRunningProfile ? 'profile' :
-        isRunningRelease ? 'release' : 'this';
-    throw '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode';
-  }
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason });
 
   Future<void> exit() async {
     _exited = true;
@@ -750,8 +746,9 @@ abstract class ResidentRunner {
     Restart restart,
     CompileExpression compileExpression,
   }) async {
-    if (!debuggingOptions.debuggingEnabled)
-      throw 'The service protocol is not enabled.';
+    if (!debuggingOptions.debuggingEnabled) {
+      throw Exception('The service protocol is not enabled.');
+    }
 
     bool viewFound = false;
     for (FlutterDevice device in flutterDevices) {
@@ -762,14 +759,19 @@ abstract class ResidentRunner {
       );
       await device.getVMs();
       await device.refreshViews();
-      if (device.views.isNotEmpty)
+      if (device.views.isNotEmpty) {
         viewFound = true;
+      }
     }
     if (!viewFound) {
-      if (flutterDevices.length == 1)
-        throw 'No Flutter view is available on ${flutterDevices.first.device.name}.';
-      throw 'No Flutter view is available on any device '
-            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).';
+      if (flutterDevices.length == 1) {
+        throw Exception(
+            'No Flutter view is available on ${flutterDevices.first.device.name}.');
+      }
+      throw Exception(
+          'No Flutter view is available on any device '
+          '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).'
+      );
     }
 
     // Listen for service protocol connection to close.

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -204,4 +204,9 @@ class ColdRunner extends ResidentRunner {
         await device.device.stopApp(device.package);
     }
   }
+
+  @override
+  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) {
+    throw UnsupportedError('${fullRestart ? 'Restart' : 'Reload'} is not supported in cold mode');
+  }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -51,7 +51,6 @@ class DeviceReloadReport {
   List<Map<String, dynamic>> reports; // List has one report per Flutter view.
 }
 
-// TODO(mklim): Test this, flutter/flutter#23031.
 class HotRunner extends ResidentRunner {
   HotRunner(
     List<FlutterDevice> devices, {
@@ -481,8 +480,11 @@ class HotRunner extends ResidentRunner {
            )
           )
          )) {
-      if (printErrors)
+      if (printErrors) {
+        // TODO(jonahwilliams): this message is dumped as raw json and formatted
+        // quite poorly. It should be cleaned up and presented in a nicer way.
         printError('Hot reload received invalid response: $reloadReport');
+      }
       return false;
     }
     if (!reloadReport['success']) {
@@ -648,7 +650,7 @@ class HotRunner extends ResidentRunner {
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         if (view.uiIsolate == null) {
-          throw 'Application isolate not found';
+          throw Exception('Application isolate not found');
         }
       }
     }
@@ -701,9 +703,8 @@ class HotRunner extends ResidentRunner {
             final Map<String, dynamic> firstReport = reports.first;
             // Don't print errors because they will be printed further down when
             // `validateReloadReport` is called again.
-            await device.updateReloadStatus(
-              validateReloadReport(firstReport, printErrors: false),
-            );
+            final bool isReportValid = validateReloadReport(firstReport, printErrors: false);
+            await device.updateReloadStatus(isReportValid);
             completer.complete(DeviceReloadReport(device, reports));
           },
         ));

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -369,7 +369,7 @@ class VMService {
 }
 
 /// An error that is thrown when constructing/updating a service object.
-class VMServiceObjectLoadError {
+class VMServiceObjectLoadError implements Exception {
   VMServiceObjectLoadError(this.message, this.map);
   final String message;
   final Map<String, dynamic> map;

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
+import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -478,6 +479,30 @@ void main() {
 
     verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleProfileWidgetBuilds()).called(1);
+  }));
+
+  test('ResidentRunner throws if connectToServiceProtocol is called when debugging is disabled', () => testbed.run(() {
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release)
+    );
+
+    expect(() => residentRunner.connectToServiceProtocol(), throwsA(isInstanceOf<Exception>()));
+  }));
+
+  test('ResidentRunner throws if no views are discovered when connectToServiceProtocol is called', () => testbed.run(() {
+    when(mockFlutterDevice.views).thenReturn(<FlutterView>[]);
+
+    expect(() => residentRunner.connectToServiceProtocol(), throwsA(isInstanceOf<Exception>()));
+  }));
+
+  test('ColdRunner does not support reload or restart', () => testbed.run(() {
+    final ColdRunner coldRunner = ColdRunner(<FlutterDevice>[mockFlutterDevice]);
+
+    expect(() => coldRunner.restart(), throwsA(isInstanceOf<UnsupportedError>()));
   }));
 }
 

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -424,4 +424,10 @@ class TestRunner extends ResidentRunner {
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,
   }) async => null;
+
+  @override
+  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) {
+    throw UnsupportedError('${fullRestart ? 'Restart' : 'Reload'} is not supported in cold mode');
+  }
+
 }


### PR DESCRIPTION
## Description

Currently when the device rejects a reload request, we inform the frontend_server that the request was rejected. In the StdoutHandler state machine, this reject is represented as

```
<- reject
 result 08fd2a59-cd05-47f2-b1cb-255ed7ef7202
-> 08fd2a59-cd05-47f2-b1cb-255ed7ef7202
```

That is, the response is simply a boundary key and no other messages. However, when reset the state machine assumes a default state of `expectSources: true`. If no additional data is sent besides the boundary key, the compiler will hang indefinitely:

```
    if (message.startsWith(boundaryKey)) {
      if (_expectSources) {
        if (state == StdoutState.CollectDiagnostic) {
          // If expectSources is true, we get stuck here and return. Since no more content is sent, we're
          /// trapped forever
          state = StdoutState.CollectDependencies;
          return;
        }
      }
      if (message.length <= boundaryKey.length) {
        compilerOutput.complete(null);
        return;
      }
```

The fix is fairly trivial, when resetting the StdoutState for a reject request, we must explicitly set `expectSources: false`

https://github.com/flutter/flutter/issues/37251
https://github.com/flutter/flutter/issues/35924


EDIT:

To reproduce this, flutter run the gallery app. After it has started, add an import of dart:mirrors and hot reload