### PR TITLE
Handle thrown maps and rejects from fe server

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -653,7 +653,7 @@ class ResidentCompiler {
     if (!_compileRequestNeedsConfirmation) {
       return Future<CompilerOutput>.value(null);
     }
-    _stdoutHandler.reset();
+    _stdoutHandler.reset(expectSources: false);
     _server.stdin.writeln('reject');
     printTrace('<- reject');
     _compileRequestNeedsConfirmation = false;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -542,12 +542,10 @@ abstract class ResidentRunner {
     this.stayResident = true,
     this.hotMode = true,
     this.dillOutputPath,
-  }) {
-    _mainPath = findMainDartFile(target);
-    _projectRootPath = projectRootPath ?? fs.currentDirectory.path;
-    _packagesFilePath =
-        packagesFilePath ?? fs.path.absolute(PackageMap.globalPackagesPath);
-    _assetBundle = AssetBundleFactory.instance.createBundle();
+  }) : mainPath = findMainDartFile(target),
+       projectRootPath = projectRootPath ?? fs.currentDirectory.path,
+       packagesFilePath = packagesFilePath ?? fs.path.absolute(PackageMap.globalPackagesPath),
+       assetBundle = AssetBundleFactory.instance.createBundle() {
     // TODO(jonahwilliams): this is transitionary logic to allow us to support
     // platforms that are not yet using flutter assemble. In the "new world",
     // builds are isolated based on a number of factors. Thus, we cannot assume
@@ -572,18 +570,14 @@ abstract class ResidentRunner {
   final bool ipv6;
   final Completer<int> _finished = Completer<int>();
   final String dillOutputPath;
+  final String packagesFilePath;
+  final String projectRootPath;
+  final String mainPath;
+  final AssetBundle assetBundle;
+
   bool _exited = false;
   bool hotMode ;
-  String _packagesFilePath;
-  String get packagesFilePath => _packagesFilePath;
-  String _projectRootPath;
-  String get projectRootPath => _projectRootPath;
-  String _mainPath;
-  String get mainPath => _mainPath;
   String getReloadPath({ bool fullRestart }) => mainPath + (fullRestart ? '' : '.incremental') + '.dill';
-
-  AssetBundle _assetBundle;
-  AssetBundle get assetBundle => _assetBundle;
 
   bool get isRunningDebug => debuggingOptions.buildInfo.isDebug;
   bool get isRunningProfile => debuggingOptions.buildInfo.isProfile;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -656,7 +656,7 @@ class HotRunner extends ResidentRunner {
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         if (view.uiIsolate == null) {
-          throw Exception('Application isolate not found');
+          return OperationResult(2, 'Application isolate not found', fatal: true);
         }
       }
     }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -656,7 +656,7 @@ class HotRunner extends ResidentRunner {
     for (FlutterDevice device in flutterDevices) {
       for (FlutterView view in device.views) {
         if (view.uiIsolate == null) {
-          throw 'Application isolate not found';
+          throw Exception('Application isolate not found');
         }
       }
     }
@@ -764,7 +764,7 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took for the VM to reload the sources.
     _addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
-
+    print('?????????????????????');
     final Stopwatch reassembleTimer = Stopwatch()..start();
     // Reload the isolate.
     final List<Future<void>> allDevices = <Future<void>>[];
@@ -805,6 +805,7 @@ class HotRunner extends ResidentRunner {
         }
       }
     }
+    print('!!!!!!!!!!!!!!!!!!!!!!!!');
     if (pausedIsolatesFound > 0) {
       if (onSlow != null)
         onSlow('${_describePausedIsolates(pausedIsolatesFound, serviceEventKind)}; interface might not update.');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -764,7 +764,6 @@ class HotRunner extends ResidentRunner {
     }
     // Record time it took for the VM to reload the sources.
     _addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
-    print('?????????????????????');
     final Stopwatch reassembleTimer = Stopwatch()..start();
     // Reload the isolate.
     final List<Future<void>> allDevices = <Future<void>>[];
@@ -805,7 +804,6 @@ class HotRunner extends ResidentRunner {
         }
       }
     }
