### PR TITLE
[flutter_tool] Remove some async file io

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -179,12 +179,12 @@ Future<File> _createLocalCrashReport(List<String> args, dynamic error, StackTrac
   buffer.writeln('```\n${await _doctorText()}```');
 
   try {
-    await crashFile.writeAsString(buffer.toString());
+    crashFile.writeAsStringSync(buffer.toString());
   } on FileSystemException catch (_) {
     // Fallback to the system temporary directory.
     crashFile = getUniqueFile(crashFileSystem.systemTempDirectory, 'flutter', 'log');
     try {
-      await crashFile.writeAsString(buffer.toString());
+      crashFile.writeAsStringSync(buffer.toString());
     } on FileSystemException catch (e) {
       printError('Could not write crash report to disk: $e');
       printError(buffer.toString());

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -180,7 +180,7 @@ class AOTSnapshotter {
     // gen_snapshot would provide an argument to do this automatically.
     if (platform == TargetPlatform.ios && bitcode) {
       final IOSink sink = fs.file('$assembly.bitcode').openWrite();
-      for (String line in await fs.file(assembly).readAsLines()) {
+      for (String line in fs.file(assembly).readAsLinesSync()) {
         if (line.startsWith('.section __DWARF')) {
           break;
         }
@@ -192,7 +192,7 @@ class AOTSnapshotter {
     // Write path to gen_snapshot, since snapshots have to be re-generated when we roll
     // the Dart SDK.
     final String genSnapshotPath = GenSnapshot.getSnapshotterPath(snapshotType);
-    await outputDir.childFile('gen_snapshot.d').writeAsString('gen_snapshot.d: $genSnapshotPath\n');
+    outputDir.childFile('gen_snapshot.d').writeAsStringSync('gen_snapshot.d: $genSnapshotPath\n');
 
     // On iOS, we use Xcode to compile the snapshot into a dynamic library that the
     // end-developer can link into their app.
@@ -313,7 +313,7 @@ class AOTSnapshotter {
 
     // Write path to frontend_server, since things need to be re-generated when that changes.
     final String frontendPath = artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk);
-    await fs.directory(outputPath).childFile('frontend_server.d').writeAsString('frontend_server.d: $frontendPath\n');
+    fs.directory(outputPath).childFile('frontend_server.d').writeAsStringSync('frontend_server.d: $frontendPath\n');
 
     return compilerOutput?.outputFilename;
   }

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:crypto/crypto.dart' show md5;
 import 'package:meta/meta.dart';
 import 'package:quiver/core.dart' show hash2;
@@ -52,12 +50,12 @@ class Fingerprinter {
   final List<String> _depfilePaths;
   final FingerprintPathFilter _pathFilter;
 
-  Future<Fingerprint> buildFingerprint() async {
-    final List<String> paths = await _getPaths();
+  Fingerprint buildFingerprint() {
+    final List<String> paths = _getPaths();
     return Fingerprint.fromBuildInputs(_properties, paths);
   }
 
-  Future<bool> doesFingerprintMatch() async {
+  bool doesFingerprintMatch() {
     if (_disableBuildCache) {
       return false;
     }
@@ -69,12 +67,12 @@ class Fingerprinter {
       if (!_depfilePaths.every(fs.isFileSync))
         return false;
 
-      final List<String> paths = await _getPaths();
+      final List<String> paths = _getPaths();
       if (!paths.every(fs.isFileSync))
         return false;
 
-      final Fingerprint oldFingerprint = Fingerprint.fromJson(await fingerprintFile.readAsString());
-      final Fingerprint newFingerprint = await buildFingerprint();
+      final Fingerprint oldFingerprint = Fingerprint.fromJson(fingerprintFile.readAsStringSync());
+      final Fingerprint newFingerprint = buildFingerprint();
       return oldFingerprint == newFingerprint;
     } catch (e) {
       // Log exception and continue, fingerprinting is only a performance improvement.
@@ -83,9 +81,9 @@ class Fingerprinter {
     return false;
   }
 
-  Future<void> writeFingerprint() async {
+  void writeFingerprint() {
     try {
-      final Fingerprint fingerprint = await buildFingerprint();
+      final Fingerprint fingerprint = buildFingerprint();
       fs.file(fingerprintPath).writeAsStringSync(fingerprint.toJson());
     } catch (e) {
       // Log exception and continue, fingerprinting is only a performance improvement.
@@ -93,11 +91,11 @@ class Fingerprinter {
     }
   }
 
-  Future<List<String>> _getPaths() async {
+  List<String> _getPaths() {
     final Set<String> paths = <String>{
       ..._paths,
       for (String depfilePath in _depfilePaths)
-        ...await readDepfile(depfilePath),
+        ...readDepfile(depfilePath),
     };
     final FingerprintPathFilter filter = _pathFilter ?? (String path) => true;
     return paths.where(filter).toList()..sort();
@@ -183,10 +181,10 @@ final RegExp _escapeExpr = RegExp(r'\\(.)');
 /// outfile : file1.dart fil\\e2.dart fil\ e3.dart
 ///
 /// will return a set containing: 'file1.dart', 'fil\e2.dart', 'fil e3.dart'.
-Future<Set<String>> readDepfile(String depfilePath) async {
+Set<String> readDepfile(String depfilePath) {
   // Depfile format:
   // outfile1 outfile2 : file1.dart file2.dart file3.dart
-  final String contents = await fs.file(depfilePath).readAsString();
+  final String contents = fs.file(depfilePath).readAsStringSync();
 
   final String dependencies = contents.split(': ')[1];
   return dependencies

--- a/packages/flutter_tools/lib/src/base/platform.dart
+++ b/packages/flutter_tools/lib/src/base/platform.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:platform/platform.dart';
 
 import 'context.dart';
@@ -25,17 +23,17 @@ Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
 /// subdirectory.
 ///
 /// Returns the existing platform.
-Future<Platform> getRecordingPlatform(String location) async {
+Platform getRecordingPlatform(String location) {
   final Directory dir = getRecordingSink(location, _kRecordingType);
   final File file = _getPlatformManifest(dir);
-  await file.writeAsString(platform.toJson(), flush: true);
+  file.writeAsStringSync(platform.toJson(), flush: true);
   return platform;
 }
 
-Future<FakePlatform> getReplayPlatform(String location) async {
+FakePlatform getReplayPlatform(String location) {
   final Directory dir = getReplaySource(location, _kRecordingType);
   final File file = _getPlatformManifest(dir);
-  final String json = await file.readAsString();
+  final String json = file.readAsStringSync();
   return FakePlatform.fromJson(json);
 }
 

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -15,7 +15,7 @@ import 'utils.dart';
 typedef StringConverter = String Function(String string);
 
 /// A function that will be run before the VM exits.
-typedef ShutdownHook = Future<dynamic> Function();
+typedef ShutdownHook = FutureOr<dynamic> Function();
 
 // TODO(ianh): We have way too many ways to run subprocesses in this project.
 // Convert most of these into one or more lightweight wrappers around the
@@ -83,8 +83,12 @@ Future<void> runShutdownHooks() async {
       printTrace('Shutdown hook priority ${stage.priority}');
       final List<ShutdownHook> hooks = _shutdownHooks.remove(stage);
       final List<Future<dynamic>> futures = <Future<dynamic>>[];
-      for (ShutdownHook shutdownHook in hooks)
-        futures.add(shutdownHook());
+      for (ShutdownHook shutdownHook in hooks) {
+        final FutureOr<dynamic> result = shutdownHook();
+        if (result is Future<dynamic>) {
+          futures.add(result);
+        }
+      }
       await Future.wait<dynamic>(futures);
     }
   } finally {

--- a/packages/flutter_tools/lib/src/build_runner/build_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_runner.dart
@@ -102,7 +102,7 @@ class BuildRunner extends CodeGenerator {
       }
       stringBuffer.writeln('  build_runner: ^$kMinimumBuildRunnerVersion');
       stringBuffer.writeln('  build_daemon: $kSupportedBuildDaemonVersion');
-      await syntheticPubspec.writeAsString(stringBuffer.toString());
+      syntheticPubspec.writeAsStringSync(stringBuffer.toString());
 
       await pubGet(
         context: PubContext.pubGet,

--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -376,7 +376,7 @@ Future<void> bootstrapDart2Js(BuildStep buildStep, String flutterWebSdk) async {
   final Iterable<AssetId> allSrcs = allDeps.expand((Module module) => module.sources);
   await scratchSpace.ensureAssets(allSrcs, buildStep);
 
-  final String packageFile = await _createPackageFile(allSrcs, buildStep, scratchSpace);
+  final String packageFile = _createPackageFile(allSrcs, buildStep, scratchSpace);
   final String dartPath = dartEntrypointId.path.startsWith('lib/')
       ? 'package:${dartEntrypointId.package}/'
           '${dartEntrypointId.path.substring('lib/'.length)}'
@@ -430,7 +430,7 @@ Future<void> _copyIfExists(
 /// The filename is based off the MD5 hash of the asset path so that files are
 /// unique regarless of situations like `web/foo/bar.dart` vs
 /// `web/foo-bar.dart`.
-Future<String> _createPackageFile(Iterable<AssetId> inputSources, BuildStep buildStep, ScratchSpace scratchSpace) async {
+String _createPackageFile(Iterable<AssetId> inputSources, BuildStep buildStep, ScratchSpace scratchSpace) {
   final Uri inputUri = buildStep.inputId.uri;
   final String packageFileName =
       '.package-${md5.convert(inputUri.toString().codeUnits)}';
@@ -439,8 +439,7 @@ Future<String> _createPackageFile(Iterable<AssetId> inputSources, BuildStep buil
   final Set<String> packageNames = inputSources.map((AssetId s) => s.package).toSet();
   final String packagesFileContent =
       packageNames.map((String name) => '$name:packages/$name/').join('\n');
-  await packagesFile
-      .writeAsString('# Generated for $inputUri\n$packagesFileContent');
+  packagesFile .writeAsStringSync('# Generated for $inputUri\n$packagesFileContent');
   return packageFileName;
 }
 

--- a/packages/flutter_tools/lib/src/build_runner/build_script_generator.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script_generator.dart
@@ -49,8 +49,8 @@ class BuildScriptGenerator {
         // ignore_for_file: directives_ordering
         ${library.accept(emitter)}''');
       final File output = fs.file(location);
-      await output.create(recursive: true);
-      await fs.file(location).writeAsString(result);
+      output.createSync(recursive: true);
+      fs.file(location).writeAsStringSync(result);
     } on FormatterException {
       throwToolExit('Generated build script could not be parsed. '
         'This is likely caused by a misconfigured builder definition.');

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -99,8 +99,8 @@ class BundleBuilder {
       }
       kernelContent = DevFSFileContent(fs.file(compilerOutput.outputFilename));
 
-      await fs.directory(getBuildDirectory()).childFile('frontend_server.d')
-          .writeAsString('frontend_server.d: ${artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk)}\n');
+      fs.directory(getBuildDirectory()).childFile('frontend_server.d')
+          .writeAsStringSync('frontend_server.d: ${artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk)}\n');
     }
 
     final AssetBundle assets = await buildAssets(

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -407,7 +407,7 @@ class CreateCommand extends FlutterCommand {
         break;
     }
     if (sampleCode != null) {
-      generatedFileCount += await _applySample(relativeDir, sampleCode);
+      generatedFileCount += _applySample(relativeDir, sampleCode);
     }
     printStatus('Wrote $generatedFileCount files.');
     printStatus('\nAll done!');
@@ -566,13 +566,13 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
   // documentation website in sampleCode.  Returns the difference in the number
   // of files after applying the sample, since it also deletes the application's
   // test directory (since the template's test doesn't apply to the sample).
-  Future<int> _applySample(Directory directory, String sampleCode) async {
+  int _applySample(Directory directory, String sampleCode) {
     final File mainDartFile = directory.childDirectory('lib').childFile('main.dart');
-    await mainDartFile.create(recursive: true);
-    await mainDartFile.writeAsString(sampleCode);
+    mainDartFile.createSync(recursive: true);
+    mainDartFile.writeAsStringSync(sampleCode);
     final Directory testDir = directory.childDirectory('test');
     final List<FileSystemEntity> files = testDir.listSync(recursive: true);
-    await testDir.delete(recursive: true);
+    testDir.deleteSync(recursive: true);
     return -files.length;
   }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -79,9 +79,9 @@ class PackagesGetCommand extends FlutterCommand {
       return usageValues;
     }
     final FlutterProject rootProject = FlutterProject.fromPath(target);
-    final bool hasPlugins = await rootProject.flutterPluginsFile.exists();
+    final bool hasPlugins = rootProject.flutterPluginsFile.existsSync();
     if (hasPlugins) {
-      final int numberOfPlugins = (await rootProject.flutterPluginsFile.readAsLines()).length;
+      final int numberOfPlugins = (rootProject.flutterPluginsFile.readAsLinesSync()).length;
       usageValues[CustomDimensions.commandPackagesNumberPlugins] = '$numberOfPlugins';
     } else {
       usageValues[CustomDimensions.commandPackagesNumberPlugins] = '0';

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -269,7 +269,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   bool codesign = true,
   bool usesTerminalUi = true,
 }) async {
-  if (!await upgradePbxProjWithFlutterAssets(app.project))
+  if (!upgradePbxProjWithFlutterAssets(app.project))
     return XcodeBuildResult(success: false);
 
   if (!_checkXcodeVersion())
@@ -679,10 +679,10 @@ void _copyServiceDefinitionsManifest(List<Map<String, String>> services, File ma
   manifest.writeAsStringSync(json.encode(jsonObject), mode: FileMode.write, flush: true);
 }
 
-Future<bool> upgradePbxProjWithFlutterAssets(IosProject project) async {
+bool upgradePbxProjWithFlutterAssets(IosProject project) {
   final File xcodeProjectFile = project.xcodeProjectInfoFile;
-  assert(await xcodeProjectFile.exists());
-  final List<String> lines = await xcodeProjectFile.readAsLines();
+  assert(xcodeProjectFile.existsSync());
+  final List<String> lines = xcodeProjectFile.readAsLinesSync();
 
   final RegExp oldAssets = RegExp(r'\/\* (flutter_assets|app\.flx)');
   final StringBuffer buffer = StringBuffer();
@@ -697,6 +697,6 @@ Future<bool> upgradePbxProjWithFlutterAssets(IosProject project) async {
       buffer.writeln(line);
     }
   }
-  await xcodeProjectFile.writeAsString(buffer.toString());
+  xcodeProjectFile.writeAsStringSync(buffer.toString());
   return true;
 }

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -38,9 +38,9 @@ Future<void> processPodsIfNeeded(XcodeBasedProject xcodeProject,
     xcodeProject: xcodeProject,
     engineDir: flutterFrameworkDir(buildMode),
     isSwift: xcodeProject.isSwift,
-    dependenciesChanged: !await fingerprinter.doesFingerprintMatch(),
+    dependenciesChanged: !fingerprinter.doesFingerprintMatch(),
   );
   if (didPodInstall) {
-    await fingerprinter.writeFingerprint();
+    fingerprinter.writeFingerprint();
   }
 }

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -106,7 +106,7 @@ class CocoaPods {
     bool isSwift = false,
     bool dependenciesChanged = true,
   }) async {
-    if (!(await xcodeProject.podfile.exists())) {
+    if (!xcodeProject.podfile.existsSync()) {
       throwToolExit('Podfile missing');
     }
     if (await _checkPodCondition()) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -747,7 +747,7 @@ abstract class ResidentRunner {
           }
         }
       }
-      final int sizeKB = (await outputFile.length()) ~/ 1024;
+      final int sizeKB = outputFile.lengthSync() ~/ 1024;
       status.stop();
       printStatus('Screenshot written to ${fs.path.relative(outputFile.path)} (${sizeKB}kB).');
     } catch (error) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -303,15 +303,15 @@ class FlutterCommandRunner extends CommandRunner<void> {
         ..writeln()
         ..writeln('# rest')
         ..writeln(topLevelResults.rest);
-      await manifest.writeAsString(buffer.toString(), flush: true);
+      manifest.writeAsStringSync(buffer.toString(), flush: true);
 
       // ZIP the recording up once the recording has been serialized.
-      addShutdownHook(() async {
+      addShutdownHook(() {
         final File zipFile = getUniqueFile(fs.currentDirectory, 'bugreport', 'zip');
         os.zip(tempDir, zipFile);
         printStatus(userMessages.runnerBugReportFinished(zipFile.basename));
       }, ShutdownStage.POST_PROCESS_RECORDING);
-      addShutdownHook(() => tempDir.delete(recursive: true), ShutdownStage.CLEANUP);
+      addShutdownHook(() => tempDir.deleteSync(recursive: true), ShutdownStage.CLEANUP);
     }
 
     assert(recordTo == null || replayFrom == null);
@@ -323,7 +323,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
       contextOverrides.addAll(<Type, dynamic>{
         ProcessManager: getRecordingProcessManager(recordTo),
         FileSystem: getRecordingFileSystem(recordTo),
-        Platform: await getRecordingPlatform(recordTo),
+        Platform: getRecordingPlatform(recordTo),
       });
       VMService.enableRecordingConnection(recordTo);
     }
@@ -335,7 +335,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
       contextOverrides.addAll(<Type, dynamic>{
         ProcessManager: await getReplayProcessManager(replayFrom),
         FileSystem: getReplayFileSystem(replayFrom),
-        Platform: await getReplayPlatform(replayFrom),
+        Platform: getReplayPlatform(replayFrom),
       });
       VMService.enableReplayConnection(replayFrom);
     }

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -78,12 +78,14 @@ Future<void> downloadStartupTrace(VMService observatory, { bool awaitFirstFrame 
   final File traceInfoFile = fs.file(traceInfoFilePath);
 
   // Delete old startup data, if any.
-  if (await traceInfoFile.exists())
-    await traceInfoFile.delete();
+  if (traceInfoFile.existsSync()) {
+    traceInfoFile.deleteSync();
+  }
 
   // Create "build" directory, if missing.
-  if (!(await traceInfoFile.parent.exists()))
-    await traceInfoFile.parent.create();
+  if (!traceInfoFile.parent.existsSync()) {
+    traceInfoFile.parent.createSync();
+  }
 
   final Tracing tracing = Tracing(observatory);
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -99,8 +99,9 @@ class FlutterVersion {
   String get engineRevision => Cache.instance.engineRevision;
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
-  Future<void> ensureVersionFile() async {
+  Future<void> ensureVersionFile() {
     fs.file(fs.path.join(Cache.flutterRoot, 'version')).writeAsStringSync(_frameworkVersion);
+    return Future<void>.value();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/vmservice_record_replay.dart
+++ b/packages/flutter_tools/lib/src/vmservice_record_replay.dart
@@ -24,7 +24,7 @@ const String _kData = 'data';
 class RecordingVMServiceChannel extends DelegatingStreamChannel<String> {
   RecordingVMServiceChannel(StreamChannel<String> delegate, Directory location)
       : super(delegate) {
-    addShutdownHook(() async {
+    addShutdownHook(() {
       // Sort the messages such that they are ordered
       // `[request1, response1, request2, response2, ...]`. This serves no
       // purpose other than to make the serialized format more human-readable.
@@ -32,7 +32,7 @@ class RecordingVMServiceChannel extends DelegatingStreamChannel<String> {
 
       final File file = _getManifest(location);
       final String json = const JsonEncoder.withIndent('  ').convert(_messages);
-      await file.writeAsString(json, flush: true);
+      file.writeAsStringSync(json, flush: true);
     }, ShutdownStage.SERIALIZE_RECORDING);
   }
 

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -32,10 +32,10 @@ void main() {
       FileSystem: () => fs,
     };
 
-    testUsingContext('throws when depfile is malformed', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
-      await fs.file('depfile').create();
+    testUsingContext('throws when depfile is malformed', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
+      fs.file('depfile').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -46,11 +46,11 @@ void main() {
           'wobble': 'womble',
         },
       );
-      expect(() async => await fingerprinter.buildFingerprint(), throwsA(anything));
+      expect(() => fingerprinter.buildFingerprint(), throwsA(anything));
     }, overrides: contextOverrides);
 
-    testUsingContext('creates fingerprint with specified properties and files', () async {
-      await fs.file('a.dart').create();
+    testUsingContext('creates fingerprint with specified properties and files', () {
+      fs.file('a.dart').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -60,17 +60,17 @@ void main() {
           'wibble': 'wobble',
         },
       );
-      final Fingerprint fingerprint = await fingerprinter.buildFingerprint();
+      final Fingerprint fingerprint = fingerprinter.buildFingerprint();
       expect(fingerprint, Fingerprint.fromBuildInputs(<String, String>{
         'foo': 'bar',
         'wibble': 'wobble',
       }, <String>['a.dart']));
     }, overrides: contextOverrides);
 
-    testUsingContext('creates fingerprint with file checksums', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
-      await fs.file('depfile').writeAsString('depfile : b.dart');
+    testUsingContext('creates fingerprint with file checksums', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
+      fs.file('depfile').writeAsStringSync('depfile : b.dart');
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -81,16 +81,16 @@ void main() {
           'wobble': 'womble',
         },
       );
-      final Fingerprint fingerprint = await fingerprinter.buildFingerprint();
+      final Fingerprint fingerprint = fingerprinter.buildFingerprint();
       expect(fingerprint, Fingerprint.fromBuildInputs(<String, String>{
         'bar': 'baz',
         'wobble': 'womble',
       }, <String>['a.dart', 'b.dart']));
     }, overrides: contextOverrides);
 
-    testUsingContext('fingerprint does not match if not present', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
+    testUsingContext('fingerprint does not match if not present', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -100,12 +100,12 @@ void main() {
           'wobble': 'womble',
         },
       );
-      expect(await fingerprinter.doesFingerprintMatch(), isFalse);
+      expect(fingerprinter.doesFingerprintMatch(), isFalse);
     }, overrides: contextOverrides);
 
-    testUsingContext('fingerprint does match if different', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
+    testUsingContext('fingerprint does match if different', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
 
       final Fingerprinter fingerprinter1 = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -115,7 +115,7 @@ void main() {
           'wobble': 'womble',
         },
       );
-      await fingerprinter1.writeFingerprint();
+      fingerprinter1.writeFingerprint();
 
       final Fingerprinter fingerprinter2 = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -125,13 +125,13 @@ void main() {
           'wobble': 'elbmow',
         },
       );
-      expect(await fingerprinter2.doesFingerprintMatch(), isFalse);
+      expect(fingerprinter2.doesFingerprintMatch(), isFalse);
     }, overrides: contextOverrides);
 
-    testUsingContext('fingerprint does not match if depfile is malformed', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
-      await fs.file('depfile').writeAsString('depfile : b.dart');
+    testUsingContext('fingerprint does not match if depfile is malformed', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
+      fs.file('depfile').writeAsStringSync('depfile : b.dart');
 
       // Write a valid fingerprint
       final Fingerprinter fingerprinter = Fingerprinter(
@@ -143,10 +143,10 @@ void main() {
           'wobble': 'womble',
         },
       );
-      await fingerprinter.writeFingerprint();
+      fingerprinter.writeFingerprint();
 
       // Write a corrupt depfile.
-      await fs.file('depfile').writeAsString('');
+      fs.file('depfile').writeAsStringSync('');
       final Fingerprinter badFingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
         paths: <String>['a.dart', 'b.dart'],
@@ -157,13 +157,13 @@ void main() {
         },
       );
 
-      expect(await badFingerprinter.doesFingerprintMatch(), isFalse);
+      expect(badFingerprinter.doesFingerprintMatch(), isFalse);
     }, overrides: contextOverrides);
 
-    testUsingContext('fingerprint does not match if previous fingerprint is malformed', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
-      await fs.file('out.fingerprint').writeAsString('** not JSON **');
+    testUsingContext('fingerprint does not match if previous fingerprint is malformed', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
+      fs.file('out.fingerprint').writeAsStringSync('** not JSON **');
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -174,12 +174,12 @@ void main() {
           'wobble': 'womble',
         },
       );
-      expect(await fingerprinter.doesFingerprintMatch(), isFalse);
+      expect(fingerprinter.doesFingerprintMatch(), isFalse);
     }, overrides: contextOverrides);
 
-    testUsingContext('fingerprint does match if identical', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
+    testUsingContext('fingerprint does match if identical', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -189,15 +189,15 @@ void main() {
           'wobble': 'womble',
         },
       );
-      await fingerprinter.writeFingerprint();
-      expect(await fingerprinter.doesFingerprintMatch(), isTrue);
+      fingerprinter.writeFingerprint();
+      expect(fingerprinter.doesFingerprintMatch(), isTrue);
     }, overrides: contextOverrides);
 
     final Platform mockPlatformDisabledCache = MockPlatform();
     mockPlatformDisabledCache.environment['DISABLE_FLUTTER_BUILD_CACHE']  = 'true';
-    testUsingContext('can be disabled with an environment variable', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
+    testUsingContext('can be disabled with an environment variable', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -207,8 +207,8 @@ void main() {
           'wobble': 'womble',
         },
       );
-      await fingerprinter.writeFingerprint();
-      expect(await fingerprinter.doesFingerprintMatch(), isFalse);
+      fingerprinter.writeFingerprint();
+      expect(fingerprinter.doesFingerprintMatch(), isFalse);
     }, overrides: <Type, Generator>{
       Platform: () => mockPlatformDisabledCache,
       ...contextOverrides,
@@ -216,9 +216,9 @@ void main() {
 
     final Platform mockPlatformEnabledCache = MockPlatform();
     mockPlatformEnabledCache.environment['DISABLE_FLUTTER_BUILD_CACHE']  = 'false';
-    testUsingContext('can be not-disabled with an environment variable', () async {
-      await fs.file('a.dart').create();
-      await fs.file('b.dart').create();
+    testUsingContext('can be not-disabled with an environment variable', () {
+      fs.file('a.dart').createSync();
+      fs.file('b.dart').createSync();
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -228,14 +228,14 @@ void main() {
           'wobble': 'womble',
         },
       );
-      await fingerprinter.writeFingerprint();
-      expect(await fingerprinter.doesFingerprintMatch(), isTrue);
+      fingerprinter.writeFingerprint();
+      expect(fingerprinter.doesFingerprintMatch(), isTrue);
     }, overrides: <Type, Generator>{
       Platform: () => mockPlatformEnabledCache,
       ...contextOverrides,
     });
 
-    testUsingContext('fails to write fingerprint if inputs are missing', () async {
+    testUsingContext('fails to write fingerprint if inputs are missing', () {
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
         paths: <String>['a.dart'],
@@ -244,14 +244,14 @@ void main() {
           'wibble': 'wobble',
         },
       );
-      await fingerprinter.writeFingerprint();
+      fingerprinter.writeFingerprint();
       expect(fs.file('out.fingerprint').existsSync(), isFalse);
     }, overrides: contextOverrides);
 
-    testUsingContext('applies path filter to inputs paths', () async {
-      await fs.file('a.dart').create();
-      await fs.file('ab.dart').create();
-      await fs.file('depfile').writeAsString('depfile : ab.dart c.dart');
+    testUsingContext('applies path filter to inputs paths', () {
+      fs.file('a.dart').createSync();
+      fs.file('ab.dart').createSync();
+      fs.file('depfile').writeAsStringSync('depfile : ab.dart c.dart');
 
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',
@@ -263,7 +263,7 @@ void main() {
         },
         pathFilter: (String path) => path.startsWith('a'),
       );
-      await fingerprinter.writeFingerprint();
+      fingerprinter.writeFingerprint();
       expect(fs.file('out.fingerprint').existsSync(), isTrue);
     }, overrides: contextOverrides);
   });
@@ -284,17 +284,17 @@ void main() {
         fs = MemoryFileSystem();
       });
 
-      testUsingContext('throws if any input file does not exist', () async {
-        await fs.file('a.dart').create();
+      testUsingContext('throws if any input file does not exist', () {
+        fs.file('a.dart').createSync();
         expect(
           () => Fingerprint.fromBuildInputs(<String, String>{}, <String>['a.dart', 'b.dart']),
           throwsArgumentError,
         );
       }, overrides: <Type, Generator>{FileSystem: () => fs});
 
-      testUsingContext('populates checksums for valid files', () async {
-        await fs.file('a.dart').writeAsString('This is a');
-        await fs.file('b.dart').writeAsString('This is b');
+      testUsingContext('populates checksums for valid files', () {
+        fs.file('a.dart').writeAsStringSync('This is a');
+        fs.file('b.dart').writeAsStringSync('This is b');
         final Fingerprint fingerprint = Fingerprint.fromBuildInputs(<String, String>{}, <String>['a.dart', 'b.dart']);
 
         final Map<String, dynamic> jsonObject = json.decode(fingerprint.toJson());
@@ -321,13 +321,13 @@ void main() {
     });
 
     group('fromJson', () {
-      testUsingContext('throws if JSON is invalid', () async {
+      testUsingContext('throws if JSON is invalid', () {
         expect(() => Fingerprint.fromJson('<xml></xml>'), throwsA(anything));
       }, overrides: <Type, Generator>{
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('creates fingerprint from valid JSON', () async {
+      testUsingContext('creates fingerprint from valid JSON', () {
         final String jsonString = json.encode(<String, dynamic>{
           'version': kVersion,
           'properties': <String, String>{
@@ -355,7 +355,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('throws ArgumentError for unknown versions', () async {
+      testUsingContext('throws ArgumentError for unknown versions', () {
         final String jsonString = json.encode(<String, dynamic>{
           'version': 'bad',
           'properties': <String, String>{},
@@ -366,7 +366,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('throws ArgumentError if version is not present', () async {
+      testUsingContext('throws ArgumentError if version is not present', () {
         final String jsonString = json.encode(<String, dynamic>{
           'properties': <String, String>{},
           'files': <String, String>{},
@@ -376,7 +376,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('treats missing properties and files entries as if empty', () async {
+      testUsingContext('treats missing properties and files entries as if empty', () {
         final String jsonString = json.encode(<String, dynamic>{
           'version': kVersion,
         });
@@ -387,7 +387,7 @@ void main() {
     });
 
     group('operator ==', () {
-      testUsingContext('reports not equal if properties do not match', () async {
+      testUsingContext('reports not equal if properties do not match', () {
         final Map<String, dynamic> a = <String, dynamic>{
           'version': kVersion,
           'properties': <String, String>{
@@ -404,7 +404,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('reports not equal if file checksums do not match', () async {
+      testUsingContext('reports not equal if file checksums do not match', () {
         final Map<String, dynamic> a = <String, dynamic>{
           'version': kVersion,
           'properties': <String, String>{},
@@ -423,7 +423,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('reports not equal if file paths do not match', () async {
+      testUsingContext('reports not equal if file paths do not match', () {
         final Map<String, dynamic> a = <String, dynamic>{
           'version': kVersion,
           'properties': <String, String>{},
@@ -442,7 +442,7 @@ void main() {
         FlutterVersion: () => mockVersion,
       });
 
-      testUsingContext('reports equal if properties and file checksums match', () async {
+      testUsingContext('reports equal if properties and file checksums match', () {
         final Map<String, dynamic> a = <String, dynamic>{
           'version': kVersion,
           'properties': <String, String>{
@@ -461,7 +461,7 @@ void main() {
       });
     });
     group('hashCode', () {
-      testUsingContext('is consistent with equals, even if map entries are reordered', () async {
+      testUsingContext('is consistent with equals, even if map entries are reordered', () {
         final Fingerprint a = Fingerprint.fromJson('{"version":"$kVersion","properties":{"a":"A","b":"B"},"files":{}}');
         final Fingerprint b = Fingerprint.fromJson('{"version":"$kVersion","properties":{"b":"B","a":"A"},"files":{}}');
         expect(a, b);
@@ -482,31 +482,31 @@ void main() {
 
     final Map<Type, Generator> contextOverrides = <Type, Generator>{FileSystem: () => fs};
 
-    testUsingContext('returns one file if only one is listed', () async {
-      await fs.file('a.d').writeAsString('snapshot.d: /foo/a.dart');
-      expect(await readDepfile('a.d'), unorderedEquals(<String>['/foo/a.dart']));
+    testUsingContext('returns one file if only one is listed', () {
+      fs.file('a.d').writeAsStringSync('snapshot.d: /foo/a.dart');
+      expect(readDepfile('a.d'), unorderedEquals(<String>['/foo/a.dart']));
     }, overrides: contextOverrides);
 
-    testUsingContext('returns multiple files', () async {
-      await fs.file('a.d').writeAsString('snapshot.d: /foo/a.dart /foo/b.dart');
-      expect(await readDepfile('a.d'), unorderedEquals(<String>[
+    testUsingContext('returns multiple files', () {
+      fs.file('a.d').writeAsStringSync('snapshot.d: /foo/a.dart /foo/b.dart');
+      expect(readDepfile('a.d'), unorderedEquals(<String>[
         '/foo/a.dart',
         '/foo/b.dart',
       ]));
     }, overrides: contextOverrides);
 
-    testUsingContext('trims extra spaces between files', () async {
-      await fs.file('a.d').writeAsString('snapshot.d: /foo/a.dart    /foo/b.dart  /foo/c.dart');
-      expect(await readDepfile('a.d'), unorderedEquals(<String>[
+    testUsingContext('trims extra spaces between files', () {
+      fs.file('a.d').writeAsStringSync('snapshot.d: /foo/a.dart    /foo/b.dart  /foo/c.dart');
+      expect(readDepfile('a.d'), unorderedEquals(<String>[
         '/foo/a.dart',
         '/foo/b.dart',
         '/foo/c.dart',
       ]));
     }, overrides: contextOverrides);
 
-    testUsingContext('returns files with spaces and backslashes', () async {
-      await fs.file('a.d').writeAsString(r'snapshot.d: /foo/a\ a.dart /foo/b\\b.dart /foo/c\\ c.dart');
-      expect(await readDepfile('a.d'), unorderedEquals(<String>[
+    testUsingContext('returns files with spaces and backslashes', () {
+      fs.file('a.d').writeAsStringSync(r'snapshot.d: /foo/a\ a.dart /foo/b\\b.dart /foo/c\\ c.dart');
+      expect(readDepfile('a.d'), unorderedEquals(<String>[
         r'/foo/a a.dart',
         r'/foo/b\b.dart',
         r'/foo/c\ c.dart',

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -434,12 +434,12 @@ Could not build the precompiled application for the device.''',
 
       when(project.xcodeProjectInfoFile).thenReturn(pbxprojFile);
       when(project.hostAppBundleName).thenReturn('UnitTestRunner.app');
-      when(pbxprojFile.readAsLines())
-          .thenAnswer((_) => Future<List<String>>.value(flutterAssetPbxProjLines));
-      when(pbxprojFile.exists())
-          .thenAnswer((_) => Future<bool>.value(true));
+      when(pbxprojFile.readAsLinesSync())
+          .thenAnswer((_) => flutterAssetPbxProjLines);
+      when(pbxprojFile.existsSync())
+          .thenAnswer((_) => true);
 
-      bool result = await upgradePbxProjWithFlutterAssets(project);
+      bool result = upgradePbxProjWithFlutterAssets(project);
       expect(result, true);
       expect(
         testLogger.statusText,
@@ -447,9 +447,9 @@ Could not build the precompiled application for the device.''',
       );
       testLogger.clear();
 
-      when(pbxprojFile.readAsLines())
-          .thenAnswer((_) => Future<List<String>>.value(appFlxPbxProjLines));
-      result = await upgradePbxProjWithFlutterAssets(project);
+      when(pbxprojFile.readAsLinesSync())
+          .thenAnswer((_) => appFlxPbxProjLines);
+      result = upgradePbxProjWithFlutterAssets(project);
       expect(result, true);
       expect(
         testLogger.statusText,
@@ -457,9 +457,9 @@ Could not build the precompiled application for the device.''',
       );
       testLogger.clear();
 
-      when(pbxprojFile.readAsLines())
-          .thenAnswer((_) => Future<List<String>>.value(cleanPbxProjLines));
-      result = await upgradePbxProjWithFlutterAssets(project);
+      when(pbxprojFile.readAsLinesSync())
+          .thenAnswer((_) => cleanPbxProjLines);
+      result = upgradePbxProjWithFlutterAssets(project);
       expect(result, true);
       expect(
         testLogger.statusText,


### PR DESCRIPTION
## Description

This PR replaces the uses I could find of small file IO operations that seemed to be needlessly asynchronous. The rationale is that for small operations, the asynchronous versions are slower since they involve a few thread hops. Additionally, when an asynchronous operation fails unexpectedly, the stack trace is generally not very helpful, consisting mostly/entirely of SDK-internal frames.

## Related Issues

Stack traces from crash reporting that are not useful.

## Tests

Updated existing tests as needed.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.