### PR TITLE
Clamp scrollOffset to prevent textfield bouncing

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' show min, max;
-import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment, BoxHeightStyle;
+import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -553,8 +553,6 @@ class TextPainter {
     }
     _inlinePlaceholderBoxes = _paragraph.getBoxesForPlaceholders();
   }
-
-  ui.Paragraph get para => _paragraph;
 
   /// Paints the text onto the given canvas at the given offset.
   ///

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -433,6 +433,14 @@ class TextPainter {
     return _layoutTemplate.height;
   }
 
+  double _firstLineHeight;
+  double getRealFirstLineHeight() {
+    assert(!_needsLayout);
+    List<TextBox> boxes = _paragraph.getBoxesForRange(0, 1, boxHeightStyle: BoxHeightStyle.max);
+    if (!boxes.isEmpty())
+      return boxes[0].bottom - boxes[0].top;
+  }
+
   // Unfortunately, using full precision floating point here causes bad layouts
   // because floating point math isn't associative. If we add and subtract
   // padding, for example, we'll get different values when we estimate sizes and
@@ -553,6 +561,8 @@ class TextPainter {
     }
     _inlinePlaceholderBoxes = _paragraph.getBoxesForPlaceholders();
   }
+
+  ui.Paragraph get para => _paragraph;
 
   /// Paints the text onto the given canvas at the given offset.
   ///

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' show min, max;
-import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment;
+import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment, BoxHeightStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -431,14 +431,6 @@ class TextPainter {
         ..layout(const ui.ParagraphConstraints(width: double.infinity));
     }
     return _layoutTemplate.height;
-  }
-
-  double _firstLineHeight;
-  double getRealFirstLineHeight() {
-    assert(!_needsLayout);
-    List<TextBox> boxes = _paragraph.getBoxesForRange(0, 1, boxHeightStyle: BoxHeightStyle.max);
-    if (!boxes.isEmpty())
-      return boxes[0].bottom - boxes[0].top;
   }
 
   // Unfortunately, using full precision floating point here causes bad layouts

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1020,7 +1020,7 @@ class RenderEditable extends RenderBox {
   /// The maximum amount the text is allowed to scroll.
   ///
   /// This value is only valid after layout and can change as additional
-  /// text is entered or removed in order to accommodate expanding
+  /// text is entered or removed in order to accommodate expanding when
   /// [expands] is set to true.
   double get maxScrollExtent => _maxScrollExtent;
   double _maxScrollExtent = 0;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1321,7 +1321,6 @@ class RenderEditable extends RenderBox {
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
   /// This does not required the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
-  double get getRealFirstLineHeight => _textPainter.getRealFirstLineHeight();
 
   double _preferredHeight(double width) {
     // Lock height to maxLines if needed.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1017,6 +1017,14 @@ class RenderEditable extends RenderBox {
     return enableInteractiveSelection ?? !obscureText;
   }
 
+  /// The maximum amount the text is allowed to scroll.
+  ///
+  /// This value is only valid after layout and can change as additional
+  /// text is entered or removed in order to accommodate expanding
+  /// [expands] is set to true.
+  double get maxScrollExtent => _maxScrollExtent;
+  double _maxScrollExtent = 0;
+
   double get _caretMargin => _kCaretGap + cursorWidth;
 
   @override
@@ -1228,8 +1236,6 @@ class RenderEditable extends RenderBox {
     }
     return null;
   }
-
-  double _maxScrollExtent = 0;
 
   // We need to check the paint offset here because during animation, the start of
   // the text may position outside the visible region even when the text fits.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1321,6 +1321,7 @@ class RenderEditable extends RenderBox {
   /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
   /// This does not required the layout to be updated.
   double get preferredLineHeight => _textPainter.preferredLineHeight;
+  double get getRealFirstLineHeight => _textPainter.getRealFirstLineHeight();
 
   double _preferredHeight(double width) {
     // Lock height to maxLines if needed.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1290,11 +1290,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
     if (caretStart < 0.0) { // cursor before start of bounds
-      scrollOffset = math.max(scrollOffset + caretStart, 0);
+      scrollOffset += caretStart;
     } else if (caretEnd >= viewportExtent) { // cursor after end of bounds
-      scrollOffset = math.min(renderEditable.size.height, scrollOffset + caretRect.bottom - viewportExtent);
+      scrollOffset += caretEnd - viewportExtent;
     }
-    return scrollOffset;
+    return scrollOffset.clamp(0, renderEditable.size.height);
   }
 
   // Calculates where the `caretRect` would be if `_scrollController.offset` is set to `scrollOffset`.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1294,6 +1294,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     } else if (caretEnd >= viewportExtent) { // cursor after end of bounds
       scrollOffset += caretEnd - viewportExtent;
     }
