### PR TITLE
Do not validate SDK when building appbundle

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -9,9 +9,7 @@ import 'package:meta/meta.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../build_info.dart';
-import '../globals.dart';
 import '../project.dart';
-
 import 'android_sdk.dart';
 import 'gradle.dart';
 
@@ -126,19 +124,14 @@ class _AndroidBuilderImpl extends AndroidBuilder {
     if (androidSdk == null) {
       throwToolExit('No Android SDK found. Try setting the ANDROID_HOME environment variable.');
     }
-    final List<String> validationResult = androidSdk.validateSdkWellFormed();
-    if (validationResult.isNotEmpty) {
-      for (String message in validationResult) {
-        printError(message, wrap: false);
-      }
-      throwToolExit('Try re-installing or updating your Android SDK.');
-    }
-    return buildGradleProject(
+    await buildGradleProject(
       project: project,
       androidBuildInfo: androidBuildInfo,
       target: target,
       isBuildingBundle: true,
     );
+    // Gradle may download SDK components. Re-initialize SDK to pick them up.
+    androidSdk.reinitialize();
   }
 }
 


### PR DESCRIPTION
## Description

Do not validate SDK when building `appbundle`.

We don't do this for APK, and should not need for AAB.
This is preventing the usage of Gradle feature to automatically download Android
SDK components, by verifying the presence of e.g. "adb".

Android Debug Bridge is unnecessary for building an AAB.

## Related Issues

* #28076 (regression)

See #28355 (PR).

## Tests

Test added.
Verified manually by testing against empty `ANDROID_HOME` directory (licenses only).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.