### PR TITLE
Switch ObserverList to use a reference-counted LinkedHashMap instead of a list and a set.

### DIFF
--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -80,7 +80,7 @@ mixin AnimationEagerListenerMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalListenersMixin {
-  final ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
+  final Set<VoidCallback> _listeners = <VoidCallback>{};
 
   /// Called immediately before a listener is added via [addListener].
   ///
@@ -149,7 +149,7 @@ mixin AnimationLocalListenersMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalStatusListenersMixin {
-  final ObserverList<AnimationStatusListener> _statusListeners = ObserverList<AnimationStatusListener>();
+  final Set<AnimationStatusListener> _statusListeners = <AnimationStatusListener>{};
 
   /// Called immediately before a status listener is added via [addStatusListener].
   ///

--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -80,7 +80,7 @@ mixin AnimationEagerListenerMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalListenersMixin {
-  final Set<VoidCallback> _listeners = <VoidCallback>{};
+  final ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
 
   /// Called immediately before a listener is added via [addListener].
   ///
@@ -149,7 +149,7 @@ mixin AnimationLocalListenersMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalStatusListenersMixin {
-  final Set<AnimationStatusListener> _statusListeners = <AnimationStatusListener>{};
+  final ObserverList<AnimationStatusListener> _statusListeners = ObserverList<AnimationStatusListener>();
 
   /// Called immediately before a status listener is added via [addStatusListener].
   ///

--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -117,27 +117,27 @@ mixin AnimationLocalListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   void notifyListeners() {
-    final List<VoidCallback> localListeners = List<VoidCallback>.from(_listeners);
-    for (VoidCallback listener in localListeners) {
-      try {
-        if (_listeners.contains(listener))
+    _listeners.safeIteration((Iterable<VoidCallback> iterable) {
+      for (VoidCallback listener in iterable) {
+        try {
           listener();
-      } catch (exception, stack) {
-        FlutterError.reportError(FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'animation library',
-          context: ErrorDescription('while notifying listeners for $runtimeType'),
-          informationCollector: () sync* {
-            yield DiagnosticsProperty<AnimationLocalListenersMixin>(
-              'The $runtimeType notifying listeners was',
-              this,
-              style: DiagnosticsTreeStyle.errorProperty,
-            );
-          },
-        ));
+        } catch (exception, stack) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: exception,
+            stack: stack,
+            library: 'animation library',
+            context: ErrorDescription('while notifying listeners for $runtimeType'),
+            informationCollector: () sync* {
+              yield DiagnosticsProperty<AnimationLocalListenersMixin>(
+                'The $runtimeType notifying listeners was',
+                this,
+                style: DiagnosticsTreeStyle.errorProperty,
+              );
+            },
+          ));
+        }
       }
-    }
+    });
   }
 }
 
@@ -186,26 +186,26 @@ mixin AnimationLocalStatusListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   void notifyStatusListeners(AnimationStatus status) {
-    final List<AnimationStatusListener> localListeners = List<AnimationStatusListener>.from(_statusListeners);
-    for (AnimationStatusListener listener in localListeners) {
-      try {
-        if (_statusListeners.contains(listener))
+    _statusListeners.safeIteration((Iterable<AnimationStatusListener> iterable) {
+      for (AnimationStatusListener listener in iterable) {
+        try {
           listener(status);
-      } catch (exception, stack) {
-        FlutterError.reportError(FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'animation library',
-          context: ErrorDescription('while notifying status listeners for $runtimeType'),
-          informationCollector: () sync* {
-            yield DiagnosticsProperty<AnimationLocalStatusListenersMixin>(
-              'The $runtimeType notifying status listeners was',
-              this,
-              style: DiagnosticsTreeStyle.errorProperty,
-            );
-          },
-        ));
+        } catch (exception, stack) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: exception,
+            stack: stack,
+            library: 'animation library',
+            context: ErrorDescription('while notifying status listeners for $runtimeType'),
+            informationCollector: () sync* {
+              yield DiagnosticsProperty<AnimationLocalStatusListenersMixin>(
+                'The $runtimeType notifying status listeners was',
+                this,
+                style: DiagnosticsTreeStyle.errorProperty,
+              );
+            },
+          ));
+        }
       }
-    }
+    });
   }
 }

