### PR TITLE
Fix AnimationStatus for repeat(reverse: true) and animateWith

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -597,7 +597,9 @@ class AnimationController extends Animation<double>
   /// [AnimationController] when no explicit value is set for [min] and [max].
   ///
   /// With [reverse] set to true, instead of always starting over at [min]
-  /// the value will alternate between [min] and [max] values on each repeat.
+  /// the starting value will alternate between [min] and [max] values on each
+  /// repeat. Regardless of the current starting value, the [status] will
+  /// always be reported at [AnimationStatus.forward].
   ///
   /// Returns a [TickerFuture] that never completes. The [TickerFuture.orCancel] future
   /// completes with an error when the animation is stopped (e.g. with [stop]).
@@ -666,6 +668,9 @@ class AnimationController extends Animation<double>
   /// The most recently returned [TickerFuture], if any, is marked as having been
   /// canceled, meaning the future never completes and its [TickerFuture.orCancel]
   /// derivative future completes with a [TickerCanceled] error.
+  ///
+  /// The [status] is always [AnimationStatus.forward] for the entire duration
+  /// of the simulation.
   TickerFuture animateWith(Simulation simulation) {
     assert(
       _ticker != null,
@@ -673,6 +678,7 @@ class AnimationController extends Animation<double>
       'AnimationController methods should not be used after calling dispose.'
     );
     stop();
+    _direction = _AnimationDirection.forward;
     return _startSimulation(simulation);
   }
 

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -658,7 +658,8 @@ class AnimationController extends Animation<double>
     }
     final Simulation simulation = SpringSimulation(_kFlingSpringDescription, value, target, velocity * scale)
       ..tolerance = _kFlingTolerance;
-    return animateWith(simulation);
+    stop();
+    return _startSimulation(simulation);
   }
 
   /// Drives the animation according to the given simulation.

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -828,7 +828,7 @@ class _InterpolationSimulation extends Simulation {
   bool isDone(double timeInSeconds) => timeInSeconds > _durationInSeconds;
 }
 
-typedef _DirectionSetter = Function(_AnimationDirection direction);
+typedef _DirectionSetter = void Function(_AnimationDirection direction);
 
 class _RepeatingSimulation extends Simulation {
   _RepeatingSimulation(double initialValue, this.min, this.max, this.reverse, Duration period, this.directionSetter)

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -883,7 +883,7 @@ void main() {
     expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
   });
 
-  test('Repating animation with reverse: true report as forward and reverse', () {
+  test('Repeating animation with reverse: true report as forward and reverse', () {
     final List<AnimationStatus> statuses = <AnimationStatus>[];
     final AnimationController controller = AnimationController(
       vsync: const TestVSync(),

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -846,6 +846,40 @@ void main() {
     expect(() => controller.stop(), throwsAssertionError);
     expect(() => controller.forward(), throwsAssertionError);
     expect(() => controller.reverse(), throwsAssertionError);
+  });
 
+  test('Simulations always run forward (prev animation was reverse)', () {
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    final AnimationController controller = AnimationController(
+      vsync: const TestVSync(),
+      duration: const Duration(seconds: 1),
+    )..addStatusListener((AnimationStatus status) {
+      statuses.add(status);
+    });
+    controller.reverse(from: 1.0);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(seconds: 2));
+    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse, AnimationStatus.dismissed]);
+    statuses.clear();
+
+    controller.repeat(reverse: true);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(seconds: 2));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+  });
+
+  test('Simulations always run forward (precious animation was forward)', () {
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    final AnimationController controller = AnimationController(
+      vsync: const TestVSync(),
+      duration: const Duration(seconds: 1),
+    )..addStatusListener((AnimationStatus status) {
+      statuses.add(status);
+    });
+
+    controller.repeat(reverse: true);
+    tick(const Duration(milliseconds: 0));
+    tick(const Duration(seconds: 2));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
   });
 }


### PR DESCRIPTION
## Description

Previously, simulations running via `AnimationController.animateWith` would report whatever the previous animation direction was as `AnimationController.status`. So, if you had run the controller in reverse and then start a simulation, `AnimationController.status` was `AnimationDirection.reverse`. If you had run the controller in forward and then start the same simulation, it reported as `AnimationDirection.forward`. This change makes simulations always report `AnimationDirection.forward`.

The same behavior used to be true for `AniamtionController.repeat` as well because behind the scene it would just run a simulation. I consider that an implementation detail, though, that shouldn't be exposed to the user. This PR makes `AniamtionController.repeat` report `AnimationDirection.forward` when running from `min` to `max` and `AnimationDirection.reverse` when running from `max` to `min` via the `reverse` flag.

Further justification for the latter change: `AnimationController.fling`, which is also implemented as a simulation, also sets the AnimationDirection correctly according to the type of fling.

## Related Issues

None

## Tests

I added the following tests:

* verify that simulations always run forward
* verify that repeat(reverse: true) reports as forward and reverse

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]): https://groups.google.com/forum/#!topic/flutter-announce/yYqqt4Z5IIo
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
