### PR TITLE
Remove no-constant-update-2018, the underlying issue has been resolved.

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -42,9 +42,6 @@ class FuchsiaKernelCompiler {
         fs.path.relative(packagesFile, from: fsRoot);
     final String manifestPath = fs.path.join(outDir, '$appName.dilpmanifest');
     List<String> flags = <String>[
-      // https://github.com/dart-lang/sdk/issues/36639:
-      // Remove when new constant eval supports dilp files.
-      '--enable-experiment=no-constant-update-2018',
       '--target', 'flutter_runner',
       '--platform', fuchsiaArtifacts.platformKernelDill.path,
       '--filesystem-scheme', 'main-root',


### PR DESCRIPTION
According to @a-siva , issue https://github.com/dart-lang/sdk/issues/36584 has been resolved and this can be removed.

I've personally tried to run the sample app without any issues.