### PR TITLE
Repro CL with fix to make sure the initialRoute is opaque.

### DIFF
--- a/examples/flutter_gallery/lib/gallery/app.dart
+++ b/examples/flutter_gallery/lib/gallery/app.dart
@@ -8,7 +8,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;
+import 'package:flutter_gallery/demo/pesto_demo.dart';
 import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
+import 'package:flutter_gallery/demo/shrine_demo.dart';
 import 'package:scoped_model/scoped_model.dart';
 
 import 'package:url_launcher/url_launcher.dart';
@@ -142,6 +144,7 @@ class _GalleryAppState extends State<GalleryApp> {
         showPerformanceOverlay: _options.showPerformanceOverlay,
         checkerboardOffscreenLayers: _options.showOffscreenLayersCheckerboard,
         checkerboardRasterCacheImages: _options.showRasterCacheImagesCheckerboard,
+        initialRoute: PestoDemo.routeName,
         routes: _buildRoutes(),
         builder: (BuildContext context, Widget child) {
           return Directionality(

--- a/examples/flutter_gallery/lib/gallery/home.dart
+++ b/examples/flutter_gallery/lib/gallery/home.dart
@@ -154,7 +154,7 @@ class _CategoriesPage extends StatelessWidget {
                       );
                     }),
                   );
-                }),
+                })..insert(0,               CircularProgressIndicator()),
               ),
             );
           },

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1540,6 +1540,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     }
     for (Route<dynamic> route in _history)
       _initialOverlayEntries.addAll(route.overlayEntries);
+
+    _history.last.overlayEntries.first.makeOpaqueHack();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -90,6 +90,10 @@ class OverlayEntry {
     _overlay._didChangeEntryOpacity();
   }
 
+  void makeOpaqueHack() {
+    _opaque = true;
+  }
+
   /// Whether this entry must be included in the tree even if there is a fully
   /// [opaque] entry above it.
   ///
@@ -162,6 +166,12 @@ class _OverlayEntry extends StatefulWidget {
 
   @override
   _OverlayEntryState createState() => _OverlayEntryState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder builder) {
+    super.debugFillProperties(builder);
+    builder.add(DiagnosticsProperty<OverlayEntry>('entry', entry));
+  }
 }
 
 class _OverlayEntryState extends State<_OverlayEntry> {


### PR DESCRIPTION
## Description
For discussion. This CL shows the outline for a fix for a bug where specifying `initialRoute` results in UI from multiple routes being active at the same time.
I believe the problem is that that when performing route navigation transitions, the `OverlayEntry` is only made opaque when the transition completes and when the route is triggered as the `initialRoute` there is never an event when the navigation ends so the `OverlayEntry` is not opaque. This bug went unnoticed as aside from the inspector there is typically not an obvious side effect other than Flutter performing a bit more work than it should.
This results in tickers being active which should not be active and layers being rendered that should not be rendered.

Notes on this repro CL:
The tweak to add a spinner to the home screen of the Gallery app illustrates that work is still done updating the spinner each frame when the app is displaying the `pesto` demo. You can verify the work being done with the rebuild indicators in IntelliJ or just the performance overlay which will show frames being rendered continuously for the route that should be inactive.

## Related Issues
https://github.com/flutter/flutter/issues/38038 where a user noticed that widget selection in the inspector was behaving badly due to this issue.
