### PR TITLE
Catch failure to create directory in cache

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -398,7 +398,15 @@ abstract class CachedArtifact {
       return;
     }
     if (!location.existsSync()) {
-      location.createSync(recursive: true);
+      try {
+        location.createSync(recursive: true);
+      } on FileSystemException catch (err) {
+        printError(err.toString());
+        throwToolExit(
+          'Failed to create directory for flutter cache. Flutter may be missing '
+          'permissions in its cache directory.'
+        );
+      }
     }
     await updateInner();
     cache.setStampFor(stampName, version);

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -403,8 +403,8 @@ abstract class CachedArtifact {
       } on FileSystemException catch (err) {
         printError(err.toString());
         throwToolExit(
-          'Failed to create directory for flutter cache. Flutter may be missing '
-          'permissions in its cache directory.'
+          'Failed to create directory for flutter cache at ${location.path}. '
+          'Flutter may be missing permissions in its cache directory.'
         );
       }
     }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -243,6 +243,27 @@ void main() {
       Platform: () => fakePlatform,
     });
   });
+
+  testUsingContext('throws tool exit on fs exception', () async {
+    final FakeCachedArtifact fakeCachedArtifact = FakeCachedArtifact(
+      cache: MockCache(),
+      requiredArtifacts: <DevelopmentArtifact>{
+        DevelopmentArtifact.android,
+      }
+    );
+    final Directory mockDirectory = MockDirectory();
+    when(fakeCachedArtifact.cache.getArtifactDirectory(any))
+        .thenReturn(mockDirectory);
+    when(mockDirectory.existsSync()).thenReturn(false);
+    when(mockDirectory.createSync(recursive: true))
+        .thenThrow(const FileSystemException());
+
+    expect(() => fakeCachedArtifact.update(<DevelopmentArtifact>{
+        DevelopmentArtifact.android,
+    }), throwsA(isInstanceOf<ToolExit>()));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+  });
 }
 
 class FakeCachedArtifact extends EngineCachedArtifact {
@@ -271,6 +292,7 @@ class FakeCachedArtifact extends EngineCachedArtifact {
 
 class MockFileSystem extends Mock implements FileSystem {}
 class MockFile extends Mock implements File {}
+class MockDirectory extends Mock implements Directory {}
 
 class MockRandomAccessFile extends Mock implements RandomAccessFile {}
 class MockCachedArtifact extends Mock implements CachedArtifact {}


### PR DESCRIPTION
## Description

If the flutter cache does not have permission to create directories under bin/cache, this is the first place it can be detected. Catch this error and throw a tool exit instead of crashing. I'm not currently checking the FileSystemException's oserror, I'm not sure how accurate/portable that is but I could use that to narrow down the particular error case.
