### PR TITLE
Dont throw StateError when calling assemble

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -71,7 +71,12 @@ class AssembleCommand extends FlutterCommand {
       throwToolExit('missing target name for flutter assemble.');
     }
     final String name = argResults.rest.first;
-    return _kDefaultTargets.firstWhere((Target target) => target.name == name);
+    final Target result = _kDefaultTargets
+        .firstWhere((Target target) => target.name == name, orElse: () => null);
+    if (result == null) {
+      throwToolExit('No target named "{target.name} defined."');
+    }
+    return result;
   }
 
   /// The environmental configuration for a build invocation.

--- a/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/assemble_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -41,6 +42,15 @@ void main() {
     expect(bufferLogger.statusText.trim(), 'build succeeded.');
   }));
 
+  test('Throws ToolExit if called with non-existent rule', () => testbed.run(() async {
+    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+        .thenAnswer((Invocation invocation) async {
+      return BuildResult(success: true);
+    });
+    final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
+
+    expect(commandRunner.run(<String>['assemble', 'undefined']), throwsA(isInstanceOf<ToolExit>()));
+  }));
   test('Only writes input and output files when the values change', () => testbed.run(() async {
     when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
         .thenAnswer((Invocation invocation) async {


### PR DESCRIPTION
## Description

Instead of crashing, exit with a message that the rule doesn't exist.