### PR TITLE
Catch FormatException caused by bad simctl output

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -93,8 +93,9 @@ class SimControl {
       return json.decode(results.stdout)[section.name];
     } on FormatException {
       // We failed to parse the simctl output, or it returned junk.
-      // One known message is "Install Started" which seems to be retunred when
-      // the binary needs to download additional artifacts.
+      // One known message is "Install Started" isn't valid JSON but is
+      // returned sometimes.
+      printError('simctl returned non-JSON response: ${results.stdout}');
       return <String, dynamic>{};
     }
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -46,11 +46,12 @@ class IOSSimulatorUtils {
   /// Returns [IOSSimulatorUtils] active in the current app context (i.e. zone).
   static IOSSimulatorUtils get instance => context.get<IOSSimulatorUtils>();
 
-  List<IOSSimulator> getAttachedDevices() {
+  Future<List<IOSSimulator>> getAttachedDevices() async {
     if (!xcode.isInstalledAndMeetsVersionCheck)
       return <IOSSimulator>[];
 
-    return SimControl.instance.getConnectedDevices().map<IOSSimulator>((SimDevice device) {
+    final List<SimDevice> connected = await SimControl.instance.getConnectedDevices();
+    return connected.map<IOSSimulator>((SimDevice device) {
       return IOSSimulator(device.udid, name: device.name, simulatorCategory: device.category);
     }).toList();
   }
@@ -63,7 +64,7 @@ class SimControl {
 
   /// Runs `simctl list --json` and returns the JSON of the corresponding
   /// [section].
-  Map<String, dynamic> _list(SimControlListSection section) {
+  Future<Map<String, dynamic>> _list(SimControlListSection section) async {
     // Sample output from `simctl list --json`:
     //
     // {
@@ -83,20 +84,26 @@ class SimControl {
 
     final List<String> command = <String>[_xcrunPath, 'simctl', 'list', '--json', section.name];
     printTrace(command.join(' '));
-    final ProcessResult results = processManager.runSync(command);
+    final ProcessResult results = await processManager.run(command);
     if (results.exitCode != 0) {
       printError('Error executing simctl: ${results.exitCode}\n${results.stderr}');
       return <String, Map<String, dynamic>>{};
     }
-
-    return json.decode(results.stdout)[section.name];
+    try {
+      return json.decode(results.stdout)[section.name];
+    } on FormatException {
+      // We failed to parse the simctl output, or it returned junk.
+      // One known message is "Install Started" which seems to be retunred when
+      // the binary needs to download additional artifacts.
+      return <String, dynamic>{};
+    }
   }
 
   /// Returns a list of all available devices, both potential and connected.
-  List<SimDevice> getDevices() {
+  Future<List<SimDevice>> getDevices() async {
     final List<SimDevice> devices = <SimDevice>[];
 
-    final Map<String, dynamic> devicesSection = _list(SimControlListSection.devices);
+    final Map<String, dynamic> devicesSection = await _list(SimControlListSection.devices);
 
     for (String deviceCategory in devicesSection.keys) {
       final List<dynamic> devicesData = devicesSection[deviceCategory];
@@ -109,8 +116,9 @@ class SimControl {
   }
 
   /// Returns all the connected simulator devices.
-  List<SimDevice> getConnectedDevices() {
-    return getDevices().where((SimDevice device) => device.isBooted).toList();
+  Future<List<SimDevice>> getConnectedDevices() async {
+    final List<SimDevice> simDevices = await getDevices();
+    return simDevices.where((SimDevice device) => device.isBooted).toList();
   }
 
   Future<bool> isInstalled(String deviceId, String appId) {

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -396,8 +396,8 @@ void main() {
       simControl = SimControl();
     });
 
-    testUsingContext('getDevices succeeds', () {
-      final List<SimDevice> devices = simControl.getDevices();
+    testUsingContext('getDevices succeeds', () async {
+      final List<SimDevice> devices = await simControl.getDevices();
 
       final SimDevice watch = devices[0];
       expect(watch.category, 'watchOS 4.3');

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -390,8 +390,9 @@ void main() {
 
     setUp(() {
       mockProcessManager = MockProcessManager();
-      when(mockProcessManager.runSync(any))
-          .thenReturn(ProcessResult(mockPid, 0, validSimControlOutput, ''));
+      when(mockProcessManager.run(any)).thenAnswer((Invocation _) async {
+        return ProcessResult(mockPid, 0, validSimControlOutput, '');
+      });
 
       simControl = SimControl();
     });
@@ -422,6 +423,17 @@ void main() {
       expect(tv.name, 'Apple TV');
       expect(tv.udid, 'TEST-TV-UDID');
       expect(tv.isBooted, isFalse);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      SimControl: () => simControl,
+    });
+
+    testUsingContext('getDevices handles bad simctl output', () async {
+      when(mockProcessManager.run(any))
+          .thenAnswer((Invocation _) async => ProcessResult(mockPid, 0, 'Install Started', ''));
+      final List<SimDevice> devices = await simControl.getDevices();
+
+      expect(devices, isEmpty);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       SimControl: () => simControl,

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -77,7 +77,7 @@ void testUsingContext(
           HttpClient: () => MockHttpClient(),
           IOSSimulatorUtils: () {
             final MockIOSSimulatorUtils mock = MockIOSSimulatorUtils();
-            when(mock.getAttachedDevices()).thenReturn(<IOSSimulator>[]);
+            when(mock.getAttachedDevices()).thenAnswer((Invocation _) async => <IOSSimulator>[]);
             return mock;
           },
           OutputPreferences: () => OutputPreferences(showColor: false),
@@ -227,7 +227,7 @@ class FakeDoctor extends Doctor {
 
 class MockSimControl extends Mock implements SimControl {
   MockSimControl() {
-    when(getConnectedDevices()).thenReturn(<SimDevice>[]);
+    when(getConnectedDevices()).thenAnswer((Invocation _) async => <SimDevice>[]);
   }
 }
 


### PR DESCRIPTION

## Description
Sometimes simctl seems to return bad output. Not sure what the exact cause is because it seems fairly rare. Instead of crashing, we should return an empty map/no devices.

```
FormatException: Unexpected character (at character 1)
Install Started
^

  | at _ChunkedJsonParser.fail | (convert_patch.dart:1392 )
-- | -- | --
  | at _ChunkedJsonParser.parseNumber | (convert_patch.dart:1259 )
  | at _ChunkedJsonParser.parse | (convert_patch.dart:924 )
  | at _parseJson | (convert_patch.dart:29 )
  | at JsonDecoder.convert | (json.dart:493 )
  | at JsonCodec.decode | (json.dart:151 )
  | at SimControl._list | (simulators.dart:92 )
  | at SimControl.getDevices | (simulators.dart:99 )
  | at SimControl.getConnectedDevices | (simulators.dart:113 )
  | at IOSSimulatorUtils.getAttachedDevices | (simulators.dart:53 )
  | at IOSSimulators.pollingGetDevices | (simulators.dart:42 )
  | at <asynchronous gap> | (async )
  | at PollingDeviceDiscovery.devices | (device.dart:270 )
  | at <asynchronous gap> | (async )
  | at DeviceManager.getAllConnectedDevices | (device.dart:136 )
  | at <asynchronous gap> | (async )
  | at DeviceManager.getDevicesById | (device.dart:101 )
  | at <asynchronous gap> | (async )
  | at DeviceManager.getDevices | (device.dart:125 )
  | at DeviceManager.findTargetDevices | (device.dart:169 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.findAllTargetDevices | (flutter_command.dart:512 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.findTargetDevice | (flutter_command.dart:542 )
  | at <asynchronous gap> | (async )
  | at AttachCommand.validateCommand | (attach.dart:139 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:462 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run.<anonymous closure> | (flutter_command.dart:390 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:154 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:153 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run | (flutter_command.dart:381 )
  | at CommandRunner.runCommand | (command_runner.dart:197 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand.<anonymous closure> | (flutter_command_runner.dart:396 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:154 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:153 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand | (flutter_command_runner.dart:356 )
  | at <asynchronous gap> | (async )
  | at CommandRunner.run.<anonymous closure> | (command_runner.dart:112 )
  | at new Future.sync | (future.dart:224 )
  | at CommandRunner.run | (command_runner.dart:112 )
  | at FlutterCommandRunner.run | (flutter_command_runner.dart:242 )
  | at run.<anonymous closure>.<anonymous closure> | (runner.dart:62 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1500 )
  | at run.<anonymous closure> | (runner.dart:60 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:154 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:153 )
  | at <asynchronous gap> | (async )
  | at runInContext | (context_runner.dart:58 )
  | at <asynchronous gap> | (async )
  | at run | (runner.dart:51 )
  | at main | (executable.dart:63 )
  | at <asynchronous gap> | (async )
  | at main | (flutter_tools.dart:8 )
  | at _startIsolate.<anonymous closure> | (isolate_patch.dart:303 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:172 )

```


- cleanup runSync -> run