### PR TITLE
[WIP] Symlink Flutter.framework when the ephemeral directory gets generated from the template

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -758,9 +758,7 @@ Future<void> _runHostOnlyDeviceLabTests() async {
     () => _runDevicelabTest('module_host_with_custom_build_test', environment: gradleEnvironment, testEmbeddingV2: true),
     if (!Platform.isMacOS) () => _runDevicelabTest('module_test', environment: gradleEnvironment, testEmbeddingV2: false),
     if (!Platform.isMacOS) () => _runDevicelabTest('module_test', environment: gradleEnvironment, testEmbeddingV2: true),
-
-    // TODO(jmagman): Re-enable once flakiness is resolved, https://github.com/flutter/flutter/issues/37525
-    // if (Platform.isMacOS) () => _runDevicelabTest('module_test_ios'),
+    if (Platform.isMacOS) () => _runDevicelabTest('module_test_ios'),
     if (Platform.isMacOS) () => _runDevicelabTest('plugin_lint_mac'),
     () => _runDevicelabTest('plugin_test', environment: gradleEnvironment),
   ]..shuffle(math.Random(0));

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -166,19 +166,20 @@ Future<void> main() async {
         );
       });
 
-      final bool ephemeralFramework = exists(Directory(path.join(
+      final bool ephemeralFramework = exists(File(path.join(
         projectDir.path,
         '.ios',
         'Flutter',
         'engine',
         'Flutter.framework',
+        'Flutter',
       )));
 
       if (!ephemeralFramework) {
         return TaskResult.failure('Failed to copy framework after regeneration from template');
       }
 
-      final bool ephemeralPodspec = exists(Directory(path.join(
+      final bool ephemeralPodspec = exists(File(path.join(
         projectDir.path,
         '.ios',
         'Flutter',

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -161,10 +161,34 @@ Future<void> main() async {
       await pubspec.writeAsString(content, flush: true);
       await inDirectory(projectDir, () async {
         await flutter(
-          'packages',
+          'pub',
           options: <String>['get'],
         );
       });
+
+      final bool ephemeralFramework = exists(Directory(path.join(
+        projectDir.path,
+        '.ios',
+        'Flutter',
+        'engine',
+        'Flutter.framework',
+      )));
+
+      if (!ephemeralFramework) {
+        return TaskResult.failure('Failed to copy framework after regeneration from template');
+      }
+
+      final bool ephemeralPodspec = exists(Directory(path.join(
+        projectDir.path,
+        '.ios',
+        'Flutter',
+        'engine',
+        'Flutter.podspec',
+      )));
+
+      if (!ephemeralPodspec) {
+        return TaskResult.failure('Failed to copy podspec after regeneration from template');
+      }
 
       section('Build ephemeral host app with CocoaPods');
 

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -9,8 +9,6 @@ import 'package:file/file.dart';
 import 'package:file/local.dart' as io;
 import 'package:path/path.dart' as path;
 
-import 'utils.dart';
-
 const String _kProvisioningConfigFileEnvironmentVariable = 'FLUTTER_DEVICELAB_XCODE_PROVISIONING_CONFIG';
 const String _kTestXcconfigFileName = 'TestConfig.xcconfig';
 const FileSystem _fs = io.LocalFileSystem();
@@ -28,12 +26,7 @@ Future<void> prepareProvisioningCertificates(String flutterProjectPath) async {
 
   await _patchXcconfigFilesIfNotPatched(flutterProjectPath);
   final File testXcconfig = _fs.file(path.join(flutterProjectPath, 'ios/Flutter/$_kTestXcconfigFileName'));
-  await testXcconfig.writeAsString(certificateConfig);
-}
-
-Future<void> runPodInstallForCustomPodfile(String flutterProjectPath) async {
-  final String iosPath = path.join(flutterProjectPath, 'ios');
-  exec('pod', <String>['install', '--project-directory=$iosPath']);
+  await testXcconfig.writeAsString(certificateConfig, flush: true);
 }
 
 Future<void> _patchXcconfigFilesIfNotPatched(String flutterProjectPath) async {
@@ -55,6 +48,7 @@ Future<void> _patchXcconfigFilesIfNotPatched(String flutterProjectPath) async {
         final IOSink patchOut = file.openWrite(mode: FileMode.append);
         patchOut.writeln(); // in case EOF is not preceded by line break
         patchOut.writeln(include);
+        patchOut.flush();
         await patchOut.close();
       }
     }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -468,11 +468,14 @@ class IosProject implements XcodeBasedProject {
   /// Symlink the Flutter.framework as a placeholder so the host app can find the headers in its header search paths
   /// until this framework can be swapped out by the Xcode backend script or a pod install.
   void _copyFlutterFramework() {
+    final Directory cachedEngineFrameworkArtifacts = fs.directory(xcode.flutterFrameworkDir(BuildMode.debug));
+    if (!cachedEngineFrameworkArtifacts.existsSync()) {
+      // flutter build ios has not yet been run.
+      return;
+    }
+
     final Directory ephemeralFramework = ephemeralDirectory.childDirectory('Flutter').childDirectory('engine');
     ephemeralFramework.createSync(recursive: true);
-    // Just need something in the header search paths on until this framework can be swapped out by the
-    // Flutter script run in the host app.
-    final Directory cachedEngineFrameworkArtifacts = fs.directory(xcode.flutterFrameworkDir(BuildMode.debug));
     final Directory cachedFlutterFramework = cachedEngineFrameworkArtifacts.childDirectory('Flutter.framework');
     final Link temporaryFramework = ephemeralFramework.childLink('Flutter.framework');
     temporaryFramework.createSync(cachedFlutterFramework.path);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -455,7 +455,6 @@ class IosProject implements XcodeBasedProject {
     _deleteIfExistsSync(ephemeralDirectory);
 
     _copyFlutterFramework();
-
     _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), ephemeralDirectory);
     // Add ephemeral host app, if a editable host app does not already exist.
     if (!_editableDirectory.existsSync()) {
@@ -473,14 +472,14 @@ class IosProject implements XcodeBasedProject {
     ephemeralFramework.createSync(recursive: true);
     // Just need something in the header search paths on until this framework can be swapped out by the
     // Flutter script run in the host app.
-    final String cachedEngineFrameworkArtifacts = fs.path.join(xcode.flutterFrameworkDir(BuildMode.debug));
-    final String cachedFlutterFramework = fs.path.join(cachedEngineFrameworkArtifacts, 'Flutter.framework');
+    final Directory cachedEngineFrameworkArtifacts = fs.directory(xcode.flutterFrameworkDir(BuildMode.debug));
+    final Directory cachedFlutterFramework = cachedEngineFrameworkArtifacts.childDirectory('Flutter.framework');
     final Link temporaryFramework = ephemeralFramework.childLink('Flutter.framework');
-    temporaryFramework.createSync(cachedFlutterFramework);
+    temporaryFramework.createSync(cachedFlutterFramework.path);
 
-    final String cachedFlutterPodspec = fs.path.join(cachedEngineFrameworkArtifacts, 'Flutter.podspec');
-    final Link temporaryPodspec = ephemeralFramework.childLink('Flutter.podspec');
-    temporaryPodspec.createSync(cachedFlutterPodspec);
+    final File cachedFlutterPodspec = cachedEngineFrameworkArtifacts.childFile('Flutter.podspec');
+    final File temporaryPodspec = ephemeralFramework.childFile('Flutter.podspec');
+    cachedFlutterPodspec.copySync(temporaryPodspec.path);
   }
 
   Future<void> makeHostAppEditable() async {


### PR DESCRIPTION
## Description

When the pubspec changes in an add-to-app module, `flutter pub get` will trigger a regeneration of the ephemeral directory from the template.  If `flutter build ios` isn't run in the module or `pod install` in the host app, the framework never gets copied from the engine artifacts cache, and the Xcode host app won't subsequently compile.

## Tests
Re-enable flaky test turned off in https://github.com/flutter/flutter/pull/37442.
Add check for these directories.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37525.
Fixes https://github.com/flutter/flutter/issues/42956
