### PR TITLE
Store file hashes per build configuration.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/file_hash_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_hash_store.dart
@@ -107,5 +107,5 @@ class FileHashStore {
     return dirty;
   }
 
-  File get _cacheFile => environment.rootBuildDir.childFile(_kFileCache);
+  File get _cacheFile => environment.buildDir.childFile(_kFileCache);
 }

--- a/packages/flutter_tools/test/general.shard/build_system/filecache_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/filecache_test.dart
@@ -20,6 +20,7 @@ void main() {
       environment = Environment(
         projectDir: fs.currentDirectory,
       );
+      environment.buildDir.createSync(recursive: true);
     });
   });
 
@@ -28,9 +29,10 @@ void main() {
     fileCache.initialize();
     fileCache.persist();
 
-    expect(fs.file(fs.path.join('build', '.filecache')).existsSync(), true);
+    expect(fs.file(fs.path.join(environment.buildDir.path, '.filecache')).existsSync(), true);
 
-    final List<int> buffer = fs.file(fs.path.join('build', '.filecache')).readAsBytesSync();
+    final List<int> buffer = fs.file(fs.path.join(environment.buildDir.path, '.filecache'))
+        .readAsBytesSync();
     final pb.FileStorage fileStorage = pb.FileStorage.fromBuffer(buffer);
 
     expect(fileStorage.files, isEmpty);
@@ -46,7 +48,8 @@ void main() {
     fileCache.hashFiles(<File>[file]);
     fileCache.persist();
     final String currentHash =  fileCache.currentHashes[file.resolveSymbolicLinksSync()];
-    final List<int> buffer = fs.file(fs.path.join('build', '.filecache')).readAsBytesSync();
+    final List<int> buffer = fs.file(fs.path.join(environment.buildDir.path, '.filecache'))
+        .readAsBytesSync();
     pb.FileStorage fileStorage = pb.FileStorage.fromBuffer(buffer);
 
     expect(fileStorage.files.single.hash, currentHash);


### PR DESCRIPTION
## Description

Store cached file hashes per configuration. Since different configurations can output different files at the same locations in the project directory, a global cache isn't safe for outputs.