### PR TITLE
Add missing library to flutter tools BUILD.gn

### DIFF
--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -24,6 +24,7 @@ dart_library("flutter_tools") {
     "//third_party/dart-pkg/pub/completion",
     "//third_party/dart-pkg/pub/coverage",
     "//third_party/dart-pkg/pub/crypto",
+    "//third_party/dart-pkg/pub/dwds",
     "//third_party/dart-pkg/pub/file",
     # The HTTP dependency is removed because http doesn't work on Fuchsia
     # because it uses mirrors which Fuchsia's Dart VM doesn't support.


### PR DESCRIPTION
## Description

This library is directly used for the flutter web work and will likely need to be in the BUILD.gn file