### PR TITLE
[flutter_tool] Some additional input validation for 'version'

### DIFF
--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -65,6 +65,10 @@ class VersionCommand extends FlutterCommand {
 
     // check min supported version
     final Version targetVersion = Version.parse(version);
+    if (targetVersion == null) {
+      throwToolExit('Failed to parse version "$version"');
+    }
+
     bool withForce = false;
     if (targetVersion < minSupportedVersion) {
       if (!argResults['force']) {

--- a/packages/flutter_tools/test/general.shard/commands/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/version_test.dart
@@ -62,6 +62,16 @@ void main() {
       ProcessManager: () => MockProcessManager(),
     });
 
+    testUsingContext('tool exit on confusing version', () async {
+      const String version = 'master';
+      final VersionCommand command = VersionCommand();
+      final Future<void> runCommand = createTestCommandRunner(command).run(<String>['version', version]);
+      expect(() async => await Future.wait<void>(<Future<void>>[runCommand]),
+             throwsA(isInstanceOf<ToolExit>()));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => MockProcessManager(),
+    });
+
     testUsingContext('exit tool if can\'t get the tags', () async {
       final VersionCommand command = VersionCommand();
 


### PR DESCRIPTION
## Description

Checks for a parse error on the version string from the command line.

## Related Issues

Seen in crash logging

## Tests

I added the following tests:

New test in version_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.