### PR TITLE
use common emulator/device list

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -211,7 +211,7 @@ Future<Device> findTargetDevice() async {
     return null;
   } else if (devices.length > 1) {
     printStatus('Found multiple connected devices:');
-    printStatus(devices.map<String>((Device d) => '  - ${d.name}\n').join(''));
+    await Device.printDevices(devices);
   }
   printStatus('Using device ${devices.first.name}.');
   return devices.first;

--- a/packages/flutter_tools/test/general.shard/commands/drive_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/drive_test.dart
@@ -324,6 +324,7 @@ void main() {
       });
 
       Future<void> appStarterSetup() async {
+        mockDevice = MockDevice();
         testDeviceManager.addDevice(mockDevice);
 
         final MockDeviceLogReader mockDeviceLogReader = MockDeviceLogReader();

--- a/packages/flutter_tools/test/general.shard/commands/drive_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/drive_test.dart
@@ -266,18 +266,18 @@ void main() {
             .thenReturn(false);
         when(mockUnsupportedDevice.name).thenReturn('mock-web');
         when(mockUnsupportedDevice.id).thenReturn('web-1');
-        when(mockUnsupportedDevice.targetPlatform).thenAnswer((_) => new Future(() => TargetPlatform.web_javascript));
-        when(mockUnsupportedDevice.isLocalEmulator).thenAnswer((_) => new Future(() => false));
-        when(mockUnsupportedDevice.sdkNameAndVersion).thenAnswer((_) => new Future(() => 'html5'));
+        when(mockUnsupportedDevice.targetPlatform).thenAnswer((_) => Future<TargetPlatform>(() => TargetPlatform.web_javascript));
+        when(mockUnsupportedDevice.isLocalEmulator).thenAnswer((_) => Future<bool>(() => false));
+        when(mockUnsupportedDevice.sdkNameAndVersion).thenAnswer((_) => Future<String>(() => 'html5'));
         when(mockDevice.name).thenReturn('mock-android-device');
         when(mockDevice.id).thenReturn('mad-28');
         when(mockDevice.isSupported())
             .thenReturn(true);
         when(mockDevice.isSupportedForProject(any))
             .thenReturn(true);
-        when(mockDevice.targetPlatform).thenAnswer((_) => new Future(() => TargetPlatform.android_x64));
-        when(mockDevice.isLocalEmulator).thenAnswer((_) => new Future(() => false));
-        when(mockDevice.sdkNameAndVersion).thenAnswer((_) => new Future(() => 'sdk-28'));
+        when(mockDevice.targetPlatform).thenAnswer((_) => Future<TargetPlatform>(() => TargetPlatform.android_x64));
+        when(mockDevice.isLocalEmulator).thenAnswer((_) => Future<bool>(() => false));
+        when(mockDevice.sdkNameAndVersion).thenAnswer((_) => Future<String>(() => 'sdk-28'));
         testDeviceManager.addDevice(mockDevice);
         testDeviceManager.addDevice(mockUnsupportedDevice);
 

--- a/packages/flutter_tools/test/general.shard/commands/drive_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/drive_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/drive.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
@@ -261,9 +262,22 @@ void main() {
         mockUnsupportedDevice = MockDevice();
         when(mockUnsupportedDevice.isSupportedForProject(any))
             .thenReturn(false);
+        when(mockUnsupportedDevice.isSupported())
+            .thenReturn(false);
+        when(mockUnsupportedDevice.name).thenReturn('mock-web');
+        when(mockUnsupportedDevice.id).thenReturn('web-1');
+        when(mockUnsupportedDevice.targetPlatform).thenAnswer((_) => new Future(() => TargetPlatform.web_javascript));
+        when(mockUnsupportedDevice.isLocalEmulator).thenAnswer((_) => new Future(() => false));
+        when(mockUnsupportedDevice.sdkNameAndVersion).thenAnswer((_) => new Future(() => 'html5'));
+        when(mockDevice.name).thenReturn('mock-android-device');
+        when(mockDevice.id).thenReturn('mad-28');
+        when(mockDevice.isSupported())
+            .thenReturn(true);
         when(mockDevice.isSupportedForProject(any))
             .thenReturn(true);
-        when(mockDevice.name).thenReturn('mock-android-device');
+        when(mockDevice.targetPlatform).thenAnswer((_) => new Future(() => TargetPlatform.android_x64));
+        when(mockDevice.isLocalEmulator).thenAnswer((_) => new Future(() => false));
+        when(mockDevice.sdkNameAndVersion).thenAnswer((_) => new Future(() => 'sdk-28'));
         testDeviceManager.addDevice(mockDevice);
         testDeviceManager.addDevice(mockUnsupportedDevice);
 


### PR DESCRIPTION
## Description

to be more clear in usage use the common device/emulator list.
We can see more detailed information to chose the device name oder device id at flutter -d


## Related Issues

fix #37395

