### PR TITLE
Allow flutter build macos command to configure outputs, default to build

### DIFF
--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -85,7 +85,7 @@ class PrebuiltMacOSApp extends MacOSApp {
     @required this.bundleDir,
     @required this.bundleName,
     @required this.executableAndId,
-  });
+  }) : super(projectBundleId: executableAndId.id);
 
   final Directory bundleDir;
   final String bundleName;

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -88,7 +88,7 @@ class MacOSDevice extends Device {
     if (prebuiltApplication) {
       prebuiltMacOSApp = package;
     } else {
-      prebuiltMacOSApp = await buildMacOS(
+      prebuiltMacOSApp = await macOSBuilder.buildMacOS(
         flutterProject: FlutterProject.current(),
         buildInfo: debuggingOptions?.buildInfo,
         targetOverride: mainPath,


### PR DESCRIPTION
## Description

Allow flutter build macos to output to the build directory. Allow customization of output path and add test case. By default outputs to build/macos.

This allows flutter assemble to freely cache the artifacts without worrying about stepping on other builds. At worst, we end up copying the directory again.