### PR TITLE
Don't reload if compilation has errors

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -467,7 +467,7 @@ class DevFS {
       outputPath:  dillOutputPath ?? getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation),
       packagesFilePath : _packagesFilePath,
     );
-    if (compilerOutput == null) {
+    if (compilerOutput == null || compilerOutput.errorCount > 0) {
       return UpdateFSReport(success: false);
     }
     // list of sources that needs to be monitored are in [compilerOutput.sources]


### PR DESCRIPTION
## Description

I'm not sure why this was missing. For non-fatal errors like an invalid import or mirrors dependency we should not be continuing with the hot reload