### PR TITLE
Closes #37593 Add flutter_export_environment.sh to gitignore

### DIFF
--- a/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/.gitignore
+++ b/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/.gitignore
@@ -64,6 +64,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/dev/integration_tests/android_splash_screens/splash_screen_load_rotate/.gitignore
+++ b/dev/integration_tests/android_splash_screens/splash_screen_load_rotate/.gitignore
@@ -61,6 +61,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/dev/integration_tests/android_splash_screens/splash_screen_trans_rotate/.gitignore
+++ b/dev/integration_tests/android_splash_screens/splash_screen_trans_rotate/.gitignore
@@ -61,6 +61,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/dev/integration_tests/android_views/ios/.gitignore
+++ b/dev/integration_tests/android_views/ios/.gitignore
@@ -39,6 +39,7 @@ Icon?
 /Flutter/App.framework
 /Flutter/Flutter.framework
 /Flutter/Generated.xcconfig
+/Flutter/flutter_export_environment.sh
 /ServiceDefinitions.json
 
 Pods/

--- a/dev/integration_tests/release_smoke_test/.gitignore
+++ b/dev/integration_tests/release_smoke_test/.gitignore
@@ -61,6 +61,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -61,6 +61,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -61,6 +61,7 @@ build/
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/packages/flutter_tools/templates/plugin/ios.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/plugin/ios.tmpl/.gitignore
@@ -34,3 +34,4 @@ Icon?
 .tags*
 
 /Flutter/Generated.xcconfig
+/Flutter/flutter_export_environment.sh


### PR DESCRIPTION
## Description

Closes #37593 - Please see that issue description.

## Tests

Manually tested to confirm that `.gitignore` templates with changes are implemented when using `flutter create`

## Checklist

All tasks completed: 

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.