### PR TITLE
Fixing layout issues with LayoutBuilder and Intrinsic Measurement.

### DIFF
--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -213,26 +213,22 @@ class LayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {
 class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<RenderBox>, RenderConstrainedLayoutBuilder<BoxConstraints, RenderBox> {
   @override
   double computeMinIntrinsicWidth(double height) {
-    assert(_debugThrowIfNotCheckingIntrinsics());
-    return 0.0;
+    return child != null ? child.computeMinIntrinsicWidth(height) : 0.0;
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    assert(_debugThrowIfNotCheckingIntrinsics());
-    return 0.0;
+    return child != null ? child.computeMaxIntrinsicWidth(height) : 0.0;
   }
 
   @override
   double computeMinIntrinsicHeight(double width) {
-    assert(_debugThrowIfNotCheckingIntrinsics());
-    return 0.0;
+    return child != null ? child.computeMinIntrinsicHeight(width) : 0.0;
   }
 
   @override
   double computeMaxIntrinsicHeight(double width) {
-    assert(_debugThrowIfNotCheckingIntrinsics());
-    return 0.0;
+    return child != null ? child.computeMaxIntrinsicHeight(width) : 0.0;
   }
 
   @override
@@ -255,21 +251,6 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
       context.paintChild(child, offset);
-  }
-
-  bool _debugThrowIfNotCheckingIntrinsics() {
-    assert(() {
-      if (!RenderObject.debugCheckingIntrinsics) {
-        throw FlutterError(
-          'LayoutBuilder does not support returning intrinsic dimensions.\n'
-          'Calculating the intrinsic dimensions would require running the layout '
-          'callback speculatively, which might mutate the live render object tree.'
-        );
-      }
-      return true;
-    }());
-
-    return true;
   }
 }
 


### PR DESCRIPTION
Start of conversation about this issue with @eseidel and @Hixie 
https://twitter.com/devangelslondon/status/1148326111094464519

There is a common use case of wanting a Widget to expand to fill the height of a scrolling viewport if its size is smaller. The common pattern in Flutter is to use a LayoutBuilder, SingleChildScrollView, ConstrainedBox, and IntrinsicHeight as explained in the [SingleChildScrollView](https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html) documentation.

This works however you can no longer use any more LayoutBuilder's inside your scrolling content without the following error message appearing during layout.

```
LayoutBuilder does not support returning intrinsic dimensions.
Calculating the intrinsic dimensions would require running the layout callback speculatively, which might mutate the live render object tree.
```

The changes in this PR fix issues around this as shown here:
https://github.com/evelyne24/flutter_layout_weirdness/commit/d1bba6d756901d4df6c9a4c7b7f5931dc6e9f19a

Example:
```
Widget build(BuildContext context) {
  return LayoutBuilder(
    builder: (BuildContext context, BoxConstraints viewportConstraints) {
      return SingleChildScrollView(
        child: ConstrainedBox(
          constraints: BoxConstraints(
            minHeight: viewportConstraints.maxHeight,
            maxHeight: double.infinity,
          ),
          child: IntrinsicHeight(
            child: Column(
              children: <Widget>[
                Container(
                  color: const Color(0xff808000), // Yellow
                  height: 120.0,
                ),
                Expanded(
                  child: Container(
                    color: const Color(0xff800000), // Red
                    child: LayoutBuilder(
                      builder: (BuildContext context, BoxConstraints viewportConstraints) {
                        return Icon(Icons.help);
                      },
                    ),
                  ),
                ),
              ],
            ),
          ),
        ),
      );
    },
  );
}
```

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
