### PR TITLE
Handle PowerShell version failures better

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -102,11 +102,17 @@ GOTO :after_subroutine
     SET update_dart_bin=%FLUTTER_ROOT%/bin/internal/update_dart_sdk.ps1
     REM Escape apostrophes from the executable path
     SET "update_dart_bin=!update_dart_bin:'=''!"
-    PowerShell.exe -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'"
+    PowerShell.exe -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'; exit $LastExitCode"
     IF "%ERRORLEVEL%" NEQ "0" (
-      ECHO Error: Unable to update Dart SDK. Retrying...
-      timeout /t 5 /nobreak
-      GOTO :do_sdk_update_and_snapshot
+      REM Error code 3 is returned by the PowerShell script if the version is not good enough.
+      IF "%ERRORLEVEL%" EQU "3" (
+        SET exit_code=%ERRORLEVEL%
+        GOTO :final_exit
+      ) ELSE (
+        ECHO Error: Unable to update Dart SDK. Retrying...
+        timeout /t 5 /nobreak
+        GOTO :do_sdk_update_and_snapshot
+      )
     )
 
   :do_snapshot

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -24,7 +24,7 @@ $engineVersion = (Get-Content "$flutterRoot\bin\internal\engine.version")
 $oldDartSdkPrefix = "dart-sdk.old"
 
 # Make sure that PowerShell has expected version.
-$psMajorVersionRequired = 50
+$psMajorVersionRequired = 5
 $psMajorVersionLocal = $PSVersionTable.PSVersion.Major
 if ($psMajorVersionLocal -lt $psMajorVersionRequired) {
     Write-Host "Flutter requires PowerShell $psMajorVersionRequired.0 or newer."

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -24,12 +24,12 @@ $engineVersion = (Get-Content "$flutterRoot\bin\internal\engine.version")
 $oldDartSdkPrefix = "dart-sdk.old"
 
 # Make sure that PowerShell has expected version.
-$psMajorVersionRequired = 5
+$psMajorVersionRequired = 50
 $psMajorVersionLocal = $PSVersionTable.PSVersion.Major
 if ($psMajorVersionLocal -lt $psMajorVersionRequired) {
     Write-Host "Flutter requires PowerShell $psMajorVersionRequired.0 or newer."
     Write-Host "See https://flutter.dev/docs/get-started/install/windows for more."
-    return
+    exit 3
 }
 
 if ((Test-Path $engineStamp) -and ($engineVersion -eq (Get-Content $engineStamp))) {


### PR DESCRIPTION
This is an attempt to fix https://github.com/flutter/flutter/issues/27938. Currently if your PoSh version is too old, we write a message but the `.bat` file still tries to continue and results in a confusing message.

This changes the PowerShell script to return an exit code that we can use to bail out. However, this currently fails and gets stuck in a different loop:

```
Checking Dart SDK version...
Flutter requires PowerShell 50.0 or newer.
See https://flutter.dev/docs/get-started/install/windows for more.
Checking Dart SDK version...
Flutter requires PowerShell 50.0 or newer.
See https://flutter.dev/docs/get-started/install/windows for more.
Checking Dart SDK version...
Flutter requires PowerShell 50.0 or newer.
See https://flutter.dev/docs/get-started/install/windows for more.
```

I think that's because of this:

```
:acquire_lock
2>NUL (
  REM "3" is now stderr because of "2>NUL".
  CALL :subroutine %* 2>&3 9> "%cache_dir%\flutter.bat.lock" || GOTO acquire_lock
)
```

Which I think will forever call `:aquire_lock` until a lock file is created. I don't understand why calling `:final_exit` isn't working, since it explicitly calls `EXIT` (and if I put an echo there, it's definitely being called). That said, I don't totally understand the line above (what is `9>` doing for ex?).

The reason this doesn't come up for the normal failure, is that it just sits in a loop forever telling the user to press Ctrl+C (the pub fetch does have limited retries, but "Checking Dart SDK version" does not, it loops infinitely.. if it tried to bail out after some retries, I think the same might happen?).

@goderbauer since you wrote much of this code, you might understand it better than me. Is there an easy way for me to bail out here?