### PR TITLE
Remove ephemeral directories during flutter clean

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -28,41 +28,38 @@ class CleanCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final FlutterProject flutterProject = FlutterProject.current();
     final Directory buildDir = fs.directory(getBuildDirectory());
+    _deleteFile(buildDir);
 
-    printStatus("Deleting '${buildDir.path}${fs.path.separator}'.");
-    if (buildDir.existsSync()) {
-      try {
-        buildDir.deleteSync(recursive: true);
-      } on FileSystemException catch (error) {
-        if (platform.isWindows) {
-          _windowsDeleteFailure(buildDir.path);
-        }
-        throwToolExit(error.toString());
-      }
-    }
+    final FlutterProject flutterProject = FlutterProject.current();
+    _deleteFile(flutterProject.dartTool);
 
-    printStatus("Deleting '${flutterProject.dartTool.path}${fs.path.separator}'.");
-    if (flutterProject.dartTool.existsSync()) {
-      try {
-        flutterProject.dartTool.deleteSync(recursive: true);
-      } on FileSystemException catch (error) {
-        if (platform.isWindows) {
-          _windowsDeleteFailure(flutterProject.dartTool.path);
-        }
-        throwToolExit(error.toString());
-      }
-    }
+    final Directory androidEphemeralDirectory = flutterProject.android.ephemeralDirectory;
+    _deleteFile(androidEphemeralDirectory);
+
+    final Directory iosEphemeralDirectory = flutterProject.ios.ephemeralDirectory;
+    _deleteFile(iosEphemeralDirectory);
+
     return const FlutterCommandResult(ExitStatus.success);
   }
 
-  void _windowsDeleteFailure(String path) {
-    printError(
-      'Failed to remove $path. '
-      'A program may still be using a file in the directory or the directory itself. '
-      'To find and stop such a program, see: '
-      'https://superuser.com/questions/1333118/cant-delete-empty-folder-because-it-is-used');
+  void _deleteFile(FileSystemEntity file) {
+    final String path = file.path;
+    printStatus("Deleting '$path${fs.path.separator}'.");
+    if (file.existsSync()) {
+      try {
+        file.deleteSync(recursive: true);
+      } on FileSystemException catch (error) {
+        if (platform.isWindows) {
+          printError(
+            'Failed to remove $path. '
+            'A program may still be using a file in the directory or the directory itself. '
+            'To find and stop such a program, see: '
+            'https://superuser.com/questions/1333118/cant-delete-empty-folder-because-it-is-used');
+        }
+        throwToolExit(error.toString());
+      }
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -293,14 +293,14 @@ class IosProject implements XcodeBasedProject {
   static const String _productBundleIdVariable = r'$(PRODUCT_BUNDLE_IDENTIFIER)';
   static const String _hostAppBundleName = 'Runner';
 
-  Directory get _ephemeralDirectory => parent.directory.childDirectory('.ios');
+  Directory get ephemeralDirectory => parent.directory.childDirectory('.ios');
   Directory get _editableDirectory => parent.directory.childDirectory('ios');
 
   /// This parent folder of `Runner.xcodeproj`.
   Directory get hostAppRoot {
     if (!isModule || _editableDirectory.existsSync())
       return _editableDirectory;
-    return _ephemeralDirectory;
+    return ephemeralDirectory;
   }
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
@@ -309,7 +309,7 @@ class IosProject implements XcodeBasedProject {
   ///
   /// This is the same as [hostAppRoot] except when the project is
   /// a Flutter module with an editable host app.
-  Directory get _flutterLibRoot => isModule ? _ephemeralDirectory : _editableDirectory;
+  Directory get _flutterLibRoot => isModule ? ephemeralDirectory : _editableDirectory;
 
   /// The bundle name of the host app, `Runner.app`.
   String get hostAppBundleName => '$_hostAppBundleName.app';
@@ -413,17 +413,17 @@ class IosProject implements XcodeBasedProject {
   void _regenerateFromTemplateIfNeeded() {
     if (!isModule)
       return;
-    final bool pubspecChanged = isOlderThanReference(entity: _ephemeralDirectory, referenceFile: parent.pubspecFile);
-    final bool toolingChanged = Cache.instance.isOlderThanToolsStamp(_ephemeralDirectory);
+    final bool pubspecChanged = isOlderThanReference(entity: ephemeralDirectory, referenceFile: parent.pubspecFile);
+    final bool toolingChanged = Cache.instance.isOlderThanToolsStamp(ephemeralDirectory);
     if (!pubspecChanged && !toolingChanged)
       return;
-    _deleteIfExistsSync(_ephemeralDirectory);
-    _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), _ephemeralDirectory);
+    _deleteIfExistsSync(ephemeralDirectory);
+    _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), ephemeralDirectory);
     // Add ephemeral host app, if a editable host app does not already exist.
     if (!_editableDirectory.existsSync()) {
-      _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral'), _ephemeralDirectory);
+      _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral'), ephemeralDirectory);
       if (hasPlugins(parent)) {
-        _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral_cocoapods'), _ephemeralDirectory);
+        _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral_cocoapods'), ephemeralDirectory);
       }
     }
   }
@@ -432,8 +432,8 @@ class IosProject implements XcodeBasedProject {
     assert(isModule);
     if (_editableDirectory.existsSync())
       throwToolExit('iOS host app is already editable. To start fresh, delete the ios/ folder.');
-    _deleteIfExistsSync(_ephemeralDirectory);
-    _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), _ephemeralDirectory);
+    _deleteIfExistsSync(ephemeralDirectory);
+    _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), ephemeralDirectory);
     _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral'), _editableDirectory);
     _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_ephemeral_cocoapods'), _editableDirectory);
     _overwriteFromTemplate(fs.path.join('module', 'ios', 'host_app_editable_cocoapods'), _editableDirectory);