+    // Clamp the final results to prevent programmatically scrolling to out-of-paragraph-bounds
+    // positions when encountering tall fonts/scripts that extend past the ascent.
     return scrollOffset.clamp(0, renderEditable.size.height);
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1278,7 +1278,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // The caret is vertically centered within the line. Expand the caret's
       // height so that it spans the line because we're going to ensure that the entire
       // expanded caret is scrolled into view.
-      final double lineHeight = renderEditable.realFirstLineHeight;
+      final double lineHeight = renderEditable.preferredLineHeight;
       final double caretOffset = (lineHeight - caretRect.height) / 2;
       caretStart = caretRect.top - caretOffset;
       caretEnd = caretRect.bottom + caretOffset;
@@ -1290,9 +1290,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     double scrollOffset = _scrollController.offset;
     final double viewportExtent = _scrollController.position.viewportDimension;
     if (caretStart < 0.0) { // cursor before start of bounds
-      scrollOffset += caretStart;
+      scrollOffset = math.max(scrollOffset + caretStart, 0);
     } else if (caretEnd >= viewportExtent) { // cursor after end of bounds
-      scrollOffset += caretEnd - viewportExtent;
+      scrollOffset = math.min(renderEditable.size.height, scrollOffset + caretRect.bottom - viewportExtent);
     }
     return scrollOffset;
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1294,9 +1294,14 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     } else if (caretEnd >= viewportExtent) { // cursor after end of bounds
       scrollOffset += caretEnd - viewportExtent;
     }
-    // Clamp the final results to prevent programmatically scrolling to out-of-paragraph-bounds
-    // positions when encountering tall fonts/scripts that extend past the ascent.
-    return scrollOffset.clamp(0, renderEditable.size.height);
+
+    if (_isMultiline) {
+      // Clamp the final results to prevent programmatically scrolling to
+      // out-of-paragraph-bounds positions when encountering tall fonts/scripts that
+      // extend past the ascent.
+      scrollOffset.clamp(0.0, renderEditable.size.height);
+    }
+    return scrollOffset;
   }
 
   // Calculates where the `caretRect` would be if `_scrollController.offset` is set to `scrollOffset`.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1283,6 +1283,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       caretStart = caretRect.top - caretOffset;
       caretEnd = caretRect.bottom + caretOffset;
     } else {
+      // Scrolls horizontally for single-line fields.
       caretStart = caretRect.left;
       caretEnd = caretRect.right;
     }
@@ -1299,7 +1300,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // Clamp the final results to prevent programmatically scrolling to
       // out-of-paragraph-bounds positions when encountering tall fonts/scripts that
       // extend past the ascent.
-      scrollOffset.clamp(0.0, renderEditable.size.height);
+      scrollOffset = scrollOffset.clamp(0.0, renderEditable.maxScrollExtent);
     }
     return scrollOffset;
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1278,7 +1278,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // The caret is vertically centered within the line. Expand the caret's
       // height so that it spans the line because we're going to ensure that the entire
       // expanded caret is scrolled into view.
