### PR TITLE
Added a Driver wait condition for no pending platform messages

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -44,7 +44,7 @@ mixin ServicesBinding on BindingBase {
   /// platform messages.
   @protected
   BinaryMessenger createBinaryMessenger() {
-    return const DefaultBinaryMessenger();
+    return const _DefaultBinaryMessenger._();
   }
 
   /// Adds relevant licenses to the [LicenseRegistry].
@@ -141,9 +141,8 @@ mixin ServicesBinding on BindingBase {
 /// This messenger sends messages from the app-side to the platform-side and
 /// dispatches incoming messages from the platform-side to the appropriate
 /// handler.
-class DefaultBinaryMessenger extends BinaryMessenger {
-  /// Creates a [DefaultBinaryMessenger] instance.
-  const DefaultBinaryMessenger();
+class _DefaultBinaryMessenger extends BinaryMessenger {
+  const _DefaultBinaryMessenger._();
 
   // Handlers for incoming messages from platform plugins.
   // This is static so that this class can have a const constructor.

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -44,7 +44,7 @@ mixin ServicesBinding on BindingBase {
   /// platform messages.
   @protected
   BinaryMessenger createBinaryMessenger() {
-    return const _DefaultBinaryMessenger._();
+    return const DefaultBinaryMessenger();
   }
 
   /// Adds relevant licenses to the [LicenseRegistry].
@@ -141,8 +141,9 @@ mixin ServicesBinding on BindingBase {
 /// This messenger sends messages from the app-side to the platform-side and
 /// dispatches incoming messages from the platform-side to the appropriate
 /// handler.
-class _DefaultBinaryMessenger extends BinaryMessenger {
-  const _DefaultBinaryMessenger._();
+class DefaultBinaryMessenger extends BinaryMessenger {
+  /// Creates a [DefaultBinaryMessenger] instance.
+  const DefaultBinaryMessenger();
 
   // Handlers for incoming messages from platform plugins.
   // This is static so that this class can have a const constructor.

--- a/packages/flutter_driver/lib/src/common/wait.dart
+++ b/packages/flutter_driver/lib/src/common/wait.dart
@@ -201,7 +201,7 @@ class FirstFrameRasterized extends SerializableWaitCondition {
   String get conditionName => 'FirstFrameRasterizedCondition';
 }
 
-/// A condition that waits until there's no pending platform messages.
+/// A condition that waits until there are no pending platform messages.
 class NoPendingPlatformMessages extends SerializableWaitCondition {
   /// Creates a [NoPendingPlatformMessages] condition.
   const NoPendingPlatformMessages();

--- a/packages/flutter_driver/lib/src/common/wait.dart
+++ b/packages/flutter_driver/lib/src/common/wait.dart
@@ -201,6 +201,26 @@ class FirstFrameRasterized extends SerializableWaitCondition {
   String get conditionName => 'FirstFrameRasterizedCondition';
 }
 
+/// A condition that waits until there's no pending platform messages.
+class NoPendingPlatformMessages extends SerializableWaitCondition {
+  /// Creates a [NoPendingPlatformMessages] condition.
+  const NoPendingPlatformMessages();
+
+  /// Factory constructor to parse a [NoPendingPlatformMessages] instance from the
+  /// given JSON map.
+  ///
+  /// The [json] argument must not be null.
+  factory NoPendingPlatformMessages.deserialize(Map<String, dynamic> json) {
+    assert(json != null);
+    if (json['conditionName'] != 'NoPendingPlatformMessagesCondition')
+      throw SerializationException('Error occurred during deserializing the NoPendingPlatformMessagesCondition JSON string: $json');
+    return const NoPendingPlatformMessages();
+  }
+
+  @override
+  String get conditionName => 'NoPendingPlatformMessagesCondition';
+}
+
 /// A combined condition that waits until all the given [conditions] are met.
 class CombinedCondition extends SerializableWaitCondition {
   /// Creates a [CombinedCondition] condition.
@@ -260,6 +280,8 @@ SerializableWaitCondition _deserialize(Map<String, dynamic> json) {
       return NoPendingFrame.deserialize(json);
     case 'FirstFrameRasterizedCondition':
       return FirstFrameRasterized.deserialize(json);
+    case 'NoPendingPlatformMessagesCondition':
+      return NoPendingPlatformMessages.deserialize(json);
     case 'CombinedCondition':
       return CombinedCondition.deserialize(json);
   }

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -59,7 +59,7 @@ class _DriverBinding extends BindingBase with ServicesBinding, SchedulerBinding,
 
   @override
   BinaryMessenger createBinaryMessenger() {
-    return TestDefaultBinaryMessenger();
+    return TestDefaultBinaryMessenger(super.createBinaryMessenger());
   }
 }
 

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -56,6 +56,11 @@ class _DriverBinding extends BindingBase with ServicesBinding, SchedulerBinding,
       callback: extension.call,
     );
   }
+
+  @override
+  BinaryMessenger createBinaryMessenger() {
+    return TestDefaultBinaryMessenger();
+  }
 }
 
 /// Enables Flutter Driver VM service extension.

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -262,6 +262,18 @@ void main() {
         await driver.waitForCondition(const NoPendingFrame(), timeout: _kTestTimeout);
       });
 
+      test('sends the wait for NoPendingPlatformMessages command', () async {
+        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+          expect(i.positionalArguments[1], <String, dynamic>{
+            'command': 'waitForCondition',
+            'timeout': _kSerializedTestTimeout,
+            'conditionName': 'NoPendingPlatformMessagesCondition',
+          });
+          return makeMockResponse(<String, dynamic>{});
+        });
+        await driver.waitForCondition(const NoPendingPlatformMessages(), timeout: _kTestTimeout);
+      });
+
       test('sends the waitForCondition of combined conditions command', () async {
         when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
           expect(i.positionalArguments[1], <String, dynamic>{

--- a/packages/flutter_driver/test/src/extension_test.dart
+++ b/packages/flutter_driver/test/src/extension_test.dart
@@ -248,7 +248,7 @@ void main() {
     });
 
     testWidgets(
-        'waiting for NoPendingPlatformMessages returns immediately when there\'s no platform messages', (WidgetTester tester) async {
+        'waiting for NoPendingPlatformMessages returns immediately when there\'re no platform messages', (WidgetTester tester) async {
       extension
           .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
           .then<void>(expectAsync1((Map<String, dynamic> r) {
@@ -448,7 +448,6 @@ void main() {
       );
     });
   });
-
 
   group('getSemanticsId', () {
     FlutterDriverExtension extension;

--- a/packages/flutter_driver/test/src/extension_test.dart
+++ b/packages/flutter_driver/test/src/extension_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:flutter_driver/src/common/diagnostics_tree.dart';
@@ -245,7 +246,209 @@ void main() {
         },
       );
     });
+
+    testWidgets(
+        'waiting for NoPendingPlatformMessages returns immediately when there\'s no platform messages', (WidgetTester tester) async {
+      extension
+          .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
+          .then<void>(expectAsync1((Map<String, dynamic> r) {
+        result = r;
+      }));
+
+      await tester.idle();
+      expect(
+        result,
+        <String, dynamic>{
+          'isError': false,
+          'response': null,
+        },
+      );
+    });
+
+    testWidgets(
+        'waiting for NoPendingPlatformMessages returns until a single method channel call returns', (WidgetTester tester) async {
+      const MethodChannel channel = MethodChannel('helloChannel', JSONMethodCodec());
+      const MessageCodec<dynamic> jsonMessage = JSONMessageCodec();
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 10),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+      channel.invokeMethod<String>('sayHello', 'hello');
+
+      extension
+          .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
+          .then<void>(expectAsync1((Map<String, dynamic> r) {
+        result = r;
+      }));
+
+      // The channel message are delayed for 10 milliseconds, so nothing happens yet.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(result, isNull);
+
+      // Now we receive the result.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(
+        result,
+        <String, dynamic>{
+          'isError': false,
+          'response': null,
+        },
+      );
+    });
+
+    testWidgets(
+        'waiting for NoPendingPlatformMessages returns until both method channel calls return', (WidgetTester tester) async {
+      const MessageCodec<dynamic> jsonMessage = JSONMessageCodec();
+      // Configures channel 1
+      const MethodChannel channel1 = MethodChannel('helloChannel1', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel1', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 10),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      // Configures channel 2
+      const MethodChannel channel2 = MethodChannel('helloChannel2', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel2', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 20),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      channel1.invokeMethod<String>('sayHello', 'hello');
+      channel2.invokeMethod<String>('sayHello', 'hello');
+
+      extension
+          .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
+          .then<void>(expectAsync1((Map<String, dynamic> r) {
+        result = r;
+      }));
+
+      // Neither of the channel responses is received, so nothing happens yet.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(result, isNull);
+
+      // Result of channel 1 is received, but channel 2 is still pending, so still waiting.
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(result, isNull);
+
+      // Both of the results are received. Now we receive the result.
+      await tester.pump(const Duration(milliseconds: 30));
+      expect(
+        result,
+        <String, dynamic>{
+          'isError': false,
+          'response': null,
+        },
+      );
+    });
+
+    testWidgets(
+        'waiting for NoPendingPlatformMessages returns until new method channel call returns', (WidgetTester tester) async {
+      const MessageCodec<dynamic> jsonMessage = JSONMessageCodec();
+      // Configures channel 1
+      const MethodChannel channel1 = MethodChannel('helloChannel1', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel1', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 10),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      // Configures channel 2
+      const MethodChannel channel2 = MethodChannel('helloChannel2', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel2', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 20),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      channel1.invokeMethod<String>('sayHello', 'hello');
+
+      // Calls the waiting API before the second channel message is sent.
+      extension
+          .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
+          .then<void>(expectAsync1((Map<String, dynamic> r) {
+        result = r;
+      }));
+
+      // The first channel message is not received, so nothing happens yet.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(result, isNull);
+
+      channel2.invokeMethod<String>('sayHello', 'hello');
+
+      // Result of channel 1 is received, but channel 2 is still pending, so still waiting.
+      await tester.pump(const Duration(milliseconds: 15));
+      expect(result, isNull);
+
+      // Both of the results are received. Now we receive the result.
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(
+        result,
+        <String, dynamic>{
+          'isError': false,
+          'response': null,
+        },
+      );
+    });
+
+    testWidgets(
+        'waiting for NoPendingPlatformMessages returns until both old and new method channel calls return', (WidgetTester tester) async {
+      const MessageCodec<dynamic> jsonMessage = JSONMessageCodec();
+      // Configures channel 1
+      const MethodChannel channel1 = MethodChannel('helloChannel1', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel1', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 20),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      // Configures channel 2
+      const MethodChannel channel2 = MethodChannel('helloChannel2', JSONMethodCodec());
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+          'helloChannel2', (ByteData message) {
+            return Future<ByteData>.delayed(
+                const Duration(milliseconds: 10),
+                () => jsonMessage.encodeMessage(<dynamic>['hello world']));
+          });
+
+      channel1.invokeMethod<String>('sayHello', 'hello');
+
+      extension
+          .call(const WaitForCondition(NoPendingPlatformMessages()).serialize())
+          .then<void>(expectAsync1((Map<String, dynamic> r) {
+        result = r;
+      }));
+
+      // The first channel message is not received, so nothing happens yet.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(result, isNull);
+
+      channel2.invokeMethod<String>('sayHello', 'hello');
+
+      // Result of channel 2 is received, but channel 1 is still pending, so still waiting.
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(result, isNull);
+
+      // Now we receive the result.
+      await tester.pump(const Duration(milliseconds: 5));
+      expect(
+        result,
+        <String, dynamic>{
+          'isError': false,
+          'response': null,
+        },
+      );
+    });
   });
+
 
   group('getSemanticsId', () {
     FlutterDriverExtension extension;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -80,6 +80,41 @@ enum TestBindingEventSource {
 
 const Size _kDefaultTestViewportSize = Size(800.0, 600.0);
 
+/// A [BinaryMessenger] subclass that is used as the default binary messenger
+/// under testing environment.
+///
+/// It tracks status of data sent across the Flutter platform barrier, which is
+/// useful for testing frameworks to monitor and synchronize against the
+/// platform messages.
+class TestDefaultBinaryMessenger extends DefaultBinaryMessenger {
+  /// Creates a [TestDefaultBinaryMessenger] instance.
+  TestDefaultBinaryMessenger();
+
+  final List<Future<ByteData>> _pendingMessages = <Future<ByteData>>[];
+
+  /// The number of incomplete/pending calls sent to the platform channels.
+  int get pendingMessageCount => _pendingMessages.length;
+
+  @override
+  Future<ByteData> send(String channel, ByteData message) {
+    final Future<ByteData> resultFuture = super.send(channel, message);
+    // Removes the future itself from the [_pendingMessages] list when it
+    // completes.
+    resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
+    _pendingMessages.add(resultFuture);
+    return resultFuture;
+  }
+
+  /// Returns a Future that completes after all the platform calls are finished.
+  ///
+  /// If a new platform message is sent after this method is called, this new
+  /// message is not tracked. Use with [pendingMessageCount] to guarantee no
+  /// pending message calls.
+  Future<void> get platformMessagesFinished {
+    return Future.wait<void>(_pendingMessages);
+  }
+}
+
 /// Base class for bindings used by widgets library tests.
 ///
 /// The [ensureInitialized] method creates (if necessary) and returns
@@ -218,6 +253,11 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   void initLicenses() {
     // Do not include any licenses, because we're a test, and the LICENSE file
     // doesn't get generated for tests.
+  }
+
+  @override
+  BinaryMessenger createBinaryMessenger() {
+    return TestDefaultBinaryMessenger();
   }
 
   /// Whether there is currently a test executing.

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -106,8 +106,8 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
     // Removes the future itself from the [_pendingMessages] list when it
     // completes.
     if (resultFuture != null) {
-      resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
       _pendingMessages.add(resultFuture);
+      resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
     }
     return resultFuture;
   }
@@ -125,7 +125,8 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
   Future<void> handlePlatformMessage(
       String channel,
       ByteData data,
-      ui.PlatformMessageResponseCallback callback) {
+      ui.PlatformMessageResponseCallback callback,
+  ) {
     return delegate.handlePlatformMessage(channel, data, callback);
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -100,8 +100,10 @@ class TestDefaultBinaryMessenger extends DefaultBinaryMessenger {
     final Future<ByteData> resultFuture = super.send(channel, message);
     // Removes the future itself from the [_pendingMessages] list when it
     // completes.
-    resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
-    _pendingMessages.add(resultFuture);
+    if (resultFuture != null) {
+      resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
+      _pendingMessages.add(resultFuture);
+    }
     return resultFuture;
   }
 


### PR DESCRIPTION
## Description

Added a Driver wait condition for no pending platform messages.

## Related Issues

https://github.com/flutter/flutter/issues/37409

## Tests

I added the following tests:

extension_test.dart
flutter_driver_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
