### PR TITLE
Update shader warm-up for recent Skia changes

### DIFF
--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -189,7 +189,9 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
         ..clipRRect(ui.RRect.fromLTRBR(8, 8, 328, 248, const ui.Radius.circular(16)))
         ..drawRect(ui.Rect.fromLTRB(10, 10, 320, 240), ui.Paint())
         ..restore();
+      canvas.translate(drawCallSpacing, 0.0);
     }
+    canvas.translate(0.0, drawCallSpacing);
 
     // Warm up shadow shaders.
     const ui.Color black = ui.Color(0xFF000000);

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -176,23 +176,6 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
       canvas.translate(0.0, drawCallSpacing);
     }
 
-    // Draw a rect inside a rrect with a non-trivial intersection. If the
-    // intersection is trivial (e.g., equals the rrect clip), Skia will optimize
-    // the clip out.
-    //
-    // Add an integral or fractional translation to trigger Skia's non-AA or AA
-    // optimizations (as did before in normal FillRectOp in rrect clip cases).
-    for (double fraction in <double>[0.0, 0.5]) {
-      canvas
-        ..save()
-        ..translate(fraction, fraction)
-        ..clipRRect(ui.RRect.fromLTRBR(8, 8, 328, 248, const ui.Radius.circular(16)))
-        ..drawRect(ui.Rect.fromLTRB(10, 10, 320, 240), ui.Paint())
-        ..restore();
-      canvas.translate(drawCallSpacing, 0.0);
-    }
-    canvas.translate(0.0, drawCallSpacing);
-
     // Warm up shadow shaders.
     const ui.Color black = ui.Color(0xFF000000);
     canvas.save();
@@ -209,5 +192,22 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
     final ui.Paragraph paragraph = paragraphBuilder.build()
       ..layout(const ui.ParagraphConstraints(width: 60.0));
     canvas.drawParagraph(paragraph, const ui.Offset(20.0, 20.0));
+
+    // Draw a rect inside a rrect with a non-trivial intersection. If the
+    // intersection is trivial (e.g., equals the rrect clip), Skia will optimize
+    // the clip out.
+    //
+    // Add an integral or fractional translation to trigger Skia's non-AA or AA
+    // optimizations (as did before in normal FillRectOp in rrect clip cases).
+    for (double fraction in <double>[0.0, 0.5]) {
+      canvas
+        ..save()
+        ..translate(fraction, fraction)
+        ..clipRRect(ui.RRect.fromLTRBR(8, 8, 328, 248, const ui.Radius.circular(16)))
+        ..drawRect(const ui.Rect.fromLTRB(10, 10, 320, 240), ui.Paint())
+        ..restore();
+      canvas.translate(drawCallSpacing, 0.0);
+    }
+    canvas.translate(0.0, drawCallSpacing);
   }
 }

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -176,6 +176,21 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
       canvas.translate(0.0, drawCallSpacing);
     }
 
+    // Draw a rect inside a rrect with a non-trivial intersection. If the
+    // intersection is trivial (e.g., equals the rrect clip), Skia will optimize
+    // the clip out.
+    //
+    // Add an integral or fractional translation to trigger Skia's non-AA or AA
+    // optimizations (as did before in normal FillRectOp in rrect clip cases).
+    for (double fraction in <double>[0.0, 0.5]) {
+      canvas
+        ..save()
+        ..translate(fraction, fraction)
+        ..clipRRect(ui.RRect.fromLTRBR(8, 8, 328, 248, const ui.Radius.circular(16)))
+        ..drawRect(ui.Rect.fromLTRB(10, 10, 320, 240), ui.Paint())
+        ..restore();
+    }
+
     // Warm up shadow shaders.
     const ui.Color black = ui.Color(0xFF000000);
     canvas.save();

--- a/packages/flutter/test/painting/shader_warm_up_test.dart
+++ b/packages/flutter/test/painting/shader_warm_up_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestCanvas implements Canvas {
+  TestCanvas([this.invocations]);
+
+  final List<Invocation> invocations;
+
+  @override
+  void noSuchMethod(Invocation invocation) {
+    invocations?.add(invocation);
+  }
+}
+
+void main() {
+  test('DefaultShaderWarmUp has expected canvas invocations', () {
+    final List<Invocation> invocations = <Invocation>[];
+    final TestCanvas canvas = TestCanvas(invocations);
+    const DefaultShaderWarmUp s = DefaultShaderWarmUp();
+    s.warmUpOnCanvas(canvas);
+
+    bool hasDrawRectAfterClipRRect = false;
+    for (int i = 0; i < invocations.length - 1; i += 1) {
+      if (invocations[i].memberName == #clipRRect && invocations[i + 1].memberName == #drawRect) {
+        hasDrawRectAfterClipRRect = true;
+        break;
+      }
+    }
+
+    expect(hasDrawRectAfterClipRRect, true);
+  });
+}


### PR DESCRIPTION
The update is copied from an update we made to a Google-internal
client: cl/260202900

The update will save 1 shader compilation.

This should help solve our regression:
https://github.com/flutter/flutter/issues/31203

More regressions on iOS might be introduced later by
https://github.com/flutter/engine/pull/9813#issuecomment-520039890

Unfortunately, we didn't rebase our benchmarks so such regressions
were not detected.

Hence to fully solve https://github.com/flutter/flutter/issues/31203,
we might need to revert some change in
https://github.com/flutter/engine/pull/9813 to make iOS shader warm-up
happen on the GPU thread again.
