### PR TITLE
Rename iOS arch for macOS release mode (macOS release mode 2 of 3)

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -46,7 +46,7 @@ class GenSnapshot {
 
   Future<int> run({
     @required SnapshotType snapshotType,
-    AppleArch appleArch,
+    DarwinArch darwinArch,
     Iterable<String> additionalArgs = const <String>[],
   }) {
     final List<String> args = <String>[
@@ -59,7 +59,7 @@ class GenSnapshot {
     // iOS has a separate gen_snapshot for armv7 and arm64 in the same,
     // directory. So we need to select the right one.
     if (snapshotType.platform == TargetPlatform.ios) {
-      snapshotterPath += '_' + getNameForAppleArch(appleArch);
+      snapshotterPath += '_' + getNameForDarwinArch(darwinArch);
     }
 
     StringConverter outputFilter;
@@ -89,7 +89,7 @@ class AOTSnapshotter {
     @required String mainPath,
     @required String packagesPath,
     @required String outputPath,
-    AppleArch appleArch,
+    DarwinArch darwinArch,
     List<String> extraGenSnapshotOptions = const <String>[],
     @required bool bitcode,
   }) async {
@@ -103,7 +103,7 @@ class AOTSnapshotter {
       return 1;
     }
     // TODO(cbracken): replace IOSArch with TargetPlatform.ios_{armv7,arm64}.
-    assert(platform != TargetPlatform.ios || appleArch != null);
+    assert(platform != TargetPlatform.ios || darwinArch != null);
 
     final PackageMap packageMap = PackageMap(packagesPath);
     final String packageMapError = packageMap.checkValid();
@@ -143,7 +143,7 @@ class AOTSnapshotter {
       genSnapshotArgs.add('--strip');
     }
 
-    if (platform == TargetPlatform.android_arm || appleArch == AppleArch.armv7) {
+    if (platform == TargetPlatform.android_arm || darwinArch == DarwinArch.armv7) {
       // Use softfp for Android armv7 devices.
       // This is the default for armv7 iOS builds, but harmless to set.
       // TODO(cbracken): eliminate this when we fix https://github.com/flutter/flutter/issues/17489
@@ -168,7 +168,7 @@ class AOTSnapshotter {
         () => genSnapshot.run(
       snapshotType: snapshotType,
       additionalArgs: genSnapshotArgs,
-      appleArch: appleArch,
+      darwinArch: darwinArch,
     ));
     if (genSnapshotExitCode != 0) {
       printError('Dart snapshot generator failed with exit code $genSnapshotExitCode');
@@ -199,7 +199,7 @@ class AOTSnapshotter {
     // end-developer can link into their app.
     if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
       final RunResult result = await _buildFramework(
-        appleArch: appleArch,
+        appleArch: darwinArch,
         assemblyPath: bitcode ? '$assembly.bitcode' : assembly,
         outputPath: outputDir.path,
         bitcode: bitcode,
@@ -213,16 +213,16 @@ class AOTSnapshotter {
   /// Builds an iOS or macOS framework at [outputPath]/App.framework from the assembly
   /// source at [assemblyPath].
   Future<RunResult> _buildFramework({
-    @required AppleArch appleArch,
+    @required DarwinArch appleArch,
     @required String assemblyPath,
     @required String outputPath,
     @required bool bitcode,
   }) async {
-    final String targetArch = getNameForAppleArch(appleArch);
+    final String targetArch = getNameForDarwinArch(appleArch);
     printStatus('Building App.framework for $targetArch...');
     final List<String> commonBuildOptions = <String>[
       '-arch', targetArch,
-      if (appleArch == AppleArch.arm64 || appleArch == AppleArch.armv7)
+      if (appleArch == DarwinArch.arm64 || appleArch == DarwinArch.armv7)
         '-miphoneos-version-min=8.0',
     ];
 

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -46,7 +46,7 @@ class GenSnapshot {
 
   Future<int> run({
     @required SnapshotType snapshotType,
-    IOSArch iosArch,
+    AppleArch appleArch,
     Iterable<String> additionalArgs = const <String>[],
   }) {
     final List<String> args = <String>[
@@ -59,7 +59,7 @@ class GenSnapshot {
     // iOS has a separate gen_snapshot for armv7 and arm64 in the same,
     // directory. So we need to select the right one.
     if (snapshotType.platform == TargetPlatform.ios) {
-      snapshotterPath += '_' + getNameForIOSArch(iosArch);
+      snapshotterPath += '_' + getNameForAppleArch(appleArch);
     }
 
     StringConverter outputFilter;
@@ -89,7 +89,7 @@ class AOTSnapshotter {
     @required String mainPath,
     @required String packagesPath,
     @required String outputPath,
-    IOSArch iosArch,
+    AppleArch appleArch,
     List<String> extraGenSnapshotOptions = const <String>[],
     @required bool bitcode,
   }) async {
@@ -103,7 +103,7 @@ class AOTSnapshotter {
       return 1;
     }
     // TODO(cbracken): replace IOSArch with TargetPlatform.ios_{armv7,arm64}.
-    assert(platform != TargetPlatform.ios || iosArch != null);
+    assert(platform != TargetPlatform.ios || appleArch != null);
 
     final PackageMap packageMap = PackageMap(packagesPath);
     final String packageMapError = packageMap.checkValid();
@@ -130,7 +130,7 @@ class AOTSnapshotter {
     }
 
     final String assembly = fs.path.join(outputDir.path, 'snapshot_assembly.S');
-    if (platform == TargetPlatform.ios) {
+    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
       // Assembly AOT snapshot.
       outputPaths.add(assembly);
       genSnapshotArgs.add('--snapshot_kind=app-aot-assembly');
@@ -143,7 +143,7 @@ class AOTSnapshotter {
       genSnapshotArgs.add('--strip');
     }
 
-    if (platform == TargetPlatform.android_arm || iosArch == IOSArch.armv7) {
+    if (platform == TargetPlatform.android_arm || appleArch == AppleArch.armv7) {
       // Use softfp for Android armv7 devices.
       // This is the default for armv7 iOS builds, but harmless to set.
       // TODO(cbracken): eliminate this when we fix https://github.com/flutter/flutter/issues/17489
@@ -168,7 +168,7 @@ class AOTSnapshotter {
         () => genSnapshot.run(
       snapshotType: snapshotType,
       additionalArgs: genSnapshotArgs,
-      iosArch: iosArch,
+      appleArch: appleArch,
     ));
     if (genSnapshotExitCode != 0) {
       printError('Dart snapshot generator failed with exit code $genSnapshotExitCode');
@@ -197,9 +197,9 @@ class AOTSnapshotter {
 
     // On iOS, we use Xcode to compile the snapshot into a dynamic library that the
     // end-developer can link into their app.
-    if (platform == TargetPlatform.ios) {
-      final RunResult result = await _buildIosFramework(
-        iosArch: iosArch,
+    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
+      final RunResult result = await _buildFramework(
+        appleArch: appleArch,
         assemblyPath: bitcode ? '$assembly.bitcode' : assembly,
         outputPath: outputDir.path,
         bitcode: bitcode,
@@ -210,17 +210,21 @@ class AOTSnapshotter {
     return 0;
   }
 
-  /// Builds an iOS framework at [outputPath]/App.framework from the assembly
+  /// Builds an iOS or macOS framework at [outputPath]/App.framework from the assembly
   /// source at [assemblyPath].
-  Future<RunResult> _buildIosFramework({
-    @required IOSArch iosArch,
+  Future<RunResult> _buildFramework({
+    @required AppleArch appleArch,
     @required String assemblyPath,
     @required String outputPath,
     @required bool bitcode,
   }) async {
-    final String targetArch = iosArch == IOSArch.armv7 ? 'armv7' : 'arm64';
+    final String targetArch = getNameForAppleArch(appleArch);
     printStatus('Building App.framework for $targetArch...');
-    final List<String> commonBuildOptions = <String>['-arch', targetArch, '-miphoneos-version-min=8.0'];
+    final List<String> commonBuildOptions = <String>[
+      '-arch', targetArch,
+      if (appleArch == AppleArch.arm64 || appleArch == AppleArch.armv7)
+        '-miphoneos-version-min=8.0',
+    ];
 
     final String assemblyO = fs.path.join(outputPath, 'snapshot_assembly.o');
     final RunResult compileResult = await xcode.cc(<String>[
@@ -322,6 +326,7 @@ class AOTSnapshotter {
       TargetPlatform.android_arm,
       TargetPlatform.android_arm64,
       TargetPlatform.ios,
+      TargetPlatform.darwin_x64,
     ].contains(platform);
   }
 

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -268,7 +268,7 @@ enum TargetPlatform {
 /// iOS and macOS target device architecture.
 //
 // TODO(cbracken): split TargetPlatform.ios into ios_armv7, ios_arm64.
-enum AppleArch {
+enum DarwinArch {
   armv7,
   arm64,
   x86_64,
@@ -282,29 +282,29 @@ enum AndroidArch {
 }
 
 /// The default set of iOS device architectures to build for.
-const List<AppleArch> defaultIOSArchs = <AppleArch>[
-  AppleArch.arm64,
+const List<DarwinArch> defaultIOSArchs = <DarwinArch>[
+  DarwinArch.arm64,
 ];
 
-String getNameForAppleArch(AppleArch arch) {
+String getNameForDarwinArch(DarwinArch arch) {
   switch (arch) {
-    case AppleArch.armv7:
+    case DarwinArch.armv7:
       return 'armv7';
-    case AppleArch.arm64:
+    case DarwinArch.arm64:
       return 'arm64';
-    case AppleArch.x86_64:
+    case DarwinArch.x86_64:
       return 'x86_64';
   }
   assert(false);
   return null;
 }
 
-AppleArch getIOSArchForName(String arch) {
+DarwinArch getIOSArchForName(String arch) {
   switch (arch) {
     case 'armv7':
-      return AppleArch.armv7;
+      return DarwinArch.armv7;
     case 'arm64':
-      return AppleArch.arm64;
+      return DarwinArch.arm64;
   }
   assert(false);
   return null;

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -265,12 +265,13 @@ enum TargetPlatform {
   web_javascript,
 }
 
-/// iOS target device architecture.
+/// iOS and macOS target device architecture.
 //
 // TODO(cbracken): split TargetPlatform.ios into ios_armv7, ios_arm64.
-enum IOSArch {
+enum AppleArch {
   armv7,
   arm64,
+  x86_64,
 }
 
 enum AndroidArch {
@@ -281,27 +282,29 @@ enum AndroidArch {
 }
 
 /// The default set of iOS device architectures to build for.
-const List<IOSArch> defaultIOSArchs = <IOSArch>[
-  IOSArch.arm64,
+const List<AppleArch> defaultIOSArchs = <AppleArch>[
+  AppleArch.arm64,
 ];
 
-String getNameForIOSArch(IOSArch arch) {
+String getNameForAppleArch(AppleArch arch) {
   switch (arch) {
-    case IOSArch.armv7:
+    case AppleArch.armv7:
       return 'armv7';
-    case IOSArch.arm64:
+    case AppleArch.arm64:
       return 'arm64';
+    case AppleArch.x86_64:
+      return 'x86_64';
   }
   assert(false);
   return null;
 }
 
-IOSArch getIOSArchForName(String arch) {
+AppleArch getIOSArchForName(String arch) {
   switch (arch) {
     case 'armv7':
-      return IOSArch.armv7;
+      return AppleArch.armv7;
     case 'arm64':
-      return IOSArch.arm64;
+      return AppleArch.arm64;
   }
   assert(false);
   return null;

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -32,8 +32,8 @@ abstract class AotAssemblyBase extends Target {
     final bool bitcode = environment.defines[kBitcodeFlag] == 'true';
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final TargetPlatform targetPlatform = getTargetPlatformForName(environment.defines[kTargetPlatform]);
-    final List<IOSArch> iosArchs = environment.defines[kIosArchs]?.split(',')?.map(getIOSArchForName)?.toList()
-        ?? <IOSArch>[IOSArch.arm64];
+    final List<AppleArch> iosArchs = environment.defines[kIosArchs]?.split(',')?.map(getIOSArchForName)?.toList()
+        ?? <AppleArch>[AppleArch.arm64];
     if (targetPlatform != TargetPlatform.ios) {
       throw Exception('aot_assembly is only supported for iOS applications');
     }
@@ -46,7 +46,7 @@ abstract class AotAssemblyBase extends Target {
         mainPath: environment.buildDir.childFile('app.dill').path,
         packagesPath: environment.projectDir.childFile('.packages').path,
         outputPath: outputPath,
-        iosArch: iosArchs.single,
+        appleArch: iosArchs.single,
         bitcode: bitcode,
       );
       if (snapshotExitCode != 0) {
@@ -56,14 +56,14 @@ abstract class AotAssemblyBase extends Target {
       // If we're building multiple iOS archs the binaries need to be lipo'd
       // together.
       final List<Future<int>> pending = <Future<int>>[];
-      for (IOSArch iosArch in iosArchs) {
+      for (AppleArch iosArch in iosArchs) {
         pending.add(snapshotter.build(
           platform: targetPlatform,
           buildMode: buildMode,
           mainPath: environment.buildDir.childFile('app.dill').path,
           packagesPath: environment.projectDir.childFile('.packages').path,
-          outputPath: fs.path.join(outputPath, getNameForIOSArch(iosArch)),
-          iosArch: iosArch,
+          outputPath: fs.path.join(outputPath, getNameForAppleArch(iosArch)),
+          appleArch: iosArch,
           bitcode: bitcode,
         ));
       }
@@ -73,8 +73,8 @@ abstract class AotAssemblyBase extends Target {
       }
       final ProcessResult result = await processManager.run(<String>[
         'lipo',
-        ...iosArchs.map((IOSArch iosArch) =>
-            fs.path.join(outputPath, getNameForIOSArch(iosArch), 'App.framework', 'App')),
+        ...iosArchs.map((AppleArch iosArch) =>
+            fs.path.join(outputPath, getNameForAppleArch(iosArch), 'App.framework', 'App')),
         '-create',
         '-output',
         fs.path.join(outputPath, 'App.framework', 'App'),

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -40,8 +40,8 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
       )
       ..addMultiOption('ios-arch',
         splitCommas: true,
-        defaultsTo: defaultIOSArchs.map<String>(getNameForAppleArch),
-        allowed: AppleArch.values.map<String>(getNameForAppleArch),
+        defaultsTo: defaultIOSArchs.map<String>(getNameForDarwinArch),
+        allowed: DarwinArch.values.map<String>(getNameForDarwinArch),
         help: 'iOS architectures to build.',
       )
       ..addMultiOption(FlutterOptions.kExtraFrontEndOptions,
@@ -118,17 +118,17 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
       // Build AOT snapshot.
       if (platform == TargetPlatform.ios) {
         // Determine which iOS architectures to build for.
-        final Iterable<AppleArch> buildArchs = argResults['ios-arch'].map<AppleArch>(getIOSArchForName);
-        final Map<AppleArch, String> iosBuilds = <AppleArch, String>{};
-        for (AppleArch arch in buildArchs)
-          iosBuilds[arch] = fs.path.join(outputPath, getNameForAppleArch(arch));
+        final Iterable<DarwinArch> buildArchs = argResults['ios-arch'].map<DarwinArch>(getIOSArchForName);
+        final Map<DarwinArch, String> iosBuilds = <DarwinArch, String>{};
+        for (DarwinArch arch in buildArchs)
+          iosBuilds[arch] = fs.path.join(outputPath, getNameForDarwinArch(arch));
 
         // Generate AOT snapshot and compile to arch-specific App.framework.
-        final Map<AppleArch, Future<int>> exitCodes = <AppleArch, Future<int>>{};
-        iosBuilds.forEach((AppleArch iosArch, String outputPath) {
+        final Map<DarwinArch, Future<int>> exitCodes = <DarwinArch, Future<int>>{};
+        iosBuilds.forEach((DarwinArch iosArch, String outputPath) {
           exitCodes[iosArch] = snapshotter.build(
             platform: platform,
-            appleArch: iosArch,
+            darwinArch: iosArch,
             buildMode: buildMode,
             mainPath: mainPath,
             packagesPath: PackageMap.globalPackagesPath,
@@ -160,7 +160,7 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
           ]);
         } else {
           status?.cancel();
-          exitCodes.forEach((AppleArch iosArch, Future<int> exitCodeFuture) async {
+          exitCodes.forEach((DarwinArch iosArch, Future<int> exitCodeFuture) async {
             final int buildExitCode = await exitCodeFuture;
             printError('Snapshotting ($iosArch) exited with non-zero exit code: $buildExitCode');
           });

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -40,8 +40,8 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
       )
       ..addMultiOption('ios-arch',
         splitCommas: true,
-        defaultsTo: defaultIOSArchs.map<String>(getNameForIOSArch),
-        allowed: IOSArch.values.map<String>(getNameForIOSArch),
+        defaultsTo: defaultIOSArchs.map<String>(getNameForAppleArch),
+        allowed: AppleArch.values.map<String>(getNameForAppleArch),
         help: 'iOS architectures to build.',
       )
       ..addMultiOption(FlutterOptions.kExtraFrontEndOptions,
@@ -118,17 +118,17 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
       // Build AOT snapshot.
       if (platform == TargetPlatform.ios) {
         // Determine which iOS architectures to build for.
-        final Iterable<IOSArch> buildArchs = argResults['ios-arch'].map<IOSArch>(getIOSArchForName);
-        final Map<IOSArch, String> iosBuilds = <IOSArch, String>{};
-        for (IOSArch arch in buildArchs)
-          iosBuilds[arch] = fs.path.join(outputPath, getNameForIOSArch(arch));
+        final Iterable<AppleArch> buildArchs = argResults['ios-arch'].map<AppleArch>(getIOSArchForName);
+        final Map<AppleArch, String> iosBuilds = <AppleArch, String>{};
+        for (AppleArch arch in buildArchs)
+          iosBuilds[arch] = fs.path.join(outputPath, getNameForAppleArch(arch));
 
         // Generate AOT snapshot and compile to arch-specific App.framework.
-        final Map<IOSArch, Future<int>> exitCodes = <IOSArch, Future<int>>{};
-        iosBuilds.forEach((IOSArch iosArch, String outputPath) {
+        final Map<AppleArch, Future<int>> exitCodes = <AppleArch, Future<int>>{};
+        iosBuilds.forEach((AppleArch iosArch, String outputPath) {
           exitCodes[iosArch] = snapshotter.build(
             platform: platform,
-            iosArch: iosArch,
+            appleArch: iosArch,
             buildMode: buildMode,
             mainPath: mainPath,
             packagesPath: PackageMap.globalPackagesPath,
@@ -160,7 +160,7 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
           ]);
         } else {
           status?.cancel();
-          exitCodes.forEach((IOSArch iosArch, Future<int> exitCodeFuture) async {
+          exitCodes.forEach((AppleArch iosArch, Future<int> exitCodeFuture) async {
             final int buildExitCode = await exitCodeFuture;
             printError('Snapshotting ($iosArch) exited with non-zero exit code: $buildExitCode');
           });

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -265,7 +265,7 @@ class IOSDevice extends Device {
       printTrace('Building ${package.name} for $id');
 
       final String cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
-      final IOSArch iosArch = getIOSArchForName(cpuArchitecture);
+      final AppleArch iosArch = getIOSArchForName(cpuArchitecture);
 
       // Step 1: Build the precompiled/DBC application if necessary.
       final XcodeBuildResult buildResult = await buildXcodeProject(

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -265,7 +265,7 @@ class IOSDevice extends Device {
       printTrace('Building ${package.name} for $id');
 
       final String cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
-      final AppleArch iosArch = getIOSArchForName(cpuArchitecture);
+      final DarwinArch iosArch = getIOSArchForName(cpuArchitecture);
 
       // Step 1: Build the precompiled/DBC application if necessary.
       final XcodeBuildResult buildResult = await buildXcodeProject(

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -201,7 +201,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   BuildInfo buildInfo,
   String targetOverride,
   bool buildForDevice,
-  IOSArch activeArch,
+  AppleArch activeArch,
   bool codesign = true,
   bool usesTerminalUi = true,
 }) async {
@@ -317,7 +317,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   if (activeArch != null) {
-    final String activeArchName = getNameForIOSArch(activeArch);
+    final String activeArchName = getNameForAppleArch(activeArch);
     if (activeArchName != null) {
       buildCommands.add('ONLY_ACTIVE_ARCH=YES');
       buildCommands.add('ARCHS=$activeArchName');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -201,7 +201,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   BuildInfo buildInfo,
   String targetOverride,
   bool buildForDevice,
-  AppleArch activeArch,
+  DarwinArch activeArch,
   bool codesign = true,
   bool usesTerminalUi = true,
 }) async {
@@ -317,7 +317,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   if (activeArch != null) {
-    final String activeArchName = getNameForAppleArch(activeArch);
+    final String activeArchName = getNameForDarwinArch(activeArch);
     if (activeArchName != null) {
       buildCommands.add('ONLY_ACTIVE_ARCH=YES');
       buildCommands.add('ARCHS=$activeArchName');

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -50,7 +50,7 @@ class _FakeGenSnapshot implements GenSnapshot {
   Future<int> run({
     SnapshotType snapshotType,
     String depfilePath,
-    IOSArch iosArch,
+    AppleArch appleArch,
     Iterable<String> additionalArgs = const <String>[],
   }) async {
     _callCount += 1;
@@ -191,7 +191,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        iosArch: IOSArch.armv7,
+        appleArch: AppleArch.armv7,
         bitcode: true,
       );
 
@@ -245,7 +245,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        iosArch: IOSArch.armv7,
+        appleArch: AppleArch.armv7,
         bitcode: false,
       );
 
@@ -292,7 +292,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        iosArch: IOSArch.arm64,
+        appleArch: AppleArch.arm64,
         bitcode: false,
       );
 
@@ -328,7 +328,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        iosArch: IOSArch.armv7,
+        appleArch: AppleArch.armv7,
         bitcode: false,
       );
 
@@ -366,7 +366,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        iosArch: IOSArch.arm64,
+        appleArch: AppleArch.arm64,
         bitcode: false,
       );
 

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -50,7 +50,7 @@ class _FakeGenSnapshot implements GenSnapshot {
   Future<int> run({
     SnapshotType snapshotType,
     String depfilePath,
-    AppleArch appleArch,
+    DarwinArch darwinArch,
     Iterable<String> additionalArgs = const <String>[],
   }) async {
     _callCount += 1;
@@ -191,7 +191,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        appleArch: AppleArch.armv7,
+        darwinArch: DarwinArch.armv7,
         bitcode: true,
       );
 
@@ -245,7 +245,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        appleArch: AppleArch.armv7,
+        darwinArch: DarwinArch.armv7,
         bitcode: false,
       );
 
@@ -292,7 +292,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        appleArch: AppleArch.arm64,
+        darwinArch: DarwinArch.arm64,
         bitcode: false,
       );
 
@@ -328,7 +328,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        appleArch: AppleArch.armv7,
+        darwinArch: DarwinArch.armv7,
         bitcode: false,
       );
 
@@ -366,7 +366,7 @@ void main() {
         mainPath: 'main.dill',
         packagesPath: '.packages',
         outputPath: outputPath,
-        appleArch: AppleArch.arm64,
+        darwinArch: DarwinArch.arm64,
         bitcode: false,
       );
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -323,10 +323,10 @@ class MockXcode extends Mock implements Xcode {}
 class FakeGenSnapshot implements GenSnapshot {
   List<String> lastCallAdditionalArgs;
   @override
-  Future<int> run({SnapshotType snapshotType, IOSArch iosArch, Iterable<String> additionalArgs = const <String>[]}) async {
+  Future<int> run({SnapshotType snapshotType, AppleArch appleArch, Iterable<String> additionalArgs = const <String>[]}) async {
     lastCallAdditionalArgs = additionalArgs.toList();
     final Directory out = fs.file(lastCallAdditionalArgs.last).parent;
-    if (iosArch == null) {
+    if (appleArch == null) {
       out.childFile('app.so').createSync();
       out.childFile('gen_snapshot.d').createSync();
       return 0;

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -323,10 +323,10 @@ class MockXcode extends Mock implements Xcode {}
 class FakeGenSnapshot implements GenSnapshot {
   List<String> lastCallAdditionalArgs;
   @override
-  Future<int> run({SnapshotType snapshotType, AppleArch appleArch, Iterable<String> additionalArgs = const <String>[]}) async {
+  Future<int> run({SnapshotType snapshotType, DarwinArch darwinArch, Iterable<String> additionalArgs = const <String>[]}) async {
     lastCallAdditionalArgs = additionalArgs.toList();
     final Directory out = fs.file(lastCallAdditionalArgs.last).parent;
-    if (appleArch == null) {
+    if (darwinArch == null) {
       out.childFile('app.so').createSync();
       out.childFile('gen_snapshot.d').createSync();
       return 0;


### PR DESCRIPTION
## Description

Expand the support set of darwin archs to include x86-64 for macOS release mode. Only supply the  `-miphoneos-version-min` flag to xCode when building for iOS arches.