### PR TITLE
Upstream web support for IterableProperty<double>

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2224,6 +2224,28 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
     if (value.isEmpty)
       return ifEmpty ?? '[]';
 
+    // Use debugFormatDouble to format Iterable<double>.
+    if (T == double) {
+      final StringBuffer sb = StringBuffer();
+      if (parentConfiguration != null && !parentConfiguration.lineBreakProperties) {
+        for (dynamic item in value) {
+          if (sb.isNotEmpty) {
+            sb.write(', ');
+          }
+          sb.write(debugFormatDouble(item));
+        }
+        return '[${sb.toString()}]';
+      } else {
+        final bool isSingleLine = _isSingleLine(style);
+        for (dynamic item in value) {
+          if (sb.isNotEmpty)
+            sb.write(isSingleLine ? ', ' : '\n');
+          sb.write(debugFormatDouble(item));
+        }
+        return sb.toString();
+      }
+    }
+
     if (parentConfiguration != null && !parentConfiguration.lineBreakProperties) {
       // Always display the value as a single line and enclose the iterable
       // value in brackets to avoid ambiguity.

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2217,42 +2217,28 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
   );
 
   @override
-  String valueToString({ TextTreeConfiguration parentConfiguration }) {
+  String valueToString({TextTreeConfiguration parentConfiguration}) {
     if (value == null)
       return value.toString();
 
     if (value.isEmpty)
       return ifEmpty ?? '[]';
 
-    // Use debugFormatDouble to format Iterable<double>.
-    if (T == double) {
-      final StringBuffer sb = StringBuffer();
-      if (parentConfiguration != null && !parentConfiguration.lineBreakProperties) {
-        for (dynamic item in value) {
-          if (sb.isNotEmpty) {
-            sb.write(', ');
-          }
-          sb.write(debugFormatDouble(item));
-        }
-        return '[${sb.toString()}]';
+    final Iterable<String> formattedValues = value.map((T v) {
+      if (T == double && v is double) {
+        return debugFormatDouble(v);
       } else {
-        final bool isSingleLine = _isSingleLine(style);
-        for (dynamic item in value) {
-          if (sb.isNotEmpty)
-            sb.write(isSingleLine ? ', ' : '\n');
-          sb.write(debugFormatDouble(item));
-        }
-        return sb.toString();
+        return v.toString();
       }
-    }
+    });
 
     if (parentConfiguration != null && !parentConfiguration.lineBreakProperties) {
       // Always display the value as a single line and enclose the iterable
       // value in brackets to avoid ambiguity.
-      return '[${value.join(', ')}]';
+      return '[${formattedValues.join(', ')}]';
     }
 
-    return value.join(_isSingleLine(style) ? ', ' : '\n');
+    return formattedValues.join(_isSingleLine(style) ? ', ' : '\n');
   }
 
   /// Priority level of the diagnostic used to control which diagnostics should

--- a/packages/flutter/test/foundation/diagnostics_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_test.dart
@@ -1611,6 +1611,15 @@ void main() {
     expect(intsProperty.isFiltered(DiagnosticLevel.info), isFalse);
     expect(intsProperty.toString(), equals('ints: 1, 2, 3'));
 
+    final List<double> doubles = <double>[1,2,3];
+    final IterableProperty<double> doublesProperty = IterableProperty<double>(
+      'doubles',
+      doubles,
+    );
+    expect(doublesProperty.value, equals(doubles));
+    expect(doublesProperty.isFiltered(DiagnosticLevel.info), isFalse);
+    expect(doublesProperty.toString(), equals('doubles: 1.0, 2.0, 3.0'));
+
     final IterableProperty<Object> emptyProperty = IterableProperty<Object>(
       'name',
       <Object>[],


### PR DESCRIPTION
## Description

table_rendering_test uses IterableProperty<double> which fails on web platform due to default double.toString() behavior. This PR updates diagnostics to use debugFormatDouble to support web platform.

## Related Issues

#37491

## Tests

I added a test in diagnostics_test.dart for IterableProperty<double>.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
