### PR TITLE
UserAccountsDrawerHeader lacks access to Details Pressed state

### DIFF
--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -301,7 +301,7 @@ class _AccountDetailsLayout extends MultiChildLayoutDelegate {
 ///
 ///  * [DrawerHeader], for a drawer header that doesn't show user accounts.
 ///  * <https://material.io/design/components/navigation-drawer.html#anatomy>
-class UserAccountsDrawerHeader extends StatefulWidget {
+class UserAccountsDrawerHeader extends StatelessWidget {
   /// Creates a material design drawer header.
   ///
   /// Requires one of its ancestors to be a [Material] widget.
@@ -314,6 +314,7 @@ class UserAccountsDrawerHeader extends StatefulWidget {
     @required this.accountName,
     @required this.accountEmail,
     this.onDetailsPressed,
+    this.isDetailsOpen = false,
   }) : super(key: key);
 
   /// The header's background. If decoration is null then a [BoxDecoration]
@@ -344,19 +345,8 @@ class UserAccountsDrawerHeader extends StatefulWidget {
   /// [accountName] and [accountEmail] is tapped.
   final VoidCallback onDetailsPressed;
 
-  @override
-  _UserAccountsDrawerHeaderState createState() => _UserAccountsDrawerHeaderState();
-}
-
-class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
-  bool _isOpen = false;
-
-  void _handleDetailsPressed() {
-    setState(() {
-      _isOpen = !_isOpen;
-    });
-    widget.onDetailsPressed();
-  }
+  /// Whether the details section is open.
+  final bool isDetailsOpen;
 
   @override
   Widget build(BuildContext context) {
@@ -366,10 +356,10 @@ class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
       container: true,
       label: MaterialLocalizations.of(context).signedInLabel,
       child: DrawerHeader(
-        decoration: widget.decoration ?? BoxDecoration(
+        decoration: decoration ?? BoxDecoration(
           color: Theme.of(context).primaryColor,
         ),
-        margin: widget.margin,
+        margin: margin,
         padding: const EdgeInsetsDirectional.only(top: 16.0, start: 16.0),
         child: SafeArea(
           bottom: false,
@@ -380,16 +370,16 @@ class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
                 child: Padding(
                   padding: const EdgeInsetsDirectional.only(end: 16.0),
                   child: _AccountPictures(
-                    currentAccountPicture: widget.currentAccountPicture,
-                    otherAccountsPictures: widget.otherAccountsPictures,
+                    currentAccountPicture: currentAccountPicture,
+                    otherAccountsPictures: otherAccountsPictures,
                   ),
                 ),
               ),
               _AccountDetails(
-                accountName: widget.accountName,
-                accountEmail: widget.accountEmail,
-                isOpen: _isOpen,
-                onTap: widget.onDetailsPressed == null ? null : _handleDetailsPressed,
+                accountName: accountName,
+                accountEmail: accountEmail,
+                isOpen: isDetailsOpen,
+                onTap: onDetailsPressed,
               ),
             ],
           ),

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -129,11 +129,13 @@ void main() {
     // Icon is right side up.
     expect(transformWidget.transform.getRotation()[0], 1.0);
     expect(transformWidget.transform.getRotation()[4], 1.0);
+    expect(isDetailsOpen, isFalse);
 
     await tester.tap(find.byType(Icon));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(tester.hasRunningAnimations, isTrue);
+    expect(isDetailsOpen, isTrue);
 
     await tester.pumpAndSettle();
     await tester.pump();
@@ -147,6 +149,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(tester.hasRunningAnimations, isTrue);
+    expect(isDetailsOpen, isFalse);
 
     await tester.pumpAndSettle();
     await tester.pump();

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -105,7 +105,25 @@ void main() {
   });
 
   testWidgets('UserAccountsDrawerHeader icon rotation test', (WidgetTester tester) async {
-    await pumpTestWidget(tester);
+    bool isDetailsOpen = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return UserAccountsDrawerHeader(
+              onDetailsPressed: () {
+                setState(() {
+                  isDetailsOpen = !isDetailsOpen;
+                });
+              },
+              accountName: const Text('name'),
+              accountEmail: const Text('email'),
+              isDetailsOpen: isDetailsOpen,
+            );
+          },
+        ),
+      ),
+    ));
     Transform transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon is right side up.


### PR DESCRIPTION
## Description

There is no way to access UserAccountsDrawerHeader state so you cannot change the state if the user interacts with any choice given once he taps the details section.

UserAccountsDrawerHeader should be a stateless widget and be used via an statefull widget like this:

```
class MyWidget extends StatefulWidget {
  @override
  _MyWidgetState createState() => _MyWidgetState();
}

class _MyWidgetState extends State<MyWidget> {
  bool isDetailsOpen = false;

  @override
  Widget build(BuildContext context) {
    return UserAccountsDrawerHeader(
      ...
      onDetailsPressed: () {
        setState(() {
          isDetailsOpen = !isDetailsOpen;
        });
      },
      isDetailsOpen: isDetailsOpen,
      ...
    ),
  }
}

```

## Related Issues

- https://github.com/flutter/flutter/issues/27894
- https://github.com/flutter/flutter/issues/17948

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

