### PR TITLE
Revert "Moved the default BinaryMessenger instance to ServicesBinding…

### DIFF
--- a/dev/automated_tests/flutter_test/ticker_test.dart
+++ b/dev/automated_tests/flutter_test/ticker_test.dart
@@ -11,6 +11,6 @@ void main() {
     Ticker((Duration duration) { })..start();
 
     final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.paused');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) {});
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) {});
   });
 }

--- a/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/test_driver/main.dart
+++ b/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/test_driver/main.dart
@@ -36,9 +36,9 @@ Future<String> respondToHostRequestForSplashLog(String _) {
 
 void createTestChannelBetweenAndroidAndFlutter() {
   // Channel used for Android to send Flutter changes to the splash display.
-  const BasicMessageChannel<String> testChannel = BasicMessageChannel<String>(
+  final BasicMessageChannel<String> testChannel = BasicMessageChannel<String>(
       'testChannel',
-      StringCodec()
+      const StringCodec()
   );
 
   // Every splash display change message that we receive from Android is either

--- a/dev/integration_tests/ios_add2app/flutterapp/lib/main.dart
+++ b/dev/integration_tests/ios_add2app/flutterapp/lib/main.dart
@@ -25,8 +25,6 @@ const BasicMessageChannel<String> _kReloadChannel =
     BasicMessageChannel<String>(_kReloadChannelName, StringCodec());
 
 void main() {
-  // Ensures bindings are initialized before doing anything.
-  WidgetsFlutterBinding.ensureInitialized();
   // Start listening immediately for messages from the iOS side. ObjC calls
   // will be made to let us know when we should be changing the app state.
   _kReloadChannel.setMessageHandler(run);

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -9,7 +9,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
-import 'binding.dart';
+import 'binary_messenger.dart';
 
 /// A collection of resources used by the application.
 ///
@@ -212,12 +212,11 @@ abstract class CachingAssetBundle extends AssetBundle {
 
 /// An [AssetBundle] that loads resources using platform messages.
 class PlatformAssetBundle extends CachingAssetBundle {
-
   @override
   Future<ByteData> load(String key) async {
     final Uint8List encoded = utf8.encoder.convert(Uri(path: Uri.encodeFull(key)).path);
     final ByteData asset =
-        await ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData());
+        await defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData());
     if (asset == null)
       throw FlutterError('Unable to load asset: $key');
     return asset;

--- a/packages/flutter/lib/src/services/binary_messenger.dart
+++ b/packages/flutter/lib/src/services/binary_messenger.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'binding.dart';
+import 'package:flutter/foundation.dart';
 
 /// A function which takes a platform message and asynchronously returns an encoded response.
 typedef MessageHandler = Future<ByteData> Function(ByteData message);
@@ -56,14 +56,99 @@ abstract class BinaryMessenger {
   void setMockMessageHandler(String channel, Future<ByteData> handler(ByteData message));
 }
 
-/// The default instance of [BinaryMessenger].
+/// The default implementation of [BinaryMessenger].
 ///
-/// This API has been deprecated in favor of [ServicesBinding.defaultBinaryMessenger].
-/// Please use [ServicesBinding.defaultBinaryMessenger] as the default
-/// instance of [BinaryMessenger].
+/// This messenger sends messages from the app-side to the platform-side and
+/// dispatches incoming messages from the platform-side to the appropriate
+/// handler.
+class _DefaultBinaryMessenger extends BinaryMessenger {
+  const _DefaultBinaryMessenger._();
+
+  // Handlers for incoming messages from platform plugins.
+  // This is static so that this class can have a const constructor.
+  static final Map<String, MessageHandler> _handlers =
+      <String, MessageHandler>{};
+
+  // Mock handlers that intercept and respond to outgoing messages.
+  // This is static so that this class can have a const constructor.
+  static final Map<String, MessageHandler> _mockHandlers =
+      <String, MessageHandler>{};
+
+  Future<ByteData> _sendPlatformMessage(String channel, ByteData message) {
+    final Completer<ByteData> completer = Completer<ByteData>();
+    // ui.window is accessed directly instead of using ServicesBinding.instance.window
+    // because this method might be invoked before any binding is initialized.
+    // This issue was reported in #27541. It is not ideal to statically access
+    // ui.window because the Window may be dependency injected elsewhere with
+    // a different instance. However, static access at this location seems to be
+    // the least bad option.
+    ui.window.sendPlatformMessage(channel, message, (ByteData reply) {
+      try {
+        completer.complete(reply);
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'services library',
+          context: ErrorDescription('during a platform message response callback'),
+        ));
+      }
+    });
+    return completer.future;
+  }
+
+  @override
+  Future<void> handlePlatformMessage(
+    String channel,
+    ByteData data,
+    ui.PlatformMessageResponseCallback callback,
+  ) async {
+    ByteData response;
+    try {
+      final MessageHandler handler = _handlers[channel];
+      if (handler != null)
+        response = await handler(data);
+    } catch (exception, stack) {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'services library',
+        context: ErrorDescription('during a platform message callback'),
+      ));
+    } finally {
+      callback(response);
+    }
+  }
+
+
+  @override
+  Future<ByteData> send(String channel, ByteData message) {
+    final MessageHandler handler = _mockHandlers[channel];
+    if (handler != null)
+      return handler(message);
+    return _sendPlatformMessage(channel, message);
+  }
+
+  @override
+  void setMessageHandler(String channel, MessageHandler handler) {
+    if (handler == null)
+      _handlers.remove(channel);
+    else
+      _handlers[channel] = handler;
+  }
+
+  @override
+  void setMockMessageHandler(String channel, MessageHandler handler) {
+    if (handler == null)
+      _mockHandlers.remove(channel);
+    else
+      _mockHandlers[channel] = handler;
+  }
+}
+
+/// The default instance of [BinaryMessenger].
 ///
 /// This is used to send messages from the application to the platform, and
 /// keeps track of which handlers have been registered on each channel so
 /// it may dispatch incoming messages to the registered handler.
-@Deprecated('Use ServicesBinding.instance.defaultBinaryMessenger instead.')
-BinaryMessenger get defaultBinaryMessenger => ServicesBinding.instance.defaultBinaryMessenger;
+const BinaryMessenger defaultBinaryMessenger = _DefaultBinaryMessenger._();

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -31,9 +31,6 @@ import 'platform_channel.dart';
 class BinaryMessages {
   BinaryMessages._();
 
-  /// The messenger which sends the platform messages, not null.
-  static final BinaryMessenger _binaryMessenger = ServicesBinding.instance.defaultBinaryMessenger;
-
   /// Calls the handler registered for the given channel.
   ///
   /// Typically called by [ServicesBinding] to handle platform messages received
@@ -46,7 +43,7 @@ class BinaryMessages {
     ByteData data,
     ui.PlatformMessageResponseCallback callback,
   ) {
-    return _binaryMessenger.handlePlatformMessage(channel, data, callback);
+    return defaultBinaryMessenger.handlePlatformMessage(channel, data, callback);
   }
 
   /// Send a binary message to the platform plugins on the given channel.
@@ -55,7 +52,7 @@ class BinaryMessages {
   /// binary form.
   @Deprecated('Use defaultBinaryMessenger.send instead.')
   static Future<ByteData> send(String channel, ByteData message) {
-    return _binaryMessenger.send(channel, message);
+    return defaultBinaryMessenger.send(channel, message);
   }
 
   /// Set a callback for receiving messages from the platform plugins on the
@@ -68,7 +65,7 @@ class BinaryMessages {
   /// The handler's return value, if non-null, is sent as a response, unencoded.
   @Deprecated('Use defaultBinaryMessenger.setMessageHandler instead.')
   static void setMessageHandler(String channel, Future<ByteData> handler(ByteData message)) {
-    _binaryMessenger.setMessageHandler(channel, handler);
+    defaultBinaryMessenger.setMessageHandler(channel, handler);
   }
 
   /// Set a mock callback for intercepting messages from the `send*` methods on
@@ -84,6 +81,6 @@ class BinaryMessages {
   /// sent to platform plugins.
   @Deprecated('Use defaultBinaryMessenger.setMockMessageHandler instead.')
   static void setMockMessageHandler(String channel, Future<ByteData> handler(ByteData message)) {
-    _binaryMessenger.setMockMessageHandler(channel, handler);
+    defaultBinaryMessenger.setMockMessageHandler(channel, handler);
   }
 }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -251,10 +251,6 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
   void initInstances() {
     super.initInstances();
     _instance = this;
-    // Initialization of [_buildOwner] has to be done after
-    // [super.initInstances] is called, as it requires [ServicesBinding] to
-    // properly setup the [defaultBinaryMessenger] instance.
-    _buildOwner = BuildOwner();
     buildOwner.onBuildScheduled = _handleBuildScheduled;
     window.onLocaleChanged = handleLocaleChanged;
     window.onAccessibilityFeaturesChanged = handleAccessibilityFeaturesChanged;
@@ -375,10 +371,7 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
   /// The [BuildOwner] in charge of executing the build pipeline for the
   /// widget tree rooted at this binding.
   BuildOwner get buildOwner => _buildOwner;
-  // Initialization of [_buildOwner] has to be done within the [initInstances]
-  // method, as it requires [ServicesBinding] to properly setup the
-  // [defaultBinaryMessenger] instance.
-  BuildOwner _buildOwner;
+  final BuildOwner _buildOwner = BuildOwner();
 
   /// The object in charge of the focus tree.
   ///

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -125,7 +125,6 @@ class PathPointsMatcher extends Matcher {
 
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   final MockClipboard mockClipboard = MockClipboard();
   SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
 

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -429,7 +429,7 @@ void main() {
     bool completed;
 
     completed = false;
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData message) async {
+    defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData message) async {
       expect(utf8.decode(message.buffer.asUint8List()), 'test');
       completed = true;
       return ByteData(5); // 0x0000000000
@@ -448,7 +448,7 @@ void main() {
     data = await rootBundle.loadStructuredData<bool>('test', (String value) async { expect(value, '\x00\x00\x00\x00\x00'); return false; });
     expect(data, isFalse);
     expect(completed, isTrue);
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', null);
+    defaultBinaryMessenger.setMockMessageHandler('flutter/assets', null);
   });
 
   test('Service extensions - exit', () async {

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -72,7 +72,7 @@ void main() {
 
     // Simulate system back button
     final ByteData message = const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     await tester.pumpAndSettle();
 
     expect(selectedResults, <void>[null]);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -129,7 +129,6 @@ double getOpacity(WidgetTester tester, Finder finder) {
 }
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   final MockClipboard mockClipboard = MockClipboard();
   SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
 
@@ -3392,7 +3391,7 @@ void main() {
   });
 
   void sendFakeKeyEvent(Map<String, dynamic> data) {
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.keyEvent.name,
       SystemChannels.keyEvent.codec.encodeMessage(data),
           (ByteData data) { },

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -129,7 +129,7 @@ void main() {
     expect(tickCount, equals(0));
 
     final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.paused');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(ticker.isTicking, isFalse);
     expect(ticker.isActive, isTrue);
 
@@ -138,7 +138,7 @@ void main() {
 
   testWidgets('Ticker can be created before application unpauses', (WidgetTester tester) async {
     final ByteData pausedMessage = const StringCodec().encodeMessage('AppLifecycleState.paused');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', pausedMessage, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', pausedMessage, (_) { });
 
     int tickCount = 0;
     void handleTick(Duration duration) {
@@ -157,7 +157,7 @@ void main() {
     expect(ticker.isTicking, isFalse);
 
     final ByteData resumedMessage = const StringCodec().encodeMessage('AppLifecycleState.resumed');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', resumedMessage, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', resumedMessage, (_) { });
 
     await tester.pump(const Duration(milliseconds: 10));
 

--- a/packages/flutter/test/semantics/semantics_service_test.dart
+++ b/packages/flutter/test/semantics/semantics_service_test.dart
@@ -6,15 +6,10 @@ import 'dart:ui' show TextDirection;
 
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart' show SystemChannels;
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 
 import '../flutter_test_alternative.dart';
 
 void main() {
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
   test('Semantic announcement', () async {
     final List<Map<dynamic, dynamic>> log = <Map<dynamic, dynamic>>[];
 

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -63,7 +63,7 @@ class FakeAndroidPlatformViewsController {
   void invokeViewFocused(int viewId) {
     final MethodCodec codec = SystemChannels.platform_views.codec;
     final ByteData data = codec.encodeMethodCall(MethodCall('viewFocused', viewId));
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData data) {});
+    defaultBinaryMessenger.handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData data) {});
   }
 
   Future<dynamic> _onMethodCall(MethodCall call) {

--- a/packages/flutter/test/services/haptic_feedback_test.dart
+++ b/packages/flutter/test/services/haptic_feedback_test.dart
@@ -6,10 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
   test('Haptic feedback control test', () async {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -6,20 +6,14 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
-
 import '../flutter_test_alternative.dart';
 
 void main() {
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
   group('BasicMessageChannel', () {
     const MessageCodec<String> string = StringCodec();
     const BasicMessageChannel<String> channel = BasicMessageChannel<String>('ch', string);
     test('can send string message and get reply', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch',
         (ByteData message) async => string.encodeMessage(string.decodeMessage(message) + ' world'),
       );
@@ -29,7 +23,7 @@ void main() {
     test('can receive string message and send reply', () async {
       channel.setMessageHandler((String message) async => message + ' world');
       String reply;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      await defaultBinaryMessenger.handlePlatformMessage(
         'ch',
         const StringCodec().encodeMessage('hello'),
         (ByteData replyBinary) {
@@ -45,7 +39,7 @@ void main() {
     const MethodCodec jsonMethod = JSONMethodCodec();
     const MethodChannel channel = MethodChannel('ch7', jsonMethod);
     test('can invoke method and get result', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -60,7 +54,7 @@ void main() {
       expect(result, equals('hello world'));
     });
     test('can invoke list method and get result', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -76,7 +70,7 @@ void main() {
     });
 
     test('can invoke list method and get null result', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -92,7 +86,7 @@ void main() {
 
 
     test('can invoke map method and get result', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -108,7 +102,7 @@ void main() {
     });
 
     test('can invoke map method and get null result', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -123,7 +117,7 @@ void main() {
     });
 
     test('can invoke method and get error', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async {
           return jsonMessage.encodeMessage(<dynamic>[
@@ -145,7 +139,7 @@ void main() {
       }
     });
     test('can invoke unimplemented method', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
         (ByteData message) async => null,
       );
@@ -163,7 +157,7 @@ void main() {
       channel.setMethodCallHandler(null);
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+      await defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
       expect(envelope, isNull);
@@ -174,7 +168,7 @@ void main() {
       });
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+      await defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
       expect(envelope, isNull);
@@ -183,7 +177,7 @@ void main() {
       channel.setMethodCallHandler((MethodCall call) async => '${call.arguments}, world');
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+      await defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
       expect(jsonMethod.decodeEnvelope(envelope), equals('hello, world'));
@@ -194,7 +188,7 @@ void main() {
       });
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+      await defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
       try {
@@ -213,7 +207,7 @@ void main() {
       });
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
-      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+      await defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
       try {
@@ -232,7 +226,7 @@ void main() {
     const MethodCodec jsonMethod = JSONMethodCodec();
     const EventChannel channel = EventChannel('ch', jsonMethod);
     void emitEvent(dynamic event) {
-      ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      defaultBinaryMessenger.handlePlatformMessage(
         'ch',
         event,
             (ByteData reply) { },
@@ -240,7 +234,7 @@ void main() {
     }
     test('can receive event stream', () async {
       bool canceled = false;
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);
@@ -264,7 +258,7 @@ void main() {
       expect(canceled, isTrue);
     });
     test('can receive error event', () async {
-      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      defaultBinaryMessenger.setMockMessageHandler(
         'ch',
         (ByteData message) async {
           final Map<dynamic, dynamic> methodCall = jsonMessage.decodeMessage(message);

--- a/packages/flutter/test/services/platform_messages_test.dart
+++ b/packages/flutter/test/services/platform_messages_test.dart
@@ -16,18 +16,18 @@ void main() {
 
     final List<ByteData> log = <ByteData>[];
 
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('test1', (ByteData message) async {
+    defaultBinaryMessenger.setMockMessageHandler('test1', (ByteData message) async {
       log.add(message);
       return null;
     });
 
     final ByteData message = ByteData(2)..setUint16(0, 0xABCD);
-    await ServicesBinding.instance.defaultBinaryMessenger.send('test1', message);
+    await defaultBinaryMessenger.send('test1', message);
     expect(log, equals(<ByteData>[message]));
     log.clear();
 
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('test1', null);
-    await ServicesBinding.instance.defaultBinaryMessenger.send('test1', message);
+    defaultBinaryMessenger.setMockMessageHandler('test1', null);
+    await defaultBinaryMessenger.send('test1', message);
     expect(log, isEmpty);
   });
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -4,16 +4,11 @@
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import '../flutter_test_alternative.dart';
 
 import 'fake_platform_views.dart';
 
 void main() {
-
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
 
   group('Android', () {
     FakeAndroidPlatformViewsController viewsController;

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -61,7 +61,7 @@ void main() {
   test('setApplicationSwitcherDescription missing plugin', () async {
     final List<ByteData> log = <ByteData>[];
 
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/platform', (ByteData message) {
+    defaultBinaryMessenger.setMockMessageHandler('flutter/platform', (ByteData message) {
       log.add(message);
       return null;
     });

--- a/packages/flutter/test/services/system_navigator_test.dart
+++ b/packages/flutter/test/services/system_navigator_test.dart
@@ -6,10 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
   test('System navigator control test', () async {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/flutter/test/services/system_sound_test.dart
+++ b/packages/flutter/test/services/system_sound_test.dart
@@ -6,10 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  setUp(() {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
   test('System sound control test', () async {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -46,13 +46,12 @@ void main() {
     WidgetsBinding.instance.addObserver(observer);
     final ByteData message = const JSONMessageCodec().encodeMessage(
       <String, dynamic>{'type': 'memoryPressure'});
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/system', message, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/system', message, (_) { });
     expect(observer.sawMemoryPressure, true);
     WidgetsBinding.instance.removeObserver(observer);
   });
 
   testWidgets('handleLifecycleStateChanged callback', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance.defaultBinaryMessenger;
     final AppLifecycleStateObserver observer = AppLifecycleStateObserver();
     WidgetsBinding.instance.addObserver(observer);
 
@@ -80,14 +79,13 @@ void main() {
     const String testRouteName = 'testRouteName';
     final ByteData message = const JSONMethodCodec().encodeMethodCall(
       const MethodCall('pushRoute', testRouteName));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     expect(observer.pushedRoute, testRouteName);
 
     WidgetsBinding.instance.removeObserver(observer);
   });
 
   testWidgets('Application lifecycle affects frame scheduling', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance.defaultBinaryMessenger;
     ByteData message;
     expect(tester.binding.hasScheduledFrame, isFalse);
 

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void sendFakeKeyEvent(Map<String, dynamic> data) {
-  ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+  defaultBinaryMessenger.handlePlatformMessage(
     SystemChannels.keyEvent.name,
     SystemChannels.keyEvent.codec.encodeMessage(data),
     (ByteData data) {},

--- a/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
+++ b/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void sendFakeKeyEvent(Map<String, dynamic> data) {
-  ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+  defaultBinaryMessenger.handlePlatformMessage(
     SystemChannels.keyEvent.name,
     SystemChannels.keyEvent.codec.encodeMessage(data),
     (ByteData data) {},

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -122,7 +122,6 @@ double getOpacity(WidgetTester tester, Finder finder) {
 }
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
   final MockClipboard mockClipboard = MockClipboard();
   SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
 
@@ -1248,7 +1247,7 @@ void main() {
   });
 
   void sendFakeKeyEvent(Map<String, dynamic> data) {
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.keyEvent.name,
       SystemChannels.keyEvent.codec.encodeMessage(data),
           (ByteData data) { },

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void sendFakeKeyEvent(Map<String, dynamic> data) {
-  ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+  defaultBinaryMessenger.handlePlatformMessage(
     SystemChannels.keyEvent.name,
     SystemChannels.keyEvent.codec.encodeMessage(data),
     (ByteData data) {},

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -207,10 +207,10 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
 
   @override
   void initInstances() {
-    super.initInstances();
     timeDilation = 1.0; // just in case the developer has artificially changed it for development
     HttpOverrides.global = _MockHttpOverrides();
     _testTextInput = TestTextInput(onCleared: _resetFocusedEditable)..register();
+    super.initInstances();
   }
 
   @override
@@ -808,7 +808,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     final String assetFolderPath = Platform.environment['UNIT_TEST_ASSETS'];
     final String prefix =  'packages/${Platform.environment['APP_NAME']}/';
 
-    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData message) {
+    defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData message) {
       String key = utf8.decode(message.buffer.asUint8List());
       File asset = File(path.join(assetFolderPath, key));
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -36,9 +36,6 @@ class TestTextInput {
   /// first be requested, e.g. using [WidgetTester.showKeyboard].
   final VoidCallback onCleared;
 
-  /// The messenger which sends the bytes for this channel, not null.
-  BinaryMessenger get _binaryMessenger => ServicesBinding.instance.defaultBinaryMessenger;
-
   /// Installs this object as a mock handler for [SystemChannels.textInput].
   void register() {
     SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
@@ -111,7 +108,7 @@ class TestTextInput {
     // test this code does not run in a package:test test zone.
     if (_client == 0)
       throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
-    _binaryMessenger.handlePlatformMessage(
+    defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.textInput.name,
       SystemChannels.textInput.codec.encodeMethodCall(
         MethodCall(
@@ -143,7 +140,7 @@ class TestTextInput {
 
       final Completer<void> completer = Completer<void>();
 
-      _binaryMessenger.handlePlatformMessage(
+      defaultBinaryMessenger.handlePlatformMessage(
         SystemChannels.textInput.name,
         SystemChannels.textInput.codec.encodeMethodCall(
           MethodCall(


### PR DESCRIPTION
… (#37489)"

## Description

This reverts commit 92ef2b9ce1d4e54d5efb3e6a962e9e724dc7efeb.

This requires either runApp() or
WidgetsFlutterBinding.ensureInitialized() to have been called before
using any MethodChannels. Plugins broadly rely on MethodChannels and
right now there's no general requirements that they be constructed
within the runApp call, so the ecosystem breakages from this are broader
than originally thought. Reverting this for now.

## Related Issues

#37409

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
