### PR TITLE
Don't mark system_debug_ios as flaky.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -502,7 +502,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
     timeout_in_minutes: 10
-    flaky: true
 
   ios_sample_catalog_generator:
     description: >


### PR DESCRIPTION
This test has passed on all 12 runs since it was added.