### PR TITLE
[WIP] Allow attach to reload the world

### DIFF
--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -14,7 +14,7 @@ void main() {
     final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
     testUsingContext('Empty project', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(lastCompiled: DateTime.now(), urisToMonitor: <Uri>[], packagesPath: ''),
+        const ProjectFileInvalidator().findInvalidated(lastCompiled: DateTime.now(), urisToMonitor: <Uri>[], packagesPath: ''),
         isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
@@ -22,7 +22,7 @@ void main() {
 
     testUsingContext('Non-existent files are ignored', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(
+        const ProjectFileInvalidator().findInvalidated(
             lastCompiled: DateTime.now(),
             urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
             packagesPath: '',


### PR DESCRIPTION
## Description

After the initial compile, if the user attached without building null out the build time. This has the effect of forcing all used sources into the next reload. This allows a user that continually attaches to an older app to  always reload changes into the app without restarting, at the cost of a much slower first reload time.

Also makes the ProjectFileInvalidator an injectable interface and async to allow alternative implementations. 

## Related Issues
Fixes https://github.com/flutter/flutter/issues/38320