### PR TITLE
add --exit and --match-host-platform defaults to devicelab runner

### DIFF
--- a/dev/devicelab/README.md
+++ b/dev/devicelab/README.md
@@ -122,6 +122,9 @@ To run all tests defined in `manifest.yaml`, use option `-a` (`--all`):
 ../../bin/cache/dart-sdk/bin/dart bin/run.dart -a
 ```
 
+This defaults to only running tests supported by your host device's platform
+(`--match-host-platform`) and exiting after the first failure (`--exit`).
+
 ## Running specific tests
 
 To run a test, use option `-t` (`--task`):

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -89,16 +89,15 @@ void addTasks({
   if (args.wasParsed('continue-from')) {
     final int index = tasks.indexWhere((ManifestTask task) => task.name == args['continue-from']);
     if (index == -1) {
-      throw 'Invalid task name "${args['continue-from']}"';
+      throw Exception('Invalid task name "${args['continue-from']}"');
     }
     tasks.removeRange(0, index);
   }
   // Only start skipping if user specified a task to continue from
-  bool isQualifyingStage;
-  bool isQualifyingHost;
+  final String stage = args['stage'];
   for (ManifestTask task in tasks) {
-    isQualifyingStage = !args.wasParsed('stage') || task.stage == args['stage'];
-    isQualifyingHost = !args['match-host-platform'] || task.isSupportedByHost();
+    final bool isQualifyingStage = stage == null || task.stage == stage;
+    final bool isQualifyingHost = !args['match-host-platform'] || task.isSupportedByHost();
     if (isQualifyingHost && isQualifyingStage) {
       taskNames.add(task.name);
     }

--- a/dev/devicelab/lib/framework/manifest.dart
+++ b/dev/devicelab/lib/framework/manifest.dart
@@ -68,12 +68,11 @@ class ManifestTask {
 
   /// Whether the task is supported by the current host platform
   bool isSupportedByHost() {
-    final Set<String> supportedHosts = <String>{};
-    String supportedHost;
-    for (String capability in requiredAgentCapabilities) {
-      supportedHost = capability.split('/')[0];
-      supportedHosts.add(supportedHost);
-    }
+    final Set<String> supportedHosts = Set<String>.from(
+      requiredAgentCapabilities.map<String>(
+        (String str) => str.split('/')[0]
+      )
+    );
     String hostPlatform = platform.operatingSystem;
     if (hostPlatform == 'macos') {
       hostPlatform = 'mac'; // package:platform uses 'macos' while manifest.yaml uses 'mac'

--- a/dev/devicelab/lib/framework/manifest.dart
+++ b/dev/devicelab/lib/framework/manifest.dart
@@ -3,9 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
+
+Platform get platform => _platform ??= const LocalPlatform();
+Platform _platform;
 
 /// Loads manifest data from `manifest.yaml` file or from [yaml], if present.
 Manifest loadTaskManifest([ String yaml ]) {
@@ -52,7 +56,7 @@ class ManifestTask {
   final String stage;
 
   /// Capabilities required of the build agent to be able to perform this task.
-  final List<dynamic> requiredAgentCapabilities;
+  final List<String> requiredAgentCapabilities;
 
   /// Whether this test is flaky.
   ///
@@ -61,6 +65,21 @@ class ManifestTask {
 
   /// An optional custom timeout specified in minutes.
   final int timeoutInMinutes;
+
+  /// Whether the task is supported by the current host platform
+  bool isSupportedByHost() {
+    final Set<String> supportedHosts = <String>{};
+    String supportedHost;
+    for (String capability in requiredAgentCapabilities) {
+      supportedHost = capability.split('/')[0];
+      supportedHosts.add(supportedHost);
+    }
+    String hostPlatform = platform.operatingSystem;
+    if (hostPlatform == 'macos') {
+      hostPlatform = 'mac'; // package:platform uses 'macos' while manifest.yaml uses 'mac'
+    }
+    return supportedHosts.contains(hostPlatform);
+  }
 }
 
 /// Thrown when the manifest YAML is not valid.

--- a/dev/devicelab/lib/tasks/sample_catalog_generator.dart
+++ b/dev/devicelab/lib/tasks/sample_catalog_generator.dart
@@ -39,7 +39,7 @@ Future<TaskResult> samplePageCatalogGenerator(String authorizationToken) async {
     await saveCatalogScreenshots(
       directory: dir('${flutterDirectory.path}/examples/catalog/.generated'),
       commit: commit,
-      token: authorizationToken,
+      token: authorizationToken, // TODO(fujino): workaround auth token for local runs
       prefix: isIosDevice ? 'ios_' : '',
     );
   });


### PR DESCRIPTION
This makes it easier to run the devicelab test runner locally. Changes the default behavior, but I believe that `dart bin/run.dart -a` is only used locally when troubleshooting, and not in the devicelab.