### PR TITLE
Instrument pending timers in tests

### DIFF
--- a/dev/automated_tests/test_smoke_test/pending_timer_fail_test.dart
+++ b/dev/automated_tests/test_smoke_test/pending_timer_fail_test.dart
@@ -12,6 +12,6 @@ void main() {
 
 void failingPendingTimerTest() {
   testWidgets('flutter_test pending timer - negative', (WidgetTester tester) async {
-    Timer(const Duration(seconds: 1), () {});
+    Timer(const Duration(minutes: 10), () {});
   });
 }

--- a/dev/automated_tests/test_smoke_test/pending_timer_fail_test.dart
+++ b/dev/automated_tests/test_smoke_test/pending_timer_fail_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  failingPendingTimerTest();
+}
+
+void failingPendingTimerTest() {
+  testWidgets('flutter_test pending timer - negative', (WidgetTester tester) async {
+    Timer(const Duration(seconds: 1), () {});
+  });
+}

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -111,6 +111,16 @@ Future<void> _runSmokeTests() async {
     printOutput: false,
     timeout: _kShortTimeout,
   );
+  await _runFlutterTest(automatedTests,
+    script: path.join('test_smoke_test', 'pending_timer_fail_test.dart'),
+    expectFailure: true,
+    printOutput: false,
+    outputChecker: (CapturedOutput output) =>
+      output.stdout.contains('failingPendingTimerTest')
+      ? null
+      : 'Failed to find the stack trace for the pending Timer.',
+    timeout: _kShortTimeout,
+  );
   // We run the remaining smoketests in parallel, because they each take some
   // time to run (e.g. compiling), so we don't want to run them in series,
   // especially on 20-core machines...

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -743,7 +743,8 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
 /// If `stackTrace` is null, dumps the current stack using [StackTrace.current].
 ///
 /// The `maxFrames` argument can be given to limit the stack to the given number
-/// of non-filtered lines. By default, all non-filtered stack lines are shown.
+/// of lines before filtering is applied. By default, all stack lines are
+/// included.
 ///
 /// The `label` argument, if present, will be printed before the stack.
 void debugPrintStack({StackTrace stackTrace, String label, int maxFrames}) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -737,20 +737,23 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   }
 }
 
-/// Dump the current stack to the console using [debugPrint] and
+/// Dump the stack to the console using [debugPrint] and
 /// [FlutterError.defaultStackFilter].
 ///
-/// The current stack is obtained using [StackTrace.current].
+/// If `stackTrace` is null, dumps the current stack using [StackTrace.current].
 ///
 /// The `maxFrames` argument can be given to limit the stack to the given number
-/// of lines. By default, all non-filtered stack lines are shown.
+/// of non-filtered lines. By default, all non-filtered stack lines are shown.
 ///
 /// The `label` argument, if present, will be printed before the stack.
-void debugPrintStack({ String label, int maxFrames }) {
+void debugPrintStack({StackTrace stackTrace, String label, int maxFrames}) {
   if (label != null)
     debugPrint(label);
-  Iterable<String> lines = StackTrace.current.toString().trimRight().split('\n');
-  if (kIsWeb) {
+  stackTrace ??= StackTrace.current;
+  Iterable<String> lines = stackTrace.toString().trimRight().split('\n');
+  if (   kIsWeb
+      && lines.isNotEmpty
+      && lines.first.contains('StackTrace.current')) {
     // Remove extra call to StackTrace.current for web platform.
     // TODO(ferhat): remove when https://github.com/flutter/flutter/issues/37635
     // is addressed.

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -740,7 +740,8 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
 /// Dump the stack to the console using [debugPrint] and
 /// [FlutterError.defaultStackFilter].
 ///
-/// If `stackTrace` is null, dumps the current stack using [StackTrace.current].
+/// If the `stackTrace` parameter is null, the [StackTrace.current] is used to
+/// obtain the stack.
 ///
 /// The `maxFrames` argument can be given to limit the stack to the given number
 /// of lines before filtering is applied. By default, all stack lines are

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1065,7 +1065,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         debugPrint('');
       }
       return false;
-    }(),'A Timer is still pending even after the widget tree was disposed.');
+    }(), 'A Timer is still pending even after the widget tree was disposed.');
 
     assert(_currentFakeAsync.microtaskCount == 0); // Shouldn't be possible.
   }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1044,14 +1044,32 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void _verifyInvariants() {
     super._verifyInvariants();
-    assert(
-      _currentFakeAsync.periodicTimerCount == 0,
-      'A periodic Timer is still running even after the widget tree was disposed.'
-    );
-    assert(
-      _currentFakeAsync.nonPeriodicTimerCount == 0,
-      'A Timer is still pending even after the widget tree was disposed.'
-    );
+    try {
+      assert(
+        _currentFakeAsync.periodicTimerCount == 0,
+        'A periodic Timer is still running even after the widget tree was '
+        'disposed.',
+      );
+      assert(
+        _currentFakeAsync.nonPeriodicTimerCount == 0,
+        'A Timer is still pending even after the widget tree was disposed.',
+      );
+    } on AssertionError {
+      debugPrint('Pending timers:');
+      for (String timerInfo in _currentFakeAsync.pendingTimersDebugInfo) {
+        final int firstLineEnd = timerInfo.indexOf('\n');
+        assert(firstLineEnd != -1);
+
+        // No need to include the newline.
+        final String firstLine = timerInfo.substring(0, firstLineEnd);
+        final String stackTrace = timerInfo.substring(firstLineEnd + 1);
+
+        debugPrint(firstLine);
+        debugPrintStack(stackTrace: StackTrace.fromString(stackTrace));
+        debugPrint('');
+      }
+      rethrow;
+    }
     assert(_currentFakeAsync.microtaskCount == 0); // Shouldn't be possible.
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1044,17 +1044,13 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void _verifyInvariants() {
     super._verifyInvariants();
-    try {
-      assert(
-        _currentFakeAsync.periodicTimerCount == 0,
-        'A periodic Timer is still running even after the widget tree was '
-        'disposed.',
-      );
-      assert(
-        _currentFakeAsync.nonPeriodicTimerCount == 0,
-        'A Timer is still pending even after the widget tree was disposed.',
-      );
-    } on AssertionError {
+
+    assert(() {
+      if (   _currentFakeAsync.periodicTimerCount == 0
+          && _currentFakeAsync.nonPeriodicTimerCount == 0) {
+        return true;
+      }
+
       debugPrint('Pending timers:');
       for (String timerInfo in _currentFakeAsync.pendingTimersDebugInfo) {
         final int firstLineEnd = timerInfo.indexOf('\n');
@@ -1068,8 +1064,9 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         debugPrintStack(stackTrace: StackTrace.fromString(stackTrace));
         debugPrint('');
       }
-      rethrow;
-    }
+      return false;
+    }(),'A Timer is still pending even after the widget tree was disposed.');
+
     assert(_currentFakeAsync.microtaskCount == 0); // Shouldn't be possible.
   }
 


### PR DESCRIPTION
## Description

Flutter widget tests assert if a test completes with timers still
pending.  However, it can be hard to diagnose where a pending timer
came from.  For example, a widget might consume a third-party library
that internally uses a timer.

I added a FakeAsync.pendingTimersDebugInfo getter to quiver
(https://github.com/google/quiver-dart/pull/500).  Make flutter_test
use it.

Additionally modify Flutter's debugPrintStack to take an optional
StackTrace argument instead of always printing StackTrace.current.

## Related Issues

Fixes #4237.

## Tests

Since this adjusts error reporting for specific types of test failures, I did not add any tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.
