### PR TITLE
Regulate animation status in animatedswitcher

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -349,6 +349,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
       assert(!_outgoingEntries.contains(_currentEntry));
       _outgoingEntries.add(_currentEntry);
       _currentEntry.controller.reverse();
+      // Rebuilds the child since its animation status changes from completed to reverse
       _updateTransitionForEntry(_currentEntry);
       _markChildWidgetCacheAsDirty();
       _currentEntry = null;
@@ -365,7 +366,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
       curve: widget.switchInCurve,
       reverseCurve: widget.switchOutCurve,
     );
-    // Initial child should start at reverse state.
+    // Initial child should start at completed state.
     if (!animate) {
       assert(_outgoingEntries.isEmpty);
       controller.value = 1.0;
@@ -411,7 +412,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
     _outgoingWidgets = null;
   }
 
-  // This function should be called when entry.animation is updated appropriately.
+  // This function should be called after entry.animation is updated appropriately.
   void _updateTransitionForEntry(_ChildEntry entry) {
     entry.transition = KeyedSubtree(
       key: entry.transition.key,

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -317,10 +317,13 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
   @override
   void didUpdateWidget(AnimatedSwitcher oldWidget) {
     super.didUpdateWidget(oldWidget);
-
-    _outgoingEntries.forEach(_updateTransitionForEntry);
     final bool hasNewChild = widget.child != null;
     final bool hasOldChild = _currentEntry != null;
+    final bool builderChanged = widget.transitionBuilder != oldWidget.transitionBuilder;
+
+    if (builderChanged)
+      _outgoingEntries.forEach(_updateTransitionForEntry);
+
     if (hasNewChild != hasOldChild ||
         hasNewChild && !Widget.canUpdate(widget.child, _currentEntry.widgetChild)) {
       // Child has changed, fade current entry out and add new entry.
@@ -335,13 +338,6 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
       // update the transition instead of replacing it.
       _currentEntry.widgetChild = widget.child;
       _updateTransitionForEntry(_currentEntry); // uses entry.widgetChild
-      _markChildWidgetCacheAsDirty();
-    } else if (widget.transitionBuilder != oldWidget.transitionBuilder) {
-      // If the transition builder changed, then update all of the previous
-      // transitions.
-      _outgoingEntries.forEach(_updateTransitionForEntry);
-      if(_currentEntry != null)
-        _updateTransitionForEntry(_currentEntry);
       _markChildWidgetCacheAsDirty();
     }
   }


### PR DESCRIPTION
## Description

Customer has use case that he would like to have a new api to specify the animation of transitioning out. This is not possible with the current api, and it might have unexpected behavior if animation differ between transition in and transition out. It is not wise to provide an api that dedicate to do that.

As an alternative, we can promise the animation status is correctly reflect the current transition phase when transitionBuilder is called which it currently does not. Customer can use this promise to do their own custom logic if they really want to.

While we should not encourage changing animation between different transition phase using this promise, I still think this is a good refactoring anyway.

## Related Issues

https://github.com/flutter/flutter/issues/19395

## Tests

I added the following tests:

animation.status in transitionBuilder dictates correct transition phase

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
