### PR TITLE
have android_semantics_testing use adb from ENV provided android sdk

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -10,6 +10,16 @@ import 'package:android_semantics_testing/android_semantics_testing.dart';
 
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 import 'package:flutter_driver/flutter_driver.dart';
+import 'package:path/path.dart' as path;
+
+String adbPath() {
+  final String androidHome = io.Platform.environment['ANDROID_HOME'] ?? io.Platform.environment['ANDROID_SDK_ROOT'];
+  if (androidHome == null) {
+    return 'adb';
+  } else {
+    return path.join(androidHome, 'platform-tools', 'adb');
+  }
+}
 
 void main() {
   group('AccessibilityBridge', () {
@@ -23,7 +33,7 @@ void main() {
     setUpAll(() async {
       driver = await FlutterDriver.connect();
       // Say the magic words..
-      final io.Process run = await io.Process.start('adb', const <String>[
+      final io.Process run = await io.Process.start(adbPath(), const <String>[
         'shell',
         'settings',
         'put',
@@ -36,7 +46,7 @@ void main() {
 
     tearDownAll(() async {
       // ... And turn it off again
-      final io.Process run = await io.Process.start('adb', const <String>[
+      final io.Process run = await io.Process.start(adbPath(), const <String>[
         'shell',
         'settings',
         'put',


### PR DESCRIPTION
## Description

While running the devicelab tests on a brand new mac, I had `android_semantics_integration_test` fail because the `adb` file could not be found (though I had provided an `ANDROID_SDK_ROOT` env variable. While the devicelab test runner will read the env variable and use it, this particular test manually invoked `adb` from path to turn on and off the talkback accessibility feature. This PR updates the test to first check for the env vars and use the `adb` binary from them if provided, and if not default back to the `PATH` version.

This assures that we are using the provided version of `adb`.

## Related Issues

Found this myself.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.