### PR TITLE
Improve bitcode check

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-
 import '../artifacts.dart';
 import '../base/build.dart';
 import '../base/common.dart';

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+
 import '../artifacts.dart';
 import '../base/build.dart';
 import '../base/common.dart';
@@ -11,6 +12,7 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
+import '../base/version.dart';
 import '../build_info.dart';
 import '../dart/package_map.dart';
 import '../globals.dart';
@@ -225,13 +227,35 @@ Future<void> validateBitcode() async {
     fs.path.join(flutterFrameworkPath, 'Info.plist'),
     'ClangVersion',
   );
-  if (clangVersion != engineClangVersion) {
-    printStatus(
+  final Version engineClangSemVer = _parseVersionFromClang(engineClangVersion);
+  final Version clangSemVer = _parseVersionFromClang(clangVersion);
+  if (engineClangSemVer > clangSemVer) {
+    throwToolExit(
       'The Flutter.framework at $flutterFrameworkPath was built '
       'with "${engineClangVersion ?? 'unknown'}", but the current version '
-      'of clang is "$clangVersion". This may result in failures when '
-      'archiving your application in Xcode.',
-      emphasis: true,
+      'of clang is "$clangVersion". This will result in failures when trying to'
+      'archive an IPA. To resolve this issue, update your version of Xcode to '
+      'at least $engineClangSemVer.',
     );
   }
+}
+
+Version _parseVersionFromClang(String clangVersion) {
+  const String prefix = 'Apple LLVM version ';
+  void _invalid() {
+    throwToolExit('Unable to parse Clang version from "$clangVersion". '
+                  'Expected a string like "$prefix #.#.# (clang-####.#.##.#)".');
+  }
+  if (clangVersion == null || clangVersion.length <= prefix.length || !clangVersion.startsWith(prefix)) {
+    _invalid();
+  }
+  final int lastSpace = clangVersion.lastIndexOf(' ');
+  if (lastSpace == -1) {
+    _invalid();
+  }
+  final Version version = Version.parse(clangVersion.substring(prefix.length, lastSpace));
+  if (version == null) {
+    _invalid();
+  }
+  return version;
 }

--- a/packages/flutter_tools/test/general.shard/commands/build_aot_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_aot_test.dart
@@ -82,18 +82,19 @@ void main() {
       const <String>['foo'],
     );
     final RunResult clangResult = RunResult(
-      FakeProcessResult(stdout: 'BadVersion\nBlahBlah\n', stderr: ''),
+      FakeProcessResult(stdout: 'Apple LLVM version 10.0.0 (clang-4567.1.1.1)\nBlahBlah\n', stderr: ''),
       const <String>['foo'],
     );
     when(mockXcode.otool(any)).thenAnswer((_) => Future<RunResult>.value(otoolResult));
     when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(clangResult));
-    when(mockIOSWorkflow.getPlistValueFromFile(infoPlist.path, 'ClangVersion')).thenReturn('Apple LLVM Version 10.0.1');
+    when(mockIOSWorkflow.getPlistValueFromFile(infoPlist.path, 'ClangVersion')).thenReturn('Apple LLVM version 10.0.1 (clang-1234.1.12.1)');
 
-    await validateBitcode();
-
-    expect(
-      bufferLogger.statusText,
-      startsWith('The Flutter.framework at ${flutterFramework.path} was built with "Apple LLVM Version 10.0.1'),
+    await expectToolExitLater(
+      validateBitcode(),
+      equals('The Flutter.framework at ios_profile/Flutter.framework was built with "Apple LLVM version 10.0.1 '
+             '(clang-1234.1.12.1)", but the current version of clang is "Apple LLVM version 10.0.0 (clang-4567.1.1.1)". '
+             'This will result in failures when trying toarchive an IPA. To resolve this issue, update your version '
+             'of Xcode to at least 10.0.1.'),
     );
   }, overrides: <Type, Generator>{
     Artifacts: () => LocalEngineArtifacts('/engine', 'ios_profile', 'host_profile'),
@@ -104,7 +105,7 @@ void main() {
     IOSWorkflow: () => mockIOSWorkflow,
   });
 
-  testUsingContext('build aot validates and succeeds', () async {
+  testUsingContext('build aot validates and succeeds - same version of Xcode', () async {
     final Directory flutterFramework = memoryFileSystem.directory('ios_profile/Flutter.framework')
       ..createSync(recursive: true);
     flutterFramework.childFile('Flutter').createSync();
@@ -115,12 +116,42 @@ void main() {
       const <String>['foo'],
     );
     final RunResult clangResult = RunResult(
-      FakeProcessResult(stdout: 'Apple LLVM Version 10.0.1\nBlahBlah\n', stderr: ''),
+      FakeProcessResult(stdout: 'Apple LLVM version 10.0.1 (clang-1234.1.12.1)\nBlahBlah\n', stderr: ''),
       const <String>['foo'],
     );
     when(mockXcode.otool(any)).thenAnswer((_) => Future<RunResult>.value(otoolResult));
     when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(clangResult));
-    when(mockIOSWorkflow.getPlistValueFromFile(infoPlist.path, 'ClangVersion')).thenReturn('Apple LLVM Version 10.0.1');
+    when(mockIOSWorkflow.getPlistValueFromFile(infoPlist.path, 'ClangVersion')).thenReturn('Apple LLVM version 10.0.1 (clang-1234.1.12.1)');
+
+    await validateBitcode();
+
+    expect(bufferLogger.statusText, '');
+  }, overrides: <Type, Generator>{
+    Artifacts: () => LocalEngineArtifacts('/engine', 'ios_profile', 'host_profile'),
+    FileSystem: () => memoryFileSystem,
+    ProcessManager: () => mockProcessManager,
+    Xcode: () => mockXcode,
+    Logger: () => bufferLogger,
+    IOSWorkflow: () => mockIOSWorkflow,
+  });
+
+  testUsingContext('build aot validates and succeeds when user has newer version of Xcode', () async {
+    final Directory flutterFramework = memoryFileSystem.directory('ios_profile/Flutter.framework')
+      ..createSync(recursive: true);
+    flutterFramework.childFile('Flutter').createSync();
+    final File infoPlist = flutterFramework.childFile('Info.plist')..createSync();
+
+    final RunResult otoolResult = RunResult(
+      FakeProcessResult(stdout: '__LLVM', stderr: ''),
+      const <String>['foo'],
+    );
+    final RunResult clangResult = RunResult(
+      FakeProcessResult(stdout: 'Apple LLVM version 11.0.1 (clang-1234.1.12.1)\nBlahBlah\n', stderr: ''),
+      const <String>['foo'],
+    );
+    when(mockXcode.otool(any)).thenAnswer((_) => Future<RunResult>.value(otoolResult));
+    when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(clangResult));
+    when(mockIOSWorkflow.getPlistValueFromFile(infoPlist.path, 'ClangVersion')).thenReturn('Apple LLVM version 10.0.1 (clang-1234.1.12.1)');
 
     await validateBitcode();
 


### PR DESCRIPTION
## Description

Previously, we were checking that the Xcode versions matched exactly and printing a warning. We should be throwing if the user's Xcode version is < the engine's Xcode version, and allowing older versions to go through.  This is based on feedback from multiple maintainers of bitcode enabled frameworks internally.

## Related Issues

Addresses https://github.com/flutter/flutter/issues/15288

We want a check like this before we start turning on bitcode on CI.

## Tests

I added the following tests:

Updated some existing tests for the strict-er checks, added a new test for acceptable version mismatch.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change but only for an experimental feature that isn't yet supported, so I'm skipping announcing it.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
