### PR TITLE
have xcodeSelectPath also catch ArgumentError

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -26,6 +26,8 @@ class Xcode {
         _xcodeSelectPath = processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']).stdout.trim();
       } on ProcessException {
         // Ignored, return null below.
+      } on ArgumentError {
+        // Ignored, return null below.
       }
     }
     return _xcodeSelectPath;

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -30,6 +30,9 @@ void main() {
       when(mockProcessManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
           .thenThrow(const ProcessException('/usr/bin/xcode-select', <String>['--print-path']));
       expect(xcode.xcodeSelectPath, isNull);
+      when(mockProcessManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+          .thenThrow(ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'));
+      expect(xcode.xcodeSelectPath, isNull);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });


### PR DESCRIPTION
## Description

This is in response to crash reports of the form:

```
Invalid argument(s): Cannot find executable for /usr/bin/xcode-select
  | at _getExecutable | (local_process_manager.dart:113 )
  | at LocalProcessManager.runSync | (local_process_manager.dart:84 )
  | at Xcode.xcodeSelectPath | (xcode.dart:26 )
  | at Xcode.isInstalled | (xcode.dart:35 )
  | at Xcode.isInstalledAndMeetsVersionCheck | (xcode.dart:20 )
  | at IOSWorkflow.canListDevices | (ios_workflow.dart:21 )

...

```

## Tests

I updated the existing test to throw both `ProcessException` AND `ArgumentError`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.