### PR TITLE
expose drawer close/open animation end callback

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -359,7 +359,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   }
 
   void _settle(DragEndDetails details) {
-    if (_controller.isDismissed)
+    if (_controller.isDismissed || _controller.isCompleted)
       return;
     if (details.velocity.pixelsPerSecond.dx.abs() >= _kMinFlingVelocity) {
       double visualVelocity = details.velocity.pixelsPerSecond.dx / _width;

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -181,6 +181,7 @@ class DrawerController extends StatefulWidget {
     @required this.alignment,
     this.drawerCallback,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.onDrawerAnimationStatusChange,
     this.scrimColor,
   }) : assert(child != null),
        assert(dragStartBehavior != null),
@@ -228,6 +229,9 @@ class DrawerController extends StatefulWidget {
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
 
+  /// The callback function that is called when animation controller has status change.
+  final AnimationStatusListener onDrawerAnimationStatusChange;
+
   @override
   DrawerControllerState createState() => DrawerControllerState();
 }
@@ -243,6 +247,8 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     _controller = AnimationController(duration: _kBaseSettleDuration, vsync: this)
       ..addListener(_animationChanged)
       ..addStatusListener(_animationStatusChanged);
+    if (widget.onDrawerAnimationStatusChange != null)
+      _controller.addStatusListener(widget.onDrawerAnimationStatusChange);
   }
 
   @override

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -958,7 +958,9 @@ class Scaffold extends StatefulWidget {
     this.floatingActionButtonAnimator,
     this.persistentFooterButtons,
     this.drawer,
+    this.onDrawerAnimationEnd,
     this.endDrawer,
+    this.onEndDrawerAnimationEnd,
     this.bottomNavigationBar,
     this.bottomSheet,
     this.backgroundColor,
@@ -1057,6 +1059,14 @@ class Scaffold extends StatefulWidget {
   ///
   /// Typically a [Drawer].
   final Widget endDrawer;
+
+  /// A callback function that is called when the [drawer] open or close
+  /// animation ends.
+  final DrawerCallback onDrawerAnimationEnd;
+
+  /// A callback function that is called when the [endDrawer] open or close
+  /// animation ends.
+  final DrawerCallback onEndDrawerAnimationEnd;
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.
   ///
@@ -1971,6 +1981,19 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     }
   }
 
+  void _handleEndDrawerAnimationStatusChange(AnimationStatus status) {
+    switch (status) {
+      case AnimationStatus.dismissed:
+        widget.onEndDrawerAnimationEnd(false);
+        return;
+      case AnimationStatus.completed:
+        widget.onEndDrawerAnimationEnd(true);
+        return;
+      default:
+        return;
+    }
+  }
+
   void _buildEndDrawer(List<LayoutId> children, TextDirection textDirection) {
     if (widget.endDrawer != null) {
       assert(hasEndDrawer);
@@ -1979,6 +2002,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         DrawerController(
           key: _endDrawerKey,
           alignment: DrawerAlignment.end,
+          onDrawerAnimationStatusChange: widget.onEndDrawerAnimationEnd != null ?
+            _handleEndDrawerAnimationStatusChange : null,
           child: widget.endDrawer,
           drawerCallback: _endDrawerOpenedCallback,
           dragStartBehavior: widget.drawerDragStartBehavior,
@@ -1994,6 +2019,19 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     }
   }
 
+  void _handleDrawerAnimationStatusChange(AnimationStatus status) {
+    switch (status) {
+      case AnimationStatus.dismissed:
+        widget.onDrawerAnimationEnd(false);
+        return;
+      case AnimationStatus.completed:
+        widget.onDrawerAnimationEnd(true);
+        return;
+      default:
+        return;
+    }
+  }
+
   void _buildDrawer(List<LayoutId> children, TextDirection textDirection) {
     if (widget.drawer != null) {
       assert(hasDrawer);
@@ -2002,6 +2040,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
         DrawerController(
           key: _drawerKey,
           alignment: DrawerAlignment.start,
+          onDrawerAnimationStatusChange: widget.onDrawerAnimationEnd != null ?
+          _handleDrawerAnimationStatusChange : null,
           child: widget.drawer,
           drawerCallback: _drawerOpenedCallback,
           dragStartBehavior: widget.drawerDragStartBehavior,

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -209,7 +209,7 @@ void main() {
 
     expect(isDrawerOpenCount, 0);
     expect(isDrawerCloseCount, 0);
-    // Fully drag to the right.
+    // Fully drags to the right.
     TestGesture gesture = await tester.startGesture(const Offset(10.0, 200.0));
     await tester.pump();
     expect(isDrawerOpenCount, 0);
@@ -227,9 +227,12 @@ void main() {
     expect(isDrawerOpenCount, 1);
     expect(isDrawerCloseCount, 0);
     await gesture.up();
-    await tester.pump();
+    // Makes sure animation settling does not cause another callback.
+    await tester.pumpAndSettle();
+    expect(isDrawerOpenCount, 1);
+    expect(isDrawerCloseCount, 0);
 
-    // Fully drag it back.
+    // Fully drags it back.
     gesture = await tester.startGesture(const Offset(400.0, 200.0));
     await tester.pump();
     expect(isDrawerOpenCount, 1);
@@ -253,7 +256,7 @@ void main() {
     expect(isDrawerOpenCount, 1);
     expect(isDrawerCloseCount, 1);
 
-    // Slightly drag to the right should close upon release.
+    // Slightly drags to the right should close upon release.
     gesture = await tester.startGesture(const Offset(10.0, 200.0));
     await tester.pump();
     expect(isDrawerOpenCount, 1);


### PR DESCRIPTION
## Description

Add callbacks for both drawer and endDrawer. This callback will drill down to the animation controller in drawercontroller.
I choose this approach because it seems the customer use cases are all around wanting animation end callbacks.

There are two other ways of doing this.

1. expose animation controller from drawcontroller widget as @Hixie mentioned in the issue. I didn't choose this approach because it means we need to set up the controller a certain way that drawercontroller can consume outside drawercontroller, which is weird, and we have to manage the controller live cycle ourselves.

2. DrawController throw notification about the drawer status, and customer can use notificationlistener to decide what to do with the notification. I think this is probably another plausible solution, but I worry about performance and how often should we throw notification.

## Related Issues

https://github.com/flutter/flutter/issues/14510

## Tests

I added the following tests:

'Drawer callback is called when drag'
'Drawer callback is called when animation ends'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
