### PR TITLE
Prevent killProcess() from killing our own pid

### DIFF
--- a/packages/flutter_tools/lib/src/desktop.dart
+++ b/packages/flutter_tools/lib/src/desktop.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'base/io.dart';
 import 'base/process_manager.dart';
@@ -29,9 +30,14 @@ Future<bool> killProcess(String executable) async {
       if (values.length < 2) {
         continue;
       }
-      final String pid = values[1];
+      final String nextPid = values[1];
+      // Some toolchains run this code from a command that includes [executable]
+      // on the command line. Muke sure we don't kill our own pid.
+      if (int.tryParse(nextPid) == pid) {
+        continue;
+      }
       final ProcessResult killResult = await processManager.run(<String>[
-        'kill', pid,
+        'kill', nextPid,
       ]);
       succeeded &= killResult.exitCode == 0;
     }


### PR DESCRIPTION
## Description

When running Flutter Desktop applications the killProcess() method looks for stale instances of the application and kills them. It locates these applications by searching for processes that include the application's path in their command line. In certain toolchains (specifically, the one internal to Google) the process executing the killProcess() code includes the application's path as a command line parameter. The result is killProcess() kills its own pid. This PR filters out the current process's pid before proceeding with the kill.

## Tests

As far as I can tell there are no tests for desktop.dart? 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
