### PR TITLE
Kill resident runner on browser disconnect.

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -160,9 +160,7 @@ class ResidentWebRunner extends ResidentRunner {
       );
       if (supportsServiceProtocol) {
         _debugConnection = await _webFs.runAndDebug();
-        unawaited(_debugConnection.onDone.whenComplete(() {
-          exit();
-        }));
+        unawaited(_debugConnection.onDone.whenComplete(exit));
       }
     } catch (err, stackTrace) {
       printError(err.toString());

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -160,6 +160,9 @@ class ResidentWebRunner extends ResidentRunner {
       );
       if (supportsServiceProtocol) {
         _debugConnection = await _webFs.runAndDebug();
+        unawaited(_debugConnection.onDone.whenComplete(() {
+          exit();
+        }));
       }
     } catch (err, stackTrace) {
       printError(err.toString());

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -65,6 +65,9 @@ void main() {
       return Future<bool>.value(false);
     });
     when(mockDebugConnection.vmService).thenReturn(mockVmService);
+    when(mockDebugConnection.onDone).thenAnswer((Invocation invocation) {
+      return Completer<void>().future;
+    });
     when(mockVmService.onStdoutEvent).thenAnswer((Invocation _) {
       return const Stream<Event>.empty();
     });


### PR DESCRIPTION
## Description

If the user closes the browser tab that is currently running the flutter web app, kill the resident runner like we would if an Android/iOS app was closed.

Turns out this will already supported.