### PR TITLE
Update BUILD.gn for package:flutter_test

### DIFF
--- a/packages/flutter_test/BUILD.gn
+++ b/packages/flutter_test/BUILD.gn
@@ -14,7 +14,12 @@ dart_library("flutter_test") {
 
   deps = [
     "../flutter",
+    "//third_party/dart-pkg/pub/image",
+    "//third_party/dart-pkg/pub/path",
     "//third_party/dart-pkg/pub/quiver",
+    "//third_party/dart-pkg/pub/stack_trace",
     "//third_party/dart-pkg/pub/test",
+    "//third_party/dart-pkg/pub/test_api",
+    "//third_party/dart-pkg/pub/vector_math",
   ]
 }


### PR DESCRIPTION
Syncs the BUILD.gn with pubspec.yaml for package:test. This fixes a
breakage in the Fuchsia tree.