### PR TITLE
Fix plugin template app's tests

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -89,7 +89,7 @@ abstract class _FlutterProject {
 }
 
 class _FlutterPlugin extends _FlutterProject {
-  _FlutterPlugin(this.parent, this.name) : _FlutterProject(parent, name);
+  _FlutterPlugin(Directory parent, String name) : super(parent, name);
 
   static Future<_FlutterPlugin> create(
       Directory directory, List<String> options) async {
@@ -116,7 +116,7 @@ class _FlutterPlugin extends _FlutterProject {
 }
 
 class _FlutterApp extends _FlutterProject {
-  _FlutterApp(this.parent, this.name) : _FlutterProject(parent, name);
+  _FlutterApp(Directory parent, String name) : super(parent, name);
 
   static Future<_FlutterApp> create(
       Directory directory, List<String> options) async {

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -71,6 +71,18 @@ abstract class _FlutterProject {
 
   String get rootPath => path.join(parent.path, name);
 
+  Future<void> addPlugin(String plugin, {String pluginPath}) async {
+    final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
+    String content = await pubspec.readAsString();
+    String dependency =
+    pluginPath != null ? '$plugin:\n    path: $pluginPath' : plugin;
+    content = content.replaceFirst(
+      '\ndependencies:\n',
+      '\ndependencies:\n  $dependency\n',
+    );
+    await pubspec.writeAsString(content, flush: true);
+  }
+  
   Future<void> delete() async {
     if (Platform.isWindows) {
       // A running Gradle daemon might prevent us from deleting the project
@@ -133,18 +145,6 @@ class _FlutterApp extends _FlutterProject {
       );
     });
     return _FlutterApp(directory, 'plugintestapp');
-  }
-
-  Future<void> addPlugin(String plugin, {String pluginPath}) async {
-    final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
-    String content = await pubspec.readAsString();
-    String dependency =
-        pluginPath != null ? '$plugin:\n    path: $pluginPath' : plugin;
-    content = content.replaceFirst(
-      '\ndependencies:\n',
-      '\ndependencies:\n  $dependency\n',
-    );
-    await pubspec.writeAsString(content, flush: true);
   }
 
   Future<void> build(String target) async {

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -48,7 +48,8 @@ class PluginTest {
         if (buildTarget == 'ios')
           await prepareProvisioningCertificates(app.rootPath);
         section('Add plugins');
-        await app.addPlugin('plugintest', pluginPath: '../plugintest');
+        await app.addPlugin('plugintest',
+            pluginPath: path.join('..', 'plugintest'));
         await app.addPlugin('path_provider');
         section('Build app');
         await app.build(buildTarget);
@@ -121,11 +122,11 @@ class _FlutterProject {
     if (Platform.isWindows) {
       // A running Gradle daemon might prevent us from deleting the project
       // folder on Windows.
-      await exec(
-        path.absolute(path.join(rootPath, 'android', 'gradlew.bat')),
-        <String>['--stop'],
-        canFail: true,
-      );
+      String wrapperPath =
+          path.absolute(path.join(rootPath, 'android', 'gradlew.bat'));
+      if (await File(wrapperPath).exists()) {
+        await exec(wrapperPath, <String>['--stop'], canFail: true);
+      }
       // TODO(ianh): Investigating if flakiness is timing dependent.
       await Future<void>.delayed(const Duration(seconds: 10));
     }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -82,8 +82,6 @@ class _FlutterProject {
       '\ndependencies:\n',
       '\ndependencies:\n  $dependency\n',
     );
-    print('COLLIN');
-    print(content);
     await pubspec.writeAsString(content, flush: true);
   }
 

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -122,9 +122,9 @@ class _FlutterProject {
     if (Platform.isWindows) {
       // A running Gradle daemon might prevent us from deleting the project
       // folder on Windows.
-      String wrapperPath =
+      final String wrapperPath =
           path.absolute(path.join(rootPath, 'android', 'gradlew.bat'));
-      if (await File(wrapperPath).exists()) {
+      if (File(wrapperPath).existsSync()) {
         await exec(wrapperPath, <String>['--stop'], canFail: true);
       }
       // TODO(ianh): Investigating if flakiness is timing dependent.

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -139,7 +139,7 @@ class _FlutterApp {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();
     String dependency =
-        pluginPath != null ? '$plugin\n    path: $pluginPath' : plugin;
+        pluginPath != null ? '$plugin:\n    path: $pluginPath' : plugin;
     content = content.replaceFirst(
       '\ndependencies:\n',
       '\ndependencies:\n  $dependency\n',

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -63,11 +63,33 @@ class PluginTest {
   }
 }
 
-class _FlutterPlugin {
-  _FlutterPlugin(this.parent, this.name);
+abstract class _FlutterProject {
+  _FlutterProject(this.parent, this.name);
 
   final Directory parent;
   final String name;
+
+  String get rootPath => path.join(parent.path, name);
+
+  Future<void> delete() async {
+    if (Platform.isWindows) {
+      // A running Gradle daemon might prevent us from deleting the project
+      // folder on Windows.
+      await exec(
+        path.absolute(path.join(rootPath, 'android', 'gradlew.bat')),
+        <String>['--stop'],
+        canFail: true,
+      );
+      // TODO(ianh): Investigating if flakiness is timing dependent.
+      await Future<void>.delayed(const Duration(seconds: 10));
+    }
+    rmTree(parent);
+  }
+
+}
+
+class _FlutterPlugin extends _FlutterProject {
+  _FlutterPlugin(this.parent, this.name) : _FlutterProject(parent, name);
 
   static Future<_FlutterPlugin> create(
       Directory directory, List<String> options) async {
@@ -86,35 +108,15 @@ class _FlutterPlugin {
     return _FlutterPlugin(directory, 'plugintest');
   }
 
-  String get rootPath => path.join(parent.path, name);
-
   Future<void> test() async {
     await inDirectory(Directory(rootPath), () async {
       await flutter('test');
     });
   }
-
-  Future<void> delete() async {
-    if (Platform.isWindows) {
-      // A running Gradle daemon might prevent us from deleting the project
-      // folder on Windows.
-      await exec(
-        path.absolute(path.join(rootPath, 'android', 'gradlew.bat')),
-        <String>['--stop'],
-        canFail: true,
-      );
-      // TODO(ianh): Investigating if flakiness is timing dependent.
-      await Future<void>.delayed(const Duration(seconds: 10));
-    }
-    rmTree(parent);
-  }
 }
 
-class _FlutterApp {
-  _FlutterApp(this.parent, this.name);
-
-  final Directory parent;
-  final String name;
+class _FlutterApp extends _FlutterProject {
+  _FlutterApp(this.parent, this.name) : _FlutterProject(parent, name);
 
   static Future<_FlutterApp> create(
       Directory directory, List<String> options) async {
@@ -133,8 +135,6 @@ class _FlutterApp {
     return _FlutterApp(directory, 'plugintestapp');
   }
 
-  String get rootPath => path.join(parent.path, name);
-
   Future<void> addPlugin(String plugin, {String pluginPath}) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();
@@ -151,20 +151,5 @@ class _FlutterApp {
     await inDirectory(Directory(rootPath), () async {
       await flutter('build', options: <String>[target]);
     });
-  }
-
-  Future<void> delete() async {
-    if (Platform.isWindows) {
-      // A running Gradle daemon might prevent us from deleting the project
-      // folder on Windows.
-      await exec(
-        path.absolute(path.join(rootPath, 'android', 'gradlew.bat')),
-        <String>['--stop'],
-        canFail: true,
-      );
-      // TODO(ianh): Investigating if flakiness is timing dependent.
-      await Future<void>.delayed(const Duration(seconds: 10));
-    }
-    rmTree(parent);
   }
 }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -48,8 +48,10 @@ class PluginTest {
         section('Add plugins');
         await app.addPlugin('plugintest', pluginPath: '../plugintest');
         await app.addPlugin('path_provider');
-        section('Build');
+        section('Build app');
         await app.build(buildTarget);
+        section('Test app');
+        await app.test();
       } finally {
         await plugin.delete();
         await app.delete();
@@ -82,7 +84,13 @@ abstract class _FlutterProject {
     );
     await pubspec.writeAsString(content, flush: true);
   }
-  
+
+  Future<void> test() async {
+    await inDirectory(Directory(rootPath), () async {
+      await flutter('test');
+    });
+  }
+
   Future<void> delete() async {
     if (Platform.isWindows) {
       // A running Gradle daemon might prevent us from deleting the project
@@ -118,12 +126,6 @@ class _FlutterPlugin extends _FlutterProject {
       );
     });
     return _FlutterPlugin(directory, 'plugintest');
-  }
-
-  Future<void> test() async {
-    await inDirectory(Directory(rootPath), () async {
-      await flutter('test');
-    });
   }
 }
 

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -36,12 +36,14 @@ class PluginTest {
         Directory.systemTemp.createTempSync('flutter_devicelab_plugin_test.');
     try {
       section('Create plugin');
-      final _FlutterProject plugin =
-          await _FlutterProject.create(tempDir, options, name: 'plugintest', template: 'plugin');
+      final _FlutterProject plugin = await _FlutterProject.create(
+          tempDir, options,
+          name: 'plugintest', template: 'plugin');
       section('Test plugin');
       await plugin.test();
       section('Create Flutter app');
-      final _FlutterProject app = await _FlutterProject.create(tempDir, options, name: 'plugintestapp', template: 'app');
+      final _FlutterProject app = await _FlutterProject.create(tempDir, options,
+          name: 'plugintestapp', template: 'app');
       try {
         if (buildTarget == 'ios')
           await prepareProvisioningCertificates(app.rootPath);
@@ -76,8 +78,8 @@ class _FlutterProject {
   Future<void> addPlugin(String plugin, {String pluginPath}) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();
-    String dependency =
-    pluginPath != null ? '$plugin:\n    path: $pluginPath' : '$plugin:';
+    final String dependency =
+        pluginPath != null ? '$plugin:\n    path: $pluginPath' : '$plugin:';
     content = content.replaceFirst(
       '\ndependencies:\n',
       '\ndependencies:\n  $dependency\n',
@@ -92,7 +94,8 @@ class _FlutterProject {
   }
 
   static Future<_FlutterProject> create(
-      Directory directory, List<String> options, { String name, String template }) async {
+      Directory directory, List<String> options,
+      {String name, String template}) async {
     await inDirectory(directory, () async {
       await flutter(
         'create',
@@ -128,5 +131,4 @@ class _FlutterProject {
     }
     rmTree(parent);
   }
-
 }

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -23,8 +23,8 @@ TaskFunction combine(List<TaskFunction> tasks) {
   };
 }
 
-/// Defines task that creates new Flutter project, adds a plugin, and then
-/// builds the specified [buildTarget].
+/// Defines task that creates new Flutter project, adds a local and remote
+/// plugin, and then builds the specified [buildTarget].
 class PluginTest {
   PluginTest(this.buildTarget, this.options);
 
@@ -32,19 +32,25 @@ class PluginTest {
   final List<String> options;
 
   Future<TaskResult> call() async {
-    section('Create Flutter project');
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_plugin_test.');
     try {
-      final FlutterProject project = await FlutterProject.create(tempDir, options);
+      section('Create plugin');
+      final _FlutterApp plugin = await _FlutterPlugin.create(tempDir, options);
+      section('Test plugin');
+      await plugin.test();
+      section('Create Flutter app');
+      final _FlutterApp app = await _FlutterApp.create(tempDir, options);
       try {
         if (buildTarget == 'ios')
           await prepareProvisioningCertificates(project.rootPath);
-        section('Add plugin');
-        await project.addPlugin('path_provider');
+        section('Add plugins');
+        await app.addPlugin('plugintest', :path => '../plugintest')
+        await app.addPlugin('path_provider');
         section('Build');
-        await project.build(buildTarget);
+        await app.build(buildTarget);
       } finally {
-        await project.delete();
+        await plugin.delete();
+        await app.delete();
       }
       return TaskResult.success(null);
     } catch (e) {
@@ -55,17 +61,17 @@ class PluginTest {
   }
 }
 
-class FlutterProject {
-  FlutterProject(this.parent, this.name);
+class _FlutterPlugin {
+  _FlutterPlugin(this.parent, this.name);
 
   final Directory parent;
   final String name;
 
-  static Future<FlutterProject> create(Directory directory, List<String> options) async {
+  static Future<_FlutterPlugin> create(Directory directory, List<String> options) async {
     await inDirectory(directory, () async {
       await flutter(
         'create',
-        options: <String>['--template=app', '--org', 'io.flutter.devicelab', ...options, 'plugintest'],
+        options: <String>['--template=plugin', '--org', 'io.flutter.devicelab', ...options, 'plugintest'],
       );
     });
     return FlutterProject(directory, 'plugintest');
@@ -73,12 +79,53 @@ class FlutterProject {
 
   String get rootPath => path.join(parent.path, name);
 
-  Future<void> addPlugin(String plugin) async {
+  Future<void> test() async {
+    await inDirectory(Directory(rootPath), () async {
+      await flutter('test');
+    });
+  }
+
+  Future<void> delete() async {
+    if (Platform.isWindows) {
+      // A running Gradle daemon might prevent us from deleting the project
+      // folder on Windows.
+      await exec(
+        path.absolute(path.join(rootPath, 'android', 'gradlew.bat')),
+        <String>['--stop'],
+        canFail: true,
+      );
+      // TODO(ianh): Investigating if flakiness is timing dependent.
+      await Future<void>.delayed(const Duration(seconds: 10));
+    }
+    rmTree(parent);
+  }
+}
+
+class _FlutterApp {
+  _FlutterApp(this.parent, this.name);
+
+  final Directory parent;
+  final String name;
+
+  static Future<_FlutterApp> create(Directory directory, List<String> options) async {
+    await inDirectory(directory, () async {
+      await flutter(
+        'create',
+        options: <String>['--template=app', '--org', 'io.flutter.devicelab', ...options, 'plugintestapp'],
+      );
+    });
+    return _FlutterApp(directory, 'plugintestapp');
+  }
+
+  String get rootPath => path.join(parent.path, name);
+
+  Future<void> addPlugin(String plugin, { String path }) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();
+    String dependency = path != null ? '$plugin\n    path: $path' : plugin;
     content = content.replaceFirst(
       '\ndependencies:\n',
-      '\ndependencies:\n  $plugin:\n',
+      '\ndependencies:\n  $dependency\n',
     );
     await pubspec.writeAsString(content, flush: true);
   }

--- a/packages/flutter_tools/templates/plugin/test/projectName_test.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/test/projectName_test.dart.tmpl
@@ -5,6 +5,8 @@ import 'package:{{projectName}}/{{projectName}}.dart';
 void main() {
   const MethodChannel channel = MethodChannel('{{projectName}}');
 
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       return '42';


### PR DESCRIPTION
## Description

Plugin template app needs to be updated with this breaking change:

https://groups.google.com/forum/#!msg/flutter-announce/sHAL2fBtJ1Y/mGjrKH3dEwAJ

> https://github.com/flutter/flutter/pull/37489 proposed to move the default BinaryMessenger instance to ServicesBinding, and deprecate the former. This is going to be a breaking change, if users reference to the defaultBinaryMessenger directly. Instead, users will use ServicesBinding.instance.defaultBinaryMessenger to access the default BinaryMessenger that's used for sending platform messages.
> 
> Why this change?
> By this change, we are capable of registering a different default BinaryMessenger under testing environment, by creating a ServicesBinding subclass for testing. With that, we can track # of pending platform messages for synchronization purposes. See more details in https://github.com/flutter/flutter/issues/37409.
> 
> Path to migrate
> You'll use ServicesBinding.instance.defaultBinaryMessenger to access the default BinaryMessenger. In your tests, make sure the ServicesBinding is properly initialized before accessing any message channels.
> 
> If you have any concerns or otherwise feel that this change should not be made, please comment on the above PR or on the associated issue: https://github.com/flutter/flutter/issues/37409 -- or just reply to this email.

## Related Issues

Fixes #39077 

## Tests

I included the following tests:

- dev/devicelab/lib/tasks/plugin_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes