### PR TITLE
Add showAboutDialog sample

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -36,7 +36,7 @@ import 'theme.dart';
 /// {@tool snippet --template=stateless_widget_material}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
-/// using a [AboutListTile], while the second one is by clicking a [RaisedButton].
+/// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
 ///
 /// ```dart
 /// Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -42,7 +42,7 @@ import 'theme.dart';
 /// Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       appBar: AppBar(
-///         title: Text("Show About Example"),
+///         title: Text('Show About Example'),
 ///       ),
 ///       drawer: Drawer(
 ///         child: ListView(
@@ -50,9 +50,9 @@ import 'theme.dart';
 ///             AboutListTile(
 ///               icon: Icon(Icons.info),
 ///               applicationIcon: FlutterLogo(),
-///               applicationName: "Show About Example",
-///               applicationVersion: "V1.0.1",
-///               applicationLegalese: "This is a Show About Example",
+///               applicationName: 'Show About Example',
+///               applicationVersion: 'V1.0.1',
+///               applicationLegalese: 'This is a Show About Example',
 ///               aboutBoxChildren: <Widget>[
 ///                 Text('Extra 1'),
 ///                 Text('Extra 2'),
@@ -63,13 +63,13 @@ import 'theme.dart';
 ///       ),
 ///       body: Center(
 ///         child: RaisedButton(
-///           child: Text("Show About Example"),
+///           child: Text('Show About Example'),
 ///           onPressed: () => showAboutDialog(
 ///             context: context,
 ///             applicationIcon: FlutterLogo(),
-///             applicationName: "Show About Example",
-///             applicationVersion: "V1.0.1",
-///             applicationLegalese: "This is a Show About Example",
+///             applicationName: 'Show About Example',
+///             applicationVersion: 'V1.0.1',
+///             applicationLegalese: 'This is a Show About Example',
 ///             children: <Widget>[
 ///               Text('Widget 1'),
 ///               Text('Widget 2'),

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -33,6 +33,55 @@ import 'theme.dart';
 ///
 /// If your application does not have a [Drawer], you should provide an
 /// affordance to call [showAboutDialog] or (at least) [showLicensePage].
