### PR TITLE
fix sliverfixedextent with sliverchildbuilderdelegate does not correc…

### DIFF
--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -350,6 +350,70 @@ void main() {
     expect(tester.takeException(), 'builder');
     ErrorWidget.builder = oldBuilder;
   });
+
+  testWidgets('SliverFixedExtentList with SliverChildBuilderDelegate auto-correct scroll offset - super fast', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 600);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          cacheExtent: 0,
+          slivers: <Widget>[
+            SliverFixedExtentList(
+              itemExtent: 200,
+              delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) {
+                  if (index <= 6) {
+                    return Center(child: Text('Page $index'));
+                  }
+                  return null;
+                },
+              ),
+            )
+          ],
+        ),
+      )
+    );
+    await tester.drag(find.text('Page 5'), const Offset(0, -1000));
+    // Controller will be temporarily over-scrolled.
+    expect(controller.offset, 1600.0);
+    await tester.pumpAndSettle();
+    // It will be corrected after a auto scroll animation.
+    expect(controller.offset, 800.0);
+  });
+
+  testWidgets('SliverFixedExtentList with SliverChildBuilderDelegate auto-correct scroll offset - reasonable', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 600);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          cacheExtent: 0,
+          slivers: <Widget>[
+            SliverFixedExtentList(
+              itemExtent: 200,
+              delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) {
+                  if (index <= 6) {
+                    return Center(child: Text('Page $index'));
+                  }
+                  return null;
+                },
+              ),
+            )
+          ],
+        ),
+      )
+    );
+    await tester.drag(find.text('Page 5'), const Offset(0, -210));
+    // Controller will be temporarily over-scrolled.
+    expect(controller.offset, 810.0);
+    await tester.pumpAndSettle();
+    // It will be corrected after a auto scroll animation.
+    expect(controller.offset, 800.0);
+  });
 }
 
 bool isRight(Offset a, Offset b) => b.dx > a.dx;


### PR DESCRIPTION
…t calculate max scroll extent

## Description

When using SliverChildBuilderDelegate without specify the childcount. Sliverfixedextendlist does not correctly calculate the max scroll offset. It always set it to infinite. This pr fixes it.

## Related Issues

https://github.com/flutter/flutter/issues/39002

## Tests

I added the following tests:
"SliverFixedExtentList with SliverChildBuilderDelegate auto-correct scroll offset - super fast"
"SliverFixedExtentList with SliverChildBuilderDelegate auto-correct scroll offset - reasonable"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
