### PR TITLE
[flutter_tool] Teach crash reporter about HttpException

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -127,7 +127,7 @@ class CrashReportSender {
         printError('Failed to send crash report. Server responded with HTTP status code ${resp.statusCode}');
       }
     } catch (sendError, sendStackTrace) {
-      if (sendError is SocketException) {
+      if (sendError is SocketException || sendError is HttpException) {
         printError('Failed to send crash report due to a network error: $sendError');
       } else {
         // If the sender itself crashes, just print. We did our best.


### PR DESCRIPTION
## Description

This PR makes the crash reporter complain of a network issue not only when there is a `SocketException`, but also when there is an `HttpException`.

## Related Issues

Issue reported on twitter.

## Tests

I added the following tests:

New tests in crash_reporting_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.