### PR TITLE
Change priority of gen_snapshot search paths

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -411,7 +411,7 @@ class LocalEngineArtifacts extends Artifacts {
   }
 
   String _genSnapshotPath() {
-    const List<String> clangDirs = <String>['.', 'clang_x86', 'clang_x64', 'clang_i386'];
+    const List<String> clangDirs = <String>['.', 'clang_x64', 'clang_x86', 'clang_i386'];
     final String genSnapshotName = _artifactToFileName(Artifact.genSnapshot);
     for (String clangDir in clangDirs) {
       final String genSnapshotPath = fs.path.join(engineOutPath, clangDir, genSnapshotName);


### PR DESCRIPTION
## Description

Arm gen_snapshot has moved from clang_x86 to clang_x64 as of https://github.com/flutter/engine/pull/10010. This causes a problem for people upgrading from older versions of flutter, because they will still have the old gen_snapshot in the clang_x86 directory in their artifacts cache.

We can't delete the clang_x86 directory from the list of searched directories, because we still build x86 targeting gen_snapshot as an x86 binary. So as a hacky fix I've changed the order of the directories so that we search for clang_x64 before falling back to clang_x86. This should handle the upgrade case.

## Related Issues

https://github.com/flutter/flutter/issues/22598