### PR TITLE
[flutter_tool] Throw tool exit on malformed storage url override

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -8,6 +8,7 @@ import '../base/context.dart';
 import '../globals.dart';
 import 'common.dart';
 import 'io.dart';
+import 'platform.dart';
 
 const int kNetworkProblemExitCode = 50;
 
@@ -53,6 +54,19 @@ Future<List<int>> _attempt(Uri url, { bool onlyHeaders = false }) async {
     } else {
       request = await httpClient.getUrl(url);
     }
+  } on ArgumentError catch (error) {
+    final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
+    if (overrideUrl != null && url.toString().contains(overrideUrl)) {
+      printError(error.toString());
+      throwToolExit(
+        'The value of FLUTTER_STORAGE_BASE_URL ($overrideUrl) could not be '
+        'parsed as a valid url. Please see https://flutter.dev/community/china '
+        'for an example of how to use it.\n'
+        'Full URL: $url',
+        exitCode: kNetworkProblemExitCode,);
+    }
+    printError(error.toString());
+    rethrow;
   } on HandshakeException catch (error) {
     printTrace(error.toString());
     throwToolExit(


### PR DESCRIPTION
## Description

If `FLUTTER_STORAGE_BASE_URL` is malformed, throw a tool exit with a helpful message when we try to use it and catch the resulting `ArgumentError`.

## Related Issues

Seen in crash logging

## Tests

I added the following tests:

New test in net_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.