### PR TITLE
respect reversed scroll views

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -9,6 +9,7 @@ import 'dart:ui';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/painting.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -532,7 +533,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
         ? event.scrollDelta.dx
         : event.scrollDelta.dy;
 
-    if (widget.axisDirection == AxisDirection.up || widget.axisDirection == AxisDirection.left) {
+    if (axisDirectionIsReversed(widget.axisDirection)) {
       delta *= -1;
     }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -528,9 +528,14 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
   // Returns the offset that should result from applying [event] to the current
   // position, taking min/max scroll extent into account.
   double _targetScrollOffsetForPointerScroll(PointerScrollEvent event) {
-    final double delta = widget.axis == Axis.horizontal
+    double delta = widget.axis == Axis.horizontal
         ? event.scrollDelta.dx
         : event.scrollDelta.dy;
+
+    if (widget.axisDirection == AxisDirection.up || widget.axisDirection == AxisDirection.left) {
+      delta *= -1;
+    }
+
     return math.min(math.max(position.pixels + delta, position.minScrollExtent),
         position.maxScrollExtent);
   }

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -8,12 +8,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-Future<void> pumpTest(WidgetTester tester, TargetPlatform platform, {bool scrollable = true}) async {
+Future<void> pumpTest(
+  WidgetTester tester,
+  TargetPlatform platform, {
+  bool scrollable = true,
+  bool reverse = false,
+}) async {
   await tester.pumpWidget(MaterialApp(
     theme: ThemeData(
       platform: platform,
     ),
     home: CustomScrollView(
+      reverse: reverse,
       physics: scrollable ? null : const NeverScrollableScrollPhysics(),
       slivers: const <Widget>[
         SliverToBoxAdapter(child: SizedBox(height: 2000.0)),
@@ -247,5 +253,18 @@ void main() {
     final HitTestResult result = tester.hitTestOnBinding(scrollEventLocation);
     await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 20.0)), result);
     expect(getScrollOffset(tester), 0.0);
+  });
+
+  testWidgets('Scrolls in correct direction when scroll axis is reversed', (WidgetTester tester) async {
+    await pumpTest(tester, TargetPlatform.fuchsia, reverse: true);
+
+    final Offset scrollEventLocation = tester.getCenter(find.byType(Viewport));
+    final TestPointer testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
+    // Create a hover event so that |testPointer| has a location when generating the scroll.
+    testPointer.hover(scrollEventLocation);
+    final HitTestResult result = tester.hitTestOnBinding(scrollEventLocation);
+    await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, -20.0)), result);
+
+    expect(getScrollOffset(tester), 20.0);
   });
 }


### PR DESCRIPTION
## Description

This PR makes `Scrollable` scroll in correct direction when `reverse: true` on desktop and web

## Related Issues

~#39194~
Closes #35442

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
