### PR TITLE
[flutter_tool] Move http request close under try-catch

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -48,12 +48,14 @@ Future<List<int>> _attempt(Uri url, { bool onlyHeaders = false }) async {
     httpClient = HttpClient();
   }
   HttpClientRequest request;
+  HttpClientResponse response;
   try {
     if (onlyHeaders) {
       request = await httpClient.headUrl(url);
     } else {
       request = await httpClient.getUrl(url);
     }
+    response = await request.close();
   } on ArgumentError catch (error) {
     final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
     if (overrideUrl != null && url.toString().contains(overrideUrl)) {
@@ -82,7 +84,8 @@ Future<List<int>> _attempt(Uri url, { bool onlyHeaders = false }) async {
     printTrace('Download error: $error');
     return null;
   }
-  final HttpClientResponse response = await request.close();
+  assert(response != null);
+
   // If we're making a HEAD request, we're only checking to see if the URL is
   // valid.
   if (onlyHeaders) {


### PR DESCRIPTION
## Description

This PR moves the `close()` call on a `HttpClientRequest` object under a `try-catch`. The http request may still fail after the connection is established.

## Related Issues

Seen in crash reports.

## Tests

I added the following tests:

Test in net_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.