### PR TITLE
Break dependency of tools/lib/src from lib/src/commands/

### DIFF
--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -329,6 +329,11 @@ void main() {
       ));
     }, overrides: noColorTerminalOverride);
 
+    testUsingContext('validate verbose output format contains trace for run with crash', () async {
+      expect(await FakeCrashingDoctor().diagnose(verbose: true), isFalse);
+      expect(testLogger.statusText, contains('#0      CrashingValidator.validate'));
+    }, overrides: noColorTerminalOverride);
+
     testUsingContext('validate non-verbose output format when only one category fails', () async {
       expect(await FakeSinglePassingDoctor().diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -10,7 +10,7 @@ void main() {
   final String flutterTools = fs.path.join(getFlutterRoot(), 'packages', 'flutter_tools');
 
   test('no imports of commands/* or test/* in lib/src/*', () {
-    final skippedPaths = <String> [
+    final List<String> skippedPaths = <String> [
       fs.path.join(flutterTools, 'lib', 'src', 'commands'),
       fs.path.join(flutterTools, 'lib', 'src', 'test')
     ];
@@ -29,8 +29,8 @@ void main() {
         if (line.startsWith(RegExp(r'import.*commands/'))
          || line.startsWith(RegExp(r'import.*test/'))) {
           final String relativePath = fs.path.relative(file.path, from:flutterTools);
-          fail("$relativePath imports $line. This import introduces a layering violation. "
-               "Please find another way to access the information you are using.");
+          fail('$relativePath imports $line. This import introduces a layering violation. '
+               'Please find another way to access the information you are using.');
         }
       }
     }

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -9,6 +9,32 @@ import '../src/common.dart';
 void main() {
   final String flutterTools = fs.path.join(getFlutterRoot(), 'packages', 'flutter_tools');
 
+  test('no imports of commands/* or test/* in lib/src/*', () {
+    final skippedPaths = <String> [
+      fs.path.join(flutterTools, 'lib', 'src', 'commands'),
+      fs.path.join(flutterTools, 'lib', 'src', 'test')
+    ];
+    bool _isNotSkipped(FileSystemEntity entity) => skippedPaths.every((String path) => !entity.path.startsWith(path));
+
+    final Iterable<File> files = fs.directory(fs.path.join(flutterTools, 'lib', 'src'))
+      .listSync(recursive: true)
+      .where(_isDartFile)
+      .where(_isNotSkipped)
+      .map(_asFile);
+    for (File file in files) {
+      for (String line in file.readAsLinesSync()) {
+        if (line.startsWith(RegExp(r'import.*package:'))) {
+          continue;
+        }
+        if (line.startsWith(RegExp(r'import.*commands/'))
+         || line.startsWith(RegExp(r'import.*test/'))) {
+          final String relativePath = fs.path.relative(file.path, from:flutterTools);
+          fail("$relativePath imports $line. This is an antipattern, please find another way to access the information you are using.");
+        }
+      }
+    }
+  });
+
   test('no unauthorized imports of dart:io', () {
     final List<String> whitelistedPaths = <String>[
       fs.path.join(flutterTools, 'lib', 'src', 'base', 'io.dart'),

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -29,7 +29,8 @@ void main() {
         if (line.startsWith(RegExp(r'import.*commands/'))
          || line.startsWith(RegExp(r'import.*test/'))) {
           final String relativePath = fs.path.relative(file.path, from:flutterTools);
-          fail("$relativePath imports $line. This is an antipattern, please find another way to access the information you are using.");
+          fail("$relativePath imports $line. This import introduces a layering violation. "
+               "Please find another way to access the information you are using.");
         }
       }
     }


### PR DESCRIPTION
This is considered an anti-pattern since it creates circular dependency within this large package. We compile each command separately internally for performance.

Instead of consuming the verbose flag, we can emit stack trace as informational message which only gets printed in verbose mode.

I also added a test for printing the stack trace.