### PR TITLE
Fix publish cmd

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -17,8 +17,8 @@ class PackagesCommand extends FlutterCommand {
     addSubcommand(PackagesGetCommand('get', false));
     addSubcommand(PackagesGetCommand('upgrade', true));
     addSubcommand(PackagesTestCommand());
+    addSubcommand(PackagesPublishCommand());
     addSubcommand(PackagesForwardCommand('downgrade', 'Downgrade packages in a Flutter project', requiresPubspec: true));
-    addSubcommand(PackagesForwardCommand('publish', 'Publish the current package to pub.dev', requiresPubspec: true));
     addSubcommand(PackagesForwardCommand('deps', 'Print package dependencies', requiresPubspec: true));
     addSubcommand(PackagesForwardCommand('run', 'Run an executable from a package', requiresPubspec: true));
     addSubcommand(PackagesForwardCommand('cache', 'Work with the Pub system cache'));
@@ -166,6 +166,47 @@ class PackagesTestCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     Cache.releaseLockEarly();
     await pub(<String>['run', 'test', ...argResults.rest], context: PubContext.runTest, retry: false);
+    return null;
+  }
+}
+
+class PackagesPublishCommand extends FlutterCommand {
+  PackagesPublishCommand() {
+    requiresPubspecYaml();
+    argParser.addFlag('dry-run',
+      abbr: 'n',
+      negatable: false,
+      help: 'Validate but do not publish the package.',
+    );
+    argParser.addFlag('force',
+      abbr: 'f',
+      negatable: false,
+      help: 'Publish without confirmation if there are no errors.',
+    );
+  }
+
+  @override
+  String get name => 'publish';
+
+  @override
+  String get description {
+    return 'Publish the current package to pub.dev';
+  }
+
+  @override
+  String get invocation {
+    return '${runner.executableName} pub publish [--dry-run]';
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final List<String> args = <String>[
+      ...argResults.rest,
+      if (argResults['dry-run']) '--dry-run',
+      if (argResults['force']) '--force',
+    ];
+    Cache.releaseLockEarly();
+    await pubInteractively(<String>['publish', ...args]);
     return null;
   }
 }

--- a/packages/flutter_tools/test/general.shard/commands/packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/packages_test.dart
@@ -348,7 +348,7 @@ void main() {
     testUsingContext('pub publish', () async {
       final PromptingProcess process = PromptingProcess();
       mockProcessManager.processFactory = (List<String> commands) => process;
-      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
+      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'publish']);
       final Future<void> runPrompt = process.showPrompt('Proceed (y/n)? ', <String>['hello', 'world']);
       final Future<void> simulateUserInput = Future<void>(() {
         mockStdio.simulateStdin('y');
@@ -370,12 +370,23 @@ void main() {
     });
 
     testUsingContext('publish', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'publish']);
+      await createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'publish']);
       final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(3));
+      expect(commands, hasLength(2));
       expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], '--trace');
-      expect(commands[2], 'publish');
+      expect(commands[1], 'publish');
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Stdio: () => mockStdio,
+      BotDetector: () => const AlwaysTrueBotDetector(),
+    });
+
+      testUsingContext('publish', () async {
+      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
+      final List<String> commands = mockProcessManager.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
+      expect(commands[1], 'publish');
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,

--- a/packages/flutter_tools/test/general.shard/commands/packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/packages_test.dart
@@ -381,7 +381,7 @@ void main() {
       BotDetector: () => const AlwaysTrueBotDetector(),
     });
 
-      testUsingContext('publish', () async {
+    testUsingContext('packages publish', () async {
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
       final List<String> commands = mockProcessManager.commands;
       expect(commands, hasLength(2));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/33302
Fixes https://github.com/flutter/flutter/issues/38485

Core issues found that this fixes:
  * publish prompts the user and thus needs to run interactively
  * argsparser passes through arguments in `.rest`. but not flags, so need to define those explicitly