### PR TITLE
Disable gem documentation generation on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -405,7 +405,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods -N # Disable documentation generation
+    - sudo gem install cocoapods --no-document
   git_fetch_script:
     - git clean -xfd
     - git fetch origin
@@ -483,7 +483,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods -N # Disable documentation generation
+    - sudo gem install cocoapods --no-document
   git_fetch_script:
     - git clean -xfd
     - git fetch origin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -405,7 +405,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods
+    - sudo gem install cocoapods -N # Disable documentation generation
   git_fetch_script:
     - git clean -xfd
     - git fetch origin
@@ -483,7 +483,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods
+    - sudo gem install cocoapods -N # Disable documentation generation
   git_fetch_script:
     - git clean -xfd
     - git fetch origin


### PR DESCRIPTION
## Description

Pass in -N when gem installing on Cirrus to disable document generation.  This flag is already used in the Dockerfile for coveralls, bundler, etc.

Shaves off ~2.5 seconds on my machine.  Not the most impressive, but there's no need for gem documents on CI so save the time, networking, and disk space.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.