### PR TITLE
fix catalina crasher

### DIFF
--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:args/args.dart';
 import '../cache.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
@@ -49,17 +50,21 @@ class PrecacheCommand extends FlutterCommand {
     if (argResults['all-platforms']) {
       cache.includeAllPlatforms = true;
     }
+    return await precacheArtifacts(argResults);
+  }
+
+  static Future<FlutterCommandResult> precacheArtifacts([ArgResults argResults]) async {
     final Set<DevelopmentArtifact> requiredArtifacts = <DevelopmentArtifact>{};
     for (DevelopmentArtifact artifact in DevelopmentArtifact.values) {
       // Don't include unstable artifacts on stable branches.
       if (!FlutterVersion.instance.isMaster && artifact.unstable) {
         continue;
       }
-      if (argResults[artifact.name]) {
+      if (argResults != null && argResults[artifact.name]) {
         requiredArtifacts.add(artifact);
       }
     }
-    final bool forceUpdate = argResults['force'];
+    final bool forceUpdate = argResults == null ? false : argResults['force'];
     if (forceUpdate || !cache.isUpToDate()) {
       await cache.updateAll(requiredArtifacts);
     } else {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -12,6 +12,7 @@ import '../base/io.dart';
 import '../base/os.dart';
 import '../base/process.dart';
 import '../cache.dart';
+import '../commands/precache.dart';
 import '../dart/pub.dart';
 import '../globals.dart';
 import '../runner/flutter_command.dart';
@@ -185,16 +186,7 @@ class UpgradeCommandRunner {
   Future<void> precacheArtifacts() async {
     printStatus('');
     printStatus('Upgrading engine...');
-    final int code = await runCommandAndStreamOutput(
-      <String>[
-        fs.path.join('bin', 'flutter'), '--no-color', '--no-version-check', 'precache',
-      ],
-      workingDirectory: Cache.flutterRoot,
-      allowReentrantFlutter: true,
-    );
-    if (code != 0) {
-      throwToolExit(null, exitCode: code);
-    }
+    await PrecacheCommand.precacheArtifacts();
   }
 
   /// Update the user's packages.


### PR DESCRIPTION
## Description

Currently, if you run `flutter upgrade` on macOS Catalina and the upgrade path has a Dart SDK revision change, you will get an exception with a misleading `VersionCheckError: Command exited with code -9: git log -n 1 --pretty=format:%ad --date=iso`. The actual cause is calling the Flutter tool re-entrantly, which deletes the current Dart SDK (which the `flutter upgrade` process is using), after which any forked sub-processes would be killed (code -9 from the `VersionCheckError` message) by the macOS anti-malware software.

This fixes the issue by refactoring the pre-cache step to just call the code directly, rather than re-entrantly invoking the flutter tool. The new Dart SDK will then be downloaded in the final step of the upgrade flow, which is to run `flutter doctor` re-entrantly.

## Related Issues

This PR fixes https://github.com/flutter/flutter/issues/33890

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.