### PR TITLE
Fix two memory leaks in InkWell and ObservableList

### DIFF
--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -28,6 +28,7 @@ class ObserverList<T> extends Iterable<T> {
   /// Returns whether the item was present in the list.
   bool remove(T item) {
     _isDirty = true;
+    _set?.clear();
     return _list.remove(item);
   }
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -473,12 +473,17 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
   bool get highlightsExist => _highlights.values.where((InkHighlight highlight) => highlight != null).isNotEmpty;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _focusNode?.removeListener(_handleFocusUpdate);
     _focusNode = Focus.of(context, nullOk: true);
     _focusNode?.addListener(_handleFocusUpdate);
-    WidgetsBinding.instance.focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   @override


### PR DESCRIPTION
## Description

Found this when using heap snapshots in Observatory to track where Image objects were being leaked.

In InkWell, the highlight mode listener was being added multiple times (every time a dependency updated). This caused a leak because the number of removals did not equal the number of additions.

Then in ObservableList, when items are removed from the list the set is not cleared, even though the set will be cleared and repopulated during the next call to `contains`. This caused a leak because removed items technically were not removed. This caused entire TransitionRoutes to leak in a chain.

This fixes the last issues I had with image loading in Flutter.

## Related Issues

N/A

## Tests

I added the following tests:

None, I don't think there's a good way to test memory leaks right now.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
