### PR TITLE
Fix up iOS Add to App tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -535,7 +535,7 @@ task:
       env:
         SHARD: add2app_test
       setup_xcpretty_script:
-        - gem install xcpretty
+        - sudo gem install xcpretty
       test_all_script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts dev/bots/test.dart

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -534,6 +534,8 @@ task:
     - name: add2app-macos
       env:
         SHARD: add2app_test
+      setup_xcpretty_script:
+        - gem install xcpretty
       test_all_script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts dev/bots/test.dart

--- a/dev/integration_tests/ios_add2app/build_and_test.sh
+++ b/dev/integration_tests/ios_add2app/build_and_test.sh
@@ -10,4 +10,15 @@ popd
 
 pod install
 os_version=$(xcrun --show-sdk-version --sdk iphonesimulator)
-xcodebuild -workspace ios_add2app.xcworkspace -scheme ios_add2appTests -sdk "iphonesimulator$os_version" -destination "OS=$os_version,name=iPhone X" test
+
+PRETTY="cat"
+if which xcpretty; then
+  PRETTY="xcpretty"
+fi
+
+set -o pipefail && xcodebuild \
+  -workspace ios_add2app.xcworkspace \
+  -scheme ios_add2appTests \
+  -sdk "iphonesimulator$os_version" \
+  -destination "OS=$os_version,name=iPhone X" test | $PRETTY
+

--- a/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 			name = "[CP-User] Run Flutter Build Script";
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build\n";
+			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
 		};
 		DE5CDCD8B3565EAB9F38F455 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -502,8 +502,10 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -513,6 +515,11 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				WARNING_CFLAGS = "-Wno-gnu";
+				WARNING_LDFLAGS = (
+					"-Wall",
+					"-Werror",
+				);
 			};
 			name = Debug;
 		};
@@ -556,8 +563,10 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -567,6 +576,11 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
+				WARNING_CFLAGS = "-Wno-gnu";
+				WARNING_LDFLAGS = (
+					"-Wall",
+					"-Werror",
+				);
 			};
 			name = Release;
 		};

--- a/dev/integration_tests/ios_add2app/ios_add2app/AppDelegate.h
+++ b/dev/integration_tests/ios_add2app/ios_add2app/AppDelegate.h
@@ -8,7 +8,6 @@
 @interface AppDelegate : FlutterAppDelegate
 
 @property(nonatomic, strong) FlutterEngine* engine;
-@property(nonatomic, strong) UIWindow* window;
 @property(nonatomic, strong) FlutterBasicMessageChannel* reloadMessageChannel;
 
 @end

--- a/dev/integration_tests/ios_add2app/ios_add2app/AppDelegate.m
+++ b/dev/integration_tests/ios_add2app/ios_add2app/AppDelegate.m
@@ -41,7 +41,7 @@ static NSString *_kReloadChannelName = @"reload";
 
   _reloadMessageChannel = [[FlutterBasicMessageChannel alloc]
          initWithName:_kReloadChannelName
-      binaryMessenger:_engine
+      binaryMessenger:_engine.binaryMessenger
                 codec:[FlutterStringCodec sharedInstance]];
 
   self.window.rootViewController = _navigationController;

--- a/dev/integration_tests/ios_add2app/ios_add2app/HybridViewController.m
+++ b/dev/integration_tests/ios_add2app/ios_add2app/HybridViewController.m
@@ -56,7 +56,7 @@ static NSString *_kPing = @"ping";
 
   _messageChannel = [[FlutterBasicMessageChannel alloc]
          initWithName:_kChannel
-      binaryMessenger:_flutterViewController
+      binaryMessenger:_flutterViewController.binaryMessenger
                 codec:[FlutterStringCodec sharedInstance]];
   [self addChildViewController:_flutterViewController];
   [stackView addArrangedSubview:_flutterViewController.view];

--- a/dev/integration_tests/ios_add2app/ios_add2appTests/FlutterViewControllerTests.m
+++ b/dev/integration_tests/ios_add2app/ios_add2appTests/FlutterViewControllerTests.m
@@ -21,7 +21,7 @@
    [viewController viewWillAppear:NO];
    [viewController viewDidDisappear:NO];
  }
- XCTAssertNil(weakEngine);
+ XCTAssertNil(weakEngine, @"Engine failed to release.");
 }
 
 @end

--- a/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
+++ b/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
@@ -11,36 +11,6 @@
 #import "../ios_add2app/MainViewController.h"
 #import "../ios_add2app/HybridViewController.h"
 