-      final double lineHeight = renderEditable.preferredLineHeight;
+      final double lineHeight = renderEditable.realFirstLineHeight;
       final double caretOffset = (lineHeight - caretRect.height) / 2;
       caretStart = caretRect.top - caretOffset;
       caretEnd = caretRect.bottom + caretOffset;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -547,7 +547,6 @@ void main() {
 
   test('has correct maxScrollExtent', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
-    final ValueNotifier<bool> showCursor = ValueNotifier<bool>(true);
     EditableText.debugDeterministicCursor = true;
 
     final RenderEditable editable = RenderEditable(
@@ -572,7 +571,7 @@ void main() {
     );
 
     editable.layout(BoxConstraints.loose(const Size(100.0, 1000.0)));
-    expect(editable.size, equals(Size(100, 20)));
+    expect(editable.size, equals(const Size(100, 20)));
     expect(editable.maxLines, equals(2));
     expect(editable.maxScrollExtent, equals(90));
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -544,4 +544,48 @@ void main() {
     editable.hasFocus = false;
     expect(editable.hasFocus, false);
   });
+
+  test('has correct maxScrollExtent', () {
+    final TextSelectionDelegate delegate = FakeEditableTextState();
+    final ValueNotifier<bool> showCursor = ValueNotifier<bool>(true);
+    EditableText.debugDeterministicCursor = true;
+
+    final RenderEditable editable = RenderEditable(
+      maxLines: 2,
+      backgroundCursorColor: Colors.grey,
+      textDirection: TextDirection.ltr,
+      cursorColor: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: delegate,
+      text: const TextSpan(
+        text: '撒地方加咖啡哈金凤凰卡号方式剪坏算法发挥福建垃\nasfjafjajfjaslfjaskjflasjfksajf撒分开建安路口附近拉设\n计费可使肌肤撒附近埃里克圾房卡设计费"',
+        style: TextStyle(
+          height: 1.0, fontSize: 10.0, fontFamily: 'Roboto',
+        ),
+      ),
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      selection: const TextSelection.collapsed(
+        offset: 4,
+        affinity: TextAffinity.upstream,
+      ),
+    );
+
+    editable.layout(BoxConstraints.loose(const Size(100.0, 1000.0)));
+    expect(editable.size, equals(Size(100, 20)));
+    expect(editable.maxLines, equals(2));
+    expect(editable.maxScrollExtent, equals(90));
+
+    editable.layout(BoxConstraints.loose(const Size(150.0, 1000.0)));
+    expect(editable.maxScrollExtent, equals(50));
+
+    editable.layout(BoxConstraints.loose(const Size(200.0, 1000.0)));
+    expect(editable.maxScrollExtent, equals(40));
+
+    editable.layout(BoxConstraints.loose(const Size(500.0, 1000.0)));
+    expect(editable.maxScrollExtent, equals(10));
+
+    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    expect(editable.maxScrollExtent, equals(10));
+  });
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2568,6 +2568,56 @@ void main() {
 
     debugDefaultTargetPlatformOverride = null;
   }, skip: isBrowser);
+
+  testWidgets('scrolling doesn\'t bounce', (WidgetTester tester) async {
+    // 3 lines of text, where the last line overflows and requires scrolling.
+    const String testText = 'XXXXX\nXXXXX\nXXXXX';
+    final TextEditingController controller = TextEditingController(text: testText);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: EditableText(
+            showSelectionHandles: true,
+            maxLines: 2,
+            controller: controller,
+            focusNode: FocusNode(),
+            style: Typography(platform: TargetPlatform.android).black.subhead.copyWith(fontFamily: 'Roboto'),
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+          ),
+        ),
+      ),
+    ));
+
+    final EditableTextState state =
+      tester.state<EditableTextState>(find.byType(EditableText));
+    final RenderEditable renderEditable = state.renderEditable;
+    final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+
+    expect(scrollable.controller.position.viewportDimension, equals(28));
+    expect(scrollable.controller.position.pixels, equals(0));
+
+    expect(renderEditable.maxScrollExtent, equals(14));
+
+    scrollable.controller.jumpTo(20.0);
+    await tester.pump();
+    expect(scrollable.controller.position.pixels, equals(20));
+
+    state.bringIntoView(TextPosition(offset: 0));
+    await tester.pump();
+    expect(scrollable.controller.position.pixels, equals(0));
+
+
+    state.bringIntoView(TextPosition(offset: 13));
+    await tester.pump();
+    expect(scrollable.controller.position.pixels, equals(14));
+    expect(scrollable.controller.position.pixels, equals(renderEditable.maxScrollExtent));
+  }, skip: isBrowser);
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2608,12 +2608,12 @@ void main() {
     await tester.pump();
     expect(scrollable.controller.position.pixels, equals(20));
 
-    state.bringIntoView(TextPosition(offset: 0));
+    state.bringIntoView(const TextPosition(offset: 0));
     await tester.pump();
     expect(scrollable.controller.position.pixels, equals(0));
 
 
-    state.bringIntoView(TextPosition(offset: 13));
+    state.bringIntoView(const TextPosition(offset: 13));
     await tester.pump();
     expect(scrollable.controller.position.pixels, equals(14));
     expect(scrollable.controller.position.pixels, equals(renderEditable.maxScrollExtent));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/38417 and https://github.com/flutter/flutter/issues/37377

This PR clamps the scrollOffset between 0 and the max scroll extent to prevent overscrolling while typing.

To accomplish this, `maxScrollExtent` is exposed in RenderEditable where the scroll extents are computed.