### PR TITLE
Use relative paths when installing module pods

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -32,7 +32,13 @@ def install_flutter_engine_pod
     FileUtils.cp(File.join(debug_framework_dir, 'Flutter.podspec'), engine_dir)
   end
 
-  pod 'Flutter', :path => engine_dir, :inhibit_warnings => true
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  # Process will be run from project directory.
+  engine_pathname = Pathname.new engine_dir
+  project_directory_pathname = Pathname.new Dir.pwd
+  relative = engine_pathname.relative_path_from project_directory_pathname
+
+  pod 'Flutter', :path => relative.to_s, :inhibit_warnings => true
 end
 
 # Install Flutter plugin pods.
@@ -46,9 +52,15 @@ end
 #                                          MyApp/my_flutter/.ios/Flutter/../..
 def install_flutter_plugin_pods(flutter_application_path)
   flutter_application_path ||= File.join('..', '..')
-  pod 'FlutterPluginRegistrant', :path => File.join(__dir__, 'FlutterPluginRegistrant'), :inhibit_warnings => true
 
-  symlinks_dir = File.join(__dir__, '.symlinks')
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  # Process will be run from project directory.
+  current_directory_pathname = Pathname.new __dir__
+  project_directory_pathname = Pathname.new Dir.pwd
+  relative = current_directory_pathname.relative_path_from project_directory_pathname
+  pod 'FlutterPluginRegistrant', :path => File.join(relative, 'FlutterPluginRegistrant'), :inhibit_warnings => true
+
+  symlinks_dir = File.join(relative, '.symlinks')
   FileUtils.mkdir_p(symlinks_dir)
   plugin_pods = parse_KV_file(File.join(flutter_application_path, '.flutter-plugins'))
   plugin_pods.map do |r|
@@ -79,13 +91,12 @@ def install_flutter_application_pod(flutter_application_path)
     `echo "static const int Moo = 88;" | xcrun clang -x c -dynamiclib -o "#{app_framework_dylib}" -`
   end
 
-  pod '{{projectName}}', :path => __dir__, :inhibit_warnings => true
-
-  # Use relative paths for script phase paths since these strings will likely be checked into source controls.
+  # Keep pod and script phase paths relative so they can be checked into source control.
   # Process will be run from project directory.
-  current_directory_pathname = Pathname.new __dir__.to_s
+  current_directory_pathname = Pathname.new __dir__
   project_directory_pathname = Pathname.new Dir.pwd
   relative = current_directory_pathname.relative_path_from project_directory_pathname
+  pod '{{projectName}}', :path => relative.to_s, :inhibit_warnings => true
 
   flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
   script_phase :name => 'Run Flutter Build Script',


### PR DESCRIPTION
## Description
Use relative paths to install pods to allow versioning of Podfile.lock.


## Related Issues

Fixes https://github.com/flutter/flutter/issues/37734
See also https://github.com/flutter/flutter/issues/9502

## Tests

Made sure module_test_ios still passed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.