### PR TITLE
Fix missing version in iOS plugin example project

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -15,8 +15,8 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
 {{/withPluginHook}}
+version: 1.0.0+1
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -3,7 +3,6 @@ description: {{description}}
 {{#withPluginHook}}
 publish_to: 'none'
 {{/withPluginHook}}
-{{^withPluginHook}}
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -15,7 +14,6 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-{{/withPluginHook}}
 version: 1.0.0+1
 
 environment:


### PR DESCRIPTION
## Description

I encountered this problem when working on a plugin.

1. Run `flutter create --template plugin hello_world`.
2. Build example on simulator - works ok.
3. Build example on simulator again - fails with very cryptic `Could not hardlink copy...` error.

After some investigation, I found out that Info.plist specifies build versions to be FLUTTER_BUILD_NUMBER & FLUTTER_BUILD_NAME. These variables were never defined because version parameter was missing. This caused very strange behavior when trying to install the app for the second time.

Adding version in pubspec fixes the problem.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
