### PR TITLE
Add a diagnostic message in analyze.dart

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -442,9 +442,11 @@ Future<void> verifyNoBadImportsInFlutter(String workingDirectory) async {
         continue;
       // Sanity check before performing _deepSearch, to ensure there's no rogue
       // dependencies.
+      final String validFilenames = dependencyMap.keys.map((String name) => name + '.dart').join(', ');
       errors.add(
-        '$key imported $dependency which is not one of the valid directories ${dependencyMap.keys}. '
-        'Consider changing $dependency to one of them.'
+        '$key imported package:flutter/$dependency.dart '
+        'which is not one of the valid exports { $validFilenames }.\n'
+        'Consider changing $dependency.dart to one of them.'
       );
     }
   }

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -435,6 +435,20 @@ Future<void> verifyNoBadImportsInFlutter(String workingDirectory) async {
       );
     }
   }
+
+  for (final String key in dependencyMap.keys) {
+    for (final String dependency in dependencyMap[key]) {
+      if (dependencyMap[dependency] != null)
+        continue;
+      // Sanity check before performing _deepSearch, to ensure there's no rogue
+      // dependencies.
+      errors.add(
+        '$key imported $dependency which is not one of the valid directories ${dependencyMap.keys}. '
+        'Consider changing $dependency to one of them.'
+      );
+    }
+  }
+
   for (final String package in dependencyMap.keys) {
     final List<String> loop = _deepSearch<String>(dependencyMap, package);
     if (loop != null) {
@@ -1180,6 +1194,9 @@ Set<String> _findFlutterDependencies(String srcPath, List<String> errors, { bool
 }
 
 List<T> _deepSearch<T>(Map<T, Set<T>> map, T start, [ Set<T> seen ]) {
+  if (map[start] == null)
+    return null; // We catch these separately.
+
   for (final T key in map[start]) {
     if (key == start)
       continue; // we catch these separately


### PR DESCRIPTION
## Description

I ran into an analyzer failure in 
https://github.com/flutter/flutter/pull/37719/checks?check_run_id=191556624 because I wrote
`import 'package:flutter/src/widgets/basic.dart';`

the output wasn't the most helpful:
```
dart --enable-asserts ./dev/bots/analyze.dart
⏩ RUNNING: cd examples/hello_world; ../../bin/flutter inject-plugins
🕐 ELAPSED TIME: 0:00:01.003618 for ../../bin/flutter inject-plugins in examples/hello_world: 
Unhandled exception:
NoSuchMethodError: The getter 'iterator' was called on null.
Receiver: null
Tried calling: iterator
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:50:5)
#1      _deepSearch (file:///tmp/flutter%20sdk/dev/bots/analyze.dart:459:20)
#2      _deepSearch (file:///tmp/flutter%20sdk/dev/bots/analyze.dart:464:28)
#3      _verifyNoBadImportsInFlutter (file:///tmp/flutter%20sdk/dev/bots/analyze.dart:393:31)
<asynchronous suspension>
#4      main (file:///tmp/flutter%20sdk/dev/bots/analyze.dart:37:9)
<asynchronous suspension>
#5      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:303:32)
#6      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:12)

Exit status: 255
```
Now it should say:
```
⏩ RUNNING: cd ../integration_tests/ui; ../../../bin/flutter inject-plugins
🕐 ELAPSED TIME: 0:00:00.582985 for ../../../bin/flutter inject-plugins in ../integration_tests/ui:
⏩ RUNNING: cd ../../examples/hello_world; ../../bin/flutter inject-plugins
🕐 ELAPSED TIME: 0:00:00.569801 for ../../bin/flutter inject-plugins in ../../examples/hello_world:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
An error was detected when looking at import dependencies within the Flutter package:

cupertino imported package:flutter/src/widgets/basic.dart which is not one of the valid exports { animation.dart, cupertino.dart, foundation.dart, gestures.dart, material.dart, painting.dart, physics.dart, rendering.dart, scheduler.dart, semantics.dart, services.dart, widgets.dart }.                                  
Consider changing src/widgets/basic.dart to one of them.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

```

## Tests

Not sure if tests are needed?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
