### PR TITLE
Cache caret parameters

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -782,6 +782,10 @@ class TextPainter {
       offset: rect != null ? Offset(rect.left, rect.top) : _emptyOffset,
       fullHeight: rect != null ? rect.bottom - rect.top : null,
     );
+
+    // Cache the input parameters to prevent repeat work later.
+    _previousCaretPosition = position;
+    _previousCaretPrototype = caretPrototype;
   }
 
   /// Returns a list of rects that bound the given selection.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/36707

We were not caching the caret parameters before, causing the short circuit to never trigger, resulting in additional redundant work. This adds the caching to bring it into line with what it was meant to be.

This does not change the output at all and slightly increases performance for cases like blinking carets.