### PR TITLE
remove bsdiff from  BUILD.gn

### DIFF
--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -17,7 +17,6 @@ dart_library("flutter_tools") {
     "//third_party/dart-pkg/pub/analyzer",
     "//third_party/dart-pkg/pub/archive",
     "//third_party/dart-pkg/pub/args",
-    "//third_party/dart-pkg/pub/bsdiff",
     "//third_party/dart-pkg/pub/build_daemon",
     "//third_party/dart-pkg/pub/build_runner_core",
     "//third_party/dart-pkg/pub/collection",


### PR DESCRIPTION
This is no longer used by anything in the tool