-static void waitForFlutterSemanticsTree(FlutterViewController *viewController) {
-  int tries = 10;
-  double delay = 1.0;
-
-  // ensureSemanticsEnabled is a synchronous call, but only ensures that the
-  // semantics tree will be built on a subsequent frame (as opposed to being
-  // available at time it returns).
-  // To actually get the tree, we have to wait for the FlutterSemanticsUpdate
-  // notification, which lets us know that a semantics tree has been built;
-  // but we cannot block the main thread while waiting (so we use
-  // CFRunLoopRunInMode).
-
-  __block BOOL semanticsAvailable = NO;
-  __block id<NSObject> observer = [[NSNotificationCenter defaultCenter]
-      addObserverForName:@"FlutterSemanticsUpdate"
-                  object:viewController
-                   queue:nil
-              usingBlock:^(NSNotification *notification) {
-                semanticsAvailable = YES;
-                [[NSNotificationCenter defaultCenter] removeObserver:observer];
-              }];
-  [viewController.engine ensureSemanticsEnabled];
-  while (semanticsAvailable == NO && tries != 0) {
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, delay, false);
-    tries--;
-    [viewController.engine ensureSemanticsEnabled];
-  }
-  GREYAssertTrue(semanticsAvailable, @"Semantics Tree did not build!");
-}
-
 @interface FlutterTests : XCTestCase
 @end
 
@@ -56,6 +26,12 @@ static void waitForFlutterSemanticsTree(FlutterViewController *viewController) {
   }
 
   return self;
+}
+
+- (void)expectSemanticsNotification:(FlutterViewController*)viewController {
+  [self expectationForNotification:FlutterSemanticsUpdateNotification object:viewController handler:nil];
+  [viewController.engine ensureSemanticsEnabled];
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
 }
 
 - (void)testFullScreenCanPop {
@@ -74,7 +50,7 @@ static void waitForFlutterSemanticsTree(FlutterViewController *viewController) {
             .window.rootViewController;
     weakViewController =
         (FullScreenViewController *)navController.visibleViewController;
-    waitForFlutterSemanticsTree(weakViewController);
+    [self expectSemanticsNotification:weakViewController];
     GREYAssertNotNil(weakViewController,
                      @"Expected non-nil FullScreenViewController.");
   }
@@ -112,8 +88,8 @@ static void waitForFlutterSemanticsTree(FlutterViewController *viewController) {
         (DualFlutterViewController *)navController.visibleViewController;
     GREYAssertNotNil(viewController,
                      @"Expected non-nil DualFlutterViewController.");
-    waitForFlutterSemanticsTree(viewController.topFlutterViewController);
-    waitForFlutterSemanticsTree(viewController.bottomFlutterViewController);
+    [self expectSemanticsNotification:viewController.topFlutterViewController];
+    [self expectSemanticsNotification:viewController.topFlutterViewController];
   }
 
   // Verify that there are two Flutter views with the expected marquee text.
@@ -148,7 +124,7 @@ static void waitForFlutterSemanticsTree(FlutterViewController *viewController) {
         (HybridViewController *)navController.visibleViewController;
     GREYAssertNotNil(viewController.flutterViewController,
                      @"Expected non-nil FlutterViewController.");
-    waitForFlutterSemanticsTree(viewController.flutterViewController);
+    [self expectSemanticsNotification:viewController.flutterViewController];
   }
 
   [self validateCountsFlutter:@"Platform" count:0];

--- a/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
+++ b/dev/integration_tests/ios_add2app/ios_add2appTests/IntegrationTests.m
@@ -89,7 +89,7 @@
     GREYAssertNotNil(viewController,
                      @"Expected non-nil DualFlutterViewController.");
     [self expectSemanticsNotification:viewController.topFlutterViewController];
-    [self expectSemanticsNotification:viewController.topFlutterViewController];
+    [self expectSemanticsNotification:viewController.bottomFlutterViewController];
   }
 
   // Verify that there are two Flutter views with the expected marquee text.


### PR DESCRIPTION
## Description

A previous engine roll changed the way some of these interfaces worked.  Warnings were issued but not treated as errors.  This adds pedantic warnings and treats warnings as errors, but excludes the GNU warnings.  it updates sites where warnings were being issued, and simplifies the logic for waiting for the semantics notification to happen. It also extends the timeout on that to 30 seconds from 10, which should make this test less flaky.

Also tries to use xcpretty if available so the output is more legible.

## Tests

Updates/fixes tests for iOS Add to App

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
