### PR TITLE
refactor `flutter upgrade` to be 2 part, with the second part re-entrant

### DIFF
--- a/packages/flutter_tools/test/general.shard/commands/upgrade_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/upgrade_test.dart
@@ -17,7 +17,6 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 
 Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr = '' }) {
   final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(<List<int>>[
@@ -127,7 +126,8 @@ void main() {
         environment:anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory')),
       ).thenAnswer((Invocation invocation) async {
-        return FakeProcessResult();
+        return FakeProcessResult()
+          ..exitCode = 0;
       });
       await realCommandRunner.verifyUpstreamConfigured();
     }, overrides: <Type, Generator>{
@@ -219,3 +219,16 @@ class FakeUpgradeCommandRunner extends UpgradeCommandRunner {
 class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockProcess extends Mock implements Process {}
 class MockProcessManager extends Mock implements ProcessManager {}
+class FakeProcessResult implements ProcessResult {
+  @override
+  int exitCode;
+
+  @override
+  int pid = 0;
+
+  @override
+  String stderr = '';
+
+  @override
+  String stdout = '';
+}

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -592,8 +592,8 @@ class FakeProcessResult implements ProcessResult {
   FakeProcessResult({
     this.exitCode = 0,
     this.pid = 1,
-    this.stderr = '',
-    this.stdout = '',
+    this.stderr,
+    this.stdout,
   });
 
   @override
@@ -610,19 +610,4 @@ class FakeProcessResult implements ProcessResult {
 
   @override
   String toString() => stdout?.toString() ?? stderr?.toString() ?? runtimeType.toString();
-}
-
-Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr = '' }) {
-  final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(<List<int>>[
-    utf8.encode(stdout),
-  ]);
-  final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(<List<int>>[
-    utf8.encode(stderr),
-  ]);
-  final Process process = MockProcess();
-
-  when(process.stdout).thenAnswer((_) => stdoutStream);
-  when(process.stderr).thenAnswer((_) => stderrStream);
-  when(process.exitCode).thenAnswer((_) => Future<int>.value(exitCode));
-  return process;
 }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -592,8 +592,8 @@ class FakeProcessResult implements ProcessResult {
   FakeProcessResult({
     this.exitCode = 0,
     this.pid = 1,
-    this.stderr,
-    this.stdout,
+    this.stderr = '',
+    this.stdout = '',
   });
 
   @override
@@ -610,4 +610,19 @@ class FakeProcessResult implements ProcessResult {
 
   @override
   String toString() => stdout?.toString() ?? stderr?.toString() ?? runtimeType.toString();
+}
+
+Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr = '' }) {
+  final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(<List<int>>[
+    utf8.encode(stdout),
+  ]);
+  final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(<List<int>>[
+    utf8.encode(stderr),
+  ]);
+  final Process process = MockProcess();
+
+  when(process.stdout).thenAnswer((_) => stdoutStream);
+  when(process.stderr).thenAnswer((_) => stderrStream);
+  when(process.exitCode).thenAnswer((_) => Future<int>.value(exitCode));
+  return process;
 }


### PR DESCRIPTION
Currently, if you run flutter upgrade on macOS Catalina and the upgrade path has a Dart SDK revision change, you will get an exception with a misleading VersionCheckError: Command exited with code -9: git log -n 1 --pretty=format:%ad --date=iso. The actual cause is calling the Flutter tool re-entrantly, which deletes the current Dart SDK (which the flutter upgrade process is using), after which any forked sub-processes would be killed (code -9 from the VersionCheckError message) by the macOS anti-malware software. See #33890 and https://github.com/dart-lang/sdk/issues/37662 for more info.

This PR breaks up the `flutter upgrade` flow into two parts, the second half invoked re-entrantly via the hidden flag `flutter upgrade --continue`. This fixes the issue because after there are no steps following the re-entrant call of `flutter upgrade --continue` from the first dart process.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).*

## Related Issues

Fixes https://github.com/flutter/flutter/issues/33890

## Tests

I re-wrote the existing `upgrade_test.dart` file to accommodate the new re-entrant command.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
