### PR TITLE
Explain const values in MediaQuery test file

### DIFF
--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -15,8 +15,8 @@ void main() {
           tested = true;
           MediaQuery.of(context); // should throw
           return Container();
-        }
-      )
+        },
+      ),
     );
     expect(tested, isTrue);
     expect(tester.takeException(), isFlutterError);
@@ -31,8 +31,8 @@ void main() {
           expect(data, isNull);
           tested = true;
           return Container();
-        }
-      )
+        },
+      ),
     );
     expect(tested, isTrue);
   });
@@ -70,16 +70,27 @@ void main() {
   });
 
   testWidgets('MediaQuery.copyWith copies specified values', (WidgetTester tester) async {
+    // Random and unique double values are used to ensure that the correct
+    // values are copied over exactly
+    const Size customSize = Size(3.14, 2.72);
+    const double customDevicePixelRatio = 1.41;
+    const double customTextScaleFactor = 1.62;
+    const EdgeInsets customPadding = EdgeInsets.all(9.10938);
+    const EdgeInsets customViewPadding = EdgeInsets.all(11.24031);
+    const EdgeInsets customViewInsets = EdgeInsets.all(1.67262);
+    const EdgeInsets customSystemGestureInsets = EdgeInsets.all(1.5556);
+    const double customPhysicalDepth = 120.0;
+
     final MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
     final MediaQueryData copied = data.copyWith(
-      size: const Size(3.14, 2.72),
-      devicePixelRatio: 1.41,
-      textScaleFactor: 1.62,
-      padding: const EdgeInsets.all(9.10938),
-      viewPadding: const EdgeInsets.all(11.24031),
-      viewInsets: const EdgeInsets.all(1.67262),
-      systemGestureInsets: const EdgeInsets.all(1.5556),
-      physicalDepth: 120.0,
+      size: customSize,
+      devicePixelRatio: customDevicePixelRatio,
+      textScaleFactor: customTextScaleFactor,
+      padding: customPadding,
+      viewPadding: customViewPadding,
+      viewInsets: customViewInsets,
+      systemGestureInsets: customSystemGestureInsets,
+      physicalDepth: customPhysicalDepth,
       alwaysUse24HourFormat: true,
       accessibleNavigation: true,
       invertColors: true,
@@ -87,14 +98,14 @@ void main() {
       boldText: true,
       platformBrightness: Brightness.dark,
     );
-    expect(copied.size, const Size(3.14, 2.72));
-    expect(copied.devicePixelRatio, 1.41);
-    expect(copied.textScaleFactor, 1.62);
-    expect(copied.padding, const EdgeInsets.all(9.10938));
-    expect(copied.viewPadding, const EdgeInsets.all(11.24031));
-    expect(copied.viewInsets, const EdgeInsets.all(1.67262));
-    expect(copied.systemGestureInsets, const EdgeInsets.all(1.5556));
-    expect(copied.physicalDepth, 120.0);
+    expect(copied.size, customSize);
+    expect(copied.devicePixelRatio, customDevicePixelRatio);
+    expect(copied.textScaleFactor, customTextScaleFactor);
+    expect(copied.padding, customPadding);
+    expect(copied.viewPadding, customViewPadding);
+    expect(copied.viewInsets, customViewInsets);
+    expect(copied.systemGestureInsets, customSystemGestureInsets);
+    expect(copied.physicalDepth, customPhysicalDepth);
     expect(copied.alwaysUse24HourFormat, true);
     expect(copied.accessibleNavigation, true);
     expect(copied.invertColors, true);
@@ -139,12 +150,12 @@ void main() {
                 builder: (BuildContext context) {
                   unpadded = MediaQuery.of(context);
                   return Container();
-                }
+                },
               ),
             );
           },
         ),
-      )
+      ),
     );
 
     expect(unpadded.size, size);
@@ -196,12 +207,12 @@ void main() {
                 builder: (BuildContext context) {
                   unpadded = MediaQuery.of(context);
                   return Container();
-                }
+                },
               ),
             );
           },
         ),
-      )
+      ),
     );
 
     expect(unpadded.size, size);
@@ -253,12 +264,12 @@ void main() {
                 builder: (BuildContext context) {
                   unpadded = MediaQuery.of(context);
                   return Container();
-                }
+                },
               ),
             );
           },
         ),
-      )
+      ),
     );
 
     expect(unpadded.size, size);


### PR DESCRIPTION
## Description

Pull out double values into named variables with a comment to explain why the values are unique and consist of random, longer double values. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39012

## Tests

I added the following tests:

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
