### PR TITLE
Handle case of a connected unpaired iOS device

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -185,6 +185,8 @@ class IOSDevice extends Device {
       } on IOSDeviceNotFoundError catch (error) {
         // Unable to find device with given udid. Possibly a network device.
         printTrace('Error getting attached iOS device: $error');
+      } on IOSDeviceNotTrustedError catch (error) {
+        printTrace('Error getting attached iOS device information: $error');
       }
     }
     return devices;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -20,6 +20,7 @@ import '../device.dart';
 import '../globals.dart';
 import '../project.dart';
 import '../protocol_discovery.dart';
+import '../reporting/reporting.dart';
 import 'code_signing.dart';
 import 'ios_workflow.dart';
 import 'mac.dart';
@@ -187,6 +188,7 @@ class IOSDevice extends Device {
         printTrace('Error getting attached iOS device: $error');
       } on IOSDeviceNotTrustedError catch (error) {
         printTrace('Error getting attached iOS device information: $error');
+        UsageEvent('device', 'ios-trust-failure').send();
       }
     }
     return devices;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -45,12 +45,51 @@ class IOSDeviceNotFoundError implements Exception {
 /// Exception representing an attempt to find information on an iOS device
 /// that failed because the user had not paired the device with the host yet.
 class IOSDeviceNotTrustedError implements Exception {
-  const IOSDeviceNotTrustedError(this.message);
+  const IOSDeviceNotTrustedError(this.message, this.lockdownCode);
 
+  /// The error message to show to the user.
   final String message;
 
+  /// The associated `lockdownd` error code.
+  final LockdownReturnCode lockdownCode;
+
   @override
-  String toString() => message;
+  String toString() => '$message (lockdownd error code ${lockdownCode.code})';
+}
+
+/// Class specifying possible return codes from `lockdownd`.
+///
+/// This contains only a subset of the return codes that `lockdownd` can return,
+/// as we only care about a limited subset. These values should be kept in sync with
+/// https://github.com/libimobiledevice/libimobiledevice/blob/26373b3/include/libimobiledevice/lockdown.h#L37
+class LockdownReturnCode {
+  const LockdownReturnCode._(this.code);
+
+  /// The OS exit code.
+  final int code;
+
+  /// Creates a new [LockdownReturnCode] from the specified OS exit code.
+  ///
+  /// If the [code] maps to one of the known codes, a `const` instance will be
+  /// returned.
+  factory LockdownReturnCode.fromCode(int code) {
+    const Map<int, LockdownReturnCode> knownCodes = <int, LockdownReturnCode>{
+      19: pairingDialogResponsePending,
+      21: invalidHostId,
+    };
+
+    return knownCodes.containsKey(code) ? knownCodes[code] : LockdownReturnCode._(code);
+  }
+
+  /// Error code indicating that the pairing dialog has been shown to the user,
+  /// and the user has not yet responded as to whether to trust the host.
+  static const LockdownReturnCode pairingDialogResponsePending = LockdownReturnCode._(19);
+
+  /// Error code indicating that the host is not trusted.
+  ///
+  /// This can happen if the user explicitly says "do not trust this  computer"
+  /// or if they revoke all trusted computers in the device settings.
+  static const LockdownReturnCode invalidHostId = LockdownReturnCode._(21);
 }
 
 class IMobileDevice {
@@ -171,8 +210,20 @@ class IMobileDevice {
       );
       if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
         throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}');
-      if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd'))
-        throw IOSDeviceNotTrustedError('Device info unavailable until the user selects "Trust This Computer" on the device (${result.stderr.trim()})');
+      if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd')) {
+        if (result.stderr.contains('error code -${LockdownReturnCode.pairingDialogResponsePending.code}')) {
+          throw const IOSDeviceNotTrustedError(
+            'Device info unavailable until the user selects "Trust This Computer" on the device',
+            LockdownReturnCode.pairingDialogResponsePending,
+          );
+        }
+        if (result.stderr.contains('error code -${LockdownReturnCode.invalidHostId.code}')) {
+          throw const IOSDeviceNotTrustedError(
+            'Device info unavailable until the user resets their trust settings on the device',
+            LockdownReturnCode.invalidHostId,
+          );
+        }
+      }
       if (result.exitCode != 0)
         throw ToolExit('ideviceinfo returned an error:\n${result.stderr}');
       return result.stdout.trim();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -65,9 +65,6 @@ class IOSDeviceNotTrustedError implements Exception {
 class LockdownReturnCode {
   const LockdownReturnCode._(this.code);
 
-  /// The OS exit code.
-  final int code;
-
   /// Creates a new [LockdownReturnCode] from the specified OS exit code.
   ///
   /// If the [code] maps to one of the known codes, a `const` instance will be
@@ -80,6 +77,9 @@ class LockdownReturnCode {
 
     return knownCodes.containsKey(code) ? knownCodes[code] : LockdownReturnCode._(code);
   }
+
+  /// The OS exit code.
+  final int code;
 
   /// Error code indicating that the pairing dialog has been shown to the user,
   /// and the user has not yet responded as to whether to trust the host.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -213,7 +213,7 @@ class IMobileDevice {
       if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd')) {
         if (result.stderr.contains('error code -${LockdownReturnCode.pairingDialogResponsePending.code}')) {
           throw const IOSDeviceNotTrustedError(
-            'Device info unavailable. Is the device asking to "Trust This Computer?"',
+            'Device info unavailable. Is the device asking to "Trust This Computer?" Try unlocking attached devices.',
             LockdownReturnCode.pairingDialogResponsePending,
           );
         }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -213,13 +213,13 @@ class IMobileDevice {
       if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd')) {
         if (result.stderr.contains('error code -${LockdownReturnCode.pairingDialogResponsePending.code}')) {
           throw const IOSDeviceNotTrustedError(
-            'Device info unavailable until the user selects "Trust This Computer" on the device',
+            'Device info unavailable. Is the device asking to "Trust This Computer?"',
             LockdownReturnCode.pairingDialogResponsePending,
           );
         }
         if (result.stderr.contains('error code -${LockdownReturnCode.invalidHostId.code}')) {
           throw const IOSDeviceNotTrustedError(
-            'Device info unavailable until the user resets their trust settings on the device',
+            'Device info unavailable. Device pairing "trust" may have been revoked.',
             LockdownReturnCode.invalidHostId,
           );
         }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -70,9 +70,9 @@ class LockdownReturnCode {
   /// If the [code] maps to one of the known codes, a `const` instance will be
   /// returned.
   factory LockdownReturnCode.fromCode(int code) {
-    const Map<int, LockdownReturnCode> knownCodes = <int, LockdownReturnCode>{
-      19: pairingDialogResponsePending,
-      21: invalidHostId,
+    final Map<int, LockdownReturnCode> knownCodes = <int, LockdownReturnCode>{
+      pairingDialogResponsePending.code: pairingDialogResponsePending,
+      invalidHostId.code: invalidHostId,
     };
 
     return knownCodes.containsKey(code) ? knownCodes[code] : LockdownReturnCode._(code);

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -34,7 +34,18 @@ IMobileDevice get iMobileDevice => context.get<IMobileDevice>();
 /// Specialized exception for expected situations where the ideviceinfo
 /// tool responds with exit code 255 / 'No device found' message
 class IOSDeviceNotFoundError implements Exception {
-  IOSDeviceNotFoundError(this.message);
+  const IOSDeviceNotFoundError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Exception representing an attempt to find information on an iOS device
+/// that failed because the user had not paired the device with the host yet.
+class IOSDeviceNotTrustedError implements Exception {
+  const IOSDeviceNotTrustedError(this.message);
 
   final String message;
 
@@ -160,6 +171,8 @@ class IMobileDevice {
       );
       if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
         throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}');
+      if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd'))
+        throw IOSDeviceNotTrustedError('Device info unavailable until the user selects "Trust This Computer" on the device (${result.stderr.trim()})');
       if (result.exitCode != 0)
         throw ToolExit('ideviceinfo returned an error:\n${result.stderr}');
       return result.stdout.trim();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -209,11 +209,11 @@ class IMobileDevice {
         ),
       );
       if (result.exitCode == 255 && result.stdout != null && result.stdout.contains('No device found'))
-        throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}');
+        throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n${result.stdout}. Try unlocking attached devices.');
       if (result.exitCode == 255 && result.stderr != null && result.stderr.contains('Could not connect to lockdownd')) {
         if (result.stderr.contains('error code -${LockdownReturnCode.pairingDialogResponsePending.code}')) {
           throw const IOSDeviceNotTrustedError(
-            'Device info unavailable. Is the device asking to "Trust This Computer?" Try unlocking attached devices.',
+            'Device info unavailable. Is the device asking to "Trust This Computer?"',
             LockdownReturnCode.pairingDialogResponsePending,
           );
         }

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -230,7 +230,7 @@ f577a7903cc54959be2e34bc4f7f80b7009efcf4
       when(iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
           .thenAnswer((_) => Future<String>.value('La tele me regarde'));
       when(iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
-          .thenThrow(IOSDeviceNotFoundError('Device not found'));
+          .thenThrow(const IOSDeviceNotFoundError('Device not found'));
       final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
       expect(devices, hasLength(1));
       expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -113,12 +113,62 @@ void main() {
       Artifacts: () => mockArtifacts,
     });
 
-    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when ideviceinfo cannot connect to lockdownd', () async {
+    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when user has not yet trusted the host', () async {
       when(mockArtifacts.getArtifactPath(Artifact.ideviceinfo, platform: anyNamed('platform'))).thenReturn(ideviceInfoPath);
       when(mockProcessManager.run(
         <String>[ideviceInfoPath, '-u', 'foo', '-k', 'bar'],
         environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
-      )).thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 255, '', 'ERROR: Could not connect to lockdownd, error code -irrelevant')));
+      )).thenAnswer((_) {
+        final ProcessResult result = ProcessResult(
+          1,
+          255,
+          '',
+          'ERROR: Could not connect to lockdownd, error code -${LockdownReturnCode.pairingDialogResponsePending.code}',
+        );
+        return Future<ProcessResult>.value(result);
+      });
+      expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotTrustedError>()));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Cache: () => mockCache,
+      Artifacts: () => mockArtifacts,
+    });
+
+    testUsingContext('getInfoForDevice throws ToolExit lockdownd fails for unknown reason', () async {
+      when(mockArtifacts.getArtifactPath(Artifact.ideviceinfo, platform: anyNamed('platform'))).thenReturn(ideviceInfoPath);
+      when(mockProcessManager.run(
+        <String>[ideviceInfoPath, '-u', 'foo', '-k', 'bar'],
+        environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+      )).thenAnswer((_) {
+        final ProcessResult result = ProcessResult(
+          1,
+          255,
+          '',
+          'ERROR: Could not connect to lockdownd, error code -12345',
+        );
+        return Future<ProcessResult>.value(result);
+      });
+      expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsToolExit());
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Cache: () => mockCache,
+      Artifacts: () => mockArtifacts,
+    });
+
+    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when host trust is revoked', () async {
+      when(mockArtifacts.getArtifactPath(Artifact.ideviceinfo, platform: anyNamed('platform'))).thenReturn(ideviceInfoPath);
+      when(mockProcessManager.run(
+        <String>[ideviceInfoPath, '-u', 'foo', '-k', 'bar'],
+        environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+      )).thenAnswer((_) {
+        final ProcessResult result = ProcessResult(
+          1,
+          255,
+          '',
+          'ERROR: Could not connect to lockdownd, error code -${LockdownReturnCode.invalidHostId.code}',
+        );
+        return Future<ProcessResult>.value(result);
+      });
       expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotTrustedError>()));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -113,6 +113,19 @@ void main() {
       Artifacts: () => mockArtifacts,
     });
 
