### PR TITLE
TweenAnimationBuilder for building custom animations without managing an AnimationController

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -247,6 +247,8 @@ class TextStyleTween extends Tween<TextStyle> {
 /// usually named `AnimatedFoo`, where `Foo` is the name of the non-animated
 /// version of that widget. Commonly used implicitly animated widgets include:
 ///
+///  * [TweenAnimationBuilder], which animates any property expressed by
+///    a [Tween] to a specified target value.
 ///  * [AnimatedAlign], which is an implicitly animated version of [Align].
 ///  * [AnimatedContainer], which is an implicitly animated version of
 ///    [Container].

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -364,9 +364,10 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   @override
   void didUpdateWidget(T oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final bool curveChanged = widget.curve != oldWidget.curve;
+    if (widget.curve != oldWidget.curve)
+      _updateCurve();
     _controller.duration = widget.duration;
-    if (_constructTweens() || (_controller.isAnimating && curveChanged)) {
+    if (_constructTweens()) {
       forEachTween((Tween<dynamic> tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
         _updateTween(tween, targetValue);
         return tween;
@@ -375,9 +376,6 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
         ..value = 0.0
         ..forward();
       didUpdateTweens();
-    }
-    if (curveChanged) {
-      _updateCurve();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -362,10 +362,9 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   @override
   void didUpdateWidget(T oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.curve != oldWidget.curve)
-      _updateCurve();
+    final bool curveChanged = widget.curve != oldWidget.curve;
     _controller.duration = widget.duration;
-    if (_constructTweens()) {
+    if (_constructTweens() || (_controller.isAnimating && curveChanged)) {
       forEachTween((Tween<dynamic> tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
         _updateTween(tween, targetValue);
         return tween;
@@ -374,6 +373,9 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
         ..value = 0.0
         ..forward();
       didUpdateTweens();
+    }
+    if (curveChanged) {
+      _updateCurve();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -917,6 +917,11 @@ class DefaultTextStyleTransition extends AnimatedWidget {
 /// }
 /// ```
 /// {@end-tool}
+///
+/// See also:
+///
+///  * [TweenAnimationBuilder], which animates a property to a target value
+///    without requiring manual management of an [AnimationController].
 class AnimatedBuilder extends AnimatedWidget {
   /// Creates an animated builder.
   ///

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -205,8 +205,8 @@ class _TweenAnimationBuilderState<T> extends AnimatedWidgetBaseState<TweenAnimat
 
   @override
   void initState() {
-    widget.tween.begin ??= widget.tween.end;
     _currentTween = widget.tween;
+    _currentTween.begin ??= _currentTween.end;
     super.initState();
     // The statusListener is removed when the superclass disposes the controller.
     controller.addStatusListener(_onAnimationStatusChanged);

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -1,0 +1,224 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'framework.dart';
+
+// ignore_for_file: public_member_api_docs
+
+typedef TweenAnimationBuilderCallback<T> = Widget Function(BuildContext context, T value, Widget child);
+
+
+enum PlaybackDirection {
+  forward,
+  reverse,
+  repeat,
+  repeatReverse,
+}
+
+class TweenAnimationBuilder<T> extends StatefulWidget {
+  const TweenAnimationBuilder({
+    Key key,
+    @required this.tween,
+    @required this.duration,
+    this.curve = Curves.linear,
+    this.direction = PlaybackDirection.forward,
+    this.gapless = true,
+    @required this.builder,
+    this.animationStatusListener,
+    this.child,
+  }) : assert(tween != null),
+       assert(direction != null),
+       assert(curve != null),
+       assert(direction != null),
+       assert(builder != null),
+       assert(gapless != null),
+       super(key: key);
+
+  final Tween<T> tween;
+  final Duration duration;
+  final Curve curve;
+  final PlaybackDirection direction;
+  final TweenAnimationBuilderCallback<T> builder;
+  final Widget child;
+  final AnimationStatusListener animationStatusListener;
+  final bool gapless;
+
+  @override
+  State<TweenAnimationBuilder<T>> createState() => _TweenAnimationBuilderState<T>();
+}
+
+class _TweenAnimationBuilderState<T> extends State<TweenAnimationBuilder<T>> with SingleTickerProviderStateMixin {
+  AnimationController _controller;
+  Animation<T> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration)
+    ..addListener(() {
+      setState(() { });
+    });
+    if (widget.animationStatusListener != null) {
+      _controller.addStatusListener(widget.animationStatusListener);
+    }
+    _animation = widget.tween.chain(CurveTween(curve: widget.curve)).animate(_controller);
+    _updateDirection();
+  }
+
+  T _cachedBegin;
+  T _cachedEnd;
+
+  @override
+  void didUpdateWidget(TweenAnimationBuilder<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+
+    if (oldWidget.animationStatusListener != widget.animationStatusListener) {
+      if (oldWidget.animationStatusListener != null) {
+        _controller.removeStatusListener(oldWidget.animationStatusListener);
+      }
+      if (widget.animationStatusListener != null) {
+        _controller.addStatusListener(widget.animationStatusListener);
+      }
+    }
+
+    final T currentAnimationValue = _animation.value;
+
+    final bool hasStatusListener = _cachedEnd != null || _cachedBegin != null;
+    if (identical(oldWidget.tween, widget.tween)) {
+      if (_cachedBegin != null) {
+        widget.tween.begin = _cachedBegin;
+      }
+      if (_cachedEnd != null) {
+        widget.tween.end = _cachedEnd;
+      }
+    }
+    _cachedEnd = null;
+    _cachedBegin = null;
+
+    final bool tweenChanged = oldWidget.tween != widget.tween;
+
+    if (widget.gapless) {
+      _updateTween(currentAnimationValue);
+    }
+
+    if (!identical(oldWidget.tween, widget.tween) || oldWidget.curve != widget.curve) {
+      _updateAnimation();
+    }
+
+    if (_tweenIsAnimatable && (oldWidget.direction != widget.direction || tweenChanged)) {
+      _updateDirection();
+    }
+
+    final bool shouldHaveStatusListener = _cachedEnd != null || _cachedBegin != null;
+    if (hasStatusListener != shouldHaveStatusListener) {
+      if (hasStatusListener) {
+        _controller.removeStatusListener(_resetTweenWhenAnimationIsDone);
+      } else {
+        _controller.addStatusListener(_resetTweenWhenAnimationIsDone);
+      }
+    }
+  }
+
+  void _resetTweenWhenAnimationIsDone(AnimationStatus status) {
+    switch (status) {
+      case AnimationStatus.dismissed:
+        if (_cachedEnd != null) {
+          widget.tween.end = _cachedEnd;
+          _cachedEnd = null;
+        }
+        break;
+      case AnimationStatus.completed:
+        if (_cachedBegin != null) {
+          widget.tween.begin = _cachedBegin;
+          _cachedBegin = null;
+        }
+        break;
+      case AnimationStatus.forward:
+      case AnimationStatus.reverse:
+        // Nothing to do.
+        break;
+    }
+    if (_cachedEnd == null && _cachedBegin == null) {
+      _controller.removeStatusListener(_resetTweenWhenAnimationIsDone);
+    }
+  }
+
+  void _updateTween(T currentAnimationValue) {
+    assert(widget.gapless);
+    switch (widget.direction) {
+      case PlaybackDirection.repeatReverse:
+      // Ideally, we would set begin to the currentValue when the animation
+      // is running forward, and end to the currentValue when the animation
+      // is running in reverse. However, since [AnimationController.repeat]
+      // starts a simulation and simulations always run forward,
+      // we cannot differentiate between the two cases. Therefore, we just
+      // fallthrough here to the forward case.
+      case PlaybackDirection.repeat:
+      case PlaybackDirection.forward:
+        if (widget.tween.begin != currentAnimationValue) {
+          assert(_cachedBegin == null);
+          _cachedBegin = widget.tween.begin;
+          widget.tween.begin = currentAnimationValue;
+          _controller.value = 0.0;
+        }
+        break;
+      case PlaybackDirection.reverse:
+        if (widget.tween.end != currentAnimationValue) {
+          assert(_cachedEnd == null);
+          _cachedEnd = widget.tween.end;
+          widget.tween.end = currentAnimationValue;
+          _controller.value = 1.0;
+        }
+        break;
+    }
+  }
+
+  void _updateAnimation() {
+    _animation = widget.tween.chain(CurveTween(curve: widget.curve)).animate(_controller);
+  }
+
+  void _updateDirection() {
+    assert(_tweenIsAnimatable);
+    switch (widget.direction) {
+      case PlaybackDirection.forward:
+        _controller.value = 0.0;
+        _controller.forward();
+        break;
+      case PlaybackDirection.reverse:
+        _controller.value = 1.0;
+        _controller.reverse();
+        break;
+      case PlaybackDirection.repeat:
+        _controller.value = 0.0;
+        _controller.repeat();
+        break;
+      case PlaybackDirection.repeatReverse:
+        _controller.value = 0.0;
+        _controller.repeat(reverse: true);
+        break;
+    }
+  }
+
+  bool get _tweenIsAnimatable => widget.tween.begin != widget.tween.end;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _animation.value, widget.child);
+  }
+}

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -167,6 +167,7 @@ class _TweenAnimationBuilderState<T> extends AnimatedWidgetBaseState<TweenAnimat
       'Tween provided to TweenAnimationBuilder must have non-null Tween.end value.',
     );
     _currentTween = visitor(_currentTween, widget.tween.end, (dynamic value) {
+      // Constructor will never be called because null is never provided as current tween.
       assert(false);
       return null;
     });

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -2,13 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'package:flutter/animation.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 
 import 'framework.dart';
-
+import 'implicit_animations.dart';
 
 /// Builder callback for [TweenAnimationBuilder].
 ///

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -42,8 +42,9 @@ typedef TweenAnimationBuilderCallback<T> = Widget Function(BuildContext context,
 ///
 /// {@tool snippet --template=stateful_widget_scaffold}
 /// This example shows an [IconButton] that "zooms" in when the widget first
-/// builds (its size smoothly increases from 0 to 24). Whenever the button
-/// is pressed, it smoothly changes it size from 24 to 48 or vice versa.
+/// builds (its size smoothly increases from 0 to 24) and whenever the button
+/// is pressed, it smoothly changes its size to the new target value of either
+/// 48 or 24).
 ///
 /// ```dart
 /// double targetValue = 24.0;

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -29,16 +29,22 @@ import 'value_listenable_builder.dart';
 /// current animation value. The [builder] is called throughout the animation
 /// for every animation value until [Tween.end] is reached.
 ///
-/// If the [builder] callback's return value contains a subtree that does not
-/// depend on the animation, it's more efficient to build that subtree once
-/// instead of rebuilding it on every animation tick. Such a pre-built subtree
-/// can be provided to the [TweenAnimationBuilder] via the [child] property
-/// and it will pass it back to the [builder] function so that it can be
-/// incorporated into the build.
-///
 /// A provided [onEnd] callback is called whenever an animation completes.
 /// Registering an [onEnd] callback my be useful to trigger an action (like
 /// another animation) at the end of the current animation.
+///
+/// ## Performance optimizations
+///
+/// If your [builder] function contains a subtree that does not depend on the
+/// animation, it's more efficient to build that subtree once instead of
+/// rebuilding it on every animation tick.
+///
+/// If you pass the pre-built subtree as the [child] parameter, the
+/// AnimatedBuilder will pass it back to your builder function so that you
+/// can incorporate it into your build.
+///
+/// Using this pre-built child is entirely optional, but can improve
+/// performance significantly in some cases and is therefore a good practice.
 ///
 /// ## Ownership of the [Tween]
 ///
@@ -87,12 +93,26 @@ import 'value_listenable_builder.dart';
 /// ```
 /// {@end-tool}
 ///
-/// See also:
+/// ## Relationship to [ImplicitlyAnimatedWidget]s and [AnimatedWidget]s
 ///
-///  * [AnimatedBuilder], which builds custom animations that are controlled
-///    by a manually managed [AnimationController].
-///  * [ImplicitlyAnimatedWidget], which is a base class for [Widget]s that
-///    automatically animate any changes to their property values.
+/// The [ImplicitlyAnimatedWidget] has many subclasses that provide animated
+/// versions of regular widgets. These subclasses (like [AnimatedOpacity],
+/// [AnimatedContainer], [AnimatedSize], etc.) animate changes in their
+/// properties smoothly and they are easier to use than this general-purpose
+/// builder. However, [TweenAnimationBuilder] (which itself is a subclass of
+/// [ImplicitlyAnimatedWidget]) is handy for animating any widget property to a
+/// given target value even when the framework (or third-party widget library)
+/// doesn't ship with an animated version of that widget.
+///
+/// Those [ImplicitlyAnimatedWidget]s (including this [TweenAnimationBuilder])
+/// all manage an internal [AnimationController] to drive the animation. If you
+/// want more control over the animation than just setting a target value,
+/// [duration], and [curve], have a look at (subclasses of) [AnimatedWidget]s.
+/// For those, you have to manually manage an [AnimationController] giving you
+/// full control over the animation. An example of an [AnimatedWidget] is the
+/// [AnimatedBuilder], which can be used similarly to this
+/// [TweenAnimationBuilder], but unlike the latter it is powered by a
+/// developer-managed [AnimationController].
 class TweenAnimationBuilder<T> extends ImplicitlyAnimatedWidget {
   /// Creates a [TweenAnimationBuilder].
   ///

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -44,7 +44,7 @@ typedef TweenAnimationBuilderCallback<T> = Widget Function(BuildContext context,
 /// This example shows an [IconButton] that "zooms" in when the widget first
 /// builds (its size smoothly increases from 0 to 24) and whenever the button
 /// is pressed, it smoothly changes its size to the new target value of either
-/// 48 or 24).
+/// 48 or 24.
 ///
 /// ```dart
 /// double targetValue = 24.0;

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -43,6 +43,39 @@ typedef TweenAnimationBuilderCallback<T> = Widget Function(BuildContext context,
 /// animation. Registering an [animationStatusListener] may be useful to trigger
 /// an action (like another animation) at the end of the current animation.
 ///
+/// {@tool snippet --template=stateful_widget_scaffold}
+/// This example shows an [IconButton] that "zooms" in when the widget first
+/// builds (its size smoothly increases from 0 to 24). Whenever the button
+/// is pressed, it smoothly changes it size from 24 to 48 or vice versa.
+///
+/// ```dart
+/// double targetValue = 24.0;
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: TweenAnimationBuilder(
+///       tween: Tween<double>(begin: 0, end: targetValue),
+///       duration: Duration(seconds: 1),
+///       builder: (BuildContext context, double size, Widget child) {
+///         return IconButton(
+///           iconSize: size,
+///           color: Colors.blue,
+///           icon: child,
+///           onPressed: () {
+///             setState(() {
+///               targetValue = targetValue == 24.0 ? 48.0 : 24.0;
+///             });
+///           },
+///         );
+///       },
+///       child: Icon(Icons.aspect_ratio),
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [AnimatedBuilder], which builds custom animations that are controlled

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -105,6 +105,7 @@ export 'src/widgets/texture.dart';
 export 'src/widgets/ticker_provider.dart';
 export 'src/widgets/title.dart';
 export 'src/widgets/transitions.dart';
+export 'src/widgets/tween_animation_builder.dart';
 export 'src/widgets/unique_widget.dart';
 export 'src/widgets/value_listenable_builder.dart';
 export 'src/widgets/viewport.dart';

--- a/packages/flutter/test/widgets/tween_animation_builder.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder.dart
@@ -1,0 +1,746 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('Animates forward when built', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    await tester.pumpWidget(
+      TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        tween: IntTween(begin: 10, end: 110),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+        animationStatusListener: (AnimationStatus status) {
+          statuses.add(status);
+        },
+      ),
+    );
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(values, <int>[10]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[10, 60]);
+
+    await tester.pump(const Duration(milliseconds: 501));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
+    expect(values, <int>[10, 60, 110]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
+    expect(values, <int>[10, 60, 110]);
+  });
+
+  testWidgets('Animates backwards when built', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    await tester.pumpWidget(
+      TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        direction: PlaybackDirection.reverse,
+        tween: IntTween(begin: 10, end: 110),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+        animationStatusListener: (AnimationStatus status) {
+          statuses.add(status);
+        },
+      ),
+    );
+    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse]);
+    expect(values, <int>[110]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[110, 60]);
+
+    await tester.pump(const Duration(milliseconds: 501));
+    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse, AnimationStatus.dismissed]);
+    expect(values, <int>[110, 60, 10]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse, AnimationStatus.dismissed]);
+    expect(values, <int>[110, 60, 10]);
+  });
+
+  testWidgets('Repeats animation', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    await tester.pumpWidget(
+      TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        direction: PlaybackDirection.repeat,
+        tween: IntTween(begin: 10, end: 110),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+        animationStatusListener: (AnimationStatus status) {
+          statuses.add(status);
+        },
+      ),
+    );
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(values, <int>[10]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[10, 60]);
+
+    await tester.pump(const Duration(milliseconds: 499));
+    expect(values, <int>[10, 60, 110]);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(values, <int>[10, 60, 110, 10]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(values, <int>[10, 60, 110, 10, 60]);
+  });
+
+  testWidgets('Repeats animation reversed', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    await tester.pumpWidget(
+      TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        direction: PlaybackDirection.repeatReverse,
+        tween: IntTween(begin: 10, end: 110),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+        animationStatusListener: (AnimationStatus status) {
+          statuses.add(status);
+        },
+      ),
+    );
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(values, <int>[10]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[10, 60]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[10, 60, 110]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[10, 60, 110, 60]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(values, <int>[10, 60, 110, 60, 10]);
+  });
+
+  testWidgets('Replace tween animates new tween', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({IntTween tween}) {
+      return TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        tween: tween,
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100)));
+    expect(values, <int>[0]);
+    await tester.pump(const Duration(seconds: 2)); // finish first animation.
+    expect(values, <int>[0, 100]);
+
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200)));
+    expect(values, <int>[0, 100, 100]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[0, 100, 100, 150]);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[0, 100, 100, 150, 200]);
+  });
+
+  testWidgets('Curve is respected', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({IntTween tween, Curve curve}) {
+      return TweenAnimationBuilder<int>(
+        duration: const Duration(seconds: 1),
+        tween: tween,
+        curve: curve,
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100), curve: Curves.easeInExpo));
+    expect(values, <int>[0]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values.last, lessThan(50));
+    expect(values.last, greaterThan(0));
+
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+
+    values.clear();
+    // Update curve (and tween to re-trigger animation).
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200), curve: Curves.linear));
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[100, 150]);
+  });
+
+  testWidgets('Duration is respected', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({IntTween tween, Duration duration}) {
+      return TweenAnimationBuilder<int>(
+        tween: tween,
+        duration: duration,
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100), duration: const Duration(seconds: 1)));
+    expect(values, <int>[0]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[0, 50]);
+
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+
+    values.clear();
+    // Update duration (and tween to re-trigger animation).
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200), duration: const Duration(seconds: 2)));
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[100, 125]);
+  });
+
+  testWidgets('Direction changes trigger animation', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({PlaybackDirection direction}) {
+      return TweenAnimationBuilder<int>(
+        tween: IntTween(begin: 0, end: 100),
+        direction: direction,
+        duration: const Duration(seconds: 1),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.forward));
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+    expect(values, <int>[0, 100]);
+
+    values.clear();
+    // Update duration (and tween to re-trigger animation).
+    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.reverse));
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+    expect(values, <int>[100, 0]);
+  });
+
+  testWidgets('animationStatusListener can be changed', (WidgetTester tester) async {
+    Widget buildWidget({PlaybackDirection direction, AnimationStatusListener listener}) {
+      return TweenAnimationBuilder<int>(
+        tween: IntTween(begin: 0, end: 100),
+        direction: direction,
+        duration: const Duration(seconds: 1),
+        animationStatusListener: listener,
+        builder: (BuildContext context, int i, Widget child) {
+          return const Placeholder();
+        },
+      );
+    }
+
+    final List<AnimationStatus> listener1 = <AnimationStatus>[];
+    final List<AnimationStatus> listener2 = <AnimationStatus>[];
+    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.forward, listener: (AnimationStatus s) {
+      listener1.add(s);
+    }));
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+    expect(listener1, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
+    expect(listener2, isEmpty);
+
+    listener1.clear();
+    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.reverse, listener: (AnimationStatus s) {
+      listener2.add(s);
+    }));
+    await tester.pump(const Duration(seconds: 2)); // finish animation.
+    expect(listener1, isEmpty);
+    expect(listener2, <AnimationStatus>[AnimationStatus.reverse, AnimationStatus.dismissed]);
+  });
+
+  testWidgets('Child is integrated into tree', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TweenAnimationBuilder<int>(
+          tween: IntTween(begin: 0, end: 100),
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            return child;
+          },
+          child: const Text('Hello World'),
+        ),
+      ),
+    );
+
+    expect(find.text('Hello World'), findsOneWidget);
+  });
+
+  group('Change tween gapless while', () {
+    testWidgets('running forward', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: direction ?? PlaybackDirection.forward,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 0, end: 100),
+      ));
+      expect(values, <int>[0]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[0, 50]);
+
+      // Change tween
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+      ));
+      expect(values, <int>[0, 50, 50]); // gapless: animation continues where it left off.
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[0, 50, 50, 175]); // 175 = halfway between 50 and new target 300.
+
+      // Run animation to end
+      await tester.pump(const Duration(seconds: 2));
+      expect(values, <int>[0, 50, 50, 175, 300]);
+      values.clear();
+
+      // Run animation back to beginning
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+        direction: PlaybackDirection.reverse,
+      ));
+      expect(values, <int>[300]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[300, 250]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[300, 250, 200]);
+    });
+
+    testWidgets('running forward and then reverse with same tween instance', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: direction ?? PlaybackDirection.forward,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      final IntTween tween1 = IntTween(begin: 0, end: 100);
+      final IntTween tween2 = IntTween(begin: 200, end: 300);
+
+      await tester.pumpWidget(buildWidget(
+        tween: tween1,
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpWidget(buildWidget(
+        tween: tween2,
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(seconds: 2));
+      expect(values, <int>[0, 50, 50, 175, 300]);
+      values.clear();
+
+      // Run animation back to beginning
+      await tester.pumpWidget(buildWidget(
+        tween: tween2,
+        direction: PlaybackDirection.reverse,
+      ));
+      expect(values, <int>[300]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[300, 250]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[300, 250, 200]);
+    });
+
+    testWidgets('running reverse', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: direction ?? PlaybackDirection.reverse,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 0, end: 100),
+      ));
+      expect(values, <int>[100]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[100, 50]);
+
+      // Change tween
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+      ));
+      expect(values, <int>[100, 50, 50]); // gapless: animation continues where it left off.
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[100, 50, 50, 125]); // 175 = halfway between 50 and new target 200.
+
+      // Run animation to end
+      await tester.pump(const Duration(seconds: 2));
+      expect(values, <int>[100, 50, 50, 125, 200]);
+      values.clear();
+
+      // Run animation forward to end
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+        direction: PlaybackDirection.forward,
+      ));
+      expect(values, <int>[200]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[200, 250]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[200, 250, 300]);
+    });
+
+    testWidgets('running reverse and then forward with same tween instance', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: direction ?? PlaybackDirection.reverse,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      final IntTween tween1 = IntTween(begin: 0, end: 100);
+      final IntTween tween2 = IntTween(begin: 200, end: 300);
+
+      await tester.pumpWidget(buildWidget(
+        tween: tween1,
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpWidget(buildWidget(
+        tween: tween2,
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(seconds: 2));
+      expect(values, <int>[100, 50, 50, 125, 200]);
+      values.clear();
+
+      // Run animation back to beginning
+      await tester.pumpWidget(buildWidget(
+        tween: tween2,
+        direction: PlaybackDirection.forward,
+      ));
+      expect(values, <int>[200]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[200, 250]);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[200, 250, 300]);
+    });
+
+    testWidgets('running repeat', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: PlaybackDirection.repeat,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 0, end: 100),
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 499));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 999));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[0, 50, 100, 0, 100, 0, 50]);
+      values.clear();
+
+      // Change tween
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+      ));
+      expect(values, <int>[50]); // gapless: animation continues where it left off.
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175]); // 175 = halfway between 50 and new target 200.
+      await tester.pump(const Duration(milliseconds: 499));
+      expect(values, <int>[50, 175, 300]);
+      values.clear();
+
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(values, <int>[200]);
+      await tester.pump(const Duration(milliseconds: 999));
+      expect(values, <int>[200, 300]);
+    });
+
+    testWidgets('running repeatReverse (replaced while runnign forward)', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: PlaybackDirection.repeatReverse,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 0, end: 100),
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[0, 50, 100, 50, 0, 50]);
+      values.clear();
+
+      // Change tween
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+      ));
+      expect(values, <int>[50]); // gapless: animation continues where it left off.
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175]); // 175 = halfway between 50 and new target 200.
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175, 300]);
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175, 300, 250, 200]);
+    });
+
+    testWidgets('running repeatReverse (replaced while runnign reverse)', (WidgetTester tester) async {
+      final List<int> values = <int>[];
+      Widget buildWidget({IntTween tween}) {
+        return TweenAnimationBuilder<int>(
+          tween: tween,
+          direction: PlaybackDirection.repeatReverse,
+          duration: const Duration(seconds: 1),
+          builder: (BuildContext context, int i, Widget child) {
+            values.add(i);
+            return const Placeholder();
+          },
+          animationStatusListener: (AnimationStatus s) {
+            print(s);
+          },
+        );
+      }
+
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 0, end: 100),
+      ));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[0, 50, 100, 50]);
+      values.clear();
+
+      // Change tween
+      await tester.pumpWidget(buildWidget(
+        tween: IntTween(begin: 200, end: 300),
+      ));
+      expect(values, <int>[50]); // gapless: animation continues where it left off.
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175]); // 125 = halfway between 50 and new target 300.
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175, 300]);
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(values, <int>[50, 175, 300, 250, 200]);
+    });
+  });
+
+  testWidgets('Changing direction while gapless tween change is in progress', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+      return TweenAnimationBuilder<int>(
+        tween: tween,
+        direction: direction,
+        duration: const Duration(seconds: 1),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    final IntTween tween1 = IntTween(begin: 0, end: 100);
+    final IntTween tween2 = IntTween(begin: 200, end: 300);
+
+    await tester.pumpWidget(buildWidget(
+      tween: tween1,
+      direction: PlaybackDirection.forward,
+    ));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[0, 50]);
+    values.clear();
+
+    // Change tween
+    await tester.pumpWidget(buildWidget(
+      tween: tween2,
+      direction: PlaybackDirection.forward,
+    ));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[50, 175]);
+    values.clear();
+
+    await tester.pumpWidget(buildWidget(
+      tween: tween2,
+      direction: PlaybackDirection.reverse,
+    ));
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[175, 200]);
+  });
+
+  testWidgets('Changing direction while gapless tween change is in progress (reverse)', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+      return TweenAnimationBuilder<int>(
+        tween: tween,
+        direction: direction,
+        duration: const Duration(seconds: 1),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    final IntTween tween1 = IntTween(begin: 0, end: 100);
+    final IntTween tween2 = IntTween(begin: 200, end: 300);
+
+    await tester.pumpWidget(buildWidget(
+      tween: tween1,
+      direction: PlaybackDirection.reverse,
+    ));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[100, 50]);
+    values.clear();
+
+    // Change tween
+    await tester.pumpWidget(buildWidget(
+      tween: tween2,
+      direction: PlaybackDirection.reverse,
+    ));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[50, 125]);
+    values.clear();
+
+    await tester.pumpWidget(buildWidget(
+      tween: tween2,
+      direction: PlaybackDirection.forward,
+    ));
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[125, 300]);
+  });
+
+  testWidgets('Changing curve while no animation is running does not trigger animation', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({Curve curve}) {
+      return TweenAnimationBuilder<int>(
+        tween: IntTween(begin: 0, end: 100),
+        curve: curve,
+        duration: const Duration(seconds: 1),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(
+      curve: Curves.linear,
+    ));
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[0, 100]);
+    values.clear();
+
+    await tester.pumpWidget(buildWidget(
+      curve: Curves.easeInExpo,
+    ));
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[100]);
+  });
+
+  testWidgets('Changed curve while animating gaplessly is respected', (WidgetTester tester) async {
+    final List<int> values = <int>[];
+    Widget buildWidget({Curve curve}) {
+      return TweenAnimationBuilder<int>(
+        tween: IntTween(begin: 0, end: 100),
+        curve: curve,
+        duration: const Duration(seconds: 1),
+        builder: (BuildContext context, int i, Widget child) {
+          values.add(i);
+          return const Placeholder();
+        },
+      );
+    }
+
+    await tester.pumpWidget(buildWidget(
+      curve: Curves.linear,
+    ));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[0, 50]);
+    values.clear();
+
+    await tester.pumpWidget(buildWidget(
+      curve: Curves.easeInExpo,
+    ));
+    expect(values, <int>[50]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, hasLength(2));
+    expect(values.last, greaterThan(50));
+    expect(values.last, lessThan(75));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, hasLength(3));
+    expect(values.last, 100);
+  });
+}

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -135,6 +135,11 @@ void main() {
     await tester.pump(const Duration(seconds: 2)); // finish animation.
 
     values.clear();
+    // Update curve (and tween to re-trigger animation).
+    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200), curve: Curves.linear));
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[100, 150]);
   });
 
   testWidgets('Duration is respected', (WidgetTester tester) async {
@@ -316,40 +321,6 @@ void main() {
     expect(values, <int>[100]);
     await tester.pump(const Duration(seconds: 2));
     expect(values, <int>[100]);
-  });
-
-  testWidgets('Changed curve while animating gaplessly is respected', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    Widget buildWidget({Curve curve}) {
-      return TweenAnimationBuilder<int>(
-        tween: IntTween(begin: 0, end: 100),
-        curve: curve,
-        duration: const Duration(seconds: 1),
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-      );
-    }
-
-    await tester.pumpWidget(buildWidget(
-      curve: Curves.linear,
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50]);
-    values.clear();
-
-    await tester.pumpWidget(buildWidget(
-      curve: Curves.easeInExpo,
-    ));
-    expect(values, <int>[50]);
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, hasLength(2));
-    expect(values.last, greaterThan(50));
-    expect(values.last, lessThan(75));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, hasLength(3));
-    expect(values.last, 100);
   });
 
   testWidgets('Setting same tween and direction does not trigger animation', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -135,11 +135,6 @@ void main() {
     await tester.pump(const Duration(seconds: 2)); // finish animation.
 
     values.clear();
-    // Update curve (and tween to re-trigger animation).
-    await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200), curve: Curves.linear));
-    expect(values, <int>[100]);
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[100, 150]);
   });
 
   testWidgets('Duration is respected', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -37,14 +37,13 @@ void main() {
     expect(values, <int>[10, 60, 110]);
   });
 
