### PR TITLE
echo error messages to stderr

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -44,13 +44,13 @@ function retry_upgrade {
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
     (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY") && break
-    >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)" >&2
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    echo "Command 'pub upgrade' still failed after $total_tries tries, giving up." >&2
     return 1
   fi
   return 0
@@ -114,7 +114,7 @@ function upgrade_flutter () {
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
     VERBOSITY="--verbosity=error"
 
-    >&2 echo Building flutter tool...
+    echo Building flutter tool... >&2
     if [[ "$CI" == "true" || "$BOT" == "true" || "$CONTINUOUS_INTEGRATION" == "true" || "$CHROME_HEADLESS" == "1" ]]; then
       PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
       VERBOSITY="--verbosity=normal"
@@ -152,23 +152,23 @@ PUB="$DART_SDK_PATH/bin/pub"
 
 # Test if running as superuser – but don't warn if running within Docker
 if [[ "$EUID" == "0" && ! -f /.dockerenv ]]; then
-  >&2 echo "   Woah! You appear to be trying to run flutter as root."
-  >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
-  >&2 echo "  /"
-  >&2 echo "📎"
+  echo "   Woah! You appear to be trying to run flutter as root." >&2
+  echo "   We strongly recommend running the flutter tool without superuser privileges." >&2
+  echo "  /" >&2
+  echo "📎" >&2
 fi
 
 # Test if Git is available on the Host
 if ! hash git 2>/dev/null; then
-  >&2 echo "Error: Unable to find git in your PATH."
+  echo "Error: Unable to find git in your PATH." >&2
   exit 1
 fi
 # Test if the flutter directory is a git clone (otherwise git rev-parse HEAD would fail)
 if [[ ! -e "$FLUTTER_ROOT/.git" ]]; then
-  >&2 echo "Error: The Flutter directory is not a clone of the GitHub project."
-  >&2 echo "       The flutter tool requires Git in order to operate properly;"
-  >&2 echo "       to set up Flutter, run the following command:"
-  >&2 echo "       git clone -b stable https://github.com/flutter/flutter.git"
+  echo "Error: The Flutter directory is not a clone of the GitHub project." >&2
+  echo "       The flutter tool requires Git in order to operate properly;" >&2
+  echo "       to set up Flutter, run the following command:" >&2
+  echo "       git clone -b stable https://github.com/flutter/flutter.git" >&2
   exit 1
 fi
 

--- a/bin/flutter
+++ b/bin/flutter
@@ -44,13 +44,13 @@ function retry_upgrade {
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
     (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY") && break
-    echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
     return 1
   fi
   return 0
@@ -114,7 +114,7 @@ function upgrade_flutter () {
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
     VERBOSITY="--verbosity=error"
 
-    echo Building flutter tool...
+    >&2 echo Building flutter tool...
     if [[ "$CI" == "true" || "$BOT" == "true" || "$CONTINUOUS_INTEGRATION" == "true" || "$CHROME_HEADLESS" == "1" ]]; then
       PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
       VERBOSITY="--verbosity=normal"
@@ -152,23 +152,23 @@ PUB="$DART_SDK_PATH/bin/pub"
 
 # Test if running as superuser – but don't warn if running within Docker
 if [[ "$EUID" == "0" && ! -f /.dockerenv ]]; then
-  echo "   Woah! You appear to be trying to run flutter as root."
-  echo "   We strongly recommend running the flutter tool without superuser privileges."
-  echo "  /"
-  echo "📎"
+  >&2 echo "   Woah! You appear to be trying to run flutter as root."
+  >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
+  >&2 echo "  /"
+  >&2 echo "📎"
 fi
 
 # Test if Git is available on the Host
 if ! hash git 2>/dev/null; then
-  echo "Error: Unable to find git in your PATH."
+  >&2 echo "Error: Unable to find git in your PATH."
   exit 1
 fi
 # Test if the flutter directory is a git clone (otherwise git rev-parse HEAD would fail)
 if [[ ! -e "$FLUTTER_ROOT/.git" ]]; then
-  echo "Error: The Flutter directory is not a clone of the GitHub project."
-  echo "       The flutter tool requires Git in order to operate properly;"
-  echo "       to set up Flutter, run the following command:"
-  echo "       git clone -b stable https://github.com/flutter/flutter.git"
+  >&2 echo "Error: The Flutter directory is not a clone of the GitHub project."
+  >&2 echo "       The flutter tool requires Git in order to operate properly;"
+  >&2 echo "       to set up Flutter, run the following command:"
+  >&2 echo "       git clone -b stable https://github.com/flutter/flutter.git"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

Title says it all, otherwise the error messages would be executed as code when the output
is supposed to be sourced, e.g. `$(flutter bash-completion)`

## Related Issues

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
