### PR TITLE
Pin package:vm_service_client to 0.2.6+2

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -26,7 +26,8 @@ const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   'test_api': '0.2.5',     //  |
   'test_core': '0.2.5',    //  |
   'build_runner': '1.6.1', // TODO(jonahwilliams): allow newer versions
-  'build_modules': '2.3.0'
+  'build_modules': '2.3.0',
+  'vm_service_client': '0.2.6+2', // Final version before being marked deprecated.
 };
 
 class UpdatePackagesCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -27,6 +27,8 @@ const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   'test_core': '0.2.5',    //  |
   'build_runner': '1.6.1', // TODO(jonahwilliams): allow newer versions
   'build_modules': '2.3.0',
+
+  // Switch to vm_service. https://github.com/flutter/flutter/issues/37499
   'vm_service_client': '0.2.6+2', // Final version before being marked deprecated.
 };
 


### PR DESCRIPTION
## Description

package:vm_service_client as of 0.2.6+3 is marked as deprecated.  To
avoid future analysis warnings when upgrading packages, pin it to
0.2.6+2 until we can fully migrate to using package:vm_service
instead.

## Tests

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
