### PR TITLE
Print service url when connecting to web applications

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -203,6 +203,9 @@ class ResidentWebRunner extends ResidentRunner {
       });
       websocketUri = Uri.parse(_debugConnection.uri);
     }
+    if (websocketUri != null) {
+      printStatus('Debug service listening on $websocketUri.');
+    }
     connectionInfoCompleter?.complete(
       DebugConnectionInfo(wsUri: websocketUri)
     );

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -88,12 +88,14 @@ void main() {
 
   test('Can successfully run and connect to vmservice', () => testbed.run(() async {
     _setupMocks();
+    final BufferLogger bufferLogger = logger;
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(residentWebRunner.run(
       connectionInfoCompleter: connectionInfoCompleter,
     ));
     final DebugConnectionInfo debugConnectionInfo = await connectionInfoCompleter.future;
 
+    expect(bufferLogger.statusText, contains('Debug service listening on ws://127.0.0.1/abcd/'));
     expect(debugConnectionInfo.wsUri.toString(), 'ws://127.0.0.1/abcd/');
   }));
 


### PR DESCRIPTION
## Description

Print the service uri when connecting to web applications. This can currently be used to connect to devtools manually.


## Related Issues

https://github.com/flutter/flutter/issues/38820

## Tests

Confirm that statusText contains service url.