### PR TITLE
Fix DragTarget not being rebuilt when a rejected Draggable enters #38786

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -524,9 +524,12 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
         _candidateAvatars.add(avatar);
       });
       return true;
+    } else {
+      setState(() {
+        _rejectedAvatars.add(avatar);
+      });
+      return false;
     }
-    _rejectedAvatars.add(avatar);
-    return false;
   }
 
   void didLeave(_DragAvatar<dynamic> avatar) {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -972,6 +972,60 @@ void main() {
             Offset(secondLocation.dx, secondLocation.dy - firstLocation.dy)));
   });
 
+  testWidgets('Drag and drop - builder called with reject data if dragged over non-accepting target', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: <Widget>[
+          const Draggable<int>(
+            data: 1,
+            child: Text('Source'),
+            feedback: Text('Dragging'),
+          ),
+          DragTarget<int>(
+            builder:
+                (BuildContext context, List<int> data, List<dynamic> rejects) {
+              return Container(
+                height: 100.0,
+                child: rejects.isNotEmpty
+                    ? const Text('Rejected')
+                    : const Text('Target'),
+              );
+            },
+            onWillAccept: (int data) => false,
+          ),
+        ],
+      ),
+    ));
+
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+
+    final Offset firstLocation = tester.getTopLeft(find.text('Source'));
+    final TestGesture gesture =
+    await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+
+    final Offset secondLocation = tester.getCenter(find.text('Target'));
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsNothing);
+    expect(find.text('Rejected'), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+  });
+
   testWidgets('Drag and drop - onDragCompleted not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
     bool onDragCompletedCalled = false;

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -972,7 +972,7 @@ void main() {
             Offset(secondLocation.dx, secondLocation.dy - firstLocation.dy)));
   });
 
-  testWidgets('Drag and drop - builder called with reject data if dragged over non-accepting target', (WidgetTester tester) async {
+  testWidgets('Drag and drop - DragTarget rebuilds with and without rejected data when a rejected draggable enters and leaves', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Column(
         children: <Widget>[
@@ -1018,9 +1018,93 @@ void main() {
     expect(find.text('Target'), findsNothing);
     expect(find.text('Rejected'), findsOneWidget);
 
+    await gesture.moveTo(firstLocation);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+  });
+
+
+  testWidgets('Drag and drop - Can drag and drop over a non-accepting target multiple times', (WidgetTester tester) async {
+    int numberOfTimesOnDraggableCanceledCalled = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: <Widget>[
+          Draggable<int>(
+            data: 1,
+            child: const Text('Source'),
+            feedback: const Text('Dragging'),
+          onDraggableCanceled: (Velocity velocity, Offset offset) {
+            numberOfTimesOnDraggableCanceledCalled++;
+          },
+          ),
+          DragTarget<int>(
+            builder:
+                (BuildContext context, List<int> data, List<dynamic> rejects) {
+              return Container(
+                height: 100.0,
+                child: rejects.isNotEmpty
+                    ? const Text('Rejected')
+                    : const Text('Target'),
+              );
+            },
+            onWillAccept: (int data) => false,
+          ),
+        ],
+      ),
+    ));
+
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+
+    final Offset firstLocation = tester.getTopLeft(find.text('Source'));
+    final TestGesture gesture =
+    await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+
+    final Offset secondLocation = tester.getCenter(find.text('Target'));
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsNothing);
+    expect(find.text('Rejected'), findsOneWidget);
+
     await gesture.up();
     await tester.pump();
 
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+    expect(numberOfTimesOnDraggableCanceledCalled, 1);
+
+    // Drag and drop the Draggable onto the Target a second time.
+    final TestGesture secondGesture =
+    await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsOneWidget);
+    expect(find.text('Rejected'), findsNothing);
+
+    await secondGesture.moveTo(secondLocation);
+    await tester.pump();
+
+    expect(find.text('Dragging'), findsOneWidget);
+    expect(find.text('Target'), findsNothing);
+    expect(find.text('Rejected'), findsOneWidget);
+
+    await secondGesture.up();
+    await tester.pump();
+
+    expect(numberOfTimesOnDraggableCanceledCalled, 2);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
     expect(find.text('Rejected'), findsNothing);


### PR DESCRIPTION
## Description

Currently, DragTarget doesn't rebuild if a rejected Draggable enters. This is because in _DragTargetState.didEnter it updates its list of rejected data _rejectedAvatars outside of a setState call. This results in the user supplied builder function not being called with any rejected data, so they can't rebuild accordingly. This PR wraps the rejectedAvatars state mutation in a setState call so this bug is fixed. Issue #38786 contains further details and an example showing the bug. 

## Related Issues

* Fixes #31659
* Fixes #38786 

## Tests

I added the following tests:
* 'Drag and drop - builder called with reject data if dragged over non-accepting target' 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
