### PR TITLE
Make module pod headers public

### DIFF
--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -3,8 +3,6 @@ platform :ios, '8.0'
 flutter_application_path = '../'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
-use_frameworks!
-
 target 'Runner' do
   install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -3,6 +3,8 @@ platform :ios, '8.0'
 flutter_application_path = '../'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
+use_frameworks!
+
 target 'Runner' do
   install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path
@@ -12,6 +14,16 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['ENABLE_BITCODE'] = 'NO'
+      # Inherit the deployment target from the `platform :ios` call above.
+      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+    end
+
+    # Aggregate targets do not have a headers build phase.
+    if target.respond_to?('headers_build_phase')
+      target.headers_build_phase.files.each do |file|
+        # Make headers public so they can be imported by the host application.
+        file.settings = { 'ATTRIBUTES' => ['Public'] }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Building iOS frameworks to be embedded in another existing app without CocoaPods requires that the plugin frameworks be built on a machine with CocoaPods to get transitive dependencies.

1. In the _module_ Podfile make headers Public instead of Project so plugin headers/modules can be imported by the host app.
1. ~~Add `use_frameworks` to produce .frameworks instead of dylibs or static frameworks.  This is more friendly to host apps where CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES "Allow Non-modular Includes In Framework Modules" is off (the default) due to bridging header issues between Swift/Obj-C, or plugins that incorrectly use "" project imports in (now-public) headers for dependencies instead of <> framework imports.  This also allows for support of xcframework generation in Xcode 11+.~~ Removed, see comment below.
1. Remove plugin IPHONEOS_DEPLOYMENT_TARGET so the host app doesn't get warnings that the plugins are outside the target range, when the implication is really that the plugin supports a _minimum_ of that deployment target.

With this change, from working directory `<path/to/module>/.ios/Pods`:
```
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Debug" ONLY_ACTIVE_ARCH=NO
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Profile" ONLY_ACTIVE_ARCH=NO
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Release" ONLY_ACTIVE_ARCH=NO
```
will produce frameworks for all plugins, CocoaPod transitive dependencies, and FlutterPluginRegistrant in the SYMROOT for every valid architecture.  They can then be embedded into an existing app since all headers are public.

## Related Issues

A step in making https://github.com/flutter/flutter/issues/36968 actually work.

## Tests

I'm not sure how to test this before having commands that use this to embed frameworks along with the rest of https://github.com/flutter/flutter/issues/36968.
Made sure module_test_ios still passes.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

This change updates the _module_ Podfile, not the _host_ Podfile.  This will therefore impact the module Runner workspace, but not in any way how the host project/workspace currently embeds these frameworks as described in [Add-Flutter-to-existing-apps#add-your-flutter-app-to-your-podfile](https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps#add-your-flutter-app-to-your-podfile).