### PR TITLE
Add a broadcast stream for FrameTiming

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -372,7 +372,6 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   // to send [FrameTiming] from engine to the framework.
   void _onFrameTimingCancel() {
       window.onReportTimings = _oldTimingsCallback;
-      _frameTimingBroadcastController = null;
   }
 
   /// A broadcast stream of the frames' time-related performance metrics.
@@ -388,12 +387,10 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   ///    and the Flutter engine use. It's recommended to use this stream instead
   ///    of overriding [Window.onReportTimings] directly.
   Stream<FrameTiming> get frameTimingStream {
-    if (_frameTimingBroadcastController == null) {
-      _frameTimingBroadcastController = StreamController<FrameTiming>.broadcast(
-        onListen: _onFrameTimingListen,
-        onCancel: _onFrameTimingCancel,
-      );
-    }
+    _frameTimingBroadcastController ??= StreamController<FrameTiming>.broadcast(
+      onListen: _onFrameTimingListen,
+      onCancel: _onFrameTimingCancel,
+    );
     return _frameTimingBroadcastController.stream;
   }
 

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -369,6 +369,17 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   }
 
   /// A broadcast stream of the frames' time-related performance metrics.
+  ///
+  /// It's recommended to listen to this stream instead of overriding
+  /// [Window.onReportTimings] directly because the latter may accidentally
+  /// break other listeners or callbacks.
+  ///
+  /// See also:
+  ///
+  ///  * [FrameTiming], the data event of this stream
+  ///  * [Window.onReportTimings], the low level callback that this stream
+  ///    and the Flutter engine use. It's recommended to use this stream instead
+  ///    of overriding [Window.onReportTimings] directly.
   Stream<FrameTiming> get frameTimingStream {
     if (_frameTimingBroadcastController == null) {
       _frameTimingBroadcastController = StreamController<FrameTiming>.broadcast(

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -740,14 +740,12 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
 
     if (_needToReportFirstFrame && _reportFirstFrame) {
       assert(!_firstFrameCompleter.isCompleted);
-      StreamSubscription<FrameTiming> firstFrameSubscription;
-      firstFrameSubscription = WidgetsBinding.instance.frameTimingStream.listen((FrameTiming timing) {
+      WidgetsBinding.instance.frameTimingStream.first.then((FrameTiming timing) {
         if (!kReleaseMode) {
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
         }
         _firstFrameCompleter.complete();
-        firstFrameSubscription.cancel();
       });
     }
 

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -163,6 +163,12 @@ void main() {
     // Checks that onReportTimings is reset to null after the first frame.
     expect(binding.window.onReportTimings, isNull);
 
+    // Checks that we can listen to frameTimnigStream again.
+    final ui.FrameTiming mockTiming = ui.FrameTiming(<int>[1, 2, 3, 4]);
+    final Future<ui.FrameTiming> frameTiming = SchedulerBinding.instance.frameTimingStream.first;
+    ui.window.onReportTimings(<ui.FrameTiming>[mockTiming]);
+    expect(await frameTiming, equals(mockTiming));
+
     expect(debugPrint, equals(debugPrintThrottled));
     debugPrint = (String message, { int wrapWidth }) {
       console.add(message);

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -31,6 +31,15 @@ class TestServiceExtensionsBinding extends BindingBase
   final Map<String, List<Map<String, dynamic>>> eventsDispatched = <String, List<Map<String, dynamic>>>{};
 
   @override
+  void initInstances() {
+    super.initInstances();
+    // Remove the subscription as we don't need it in the test. Moreover,
+    // we'll test that we properly reset onReportTimings to null after the
+    // first frame.
+    debugFlutterFrameSubscription.cancel();
+  }
+
+    @override
   void registerServiceExtension({
     @required String name,
     @required ServiceExtensionCallback callback,
@@ -150,6 +159,9 @@ void main() {
     expect(firstFrameResult, <String, String>{'enabled': 'true'});
 
     expect(binding.frameScheduled, isFalse);
+
+    // Checks that onReportTimings is reset to null after the first frame.
+    expect(binding.window.onReportTimings, isNull);
 
     expect(debugPrint, equals(debugPrintThrottled));
     debugPrint = (String message, { int wrapWidth }) {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -80,7 +80,9 @@ class TestServiceExtensionsBinding extends BindingBase
     if (ui.window.onDrawFrame != null)
       ui.window.onDrawFrame();
     if (ui.window.onReportTimings != null)
-      ui.window.onReportTimings(<ui.FrameTiming>[]);
+      ui.window.onReportTimings(<ui.FrameTiming>[
+        ui.FrameTiming(List<int>.filled(ui.FramePhase.values.length, 0)),
+      ]);
   }
 
   @override

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -79,10 +79,11 @@ class TestServiceExtensionsBinding extends BindingBase
     await flushMicrotasks();
     if (ui.window.onDrawFrame != null)
       ui.window.onDrawFrame();
-    if (ui.window.onReportTimings != null)
-      ui.window.onReportTimings(<ui.FrameTiming>[
-        ui.FrameTiming(List<int>.filled(ui.FramePhase.values.length, 0)),
-      ]);
+    final Future<ui.FrameTiming> firstFrameEventFired = SchedulerBinding.instance.frameTimingStream.first;
+    ui.window.onReportTimings(<ui.FrameTiming>[
+      ui.FrameTiming(List<int>.filled(ui.FramePhase.values.length, 0)),
+    ]);
+    await firstFrameEventFired;
   }
 
   @override

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -144,8 +144,19 @@ void main() {
 
     await firstFrameEventFired;
 
+    // Test that frameTimingStream is a broadcast stream so it won't be shut
+    // down after the completion of Stream.first.
+    final dynamic secondFrameEventFired = scheduler.frameTimingStream.first;
+    window.onReportTimings(<FrameTiming>[FrameTiming(<int>[
+      // build start, build finish
+      10000, 15000,
+      // raster start, raster finish
+      16000, 20000,
+    ])]);
+    await secondFrameEventFired;
+
     final List<Map<String, dynamic>> events = scheduler.getEventsDispatched('Flutter.Frame');
-    expect(events, hasLength(1));
+    expect(events, hasLength(2));
 
     final Map<String, dynamic> event = events.first;
     expect(event['number'], isNonNegative);

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -132,12 +132,17 @@ void main() {
   });
 
   test('Flutter.Frame event fired', () async {
+    // We can't use Future in scheduler_test so we'll use dynamic instead.
+    final dynamic firstFrameEventFired = scheduler.frameTimingStream.first;
+
     window.onReportTimings(<FrameTiming>[FrameTiming(<int>[
       // build start, build finish
       10000, 15000,
       // raster start, raster finish
       16000, 20000,
     ])]);
+
+    await firstFrameEventFired;
 
     final List<Map<String, dynamic>> events = scheduler.getEventsDispatched('Flutter.Frame');
     expect(events, hasLength(1));


### PR DESCRIPTION
Without this, developers have to override `onReportTimings` to listen for `FrameTiming`.
That can potentially break previous `onReportTimings` listeners if they forget to call
the old listener in their new callback.

This change would make it safer and more convenient to listen for `FrameTiming`
(as illustrated in the removed TODO).

The following unit tests (and many other driver tests) covered this change:
- Flutter.Frame event fired
- All tests in service_extensions_test.dart (due to `setUpAll`)