### PR TITLE
Adds canRequestFocus toggle to FocusNode

### DIFF
--- a/dev/manual_tests/lib/focus.dart
+++ b/dev/manual_tests/lib/focus.dart
@@ -13,22 +13,56 @@ void main() {
   ));
 }
 
-class DemoButton extends StatelessWidget {
-  const DemoButton({this.name});
+class DemoButton extends StatefulWidget {
+  const DemoButton({this.name, this.canRequestFocus = true, this.autofocus = false});
 
   final String name;
+  final bool canRequestFocus;
+  final bool autofocus;
+
+  @override
+  _DemoButtonState createState() => _DemoButtonState();
+}
+
+class _DemoButtonState extends State<DemoButton> {
+  FocusNode focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    focusNode = FocusNode(
+      debugLabel: widget.name,
+      canRequestFocus: widget.canRequestFocus,
+    );
+  }
+
+  @override
+  void dispose() {
+    focusNode?.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(DemoButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    focusNode.canRequestFocus = widget.canRequestFocus;
+  }
 
   void _handleOnPressed() {
-    print('Button $name pressed.');
+    focusNode.requestFocus();
+    print('Button ${widget.name} pressed.');
+    debugDumpFocusTree();
   }
 
   @override
   Widget build(BuildContext context) {
     return FlatButton(
+      focusNode: focusNode,
+      autofocus: widget.autofocus,
       focusColor: Colors.red,
       hoverColor: Colors.blue,
       onPressed: () => _handleOnPressed(),
-      child: Text(name),
+      child: Text(widget.name),
     );
   }
 }
@@ -119,14 +153,20 @@ class _FocusDemoState extends State<FocusDemo> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: const <Widget>[
-                        DemoButton(name: 'One'),
+                        DemoButton(
+                          name: 'One',
+                          autofocus: true,
+                        ),
                       ],
                     ),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: const <Widget>[
                         DemoButton(name: 'Two'),
-                        DemoButton(name: 'Three'),
+                        DemoButton(
+                          name: 'Three',
+                          canRequestFocus: false,
+                        ),
                       ],
                     ),
                     Row(

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -680,7 +680,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// need to be attached. [FocusAttachment.detach] should be called on the old
   /// node, and then [attach] called on the new node. This typically happens in
   /// the [State.didUpdateWidget] method.
-  @mustCallSuper
   FocusAttachment attach(BuildContext context, {FocusOnKeyCallback onKey}) {
     _context = context;
     _onKey = onKey ?? _onKey;
@@ -800,6 +799,30 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     return _children.map<DiagnosticsNode>((FocusNode child) {
       return child.toDiagnosticsNode(name: 'Child ${count++}');
     }).toList();
+  }
+}
+
+
+/// The type of [Focus.unfocusable], used as a sentinel value for
+/// [Focus.focusNode] to indicate that the [Focus] widget should not participate
+/// in focus operations.
+///
+/// Used to indicate and enforce that an unfocusable node doesn't appear in the
+/// focus tree.
+class UnfocusableNode extends FocusNode {
+  /// Creates an unfocusable focus node for use as the type for [Focus.unfocusable].
+  ///
+  /// This class is not useful other than as an implementation detail of [Focus.unfocusable].
+  UnfocusableNode() : super(debugLabel: 'Unfocusable Node');
+
+  @override
+  FocusAttachment attach(BuildContext context, {FocusOnKeyCallback onKey}) {
+    _context = context;
+    return null;
+  }
+
+  @override
+  void requestFocus([FocusNode node]) {
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -16,7 +16,7 @@ import 'framework.dart';
 
 // Used for debugging focus code. Set to true to see highly verbose debug output
 // when focus changes occur.
-const bool _kDebugFocus = true;
+const bool _kDebugFocus = false;
 
 bool _focusDebug(String message, [Iterable<String> details]) {
   if (_kDebugFocus) {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -382,6 +382,10 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// This may be used to place nodes in the focus tree that may be focused, but
   /// not traversed, allowing them to receive key events as part of the focus
   /// chain, but not be traversed to via focus traversal.
+  ///
+  /// This is different from [canRequestFocus] because it only implies that the
+  /// node can't be reached via traversal, not that it can't be focused. It may
+  /// still be focused explicitly.
   bool get skipTraversal => _skipTraversal;
   bool _skipTraversal;
   set skipTraversal(bool value) {
@@ -395,8 +399,22 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   ///
   /// Defaults to true.  Set to false if you want this node to do nothing when
   /// [requestFocus] is called on it. Does not affect the children of this node,
-  /// and [FocusNode.hasFocus] can still return true if this node is the
-  /// ancestor of a node with primary focus.
+  /// and [hasFocus] can still return true if this node is the ancestor of a
+  /// node with primary focus.
+  ///
+  /// This is different than [skipTraversal] because [skipTraversal] still
+  /// allows the node to be focused, just not traversed to via the
+  /// [FocusTraversalPolicy]
+  ///
+  /// Setting [canRequestFocus] to false implies that the node will also be
+  /// skipped for traversal purposes.
+  ///
+  /// See also:
+  ///
+  ///   - [DefaultFocusTraversal], a widget that sets the traversal policy for
+  ///     its descendants.
+  ///   - [FocusTraversalPolicy], a class that can be extended to describe a
+  ///     traversal policy.
   bool get canRequestFocus => _canRequestFocus;
   bool _canRequestFocus;
   set canRequestFocus(bool value) {

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -146,6 +146,7 @@ class Focus extends StatefulWidget {
     this.onFocusChange,
     this.onKey,
     this.debugLabel,
+    this.unfocusable,
     this.skipTraversal = false,
   })  : assert(child != null),
         assert(autofocus != null),
@@ -315,11 +316,6 @@ class _FocusState extends State<Focus> {
   }
 
   void _initNode() {
-    if (identical(widget.focusNode, Focus.unfocusable)) {
-      _hasFocus = false;
-      return;
-    }
-
     if (widget.focusNode == null) {
       // Only create a new node if the widget doesn't have one.
       // This calls a function instead of just allocating in place because
@@ -340,12 +336,10 @@ class _FocusState extends State<Focus> {
 
   @override
   void dispose() {
-    if (!identical(widget.focusNode, Focus.unfocusable)) {
-      // Regardless of the node owner, we need to remove it from the tree and stop
-      // listening to it.
-      focusNode.removeListener(_handleFocusChanged);
-      _focusAttachment.detach();
-    }
+    // Regardless of the node owner, we need to remove it from the tree and stop
+    // listening to it.
+    focusNode.removeListener(_handleFocusChanged);
+    _focusAttachment.detach();
 
     // Don't manage the lifetime of external nodes given to the widget, just the
     // internal node.
@@ -403,10 +397,6 @@ class _FocusState extends State<Focus> {
 
   @override
   Widget build(BuildContext context) {
-    if (identical(widget.focusNode, Focus.unfocusable)) {
-      return widget.child;
-    }
-
     _focusAttachment.reparent();
     return _FocusMarker(
       node: focusNode,

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -146,13 +146,10 @@ class Focus extends StatefulWidget {
     this.onFocusChange,
     this.onKey,
     this.debugLabel,
-    this.focusable = true,
-    this.skipTraversal = false,
+    this.canRequestFocus,
+    this.skipTraversal,
   })  : assert(child != null),
         assert(autofocus != null),
-        assert(focusable != null),
-        assert(skipTraversal != null),
-        assert(focusable == true || autofocus == false, 'Autofocus cannot be true if focusable is false.'),
         super(key: key);
 
   /// A debug label for this widget.
@@ -229,11 +226,13 @@ class Focus extends StatefulWidget {
   /// part of the focus chain, but shouldn't be accessible via focus traversal.
   final bool skipTraversal;
 
-  /// If true, this widget may be focused.
+  /// If true, this widget may request the primary focus.
   ///
   /// Defaults to true.  Set to false if you want this node to do nothing when
-  /// [requestFocus] is called on it. Does not affect the children of this node.
-  final bool focusable;
+  /// [requestFocus] is called on it. Does not affect the children of this node,
+  /// and [hasFocus] can still return true if this node is the ancestor of the
+  /// primary focus.
+  final bool canRequestFocus;
 
   /// Returns the [focusNode] of the [Focus] that most tightly encloses the
   /// given [BuildContext].
@@ -323,8 +322,8 @@ class _FocusState extends State<Focus> {
       // _createNode is overridden in _FocusScopeState.
       _internalNode ??= _createNode();
     }
-    focusNode.skipTraversal = widget.skipTraversal;
-    focusNode.focusable = widget.focusable;
+    focusNode.skipTraversal = widget.skipTraversal ?? focusNode.skipTraversal;
+    focusNode.canRequestFocus = widget.canRequestFocus ?? focusNode.canRequestFocus;
     _focusAttachment = focusNode.attach(context, onKey: widget.onKey);
     _hasFocus = focusNode.hasFocus;
 
@@ -337,8 +336,8 @@ class _FocusState extends State<Focus> {
   FocusNode _createNode() {
     return FocusNode(
       debugLabel: widget.debugLabel,
-      focusable: widget.focusable,
-      skipTraversal: widget.skipTraversal,
+      canRequestFocus: widget.canRequestFocus ?? true,
+      skipTraversal: widget.skipTraversal ?? false,
     );
   }
 
@@ -383,9 +382,9 @@ class _FocusState extends State<Focus> {
       return true;
     }());
 
-    if (oldWidget.focusNode == widget.focusNode &&
-        widget.focusNode?.focusable == widget.focusable &&
-        widget.focusNode?.skipTraversal == widget.skipTraversal) {
+    if (oldWidget.focusNode == widget.focusNode) {
+      focusNode.skipTraversal = widget.skipTraversal ?? focusNode.skipTraversal;
+      focusNode.canRequestFocus = widget.canRequestFocus ?? focusNode.canRequestFocus;
       return;
     }
 

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -224,14 +224,31 @@ class Focus extends StatefulWidget {
   ///
   /// This is sometimes useful if a Focus widget should receive key events as
   /// part of the focus chain, but shouldn't be accessible via focus traversal.
+  ///
+  /// This is different from [canRequestFocus] because it only implies that the
+  /// widget can't be reached via traversal, not that it can't be focused. It may
+  /// still be focused explicitly.
   final bool skipTraversal;
 
   /// If true, this widget may request the primary focus.
   ///
-  /// Defaults to true.  Set to false if you want this node to do nothing when
-  /// [requestFocus] is called on it. Does not affect the children of this node,
-  /// and [hasFocus] can still return true if this node is the ancestor of the
-  /// primary focus.
+  /// Defaults to true.  Set to false if you want the [FocusNode] this widget
+  /// manages to do nothing when [requestFocus] is called on it. Does not affect
+  /// the children of this node, and [FocusNode.hasFocus] can still return true
+  /// if this node is the ancestor of the primary focus.
+  ///
+  /// This is different than [skipTraversal] because [skipTraversal] still
+  /// allows the widget to be focused, just not traversed to.
+  ///
+  /// Setting [canRequestFocus] to false implies that the widget will also be
+  /// skipped for traversal purposes.
+  ///
+  /// See also:
+  ///
+  ///   - [DefaultFocusTraversal], a widget that sets the traversal policy for
+  ///     its descendants.
+  ///   - [FocusTraversalPolicy], a class that can be extended to describe a
+  ///     traversal policy.
   final bool canRequestFocus;
 
   /// Returns the [focusNode] of the [Focus] that most tightly encloses the

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1157,7 +1157,7 @@ void main() {
       bool gotFocus;
       await tester.pumpWidget(
         Focus(
-          focusable: false,
+          canRequestFocus: false,
           onFocusChange: (bool focused) => gotFocus = focused,
           child: Container(key: key1),
         ),
@@ -1178,7 +1178,7 @@ void main() {
       await tester.pumpWidget(
         Focus(
           autofocus: true,
-          focusable: true,
+          canRequestFocus: true,
           onFocusChange: (bool focused) => gotFocus = focused,
           child: Container(key: key1),
         ),
@@ -1196,7 +1196,7 @@ void main() {
       gotFocus = null;
       await tester.pumpWidget(
         Focus(
-          focusable: false,
+          canRequestFocus: false,
           onFocusChange: (bool focused) => gotFocus = focused,
           child: Container(key: key1),
         ),
@@ -1208,7 +1208,7 @@ void main() {
 
       await tester.pump();
 
-      expect(gotFocus, isNull);
+      expect(gotFocus, false);
       expect(node.hasFocus, isFalse);
     });
     testWidgets('Child of unfocusable Focus can get focus.', (WidgetTester tester) async {
@@ -1218,7 +1218,7 @@ void main() {
       bool gotFocus;
       await tester.pumpWidget(
         Focus(
-          focusable: false,
+          canRequestFocus: false,
           onFocusChange: (bool focused) => gotFocus = focused,
           child: Focus(key: key1, focusNode: focusNode, child: Container(key: key2)),
         ),

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/src/gestures/debug.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1151,6 +1151,24 @@ void main() {
       expect(gotFocus, isTrue);
       expect(node.hasFocus, isTrue);
     });
+    testWidgets('Focus is ignored when set to Focus.unfocusable.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      bool gotFocus;
+      await tester.pumpWidget(
+        Focus(
+          focusNode: Focus.unfocusable,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          child: Container(key: key1),
+        ),
+      );
+
+      final Element firstNode = tester.element(find.byKey(key1));
+      final FocusNode node = Focus.of(firstNode, nullOk: true);
+      expect(node, isNull);
+      expect(find.byWidgetPredicate((Widget widget) {
+        return widget.runtimeType.toString() == '_FocusMarker';
+      }), findsNothing);
+    });
   });
   testWidgets('Nodes are removed when all Focuses are removed.', (WidgetTester tester) async {
     final GlobalKey key1 = GlobalKey(debugLabel: '1');


### PR DESCRIPTION
## Description

This PR adds the ability to mark a `FocusNode` as being unable to request focus via a `canRequestFocus` boolean.  This has the effect of making it not focusable, and it implies the same behaviors as `skipTraversal` as well (nodes that can't request focus are skipped in traversal just like `skipTraversal` nodes are). It is different than `skipTraversal` because `skipTraversal` nodes may still be focused explicitly, just not as a result of traversal.

## Issues Affected

#33985

## Tests

- make sure that the node is skipped, and
- make sure that setting `canRequestFocus` to false forces the node to lose focus if it had focus.
- make sure that children of the node can still request focus.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes