### PR TITLE
Listen to ExtensionEvent instead of TimelineEvent

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -746,24 +746,6 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
         if (!kReleaseMode) {
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
-
-          // TODO(liyuqian): figure out a more elegant fix with rmacnak.
-          //
-          // The hack here is to flush the timeline events so the host that
-          // waits for the 'Rasterized first useful frame' event won't hang.
-          // Previously 'Widgets built first useful frame' didn't cause this
-          // trouble because the GPU thread will naturally add more events later
-          // and cause a fresh. The `Rasterized...` event, however, is likely
-          // to be the last (or nearly the last) event during the app start up.
-          //
-          // rmacnak and I will figure out a better way to fix it next week.
-          // We're having this quick hack now to fix our device lab performance
-          // tests so we won't miss the data points.
-          {
-            for (int i = 0; i < 100; i += 1) {
-              developer.Timeline.instantSync('Flush');
-            }
-          }
         }
         if (oldCallback != null) {
           oldCallback(timings);

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -45,11 +45,9 @@ class Tracing {
       );
       try {
         final Completer<void> whenFirstFrameRendered = Completer<void>();
-        (await vmService.onTimelineEvent).listen((ServiceEvent timelineEvent) {
-          final List<Map<String, dynamic>> events = timelineEvent.timelineEvents;
-          for (Map<String, dynamic> event in events) {
-            if (event['name'] == firstUsefulFrameEventName)
-              whenFirstFrameRendered.complete();
+        (await vmService.onExtensionEvent).listen((ServiceEvent event) {
+          if (event.extensionKind == 'Flutter.FirstFrame') {
+            whenFirstFrameRendered.complete();
           }
         });
         bool done = false;


### PR DESCRIPTION
TimelineEvents may not be sent if there aren't enough to form a group.
Hence we should always use ExtensionEvent as the trigger.

See also https://github.com/flutter/flutter/pull/37503