### PR TITLE
Adding physicalDepth to MediaQueryData & TestWindow

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -74,6 +74,7 @@ enum Orientation {
 /// widgets that reduce those properties by the same amount.
 /// The [removePadding], [removeViewPadding], and [removeInsets] methods are
 /// useful for this.
+///
 /// See also:
 ///
 /// * [Scaffold], [SafeArea], [CupertinoTabScaffold], and
@@ -274,7 +275,8 @@ class MediaQueryData {
   ///  * [Window.AccessibilityFeatures], where the setting originates.
   final bool boldText;
 
-  /// The orientation of the media (e.g., whether the device is in landscape or portrait mode).
+  /// The orientation of the media (e.g., whether the device is in landscape or
+  /// portrait mode).
   Orientation get orientation {
     return size.width > size.height ? Orientation.landscape : Orientation.portrait;
   }
@@ -322,7 +324,7 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [new MediaQuery.removePadding], which uses this method to remove padding
+  ///  * [MediaQuery.removePadding], which uses this method to remove [padding]
   ///    from the ambient [MediaQuery].
   ///  * [SafeArea], which both removes the padding from the [MediaQuery] and
   ///    adds a [Padding] widget.
@@ -371,8 +373,8 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [new MediaQuery.removeViewInsets], which uses this method to remove
-  ///    padding from the ambient [MediaQuery].
+  ///  * [MediaQuery.removeViewInsets], which uses this method to remove
+  ///    [viewInsets] from the ambient [MediaQuery].
   ///  * [removePadding], the same thing but for [padding].
   ///  * [removeViewPadding], the same thing but for [viewPadding].
   MediaQueryData removeViewInsets({
@@ -418,8 +420,8 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [new MediaQuery.removeViewPadding], which uses this method to remove
-  ///    padding from the ambient [MediaQuery].
+  ///  * [MediaQuery.removeViewPadding], which uses this method to remove
+  ///    [viewPadding] from the ambient [MediaQuery].
   ///  * [removePadding], the same thing but for [padding].
   ///  * [removeViewInsets], the same thing but for [viewInsets].
   MediaQueryData removeViewPadding({
@@ -549,8 +551,8 @@ class MediaQuery extends InheritedWidget {
        assert(data != null),
        super(key: key, child: child);
 
-  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery] from
-  /// the given context, but removes the specified paddings.
+  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery]
+  /// from the given context, but removes the specified padding.
   ///
   /// This should be inserted into the widget tree when the [MediaQuery] padding
   /// is consumed by a widget in such a way that the padding is no longer
@@ -570,9 +572,11 @@ class MediaQuery extends InheritedWidget {
   ///
   ///  * [SafeArea], which both removes the padding from the [MediaQuery] and
   ///    adds a [Padding] widget.
-  ///  * [MediaQueryData.padding], the affected property of the [MediaQueryData].
-  ///  * [new removeViewInsets], the same thing but for removing view insets.
-  ///  * [new removeViewPadding], the same thing but for removing view insets.
+  ///  * [MediaQueryData.padding], the affected property of the
+  ///    [MediaQueryData].
+  ///  * [removeViewInsets], the same thing but for [MediaQueryData.viewInsets].
+  ///  * [removeViewPadding], the same thing but for
+  ///    [MediaQueryData.viewPadding].
   factory MediaQuery.removePadding({
     Key key,
     @required BuildContext context,
@@ -594,8 +598,8 @@ class MediaQuery extends InheritedWidget {
     );
   }
 
-  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery] from
-  /// the given context, but removes the specified view insets.
+  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery]
+  /// from the given context, but removes the specified view insets.
   ///
   /// This should be inserted into the widget tree when the [MediaQuery] view
   /// insets are consumed by a widget in such a way that the view insets are no
@@ -613,9 +617,11 @@ class MediaQuery extends InheritedWidget {
   ///
   /// See also:
   ///
-  ///  * [MediaQueryData.viewInsets], the affected property of the [MediaQueryData].
-  ///  * [new removePadding], the same thing but for removing paddings.
-  ///  * [new removeViewPadding], the same thing but for removing view insets.
+  ///  * [MediaQueryData.viewInsets], the affected property of the
+  ///    [MediaQueryData].
+  ///  * [removePadding], the same thing but for [MediaQueryData.padding].
+  ///  * [removeViewPadding], the same thing but for
+  ///    [MediaQueryData.viewPadding].
   factory MediaQuery.removeViewInsets({
     Key key,
     @required BuildContext context,
@@ -637,8 +643,8 @@ class MediaQuery extends InheritedWidget {
     );
   }
 
-  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery] from
-  /// the given context, but removes the specified view padding.
+  /// Creates a new [MediaQuery] that inherits from the ambient [MediaQuery]
+  /// from the given context, but removes the specified view padding.
   ///
   /// This should be inserted into the widget tree when the [MediaQuery] view
   /// padding is consumed by a widget in such a way that the view padding is no
@@ -658,8 +664,8 @@ class MediaQuery extends InheritedWidget {
   ///
   ///  * [MediaQueryData.viewPadding], the affected property of the
   ///  [MediaQueryData].
-  ///  * [new removePadding], the same thing but for removing paddings.
-  ///  * [new removeViewInsets], the same thing but for removing view insets.
+  ///  * [removePadding], the same thing but for [MediaQueryData.padding].
+  ///  * [removeViewInsets], the same thing but for [MediaQueryData.viewInsets].
   factory MediaQuery.removeViewPadding({
     Key key,
     @required BuildContext context,
@@ -691,8 +697,8 @@ class MediaQuery extends InheritedWidget {
   /// context.
   ///
   /// You can use this function to query the size an orientation of the screen.
-  /// When that information changes, your widget will be scheduled to be rebuilt,
-  /// keeping your widget up-to-date.
+  /// When that information changes, your widget will be scheduled to be
+  /// rebuilt, keeping your widget up-to-date.
   ///
   /// Typical usage is as follows:
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -93,6 +93,7 @@ class MediaQueryData {
     this.padding = EdgeInsets.zero,
     this.viewInsets = EdgeInsets.zero,
     this.viewPadding = EdgeInsets.zero,
+    this.physicalDepth = double.maxFinite,
     this.alwaysUse24HourFormat = false,
     this.accessibleNavigation = false,
     this.invertColors = false,
@@ -114,6 +115,7 @@ class MediaQueryData {
       padding = EdgeInsets.fromWindowPadding(window.padding, window.devicePixelRatio),
       viewPadding = EdgeInsets.fromWindowPadding(window.viewPadding, window.devicePixelRatio),
       viewInsets = EdgeInsets.fromWindowPadding(window.viewInsets, window.devicePixelRatio),
+      physicalDepth = window.physicalDepth,
       accessibleNavigation = window.accessibilityFeatures.accessibleNavigation,
       invertColors = window.accessibilityFeatures.invertColors,
       disableAnimations = window.accessibilityFeatures.disableAnimations,
@@ -210,6 +212,19 @@ class MediaQueryData {
   ///   property and how it relates to [padding] and [viewInsets].
   final EdgeInsets viewPadding;
 
+  /// The physical depth is the maximum elevation that the Window allows.
+  ///
+  /// Physical layers drawn at or above this elevation will have their elevation
+  /// clamped to this value. This can happen if the physical layer itself has
+  /// an elevation larger than available depth, or if some ancestor of the layer
+  /// causes it to have a cumulative elevation that is larger than the available
+  /// depth.
+  ///
+  /// The default value is [double.maxFinite], which is used for platforms that
+  /// do not specify a maximum elevation. This property is currently on expected
+  /// to be set to a non-default value on Fuchsia.
+  final double physicalDepth;
+
   /// Whether to use 24-hour format when formatting time.
   ///
   /// The behavior of this flag is different across platforms:
@@ -274,6 +289,7 @@ class MediaQueryData {
     EdgeInsets padding,
     EdgeInsets viewPadding,
     EdgeInsets viewInsets,
+    double physicalDepth,
     bool alwaysUse24HourFormat,
     bool disableAnimations,
     bool invertColors,
@@ -288,6 +304,7 @@ class MediaQueryData {
       padding: padding ?? this.padding,
       viewPadding: viewPadding ?? this.viewPadding,
       viewInsets: viewInsets ?? this.viewInsets,
+      physicalDepth: physicalDepth ?? this.physicalDepth,
       alwaysUse24HourFormat: alwaysUse24HourFormat ?? this.alwaysUse24HourFormat,
       invertColors: invertColors ?? this.invertColors,
       disableAnimations: disableAnimations ?? this.disableAnimations,
@@ -451,6 +468,7 @@ class MediaQueryData {
         && typedOther.padding == padding
         && typedOther.viewPadding == viewPadding
         && typedOther.viewInsets == viewInsets
+        && typedOther.physicalDepth == physicalDepth
         && typedOther.alwaysUse24HourFormat == alwaysUse24HourFormat
         && typedOther.disableAnimations == disableAnimations
         && typedOther.invertColors == invertColors
@@ -468,6 +486,7 @@ class MediaQueryData {
       padding,
       viewPadding,
       viewInsets,
+      physicalDepth,
       alwaysUse24HourFormat,
       disableAnimations,
       invertColors,
@@ -486,6 +505,7 @@ class MediaQueryData {
              'padding: $padding, '
              'viewPadding: $viewPadding, '
              'viewInsets: $viewInsets, '
+             'physicalDepth: $physicalDepth, '
              'alwaysUse24HourFormat: $alwaysUse24HourFormat, '
              'accessibleNavigation: $accessibleNavigation, '
              'disableAnimations: $disableAnimations, '

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -217,13 +217,13 @@ class MediaQueryData {
   ///
   /// Physical layers drawn at or above this elevation will have their elevation
   /// clamped to this value. This can happen if the physical layer itself has
-  /// an elevation larger than available depth, or if some ancestor of the layer
-  /// causes it to have a cumulative elevation that is larger than the available
-  /// depth.
+  /// an elevation larger than the available depth, or if some ancestor of the
+  /// layer causes it to have a cumulative elevation that is larger than the
+  /// available depth.
   ///
   /// The default value is [double.maxFinite], which is used for platforms that
-  /// do not specify a maximum elevation. This property is currently on expected
-  /// to be set to a non-default value on Fuchsia.
+  /// do not specify a maximum elevation. This property is currently only
+  /// expected to be set to a non-default value on Fuchsia.
   final double physicalDepth;
 
   /// Whether to use 24-hour format when formatting time.

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -47,6 +47,7 @@ void main() {
     expect(data.disableAnimations, false);
     expect(data.boldText, false);
     expect(data.platformBrightness, Brightness.light);
+    expect(data.physicalDepth, equals(WidgetsBinding.instance.window.physicalDepth));
   });
 
   testWidgets('MediaQueryData.copyWith defaults to source', (WidgetTester tester) async {
@@ -58,6 +59,7 @@ void main() {
     expect(copied.padding, data.padding);
     expect(copied.viewPadding, data.viewPadding);
     expect(copied.viewInsets, data.viewInsets);
+    expect(copied.physicalDepth, data.physicalDepth);
     expect(copied.alwaysUse24HourFormat, data.alwaysUse24HourFormat);
     expect(copied.accessibleNavigation, data.accessibleNavigation);
     expect(copied.invertColors, data.invertColors);
@@ -75,6 +77,7 @@ void main() {
       padding: const EdgeInsets.all(9.10938),
       viewPadding: const EdgeInsets.all(11.24031),
       viewInsets: const EdgeInsets.all(1.67262),
+      physicalDepth: 120.0,
       alwaysUse24HourFormat: true,
       accessibleNavigation: true,
       invertColors: true,
@@ -88,6 +91,7 @@ void main() {
     expect(copied.padding, const EdgeInsets.all(9.10938));
     expect(copied.viewPadding, const EdgeInsets.all(11.24031));
     expect(copied.viewInsets, const EdgeInsets.all(1.67262));
+    expect(copied.physicalDepth, 120.0);
     expect(copied.alwaysUse24HourFormat, true);
     expect(copied.accessibleNavigation, true);
     expect(copied.invertColors, true);

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -11,10 +11,10 @@ import 'package:meta/meta.dart';
 /// for testing purposes.
 ///
 /// Tests for certain widgets, e.g., [MaterialApp], might require faking certain
-/// properties of a [Window]. [TestWindow] facilitates the faking of these properties
-/// by overidding the properties of a real [Window] with desired fake values. The
-/// binding used within tests, [TestWidgetsFlutterBinding], contains a [TestWindow]
-/// that is used by all tests.
+/// properties of a [Window]. [TestWindow] facilitates the faking of these
+/// properties by overriding the properties of a real [Window] with desired fake
+/// values. The binding used within tests, [TestWidgetsFlutterBinding], contains
+/// a [TestWindow] that is used by all tests.
 ///
 /// ## Sample Code
 ///
@@ -42,10 +42,11 @@ import 'package:meta/meta.dart';
 /// return to using the real [Window] property, [TestWindow] provides
 /// methods to clear each individual test value, e.g., [clearLocaleTestValue()].
 ///
-/// To clear all fake test values in a [TestWindow], consider using [clearAllTestValues()].
+/// To clear all fake test values in a [TestWindow], consider using
+/// [clearAllTestValues()].
 class TestWindow implements Window {
-  /// Constructs a [TestWindow] that defers all behavior to the given [window] unless
-  /// explicitly overidden for test purposes.
+  /// Constructs a [TestWindow] that defers all behavior to the given [Window]
+  /// unless explicitly overridden for test purposes.
   TestWindow({
     @required Window window,
   }) : _window = window;
@@ -56,12 +57,14 @@ class TestWindow implements Window {
   @override
   double get devicePixelRatio => _devicePixelRatio ?? _window.devicePixelRatio;
   double _devicePixelRatio;
-  /// Hides the real device pixel ratio and reports the given [devicePixelRatio] instead.
+  /// Hides the real device pixel ratio and reports the given [devicePixelRatio]
+  /// instead.
   set devicePixelRatioTestValue(double devicePixelRatio) {
     _devicePixelRatio = devicePixelRatio;
     onMetricsChanged();
   }
-  /// Deletes any existing test device pixel ratio and returns to using the real device pixel ratio.
+  /// Deletes any existing test device pixel ratio and returns to using the real
+  /// device pixel ratio.
   void clearDevicePixelRatioTestValue() {
     _devicePixelRatio = null;
     onMetricsChanged();
@@ -70,43 +73,65 @@ class TestWindow implements Window {
   @override
   Size get physicalSize => _physicalSizeTestValue ?? _window.physicalSize;
   Size _physicalSizeTestValue;
-  /// Hides the real physical size and reports the given [physicalSizeTestValue] instead.
+  /// Hides the real physical size and reports the given [physicalSizeTestValue]
+  /// instead.
   set physicalSizeTestValue (Size physicalSizeTestValue) {
     _physicalSizeTestValue = physicalSizeTestValue;
     onMetricsChanged();
   }
-  /// Deletes any existing test physical size and returns to using the real physical size.
+  /// Deletes any existing test physical size and returns to using the real
+  /// physical size.
   void clearPhysicalSizeTestValue() {
     _physicalSizeTestValue = null;
     onMetricsChanged();
   }
 
   @override
+  double get physicalDepth => _physicalDepthTestValue ?? _window.physicalDepth;
+  double _physicalDepthTestValue;
+  /// Hides the real physical depth and reports the given
+  /// [physicalDepthTestValue] instead.
+  set physicalDepthTestValue (double physicalDepthTestValue) {
+    _physicalDepthTestValue = physicalDepthTestValue;
+    onMetricsChanged();
+  }
+  /// Deletes any existing test physical depth and returns to using the real
+  /// physical depth.
+  void clearPhysicalDepthTestValue() {
+    _physicalDepthTestValue = null;
+    onMetricsChanged();
+  }
+
+  @override
   WindowPadding get viewInsets => _viewInsetsTestValue ??  _window.viewInsets;
   WindowPadding _viewInsetsTestValue;
-  /// Hides the real view insets and reports the given [viewInsetsTestValue] instead.
+  /// Hides the real view insets and reports the given [viewInsetsTestValue]
+  /// instead.
   set viewInsetsTestValue(WindowPadding viewInsetsTestValue) {
     _viewInsetsTestValue = viewInsetsTestValue;
     onMetricsChanged();
   }
-  /// Deletes any existing test view insets and returns to using the real view insets.
+  /// Deletes any existing test view insets and returns to using the real view
+  /// insets.
   void clearViewInsetsTestValue() {
     _viewInsetsTestValue = null;
     onMetricsChanged();
   }
 
-  // TODO(dnfield): Remove this ignore once custom embedders have had time to catch up
-  // And make this property actually wrap _window.viewPadding.
+  // TODO(dnfield): Remove this ignore once custom embedders have had time to
+  //  catch up and make this property actually wrap _window.viewPadding.
   // @override
   // ignore: annotate_overrides, public_member_api_docs
   WindowPadding get viewPadding => _viewPaddingTestValue ?? _window.padding;
   WindowPadding _viewPaddingTestValue;
-  /// Hides the real padding and reports the given [paddingTestValue] instead.
+  /// Hides the real view padding and reports the given [paddingTestValue]
+  /// instead.
   set viewPaddingTestValue(WindowPadding viewPaddingTestValue) {
     _viewPaddingTestValue = viewPaddingTestValue;
     onMetricsChanged();
   }
-  /// Deletes any existing test padding and returns to using the real padding.
+  /// Deletes any existing test view padding and returns to using the real
+  /// viewPadding.
   void clearViewPaddingTestValue() {
     _viewPaddingTestValue = null;
     onMetricsChanged();
@@ -179,12 +204,14 @@ class TestWindow implements Window {
   @override
   double get textScaleFactor => _textScaleFactorTestValue ?? _window.textScaleFactor;
   double _textScaleFactorTestValue;
-  /// Hides the real text scale factor and reports the given [textScaleFactorTestValue] instead.
+  /// Hides the real text scale factor and reports the given
+  /// [textScaleFactorTestValue] instead.
   set textScaleFactorTestValue(double textScaleFactorTestValue) {
     _textScaleFactorTestValue = textScaleFactorTestValue;
     onTextScaleFactorChanged();
   }
-  /// Deletes any existing test text scale factor and returns to using the real text scale factor.
+  /// Deletes any existing test text scale factor and returns to using the real
+  /// text scale factor.
   void clearTextScaleFactorTestValue() {
     _textScaleFactorTestValue = null;
     onTextScaleFactorChanged();
@@ -199,12 +226,14 @@ class TestWindow implements Window {
   set onPlatformBrightnessChanged(VoidCallback callback) {
     _window.onPlatformBrightnessChanged = callback;
   }
-  /// Hides the real text scale factor and reports the given [platformBrightnessTestValue] instead.
+  /// Hides the real text scale factor and reports the given
+  /// [platformBrightnessTestValue] instead.
   set platformBrightnessTestValue(Brightness platformBrightnessTestValue) {
     _platformBrightnessTestValue = platformBrightnessTestValue;
     onPlatformBrightnessChanged();
   }
-  /// Deletes any existing test platform brightness and returns to using the real platform brightness.
+  /// Deletes any existing test platform brightness and returns to using the
+  /// real platform brightness.
   void clearPlatformBrightnessTestValue() {
     _platformBrightnessTestValue = null;
     onPlatformBrightnessChanged();
@@ -213,11 +242,13 @@ class TestWindow implements Window {
   @override
   bool get alwaysUse24HourFormat => _alwaysUse24HourFormatTestValue ?? _window.alwaysUse24HourFormat;
   bool _alwaysUse24HourFormatTestValue;
-  /// Hides the real clock format and reports the given [alwaysUse24HourFormatTestValue] instead.
+  /// Hides the real clock format and reports the given
+  /// [alwaysUse24HourFormatTestValue] instead.
   set alwaysUse24HourFormatTestValue(bool alwaysUse24HourFormatTestValue) {
     _alwaysUse24HourFormatTestValue = alwaysUse24HourFormatTestValue;
   }
-  /// Deletes any existing test clock format and returns to using the real clock format.
+  /// Deletes any existing test clock format and returns to using the real clock
+  /// format.
   void clearAlwaysUse24HourTestValue() {
     _alwaysUse24HourFormatTestValue = null;
   }
@@ -260,11 +291,13 @@ class TestWindow implements Window {
   @override
   String get defaultRouteName => _defaultRouteNameTestValue ?? _window.defaultRouteName;
   String _defaultRouteNameTestValue;
-  /// Hides the real default route name and reports the given [defaultRouteNameTestValue] instead.
+  /// Hides the real default route name and reports the given
+  /// [defaultRouteNameTestValue] instead.
   set defaultRouteNameTestValue(String defaultRouteNameTestValue) {
     _defaultRouteNameTestValue = defaultRouteNameTestValue;
   }
-  /// Deletes any existing test default route name and returns to using the real default route name.
+  /// Deletes any existing test default route name and returns to using the real
+  /// default route name.
   void clearDefaultRouteNameTestValue() {
     _defaultRouteNameTestValue = null;
   }
@@ -282,12 +315,14 @@ class TestWindow implements Window {
   @override
   bool get semanticsEnabled => _semanticsEnabledTestValue ?? _window.semanticsEnabled;
   bool _semanticsEnabledTestValue;
-  /// Hides the real semantics enabled and reports the given [semanticsEnabledTestValue] instead.
+  /// Hides the real semantics enabled and reports the given
+  /// [semanticsEnabledTestValue] instead.
   set semanticsEnabledTestValue(bool semanticsEnabledTestValue) {
     _semanticsEnabledTestValue = semanticsEnabledTestValue;
     onSemanticsEnabledChanged();
   }
-  /// Deletes any existing test semantics enabled and returns to using the real semantics enabled.
+  /// Deletes any existing test semantics enabled and returns to using the real
+  /// semantics enabled.
   void clearSemanticsEnabledTestValue() {
     _semanticsEnabledTestValue = null;
     onSemanticsEnabledChanged();
@@ -310,12 +345,14 @@ class TestWindow implements Window {
   @override
   AccessibilityFeatures get accessibilityFeatures => _accessibilityFeaturesTestValue ?? _window.accessibilityFeatures;
   AccessibilityFeatures _accessibilityFeaturesTestValue;
-  /// Hides the real accessibility features and reports the given [accessibilityFeaturesTestValue] instead.
+  /// Hides the real accessibility features and reports the given
+  /// [accessibilityFeaturesTestValue] instead.
   set accessibilityFeaturesTestValue(AccessibilityFeatures accessibilityFeaturesTestValue) {
     _accessibilityFeaturesTestValue = accessibilityFeaturesTestValue;
     onAccessibilityFeaturesChanged();
   }
-  /// Deletes any existing test accessibility features and returns to using the real accessibility features.
+  /// Deletes any existing test accessibility features and returns to using the
+  /// real accessibility features.
   void clearAccessibilityFeaturesTestValue() {
     _accessibilityFeaturesTestValue = null;
     onAccessibilityFeaturesChanged();
@@ -355,10 +392,11 @@ class TestWindow implements Window {
   }
 
   /// Delete any test value properties that have been set on this [TestWindow]
-  /// and return to reporting the real [Window] values for all [Window] properties.
+  /// and return to reporting the real [Window] values for all [Window]
+  /// properties.
   ///
-  /// If desired, clearing of properties can be done on an individual basis, e.g.,
-  /// [clearLocaleTestValue()].
+  /// If desired, clearing of properties can be done on an individual basis,
+  /// e.g., [clearLocaleTestValue()].
   void clearAllTestValues() {
     clearAccessibilityFeaturesTestValue();
     clearAlwaysUse24HourTestValue();
@@ -369,14 +407,15 @@ class TestWindow implements Window {
     clearLocalesTestValue();
     clearPaddingTestValue();
     clearPhysicalSizeTestValue();
+    clearPhysicalDepthTestValue();
     clearSemanticsEnabledTestValue();
     clearTextScaleFactorTestValue();
     clearViewInsetsTestValue();
   }
 
   /// This gives us some grace time when the dart:ui side adds something to
-  /// Window, and makes things easier when we do rolls to give us time to
-  /// catch up.
+  /// Window, and makes things easier when we do rolls to give us time to catch
+  /// up.
   @override
   dynamic noSuchMethod(Invocation invocation) {
     return null;

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -118,10 +118,7 @@ class TestWindow implements Window {
     onMetricsChanged();
   }
 
-  // TODO(dnfield): Remove this ignore once custom embedders have had time to
-  //  catch up and make this property actually wrap _window.viewPadding.
-  // @override
-  // ignore: annotate_overrides, public_member_api_docs
+  @override
   WindowPadding get viewPadding => _viewPaddingTestValue ?? _window.padding;
   WindowPadding _viewPaddingTestValue;
   /// Hides the real view padding and reports the given [paddingTestValue]

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -43,6 +43,20 @@ void main() {
     );
   });
 
+  testWidgets('TestWindow can fake physical depth', (WidgetTester tester) async {
+    verifyThatTestWindowCanFakeProperty<double>(
+      tester: tester,
+      realValue: ui.window.physicalDepth,
+      fakeValue: 120.0,
+      propertyRetriever: () {
+        return WidgetsBinding.instance.window.physicalDepth;
+      },
+      propertyFaker: (TestWidgetsFlutterBinding binding, double fakeValue) {
+        binding.window.physicalDepthTestValue = fakeValue;
+      },
+    );
+  });
+
   testWidgets('TestWindow can fake view insets', (WidgetTester tester) async {
     verifyThatTestWindowCanFakeProperty<WindowPadding>(
       tester: tester,


### PR DESCRIPTION
## Description

Following up on https://github.com/flutter/engine/pull/10414, adds the `physicalDepth` attribute to both `MediaQueryData` and `TestWindow` classes.

Also, went through affected files and updated typos and style guide nits. 

## Related Issues

Fixes #33854 

## Tests

Updated
- MediaQueryData is sane
- MediaQueryData.copyWith copies specified values
- TestWindow can fake physical depth

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
