### PR TITLE
Add smoke tests to test every commit on a Catalina host.

### DIFF
--- a/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
+++ b/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
+++ b/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
@@ -1,0 +1,16 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  // It's intended to use the Gallery startup test as a smoke test on macOS
+  // Catalina.
+  await task(createFlutterGalleryStartupTest());
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -635,6 +635,12 @@ tasks:
     required_agent_capabilities: ["mac/android"]
     flaky: true
 
+  smoke_catalina_start_up:
+    description: >
+      A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
+    stage: devicelab_ios
+    required_agent_capabilities: ["mac-catalina/ios"]
+
   android_splash_screen_integration_test:
     description: >
       Runs end-to-end test of Flutter's Android splash behavior.

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -510,6 +510,20 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
+  smoke_catalina_start_up:
+    description: >
+      A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
+    stage: devicelab_ios
+    flaky: true
+    required_agent_capabilities: ["mac-catalina/ios"]
+
+  smoke_catalina_hot_mode_dev_cycle__benchmark:
+    description: >
+      A some test that runs on macOS Catalina, which is a clone of the Dart VM hot patching performance benchmarking.
+    stage: devicelab_ios
+    flaky: true
+    required_agent_capabilities: ["mac-catalina/ios"]
+
   # Tests running on Windows host
 
   flavors_test_win:
@@ -634,12 +648,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
     flaky: true
-
-  smoke_catalina_start_up:
-    description: >
-      A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac-catalina/ios"]
 
   android_splash_screen_integration_test:
     description: >

--- a/dev/devicelab/smoke_catalina_hot_mode_dev_cycle__benchmark.dart
+++ b/dev/devicelab/smoke_catalina_hot_mode_dev_cycle__benchmark.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  await task(createHotModeTest());
+}


### PR DESCRIPTION
## Description

After this PR, every commit will trigger smoke tests on a machine running macOS Catalina. So that we could get a signal of our Catalina support.

## Related Issues

* #36290

## Tests

I added the following tests:

* Smoke tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
