### PR TITLE
Add COMPILER_INDEX_STORE_ENABLE=NO to macOS build and tests

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -250,6 +250,7 @@ Future<void> main() async {
             'CODE_SIGN_IDENTITY=-',
             'EXPANDED_CODE_SIGN_IDENTITY=-',
             'CONFIGURATION_BUILD_DIR=${tempDir.path}',
+            'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           environment: <String, String> {
             'FLUTTER_ANALYTICS_LOG_FILE': analyticsOutputFile.path,
@@ -294,6 +295,7 @@ Future<void> main() async {
             'CODE_SIGN_IDENTITY=-',
             'EXPANDED_CODE_SIGN_IDENTITY=-',
             'CONFIGURATION_BUILD_DIR=${tempDir.path}',
+            'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           canFail: true
         );

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -54,6 +54,7 @@ Future<void> buildMacOS({
     '-derivedDataPath', flutterBuildDir.absolute.path,
     'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
     'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+    'COMPILER_INDEX_STORE_ENABLE=NO',
   ]);
   final Status status = logger.startProgress(
     'Building macOS application...',

--- a/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
@@ -97,6 +97,7 @@ void main() {
       '-derivedDataPath', flutterBuildDir.absolute.path,
       'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
       'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
     ])).thenAnswer((Invocation invocation) async {
       fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
         ..createSync(recursive: true)


### PR DESCRIPTION
## Description

Turn off store indexing during xcodebuilds for macOS and tests since  jump-to-definition, find usages, global renames, etc aren't necessary until the IDE is actually opened.  iOS will be covered by https://github.com/flutter/flutter/pull/37378.

Firebase reported a 8% speed up by using COMPILER_INDEX_STORE_ENABLE=NO https://github.com/firebase/firebase-ios-sdk/pull/2452

## Related Issues

See original issue https://github.com/flutter/flutter/issues/37231 and PR https://github.com/flutter/flutter/pull/37378

## Tests

I'm interested to see how *ios__compile benchmarks and the time of the tool_tests-macos and build_tests-macos shard changes change once this and https://github.com/flutter/flutter/pull/37378 are merged.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
