### PR TITLE
Add build warning for non-debug desktop builds

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -38,6 +38,15 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
     ..createSync(recursive: true)
     ..writeAsStringSync(buffer.toString());
 
+  if (!buildInfo.isDebug) {
+    const String warning = '🚧 ';
+    printStatus(warning * 20);
+    printStatus('Warning: Only debug is currently implemented for Linux. This is effectively a debug build.');
+    printStatus('See https://github.com/flutter/flutter/issues/38478 for details and updates.');
+    printStatus(warning * 20);
+    printStatus('');
+  }
+
   // Invoke make.
   final Stopwatch sw = Stopwatch()..start();
   final Process process = await processManager.start(<String>[

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -42,6 +42,15 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
         'Please run `flutter doctor` for more details.');
   }
 
+  if (!buildInfo.isDebug) {
+    const String warning = '🚧 ';
+    printStatus(warning * 20);
+    printStatus('Warning: Only debug is currently implemented for Windows. This is effectively a debug build.');
+    printStatus('See https://github.com/flutter/flutter/issues/38477 for details and updates.');
+    printStatus(warning * 20);
+    printStatus('');
+  }
+
   final String buildScript = fs.path.join(
     Cache.flutterRoot,
     'packages',


### PR DESCRIPTION
## Description

When building in profile or release mode on desktop, add a prominent
warning that it's actually a debug build. This is to help address issues
with people being unaware of the current state of builds due to
following third-party guides rather than official documentation.

macOS is not included since PRs are in flight for macOS release support.

## Related Issues

None

## Tests

I added the following tests: Validates that output for release builds includes the new 🚧 banner.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
