### PR TITLE
Catch filesystem exception from flutter create

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -620,7 +620,13 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
 
   int _renderTemplate(String templateName, Directory directory, Map<String, dynamic> context, { bool overwrite = false }) {
     final Template template = Template.fromName(templateName);
-    return template.render(directory, context, overwriteExisting: overwrite);
+    try {
+      return template.render(directory, context, overwriteExisting: overwrite);
+    } on FileSystemException catch (err) {
+      printError(err.toString());
+      throwToolExit('Failed to create at ${directory.path}.');
+      return 0;
+    }
   }
 
   int _injectGradleWrapper(FlutterProject project) {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -620,13 +620,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
 
   int _renderTemplate(String templateName, Directory directory, Map<String, dynamic> context, { bool overwrite = false }) {
     final Template template = Template.fromName(templateName);
-    try {
-      return template.render(directory, context, overwriteExisting: overwrite);
-    } on FileSystemException catch (err) {
-      printError(err.toString());
-      throwToolExit('Failed to create at ${directory.path}.');
-      return 0;
-    }
+    return template.render(directory, context, overwriteExisting: overwrite);
   }
 
   int _injectGradleWrapper(FlutterProject project) {

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -62,6 +62,9 @@ class Template {
 
   Map<String /* relative */, String /* absolute source */> _templateFilePaths;
 
+  /// Render the template into [directory].
+  ///
+  /// May throw a [FilesystemException] if the directory is not writable.
   int render(
     Directory destination,
     Map<String, dynamic> context, {

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -4,6 +4,7 @@
 
 import 'package:mustache/mustache.dart' as mustache;
 
+import 'base/common.dart';
 import 'base/file_system.dart';
 import 'cache.dart';
 import 'globals.dart';
@@ -64,14 +65,20 @@ class Template {
 
   /// Render the template into [directory].
   ///
-  /// May throw a [FilesystemException] if the directory is not writable.
+  /// May throw a [ToolExit] if the directory is not writable.
   int render(
     Directory destination,
     Map<String, dynamic> context, {
     bool overwriteExisting = true,
     bool printStatusWhenWriting = true,
   }) {
-    destination.createSync(recursive: true);
+    try {
+      destination.createSync(recursive: true);
+    } on FileSystemException catch (err) {
+      printError(err.toString());
+      throwToolExit('Failed to flutter create at ${destination.path}.');
+      return 0;
+    }
     int fileCount = 0;
 
     /// Returns the resolved destination path corresponding to the specified

--- a/packages/flutter_tools/test/template_test.dart
+++ b/packages/flutter_tools/test/template_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/template.dart';
+import 'package:mockito/mockito.dart';
+
+import 'src/common.dart';
+import 'src/testbed.dart';
+
+void main() {
+  Testbed testbed;
+
+  setUp(() {
+    testbed = Testbed();
+  });
+
+  test('Template.render throws ToolExit when FileSystem exception is raised', () => testbed.run(() {
+    final Template template = Template(fs.directory('examples'), fs.currentDirectory);
+    final MockDirectory mockDirectory = MockDirectory();
+    when(mockDirectory.createSync(recursive: true)).thenThrow(const FileSystemException());
+
+    expect(() => template.render(mockDirectory, <String, Object>{}),
+        throwsA(isInstanceOf<ToolExit>()));
+  }));
+}
+
+class MockDirectory extends Mock implements Directory {}


### PR DESCRIPTION
## Description

Handle flutter create from a directory that does not have write permissions. 

Fixes https://github.com/flutter/flutter/issues/38064