### PR TITLE
Add profile support on macOS

### DIFF
--- a/packages/flutter_tools/lib/src/linux/application_package.dart
+++ b/packages/flutter_tools/lib/src/linux/application_package.dart
@@ -58,11 +58,7 @@ class BuildableLinuxApp extends LinuxApp {
   @override
   String executable(BuildMode buildMode) {
     final String binaryName = makefileExecutableName(project);
-    if (buildMode == BuildMode.debug) {
-      return fs.path.join(getLinuxBuildDirectory(), 'debug', binaryName);
-    } else {
-      return fs.path.join(getLinuxBuildDirectory(), 'release', binaryName);
-    }
+    return fs.path.join(getLinuxBuildDirectory(), getNameForBuildMode(buildMode), binaryName);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../base/file_system.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../globals.dart';
 import '../ios/plist_parser.dart';
@@ -131,7 +132,7 @@ class BuildableMacOSApp extends MacOSApp {
         getMacOSBuildDirectory(),
         'Build',
         'Products',
-        buildMode == BuildMode.debug ? 'Debug' : 'Release',
+        toTitleCase(getNameForBuildMode(buildMode)),
         appBundleNameFile.readAsStringSync().trim());
   }
 

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -98,7 +98,7 @@ class MacOSDevice extends Device {
     }
 
     // Make sure to call stop app after we've built.
-    _lastBuiltMode = debuggingOptions.buildInfo.mode;
+    _lastBuiltMode = debuggingOptions?.buildInfo?.mode;
     await stopApp(package);
     final Process process = await processManager.start(<String>[
       executable

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/common.dart';
-
 import '../application_package.dart';
 import '../base/io.dart';
 import '../base/os.dart';

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/common.dart';
+
 import '../application_package.dart';
 import '../base/io.dart';
 import '../base/os.dart';
@@ -98,6 +100,7 @@ class MacOSDevice extends Device {
     }
 
     // Make sure to call stop app after we've built.
+    _lastBuiltMode = debuggingOptions.buildInfo.mode;
     await stopApp(package);
     final Process process = await processManager.start(<String>[
       executable
@@ -126,7 +129,7 @@ class MacOSDevice extends Device {
   // currently we rely on killing the isolate taking down the application.
   @override
   Future<bool> stopApp(covariant MacOSApp app) async {
-    return killProcess(app.executable(BuildMode.debug));
+    return killProcess(app.executable(_lastBuiltMode));
   }
 
   @override
@@ -141,6 +144,9 @@ class MacOSDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.macos.existsSync();
   }
+
+  // Track the last built mode from startApp.
+  BuildMode _lastBuiltMode;
 }
 
 class MacOSDevices extends PollingDeviceDiscovery {

--- a/packages/flutter_tools/lib/src/windows/application_package.dart
+++ b/packages/flutter_tools/lib/src/windows/application_package.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import '../application_package.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../project.dart';
 
@@ -66,7 +67,7 @@ class BuildableWindowsApp extends WindowsApp {
     return fs.path.join(
         getWindowsBuildDirectory(),
         'x64',
-        buildMode == BuildMode.debug ? 'Debug' : 'Release',
+        toTitleCase(getNameForBuildMode(buildMode)),
         'Runner',
         exeNameFile.readAsStringSync().trim());
   }

--- a/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -20,6 +21,17 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 import '../../src/testbed.dart';
+
+class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter {
+  @override
+  Future<XcodeProjectInfo> getInfo(String projectPath) async {
+    return XcodeProjectInfo(
+      <String>['Runner'],
+      <String>['Debug', 'Profile', 'Release'],
+      <String>['Runner'],
+    );
+  }
+}
 
 void main() {
   MockProcessManager mockProcessManager;
@@ -78,7 +90,82 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
-  testUsingContext('macOS build invokes xcode build', () async {
+  testUsingContext('macOS build invokes xcode build (debug)', () async {
+    final BuildCommand command = BuildCommand();
+    applyMocksToCommand(command);
+    fs.directory('macos').createSync();
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
+    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
+    when(mockProcessManager.start(<String>[
+      '/usr/bin/env',
+      'xcrun',
+      'xcodebuild',
+      '-workspace', flutterProject.macos.xcodeWorkspace.path,
+      '-configuration', 'Debug',
+      '-scheme', 'Runner',
+      '-derivedDataPath', flutterBuildDir.absolute.path,
+      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
+    ])).thenAnswer((Invocation invocation) async {
+      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('example.app');
+      return mockProcess;
+    });
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'macos', '--debug']
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => memoryFilesystem,
+    ProcessManager: () => mockProcessManager,
+    Platform: () => macosPlatform,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+  });
+
+  testUsingContext('macOS build invokes xcode build (profile)', () async {
+    final BuildCommand command = BuildCommand();
+    applyMocksToCommand(command);
+    fs.directory('macos').createSync();
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
+    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
+    when(mockProcessManager.start(<String>[
+      '/usr/bin/env',
+      'xcrun',
+      'xcodebuild',
+      '-workspace', flutterProject.macos.xcodeWorkspace.path,
+      '-configuration', 'Profile',
+      '-scheme', 'Runner',
+      '-derivedDataPath', flutterBuildDir.absolute.path,
+      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
+    ])).thenAnswer((Invocation invocation) async {
+      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('example.app');
+      return mockProcess;
+    });
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'macos', '--profile']
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => memoryFilesystem,
+    ProcessManager: () => mockProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithProfile(),
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+  });
+
+  testUsingContext('macOS build invokes xcode build (release)', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
     fs.directory('macos').createSync();

--- a/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
@@ -63,6 +63,38 @@ void main() {
     when(notMacosPlatform.isMacOS).thenReturn(false);
   });
 
+  // Sets up the minimal mock project files necessary for macOS builds to succeed.
+  void createMinimalMockProjectFiles() {
+    fs.directory('macos').createSync();
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+  }
+
+  // Mocks the process manager to handle an xcodebuild call to build the app
+  // in the given configuration.
+  void setUpMockXcodeBuildHandler(String configuration) {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
+    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
+    when(mockProcessManager.start(<String>[
+      '/usr/bin/env',
+      'xcrun',
+      'xcodebuild',
+      '-workspace', flutterProject.macos.xcodeWorkspace.path,
+      '-configuration', configuration,
+      '-scheme', 'Runner',
+      '-derivedDataPath', flutterBuildDir.absolute.path,
+      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
+    ])).thenAnswer((Invocation invocation) async {
+      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('example.app');
+      return mockProcess;
+    });
+  }
+
   testUsingContext('macOS build fails when there is no macos project', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
@@ -93,29 +125,8 @@ void main() {
   testUsingContext('macOS build invokes xcode build (debug)', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.directory('macos').createSync();
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
-    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
-    when(mockProcessManager.start(<String>[
-      '/usr/bin/env',
-      'xcrun',
-      'xcodebuild',
-      '-workspace', flutterProject.macos.xcodeWorkspace.path,
-      '-configuration', 'Debug',
-      '-scheme', 'Runner',
-      '-derivedDataPath', flutterBuildDir.absolute.path,
-      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
-      'COMPILER_INDEX_STORE_ENABLE=NO',
-    ])).thenAnswer((Invocation invocation) async {
-      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('example.app');
-      return mockProcess;
-    });
+    createMinimalMockProjectFiles();
+    setUpMockXcodeBuildHandler('Debug');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--debug']
@@ -130,29 +141,8 @@ void main() {
   testUsingContext('macOS build invokes xcode build (profile)', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.directory('macos').createSync();
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
-    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
-    when(mockProcessManager.start(<String>[
-      '/usr/bin/env',
-      'xcrun',
-      'xcodebuild',
-      '-workspace', flutterProject.macos.xcodeWorkspace.path,
-      '-configuration', 'Profile',
-      '-scheme', 'Runner',
-      '-derivedDataPath', flutterBuildDir.absolute.path,
-      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
-      'COMPILER_INDEX_STORE_ENABLE=NO',
-    ])).thenAnswer((Invocation invocation) async {
-      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('example.app');
-      return mockProcess;
-    });
+    createMinimalMockProjectFiles();
+    setUpMockXcodeBuildHandler('Profile');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--profile']
@@ -168,29 +158,8 @@ void main() {
   testUsingContext('macOS build invokes xcode build (release)', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.directory('macos').createSync();
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-    final FlutterProject flutterProject = FlutterProject.fromDirectory(fs.currentDirectory);
-    final Directory flutterBuildDir = fs.directory(getMacOSBuildDirectory());
-    when(mockProcessManager.start(<String>[
-      '/usr/bin/env',
-      'xcrun',
-      'xcodebuild',
-      '-workspace', flutterProject.macos.xcodeWorkspace.path,
-      '-configuration', 'Release',
-      '-scheme', 'Runner',
-      '-derivedDataPath', flutterBuildDir.absolute.path,
-      'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-      'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
-      'COMPILER_INDEX_STORE_ENABLE=NO',
-    ])).thenAnswer((Invocation invocation) async {
-      fs.file(fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('example.app');
-      return mockProcess;
-    });
+    createMinimalMockProjectFiles();
+    setUpMockXcodeBuildHandler('Release');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--release']


### PR DESCRIPTION
## Description

Fix some places where Debug/Release was treated as a binary switch.

Makes similar changes to Windows and Linux to simplify adding profile
support to those platforms in the future. This means `--profile` builds
will fail on Linux and Windows for now, but that's fine since they
aren't actually supported, and unlike `--release` don't provide useful
functionality at the native code level.

Also fixes 'stopApp' always using Debug on macOS, to avoid showing an
error when running Profile (or Release).

## Related Issues

Fixes #33203

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