@@ -484,15 +484,15 @@ class AndroidProject {
   Directory get hostAppGradleRoot {
     if (!isModule || _editableHostAppDirectory.existsSync())
       return _editableHostAppDirectory;
-    return _ephemeralDirectory;
+    return ephemeralDirectory;
   }
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
   /// a Flutter module with an editable host app.
-  Directory get _flutterLibGradleRoot => isModule ? _ephemeralDirectory : _editableHostAppDirectory;
+  Directory get _flutterLibGradleRoot => isModule ? ephemeralDirectory : _editableHostAppDirectory;
 
-  Directory get _ephemeralDirectory => parent.directory.childDirectory('.android');
+  Directory get ephemeralDirectory => parent.directory.childDirectory('.android');
   Directory get _editableHostAppDirectory => parent.directory.childDirectory('android');
 
   /// True if the parent Flutter project is a module.
@@ -543,8 +543,8 @@ class AndroidProject {
       _regenerateLibrary();
       // Add ephemeral host app, if an editable host app does not already exist.
       if (!_editableHostAppDirectory.existsSync()) {
-        _overwriteFromTemplate(fs.path.join('module', 'android', 'host_app_common'), _ephemeralDirectory);
-        _overwriteFromTemplate(fs.path.join('module', 'android', 'host_app_ephemeral'), _ephemeralDirectory);
+        _overwriteFromTemplate(fs.path.join('module', 'android', 'host_app_common'), ephemeralDirectory);
+        _overwriteFromTemplate(fs.path.join('module', 'android', 'host_app_ephemeral'), ephemeralDirectory);
       }
     }
     if (!hostAppGradleRoot.existsSync()) {
@@ -554,8 +554,8 @@ class AndroidProject {
   }
 
   bool _shouldRegenerateFromTemplate() {
-    return isOlderThanReference(entity: _ephemeralDirectory, referenceFile: parent.pubspecFile)
-        || Cache.instance.isOlderThanToolsStamp(_ephemeralDirectory);
+    return isOlderThanReference(entity: ephemeralDirectory, referenceFile: parent.pubspecFile)
+        || Cache.instance.isOlderThanToolsStamp(ephemeralDirectory);
   }
 
   Future<void> makeHostAppEditable() async {
@@ -576,10 +576,10 @@ class AndroidProject {
   Directory get pluginRegistrantHost => _flutterLibGradleRoot.childDirectory(isModule ? 'Flutter' : 'app');
 
   void _regenerateLibrary() {
-    _deleteIfExistsSync(_ephemeralDirectory);
-    _overwriteFromTemplate(fs.path.join('module', 'android', 'library'), _ephemeralDirectory);
-    _overwriteFromTemplate(fs.path.join('module', 'android', 'gradle'), _ephemeralDirectory);
-    gradle.injectGradleWrapper(_ephemeralDirectory);
+    _deleteIfExistsSync(ephemeralDirectory);
+    _overwriteFromTemplate(fs.path.join('module', 'android', 'library'), ephemeralDirectory);
+    _overwriteFromTemplate(fs.path.join('module', 'android', 'gradle'), ephemeralDirectory);
+    gradle.injectGradleWrapper(ephemeralDirectory);
   }
 
   void _overwriteFromTemplate(String path, Directory target) {

--- a/packages/flutter_tools/test/general.shard/commands/clean_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/clean_test.dart
@@ -20,6 +20,8 @@ void main() {
   MockDirectory exampleDirectory;
   MockDirectory buildDirectory;
   MockDirectory dartToolDirectory;
+  MockDirectory androidEphemeralDirectory;
+  MockDirectory iosEphemeralDirectory;
   MockFile pubspec;
   MockFile examplePubspec;
   MockPlatform windowsPlatform;
@@ -30,6 +32,8 @@ void main() {
     exampleDirectory = MockDirectory();
     buildDirectory = MockDirectory();
     dartToolDirectory = MockDirectory();
+    androidEphemeralDirectory = MockDirectory();
+    iosEphemeralDirectory = MockDirectory();
     pubspec = MockFile();
     examplePubspec = MockFile();
     windowsPlatform = MockPlatform();
@@ -39,6 +43,8 @@ void main() {
     when(pubspec.path).thenReturn('/test/pubspec.yaml');
     when(exampleDirectory.childFile('pubspec.yaml')).thenReturn(examplePubspec);
     when(currentDirectory.childDirectory('.dart_tool')).thenReturn(dartToolDirectory);
+    when(currentDirectory.childDirectory('.android')).thenReturn(androidEphemeralDirectory);
+    when(currentDirectory.childDirectory('.ios')).thenReturn(iosEphemeralDirectory);
     when(examplePubspec.path).thenReturn('/test/example/pubspec.yaml');
     when(mockFileSystem.isFileSync('/test/pubspec.yaml')).thenReturn(false);
     when(mockFileSystem.isFileSync('/test/example/pubspec.yaml')).thenReturn(false);
@@ -46,14 +52,18 @@ void main() {
     when(mockFileSystem.path).thenReturn(fs.path);
     when(buildDirectory.existsSync()).thenReturn(true);
     when(dartToolDirectory.existsSync()).thenReturn(true);
+    when(androidEphemeralDirectory.existsSync()).thenReturn(true);
+    when(iosEphemeralDirectory.existsSync()).thenReturn(true);
     when(windowsPlatform.isWindows).thenReturn(true);
   });
 
   group(CleanCommand, () {
-    testUsingContext('removes build and .dart_tool directories', () async {
+    testUsingContext('removes build and .dart_tool and ephemeral directories', () async {
       await CleanCommand().runCommand();
       verify(buildDirectory.deleteSync(recursive: true)).called(1);
       verify(dartToolDirectory.deleteSync(recursive: true)).called(1);
+      verify(androidEphemeralDirectory.deleteSync(recursive: true)).called(1);
+      verify(iosEphemeralDirectory.deleteSync(recursive: true)).called(1);
     }, overrides: <Type, Generator>{
       Config: () => null,
       FileSystem: () => mockFileSystem,


### PR DESCRIPTION
## Description

Remove ephemeral directories used by modules during `flutter clean`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37909.

## Tests

Updated "removes build and .dart_tool and ephemeral directories"

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.