+/// {@tool snippet --template=stateless_widget_material}
+///
+/// This sample shows two ways to open [AboutDialog]. The first one
+/// using a [AboutListTile], while the second one is by clicking a [RaisedButton].
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(
+///         title: Text("Show About Example"),
+///       ),
+///       drawer: Drawer(
+///         child: ListView(
+///           children: <Widget>[
+///             AboutListTile(
+///               icon: Icon(Icons.info),
+///               applicationIcon: FlutterLogo(),
+///               applicationName: "Show About Example",
+///               applicationVersion: "V1.0.1",
+///               applicationLegalese: "This is a Show About Example",
+///               aboutBoxChildren: <Widget>[
+///                 Text('Extra 1'),
+///                 Text('Extra 2'),
+///               ],
+///             )
+///           ],
+///         ),
+///       ),
+///       body: Center(
+///         child: RaisedButton(
+///           child: Text("Show About Example"),
+///           onPressed: () => showAboutDialog(
+///             context: context,
+///             applicationIcon: FlutterLogo(),
+///             applicationName: "Show About Example",
+///             applicationVersion: "V1.0.1",
+///             applicationLegalese: "This is a Show About Example",
+///             children: <Widget>[
+///               Text('Widget 1'),
+///               Text('Widget 2'),
+///             ],
+///           ),
+///         ),
+///       ),
+///     );
+///   }
+/// ```
+/// {@end-tool}
+///
 class AboutListTile extends StatelessWidget {
   /// Creates a list tile for showing an about box.
   ///

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -40,7 +40,6 @@ import 'theme.dart';
 ///
 /// ```dart
 ///
-///  @override
 ///  Widget build(BuildContext context) {
 ///    final TextStyle textStyle = Theme.of(context).textTheme.body1;
 ///    final List<Widget> aboutBoxChildren = <Widget>[
@@ -101,7 +100,7 @@ import 'theme.dart';
 ///        ),
 ///      ),
 ///    );
-///
+///}
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -42,22 +42,47 @@ import 'theme.dart';
 ///
 ///  @override
 ///  Widget build(BuildContext context) {
+///    final TextStyle textStyle = Theme.of(context).textTheme.body1;
+///    final List<Widget> aboutBoxChildren = <Widget>[
+///      SizedBox(height: 24),
+///      RichText(
+///        text: TextSpan(
+///          children: <TextSpan>[
+///            TextSpan(
+///              style: textStyle,
+///              text: 'Flutter is Google’s UI toolkit for building beautiful, '
+///              'natively compiled applications for mobile, web, and desktop '
+///              'from a single codebase. Learn more about Flutter at '
+///            ),
+///            TextSpan(
+///              style: textStyle.copyWith(color: Theme.of(context).accentColor),
+///              text: 'https://flutter.dev'
+///            ),
+///            TextSpan(
+///              style: textStyle,
+///              text: '.'
+///            ),
+///          ],
+///        ),
+///      ),
+///    ];
+///
 ///    return Scaffold(
 ///      appBar: AppBar(
 ///        title: Text('Show About Example'),
 ///      ),
 ///      drawer: Drawer(
-///        child: ListView(
-///          children: <Widget>[
-///            AboutListTile(
+///        child: SingleChildScrollView(
+///          child: SafeArea(
+///            child: AboutListTile(
 ///              icon: Icon(Icons.info),
 ///              applicationIcon: FlutterLogo(),
 ///              applicationName: 'Show About Example',
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '© 2019 The Chromium Authors',
-///              aboutBoxChildren: _aboutBoxChildren(context),
-///            )
-///          ],
+///              aboutBoxChildren: aboutBoxChildren,
+///            ),
+///          ),
 ///        ),
 ///      ),
 ///      body: Center(
@@ -70,36 +95,12 @@ import 'theme.dart';
 ///              applicationName: 'Show About Example',
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '© 2019 The Chromium Authors',
-///              children: _aboutBoxChildren(context),
+///              children: aboutBoxChildren,
 ///            );
 ///          },
 ///        ),
 ///      ),
 ///    );
-///  }
-///
-///  _aboutBoxChildren(BuildContext context) {
-///    return <Widget>[
-///      Padding(
-///        padding: EdgeInsets.only(top: 24.0),
-///        child: RichText(
-///          text: TextSpan(children: <TextSpan>[
-///            TextSpan(
-///                style: Theme.of(context).textTheme.body1,
-///                text: 'Flutter is Google’s UI toolkit for building beautiful, '
-///                    'natively compiled applications for mobile, web, and desktop '
-///                    'from a single codebase. Learn more about Flutter at '),
-///            TextSpan(
-///                style: Theme.of(context)
-///                    .textTheme
-///                    .body1
-///                    .copyWith(color: Theme.of(context).accentColor),
-///                text: 'https://flutter.dev'),
-///          ]),
-///        ),
-///      )
-///    ];
-///  }
 ///
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -39,7 +39,7 @@ import 'theme.dart';
 /// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
 ///
 /// ```dart
-///class AboutDialogSample extends StatelessWidget {
+///
 ///  final String _applicationVersion = 'August 2019';
 ///  final String _applicationLegalese = '© 2019 The Chromium Authors';
 ///  final String _applicationName ='Show About Example';
@@ -103,7 +103,7 @@ import 'theme.dart';
 ///      )
 ///    ];
 ///  }
-///}
+///
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -64,17 +64,19 @@ import 'theme.dart';
 ///       body: Center(
 ///         child: RaisedButton(
 ///           child: Text('Show About Example'),
-///           onPressed: () => showAboutDialog(
-///             context: context,
-///             applicationIcon: FlutterLogo(),
-///             applicationName: 'Show About Example',
-///             applicationVersion: 'V1.0.1',
-///             applicationLegalese: 'This is a Show About Example',
-///             children: <Widget>[
-///               Text('Widget 1'),
-///               Text('Widget 2'),
-///             ],
-///           ),
+///           onPressed: () {
+///            showAboutDialog(
+///              context: context,
+///              applicationIcon: FlutterLogo(),
+///              applicationName: 'Show About Example',
+///              applicationVersion: 'V1.0.1',
+///              applicationLegalese: 'This is a Show About Example',
+///              children: <Widget>[
+///                Text('Widget 1'),
+///                Text('Widget 2'),
+///              ],
+///            );
+///          },
 ///         ),
 ///       ),
 ///     );

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -40,9 +40,6 @@ import 'theme.dart';
 ///
 /// ```dart
 ///
-///  final String _applicationVersion = 'August 2019';
-///  final String _applicationLegalese = '© 2019 The Chromium Authors';
-///  final String _applicationName ='Show About Example';
 ///  @override
 ///  Widget build(BuildContext context) {
 ///    return Scaffold(
@@ -55,9 +52,9 @@ import 'theme.dart';
 ///            AboutListTile(
 ///              icon: Icon(Icons.info),
 ///              applicationIcon: FlutterLogo(),
-///              applicationName: _applicationName,
-///              applicationVersion: _applicationVersion,
-///              applicationLegalese: _applicationLegalese,
+///              applicationName: 'Show About Example',
+///              applicationVersion: 'August 2019',
+///              applicationLegalese: '© 2019 The Chromium Authors',
 ///              aboutBoxChildren: _aboutBoxChildren(context),
 ///            )
 ///          ],
@@ -65,14 +62,14 @@ import 'theme.dart';
 ///      ),
 ///      body: Center(
 ///        child: RaisedButton(
-///          child: Text(_applicationName),
+///          child: Text('Show About Example'),
 ///          onPressed: () {
 ///            showAboutDialog(
 ///              context: context,
 ///              applicationIcon: FlutterLogo(),
-///              applicationName: _applicationName,
-///              applicationVersion: _applicationVersion,
-///              applicationLegalese: _applicationLegalese,
+///              applicationName: 'Show About Example',
+///              applicationVersion: 'August 2019',
+///              applicationLegalese: '© 2019 The Chromium Authors',
 ///              children: _aboutBoxChildren(context),
 ///            );
 ///          },

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -39,48 +39,71 @@ import 'theme.dart';
 /// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
 ///
 /// ```dart
-/// Widget build(BuildContext context) {
-///     return Scaffold(
-///       appBar: AppBar(
-///         title: Text('Show About Example'),
-///       ),
-///       drawer: Drawer(
-///         child: ListView(
-///           children: <Widget>[
-///             AboutListTile(
-///               icon: Icon(Icons.info),
-///               applicationIcon: FlutterLogo(),
-///               applicationName: 'Show About Example',
-///               applicationVersion: 'V1.0.1',
-///               applicationLegalese: 'This is a Show About Example',
-///               aboutBoxChildren: <Widget>[
-///                 Text('Extra 1'),
-///                 Text('Extra 2'),
-///               ],
-///             )
-///           ],
-///         ),
-///       ),
-///       body: Center(
-///         child: RaisedButton(
-///           child: Text('Show About Example'),
-///           onPressed: () {
+///class AboutDialogSample extends StatelessWidget {
+///  final String _applicationVersion = 'August 2019';
+///  final String _applicationLegalese = '© 2019 The Chromium Authors';
+///  final String _applicationName ='Show About Example';
+///  @override
+///  Widget build(BuildContext context) {
+///    return Scaffold(
+///      appBar: AppBar(
+///        title: Text('Show About Example'),
+///      ),
+///      drawer: Drawer(
+///        child: ListView(
+///          children: <Widget>[
+///            AboutListTile(
+///              icon: Icon(Icons.info),
+///              applicationIcon: FlutterLogo(),
+///              applicationName: _applicationName,
+///              applicationVersion: _applicationVersion,
+///              applicationLegalese: _applicationLegalese,
+///              aboutBoxChildren: _aboutBoxChildren(context),
+///            )
+///          ],
+///        ),
+///      ),
+///      body: Center(
+///        child: RaisedButton(
+///          child: Text(_applicationName),
+///          onPressed: () {
 ///            showAboutDialog(
 ///              context: context,
 ///              applicationIcon: FlutterLogo(),
-///              applicationName: 'Show About Example',
-///              applicationVersion: 'V1.0.1',
-///              applicationLegalese: 'This is a Show About Example',
-///              children: <Widget>[
-///                Text('Widget 1'),
-///                Text('Widget 2'),
-///              ],
+///              applicationName: _applicationName,
+///              applicationVersion: _applicationVersion,
+///              applicationLegalese: _applicationLegalese,
+///              children: _aboutBoxChildren(context),
 ///            );
 ///          },
-///         ),
-///       ),
-///     );
-///   }
+///        ),
+///      ),
+///    );
+///  }
+///
+///  _aboutBoxChildren(BuildContext context) {
+///    return <Widget>[
+///      Padding(
+///        padding: EdgeInsets.only(top: 24.0),
+///        child: RichText(
+///          text: TextSpan(children: <TextSpan>[
+///            TextSpan(
+///                style: Theme.of(context).textTheme.body1,
+///                text: 'Flutter is Google’s UI toolkit for building beautiful, '
+///                    'natively compiled applications for mobile, web, and desktop '
+///                    'from a single codebase. Learn more about Flutter at '),
+///            TextSpan(
+///                style: Theme.of(context)
+///                    .textTheme
+///                    .body1
+///                    .copyWith(color: Theme.of(context).accentColor),
+///                text: 'https://flutter.dev'),
+///          ]),
+///        ),
+///      )
+///    ];
+///  }
+///}
 /// ```
 /// {@end-tool}
 ///


### PR DESCRIPTION
## Description

Added a sample that shows two ways to open **AboutDialog** using showAboutDialog and AboutListTile widget
## Related Issues

[#34495]

## Tests

I added the following tests:

No tests added

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
