### PR TITLE
Place terminalUi flag on terminal interface

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -448,7 +448,6 @@ class AndroidDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
-    bool usesTerminalUi = true,
   }) async {
     if (!await _checkForSupportedAdbVersion() || !await _checkForSupportedAndroidVersion())
       return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -191,6 +191,8 @@ class AnsiTerminal {
   /// null, and the user presses enter without any other input, the return value
   /// will be the character in `acceptedCharacters` at the index given by
   /// `defaultChoiceIndex`.
+  ///
+  /// If [usesTerminalUi] is false, throws a [StateError].
   Future<String> promptForCharInput(
     List<String> acceptedCharacters, {
     String prompt,
@@ -201,6 +203,9 @@ class AnsiTerminal {
     assert(acceptedCharacters.isNotEmpty);
     assert(prompt == null || prompt.isNotEmpty);
     assert(displayAcceptedCharacters != null);
+    if (!usesTerminalUi) {
+      throw StateError('cannot prompt without a terminal ui');
+    }
     List<String> charactersToDisplay = acceptedCharacters;
     if (defaultChoiceIndex != null) {
       assert(defaultChoiceIndex >= 0 && defaultChoiceIndex < acceptedCharacters.length);

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -110,6 +110,9 @@ class AnsiTerminal {
   bool get supportsColor => platform.stdoutSupportsAnsi ?? false;
   final RegExp _boldControls = RegExp('(${RegExp.escape(resetBold)}|${RegExp.escape(bold)})');
 
+  /// Whether we are interacting with the flutter tool via the terminal.
+  bool usesTerminalUi = false;
+
   String bolden(String message) {
     assert(message != null);
     if (!supportsColor || message.isEmpty)

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -111,6 +111,8 @@ class AnsiTerminal {
   final RegExp _boldControls = RegExp('(${RegExp.escape(resetBold)}|${RegExp.escape(bold)})');
 
   /// Whether we are interacting with the flutter tool via the terminal.
+  ///
+  /// If not set, defaults to false.
   bool usesTerminalUi = false;
 
   String bolden(String message) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -60,7 +60,6 @@ class ResidentWebRunner extends ResidentRunner {
           target: target,
           debuggingOptions: debuggingOptions,
           ipv6: ipv6,
-          usesTerminalUi: true,
           stayResident: true,
         );
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -11,6 +11,7 @@ import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../commands/daemon.dart';
@@ -269,6 +270,7 @@ class AttachCommand extends FlutterCommand {
       flutterDevice.observatoryUris = <Uri>[ observatoryUri ];
       final List<FlutterDevice> flutterDevices =  <FlutterDevice>[flutterDevice];
       final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(getBuildInfo());
+      terminal.usesTerminalUi = daemon == null;
       final ResidentRunner runner = useHot ?
           hotRunnerFactory.build(
             flutterDevices,

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -275,7 +275,6 @@ class AttachCommand extends FlutterCommand {
             target: targetFile,
             debuggingOptions: debuggingOptions,
             packagesFilePath: globalResults['packages'],
-            usesTerminalUi: daemon == null,
             projectRootPath: argResults['project-root'],
             dillOutputPath: argResults['output-dill'],
             ipv6: usesIpv6,
@@ -356,7 +355,6 @@ class HotRunnerFactory {
     List<FlutterDevice> devices, {
     String target,
     DebuggingOptions debuggingOptions,
-    bool usesTerminalUi = true,
     bool benchmarkMode = false,
     File applicationBinary,
     bool hostIsIde = false,
@@ -370,7 +368,6 @@ class HotRunnerFactory {
     devices,
     target: target,
     debuggingOptions: debuggingOptions,
-    usesTerminalUi: usesTerminalUi,
     benchmarkMode: benchmarkMode,
     applicationBinary: applicationBinary,
     hostIsIde: hostIsIde,

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -426,7 +426,6 @@ class AppDomain extends Domain {
         <FlutterDevice>[flutterDevice],
         target: target,
         debuggingOptions: options,
-        usesTerminalUi: false,
         applicationBinary: applicationBinary,
         projectRootPath: projectRootPath,
         packagesFilePath: packagesFilePath,
@@ -440,7 +439,6 @@ class AppDomain extends Domain {
         target: target,
         debuggingOptions: options,
         applicationBinary: applicationBinary,
-        usesTerminalUi: false,
         ipv6: ipv6,
       );
     }

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -270,7 +270,6 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
     ),
     platformArgs: platformArgs,
     prebuiltApplication: !command.shouldBuild,
-    usesTerminalUi: false,
   );
 
   if (!result.started) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -8,6 +8,7 @@ import 'package:args/command_runner.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/terminal.dart';
 import '../base/time.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
@@ -334,6 +335,7 @@ class RunCommand extends RunCommandBase {
         endTimeOverride: appStartedTime,
       );
     }
+    terminal.usesTerminalUi = true;
 
     if (argResults['dart-flags'] != null && !FlutterVersion.instance.isMaster) {
       throw UsageException('--dart-flags is not available on the stable '

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -381,11 +381,6 @@ abstract class Device {
   ///
   /// [platformArgs] allows callers to pass platform-specific arguments to the
   /// start call. The build mode is not used by all platforms.
-  ///
-  /// If [usesTerminalUi] is true, Flutter Tools may attempt to prompt the
-  /// user to resolve fixable issues such as selecting a signing certificate
-  /// for iOS device deployment. Set to false if stdin cannot be read from while
-  /// attempting to start the app.
   Future<LaunchResult> startApp(
     ApplicationPackage package, {
     String mainPath,
@@ -394,7 +389,6 @@ abstract class Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
-    bool usesTerminalUi = true,
   });
 
   /// Whether this device implements support for hot reload.

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -226,7 +226,6 @@ class FuchsiaDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     if (!prebuiltApplication) {

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -94,7 +94,6 @@ final RegExp _certificateOrganizationalUnitExtractionPattern = RegExp(r'OU=([a-z
 /// project has a development team set in the project's build settings.
 Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   BuildableIOSApp iosApp,
-  bool usesTerminalUi = true,
 }) async {
   final Map<String, String> buildSettings = iosApp.project.buildSettings;
   if (buildSettings == null)
@@ -140,7 +139,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
       .toSet() // Unique.
       .toList();
 
-  final String signingIdentity = await _chooseSigningIdentity(validCodeSigningIdentities, usesTerminalUi);
+  final String signingIdentity = await _chooseSigningIdentity(validCodeSigningIdentities);
 
   // If none are chosen, return null.
   if (signingIdentity == null)
@@ -185,7 +184,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   };
 }
 
-Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities, bool usesTerminalUi) async {
+Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities) async {
   // The user has no valid code signing identities.
   if (validCodeSigningIdentities.isEmpty) {
     printError(noCertificatesInstruction, emphasis: true);
@@ -209,7 +208,7 @@ Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities, b
 
     // If terminal UI can't be used, just attempt with the first valid certificate
     // since we can't ask the user.
-    if (!usesTerminalUi)
+    if (!terminal.usesTerminalUi)
       return validCodeSigningIdentities.first;
 
     final int count = validCodeSigningIdentities.length;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -263,7 +263,6 @@ class IOSDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     if (!prebuiltApplication) {
@@ -279,7 +278,6 @@ class IOSDevice extends Device {
           buildInfo: debuggingOptions.buildInfo,
           targetOverride: mainPath,
           buildForDevice: true,
-          usesTerminalUi: usesTerminalUi,
           activeArch: iosArch,
       );
       if (!buildResult.success) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -267,7 +267,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   bool buildForDevice,
   DarwinArch activeArch,
   bool codesign = true,
-  bool usesTerminalUi = true,
+
 }) async {
   if (!upgradePbxProjWithFlutterAssets(app.project))
     return XcodeBuildResult(success: false);
@@ -324,7 +324,7 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   Map<String, String> autoSigningConfigs;
   if (codesign && buildForDevice)
-    autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app, usesTerminalUi: usesTerminalUi);
+    autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
 
   // Before the build, all service definitions must be updated and the dylibs
   // copied over to a location that is suitable for Xcodebuild to find them.

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -329,14 +329,13 @@ class IOSSimulator extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     if (!prebuiltApplication && package is BuildableIOSApp) {
       printTrace('Building ${package.name} for $id.');
 
       try {
-        await _setupUpdatedApplicationBundle(package, debuggingOptions.buildInfo, mainPath, usesTerminalUi);
+        await _setupUpdatedApplicationBundle(package, debuggingOptions.buildInfo, mainPath);
       } on ToolExit catch (e) {
         printError(e.message);
         return LaunchResult.failed();
@@ -406,7 +405,7 @@ class IOSSimulator extends Device {
     }
   }
 
-  Future<void> _setupUpdatedApplicationBundle(covariant BuildableIOSApp app, BuildInfo buildInfo, String mainPath, bool usesTerminalUi) async {
+  Future<void> _setupUpdatedApplicationBundle(covariant BuildableIOSApp app, BuildInfo buildInfo, String mainPath) async {
     await _sideloadUpdatedAssetsForInstalledApplicationBundle(app, buildInfo, mainPath);
 
     // Step 1: Build the Xcode project.
@@ -422,7 +421,6 @@ class IOSSimulator extends Device {
       buildInfo: debugBuildInfo,
       targetOverride: mainPath,
       buildForDevice: false,
-      usesTerminalUi: usesTerminalUi,
     );
     if (!buildResult.success)
       throwToolExit('Could not build the application for the simulator.');

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -76,7 +76,6 @@ class LinuxDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     _lastBuiltMode = debuggingOptions.buildInfo.mode;

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -77,7 +77,6 @@ class MacOSDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     // Stop any running applications with the same executable.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -620,7 +620,11 @@ abstract class ResidentRunner {
 
   bool get supportsRestart => false;
 
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason });
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) {
+    final String mode = isRunningProfile ? 'profile' :
+        isRunningRelease ? 'release' : 'this';
+    throw '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode';
+  }
 
   Future<void> exit() async {
     _exited = true;
@@ -775,7 +779,7 @@ abstract class ResidentRunner {
     CompileExpression compileExpression,
   }) async {
     if (!debuggingOptions.debuggingEnabled)
-      throw Exception('The service protocol is not enabled.');
+      throw 'The service protocol is not enabled.';
 
     bool viewFound = false;
     for (FlutterDevice device in flutterDevices) {
@@ -791,9 +795,9 @@ abstract class ResidentRunner {
     }
     if (!viewFound) {
       if (flutterDevices.length == 1)
-        throw Exception('No Flutter view is available on ${flutterDevices.first.device.name}.');
-      throw Exception('No Flutter view is available on any device '
-            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).');
+        throw 'No Flutter view is available on ${flutterDevices.first.device.name}.';
+      throw 'No Flutter view is available on any device '
+            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).';
     }
 
     // Listen for service protocol connection to close.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -382,7 +382,6 @@ class FlutterDevice {
       platformArgs: platformArgs,
       route: route,
       prebuiltApplication: prebuiltMode,
-      usesTerminalUi: hotRunner.usesTerminalUi,
       ipv6: hotRunner.ipv6,
     );
 
@@ -443,7 +442,6 @@ class FlutterDevice {
       platformArgs: platformArgs,
       route: route,
       prebuiltApplication: prebuiltMode,
-      usesTerminalUi: coldRunner.usesTerminalUi,
       ipv6: coldRunner.ipv6,
     );
 
@@ -536,7 +534,6 @@ abstract class ResidentRunner {
     String projectRootPath,
     String packagesFilePath,
     this.ipv6,
-    this.usesTerminalUi = true,
     this.stayResident = true,
     this.hotMode = true,
     this.dillOutputPath,
@@ -563,7 +560,6 @@ abstract class ResidentRunner {
   final List<FlutterDevice> flutterDevices;
   final String target;
   final DebuggingOptions debuggingOptions;
-  final bool usesTerminalUi;
   final bool stayResident;
   final bool ipv6;
   final Completer<int> _finished = Completer<int>();
@@ -624,11 +620,7 @@ abstract class ResidentRunner {
 
   bool get supportsRestart => false;
 
-  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason }) {
-    final String mode = isRunningProfile ? 'profile' :
-        isRunningRelease ? 'release' : 'this';
-    throw '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode';
-  }
+  Future<OperationResult> restart({ bool fullRestart = false, bool pauseAfterRestart = false, String reason });
 
   Future<void> exit() async {
     _exited = true;
@@ -783,7 +775,7 @@ abstract class ResidentRunner {
     CompileExpression compileExpression,
   }) async {
     if (!debuggingOptions.debuggingEnabled)
-      throw 'The service protocol is not enabled.';
+      throw Exception('The service protocol is not enabled.');
 
     bool viewFound = false;
     for (FlutterDevice device in flutterDevices) {
@@ -799,9 +791,9 @@ abstract class ResidentRunner {
     }
     if (!viewFound) {
       if (flutterDevices.length == 1)
-        throw 'No Flutter view is available on ${flutterDevices.first.device.name}.';
-      throw 'No Flutter view is available on any device '
-            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).';
+        throw Exception('No Flutter view is available on ${flutterDevices.first.device.name}.');
+      throw Exception('No Flutter view is available on any device '
+            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).');
     }
 
     // Listen for service protocol connection to close.

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -207,9 +207,4 @@ class ColdRunner extends ResidentRunner {
         await device.device.stopApp(device.package);
     }
   }
-
-  @override
-  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) async {
-    return OperationResult(1, 'Restart not supported.');
-  }
 }

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -23,13 +23,11 @@ class ColdRunner extends ResidentRunner {
     this.awaitFirstFrameWhenTracing = true,
     this.applicationBinary,
     bool ipv6 = false,
-    bool usesTerminalUi = false,
     bool stayResident = true,
   }) : super(devices,
              target: target,
              debuggingOptions: debuggingOptions,
              hotMode: false,
-             usesTerminalUi: usesTerminalUi,
              stayResident: stayResident,
              ipv6: ipv6);
 
@@ -208,5 +206,10 @@ class ColdRunner extends ResidentRunner {
       if (device.vmServices == null || device.vmServices.isEmpty)
         await device.device.stopApp(device.package);
     }
+  }
+
+  @override
+  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) async {
+    return OperationResult(1, 'Restart not supported.');
   }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -58,7 +58,6 @@ class HotRunner extends ResidentRunner {
     List<FlutterDevice> devices, {
     String target,
     DebuggingOptions debuggingOptions,
-    bool usesTerminalUi = true,
     this.benchmarkMode = false,
     this.applicationBinary,
     this.hostIsIde = false,
@@ -70,7 +69,6 @@ class HotRunner extends ResidentRunner {
   }) : super(devices,
              target: target,
              debuggingOptions: debuggingOptions,
-             usesTerminalUi: usesTerminalUi,
              projectRootPath: projectRootPath,
              packagesFilePath: packagesFilePath,
              stayResident: stayResident,

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -105,7 +105,6 @@ class FlutterTesterDevice extends Device {
     @required DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     final BuildInfo buildInfo = debuggingOptions.buildInfo;

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -123,7 +123,6 @@ class ChromeDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, Object> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -78,7 +78,6 @@ class WindowsDevice extends Device {
     DebuggingOptions debuggingOptions,
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
-    bool usesTerminalUi = true,
     bool ipv6 = false,
   }) async {
     if (!prebuiltApplication) {

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -123,7 +123,15 @@ void main() {
       terminalUnderTest = TestTerminal();
     });
 
+    testUsingContext('character prompt throws if usesTerminalUi is false', () async {
+      expect(terminalUnderTest.promptForCharInput(
+        <String>['a', 'b', 'c'],
+        prompt: 'Please choose something',
+      ), throwsA(isInstanceOf<StateError>()));
+    });
+
     testUsingContext('character prompt', () async {
+      terminalUnderTest.usesTerminalUi = true;
       mockStdInStream = Stream<String>.fromFutures(<Future<String>>[
         Future<String>.value('d'), // Not in accepted list.
         Future<String>.value('\n'), // Not in accepted list
@@ -143,6 +151,7 @@ void main() {
     });
 
     testUsingContext('default character choice without displayAcceptedCharacters', () async {
+       terminalUnderTest.usesTerminalUi = true;
       mockStdInStream = Stream<String>.fromFutures(<Future<String>>[
         Future<String>.value('\n'), // Not in accepted list
       ]).asBroadcastStream();

--- a/packages/flutter_tools/test/general.shard/commands/attach_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/attach_test.dart
@@ -147,7 +147,6 @@ void main() {
             dillOutputPath: anyNamed('dillOutputPath'),
             debuggingOptions: anyNamed('debuggingOptions'),
             packagesFilePath: anyNamed('packagesFilePath'),
-            usesTerminalUi: anyNamed('usesTerminalUi'),
             flutterProject: anyNamed('flutterProject'),
             ipv6: false,
           ),
@@ -179,7 +178,6 @@ void main() {
             dillOutputPath: outputDill,
             debuggingOptions: anyNamed('debuggingOptions'),
             packagesFilePath: anyNamed('packagesFilePath'),
-            usesTerminalUi: anyNamed('usesTerminalUi'),
             flutterProject: anyNamed('flutterProject'),
             ipv6: false,
           ),
@@ -269,7 +267,6 @@ void main() {
         target: anyNamed('target'),
         debuggingOptions: anyNamed('debuggingOptions'),
         packagesFilePath: anyNamed('packagesFilePath'),
-        usesTerminalUi: anyNamed('usesTerminalUi'),
         flutterProject: anyNamed('flutterProject'),
         ipv6: false,
       )).thenReturn(mockHotRunner);
@@ -299,7 +296,6 @@ void main() {
         target: foo.path,
         debuggingOptions: anyNamed('debuggingOptions'),
         packagesFilePath: anyNamed('packagesFilePath'),
-        usesTerminalUi: anyNamed('usesTerminalUi'),
         flutterProject: anyNamed('flutterProject'),
         ipv6: false,
       )).called(1);

--- a/packages/flutter_tools/test/general.shard/commands/drive_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/drive_test.dart
@@ -338,7 +338,6 @@ void main() {
             debuggingOptions: anyNamed('debuggingOptions'),
             platformArgs: anyNamed('platformArgs'),
             prebuiltApplication: anyNamed('prebuiltApplication'),
-            usesTerminalUi: false,
         )).thenAnswer((_) => Future<LaunchResult>.value(mockLaunchResult));
         when(mockDevice.isAppInstalled(any)).thenAnswer((_) => Future<bool>.value(false));
 
@@ -380,7 +379,6 @@ void main() {
                 debuggingOptions: anyNamed('debuggingOptions'),
                 platformArgs: anyNamed('platformArgs'),
                 prebuiltApplication: false,
-                usesTerminalUi: false,
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -407,7 +405,6 @@ void main() {
                 debuggingOptions: anyNamed('debuggingOptions'),
                 platformArgs: anyNamed('platformArgs'),
                 prebuiltApplication: false,
-                usesTerminalUi: false,
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -434,7 +431,6 @@ void main() {
                 debuggingOptions: anyNamed('debuggingOptions'),
                 platformArgs: anyNamed('platformArgs'),
                 prebuiltApplication: true,
-                usesTerminalUi: false,
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -35,6 +35,7 @@ void main() {
         'For our purposes': 'a non-empty build settings map is valid',
       });
       testTerminal = TestTerminal();
+      testTerminal.usesTerminalUi = true;
       app = BuildableIOSApp(mockIosProject);
     });
 
@@ -296,6 +297,7 @@ void main() {
     });
 
     testUsingContext('Test multiple identity in machine mode works', () async {
+      testTerminal.usesTerminalUi = false;
       when(mockProcessManager.runSync(<String>['which', 'security']))
           .thenReturn(exitsHappy);
       when(mockProcessManager.runSync(<String>['which', 'openssl']))

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -347,7 +347,7 @@ void main() {
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
       when(mockOpenSslProcess.exitCode).thenAnswer((_) => Future<int>.value(0));
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app, usesTerminalUi: false);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
 
       expect(
         testLogger.statusText,

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -423,9 +423,4 @@ class TestRunner extends ResidentRunner {
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,
   }) async => null;
-
-  @override
-  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) {
-    return null;
-  }
 }

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -423,4 +423,9 @@ class TestRunner extends ResidentRunner {
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,
   }) async => null;
+
+  @override
+  Future<OperationResult> restart({bool fullRestart = false, bool pauseAfterRestart = false, String reason}) {
+    return null;
+  }
 }


### PR DESCRIPTION
## Description

The terminalUi flag is drilled through all resident runners and devices in many places through the app. nevertheless, this is only used in a single place for an iOS codesigning prompt.  Remove the drilling and replace with a property on the terminal object.
