### PR TITLE
Add FlexibleSpaceBar setting for set title maximum scale value.

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -46,6 +46,7 @@ class FlexibleSpaceBar extends StatefulWidget {
     Key key,
     this.title,
     this.background,
+    this.expandedScale = 1.5,
     this.centerTitle,
     this.titlePadding,
     this.collapseMode = CollapseMode.parallax,
@@ -61,6 +62,11 @@ class FlexibleSpaceBar extends StatefulWidget {
   ///
   /// Typically an [Image] widget with [Image.fit] set to [BoxFit.cover].
   final Widget background;
+
+  /// Set the maximum scale value of the title.
+  ///
+  /// By default this property is 1.5.
+  final double expandedScale;
 
   /// Whether the title should be centered.
   ///
@@ -225,7 +231,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
             start: effectiveCenterTitle ? 0.0 : 72.0,
             bottom: 16.0,
           );
-        final double scaleValue = Tween<double>(begin: 1.5, end: 1.0).transform(t);
+        final double scaleValue = Tween<double>(begin: widget.expandedScale, end: 1.0).transform(t);
         final Matrix4 scaleTransform = Matrix4.identity()
           ..scale(scaleValue, scaleValue, 1.0);
         final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);


### PR DESCRIPTION
## Description

I added this option because I wanted to adjust the magnification effect for widgets with FlexibleSpaceBar set to Title.
This is equally useful for users who want to disable the scale effect.

## Tests

I added test for flexiblebar extensibility.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
