### PR TITLE
Fix: Rendering of RoundedRectSliderTrack

### DIFF
--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1677,18 +1677,46 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
     );
 
     // The arc rects create a semi-circle with radius equal to track height.
-    final Rect leftTrackArcRect = Rect.fromLTWH(trackRect.left, trackRect.top, trackRect.height, trackRect.height);
-    if (!leftTrackArcRect.isEmpty)
-      context.canvas.drawArc(leftTrackArcRect, math.pi / 2, math.pi, false, leftTrackPaint);
-    final Rect rightTrackArcRect = Rect.fromLTWH(trackRect.right - trackRect.height / 2, trackRect.top, trackRect.height, trackRect.height);
-    if (!rightTrackArcRect.isEmpty)
-      context.canvas.drawArc(rightTrackArcRect, -math.pi / 2, math.pi, false, rightTrackPaint);
+    final Rect leftTrackArcRect = Rect.fromLTWH(
+      trackRect.left - trackRect.height / 2,
+      trackRect.top,
+      trackRect.height,
+      trackRect.height,
+    );
 
-    final Size thumbSize = sliderTheme.thumbShape.getPreferredSize(isEnabled, isDiscrete);
-    final Rect leftTrackSegment = Rect.fromLTRB(trackRect.left + trackRect.height / 2, trackRect.top, thumbCenter.dx - thumbSize.width / 2, trackRect.bottom);
+    final Rect rightTrackArcRect = Rect.fromLTWH(
+      trackRect.right - trackRect.height / 2,
+      trackRect.top,
+      trackRect.height,
+      trackRect.height,
+    );
+
+    final Rect leftTrackSegment = Rect.fromLTRB(
+      trackRect.left,
+      trackRect.top,
+      thumbCenter.dx,
+      trackRect.bottom,
+    );
+
+    final Rect rightTrackSegment = Rect.fromLTRB(
+      thumbCenter.dx,
+      trackRect.top,
+      trackRect.right,
+      trackRect.bottom,
+    );
+
+    // all drawing
+    if (!leftTrackArcRect.isEmpty)
+      context.canvas.drawArc(leftTrackArcRect, math.pi / 2, math.pi, false,
+          leftTrackSegment.isEmpty ? rightTrackPaint : leftTrackPaint);
+
+    if (!rightTrackArcRect.isEmpty)
+      context.canvas.drawArc(rightTrackArcRect, -math.pi / 2, math.pi, false,
+          rightTrackSegment.isEmpty ? leftTrackPaint : rightTrackPaint);
+
     if (!leftTrackSegment.isEmpty)
       context.canvas.drawRect(leftTrackSegment, leftTrackPaint);
-    final Rect rightTrackSegment = Rect.fromLTRB(thumbCenter.dx + thumbSize.width / 2, trackRect.top, trackRect.right, trackRect.bottom);
+
     if (!rightTrackSegment.isEmpty)
       context.canvas.drawRect(rightTrackSegment, rightTrackPaint);
   }


### PR DESCRIPTION
## Description

- before: if the slider is high enough there were some bugs:
  + the left arc was always coloured even if the slider is zero.
  + the right arc was always not coloured even if the slider is full.
  + some space between the track and the thumb in the middle,
     this happened when the thumb was a circle (default) or
     any shape that does not have a flat right and left sides.

![62537738-d8c68600-b859-11e9-8ef8-600d08b09f08](https://user-images.githubusercontent.com/26300843/62603064-c7cf5080-b8fd-11e9-86c4-de86b58f7871.png)


- after: 
 + bugs above are fixed

![62537770-eda31980-b859-11e9-82f1-30735183a223](https://user-images.githubusercontent.com/26300843/62603112-e33a5b80-b8fd-11e9-9615-b9df5436378f.png)

*the above images are at 100%, 0%, 55% respectively*

![image](https://user-images.githubusercontent.com/26300843/62605644-3662dd00-b903-11e9-9f84-2691ea8e4b42.png)

*also this is for the range slider*
*0%-100%, 30%-60% and 50%-50% respectivly*

## Related Issues

I propsed this addition as an issue (#37683)

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