-    print('!!!!!!!!!!!!!!!!!!!!!!!!');
     if (pausedIsolatesFound > 0) {
       if (onSlow != null)
         onSlow('${_describePausedIsolates(pausedIsolatesFound, serviceEventKind)}; interface might not update.');

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1177,7 +1177,7 @@ class Isolate extends ServiceObjectOwner {
       final Map<String, dynamic> response = await invokeRpcRaw('_reloadSources', params: arguments);
       return response;
     } on rpc.RpcException catch (e) {
-      return Future<Map<String, dynamic>>.error(<String, dynamic>{
+      return Future<Map<String, dynamic>>.value(<String, dynamic>{
         'code': e.code,
         'message': e.message,
         'data': e.data,

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -500,41 +500,6 @@ Future<void> _recompile(
   mockFrontendServerStdIn._stdInWrites.clear();
 }
 
-Future<void> _accept(
-  StreamController<List<int>> streamController,
-  ResidentCompiler generator,
-  MockStdIn mockFrontendServerStdIn,
-  String expected,
-) async {
-  // Put content into the output stream after generator.recompile gets
-  // going few lines below, resets completer.
-  generator.accept();
-  final String commands = mockFrontendServerStdIn.getAndClear();
-  final RegExp re = RegExp(expected);
-  expect(commands, matches(re));
-  mockFrontendServerStdIn._stdInWrites.clear();
-}
-
-Future<void> _reject(
-  StreamController<List<int>> streamController,
-  ResidentCompiler generator,
-  MockStdIn mockFrontendServerStdIn,
-  String mockCompilerOutput,
-  String expected,
-) async {
-  // Put content into the output stream after generator.recompile gets
-  // going few lines below, resets completer.
-  scheduleMicrotask(() {
-    streamController.add(utf8.encode(mockCompilerOutput));
-  });
-  final CompilerOutput output = await generator.reject();
-  expect(output, isNull);
-  final String commands = mockFrontendServerStdIn.getAndClear();
-  final RegExp re = RegExp(expected);
-  expect(commands, matches(re));
-  mockFrontendServerStdIn._stdInWrites.clear();
-}
-
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockProcess extends Mock implements Process {}
 class MockStream extends Mock implements Stream<List<int>> {}

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -277,22 +277,21 @@ example:org-dartlang-app:/
       );
       expect(mockFrontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
 
-       // No accept or reject commands should be issued until we
+      // No accept or reject commands should be issued until we
       // send recompile request.
       await _accept(streamController, generator, mockFrontendServerStdIn, '');
       await _reject(streamController, generator, mockFrontendServerStdIn, '', '');
 
       await _recompile(streamController, generator, mockFrontendServerStdIn,
-      'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
+        'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
 
       await _accept(streamController, generator, mockFrontendServerStdIn, '^accept\\n\$');
 
       await _recompile(streamController, generator, mockFrontendServerStdIn,
         'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
-
-      await _reject(streamController, generator, mockFrontendServerStdIn, 'result 0\n',
+      // No sources returned from reject command.
+      await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\n',
         '^reject\\n\$');
-
       verifyNoMoreInteractions(mockFrontendServerStdIn);
       expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
       expect(logger.errorText, equals(
@@ -543,30 +542,6 @@ Future<void> _recompile(
   mockFrontendServerStdIn._stdInWrites.clear();
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcess extends Mock implements Process {}
-class MockStream extends Mock implements Stream<List<int>> {}
-class MockStdIn extends Mock implements IOSink {
-  final StringBuffer _stdInWrites = StringBuffer();
-
-  String getAndClear() {
-    final String result = _stdInWrites.toString();
-    _stdInWrites.clear();
-    return result;
-  }
-
-  @override
-  void write([ Object o = '' ]) {
-    _stdInWrites.write(o);
-  }
-
-  @override
-  void writeln([ Object o = '' ]) {
-    _stdInWrites.writeln(o);
-  }
-}
-class MockFileSystem extends Mock implements FileSystem {}
-class MockFile extends Mock implements File {}
 Future<void> _accept(
   StreamController<List<int>> streamController,
   ResidentCompiler generator,
@@ -601,3 +576,27 @@ Future<void> _reject(
   expect(commands, matches(re));
   mockFrontendServerStdIn._stdInWrites.clear();
 }
+class MockProcessManager extends Mock implements ProcessManager {}
+class MockProcess extends Mock implements Process {}
+class MockStream extends Mock implements Stream<List<int>> {}
+class MockStdIn extends Mock implements IOSink {
+  final StringBuffer _stdInWrites = StringBuffer();
+
+  String getAndClear() {
+    final String result = _stdInWrites.toString();
+    _stdInWrites.clear();
+    return result;
+  }
+
+  @override
+  void write([ Object o = '' ]) {
+    _stdInWrites.write(o);
+  }
+
+  @override
+  void writeln([ Object o = '' ]) {
+    _stdInWrites.writeln(o);
+  }
+}
+class MockFileSystem extends Mock implements FileSystem {}
+class MockFile extends Mock implements File {}

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -264,50 +264,6 @@ example:org-dartlang-app:/
       Platform: _kNoColorTerminalPlatform,
     });
 
-    testUsingContext('compile and recompile', () async {
-      final BufferLogger logger = context.get<Logger>();
-
-      final StreamController<List<int>> streamController = StreamController<List<int>>();
-      when(mockFrontendServer.stdout)
-          .thenAnswer((Invocation invocation) => streamController.stream);
-      streamController.add(utf8.encode('result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0\n'));
-      await generator.recompile(
-        '/path/to/main.dart',
-        null, /* invalidatedFiles */
-        outputPath: '/build/',
-      );
-      expect(mockFrontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
-
-      // No accept or reject commands should be issued until we
-      // send recompile request.
-      await _accept(streamController, generator, mockFrontendServerStdIn, '');
-      await _reject(streamController, generator, mockFrontendServerStdIn, '', '');
-
-      await _recompile(streamController, generator, mockFrontendServerStdIn,
-        'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
-
-      await _accept(streamController, generator, mockFrontendServerStdIn, '^accept\\n\$');
-
-      await _recompile(streamController, generator, mockFrontendServerStdIn,
-          'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
-
-      await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\nabc\nabc',
-          '^reject\\n\$');
-
-      verifyNoMoreInteractions(mockFrontendServerStdIn);
-      expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-      expect(logger.errorText, equals(
-        '\nCompiler message:\nline0\nline1\n'
-        '\nCompiler message:\nline1\nline2\n'
-        '\nCompiler message:\nline1\nline2\n'
-      ));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      OutputPreferences: () => OutputPreferences(showColor: false),
-      Logger: () => BufferLogger(),
-      Platform: _kNoColorTerminalPlatform,
-    });
-
     testUsingContext('compile and recompile twice', () async {
       final BufferLogger logger = context.get<Logger>();
 


### PR DESCRIPTION
## Description
Bugfit:
- Replace a Future.error with Future.value
- Do not expect sources on reject requests to FE server (delete broken tests)

Cleanup
- Make some fields final.
- Make a String an exception

Supersedes https://github.com/flutter/flutter/pull/37350

Fixes https://github.com/flutter/flutter/issues/37251
Possibly related to https://github.com/flutter/flutter/issues/35924