### PR TITLE
kill resident runner on browser disconnect

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -158,6 +158,7 @@ class ResidentWebRunner extends ResidentRunner {
         flutterProject: flutterProject,
         buildInfo: debuggingOptions.buildInfo,
       );
+      unawaited(_webFs.onTabClose.whenComplete(exit));
       if (supportsServiceProtocol) {
         _debugConnection = await _webFs.runAndDebug();
       }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -28,6 +28,9 @@ void main() {
   setUp(() {
     mockWebFs = MockFlutterWebFs();
     final MockWebDevice mockWebDevice = MockWebDevice();
+    when(mockWebFs.onTabClose).thenAnswer((Invocation invocation) {
+      return Future<void>.value();
+    });
     testbed = Testbed(
       setup: () {
         residentWebRunner = ResidentWebRunner(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -34,6 +34,9 @@ void main() {
     mockDebugConnection = MockDebugConnection();
     mockVmService = MockVmService();
     final MockWebDevice mockWebDevice = MockWebDevice();
+    when(mockWebFs.onTabClose).thenAnswer((Invocation invocation) {
+      return Future<void>.value();
+    });
     testbed = Testbed(
       setup: () {
         residentWebRunner = ResidentWebRunner(


### PR DESCRIPTION
## Description

Currently we kill the browser if the resident runner is terminated. We should also kill the resident runner when the browser is closed.

## Related Issues

No filled issue.

## Tests
 - can create a WIP connection from mocks