### PR TITLE
Replace deprecated onReportTimings w/ frameTimings

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -202,14 +202,10 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
     if (!kReleaseMode) {
       int frameNumber = 0;
 
-      // use frameTimings. https://github.com/flutter/flutter/issues/38838
-      // ignore: deprecated_member_use
-      window.onReportTimings = (List<FrameTiming> timings) {
-        for (FrameTiming frameTiming in timings) {
-          frameNumber += 1;
-          _profileFramePostEvent(frameNumber, frameTiming);
-        }
-      };
+      window.frameTimings.listen((FrameTiming frameTiming) {
+        frameNumber += 1;
+        _profileFramePostEvent(frameNumber, frameTiming);
+      });
     }
   }
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:developer' as developer;
-import 'dart:ui' show AppLifecycleState, Locale, AccessibilityFeatures, FrameTiming, TimingsCallback;
+import 'dart:ui' show AppLifecycleState, Locale, AccessibilityFeatures, FrameTiming;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -740,25 +740,13 @@ mixin WidgetsBinding on BindingBase, SchedulerBinding, GestureBinding, RendererB
 
     if (_needToReportFirstFrame && _reportFirstFrame) {
       assert(!_firstFrameCompleter.isCompleted);
-      // TODO(liyuqian): use a broadcast stream approach
-      // use frameTimings. https://github.com/flutter/flutter/issues/38838
-      // ignore: deprecated_member_use
-      final TimingsCallback oldCallback = WidgetsBinding.instance.window.onReportTimings;
-      // use frameTimings. https://github.com/flutter/flutter/issues/38838
-      // ignore: deprecated_member_use
-      WidgetsBinding.instance.window.onReportTimings = (List<FrameTiming> timings) {
+      WidgetsBinding.instance.window.frameTimings.first.then((FrameTiming _) {
         if (!kReleaseMode) {
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
         }
-        if (oldCallback != null) {
-          oldCallback(timings);
-        }
-        // use frameTimings. https://github.com/flutter/flutter/issues/38838
-        // ignore: deprecated_member_use
-        WidgetsBinding.instance.window.onReportTimings = oldCallback;
         _firstFrameCompleter.complete();
-      };
+      });
     }
 
     try {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -79,12 +79,11 @@ class TestServiceExtensionsBinding extends BindingBase
     await flushMicrotasks();
     if (ui.window.onDrawFrame != null)
       ui.window.onDrawFrame();
-    // use frameTimings. https://github.com/flutter/flutter/issues/38838
-    // ignore: deprecated_member_use
-    if (ui.window.onReportTimings != null)
-      // use frameTimings. https://github.com/flutter/flutter/issues/38838
-      // ignore: deprecated_member_use
-      ui.window.onReportTimings(<ui.FrameTiming>[]);
+    final Future<ui.FrameTiming> firstFrameEventFired = window.frameTimings.first;
+    ui.window.debugReportTimings(<ui.FrameTiming>[
+      ui.FrameTiming(List<int>.filled(ui.FramePhase.values.length, 0)),
+    ]);
+    await firstFrameEventFired;
   }
 
   @override

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -132,14 +132,17 @@ void main() {
   });
 
   test('Flutter.Frame event fired', () async {
-    // use frameTimings. https://github.com/flutter/flutter/issues/38838
-    // ignore: deprecated_member_use
-    window.onReportTimings(<FrameTiming>[FrameTiming(<int>[
+    // We can't use Future in scheduler_test so we'll use dynamic instead.
+    final dynamic firstFrameEventFired = window.frameTimings.first;
+
+    window.debugReportTimings(<FrameTiming>[FrameTiming(<int>[
       // build start, build finish
       10000, 15000,
       // raster start, raster finish
       16000, 20000,
     ])]);
+
+    await firstFrameEventFired;
 
     final List<Map<String, dynamic>> events = scheduler.getEventsDispatched('Flutter.Frame');
     expect(events, hasLength(1));

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -272,15 +272,7 @@ class TestWindow implements Window {
   }
 
   @override
-  // use frameTimings. https://github.com/flutter/flutter/issues/38838
-  // ignore: deprecated_member_use
-  TimingsCallback get onReportTimings => _window.onReportTimings;
-  @override
-  set onReportTimings(TimingsCallback callback) {
-    // use frameTimings. https://github.com/flutter/flutter/issues/38838
-    // ignore: deprecated_member_use
-    _window.onReportTimings = callback;
-  }
+  Stream<FrameTiming> get frameTimings => _window.frameTimings;
 
   @override
   PointerDataPacketCallback get onPointerDataPacket => _window.onPointerDataPacket;


### PR DESCRIPTION
This is the continuation of https://github.com/flutter/engine/pull/11041 and https://github.com/flutter/flutter/pull/38574

This is not a breaking change as we're not removing `onReportTimings` API.
We're simply removing the use of it in our framework.