### PR TITLE
Adds DefaultTextStyle ancestor to Tooltip Overlay

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
 import 'feedback.dart';
+import 'material.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip_theme.dart';
@@ -500,16 +501,18 @@ class _TooltipOverlay extends StatelessWidget {
             opacity: animation,
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: height),
-              child: Container(
-                decoration: decoration,
-                padding: padding,
-                margin: margin,
-                child: Center(
-                  widthFactor: 1.0,
-                  heightFactor: 1.0,
-                  child: Text(
-                    message,
-                    style: textStyle,
+              child: Material(
+                child: Container(
+                  decoration: decoration,
+                  padding: padding,
+                  margin: margin,
+                  child: Center(
+                    widthFactor: 1.0,
+                    heightFactor: 1.0,
+                    child: Text(
+                      message,
+                      style: textStyle,
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
 import 'feedback.dart';
-import 'material.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip_theme.dart';

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -501,7 +501,8 @@ class _TooltipOverlay extends StatelessWidget {
             opacity: animation,
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: height),
-              child: Material(
+              child: DefaultTextStyle(
+                style: Theme.of(context).textTheme.body1,
                 child: Container(
                   decoration: decoration,
                   padding: padding,

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -557,7 +557,7 @@ void main() {
         key: key,
         textStyle: const TextStyle(
           color: Colors.orange,
-          decoration: TextDecoration.underline
+          decoration: TextDecoration.underline,
         ),
         message: tooltipText,
         child: Container(
@@ -574,6 +574,33 @@ void main() {
     expect(textStyle.color, Colors.orange);
     expect(textStyle.fontFamily, null);
     expect(textStyle.decoration, TextDecoration.underline);
+  });
+
+  testWidgets('Tooltip overlay wrapped with Material widget', (WidgetTester tester) async {
+    // A Material widget is needed as an ancestor of the Text widget.
+    // It is invalid to have text in a Material application that
+    // does not have a Material ancestor.
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Tooltip(
+        key: key,
+        message: tooltipText,
+        child: Container(
+          width: 100.0,
+          height: 100.0,
+          color: Colors.green[500],
+        ),
+      ),
+    ));
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
+    await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+    expect(
+      find.ancestor(
+        of: find.text(tooltipText),
+        matching: find.byType(Material),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('Does tooltip end up with the right default size, shape, and color', (WidgetTester tester) async {

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -576,7 +576,7 @@ void main() {
     expect(textStyle.decoration, TextDecoration.underline);
   });
 
-  testWidgets('Tooltip overlay wrapped with Material widget', (WidgetTester tester) async {
+  testWidgets('Tooltip overlay wrapped with a non-fallback DefaultTextStyle widget', (WidgetTester tester) async {
     // A Material widget is needed as an ancestor of the Text widget.
     // It is invalid to have text in a Material application that
     // does not have a Material ancestor.
@@ -594,13 +594,19 @@ void main() {
     ));
     (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
-    expect(
+
+    final TextStyle textStyle = tester.widget<DefaultTextStyle>(
       find.ancestor(
         of: find.text(tooltipText),
-        matching: find.byType(Material),
-      ),
-      findsOneWidget,
-    );
+        matching: find.byType(DefaultTextStyle),
+      ).first,
+    ).style;
+
+    // The default fallback text style results in a text with a
+    // double underline of Color(0xffffff00).
+    expect(textStyle.decoration, isNot(TextDecoration.underline));
+    expect(textStyle.decorationColor, isNot(const Color(0xffffff00)));
+    expect(textStyle.decorationStyle, isNot(TextDecorationStyle.double));
   });
 
   testWidgets('Does tooltip end up with the right default size, shape, and color', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Adds a ~Material~ DefaultTextStyle ancestor to the Tooltip overlay's text widget. When using a custom Tooltip.textStyle, a double yellow underline appears because it has no ancestor widget to inherit properties, such as `TextStyle.decoration`, from.

cc/ @lisa-liao 

Before: 
<img src="https://user-images.githubusercontent.com/27032613/62723812-68894300-b9c6-11e9-9389-53ff91749e6a.png" width="30%">

After: 
<img src="https://user-images.githubusercontent.com/27032613/62724027-ebaa9900-b9c6-11e9-9d30-93203e58ded5.png" width="30%">

Code: 
```
Tooltip(
  textStyle: TextStyle(
    color: Colors.green,
    backgroundColor: Colors.blue,
  ),
  message: 'Example tooltip',
  child: IconButton(
    iconSize: 36.0,
    icon: Icon(Icons.touch_app),
    onPressed: () {},
  ),
),
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37876

## Tests

I added the following tests:

- A test to verify that the tooltip text has an ancestor DefaultTextStyle widget that is not the fallback text style.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
