### PR TITLE
Give `_runFlutterTest` the ability to validate command output

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -585,7 +585,7 @@ Future<void> _verifyGeneratedPluginRegistrants(String flutterRoot) async {
     }
     await runCommand(flutter, <String>['inject-plugins'],
       workingDirectory: package,
-      printOutput: false,
+      outputMode: OutputMode.discard,
     );
     for (File registrant in fileToContent.keys) {
       if (registrant.readAsStringSync() != fileToContent[registrant]) {

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -90,7 +90,9 @@ Future<void> runCommand(String executable, List<String> arguments, {
   Duration timeout = _kLongTimeout,
   bool Function(String) removeLine,
 }) async {
-  assert((outputMode == OutputMode.capture) == (output != null));
+  assert((outputMode == OutputMode.capture) == (output != null),
+      'The output parameter must be non-null with and only with '
+      'OutputMode.capture');
 
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
   final String relativeWorkingDir = path.relative(workingDirectory);

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -136,8 +136,8 @@ Future<void> runCommand(String executable, List<String> arguments, {
   print('$clock ELAPSED TIME: $bold${elapsedTime(start)}$reset for $commandDescription in $relativeWorkingDir: ');
 
   if (output != null) {
-    output.stdout = flattenToString(await savedStdout);
-    output.stderr = flattenToString(await savedStderr);
+    output.stdout = _flattenToString(await savedStdout);
+    output.stderr = _flattenToString(await savedStderr);
   }
 
   // If the test is flaky we don't care about the actual exit.
@@ -156,8 +156,8 @@ Future<void> runCommand(String executable, List<String> arguments, {
         break;
       case OutputMode.capture:
       case OutputMode.discard:
-        stdout.writeln(flattenToString(await savedStdout));
-        stderr.writeln(flattenToString(await savedStderr));
+        stdout.writeln(_flattenToString(await savedStdout));
+        stderr.writeln(_flattenToString(await savedStderr));
         break;
     }
     print(
@@ -171,11 +171,9 @@ Future<void> runCommand(String executable, List<String> arguments, {
   }
 }
 
-T identity<T>(T x) => x;
-
 /// Flattens a nested list of UTF-8 code units into a single string.
-String flattenToString(List<List<int>> chunks) =>
-  utf8.decode(chunks.expand<int>(identity).toList(growable: false));
+String _flattenToString(List<List<int>> chunks) =>
+  utf8.decode(chunks.expand<int>((List<int> ints) => ints).toList());
 
 /// Specifies what to do with command output from [runCommand].
 enum OutputMode { print, capture, discard }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -817,7 +817,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
   List<String> tests = const <String>[],
 }) async {
   // Support printing output or capturing it for matching, but not both.
-  assert(_implies(printOutput, outputChecker == null));
+  assert(!printOutput || outputChecker == null);
 
   final List<String> args = <String>[
     'test',
@@ -1009,8 +1009,3 @@ Future<void> _androidGradleTests(String subShard) async {
     await _runDevicelabTest('module_host_with_custom_build_test', env: env);
   }
 }
-
-/// Returns true if `p` logically implies `q`, false otherwise.
-///
-/// If `p` is true, `q` must be true.
-bool _implies(bool p, bool q) => !p || q;

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -816,8 +816,8 @@ Future<void> _runFlutterTest(String workingDirectory, {
   Map<String, String> environment,
   List<String> tests = const <String>[],
 }) async {
-  // Support printing output or capturing it for matching, but not both.
-  assert(!printOutput || outputChecker == null);
+  assert(!printOutput || outputChecker == null,
+      'Output either can be printed or checked but not both');
 
   final List<String> args = <String>[
     'test',


### PR DESCRIPTION
In another change (#37646), I want to test that a test fails and
prints expected output.  I didn't see an existing way to do that, so
I modified `_runFlutterTest` and `runCommand` to allow capturing the
output.  Currently capturing and printing output are mutually
exclusive since we don't need both.

Some awkward bits:
* There already exists a `runAndGetStdout` function that is very
  similar to `runCommand`, and this change makes the conceptual
  distinction more confusing.

* `runFlutterTest` has multiple code paths for different
  configurations.  I don't understand what the different paths are
  for, and I added output checking only along one of them.

## Tests

Tested manually.  Will be exercised by PR #37646.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