+    testUsingContext('getInfoForDevice throws IOSDeviceNotFoundError when ideviceinfo cannot connect to lockdownd', () async {
+      when(mockArtifacts.getArtifactPath(Artifact.ideviceinfo, platform: anyNamed('platform'))).thenReturn(ideviceInfoPath);
+      when(mockProcessManager.run(
+        <String>[ideviceInfoPath, '-u', 'foo', '-k', 'bar'],
+        environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+      )).thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 255, '', 'ERROR: Could not connect to lockdownd, error code -irrelevant')));
+      expect(() async => await iMobileDevice.getInfoForDevice('foo', 'bar'), throwsA(isInstanceOf<IOSDeviceNotTrustedError>()));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Cache: () => mockCache,
+      Artifacts: () => mockArtifacts,
+    });
+
     group('screenshot', () {
       final String outputPath = fs.path.join('some', 'test', 'path', 'image.png');
       MockProcessManager mockProcessManager;


### PR DESCRIPTION
## Description

`ideviceinfo` fails with "ERROR: Could not connect to lockdownd" when the physical device is not paired. This change handles that case.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/36789
Fixes https://github.com/flutter/flutter/issues/37000

https://github.com/flutter/flutter/issues/36524
https://github.com/flutter/flutter/issues/24600

## Tests

I added the following tests:

* A test in `mac_test.dart` to replicate the scenario

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