--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -117,27 +117,27 @@ mixin AnimationLocalListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   void notifyListeners() {
-    _listeners.safeIteration((Iterable<VoidCallback> iterable) {
-      for (VoidCallback listener in iterable) {
-        try {
+    final List<VoidCallback> localListeners = List<VoidCallback>.from(_listeners);
+    for (VoidCallback listener in localListeners) {
+      try {
+        if (_listeners.contains(listener))
           listener();
-        } catch (exception, stack) {
-          FlutterError.reportError(FlutterErrorDetails(
-            exception: exception,
-            stack: stack,
-            library: 'animation library',
-            context: ErrorDescription('while notifying listeners for $runtimeType'),
-            informationCollector: () sync* {
-              yield DiagnosticsProperty<AnimationLocalListenersMixin>(
-                'The $runtimeType notifying listeners was',
-                this,
-                style: DiagnosticsTreeStyle.errorProperty,
-              );
-            },
-          ));
-        }
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'animation library',
+          context: ErrorDescription('while notifying listeners for $runtimeType'),
+          informationCollector: () sync* {
+            yield DiagnosticsProperty<AnimationLocalListenersMixin>(
+              'The $runtimeType notifying listeners was',
+              this,
+              style: DiagnosticsTreeStyle.errorProperty,
+            );
+          },
+        ));
       }
-    });
+    }
   }
 }
 
