### PR TITLE
[flutter_tool] Fix bug in manifest yaml validation

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -355,8 +355,9 @@ void _validateFlutter(YamlMap yaml, List<String> errors) {
       case 'fonts':
         if (kvp.value is! YamlList || kvp.value[0] is! YamlMap) {
           errors.add('Expected "${kvp.key}" to be a list, but got ${kvp.value} (${kvp.value.runtimeType}).');
+        } else {
+          _validateFonts(kvp.value, errors);
         }
-        _validateFonts(kvp.value, errors);
         break;
       case 'module':
         if (kvp.value is! YamlMap) {

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -519,6 +519,25 @@ flutter:
       expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));
     });
 
+    testUsingContext('Returns proper error when font is a map instead of a list', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  fonts:
+    family: foo
+    fonts:
+      -asset: a/bar
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+
+      expect(flutterManifest, null);
+      expect(logger.errorText, contains('Expected "fonts" to be a list'));
+    });
+
     testUsingContext('Returns proper error when second font family is invalid', () async {
       final BufferLogger logger = context.get<Logger>();
       const String manifest = '''


### PR DESCRIPTION
## Description

Adds missing else.

## Related Issues

Seen in crash report

## Tests

I added the following tests:

Added a test to flutter_manifest_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