-  testWidgets('Animates backwards when built', (WidgetTester tester) async {
+  testWidgets('No initial animation when begin=null', (WidgetTester tester) async {
     final List<int> values = <int>[];
     final List<AnimationStatus> statuses = <AnimationStatus>[];
     await tester.pumpWidget(
       TweenAnimationBuilder<int>(
         duration: const Duration(seconds: 1),
-        direction: PlaybackDirection.reverse,
-        tween: IntTween(begin: 10, end: 110),
+        tween: IntTween(end: 100),
         builder: (BuildContext context, int i, Widget child) {
           values.add(i);
           return const Placeholder();
@@ -54,29 +53,20 @@ void main() {
         },
       ),
     );
-    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse]);
-    expect(values, <int>[110]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[110, 60]);
-
-    await tester.pump(const Duration(milliseconds: 501));
-    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse, AnimationStatus.dismissed]);
-    expect(values, <int>[110, 60, 10]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(statuses, <AnimationStatus>[AnimationStatus.completed, AnimationStatus.reverse, AnimationStatus.dismissed]);
-    expect(values, <int>[110, 60, 10]);
+    expect(statuses, <AnimationStatus>[]);
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[100]);
   });
 
-  testWidgets('Repeats animation', (WidgetTester tester) async {
+
+  testWidgets('No initial animation when begin=end', (WidgetTester tester) async {
     final List<int> values = <int>[];
     final List<AnimationStatus> statuses = <AnimationStatus>[];
     await tester.pumpWidget(
       TweenAnimationBuilder<int>(
         duration: const Duration(seconds: 1),
-        direction: PlaybackDirection.repeat,
-        tween: IntTween(begin: 10, end: 110),
+        tween: IntTween(begin: 100, end: 100),
         builder: (BuildContext context, int i, Widget child) {
           values.add(i);
           return const Placeholder();
@@ -86,55 +76,10 @@ void main() {
         },
       ),
     );
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
-    expect(values, <int>[10]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[10, 60]);
-
-    await tester.pump(const Duration(milliseconds: 499));
-    expect(values, <int>[10, 60, 110]);
-
-    await tester.pump(const Duration(milliseconds: 1));
-    expect(values, <int>[10, 60, 110, 10]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
-    expect(values, <int>[10, 60, 110, 10, 60]);
-  });
-
-  testWidgets('Repeats animation reversed', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    final List<AnimationStatus> statuses = <AnimationStatus>[];
-    await tester.pumpWidget(
-      TweenAnimationBuilder<int>(
-        duration: const Duration(seconds: 1),
-        direction: PlaybackDirection.repeatReverse,
-        tween: IntTween(begin: 10, end: 110),
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-        animationStatusListener: (AnimationStatus status) {
-          statuses.add(status);
-        },
-      ),
-    );
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
-    expect(values, <int>[10]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[10, 60]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[10, 60, 110]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[10, 60, 110, 60]);
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
-    expect(values, <int>[10, 60, 110, 60, 10]);
+    expect(statuses, <AnimationStatus>[]);
+    expect(values, <int>[100]);
+    await tester.pump(const Duration(seconds: 2));
+    expect(values, <int>[100]);
   });
 
   testWidgets('Replace tween animates new tween', (WidgetTester tester) async {
@@ -223,62 +168,6 @@ void main() {
     expect(values, <int>[100, 125]);
   });
 
-  testWidgets('Direction changes trigger animation', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    Widget buildWidget({PlaybackDirection direction}) {
-      return TweenAnimationBuilder<int>(
-        tween: IntTween(begin: 0, end: 100),
-        direction: direction,
-        duration: const Duration(seconds: 1),
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-      );
-    }
-
-    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.forward));
-    await tester.pump(const Duration(seconds: 2)); // finish animation.
-    expect(values, <int>[0, 100]);
-
-    values.clear();
-    // Update duration (and tween to re-trigger animation).
-    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.reverse));
-    await tester.pump(const Duration(seconds: 2)); // finish animation.
-    expect(values, <int>[100, 0]);
-  });
-
-  testWidgets('animationStatusListener can be changed', (WidgetTester tester) async {
-    Widget buildWidget({PlaybackDirection direction, AnimationStatusListener listener}) {
-      return TweenAnimationBuilder<int>(
-        tween: IntTween(begin: 0, end: 100),
-        direction: direction,
-        duration: const Duration(seconds: 1),
-        animationStatusListener: listener,
-        builder: (BuildContext context, int i, Widget child) {
-          return const Placeholder();
-        },
-      );
-    }
-
-    final List<AnimationStatus> listener1 = <AnimationStatus>[];
-    final List<AnimationStatus> listener2 = <AnimationStatus>[];
-    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.forward, listener: (AnimationStatus s) {
-      listener1.add(s);
-    }));
-    await tester.pump(const Duration(seconds: 2)); // finish animation.
-    expect(listener1, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
-    expect(listener2, isEmpty);
-
-    listener1.clear();
-    await tester.pumpWidget(buildWidget(direction: PlaybackDirection.reverse, listener: (AnimationStatus s) {
-      listener2.add(s);
-    }));
-    await tester.pump(const Duration(seconds: 2)); // finish animation.
-    expect(listener1, isEmpty);
-    expect(listener2, <AnimationStatus>[AnimationStatus.reverse, AnimationStatus.dismissed]);
-  });
-
   testWidgets('Child is integrated into tree', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
@@ -300,10 +189,9 @@ void main() {
   group('Change tween gapless while', () {
     testWidgets('running forward', (WidgetTester tester) async {
       final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+      Widget buildWidget({IntTween tween}) {
         return TweenAnimationBuilder<int>(
           tween: tween,
-          direction: direction ?? PlaybackDirection.forward,
           duration: const Duration(seconds: 1),
           builder: (BuildContext context, int i, Widget child) {
             values.add(i);
@@ -332,25 +220,13 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
       expect(values, <int>[0, 50, 50, 175, 300]);
       values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-        direction: PlaybackDirection.reverse,
-      ));
-      expect(values, <int>[300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250, 200]);
     });
 
     testWidgets('running forward and then reverse with same tween instance', (WidgetTester tester) async {
       final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
+      Widget buildWidget({IntTween tween}) {
         return TweenAnimationBuilder<int>(
           tween: tween,
-          direction: direction ?? PlaybackDirection.forward,
           duration: const Duration(seconds: 1),
           builder: (BuildContext context, int i, Widget child) {
             values.add(i);
@@ -373,317 +249,7 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
       expect(values, <int>[0, 50, 50, 175, 300]);
       values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-        direction: PlaybackDirection.reverse,
-      ));
-      expect(values, <int>[300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250, 200]);
     });
-
-    testWidgets('running reverse', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          direction: direction ?? PlaybackDirection.reverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      expect(values, <int>[100]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[100, 50]);
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[100, 50, 50]); // gapless: animation continues where it left off.
-
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[100, 50, 50, 125]); // 175 = halfway between 50 and new target 200.
-
-      // Run animation to end
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[100, 50, 50, 125, 200]);
-      values.clear();
-
-      // Run animation forward to end
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-        direction: PlaybackDirection.forward,
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-    });
-
-    testWidgets('running reverse and then forward with same tween instance', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          direction: direction ?? PlaybackDirection.reverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      final IntTween tween1 = IntTween(begin: 0, end: 100);
-      final IntTween tween2 = IntTween(begin: 200, end: 300);
-
-      await tester.pumpWidget(buildWidget(
-        tween: tween1,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[100, 50, 50, 125, 200]);
-      values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-        direction: PlaybackDirection.forward,
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-    });
-
-    testWidgets('running repeat', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          direction: PlaybackDirection.repeat,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 499));
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 999));
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 0, 100, 0, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[50]); // gapless: animation continues where it left off.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 175]); // 175 = halfway between 50 and new target 200.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 175, 300]);
-      values.clear();
-      await tester.pump(const Duration(milliseconds: 1));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 999));
-      expect(values, <int>[200, 300]);
-    });
-
-    testWidgets('running repeatReverse (replaced while runnign forward)', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          direction: PlaybackDirection.repeatReverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 50, 0, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[50]); // gapless: animation continues where it left off.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 125]); // 125 = halfway between 50 and new target 200.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 125, 200]);
-      values.clear();
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 999));
-      expect(values, <int>[200, 250, 300, 200]);
-    });
-
-    testWidgets('running repeatReverse (replaced while runnign reverse)', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          direction: PlaybackDirection.repeatReverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-          animationStatusListener: (AnimationStatus s) {
-            print(s);
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[50]); // gapless: animation continues where it left off.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 125]); // 125 = halfway between 50 and new target 200.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[50, 125, 200]);
-      values.clear();
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 999));
-      expect(values, <int>[200, 250, 300, 200]);
-    });
-  });
-
-  testWidgets('Changing direction while gapless tween change is in progress', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-      return TweenAnimationBuilder<int>(
-        tween: tween,
-        direction: direction,
-        duration: const Duration(seconds: 1),
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-      );
-    }
-
-    final IntTween tween1 = IntTween(begin: 0, end: 100);
-    final IntTween tween2 = IntTween(begin: 200, end: 300);
-
-    await tester.pumpWidget(buildWidget(
-      tween: tween1,
-      direction: PlaybackDirection.forward,
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50]);
-    values.clear();
-
-    // Change tween
-    await tester.pumpWidget(buildWidget(
-      tween: tween2,
-      direction: PlaybackDirection.forward,
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[50, 175]);
-    values.clear();
-
-    await tester.pumpWidget(buildWidget(
-      tween: tween2,
-      direction: PlaybackDirection.reverse,
-    ));
-    await tester.pump(const Duration(seconds: 2));
-    expect(values, <int>[175, 200]);
-  });
-
-  testWidgets('Changing direction while gapless tween change is in progress (reverse)', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-      return TweenAnimationBuilder<int>(
-        tween: tween,
-        direction: direction,
-        duration: const Duration(seconds: 1),
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-      );
-    }
-
-    final IntTween tween1 = IntTween(begin: 0, end: 100);
-    final IntTween tween2 = IntTween(begin: 200, end: 300);
-
-    await tester.pumpWidget(buildWidget(
-      tween: tween1,
-      direction: PlaybackDirection.reverse,
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[100, 50]);
-    values.clear();
-
-    // Change tween
-    await tester.pumpWidget(buildWidget(
-      tween: tween2,
-      direction: PlaybackDirection.reverse,
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[50, 125]);
-    values.clear();
-
-    await tester.pumpWidget(buildWidget(
-      tween: tween2,
-      direction: PlaybackDirection.forward,
-    ));
-    await tester.pump(const Duration(seconds: 2));
-    expect(values, <int>[125, 300]);
   });
 
   testWidgets('Changing tween while gapless tween change is in progress', (WidgetTester tester) async {
@@ -791,10 +357,9 @@ void main() {
 
   testWidgets('Setting same tween and direction does not trigger animation', (WidgetTester tester) async {
     final List<int> values = <int>[];
-    Widget buildWidget({PlaybackDirection direction, IntTween tween}) {
+    Widget buildWidget({IntTween tween}) {
       return TweenAnimationBuilder<int>(
         tween: tween,
-        direction: direction,
         duration: const Duration(seconds: 1),
         builder: (BuildContext context, int i, Widget child) {
           values.add(i);
@@ -804,7 +369,6 @@ void main() {
     }
 
     await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
       tween: IntTween(begin: 0, end: 100),
     ));
     await tester.pump(const Duration(milliseconds: 500));
@@ -813,53 +377,18 @@ void main() {
     values.clear();
 
     await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
       tween: IntTween(begin: 0, end: 100),
     ));
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, everyElement(100));
-  });
-
-  testWidgets('Setting same tween and direction does not trigger animation (gapless: false)', (WidgetTester tester) async {
-    final List<int> values = <int>[];
-    Widget buildWidget({PlaybackDirection direction, IntTween tween}) {
-      return TweenAnimationBuilder<int>(
-        tween: tween,
-        direction: direction,
-        duration: const Duration(seconds: 1),
-        gapless: false,
-        builder: (BuildContext context, int i, Widget child) {
-          values.add(i);
-          return const Placeholder();
-        },
-      );
-    }
-
-    await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
-      tween: IntTween(begin: 0, end: 100),
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    await tester.pump(const Duration(seconds: 2));
-    expect(values, <int>[0, 50, 100]);
-    values.clear();
-
-    await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
-      tween: IntTween(begin: 0, end: 100),
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    await tester.pump(const Duration(seconds: 2));
     expect(values, everyElement(100));
   });
 
   testWidgets('Setting same tween and direction while gapless animation is in progress works', (WidgetTester tester) async {
     final List<int> values = <int>[];
-    Widget buildWidget({PlaybackDirection direction, IntTween tween}) {
+    Widget buildWidget({IntTween tween}) {
       return TweenAnimationBuilder<int>(
         tween: tween,
-        direction: direction,
         duration: const Duration(seconds: 1),
         builder: (BuildContext context, int i, Widget child) {
           values.add(i);
@@ -869,20 +398,17 @@ void main() {
     }
 
     await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
       tween: IntTween(begin: 0, end: 100),
     ));
     await tester.pump(const Duration(milliseconds: 500));
     expect(values, <int>[0, 50]);
     await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
       tween: IntTween(begin: 200, end: 300),
     ));
     await tester.pump(const Duration(milliseconds: 500));
     expect(values, <int>[0, 50, 50, 175]);
 
     await tester.pumpWidget(buildWidget(
-      direction: PlaybackDirection.forward,
       tween: IntTween(begin: 200, end: 300),
     ));
     expect(values, <int>[0, 50, 50, 175, 175]);
@@ -892,309 +418,5 @@ void main() {
     values.clear();
     await tester.pump(const Duration(seconds: 2));
     expect(values, everyElement(300));
-  });
-
-  group('Change tween while', () {
-    testWidgets('running forward', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: direction ?? PlaybackDirection.forward,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      expect(values, <int>[0]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50]);
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[0, 50, 200]);
-
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 200, 250]);
-
-      // Run animation to end
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[0, 50, 200, 250, 300]);
-      values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-        direction: PlaybackDirection.reverse,
-      ));
-      expect(values, <int>[300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250, 200]);
-    });
-
-    testWidgets('running forward and then reverse with same tween instance', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: direction ?? PlaybackDirection.forward,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      final IntTween tween1 = IntTween(begin: 0, end: 100);
-      final IntTween tween2 = IntTween(begin: 200, end: 300);
-
-      await tester.pumpWidget(buildWidget(
-        tween: tween1,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[0, 50, 200, 250, 300]);
-      values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-        direction: PlaybackDirection.reverse,
-      ));
-      expect(values, <int>[300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[300, 250, 200]);
-    });
-
-    testWidgets('running reverse', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: direction ?? PlaybackDirection.reverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      expect(values, <int>[100]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[100, 50]);
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[100, 50, 300]);
-
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[100, 50, 300, 250]);
-
-      // Run animation to end
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[100, 50, 300, 250, 200]);
-      values.clear();
-
-      // Run animation forward to end
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-        direction: PlaybackDirection.forward,
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-    });
-
-    testWidgets('running reverse and then forward with same tween instance', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween, PlaybackDirection direction}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: direction ?? PlaybackDirection.reverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      final IntTween tween1 = IntTween(begin: 0, end: 100);
-      final IntTween tween2 = IntTween(begin: 200, end: 300);
-
-      await tester.pumpWidget(buildWidget(
-        tween: tween1,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[100, 50, 300, 250, 200]);
-      values.clear();
-
-      // Run animation back to beginning
-      await tester.pumpWidget(buildWidget(
-        tween: tween2,
-        direction: PlaybackDirection.forward,
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-    });
-
-    testWidgets('running repeat', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: PlaybackDirection.repeat,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 499));
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 999));
-      await tester.pump(const Duration(milliseconds: 1));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 0, 100, 0, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]); // 175 = halfway between 50 and new target 200.
-      await tester.pump(const Duration(milliseconds: 499));
-      expect(values, <int>[200, 250, 300]);
-      values.clear();
-
-      await tester.pump(const Duration(milliseconds: 1));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 999));
-      expect(values, <int>[200, 300]);
-    });
-
-    testWidgets('running repeatReverse (replaced while runnign forward)', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: PlaybackDirection.repeatReverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 50, 0, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300, 250, 200]);
-    });
-
-    testWidgets('running repeatReverse (replaced while runnign reverse)', (WidgetTester tester) async {
-      final List<int> values = <int>[];
-      Widget buildWidget({IntTween tween}) {
-        return TweenAnimationBuilder<int>(
-          tween: tween,
-          gapless: false,
-          direction: PlaybackDirection.repeatReverse,
-          duration: const Duration(seconds: 1),
-          builder: (BuildContext context, int i, Widget child) {
-            values.add(i);
-            return const Placeholder();
-          },
-        );
-      }
-
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 0, end: 100),
-      ));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 100, 50]);
-      values.clear();
-
-      // Change tween
-      await tester.pumpWidget(buildWidget(
-        tween: IntTween(begin: 200, end: 300),
-      ));
-      expect(values, <int>[200]);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250]); // 125 = halfway between 50 and new target 300.
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300]);
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[200, 250, 300, 250, 200]);
-    });
   });
 }

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 void main() {
   testWidgets('Animates forward when built', (WidgetTester tester) async {
     final List<int> values = <int>[];
-    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    int endCount = 0;
     await tester.pumpWidget(
       TweenAnimationBuilder<int>(
         duration: const Duration(seconds: 1),
@@ -17,29 +17,29 @@ void main() {
           values.add(i);
           return const Placeholder();
         },
-        animationStatusListener: (AnimationStatus status) {
-          statuses.add(status);
+        onEnd: () {
+          endCount++;
         },
       ),
     );
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    expect(endCount, 0);
     expect(values, <int>[10]);
 
     await tester.pump(const Duration(milliseconds: 500));
     expect(values, <int>[10, 60]);
 
     await tester.pump(const Duration(milliseconds: 501));
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
+    expect(endCount, 1);
     expect(values, <int>[10, 60, 110]);
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(statuses, <AnimationStatus>[AnimationStatus.forward, AnimationStatus.completed]);
+    expect(endCount, 1);
     expect(values, <int>[10, 60, 110]);
   });
 
   testWidgets('No initial animation when begin=null', (WidgetTester tester) async {
     final List<int> values = <int>[];
-    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    int endCount = 0;
     await tester.pumpWidget(
       TweenAnimationBuilder<int>(
         duration: const Duration(seconds: 1),
@@ -48,21 +48,22 @@ void main() {
           values.add(i);
           return const Placeholder();
         },
-        animationStatusListener: (AnimationStatus status) {
-          statuses.add(status);
+        onEnd: () {
+          endCount++;
         },
       ),
     );
-    expect(statuses, <AnimationStatus>[]);
+    expect(endCount, 0);
     expect(values, <int>[100]);
     await tester.pump(const Duration(seconds: 2));
+    expect(endCount, 0);
     expect(values, <int>[100]);
   });
 
 
   testWidgets('No initial animation when begin=end', (WidgetTester tester) async {
     final List<int> values = <int>[];
-    final List<AnimationStatus> statuses = <AnimationStatus>[];
+    int endCount = 0;
     await tester.pumpWidget(
       TweenAnimationBuilder<int>(
         duration: const Duration(seconds: 1),
@@ -71,14 +72,15 @@ void main() {
           values.add(i);
           return const Placeholder();
         },
-        animationStatusListener: (AnimationStatus status) {
-          statuses.add(status);
+        onEnd: () {
+          endCount++;
         },
       ),
     );
-    expect(statuses, <AnimationStatus>[]);
+    expect(endCount, 0);
     expect(values, <int>[100]);
     await tester.pump(const Duration(seconds: 2));
+    expect(endCount, 0);
     expect(values, <int>[100]);
   });
 


### PR DESCRIPTION
## Background

The framework ships with two types of animated widgets: FooTransition widgets (which have AnimatedWidget as base class) and AnimatedFoo widgets (which have ImplicitylAnimatedWidget as base class). The FooTransition widgets require developers to manually manage an AnimationController, which according to our user surveys some developers find cumbersome. The AnimatedFoo widgets do not require an AnimationController. They just implicitly animate to a set target value whenever that target vale changes. The framework ships with many subclasses of ImplicitylAnimatedWidget and AnimatedWidget for various use cases (e.g. AlignTransition, SizeTransition, AnimatedOpacity, AnimatedSize, etc.). For more complex use cases, the framework offers the AnimatedBuilder, which can be used to build complex custom animations. It is a subclass of AnimatedWidget and therefore requires that developers manually manage an AnimationController. The ImplicitylAnimatedWidget hierarchy currently does not offer a builder implementation to create custom animations without requiring the manual management of an AnimationController.

## Description

This PR adds a TweenAnimationBuilder, which is a builder for the ImplicitlyAnimatedWidget hierarchy: With TweenAnimationBuilder developers do not need to manage an AnimationController. Instead, they specify a target value for the animation and the TweenAnimationBuilder animates to that value. When you want to animate to a new value, you just set a new target value.

The type to animate (double, Rect, Color, etc) and the target value is specified as a Tween. When the widget first builds, it animates from Tween.begin to Tween.end. A new animation can be triggered at any time by setting a new Tween with a new Tween.end value. When that happens, the widget animates smoothly from the current animation value to the new target value. The builder callback is called for every animation value generated by the widget and it is expected to return a widget built with the current animation value.

This should simplify building custom animations as it only requires a target value for the animation. Driving the animation itself is handled internally by the widget.

## Tests

I added the following tests:

* Tests for the new widget

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
