### PR TITLE
[flutter_tool] Flip create language defaults to swift and kotlin

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -129,13 +129,13 @@ class CreateCommand extends FlutterCommand {
     argParser.addOption(
       'ios-language',
       abbr: 'i',
-      defaultsTo: 'objc',
+      defaultsTo: 'swift',
       allowed: <String>['objc', 'swift'],
     );
     argParser.addOption(
       'android-language',
       abbr: 'a',
-      defaultsTo: 'java',
+      defaultsTo: 'kotlin',
       allowed: <String>['java', 'kotlin'],
     );
     argParser.addFlag(

--- a/packages/flutter_tools/test/general.shard/commands/create_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/create_test.dart
@@ -63,7 +63,7 @@ void main() {
   testUsingContext('can create a default project', () async {
     await _createAndAnalyzeProject(
       projectDir,
-      <String>[],
+      <String>['-i', 'objc', '-a', 'java'],
       <String>[
         'android/app/src/main/java/com/example/flutter_project/MainActivity.java',
         'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
@@ -81,7 +81,7 @@ void main() {
     await projectDir.create(recursive: true);
     await _createAndAnalyzeProject(
       projectDir,
-      <String>[],
+      <String>['-i', 'objc', '-a', 'java'],
       <String>[
         'android/app/src/main/java/com/example/flutter_project/MainActivity.java',
         'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
@@ -129,7 +129,10 @@ void main() {
   testUsingContext('Will create an app project if non-empty non-project directory exists without .metadata', () async {
     await projectDir.absolute.childDirectory('blag').create(recursive: true);
     await projectDir.absolute.childDirectory('.idea').create(recursive: true);
-    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+    await _createAndAnalyzeProject(projectDir,
+      <String>[
+        '-i', 'objc', '-a', 'java'
+      ], <String>[
       'android/app/src/main/java/com/example/flutter_project/MainActivity.java',
       'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
       'flutter_project.iml',
@@ -145,7 +148,10 @@ void main() {
   testUsingContext('detects and recreates an app project correctly', () async {
     await projectDir.absolute.childDirectory('lib').create(recursive: true);
     await projectDir.absolute.childDirectory('ios').create(recursive: true);
-    await _createAndAnalyzeProject(projectDir, <String>[], <String>[
+    await _createAndAnalyzeProject(projectDir,
+      <String>[
+        '-i', 'objc', '-a', 'java'
+      ], <String>[
       'android/app/src/main/java/com/example/flutter_project/MainActivity.java',
       'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
       'flutter_project.iml',
@@ -163,8 +169,9 @@ void main() {
     await projectDir.absolute.childFile('.metadata').writeAsString('project_type: plugin\n');
     return _createAndAnalyzeProject(
       projectDir,
-      <String>[],
       <String>[
+        '-i', 'objc', '-a', 'java'
+      ], <String>[
         'android/src/main/java/com/example/flutter_project/FlutterProjectPlugin.java',
         'example/android/app/src/main/java/com/example/flutter_project_example/MainActivity.java',
         'example/ios/Runner/AppDelegate.h',
@@ -259,7 +266,7 @@ void main() {
   testUsingContext('can create a plugin project', () async {
     await _createAndAnalyzeProject(
       projectDir,
-      <String>['--template=plugin'],
+      <String>['--template=plugin', '-i', 'objc', '-a', 'java'],
       <String>[
         'android/src/main/java/com/example/flutter_project/FlutterProjectPlugin.java',
         'example/android/app/src/main/java/com/example/flutter_project_example/MainActivity.java',
@@ -304,8 +311,13 @@ void main() {
   testUsingContext('plugin project with custom org', () async {
     return _createProject(
       projectDir,
-      <String>['--no-pub', '--template=plugin', '--org', 'com.bar.foo'],
       <String>[
+        '--no-pub',
+        '--template=plugin',
+        '--org', 'com.bar.foo',
+        '-i', 'objc',
+        '-a', 'java',
+      ], <String>[
         'android/src/main/java/com/bar/foo/flutter_project/FlutterProjectPlugin.java',
         'example/android/app/src/main/java/com/bar/foo/flutter_project_example/MainActivity.java',
       ],
@@ -319,8 +331,13 @@ void main() {
   testUsingContext('plugin project with valid custom project name', () async {
     return _createProject(
       projectDir,
-      <String>['--no-pub', '--template=plugin', '--project-name', 'xyz'],
       <String>[
+        '--no-pub',
+        '--template=plugin',
+        '--project-name', 'xyz',
+        '-i', 'objc',
+        '-a', 'java',
+      ], <String>[
         'android/src/main/java/com/example/xyz/XyzPlugin.java',
         'example/android/app/src/main/java/com/example/xyz_example/MainActivity.java',
       ],
@@ -837,13 +854,19 @@ void main() {
   testUsingContext('can re-gen app android/ folder, reusing custom org', () async {
     await _createProject(
       projectDir,
-      <String>['--no-pub', '--template=app', '--org', 'com.bar.foo'],
+      <String>[
+        '--no-pub',
+        '--template=app',
+        '--org', 'com.bar.foo',
+        '-i', 'objc',
+        '-a', 'java'
+      ],
       <String>[],
     );
     projectDir.childDirectory('android').deleteSync(recursive: true);
     return _createProject(
       projectDir,
-      <String>['--no-pub'],
+      <String>['--no-pub', '-i', 'objc', '-a', 'java'],
       <String>[
         'android/app/src/main/java/com/bar/foo/flutter_project/MainActivity.java',
       ],
@@ -871,14 +894,20 @@ void main() {
   testUsingContext('can re-gen plugin ios/ and example/ folders, reusing custom org', () async {
     await _createProject(
       projectDir,
-      <String>['--no-pub', '--template=plugin', '--org', 'com.bar.foo'],
+      <String>[
+        '--no-pub',
+        '--template=plugin',
+        '--org', 'com.bar.foo',
+        '-i', 'objc',
+        '-a', 'java',
+      ],
       <String>[],
     );
     projectDir.childDirectory('example').deleteSync(recursive: true);
     projectDir.childDirectory('ios').deleteSync(recursive: true);
     await _createProject(
       projectDir,
-      <String>['--no-pub', '--template=plugin'],
+      <String>['--no-pub', '--template=plugin', '-i', 'objc', '-a', 'java'],
       <String>[
         'example/android/app/src/main/java/com/bar/foo/flutter_project_example/MainActivity.java',
         'ios/Classes/FlutterProjectPlugin.h',
@@ -964,7 +993,7 @@ void main() {
     existingFile.createSync(recursive: true);
     await _createProject(
       fs.directory(existingDirectory.path),
-      <String>['--overwrite'],
+      <String>['--overwrite', '-i', 'objc', '-a', 'java'],
       <String>[
         'android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
         'lib/main.dart',

--- a/packages/flutter_tools/test/general.shard/commands/create_usage_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/create_usage_test.dart
@@ -71,18 +71,18 @@ void main() {
       await runner.run(<String>[
         'create', '--flutter-root=flutter', '--no-pub', '--template=app', 'testy']);
       expect(await command.usageValues,
-             containsPair(CustomDimensions.commandCreateIosLanguage, 'objc'));
+             containsPair(CustomDimensions.commandCreateIosLanguage, 'swift'));
 
       await runner.run(<String>[
         'create',
         '--flutter-root=flutter',
         '--no-pub',
         '--template=app',
-        '--ios-language=swift',
+        '--ios-language=objc',
         'testy',
       ]);
       expect(await command.usageValues,
-             containsPair(CustomDimensions.commandCreateIosLanguage, 'swift'));
+             containsPair(CustomDimensions.commandCreateIosLanguage, 'objc'));
 
     }));
 
@@ -92,18 +92,18 @@ void main() {
 
       await runner.run(<String>['create', '--flutter-root=flutter', '--no-pub', '--template=app', 'testy']);
       expect(await command.usageValues,
-             containsPair(CustomDimensions.commandCreateAndroidLanguage, 'java'));
+             containsPair(CustomDimensions.commandCreateAndroidLanguage, 'kotlin'));
 
       await runner.run(<String>[
         'create',
         '--flutter-root=flutter',
         '--no-pub',
         '--template=app',
-        '--android-language=kotlin',
+        '--android-language=java',
         'testy',
       ]);
       expect(await command.usageValues,
-             containsPair(CustomDimensions.commandCreateAndroidLanguage, 'kotlin'));
+             containsPair(CustomDimensions.commandCreateAndroidLanguage, 'java'));
     }));
   });
 }


### PR DESCRIPTION
## Description

This PR changes the default languages for the `create` command. Previous behavior can be recovered by explicitly passing the `--ios-language` and `--android-language` flags.

## Related Issues

https://github.com/flutter/flutter/issues/21190

## Tests

Adjusted tests in `commands/create_test.dart`.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.