### PR TITLE
iOS 13 scrollbar vibration

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 // All values eyeballed.
@@ -207,6 +208,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
     _assertVertical();
     _fadeoutTimer?.cancel();
     _fadeoutAnimationController.forward();
+    HapticFeedback.mediumImpact();
     _dragScrollbar(details.localPosition.dy);
     _dragScrollbarPositionY = details.localPosition.dy;
   }
@@ -234,6 +236,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
     _assertVertical();
     _fadeoutTimer?.cancel();
     _thicknessAnimationController.forward();
+    HapticFeedback.mediumImpact();
     _dragScrollbar(details.localPosition.dy);
     _dragScrollbarPositionY = details.localPosition.dy;
   }

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
@@ -86,9 +87,18 @@ void main() {
     await scrollGesture.up();
     await tester.pump();
 
-    // Longpress on the scrollbar thumb.
+    int hapticFeedbackCalls = 0;
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'HapticFeedback.vibrate') {
+        hapticFeedbackCalls++;
+      }
+    });
+
+    // Longpress on the scrollbar thumb and expect a vibration.
+    expect(hapticFeedbackCalls, 0);
     final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(796.0, 50.0));
     await tester.pump(const Duration(milliseconds: 500));
+    expect(hapticFeedbackCalls, 1);
 
     // Drag the thumb down to scroll down.
     await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
@@ -145,11 +155,21 @@ void main() {
     await scrollGesture.up();
     await tester.pump();
 
-    // Drag in from the right side on top of the scrollbar thumb.
+    int hapticFeedbackCalls = 0;
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'HapticFeedback.vibrate') {
+        hapticFeedbackCalls++;
+      }
+    });
+
+    // Drag in from the right side on top of the scrollbar thumb and expect a
+    // vibration.
+    expect(hapticFeedbackCalls, 0);
     final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(796.0, 50.0));
     await tester.pump();
     await dragScrollbarGesture.moveBy(const Offset(-50.0, 0.0));
     await tester.pump(_kScrollbarResizeDuration);
+    expect(hapticFeedbackCalls, 1);
 
     // Drag the thumb down to scroll down.
     await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));


### PR DESCRIPTION
## Description

[It was pointed out](https://github.com/flutter/flutter/issues/35127#issuecomment-518310798) that the [recent implementation of draggable scrollbars](https://github.com/flutter/flutter/pull/35829) doesn't include the vibration feedback that native iOS 13 does.  This PR adds the vibration.

## Related Issues

https://github.com/flutter/flutter/pull/37724
https://github.com/flutter/flutter/issues/35127

## Tests

I tested that exactly one vibration happens at the start of both types of scrollbar dragging.