### PR TITLE
Mark smoke_catalina_start_up not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -521,7 +521,6 @@ tasks:
     description: >
       A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
     stage: devicelab_ios
-    flaky: true
     required_agent_capabilities: ["mac-catalina/ios"]
 
   smoke_catalina_hot_mode_dev_cycle__benchmark:


### PR DESCRIPTION
## Description

smoke_catalina_start_up seems to be consistently passing. Mark as not flaky.

## Related Issues

See https://github.com/flutter/flutter/issues/36290.