### PR TITLE
[flutter_tool] Additional flutter manifest yaml validation

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -404,7 +404,12 @@ void _validateFonts(YamlList fonts, List<String> errors) {
   const Set<int> fontWeights = <int>{
     100, 200, 300, 400, 500, 600, 700, 800, 900,
   };
-  for (final YamlMap fontMap in fonts) {
+  for (final dynamic fontListEntry in fonts) {
+    if (fontListEntry is! YamlMap) {
+      errors.add('Unexpected child "$fontListEntry" found under "fonts". Expected a map.');
+      continue;
+    }
+    final YamlMap fontMap = fontListEntry;
     for (dynamic key in fontMap.keys.where((dynamic key) => key != 'family' && key != 'fonts')) {
       errors.add('Unexpected child "$key" found under "fonts".');
     }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -518,6 +518,26 @@ flutter:
       expect(flutterManifest, null);
       expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));
     });
+
+    testUsingContext('Returns proper error when second font family is invalid', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: foo
+      fonts:
+        - asset: a/bar
+    - string
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+      expect(flutterManifest, null);
+      expect(logger.errorText, contains('Expected a map.'));
+    });
   });
 
   group('FlutterManifest with MemoryFileSystem', () {


### PR DESCRIPTION
## Description

This PR adds a check to flutter manifest yaml validation for the case where the fonts list is not entirely composed of maps.

## Related Issues

Seen in crash logging

## Tests

I added the following tests:

Test in flutter_manifest_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.