### PR TITLE
Disable the progress bar when downloading the Dart SDK via Invoke-WebRequest

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -59,7 +59,14 @@ Try {
 }
 Catch {
     Write-Host "Downloading the Dart SDK using the BITS service failed, retrying with WebRequest..."
+    # Invoke-WebRequest is very slow when the progress bar is visible - a 28
+    # second download can become a 33 minute download. Disable it with
+    # $ProgressPreference and then restore the original value afterwards.
+    # https://github.com/flutter/flutter/issues/37789
+    $OriginalProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri $dartSdkUrl -OutFile $dartSdkZip
+    $ProgressPreference = $OriginalProgressPreference
 }
 
 Write-Host "Unzipping Dart SDK..."


### PR DESCRIPTION
On Travis we noticed the Windows builds were timing out downloading the Dart SDK ("no output in 10 minutes"). I noticed that they don't support BITS so fall back to our `Invoke-WebRequest` code. I tested that locally (my connection is 80Mbs) and it took **33 minutes** to download the 280ish MB.

Aparently this is a known thing... Disabling the progress bar sped it up to **28 seconds**.

```
PS > Measure-Command { Invoke-WebRequest -Uri https://storage.googleapis.com/flutter_infra/flutter/739b2dd4b27151958ca5993665ba2e8f2a6e9032/dart-sdk-windows-x64.zip -OutFile M:\Dev\Google\flutter\bin\cache\dart-sdk-windows-x64.one.zip }


Days              : 0
Hours             : 0
Minutes           : 33
Seconds           : 16
Milliseconds      : 906
Ticks             : 19969066837
TotalDays         : 0.0231123458761574
TotalHours        : 0.554696301027778
TotalMinutes      : 33.2817780616667
TotalSeconds      : 1996.9066837
TotalMilliseconds : 1996906.6837
```

```
PS > $ProgressPreference = 'SilentlyContinue'
PS > Measure-Command { Invoke-WebRequest -Uri https://storage.googleapis.com/flutter_infra/flutter/739b2dd4b27151958ca5993665ba2e8f2a6e9032/dart-sdk-windows-x64.zip -OutFile M:\Dev\Google\flutter\bin\cache\dart-sdk-windows-x64.two.zip }


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 28
Milliseconds      : 297
Ticks             : 282977812
TotalDays         : 0.000327520615740741
TotalHours        : 0.00786049477777778
TotalMinutes      : 0.471629686666667
TotalSeconds      : 28.2977812
TotalMilliseconds : 28297.7812
```

Fixes #37789.