### PR TITLE
Always install the ephemeral engine copy instead of fetching from CocoaPods specs

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -187,6 +187,15 @@ Future<void> main() async {
         return TaskResult.failure('Failed to build ephemeral host .app with CocoaPods');
       }
 
+      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
+      final String podfileLockOutput = podfileLockFile.readAsStringSync();
+      if (!podfileLockOutput.contains(':path: Flutter/engine')
+        || !podfileLockOutput.contains(':path: Flutter/FlutterPluginRegistrant')
+        || !podfileLockOutput.contains(':path: Flutter/.symlinks/device_info/ios')
+        || !podfileLockOutput.contains(':path: Flutter/.symlinks/package_info/ios')) {
+        return TaskResult.failure('Building ephemeral host app Podfile.lock does not contain expected pods');
+      }
+
       section('Clean build');
 
       await inDirectory(projectDir, () async {

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -4,6 +4,7 @@ flutter_application_path = '../'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Runner' do
+  install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path
 end
 


### PR DESCRIPTION
## Description

For add-to-app the existing host app was running correctly, but the module `flutter run` will not launch:
```
[VERBOSE-2:dart_vm.cc(265)] VM snapshot must be valid.                  
[VERBOSE-3:shell.cc(210)] Check failed: vm. Must be able to initialize the VM
```
The Flutter pod was being fetched by CocoaPods instead of using the local Flutter.framework.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37756.
Fixes https://github.com/flutter/flutter/issues/37852.

## Tests

I added the following tests:

"Run ephemeral host app with CocoaPods"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
