### PR TITLE
surface errors from build runner

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -321,7 +321,25 @@ class BuildDaemonCreator {
         '--define', 'flutter_tools:shell=flutterWebSdk=$flutterWebSdk',
       ],
       logHandler: (ServerLog serverLog) {
-        printTrace(serverLog.message);
+        switch (serverLog.level) {
+          case Level.SEVERE:
+          case Level.SHOUT:
+            // This message is always returned once since we're running the
+            // build script from source.
+            if (serverLog.message.contains('Warning: Interpreting this as package URI')) {
+              return;
+            }
+            printError(serverLog.message);
+            if (serverLog.error != null) {
+              printError(serverLog.error);
+            }
+            if (serverLog.stackTrace != null) {
+              printTrace(serverLog.stackTrace);
+            }
+            break;
+          default:
+            printTrace(serverLog.message);
+        }
       },
       buildMode: daemon.BuildMode.Manual,
     );


### PR DESCRIPTION
## Description

These messages were not being forwarded correctly. Make sure severe and shout always get a printError. Place the stackTrace under printTrace, since it is usually not interesting for app developers.