@@ -186,26 +186,26 @@ mixin AnimationLocalStatusListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   void notifyStatusListeners(AnimationStatus status) {
-    _statusListeners.safeIteration((Iterable<AnimationStatusListener> iterable) {
-      for (AnimationStatusListener listener in iterable) {
-        try {
+    final List<AnimationStatusListener> localListeners = List<AnimationStatusListener>.from(_statusListeners);
+    for (AnimationStatusListener listener in localListeners) {
+      try {
+        if (_statusListeners.contains(listener))
           listener(status);
-        } catch (exception, stack) {
-          FlutterError.reportError(FlutterErrorDetails(
-            exception: exception,
-            stack: stack,
-            library: 'animation library',
-            context: ErrorDescription('while notifying status listeners for $runtimeType'),
-            informationCollector: () sync* {
-              yield DiagnosticsProperty<AnimationLocalStatusListenersMixin>(
-                'The $runtimeType notifying status listeners was',
-                this,
-                style: DiagnosticsTreeStyle.errorProperty,
-              );
-            },
-          ));
-        }
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'animation library',
+          context: ErrorDescription('while notifying status listeners for $runtimeType'),
+          informationCollector: () sync* {
+            yield DiagnosticsProperty<AnimationLocalStatusListenersMixin>(
+              'The $runtimeType notifying status listeners was',
+              this,
+              style: DiagnosticsTreeStyle.errorProperty,
+            );
+          },
+        ));
       }
-    });
+    }
   }
 }

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -199,27 +199,27 @@ class ChangeNotifier implements Listenable {
   void notifyListeners() {
     assert(_debugAssertNotDisposed());
     if (_listeners != null) {
-      final List<VoidCallback> localListeners = List<VoidCallback>.from(_listeners);
-      for (VoidCallback listener in localListeners) {
-        try {
-          if (_listeners.contains(listener))
+      _listeners.safeIteration((Iterable<VoidCallback> iterable) {
+        for (VoidCallback listener in iterable) {
+          try {
             listener();
-        } catch (exception, stack) {
-          FlutterError.reportError(FlutterErrorDetails(
-            exception: exception,
-            stack: stack,
-            library: 'foundation library',
-            context: ErrorDescription('while dispatching notifications for $runtimeType'),
-            informationCollector: () sync* {
-              yield DiagnosticsProperty<ChangeNotifier>(
-                'The $runtimeType sending notification was',
-                this,
-                style: DiagnosticsTreeStyle.errorProperty,
-              );
-            },
-          ));
+          } catch (exception, stack) {
+            FlutterError.reportError(FlutterErrorDetails(
+              exception: exception,
+              stack: stack,
+              library: 'foundation library',
+              context: ErrorDescription('while dispatching notifications for $runtimeType'),
+              informationCollector: () sync* {
+                yield DiagnosticsProperty<ChangeNotifier>(
+                  'The $runtimeType sending notification was',
+                  this,
+                  style: DiagnosticsTreeStyle.errorProperty,
+                );
+              },
+            ));
+          }
         }
-      }
+      });
     }
   }
 }

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -97,7 +97,7 @@ abstract class ValueListenable<T> extends Listenable {
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
-  ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
+  Set<VoidCallback> _listeners = <VoidCallback>{};
 
   bool _debugAssertNotDisposed() {
     assert(() {

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -199,27 +199,27 @@ class ChangeNotifier implements Listenable {
   void notifyListeners() {
     assert(_debugAssertNotDisposed());
     if (_listeners != null) {
-      _listeners.safeIteration((Iterable<VoidCallback> iterable) {
-        for (VoidCallback listener in iterable) {
-          try {
+      final List<VoidCallback> localListeners = List<VoidCallback>.from(_listeners);
+      for (VoidCallback listener in localListeners) {
+        try {
+          if (_listeners.contains(listener))
             listener();
-          } catch (exception, stack) {
-            FlutterError.reportError(FlutterErrorDetails(
-              exception: exception,
-              stack: stack,
-              library: 'foundation library',
-              context: ErrorDescription('while dispatching notifications for $runtimeType'),
-              informationCollector: () sync* {
-                yield DiagnosticsProperty<ChangeNotifier>(
-                  'The $runtimeType sending notification was',
-                  this,
-                  style: DiagnosticsTreeStyle.errorProperty,
-                );
-              },
-            ));
-          }
+        } catch (exception, stack) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: exception,
+            stack: stack,
+            library: 'foundation library',
+            context: ErrorDescription('while dispatching notifications for $runtimeType'),
+            informationCollector: () sync* {
+              yield DiagnosticsProperty<ChangeNotifier>(
+                'The $runtimeType sending notification was',
+                this,
+                style: DiagnosticsTreeStyle.errorProperty,
+              );
+            },
+          ));
         }
-      });
+      }
     }
   }
 }

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -90,8 +90,18 @@ abstract class ValueListenable<T> extends Listenable {
 /// API using [VoidCallback] for notifications.
 ///
 /// [ChangeNotifier] is optimized for small numbers (one or two) of listeners.
-/// It is O(N) for adding and removing listeners and O(N²) for dispatching
+/// It is O(1) for adding and removing listeners and O(N) for dispatching
 /// notifications (where N is the number of listeners).
+///
+/// If the same listener is added more than once, it will only be called once
+/// during a call to [notify], but must be removed as many times as it has been
+/// added in order to keep it from being called in the future.
+///
+/// Adding and removing listeners is safe to do during a notification phase
+/// (i.e. during a call to [notify]). Added listeners won't be triggered until
+/// the next notification phase. Listeners removed during iteration will be
+/// skipped if they are removed by the time their original position in the
+/// iteration is reached.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -97,7 +97,7 @@ abstract class ValueListenable<T> extends Listenable {
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
-  Set<VoidCallback> _listeners = <VoidCallback>{};
+  ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
 
   bool _debugAssertNotDisposed() {
     assert(() {

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -2,21 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-enum _ObserverOperationType {
-  add,
-  remove,
-}
-
-class _ObserverOperation<T> {
-  _ObserverOperation.add(this.callback) : type = _ObserverOperationType.add;
-  _ObserverOperation.remove(this.callback) : type = _ObserverOperationType.remove;
-
-  final _ObserverOperationType type;
-  final T callback;
-}
-
-typedef ObserverListIterationCallback<T> = void Function(Iterable<T> iterator);
-
 /// A list optimized for containment queries.
 ///
 /// Consider using an [ObserverList] instead of a [List] when the number of
@@ -28,10 +13,6 @@ class ObserverList<T> extends Iterable<T> {
 
   /// Adds an item to the end of this list.
   void add(T item) {
-    if (_pendingOperations != null) {
-      _pendingOperations.add(_ObserverOperation<T>.add(item));
-      return;
-    }
     _map[item] = (_map[item] ?? 0) + 1;
   }
 
@@ -39,10 +20,6 @@ class ObserverList<T> extends Iterable<T> {
   ///
   /// Returns whether the item was present in the list.
   bool remove(T item) {
-    if (_pendingOperations != null) {
-      _pendingOperations.add(_ObserverOperation<T>.remove(item));
-      return _map.containsKey(item);
-    }
     final int value = _map[item];
     if (value == null) {
       return false;
@@ -53,41 +30,6 @@ class ObserverList<T> extends Iterable<T> {
       _map[item] = value - 1;
     }
     return true;
-  }
-
-  List<_ObserverOperation<T>> _pendingOperations;
-  int _queueModifications = 0;
-
-  /// Allows iteration over the [ObserverList] where it is safe to modify the
-  /// list during iteration.
-  ///
-  /// Any adds/removes that are done on the list during this call are queued
-  /// until after the given callback returns, and then they are applied in the
-  /// order in which they occurred.
-  void safeIteration(ObserverListIterationCallback<T> callback) {
-    assert(callback != null);
-    _queueModifications++;
-    _pendingOperations ??= <_ObserverOperation<T>>[];
-    try {
-      callback(_map.keys);
-    } finally {
-      _queueModifications--;
-      if (_queueModifications == 0) {
-        // Apply all queued operations.
-        for (_ObserverOperation<T> operation in _pendingOperations) {
-          switch (operation.type) {
-            case _ObserverOperationType.add:
-              add(operation.callback);
-              break;
-            case _ObserverOperationType.remove:
-              remove(operation.callback);
-              break;
-          }
-        }
-        _pendingOperations.clear();
-        _pendingOperations = null;
-      }
-    }
   }
 
   @override

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -1,24 +1,37 @@
 // Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:collection';
 
-/// A list optimized for containment queries.
+/// A list optimized for the observer pattern.
 ///
-/// Consider using an [ObserverList] instead of a [List] when the number of
-/// [contains] calls dominates the number of [add] and [remove] calls.
-// TODO(ianh): Use DelegatingIterable, possibly moving it from the collection
-// package to foundation, or to dart:collection.
+/// Consider using an [ObserverList] instead of a [List] when you need a
+/// container that can contain multiple copies of the same entry in insertion
+/// order, but only returns the first copy inserted when iterating, and is
+/// optimized for [add], [remove], and [contains] operations.
+///
+/// It is O(1) (amortized) for [add], [remove], and [contains] operations.
 class ObserverList<T> extends Iterable<T> {
-  final Map<T, int> _map = <T, int>{};
+  final LinkedHashMap<T, int> _map = LinkedHashMap<T, int>();
 
-  /// Adds an item to the end of this list.
+  /// Adds an item to the end of the list.
+  ///
+  /// Multiple copies of the same item may be inserted, but only the first one
+  /// will be returned when iterating over the list.
   void add(T item) {
     _map[item] = (_map[item] ?? 0) + 1;
   }
 
   /// Removes an item from the list.
   ///
-  /// Returns whether the item was present in the list.
+  /// Returns whether the item was present in the list when it was removed.
+  ///
+  /// If more than one copy of the given item is in the list, then only the
+  /// last one is removed.
+  ///
+  /// The iteration performed by [iterator] will be unchanged until all copies
+  /// of the same item are moved (i.e. `remove` is called the same number of
+  /// times that add was called for the item).
   bool remove(T item) {
     final int value = _map[item];
     if (value == null) {
@@ -35,6 +48,10 @@ class ObserverList<T> extends Iterable<T> {
   @override
   bool contains(Object element) => _map.containsKey(element);
 
+  /// Returns an iterator that will iterate over the items in the list.
+  ///
+  /// If there are multiple copies of the same item added to the list, then only
+  /// the first copy is visited as part of the iteration.
   @override
   Iterator<T> get iterator => _map.keys.iterator;
 

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection';
-
 /// A list optimized for containment queries.
 ///
 /// Consider using an [ObserverList] instead of a [List] when the number of
@@ -20,23 +18,22 @@ class ObserverList<T> extends Iterable<T> {
 
   /// Removes an item from the list.
   ///
-  /// This is O(N) in the number of items in the list.
-  ///
   /// Returns whether the item was present in the list.
   bool remove(T item) {
-    assert(_map.containsKey(item));
-    final int count = _map[item] -= 1;
-    if (count == 0) {
-      _map.remove(item);
-      return true;
+    final int value = _map[item];
+    if (value == null) {
+      return false;
     }
-    return false;
+    if (value == 1) {
+      _map.remove(item);
+    } else {
+      _map[item] = value - 1;
+    }
+    return true;
   }
 
   @override
-  bool contains(Object element) {
-    return _map.containsKey(element);
-  }
+  bool contains(Object element) => _map.containsKey(element);
 
   @override
   Iterator<T> get iterator => _map.keys.iterator;

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -2,6 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+enum _ObserverOperationType {
+  add,
+  remove,
+}
+
+class _ObserverOperation<T> {
+  _ObserverOperation.add(this.callback) : type = _ObserverOperationType.add;
+  _ObserverOperation.remove(this.callback) : type = _ObserverOperationType.remove;
+
+  final _ObserverOperationType type;
+  final T callback;
+}
+
+typedef ObserverListIterationCallback<T> = void Function(Iterable<T> iterator);
+
 /// A list optimized for containment queries.
 ///
 /// Consider using an [ObserverList] instead of a [List] when the number of
@@ -13,6 +28,10 @@ class ObserverList<T> extends Iterable<T> {
 
   /// Adds an item to the end of this list.
   void add(T item) {
+    if (_pendingOperations != null) {
+      _pendingOperations.add(_ObserverOperation<T>.add(item));
+      return;
+    }
     _map[item] = (_map[item] ?? 0) + 1;
   }
 
@@ -20,6 +39,10 @@ class ObserverList<T> extends Iterable<T> {
   ///
   /// Returns whether the item was present in the list.
   bool remove(T item) {
+    if (_pendingOperations != null) {
+      _pendingOperations.add(_ObserverOperation<T>.remove(item));
+      return _map.containsKey(item);
+    }
     final int value = _map[item];
     if (value == null) {
       return false;
@@ -30,6 +53,41 @@ class ObserverList<T> extends Iterable<T> {
       _map[item] = value - 1;
     }
     return true;
+  }
+
+  List<_ObserverOperation<T>> _pendingOperations;
+  int _queueModifications = 0;
+
+  /// Allows iteration over the [ObserverList] where it is safe to modify the
+  /// list during iteration.
+  ///
+  /// Any adds/removes that are done on the list during this call are queued
+  /// until after the given callback returns, and then they are applied in the
+  /// order in which they occurred.
+  void safeIteration(ObserverListIterationCallback<T> callback) {
+    assert(callback != null);
+    _queueModifications++;
+    _pendingOperations ??= <_ObserverOperation<T>>[];
+    try {
+      callback(_map.keys);
+    } finally {
+      _queueModifications--;
+      if (_queueModifications == 0) {
+        // Apply all queued operations.
+        for (_ObserverOperation<T> operation in _pendingOperations) {
+          switch (operation.type) {
+            case _ObserverOperationType.add:
+              add(operation.callback);
+              break;
+            case _ObserverOperationType.remove:
+              remove(operation.callback);
+              break;
+          }
+        }
+        _pendingOperations.clear();
+        _pendingOperations = null;
+      }
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -11,14 +11,11 @@ import 'dart:collection';
 // TODO(ianh): Use DelegatingIterable, possibly moving it from the collection
 // package to foundation, or to dart:collection.
 class ObserverList<T> extends Iterable<T> {
-  final List<T> _list = <T>[];
-  bool _isDirty = false;
-  HashSet<T> _set;
+  final Map<T, int> _map = <T, int>{};
 
   /// Adds an item to the end of this list.
   void add(T item) {
-    _isDirty = true;
-    _list.add(item);
+    _map[item] = (_map[item] ?? 0) + 1;
   }
 
   /// Removes an item from the list.
@@ -27,34 +24,26 @@ class ObserverList<T> extends Iterable<T> {
   ///
   /// Returns whether the item was present in the list.
   bool remove(T item) {
-    _isDirty = true;
-    return _list.remove(item);
+    assert(_map.containsKey(item));
+    final int count = _map[item] -= 1;
+    if (count == 0) {
+      _map.remove(item);
+      return true;
+    }
+    return false;
   }
 
   @override
   bool contains(Object element) {
-    if (_list.length < 3)
-      return _list.contains(element);
-
-    if (_isDirty) {
-      if (_set == null) {
-        _set = HashSet<T>.from(_list);
-      } else {
-        _set.clear();
-        _set.addAll(_list);
-      }
-      _isDirty = false;
-    }
-
-    return _set.contains(element);
+    return _map.containsKey(element);
   }
 
   @override
-  Iterator<T> get iterator => _list.iterator;
+  Iterator<T> get iterator => _map.keys.iterator;
 
   @override
-  bool get isEmpty => _list.isEmpty;
+  bool get isEmpty => _map.isEmpty;
 
   @override
-  bool get isNotEmpty => _list.isNotEmpty;
+  bool get isNotEmpty => _map.isNotEmpty;
 }

--- a/packages/flutter/test/animation/iteration_patterns_test.dart
+++ b/packages/flutter/test/animation/iteration_patterns_test.dart
@@ -41,7 +41,7 @@ void main() {
     log.clear();
 
     controller.value = 0.4;
-    expect(log, <String>['listener2', 'listener4', 'listener4']);
+    expect(log, <String>['listener2', 'listener4']);
     log.clear();
   });
 
@@ -74,7 +74,7 @@ void main() {
     log.clear();
 
     controller.forward();
-    expect(log, <String>['listener2', 'listener4', 'listener4']);
+    expect(log, <String>['listener2', 'listener4']);
     log.clear();
 
     controller.dispose();

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -44,7 +44,7 @@ void main() {
     test.addListener(listener);
     test.addListener(listener);
     test.notify();
-    expect(log, <String>['listener', 'listener']);
+    expect(log, <String>['listener']);
     log.clear();
 
     test.removeListener(listener);
@@ -72,6 +72,11 @@ void main() {
     expect(log, <String>['listener', 'listener1']);
     log.clear();
 
+    test.addListener(listener1);
+    test.notify();
+    expect(log, <String>['listener', 'listener1']);
+    log.clear();
+
     test.addListener(listener2);
     test.notify();
     expect(log, <String>['listener', 'listener1', 'listener2']);
@@ -79,17 +84,17 @@ void main() {
 
     test.removeListener(listener1);
     test.notify();
-    expect(log, <String>['listener', 'listener2']);
+    expect(log, <String>['listener', 'listener1', 'listener2']);
     log.clear();
 
     test.addListener(listener1);
     test.notify();
-    expect(log, <String>['listener', 'listener2', 'listener1']);
+    expect(log, <String>['listener', 'listener1', 'listener2']);
     log.clear();
 
     test.addListener(badListener);
     test.notify();
-    expect(log, <String>['listener', 'listener2', 'listener1', 'badListener']);
+    expect(log, <String>['listener', 'listener1', 'listener2', 'badListener']);
     expect(tester.takeException(), isNullThrownError);
     log.clear();
 
@@ -99,7 +104,7 @@ void main() {
     test.removeListener(listener2);
     test.addListener(listener2);
     test.notify();
-    expect(log, <String>['badListener', 'listener1', 'listener2']);
+    expect(log, <String>['listener1', 'badListener', 'listener2']);
     expect(tester.takeException(), isNullThrownError);
     log.clear();
   }, skip: isBrowser);
@@ -130,7 +135,7 @@ void main() {
     log.clear();
 
     test.notify();
-    expect(log, <String>['listener2', 'listener4', 'listener4']);
+    expect(log, <String>['listener2', 'listener4']);
     log.clear();
   });
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -127,7 +127,7 @@ void main() {
     test.addListener(listener2);
     test.addListener(listener3);
     test.notify();
-    expect(log, <String>['listener1', 'listener2', 'listener3']);
+    expect(log, <String>['listener1', 'listener2']);
     log.clear();
 
     test.notify();

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -127,7 +127,7 @@ void main() {
     test.addListener(listener2);
     test.addListener(listener3);
     test.notify();
-    expect(log, <String>['listener1', 'listener2']);
+    expect(log, <String>['listener1', 'listener2', 'listener3']);
     log.clear();
 
     test.notify();


### PR DESCRIPTION
## Description

While investigating a performance regression that some of my code introduced, I noticed that switching out the List in `ObserverList` for a `Map` (which is `LinkedHashMap` under the covers) had a noticeable improvement in both `flutter_gallery__transition_perf` and `complex_layout_scroll_perf__timeline_summary`, the latter being about a 40% improvement.

This PR switches `ObserverList` to not use a `List` and `Set`, replacing those with a `LinkedHashMap` that holds the reference count for each change notifier.

The speedup makes sense, since `LinkedHashMap` is O(1) for removals, and `List` is O(n).

## Related Issues

#38860

## Tests

- Modified `observer_list_test` and `iteration_patterns_test` to not duplicate change notification calls when an observer is added more than once, but still required the correct number of calls to remove all instances.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change (Please read [Handling breaking changes]). (email to come when this is no longer a draft PR)

This PR will cause any code that expects to be called once for each time a change notifier was registered to break, in that it will only be called once, no matter how many times the change notifier was registered.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes