### PR TITLE
Show process error when iOS install fails

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -230,7 +230,8 @@ class IOSDevice extends Device {
         ),
       );
       return true;
-    } on ProcessException {
+    } on ProcessException catch (error) {
+      printError(error.message);
       return false;
     }
   }
@@ -245,7 +246,8 @@ class IOSDevice extends Device {
         ),
       );
       return true;
-    } on ProcessException {
+    } on ProcessException catch (error) {
+      printError(error.message);
       return false;
     }
   }


### PR DESCRIPTION
## Description

Print error when iOS device installation fails.
`android_device`'s `install_app` method already prints out errors on failure.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/38614.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.