### PR TITLE
Switch all uses of ObserverList to use Set (LinkedHashSet) instead.

### DIFF
--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -80,7 +80,7 @@ mixin AnimationEagerListenerMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalListenersMixin {
-  final ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
+  final Set<VoidCallback> _listeners = <VoidCallback>{};
 
   /// Called immediately before a listener is added via [addListener].
   ///
@@ -149,7 +149,7 @@ mixin AnimationLocalListenersMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalStatusListenersMixin {
-  final ObserverList<AnimationStatusListener> _statusListeners = ObserverList<AnimationStatusListener>();
+  final Set<AnimationStatusListener> _statusListeners = <AnimationStatusListener>{};
 
   /// Called immediately before a status listener is added via [addStatusListener].
   ///

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -97,7 +97,7 @@ abstract class ValueListenable<T> extends Listenable {
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
-  ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
+  Set<VoidCallback> _listeners = <VoidCallback>{};
 
   bool _debugAssertNotDisposed() {
     assert(() {


### PR DESCRIPTION
## Description

While investigating a performance regression that some of my code introduced, I noticed that switching out `ObserverList` for `Set` (which is `LinkedHashSet` under the covers) had a noticeable improvement in both `flutter_gallery__transition_perf` and `complex_layout_scroll_perf__timeline_summary`.

This PR switches out uses of `ObserverList` for `Set` in the places where it was used, most notably in `ChangeNotifier`, which is used extensively.

The speedup makes sense, since `LinkedHashSet` is O(1) for removals, and `ObserverList` is O(n). I suspect that the only reason `ObserverList` exists is that `LinkedHashSet` didn't exist (and wasn't the default `Set` implementation) when `ObserverList` was created.

## Related Issues

#38860

## Tests

- No tests needed changing as a result of this change: the behavior is expected to be identical semantically (since `Set` preserves insertion order), it's only meant to be faster.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change. (although I'm considering deprecating/removing `ObserverList` in another PR).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes