### PR TITLE
[flutter_tool] Remove unintended analytics screen send

### DIFF
--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -55,7 +55,7 @@ void main() {
 
       flutterUsage.enabled = true;
       await createProject(tempDir);
-      expect(count, flutterUsage.isFirstRun ? 0 : 2);
+      expect(count, flutterUsage.isFirstRun ? 0 : 3);
 
       count = 0;
       flutterUsage.enabled = false;
@@ -65,7 +65,10 @@ void main() {
       expect(count, 0);
     }, overrides: <Type, Generator>{
       FlutterVersion: () => FlutterVersion(const SystemClock()),
-      Usage: () => Usage(configDirOverride: tempDir.path),
+      Usage: () => Usage(
+        configDirOverride: tempDir.path,
+        logFile: tempDir.childFile('analytics.log').path
+      ),
     });
 
     // Ensure we don't send for the 'flutter config' command.
@@ -84,7 +87,10 @@ void main() {
       expect(count, 0);
     }, overrides: <Type, Generator>{
       FlutterVersion: () => FlutterVersion(const SystemClock()),
-      Usage: () => Usage(configDirOverride: tempDir.path),
+      Usage: () => Usage(
+        configDirOverride: tempDir.path,
+        logFile: tempDir.childFile('analytics.log').path
+      ),
     });
 
     testUsingContext('Usage records one feature in experiment setting', () async {


### PR DESCRIPTION
## Description

Prior to this PR there was an unintended analytics command sent before filtering out bots. This PR removes that command, and restructures code to avoid a similar mistake in the future.

## Related Issues

https://github.com/flutter/flutter/issues/37339

## Tests

I added the following tests:

Updated tests to log analytics data to a file instead. A better check here would be to run all tests in an environment that will explode if the test touches the network outside of localhost.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
