### PR TITLE
Fix keyboard overlaying modalBottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -212,9 +212,10 @@ class _BottomSheetState extends State<BottomSheet> {
 
 // MODAL BOTTOM SHEETS
 class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
-  _ModalBottomSheetLayout(this.progress, this.isScrollControlled);
+  _ModalBottomSheetLayout(this.progress, this.bottomInset, this.isScrollControlled);
 
   final double progress;
+  final double bottomInset;
   final bool isScrollControlled;
 
   @override
@@ -231,12 +232,12 @@ class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
 
   @override
   Offset getPositionForChild(Size size, Size childSize) {
-    return Offset(0.0, size.height - childSize.height * progress);
+    return Offset(0.0, size.height - bottomInset - childSize.height * progress);
   }
 
   @override
   bool shouldRelayout(_ModalBottomSheetLayout oldDelegate) {
-    return progress != oldDelegate.progress;
+    return progress != oldDelegate.progress || bottomInset != oldDelegate.bottomInset;
   }
 }
 
@@ -287,6 +288,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
         // Disable the initial animation when accessible navigation is on so
         // that the semantics are added to the tree at the correct time.
         final double animationValue = mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation.value;
+        final double bottomInset = widget.route.resizeToAvoidBottomInset ? MediaQuery.of(context).viewInsets.bottom : 0.0;
         return Semantics(
           scopesRoute: true,
           namesRoute: true,
@@ -294,7 +296,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
           explicitChildNodes: true,
           child: ClipRect(
             child: CustomSingleChildLayout(
-              delegate: _ModalBottomSheetLayout(animationValue, widget.isScrollControlled),
+              delegate: _ModalBottomSheetLayout(animationValue, bottomInset, widget.isScrollControlled),
               child: BottomSheet(
                 animationController: widget.route._animationController,
                 onClosing: () {
@@ -321,6 +323,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.theme,
     this.barrierLabel,
     this.backgroundColor,
+    this.resizeToAvoidBottomInset,
     this.elevation,
     this.shape,
     @required this.isScrollControlled,
@@ -332,6 +335,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final ThemeData theme;
   final bool isScrollControlled;
   final Color backgroundColor;
+  final bool resizeToAvoidBottomInset;
   final double elevation;
   final ShapeBorder shape;
 
@@ -405,6 +409,9 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// that a modal [BottomSheet] needs to be displayed above all other content
 /// but the caller is inside another [Navigator].
 ///
+/// The `resizeToAvoidBottomInset` parameter ensures that the modal bottomSheet is
+/// not overlayed by the keyboard when it is displayed by resizing it
+///
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///
@@ -419,6 +426,7 @@ Future<T> showModalBottomSheet<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
   Color backgroundColor,
+  bool resizeToAvoidBottomInset = false,
   double elevation,
   ShapeBorder shape,
   bool isScrollControlled = false,
@@ -437,6 +445,7 @@ Future<T> showModalBottomSheet<T>({
     isScrollControlled: isScrollControlled,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
     backgroundColor: backgroundColor,
+    resizeToAvoidBottomInset: resizeToAvoidBottomInset,
     elevation: elevation,
     shape: shape,
   ));


### PR DESCRIPTION
## Description

If a TextField is inside a modalBottomSheet, once the keyboard is displayed, it overlays the modal. The expected behaviour would be the modal to move above the keyboard, so it would be fully visible.

Original commit from @crimsonsuv (https://gist.github.com/crimsonsuv/b25d5ebd04236f9be2aa66accba19446). I just port it to the newest bottomSheet widget.

## Related Issues

This PR fixes #18564

## Tests

I tested it with a personal project. Before the bottomSheet was covered by the keyboard and after this commit it was over the keyboard as expected. I even test it with some margin and no issue was found.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
