### PR TITLE
Fix RenderMouseRegion painting child twice.

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2727,8 +2727,9 @@ class RenderMouseRegion extends RenderProxyBox {
         offset: offset,
       );
       context.pushLayer(layer, super.paint, offset);
+    } else {
+      super.paint(context, offset);
     }
-    super.paint(context, offset);
   }
 
   @override


### PR DESCRIPTION
## Description

Fixes child painting twice when a RenderMouseRegion has an active hover annotation. The bug causes text to be painted twice.

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/35114

## Tests

Added regression test to mouse_region_test.dart by using a counter on a custom painter.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
