### PR TITLE
Add .android/Flutter/flutter.iml to module template.

### DIFF
--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/flutter.iml.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/flutter.iml.copy.tmpl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":flutter" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":flutter" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/javac/debugUnitTest/compileDebugUnitTestJavaWithJavac/classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/packages/flutter_tools/test/general.shard/commands/create_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/create_test.dart
@@ -355,6 +355,7 @@ void main() {
     ], <String>[
       '.android/build.gradle',
       '.android/Flutter/build.gradle',
+      '.android/Flutter/flutter.iml',
       '.android/Flutter/src/main/AndroidManifest.xml',
       '.android/Flutter/src/main/java/io/flutter/facade/Flutter.java',
       '.android/Flutter/src/main/java/io/flutter/facade/FlutterFragment.java',


### PR DESCRIPTION
Fixes #31806 by adding flutter.iml to the module template.

@xster I moved this from #36486 since that PR isn't going to be committed.