### PR TITLE
Remove bogus code in ContainerParentDataMixin.detach

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2834,21 +2834,11 @@ mixin ContainerParentDataMixin<ChildType extends RenderObject> on ParentData {
   /// Clear the sibling pointers.
   @override
   void detach() {
+    const String assertMessage =
+        'Pointers to siblings must be nulled before detaching ParentData.';
+    assert(previousSibling == null, assertMessage);
+    assert(nextSibling == null, assertMessage);
     super.detach();
-    if (previousSibling != null) {
-      final ContainerParentDataMixin<ChildType> previousSiblingParentData = previousSibling.parentData;
-      assert(previousSibling != this);
-      assert(previousSiblingParentData.nextSibling == this);
-      previousSiblingParentData.nextSibling = nextSibling;
-    }
-    if (nextSibling != null) {
-      final ContainerParentDataMixin<ChildType> nextSiblingParentData = nextSibling.parentData;
-      assert(nextSibling != this);
-      assert(nextSiblingParentData.previousSibling == this);
-      nextSiblingParentData.previousSibling = previousSibling;
-    }
-    previousSibling = null;
-    nextSibling = null;
   }
 }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2834,9 +2834,8 @@ mixin ContainerParentDataMixin<ChildType extends RenderObject> on ParentData {
   /// Clear the sibling pointers.
   @override
   void detach() {
-    const String assertMessage = 'Pointers to siblings must be nulled before detaching ParentData.';
-    assert(previousSibling == null, assertMessage);
-    assert(nextSibling == null, assertMessage);
+    assert(previousSibling == null, 'Pointers to siblings must be nulled before detaching ParentData.');
+    assert(nextSibling == null, 'Pointers to siblings must be nulled before detaching ParentData.');
     super.detach();
   }
 }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2834,8 +2834,7 @@ mixin ContainerParentDataMixin<ChildType extends RenderObject> on ParentData {
   /// Clear the sibling pointers.
   @override
   void detach() {
-    const String assertMessage =
-        'Pointers to siblings must be nulled before detaching ParentData.';
+    const String assertMessage = 'Pointers to siblings must be nulled before detaching ParentData.';
     assert(previousSibling == null, assertMessage);
     assert(nextSibling == null, assertMessage);
     super.detach();

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -81,7 +81,26 @@ void main() {
       ),
     );
   });
+
+  test('ContainerParentDataMixin requires nulled out pointers to siblings before detach', () {
+    expect(() => TestParentData().detach(), isNot(throwsAssertionError));
+
+    final TestParentData data1 = TestParentData()
+      ..nextSibling = RenderOpacity()
+      ..previousSibling = RenderOpacity();
+    expect(() => data1.detach(), throwsAssertionError);
+
+    final TestParentData data2 = TestParentData()
+      ..previousSibling = RenderOpacity();
+    expect(() => data2.detach(), throwsAssertionError);
+
+    final TestParentData data3 = TestParentData()
+      ..nextSibling = RenderOpacity();
+    expect(() => data3.detach(), throwsAssertionError);
+  });
 }
+
+class TestParentData extends ContainerBoxParentData<RenderBox> { }
 
 class TestRenderObject extends RenderObject {
   @override

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -100,7 +100,7 @@ void main() {
   });
 }
 
-class TestParentData extends ContainerBoxParentData<RenderBox> { }
+class TestParentData extends ParentData with ContainerParentDataMixin<RenderBox> { }
 
 class TestRenderObject extends RenderObject {
   @override


### PR DESCRIPTION
## Description

As pointed out in https://github.com/flutter/flutter/issues/22105 the asserts in that code are never true. However, those code paths are never hit because the siblings pointers are nulled out in [1] before the parent data is detached. This PR removes the bogus code and instead requires via asserts that the pointers are in-fact nulled out before the parent data is detached.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/22105.

## Tests

I added the following tests:

* test verifying that asserts fire if siblings pointers are not nulled out.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
