### PR TITLE
Added ThemeData.from() method to construct a Theme from a ColorScheme

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -470,15 +470,13 @@ class ThemeData extends Diagnosticable {
        assert(bottomSheetTheme != null),
        assert(popupMenuTheme != null);
 
-  /// Create a [ThemeData] based on the colors in the given [colorScheme].
+  /// Create a [ThemeData] based on the colors in the given [colorScheme] and
+  /// text styles of the optional [textTheme].
   ///
-  /// It will derive appropriate values for all the [ThemeData] properties
-  /// based on [colorScheme] and [textTheme].
-  ///
-  /// [colorScheme] can not be [null].
+  /// The [colorScheme] can not be null.
   ///
   /// If [colorScheme.brightness] is [Brightness.dark] then
-  /// [ThemeData.applyElevationOverlayColor] will be set to [true] to support
+  /// [ThemeData.applyElevationOverlayColor] will be set to true to support
   /// the Material dark theme method for indicating elevation by overlaying
   /// a semi-transparent white color on top of the surface color.
   ///
@@ -516,8 +514,6 @@ class ThemeData extends Diagnosticable {
       brightness: colorScheme.brightness,
       primaryColor: primarySurfaceColor,
       primaryColorBrightness: ThemeData.estimateBrightnessForColor(primarySurfaceColor),
-      primaryColorLight: colorScheme.primaryVariant,
-      primaryColorDark: colorScheme.primaryVariant,
       canvasColor: colorScheme.background,
       accentColor: colorScheme.secondary,
       accentColorBrightness: ThemeData.estimateBrightnessForColor(colorScheme.secondary),

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -219,7 +219,7 @@ class ThemeData extends Diagnosticable {
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;
     indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
-    hintColor ??= isDark ?  const Color(0x80FFFFFF) : const Color(0x8A000000);
+    hintColor ??= isDark ? const Color(0x80FFFFFF) : const Color(0x8A000000);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
     pageTransitionsTheme ??= const PageTransitionsTheme();
@@ -470,9 +470,69 @@ class ThemeData extends Diagnosticable {
        assert(bottomSheetTheme != null),
        assert(popupMenuTheme != null);
 
-  // Warning: make sure these properties are in the exact same order as in
-  // hashValues() and in the raw constructor and in the order of fields in
-  // the class and in the lerp() method.
+  /// Create a [ThemeData] based on the colors in the given [colorScheme].
+  ///
+  /// It will derive appropriate values for all the [ThemeData] properties
+  /// based on [colorScheme] and [textTheme].
+  ///
+  /// [colorScheme] can not be [null].
+  ///
+  /// If [colorScheme.brightness] is [Brightness.dark] then
+  /// [ThemeData.applyElevationOverlayColor] will be set to [true] to support
+  /// the Material dark theme method for indicating elevation by overlaying
+  /// a semi-transparent white color on top of the surface color.
+  ///
+  /// This is the recommended method to theme your application. As we move
+  /// forward we will be converting all the widget implementations to only use
+  /// colors or colors derived from those in [ColorScheme].
+  ///
+  /// {@tool sample}
+  /// This example will set up an application to use the baseline Material
+  /// Design light and dark themes.
+  ///
+  /// ```dart
+  /// MaterialApp(
+  ///   theme: ThemeData.from(colorScheme: ColorScheme.light()),
+  ///   darkTheme: ThemeData.from(colorScheme: ColorScheme.dark()),
+  /// )
+  /// ```
+  /// {@end-tool}
+  ///
+  /// See <https://material.io/design/color/> for
+  /// more discussion on how to pick the right colors.
+  factory ThemeData.from({
+    @required ColorScheme colorScheme,
+    TextTheme textTheme,
+  }) {
+    assert(colorScheme != null);
+
+    final bool isDark = colorScheme.brightness == Brightness.dark;
+
+    // For surfaces that use primary color in light themes and surface color in dark
+    final Color primarySurfaceColor = isDark ? colorScheme.surface : colorScheme.primary;
+    final Color onPrimarySurfaceColor = isDark ? colorScheme.onSurface : colorScheme.onPrimary;
+
+    return ThemeData(
+      brightness: colorScheme.brightness,
+      primaryColor: primarySurfaceColor,
+      primaryColorBrightness: ThemeData.estimateBrightnessForColor(primarySurfaceColor),
+      primaryColorLight: colorScheme.primaryVariant,
+      primaryColorDark: colorScheme.primaryVariant,
+      canvasColor: colorScheme.background,
+      accentColor: colorScheme.secondary,
+      accentColorBrightness: ThemeData.estimateBrightnessForColor(colorScheme.secondary),
+      scaffoldBackgroundColor: colorScheme.background,
+      cardColor: colorScheme.surface,
+      dividerColor: colorScheme.onSurface.withOpacity(0.12),
+      backgroundColor: colorScheme.background,
+      dialogBackgroundColor: colorScheme.background,
+      errorColor: colorScheme.error,
+      textTheme: textTheme,
+      indicatorColor: onPrimarySurfaceColor,
+      applyElevationOverlayColor: isDark,
+      colorScheme: colorScheme,
+    );
+  }
 
   /// A default light blue theme.
   ///
@@ -496,6 +556,10 @@ class ThemeData extends Diagnosticable {
   /// Most applications would use [Theme.of], which provides correct localized
   /// text geometry.
   factory ThemeData.fallback() => ThemeData.light();
+
+  // Warning: make sure these properties are in the exact same order as in
+  // hashValues() and in the raw constructor and in the order of fields in
+  // the class and in the lerp() method.
 
   /// The brightness of the overall theme of the application. Used by widgets
   /// like buttons to determine what color to pick when not using the primary or

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -136,4 +136,38 @@ void main() {
   test('cursorColor', () {
     expect(ThemeData(cursorColor: Colors.red).cursorColor, Colors.red);
   });
+
+  testWidgets('ThemeData.from a light color scheme sets appropriate values', (WidgetTester tester) async {
+    const ColorScheme lightColors = ColorScheme.light();
+    final ThemeData theme = ThemeData.from(colorScheme: lightColors);
+
+    expect(theme.brightness, equals(Brightness.light));
+    expect(theme.primaryColor, equals(lightColors.primary));
+    expect(theme.accentColor, equals(lightColors.secondary));
+    expect(theme.cardColor, equals(lightColors.surface));
+    expect(theme.backgroundColor, equals(lightColors.background));
+    expect(theme.canvasColor, equals(lightColors.background));
+    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
+    expect(theme.dialogBackgroundColor, equals(lightColors.background));
+    expect(theme.errorColor, equals(lightColors.error));
+    expect(theme.applyElevationOverlayColor, isFalse);
+  });
+
+  testWidgets('ThemeData.from a dark color scheme sets appropriate values', (WidgetTester tester) async {
+    const ColorScheme darkColors = ColorScheme.dark();
+    final ThemeData theme = ThemeData.from(colorScheme: darkColors);
+
+    expect(theme.brightness, equals(Brightness.dark));
+    // in dark theme's the color used for main components is surface instead of primary
+    expect(theme.primaryColor, equals(darkColors.surface));
+    expect(theme.accentColor, equals(darkColors.secondary));
+    expect(theme.cardColor, equals(darkColors.surface));
+    expect(theme.backgroundColor, equals(darkColors.background));
+    expect(theme.canvasColor, equals(darkColors.background));
+    expect(theme.scaffoldBackgroundColor, equals(darkColors.background));
+    expect(theme.dialogBackgroundColor, equals(darkColors.background));
+    expect(theme.errorColor, equals(darkColors.error));
+    expect(theme.applyElevationOverlayColor, isTrue);
+  });
+
 }

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -85,39 +85,6 @@ void main() {
     );
   });
 
-  testWidgets('ThemeData.from a light color scheme sets appropriate values', (WidgetTester tester) async {
-    final ColorScheme lightColors = ColorScheme.light();
-    final ThemeData theme = ThemeData.from(colorScheme: lightColors);
-
-    expect(theme.brightness, equals(Brightness.light));
-    expect(theme.primaryColor, equals(lightColors.primary));
-    expect(theme.accentColor, equals(lightColors.secondary));
-    expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.backgroundColor, equals(lightColors.background));
-    expect(theme.canvasColor, equals(lightColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
-    expect(theme.dialogBackgroundColor, equals(lightColors.background));
-    expect(theme.errorColor, equals(lightColors.error));
-    expect(theme.applyElevationOverlayColor, isFalse);
-  });
-
-  testWidgets('ThemeData.from a dark color scheme sets appropriate values', (WidgetTester tester) async {
-    final ColorScheme darkColors = ColorScheme.dark();
-    final ThemeData theme = ThemeData.from(colorScheme: darkColors);
-
-    expect(theme.brightness, equals(Brightness.dark));
-    // in dark theme's the color used for main components is surface instead of primary
-    expect(theme.primaryColor, equals(darkColors.surface));
-    expect(theme.accentColor, equals(darkColors.secondary));
-    expect(theme.cardColor, equals(darkColors.surface));
-    expect(theme.backgroundColor, equals(darkColors.background));
-    expect(theme.canvasColor, equals(darkColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(darkColors.background));
-    expect(theme.dialogBackgroundColor, equals(darkColors.background));
-    expect(theme.errorColor, equals(darkColors.error));
-    expect(theme.applyElevationOverlayColor, isTrue);
-  });
-  
   testWidgets('PopupMenu inherits shadowed app theme', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/5572
     final Key popupMenuButtonKey = UniqueKey();

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -85,6 +85,39 @@ void main() {
     );
   });
 
+  testWidgets('ThemeData.from a light color scheme sets appropriate values', (WidgetTester tester) async {
+    final ColorScheme lightColors = ColorScheme.light();
+    final ThemeData theme = ThemeData.from(colorScheme: lightColors);
+
+    expect(theme.brightness, equals(Brightness.light));
+    expect(theme.primaryColor, equals(lightColors.primary));
+    expect(theme.accentColor, equals(lightColors.secondary));
+    expect(theme.cardColor, equals(lightColors.surface));
+    expect(theme.backgroundColor, equals(lightColors.background));
+    expect(theme.canvasColor, equals(lightColors.background));
+    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
+    expect(theme.dialogBackgroundColor, equals(lightColors.background));
+    expect(theme.errorColor, equals(lightColors.error));
+    expect(theme.applyElevationOverlayColor, isFalse);
+  });
+
+  testWidgets('ThemeData.from a dark color scheme sets appropriate values', (WidgetTester tester) async {
+    final ColorScheme darkColors = ColorScheme.dark();
+    final ThemeData theme = ThemeData.from(colorScheme: darkColors);
+
+    expect(theme.brightness, equals(Brightness.dark));
+    // in dark theme's the color used for main components is surface instead of primary
+    expect(theme.primaryColor, equals(darkColors.surface));
+    expect(theme.accentColor, equals(darkColors.secondary));
+    expect(theme.cardColor, equals(darkColors.surface));
+    expect(theme.backgroundColor, equals(darkColors.background));
+    expect(theme.canvasColor, equals(darkColors.background));
+    expect(theme.scaffoldBackgroundColor, equals(darkColors.background));
+    expect(theme.dialogBackgroundColor, equals(darkColors.background));
+    expect(theme.errorColor, equals(darkColors.error));
+    expect(theme.applyElevationOverlayColor, isTrue);
+  });
+  
   testWidgets('PopupMenu inherits shadowed app theme', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/5572
     final Key popupMenuButtonKey = UniqueKey();


### PR DESCRIPTION
## Description

In order to more easily provide themes based on a given [Material color scheme](https://material.io/design/color/), this PR adds a new `ThemeData.from()` method that will construct a `ThemeData` with values based on the passed `ColorScheme` and optional `TextTheme` parameters.

This will allow users to easily construct an app with the baseline Material light and dark themes with something like:

```dart
MaterialApp(
  theme: ThemeData.from(colorScheme: ColorScheme.light()),
  darkTheme: ThemeData.from(colorScheme: ColorScheme.dark()),
)
```

| Light | Dark | 
|------|------|
| ![Light](https://user-images.githubusercontent.com/19588/62258322-c6160200-b3be-11e9-9f2a-d90039fd440a.png) | ![Dark](https://user-images.githubusercontent.com/19588/62258332-d201c400-b3be-11e9-931c-97d57a95d087.png) |

## Tests

I added tests to `theme_ data_test.dart` that exercises this function with the default light and dark Material color schemes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
