### PR TITLE
Drawer edge drag width improvements

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -182,6 +182,7 @@ class DrawerController extends StatefulWidget {
     this.drawerCallback,
     this.dragStartBehavior = DragStartBehavior.start,
     this.scrimColor,
+    this.edgeDragWidth,
   }) : assert(child != null),
        assert(dragStartBehavior != null),
        assert(alignment != null),
@@ -227,6 +228,8 @@ class DrawerController extends StatefulWidget {
   ///
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
+
+  final double edgeDragWidth;
 
   @override
   DrawerControllerState createState() => DrawerControllerState();
@@ -432,7 +435,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     if (Directionality.of(context) == TextDirection.rtl)
       dragAreaWidth = drawerIsStart ? padding.right : padding.left;
 
-    dragAreaWidth = max(dragAreaWidth, _kEdgeDragWidth);
+    dragAreaWidth = max(dragAreaWidth, widget.edgeDragWidth ?? _kEdgeDragWidth);
     if (_controller.status == AnimationStatus.dismissed) {
       return Align(
         alignment: _drawerOuterAlignment,

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -229,6 +229,10 @@ class DrawerController extends StatefulWidget {
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
 
+  /// The horizontal width from the edge of the screen that will respond to a
+  /// drag gesture to open the drawer.
+  ///
+  /// By default, the value used is 20.0.
   final double edgeDragWidth;
 
   @override

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -233,6 +233,11 @@ class DrawerController extends StatefulWidget {
   /// drag gesture to open the drawer.
   ///
   /// By default, the value used is 20.0.
+  ///
+  /// If `MediaQuery.of(context).padding` is larger than the default drawer
+  /// edge width of 20.0 or the custom passed in drawerEdgeDragWidth value,
+  /// `MediaQuery.of(context).padding` will be used instead to properly
+  /// accommodate the drag widths of notched devices.
   final double edgeDragWidth;
 
   @override

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -234,7 +234,7 @@ class DrawerController extends StatefulWidget {
   /// `MediaQuery.of(context).padding` that corresponds to [alignment].
   /// This ensures that the drag area for notched devices is not obscured. For
   /// example, if [alignment] is set to [DrawerAlignment.start] and
-  /// [TextDirection.of(context)] is set to [TextDirection.ltr],
+  /// `TextDirection.of(context)` is set to [TextDirection.ltr],
   /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
   final double edgeDragWidth;
 
@@ -443,19 +443,13 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     if (widget.edgeDragWidth == null) {
       switch (textDirection) {
         case TextDirection.ltr: {
-          if (drawerIsStart) {
-            dragAreaWidth = _kEdgeDragWidth + padding.left;
-          } else {
-            dragAreaWidth = _kEdgeDragWidth + padding.right;
-          }
+          dragAreaWidth = _kEdgeDragWidth +
+            (drawerIsStart ? padding.left : padding.right);
         }
         break;
         case TextDirection.rtl: {
-          if (drawerIsStart) {
-            dragAreaWidth = _kEdgeDragWidth + padding.right;
-          } else {
-            dragAreaWidth = _kEdgeDragWidth + padding.left;
-          }
+          dragAreaWidth = _kEdgeDragWidth +
+            (drawerIsStart ? padding.right : padding.left);
         }
         break;
       }

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -439,12 +439,17 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   Widget _buildDrawer(BuildContext context) {
     final bool drawerIsStart = widget.alignment == DrawerAlignment.start;
     final EdgeInsets padding = MediaQuery.of(context).padding;
-    double dragAreaWidth = drawerIsStart ? padding.left : padding.right;
+    final TextDirection textDirection = Directionality.of(context);
 
-    if (Directionality.of(context) == TextDirection.rtl)
-      dragAreaWidth = drawerIsStart ? padding.right : padding.left;
+    double dragAreaWidth = _kEdgeDragWidth;
+    if (drawerIsStart && textDirection == TextDirection.ltr ||
+        !drawerIsStart && textDirection == TextDirection.rtl) {
+      dragAreaWidth += padding.left;
+    } else {
+      dragAreaWidth += padding.right;
+    }
+    dragAreaWidth = max(dragAreaWidth, widget.edgeDragWidth);
 
-    dragAreaWidth = max(dragAreaWidth, widget.edgeDragWidth ?? _kEdgeDragWidth);
     if (_controller.status == AnimationStatus.dismissed) {
       return Align(
         alignment: _drawerOuterAlignment,

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -229,15 +229,12 @@ class DrawerController extends StatefulWidget {
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
 
-  /// The horizontal width from the edge of the screen that will respond to a
-  /// drag gesture to open the drawer.
+  /// The width of the area within which a horizontal swipe will open the
+  /// drawer.
   ///
-  /// By default, the value used is 20.0.
-  ///
-  /// If `MediaQuery.of(context).padding` is larger than the default drawer
-  /// edge width of 20.0 or the custom passed in drawerEdgeDragWidth value,
-  /// `MediaQuery.of(context).padding` will be used instead to properly
-  /// accommodate the drag widths of notched devices.
+  /// By default, the value used is 20.0 added to the value of
+  /// `MediaQuery.of(context).padding`. This ensures that the drag area for
+  /// notched devices is not obscured.
   final double edgeDragWidth;
 
   @override
@@ -441,14 +438,14 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     final EdgeInsets padding = MediaQuery.of(context).padding;
     final TextDirection textDirection = Directionality.of(context);
 
-    double dragAreaWidth = _kEdgeDragWidth;
-    if (drawerIsStart && textDirection == TextDirection.ltr ||
-        !drawerIsStart && textDirection == TextDirection.rtl) {
-      dragAreaWidth += padding.left;
-    } else {
-      dragAreaWidth += padding.right;
+    double dragAreaWidth = widget.edgeDragWidth;
+    if (widget.edgeDragWidth == null) {
+      if (drawerIsStart && textDirection == TextDirection.ltr || !drawerIsStart && textDirection == TextDirection.rtl) {
+        dragAreaWidth = _kEdgeDragWidth + padding.left;
+      } else {
+        dragAreaWidth = _kEdgeDragWidth + padding.right;
+      }
     }
-    dragAreaWidth = max(dragAreaWidth, widget.edgeDragWidth);
 
     if (_controller.status == AnimationStatus.dismissed) {
       return Align(

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -230,9 +230,12 @@ class DrawerController extends StatefulWidget {
   /// The width of the area within which a horizontal swipe will open the
   /// drawer.
   ///
-  /// By default, the value used is 20.0 added to the value of
-  /// `MediaQuery.of(context).padding`. This ensures that the drag area for
-  /// notched devices is not obscured.
+  /// By default, the value used is 20.0 added to the padding edge of
+  /// `MediaQuery.of(context).padding` that corresponds to [alignment].
+  /// This ensures that the drag area for notched devices is not obscured. For
+  /// example, if [alignment] is set to [DrawerAlignment.start] and
+  /// [TextDirection.of(context)] is set to [TextDirection.ltr],
+  /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
   final double edgeDragWidth;
 
   @override
@@ -438,10 +441,23 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
     double dragAreaWidth = widget.edgeDragWidth;
     if (widget.edgeDragWidth == null) {
-      if (drawerIsStart && textDirection == TextDirection.ltr || !drawerIsStart && textDirection == TextDirection.rtl) {
-        dragAreaWidth = _kEdgeDragWidth + padding.left;
-      } else {
-        dragAreaWidth = _kEdgeDragWidth + padding.right;
+      switch (textDirection) {
+        case TextDirection.ltr: {
+          if (drawerIsStart) {
+            dragAreaWidth = _kEdgeDragWidth + padding.left;
+          } else {
+            dragAreaWidth = _kEdgeDragWidth + padding.right;
+          }
+        }
+        break;
+        case TextDirection.rtl: {
+          if (drawerIsStart) {
+            dragAreaWidth = _kEdgeDragWidth + padding.right;
+          } else {
+            dragAreaWidth = _kEdgeDragWidth + padding.left;
+          }
+        }
+        break;
       }
     }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -968,6 +968,7 @@ class Scaffold extends StatefulWidget {
     this.drawerDragStartBehavior = DragStartBehavior.start,
     this.extendBody = false,
     this.drawerScrimColor,
+    this.drawerEdgeDragWidth,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(drawerDragStartBehavior != null),
@@ -1139,6 +1140,8 @@ class Scaffold extends StatefulWidget {
 
   /// {@macro flutter.material.drawer.dragStartBehavior}
   final DragStartBehavior drawerDragStartBehavior;
+
+  final double drawerEdgeDragWidth;
 
   /// The state from the closest instance of this class that encloses the given context.
   ///
@@ -1983,6 +1986,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           drawerCallback: _endDrawerOpenedCallback,
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
+          edgeDragWidth: widget.drawerEdgeDragWidth,
         ),
         _ScaffoldSlot.endDrawer,
         // remove the side padding from the side we're not touching
@@ -2006,6 +2010,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           drawerCallback: _drawerOpenedCallback,
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
+          edgeDragWidth: widget.drawerEdgeDragWidth,
         ),
         _ScaffoldSlot.drawer,
         // remove the side padding from the side we're not touching

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1141,6 +1141,10 @@ class Scaffold extends StatefulWidget {
   /// {@macro flutter.material.drawer.dragStartBehavior}
   final DragStartBehavior drawerDragStartBehavior;
 
+  /// The horizontal width from the edge of the screen that will respond to a
+  /// drag gesture to open the drawer.
+  ///
+  /// By default, the value used is 20.0.
   final double drawerEdgeDragWidth;
 
   /// The state from the closest instance of this class that encloses the given context.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1145,6 +1145,11 @@ class Scaffold extends StatefulWidget {
   /// drag gesture to open the drawer.
   ///
   /// By default, the value used is 20.0.
+  ///
+  /// If `MediaQuery.of(context).padding` is larger than the default drawer
+  /// edge width of 20.0 or the custom passed in drawerEdgeDragWidth value,
+  /// `MediaQuery.of(context).padding` will be used instead to properly
+  /// accommodate the drag widths of notched devices.
   final double drawerEdgeDragWidth;
 
   /// The state from the closest instance of this class that encloses the given context.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1141,15 +1141,14 @@ class Scaffold extends StatefulWidget {
   /// {@macro flutter.material.drawer.dragStartBehavior}
   final DragStartBehavior drawerDragStartBehavior;
 
-  /// The horizontal width from the edge of the screen that will respond to a
-  /// drag gesture to open the drawer.
+  /// The width of the area within which a horizontal swipe will open the
+  /// drawer.
   ///
-  /// By default, the value used is 20.0.
-  ///
-  /// If `MediaQuery.of(context).padding` is larger than the default drawer
-  /// edge width of 20.0 or the custom passed in drawerEdgeDragWidth value,
-  /// `MediaQuery.of(context).padding` will be used instead to properly
-  /// accommodate the drag widths of notched devices.
+  /// By default, the value used is 20.0 added to the padding edge of
+  /// `MediaQuery.of(context).padding` that corresponds to [alignment].
+  /// This ensures that the drag area for notched devices is not obscured. For
+  /// example, if `TextDirection.of(context)` is set to [TextDirection.ltr],
+  /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
   final double drawerEdgeDragWidth;
 
   /// The state from the closest instance of this class that encloses the given context.

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1418,14 +1418,11 @@ void main() {
           ),
         ),
       );
-
       ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
-
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
       await tester.pumpAndSettle();
-
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.pumpWidget(
@@ -1443,14 +1440,11 @@ void main() {
           ),
         ),
       );
-
       scaffoldState = tester.state(find.byType(Scaffold));
-
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
       await tester.pumpAndSettle();
-
       expect(scaffoldState.isDrawerOpen, true);
     });
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1402,6 +1402,58 @@ void main() {
       expect(scaffoldState.isDrawerOpen, true);
     });
 
+    testWidgets('Drawer opens correctly with custom edgeDragWidth', (WidgetTester tester) async {
+      // The default edge drag width is 20.0.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            drawer: const Drawer(
+              child: Text('drawer'),
+            ),
+            body: const Text('scaffold body'),
+            appBar: AppBar(
+              centerTitle: true,
+              title: const Text('Title'),
+            ),
+          ),
+        ),
+      );
+
+      ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
+      await tester.pumpAndSettle();
+
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            drawer: const Drawer(
+              child: Text('drawer'),
+            ),
+            drawerEdgeDragWidth: 40.0,
+            body: const Text('scaffold body'),
+            appBar: AppBar(
+              centerTitle: true,
+              title: const Text('Title'),
+            ),
+          ),
+        ),
+      );
+
+      scaffoldState = tester.state(find.byType(Scaffold));
+
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
+      await tester.pumpAndSettle();
+
+      expect(scaffoldState.isDrawerOpen, true);
+    });
+
     testWidgets('Drawer opens correctly with padding from MediaQuer (RTL)', (WidgetTester tester) async {
       // The padding described by MediaQuery is larger than the default
       // drawer drag zone width which is 20.

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1490,10 +1490,10 @@ void main() {
         MaterialApp(
           home: Scaffold(
             drawer: const Drawer(
-              child: Text('drawer'),
+              child: Text('Drawer'),
             ),
             drawerEdgeDragWidth: 40.0,
-            body: const Text('scaffold body'),
+            body: const Text('Scaffold Body'),
             appBar: AppBar(
               centerTitle: true,
               title: const Text('Title'),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1423,7 +1423,7 @@ void main() {
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.dragFrom(
-        Offset(scaffoldWidth - simulatedNotchSize -15.0, 100),
+        Offset(scaffoldWidth - simulatedNotchSize - 15.0, 100),
         const Offset(-300, 0),
       );
       await tester.pumpAndSettle();
@@ -1455,7 +1455,7 @@ void main() {
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.dragFrom(
-        Offset(scaffoldWidth - simulatedNotchSize -15.0, 100),
+        Offset(scaffoldWidth - simulatedNotchSize - 15.0, 100),
         const Offset(-300, 0),
       );
       await tester.pumpAndSettle();

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1345,16 +1345,15 @@ void main() {
       expect(find.text('drawer'), findsOneWidget);
     });
 
-    testWidgets('Drawer opens correctly with padding from MediaQuery', (WidgetTester tester) async {
-      // The padding described by MediaQuery is larger than the default
-      // drawer drag zone width which is 20.
+    testWidgets('Drawer opens correctly with padding from MediaQuery (LTR)', (WidgetTester tester) async {
+      const double simulatedNotchSize = 40.0;
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             drawer: const Drawer(
-              child: Text('drawer'),
+              child: Text('Drawer'),
             ),
-            body: const Text('scaffold body'),
+            body: const Text('Scaffold Body'),
             appBar: AppBar(
               centerTitle: true,
               title: const Text('Title'),
@@ -1364,25 +1363,23 @@ void main() {
       );
 
       ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
-
       expect(scaffoldState.isDrawerOpen, false);
 
-      await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
+      await tester.dragFrom(const Offset(simulatedNotchSize + 15.0, 100), const Offset(300, 0));
       await tester.pumpAndSettle();
-
       expect(scaffoldState.isDrawerOpen, false);
 
       await tester.pumpWidget(
         MaterialApp(
           home: MediaQuery(
             data: const MediaQueryData(
-              padding: EdgeInsets.fromLTRB(40, 0, 0, 0)
+              padding: EdgeInsets.fromLTRB(simulatedNotchSize, 0, 0, 0),
             ),
             child: Scaffold(
               drawer: const Drawer(
-                child: Text('drawer'),
+                child: Text('Drawer'),
               ),
-              body: const Text('scaffold body'),
+              body: const Text('Scaffold Body'),
               appBar: AppBar(
                 centerTitle: true,
                 title: const Text('Title'),
@@ -1391,16 +1388,80 @@ void main() {
           ),
         ),
       );
-
       scaffoldState = tester.state(find.byType(Scaffold));
-
       expect(scaffoldState.isDrawerOpen, false);
 
-      await tester.dragFrom(const Offset(35, 100), const Offset(300, 0));
+      await tester.dragFrom(
+        const Offset(simulatedNotchSize + 15.0, 100),
+        const Offset(300, 0),
+      );
       await tester.pumpAndSettle();
-
       expect(scaffoldState.isDrawerOpen, true);
     });
+
+    testWidgets('Drawer opens correctly with padding from MediaQuery (RTL)', (WidgetTester tester) async {
+      const double simulatedNotchSize = 40.0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            drawer: const Drawer(
+              child: Text('Drawer'),
+            ),
+            body: const Text('Scaffold Body'),
+            appBar: AppBar(
+              centerTitle: true,
+              title: const Text('Title'),
+            ),
+          ),
+        ),
+      );
+
+      final double scaffoldWidth = tester.renderObject<RenderBox>(
+        find.byType(Scaffold),
+      ).size.width;
+      ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.dragFrom(
+        Offset(scaffoldWidth - simulatedNotchSize -15.0, 100),
+        const Offset(-300, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              padding: EdgeInsets.fromLTRB(0, 0, simulatedNotchSize, 0),
+            ),
+            child: Directionality(
+              textDirection: TextDirection.rtl,
+              child: Scaffold(
+                drawer: const Drawer(
+                  child: Text('Drawer'),
+                ),
+                body: const Text('Scaffold body'),
+                appBar: AppBar(
+                  centerTitle: true,
+                  title: const Text('Title'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      scaffoldState = tester.state(find.byType(Scaffold));
+      expect(scaffoldState.isDrawerOpen, false);
+
+      await tester.dragFrom(
+        Offset(scaffoldWidth - simulatedNotchSize -15.0, 100),
+        const Offset(-300, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(scaffoldState.isDrawerOpen, true);
+    });
+  });
 
     testWidgets('Drawer opens correctly with custom edgeDragWidth', (WidgetTester tester) async {
       // The default edge drag width is 20.0.
@@ -1408,9 +1469,9 @@ void main() {
         MaterialApp(
           home: Scaffold(
             drawer: const Drawer(
-              child: Text('drawer'),
+              child: Text('Drawer'),
             ),
-            body: const Text('scaffold body'),
+            body: const Text('Scaffold body'),
             appBar: AppBar(
               centerTitle: true,
               title: const Text('Title'),
@@ -1448,46 +1509,8 @@ void main() {
       expect(scaffoldState.isDrawerOpen, true);
     });
 
-    testWidgets('Drawer opens correctly with padding from MediaQuer (RTL)', (WidgetTester tester) async {
-      // The padding described by MediaQuery is larger than the default
-      // drawer drag zone width which is 20.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MediaQuery(
-            data: const MediaQueryData(
-              padding: EdgeInsets.fromLTRB(0, 0, 40, 0)
-            ),
-            child: Directionality(
-              textDirection: TextDirection.rtl,
-              child: Scaffold(
-                drawer: const Drawer(
-                  child: Text('drawer'),
-                ),
-                body: const Text('scaffold body'),
-                appBar: AppBar(
-                  centerTitle: true,
-                  title: const Text('Title'),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
-
-      expect(scaffoldState.isDrawerOpen, false);
-
-      await tester.dragFrom(const Offset(765, 100), const Offset(-300, 0));
-      await tester.pumpAndSettle();
-
-      expect(scaffoldState.isDrawerOpen, true);
-    });
-  });
-
   testWidgets('Nested scaffold body insets', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/20295
-
     final Key bodyKey = UniqueKey();
 
     Widget buildFrame(bool innerResizeToAvoidBottomInset, bool outerResizeToAvoidBottomInset) {


### PR DESCRIPTION
## Description

The current edge width to open a drawer when dragged is set to 20.0. However, with a notched device, the edge width is set to `MediaQuery.of(context).padding` value. This PR addresses two issues:

1) Fix padding for notched devices
Since the edge width is set to `MediaQuery.of(context).padding`, the area to drag is obscured by the notch, and the only way to open the drawer would be to drag from within the non obscured areas of the screen around the notch. This fix increases that draggable area to `MediaQuery.of(context).padding` + 20.0.

2) Custom edge drag width for drawers
This new property, `Scaffold.drawerEdgeDragWidth` allows developers to set their own custom drag widths to open drawers in the event that they need to increase sensitivity for their users. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/36929
Fixes https://github.com/flutter/flutter/issues/38313

## Tests

I added the following tests:
- A test verifying that the custom edge drag width is used.

I modified the following tests:
- The RTL and LTR tests for drawers with MediaQuery.padding values

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
