### PR TITLE
fix rpc exception for real

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1116,6 +1116,7 @@ class TerminalHandler {
       lastReceivedCommand = command;
       await _commonTerminalInputHandler(command);
     } catch (error, st) {
+      // Don't print stack traces for known error types.
       if (error is! ToolExit) {
         printError('$error\n$st');
       }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1116,7 +1116,9 @@ class TerminalHandler {
       lastReceivedCommand = command;
       await _commonTerminalInputHandler(command);
     } catch (error, st) {
-      printError('$error\n$st');
+      if (error is! ToolExit) {
+        printError('$error\n$st');
+      }
       await _cleanUp(null);
       rethrow;
     } finally {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -577,6 +577,10 @@ class HotRunner extends ResidentRunner {
       if (!(await hotRunnerConfig.setupHotRestart())) {
         return OperationResult(1, 'setupHotRestart failed');
       }
+      // The current implementation of the vmservice and JSON rpc may throw
+      // unhandled exceptions into the zone that cannot be caught with a regular
+      // try catch. The usage is [asyncGuard] is required to normalize the error
+      // handling, at least until we can refactor the underlying code.
       result = await asyncGuard(() => _restartFromSources(
         reason: reason,
         benchmarkMode: benchmarkMode,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -8,6 +8,7 @@ import 'package:json_rpc_2/error_code.dart' as rpc_error_code;
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';
 
+import 'base/async_guard.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
@@ -576,10 +577,10 @@ class HotRunner extends ResidentRunner {
       if (!(await hotRunnerConfig.setupHotRestart())) {
         return OperationResult(1, 'setupHotRestart failed');
       }
-      result = await _restartFromSources(
+      result = await asyncGuard(() => _restartFromSources(
         reason: reason,
         benchmarkMode: benchmarkMode,
-      );
+      ));
       if (!result.isOk) {
         restartEvent = 'restart-failed';
       }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -358,7 +358,7 @@ class VMService {
   Future<void> _streamListen(String streamId) async {
     if (!_listeningFor.contains(streamId)) {
       _listeningFor.add(streamId);
-      _sendRequest('streamListen', <String, dynamic>{'streamId': streamId});
+      await _sendRequest('streamListen', <String, dynamic>{'streamId': streamId});
     }
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -13,7 +13,6 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-import 'base/async_guard.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
@@ -359,7 +358,7 @@ class VMService {
   Future<void> _streamListen(String streamId) async {
     if (!_listeningFor.contains(streamId)) {
       _listeningFor.add(streamId);
-      await asyncGuard(() => _sendRequest('streamListen', <String, dynamic>{'streamId': streamId}));
+      _sendRequest('streamListen', <String, dynamic>{'streamId': streamId});
     }
   }
 


### PR DESCRIPTION
## Description

Flutter run app, add import of mirrors, hot restart -> crash. It seems the exception gets thrown above the location where I added the guard, so Iv've added a new one and confirm it fixes this case.