### PR TITLE
Add web workflow to default validators

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -113,6 +113,9 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
       if (windowsWorkflow.appliesToHostPlatform)
         _workflows.add(windowsWorkflow);
 
+      if (webWorkflow.appliesToHostPlatform)
+        _workflows.add(webWorkflow);
+
     }
     return _workflows;
   }

--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -4,6 +4,10 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/process_manager.dart';
+import 'package:flutter_tools/src/commands/doctor.dart';
+import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/web/workflow.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -22,6 +26,7 @@ import 'package:flutter_tools/src/vscode/vscode_validator.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/testbed.dart';
 
 final Generator _kNoColorOutputPlatform = () => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false;
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
@@ -570,6 +575,15 @@ void main() {
       expect(testLogger.statusText, startsWith('[✗]'));
     }, overrides: noColorTerminalOverride);
   });
+
+  testUsingContext('WebWorkflow is a part of validator workflows if enabled', () async {
+    when(processManager.canRun(any)).thenReturn(true);
+
+    expect(DoctorValidatorsProvider.defaultInstance.workflows.contains(webWorkflow), true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    ProcessManager: () => MockProcessManager(),
+  });
 }
 
 class MockUsage extends Mock implements Usage {}
@@ -845,3 +859,4 @@ class VsCodeValidatorTestTargets extends VsCodeValidator {
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
+class MockPlatform extends Mock implements Platform {}

--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -859,4 +859,3 @@ class VsCodeValidatorTestTargets extends VsCodeValidator {
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
-class MockPlatform extends Mock implements Platform {}

--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/process_manager.dart';
-import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/web/workflow.dart';
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
## Description

The WebWorkflow was missing from the doctor validators. This would prevent a user that has an available "web device" from running flutter if they didn't have any other functioning devices.


Discovered by @natebosch 