### PR TITLE
[flutter_tool] Use a timeout for xcode showBuildSettings

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -192,7 +192,7 @@ class CocoaPods {
   /// Ensures the given Xcode-based sub-project of a parent Flutter project
   /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
   /// include pods configuration.
-  void setupPodfile(XcodeBasedProject xcodeProject) {
+  Future<void> setupPodfile(XcodeBasedProject xcodeProject) async {
     if (!xcodeProjectInterpreter.isInstalled) {
       // Don't do anything for iOS when host platform doesn't support it.
       return;
@@ -202,27 +202,29 @@ class CocoaPods {
       return;
     }
     final File podfile = xcodeProject.podfile;
-    if (!podfile.existsSync()) {
-      String podfileTemplateName;
-      if (xcodeProject is MacOSProject) {
-        podfileTemplateName = 'Podfile-macos';
-      } else {
-        final bool isSwift = xcodeProjectInterpreter.getBuildSettings(
-          runnerProject.path,
-          'Runner',
-        ).containsKey('SWIFT_VERSION');
-        podfileTemplateName = isSwift ? 'Podfile-ios-swift' : 'Podfile-ios-objc';
-      }
-      final File podfileTemplate = fs.file(fs.path.join(
-        Cache.flutterRoot,
-        'packages',
-        'flutter_tools',
-        'templates',
-        'cocoapods',
-        podfileTemplateName,
-      ));
-      podfileTemplate.copySync(podfile.path);
+    if (podfile.existsSync()) {
+      addPodsDependencyToFlutterXcconfig(xcodeProject);
+      return;
     }
+    String podfileTemplateName;
+    if (xcodeProject is MacOSProject) {
+      podfileTemplateName = 'Podfile-macos';
+    } else {
+      final bool isSwift = (await xcodeProjectInterpreter.getBuildSettingsAsync(
+        runnerProject.path,
+        'Runner',
+      )).containsKey('SWIFT_VERSION');
+      podfileTemplateName = isSwift ? 'Podfile-ios-swift' : 'Podfile-ios-objc';
+    }
+    final File podfileTemplate = fs.file(fs.path.join(
+      Cache.flutterRoot,
+      'packages',
+      'flutter_tools',
+      'templates',
+      'cocoapods',
+      podfileTemplateName,
+    ));
+    podfileTemplate.copySync(podfile.path);
     addPodsDependencyToFlutterXcconfig(xcodeProject);
   }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -371,7 +371,7 @@ Future<void> injectPlugins(FlutterProject project, {bool checkProjects = false})
   if (!project.isModule && (!checkProjects || subproject.existsSync())) {
     final CocoaPods cocoaPods = CocoaPods();
     if (plugins.isNotEmpty) {
-      cocoaPods.setupPodfile(subproject);
+      await cocoaPods.setupPodfile(subproject);
     }
     /// The user may have a custom maintained Podfile that they're running `pod install`
     /// on themselves.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -22,24 +22,29 @@ import 'ios/xcodeproj.dart' as xcode;
 import 'plugins.dart';
 import 'template.dart';
 
-FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? const FlutterProjectFactory();
+FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? FlutterProjectFactory();
 
 class FlutterProjectFactory {
-  const FlutterProjectFactory();
+  FlutterProjectFactory();
+
+  final Map<String, FlutterProject> _projects =
+      <String, FlutterProject>{};
 
   /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   FlutterProject fromDirectory(Directory directory) {
     assert(directory != null);
-    final FlutterManifest manifest = FlutterProject._readManifest(
-      directory.childFile(bundle.defaultManifestPath).path,
-    );
-    final FlutterManifest exampleManifest = FlutterProject._readManifest(
-      FlutterProject._exampleDirectory(directory)
-          .childFile(bundle.defaultManifestPath)
-          .path,
-    );
-    return FlutterProject(directory, manifest, exampleManifest);
+    return _projects.putIfAbsent(directory.path, /* ifAbsent */ () {
+      final FlutterManifest manifest = FlutterProject._readManifest(
+        directory.childFile(bundle.defaultManifestPath).path,
+      );
+      final FlutterManifest exampleManifest = FlutterProject._readManifest(
+        FlutterProject._exampleDirectory(directory)
+            .childFile(bundle.defaultManifestPath)
+            .path,
+      );
+      return FlutterProject(directory, manifest, exampleManifest);
+    });
   }
 }
 
@@ -394,8 +399,13 @@ class IosProject implements XcodeBasedProject {
   Map<String, String> get buildSettings {
     if (!xcode.xcodeProjectInterpreter.isInstalled)
       return null;
-    return xcode.xcodeProjectInterpreter.getBuildSettings(xcodeProject.path, _hostAppBundleName);
+    _buildSettings ??=
+        xcode.xcodeProjectInterpreter.getBuildSettings(xcodeProject.path,
+                                                       _hostAppBundleName);
+    return _buildSettings;
   }
+
+  Map<String, String> _buildSettings;
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {
     _regenerateFromTemplateIfNeeded();

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -17,19 +17,20 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/mocks.dart' as mocks;
 import '../../src/pubspec_schema.dart';
 
 const String xcodebuild = '/usr/bin/xcodebuild';
 
 void main() {
   group('xcodebuild versioning', () {
-    MockProcessManager mockProcessManager;
+    mocks.MockProcessManager mockProcessManager;
     XcodeProjectInterpreter xcodeProjectInterpreter;
     FakePlatform macOS;
     FileSystem fs;
 
     setUp(() {
-      mockProcessManager = MockProcessManager();
+      mockProcessManager = mocks.MockProcessManager();
       xcodeProjectInterpreter = XcodeProjectInterpreter();
       macOS = fakePlatform('macos');
       fs = MemoryFileSystem();
@@ -148,6 +149,23 @@ void main() {
       when(mockProcessManager.runSync(argThat(contains(xcodebuild))))
           .thenReturn(ProcessResult(0, 1, '', ''));
       expect(xcodeProjectInterpreter.getBuildSettings('', ''), const <String, String>{});
+    });
+
+    testUsingContext('build settings flakes', () async {
+      const Duration delay = Duration(seconds: 1);
+      mockProcessManager.processFactory =
+          mocks.flakyProcessFactory(1, delay: delay + const Duration(seconds: 1));
+      expect(await xcodeProjectInterpreter.getBuildSettingsAsync(
+                 '', '', timeout: delay),
+             const <String, String>{});
+      // build settings times out and is killed once, then succeeds.
+      verify(mockProcessManager.killPid(any)).called(1);
+      // The verbose logs should tell us something timed out.
+      expect(testLogger.traceText, contains('timed out'));
+    }, overrides: <Type, Generator>{
+      Platform: () => macOS,
+      FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
     });
   });
   group('Xcode project properties', () {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -164,7 +164,7 @@ void main() {
 
   group('Setup Podfile', () {
     testUsingContext('creates objective-c Podfile when not present', () async {
-      cocoaPodsUnderTest.setupPodfile(projectUnderTest.ios);
+      await cocoaPodsUnderTest.setupPodfile(projectUnderTest.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Objective-C iOS podfile template');
     }, overrides: <Type, Generator>{
@@ -173,12 +173,13 @@ void main() {
 
     testUsingContext('creates swift Podfile if swift', () async {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.getBuildSettings(any, any)).thenReturn(<String, String>{
+      when(mockXcodeProjectInterpreter.getBuildSettingsAsync(any, any))
+          .thenAnswer((_) async => <String, String>{
         'SWIFT_VERSION': '4.0',
       });
 
       final FlutterProject project = FlutterProject.fromPath('project');
-      cocoaPodsUnderTest.setupPodfile(project.ios);
+      await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Swift iOS podfile template');
     }, overrides: <Type, Generator>{
@@ -188,7 +189,7 @@ void main() {
 
     testUsingContext('creates macOS Podfile when not present', () async {
       projectUnderTest.macos.xcodeProject.createSync(recursive: true);
-      cocoaPodsUnderTest.setupPodfile(projectUnderTest.macos);
+      await cocoaPodsUnderTest.setupPodfile(projectUnderTest.macos);
 
       expect(projectUnderTest.macos.podfile.readAsStringSync(), 'macOS podfile template');
     }, overrides: <Type, Generator>{
@@ -199,7 +200,7 @@ void main() {
       projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Existing Podfile');
 
       final FlutterProject project = FlutterProject.fromPath('project');
-      cocoaPodsUnderTest.setupPodfile(project.ios);
+      await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Existing Podfile');
     }, overrides: <Type, Generator>{
@@ -210,7 +211,7 @@ void main() {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
 
       final FlutterProject project = FlutterProject.fromPath('project');
-      cocoaPodsUnderTest.setupPodfile(project.ios);
+      await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.existsSync(), false);
     }, overrides: <Type, Generator>{
@@ -228,7 +229,7 @@ void main() {
         ..writeAsStringSync('Existing release config');
 
       final FlutterProject project = FlutterProject.fromPath('project');
-      cocoaPodsUnderTest.setupPodfile(project.ios);
+      await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
       expect(debugContents, contains(

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -244,9 +244,11 @@ void main() {
     group('language', () {
       MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
       MemoryFileSystem fs;
+      FlutterProjectFactory flutterProjectFactory;
       setUp(() {
         fs = MemoryFileSystem();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+        flutterProjectFactory = FlutterProjectFactory();
       });
 
       testInMemory('default host app language', () async {
@@ -273,6 +275,7 @@ apply plugin: 'kotlin-android'
       }, overrides: <Type, Generator>{
           FileSystem: () => fs,
           XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+          FlutterProjectFactory: () => flutterProjectFactory,
       });
     });
 
@@ -280,10 +283,12 @@ apply plugin: 'kotlin-android'
       MemoryFileSystem fs;
       MockPlistUtils mockPlistUtils;
       MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
+      FlutterProjectFactory flutterProjectFactory;
       setUp(() {
         fs = MemoryFileSystem();
         mockPlistUtils = MockPlistUtils();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+        flutterProjectFactory = FlutterProjectFactory();
       });
 
       void testWithMocks(String description, Future<void> testMethod()) {
@@ -291,6 +296,7 @@ apply plugin: 'kotlin-android'
           FileSystem: () => fs,
           PlistParser: () => mockPlistUtils,
           XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+          FlutterProjectFactory: () => flutterProjectFactory,
         });
       }
 
@@ -425,9 +431,11 @@ apply plugin: 'kotlin-android'
 
   group('Regression test for invalid pubspec', () {
     Testbed testbed;
+    FlutterProjectFactory flutterProjectFactory;
 
     setUp(() {
       testbed = Testbed();
+      flutterProjectFactory = FlutterProjectFactory();
     });
 
     test('Handles asking for builders from an invalid pubspec', () => testbed.run(() {
@@ -439,6 +447,8 @@ apply plugin: 'kotlin-android'
       final FlutterProject flutterProject = FlutterProject.current();
 
       expect(flutterProject.builders, null);
+    }, overrides: <Type, Generator>{
+      FlutterProjectFactory: () => flutterProjectFactory,
     }));
 
     test('Handles asking for builders from a trivial pubspec', () => testbed.run(() {
@@ -451,6 +461,8 @@ name: foo_bar
       final FlutterProject flutterProject = FlutterProject.current();
 
       expect(flutterProject.builders, null);
+    }, overrides: <Type, Generator>{
+      FlutterProjectFactory: () => flutterProjectFactory,
     }));
   });
 }
@@ -510,12 +522,16 @@ void testInMemory(String description, Future<void> testMethod()) {
       .childDirectory('packages')
       .childDirectory('flutter_tools')
       .childDirectory('schema'), testFileSystem);
+
+  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory();
+
   testUsingContext(
     description,
     testMethod,
     overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       Cache: () => Cache(),
+      FlutterProjectFactory: () => flutterProjectFactory,
     },
   );
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -336,6 +336,15 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   }
 
   @override
+  Future<Map<String, String>> getBuildSettingsAsync(
+    String projectPath,
+    String target, {
+    Duration timeout = const Duration(minutes: 1),
+  }) async {
+    return <String, String>{};
+  }
+
+  @override
   void cleanWorkspace(String workspacePath, String scheme) {
   }
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -182,6 +182,26 @@ class MockProcessManager extends Mock implements ProcessManager {
   }
 }
 
+/// A function that generates a process factory that gives processes that fail
+/// a given number of times before succeeding. The returned processes will
+/// fail after a delay if one is supplied.
+ProcessFactory flakyProcessFactory(int flakes, {Duration delay}) {
+  int flakesLeft = flakes;
+  return (List<String> command) {
+    if (flakesLeft == 0) {
+      return MockProcess(exitCode: Future<int>.value(0));
+    }
+    flakesLeft = flakesLeft - 1;
+    Future<int> exitFuture;
+    if (delay == null) {
+      exitFuture = Future<int>.value(-9);
+    } else {
+      exitFuture = Future<int>.delayed(delay, () => Future<int>.value(-9));
+    }
+    return MockProcess(exitCode: exitFuture);
+  };
+}
+
 /// A process that exits successfully with no output and ignores all input.
 class MockProcess extends Mock implements Process {
   MockProcess({


### PR DESCRIPTION
## Description

Subcommands called by the tool may hang. Subsequent invocations may then succeed. This PR adds optional named parameters to `runAsync()` and `runCheckedAsync()` to provide for the need to retry subcommands that time-out.

In particular, when xcode runs with the `-showBuildSettings` flag it may timeout and then succeed on retry. This PR updates the call site from the issue reported below to time out after one minute, and retry one time. Additionally, this PR caches the result of the `-showBuildSettings` subcommand that could not be made asynchronous since it is called from a constructor.

## Related Issues

https://github.com/flutter/flutter/issues/35988
https://github.com/flutter/flutter/issues/39141

## Tests

I added the following tests:

Added tests of timeout with retry to process_test.dart. Updated other affected tests.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.