### PR TITLE
Disable waitUntilFirstFrameRasterized

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -587,7 +587,6 @@ tasks:
       Measures the performance of screen transitions in Flutter Gallery on
       Android.
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["linux/android"]
 
   flutter_gallery__transition_perf_with_semantics:

--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -183,8 +183,9 @@ void main([List<String> args = const <String>[]]) {
     setUpAll(() async {
       driver = await FlutterDriver.connect();
 
+      // TODO(liyuqian): re-enable this once the driver test is no longer flaky.
       // Wait for the first frame to be rasterized.
-      await driver.waitUntilFirstFrameRasterized();
+      // await driver.waitUntilFirstFrameRasterized();
 
       if (args.contains('--with_semantics')) {
         print('Enabeling semantics...');


### PR DESCRIPTION
And mark flutter_gallery__transition_perf as non-flaky so people won't
break it without affecting the tree.

However, the error log doesn't seem to suggest that the flakiness
is due to `waitUntilFirstFrameRasterized`. Moreover, the ios and io32
versions of that test are working properly without any flakiness.

Therefore, I'm not confident that this will fix the flakiness. But
hopefully it will help solving the flakiness.
