### PR TITLE
WIP Use --consumer-only and --no-coverage in certain Cirrus tests to speed up setup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -260,7 +260,7 @@ task:
   setup_script:
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --no-coverage
     - git fetch origin master
   test_all_script:
     - dart --enable-asserts dev\bots\test.dart
@@ -314,7 +314,7 @@ task:
   setup_script:
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --no-coverage
     - git fetch origin master
   matrix:
     - name: tests_widgets-windows
@@ -415,7 +415,7 @@ task:
     - git fetch origin master # To set FETCH_HEAD
   setup_script:
     - bin/flutter config --no-analytics
-    - bin/flutter update-packages
+    - bin/flutter update-packages --no-coverage
   test_all_script:
     - ./dev/bots/deploy_gallery.sh
 
@@ -437,7 +437,7 @@ task:
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter doctor -v
-    - bin/flutter update-packages
+    - bin/flutter update-packages --no-coverage
   test_all_script:
     - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     - bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/test.dart
@@ -488,7 +488,7 @@ task:
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter doctor -v
-    - bin/flutter update-packages
+    - bin/flutter update-packages --consumer-only --no-coverage
   matrix:
     - name: integration_tests-macos
       only_if: $CIRRUS_BRANCH == 'master'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,6 @@ task:
   setup_script: ./dev/bots/cirrus_setup.sh
   matrix:
     - name: docs
-      skip: "!changesInclude('packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'packages/flutter_goldens/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         SHARD: docs
         # For uploading master docs to Firebase master branch staging site
@@ -97,7 +96,6 @@ task:
         memory: 12G
     # all of the tests except the ones in test/integration and test/commands/create_test for packages/flutter_tools
     - name: tool_tests-linux
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -108,7 +106,6 @@ task:
         cpu: 4
         memory: 12G
     - name: tool_tests_create-linux
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -120,7 +117,6 @@ task:
         memory: 12G
     # all of the tests in test/integration for packages/flutter_tools
     - name: tool_tests_integration-linux
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -267,7 +263,6 @@ task:
   matrix:
     # all of the tests except test/integration and test/commands/create_test for packages/flutter_tools
     - name: tool_tests-windows
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -275,14 +270,12 @@ task:
         SHARD_INDEX: 1
     # all of the tests in test/commands/create_test
     - name: tool_tests_create-windows
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
         SUBSHARD: create
     # all of the tests in test/integration for packages/flutter_tools
     - name: tool_tests_integration-windows
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -444,7 +437,6 @@ task:
   matrix:
     # all of the tests except test/integration and test/commands/create_test for packages/flutter_tools
     - name: tool_tests-macos
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests
@@ -452,7 +444,6 @@ task:
         SHARD_INDEX: 1
     # all of the tests in test/commands/create_test
     - name: tool_tests_create-macos
-      skip: "!changesInclude('packages/flutter_tools/**', 'bin/internal/**') && $CIRRUS_BRANCH != 'master'"
       env:
         GCLOUD_SERVICE_ACCOUNT_KEY: ENCRYPTED[f12abe60f5045d619ef4c79b83dd1e0722a0b0b13dbea95fbe334e2db7fffbcd841a5a92da8824848b539a19afe0c9fb]
         SHARD: tool_tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -256,7 +256,8 @@ task:
   setup_script:
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages --no-coverage
+    - bin/flutter update-packages --consumer-only --no-coverage
+    - bin/flutter packages get
     - git fetch origin master
   test_all_script:
     - dart --enable-asserts dev\bots\test.dart
@@ -307,7 +308,8 @@ task:
   setup_script:
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages --no-coverage
+    - bin/flutter update-packages --consumer-only --no-coverage
+    - bin/flutter packages get
     - git fetch origin master
   matrix:
     - name: tests_widgets-windows
@@ -408,7 +410,8 @@ task:
     - git fetch origin master # To set FETCH_HEAD
   setup_script:
     - bin/flutter config --no-analytics
-    - bin/flutter update-packages --no-coverage
+    - bin/flutter update-packages --consumer-only --no-coverage
+    - bin/flutter packages get
   test_all_script:
     - ./dev/bots/deploy_gallery.sh
 
@@ -430,7 +433,8 @@ task:
   setup_script:
     - bin/flutter config --no-analytics
     - bin/flutter doctor -v
-    - bin/flutter update-packages --no-coverage
+    - bin/flutter update-packages --consumer-only --no-coverage
+    - bin/flutter packages get
   test_all_script:
     - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
     - bin/cache/dart-sdk/bin/dart --enable-asserts dev/bots/test.dart
@@ -480,6 +484,7 @@ task:
     - bin/flutter config --no-analytics
     - bin/flutter doctor -v
     - bin/flutter update-packages --consumer-only --no-coverage
+    - bin/flutter packages get
   matrix:
     - name: integration_tests-macos
       only_if: $CIRRUS_BRANCH == 'master'

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -65,9 +65,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       )
       ..addFlag(
         'consumer-only',
-        help: 'Only prints the dependency graph that is the transitive closure'
-              'that a consumer of the Flutter SDK will observe (When combined '
-              'with transitive-closure)',
+        help: 'Only update packages relevant to consumers of the Flutter SDK',
         defaultsTo: false,
         negatable: false,
       )
@@ -76,6 +74,12 @@ class UpdatePackagesCommand extends FlutterCommand {
         help: 'verifies the package checksum without changing or updating deps',
         defaultsTo: false,
         negatable: false,
+      )
+      ..addFlag(
+        'coverage',
+        help: 'Download Flutter lcov data',
+        defaultsTo: true,
+        negatable: true,
       );
   }
 
@@ -122,11 +126,6 @@ class UpdatePackagesCommand extends FlutterCommand {
 
     // "consumer" packages are those that constitute our public API (e.g. flutter, flutter_test, flutter_driver, flutter_localizations).
     if (isConsumerOnly) {
-      if (!isPrintTransitiveClosure) {
-        throwToolExit(
-          '--consumer-only can only be used with the --transitive-closure flag'
-        );
-      }
       // Only retain flutter, flutter_test, flutter_driver, and flutter_localizations.
       const List<String> consumerPackages = <String>['flutter', 'flutter_test', 'flutter_driver', 'flutter_localizations'];
       // ensure we only get flutter/packages
@@ -325,7 +324,9 @@ class UpdatePackagesCommand extends FlutterCommand {
       count += 1;
     }
 
-    await _downloadCoverageData();
+    if (argResults['coverage']) {
+      await _downloadCoverageData();
+    }
 
     final double seconds = timer.elapsedMilliseconds / 1000.0;
     printStatus('\nRan \'pub\' $count time${count == 1 ? "" : "s"} and fetched coverage data in ${seconds.toStringAsFixed(1)}s.');


### PR DESCRIPTION
## Description
1. Skip downloading lcov coverage data in Cirrus tests that don't need it.
2. Only download consumer-facing packages for integration tests.

```
flutter update-packages  26.48s user 5.66s system 164% cpu 19.583 total
flutter update-packages --consumer-only --no-coverage  2.62s user 0.70s system 155% cpu 2.135 total
```