### PR TITLE
make CupertinoDynamicColor const constructible

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show Color;
-import 'package:collection/collection.dart' show DeepCollectionEquality;
 
 import '../../foundation.dart';
 import '../widgets/basic.dart';
@@ -144,7 +143,7 @@ class CupertinoDynamicColor extends Color {
   /// [BuildContext] given. The default effective color is [color].
   ///
   /// All the colors must not be null.
-  CupertinoDynamicColor({
+  const CupertinoDynamicColor({
     @required Color color,
     @required Color darkColor,
     @required Color highContrastColor,
@@ -155,16 +154,14 @@ class CupertinoDynamicColor extends Color {
     @required Color darkHighContrastElevatedColor,
   }) : this._(
          color,
-         <List<List<Color>>>[
-           <List<Color>>[
-             <Color>[darkColor, darkElevatedColor],
-             <Color>[darkHighContrastColor, darkHighContrastElevatedColor],
-           ],
-         <List<Color>>[
-             <Color>[color, elevatedColor],
-             <Color>[highContrastColor, highContrastElevatedColor],
-           ],
-         ],
+         color,
+         darkColor,
+         highContrastColor,
+         darkHighContrastColor,
+         elevatedColor,
+         darkElevatedColor,
+         highContrastElevatedColor,
+         darkHighContrastElevatedColor,
        );
 
   /// Creates an adaptive [Color] that changes its effective color based on the
@@ -173,7 +170,7 @@ class CupertinoDynamicColor extends Color {
   /// ([MediaQueryData.highContrast]). The default effective color is [color].
   ///
   /// All the colors must not be null.
-  CupertinoDynamicColor.withBrightnessAndContrast({
+  const CupertinoDynamicColor.withBrightnessAndContrast({
     @required Color color,
     @required Color darkColor,
     @required Color highContrastColor,
@@ -188,12 +185,13 @@ class CupertinoDynamicColor extends Color {
     highContrastElevatedColor: highContrastColor,
     darkHighContrastElevatedColor: darkHighContrastColor,
   );
+
   /// Creates an adaptive [Color] that changes its effective color based on the given
   /// [BuildContext]'s brightness (from [MediaQueryData.platformBrightness] or
   /// [CupertinoThemeData.brightness]). The default effective color is [color].
   ///
   /// All the colors must not be null.
-  CupertinoDynamicColor.withBrightness({
+  const CupertinoDynamicColor.withBrightness({
     @required Color color,
     @required Color darkColor,
   }) : this(
@@ -207,19 +205,31 @@ class CupertinoDynamicColor extends Color {
     darkHighContrastElevatedColor: darkColor,
   );
 
-  CupertinoDynamicColor._(
-    Color value,
-    this._colorMap,
-  ) : assert(() {
-        Iterable<Object> expand(Object a) {
-          return (a is Iterable<Object>) ? a.expand<Object>(expand) : <Object>[a];
-        }
+  const CupertinoDynamicColor._(
+    this._effectiveColor,
+    this.color,
+    this.darkColor,
+    this.highContrastColor,
+    this.darkHighContrastColor,
+    this.elevatedColor,
+    this.darkElevatedColor,
+    this.highContrastElevatedColor,
+    this.darkHighContrastElevatedColor,
+  ) : assert(color != null),
+      assert(darkColor != null),
+      assert(highContrastColor != null),
+      assert(darkHighContrastColor != null),
+      assert(elevatedColor != null),
+      assert(darkElevatedColor != null),
+      assert(highContrastElevatedColor != null),
+      assert(darkHighContrastElevatedColor != null),
+      assert(_effectiveColor != null),
+      super(0);
 
-        final Iterable<Object> expanded = expand(_colorMap);
-        assert(expanded.contains(value), '$value is not one of $_colorMap');
-        return !expanded.contains(null) && expanded.length == 8;
-      }(), 'The colorMap provided is invalid: $_colorMap'),
-      super(value.value);
+  final Color _effectiveColor;
+
+  @override
+  int get value => _effectiveColor.value;
 
   /// The color to use when the [BuildContext] implies a combination of light mode,
   /// normal contrast, and base interface elevation.
@@ -230,9 +240,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.light].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `false`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.base].
-  Color get color => _colorMap[Brightness.light.index]
-                              [0]  // 0 for normal contrast.
-                              [CupertinoUserInterfaceLevelData.base.index];
+  final Color color;
 
   /// The color to use when the [BuildContext] implies a combination of dark mode,
   /// normal contrast, and base interface elevation.
@@ -243,9 +251,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.dark].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `false`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.base].
-  Color get darkColor => _colorMap[Brightness.dark.index]
-                                  [0]  // 0 for normal contrast.
-                                  [CupertinoUserInterfaceLevelData.base.index];
+  final Color darkColor;
 
   /// The color to use when the [BuildContext] implies a combination of light mode,
   /// high contrast, and base interface elevation.
@@ -256,9 +262,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.light].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `true`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.base].
-  Color get highContrastColor => _colorMap[Brightness.light.index]
-                                          [1]  // 1 for high contrast.
-                                          [CupertinoUserInterfaceLevelData.base.index];
+  final Color highContrastColor;
 
   /// The color to use when the [BuildContext] implies a combination of dark mode,
   /// high contrast, and base interface elevation.
@@ -269,9 +273,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.dark].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `true`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.base].
-  Color get darkHighContrastColor => _colorMap[Brightness.dark.index]
-                                              [1]  // 1 for high contrast.
-                                              [CupertinoUserInterfaceLevelData.base.index];
+  final Color darkHighContrastColor;
 
   /// The color to use when the [BuildContext] implies a combination of light mode,
   /// normal contrast, and elevated interface elevation.
@@ -282,9 +284,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.light].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `false`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.elevated].
-  Color get elevatedColor => _colorMap [Brightness.light.index]
-                                       [0]  // 0 for normal contrast.
-                                       [CupertinoUserInterfaceLevelData.elevated.index];
+  final Color elevatedColor;
 
   /// The color to use when the [BuildContext] implies a combination of dark mode,
   /// normal contrast, and elevated interface elevation.
@@ -295,9 +295,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.dark].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `false`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.elevated].
-  Color get darkElevatedColor => _colorMap[Brightness.dark.index]
-                                          [0]  // 0 for normal contrast.
-                                          [CupertinoUserInterfaceLevelData.elevated.index];
+  final Color darkElevatedColor;
 
   /// The color to use when the [BuildContext] implies a combination of light mode,
   /// high contrast, and elevated interface elevation.
@@ -308,9 +306,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.light].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `true`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.elevated].
-  Color get highContrastElevatedColor => _colorMap[Brightness.light.index]
-                                                  [1]  // 1 for high contrast.
-                                                  [CupertinoUserInterfaceLevelData.elevated.index];
+  final Color highContrastElevatedColor;
 
   /// The color to use when the [BuildContext] implies a combination of dark mode,
   /// high contrast, and elevated interface elevation.
@@ -321,11 +317,7 @@ class CupertinoDynamicColor extends Color {
   /// or a [MediaQuery] whose [MediaQueryData.platformBrightness] is [PlatformBrightness.dark].
   /// - has a [MediaQuery] whose [MediaQueryData.highContrast] is `true`.
   /// - has a [CupertinoUserInterfaceLevel] that indicates [CupertinoUserInterfaceLevelData.elevated].
-  Color get darkHighContrastElevatedColor => _colorMap[Brightness.dark.index]
-                                                      [1]  // 1 for high contrast.
-                                                      [CupertinoUserInterfaceLevelData.elevated.index];
-
-  final List<List<List<Color>>> _colorMap;
+  final Color darkHighContrastElevatedColor;
 
   /// Resolves the given [Color] by calling [resolveFrom].
   ///
@@ -388,34 +380,54 @@ class CupertinoDynamicColor extends Color {
   /// If any of the required dependecies are missing from the given context, an exception
   /// will be thrown unless [nullOk] is set to `true`.
   CupertinoDynamicColor resolveFrom(BuildContext context, { bool nullOk = false }) {
-    int brightnessNumber = 0;
-    int highContrastNumber = 0;
-    int interfaceElevationNumber = 0;
+    final Brightness brightness = _isPlatformBrightnessDependent
+      ? CupertinoTheme.brightnessOf(context, nullOk: nullOk) ?? Brightness.light
+      : Brightness.light;
 
-    // If this CupertinoDynamicColor cares about brightness.
-    if (_isPlatformBrightnessDependent) {
-      final Brightness brightness = CupertinoTheme.brightnessOf(context, nullOk: nullOk) ?? Brightness.light;
-      brightnessNumber = brightness.index;
+    final bool isHighContrastEnabled = _isHighContrastDependent
+      && (MediaQuery.of(context, nullOk: nullOk)?.highContrast ?? false);
+
+
+    final CupertinoUserInterfaceLevelData level = _isInterfaceElevationDependent
+      ? CupertinoUserInterfaceLevel.of(context, nullOk: nullOk) ?? CupertinoUserInterfaceLevelData.base
+      : CupertinoUserInterfaceLevelData.base;
+
+    Color resolved;
+    switch (brightness) {
+      case Brightness.light:
+        switch (level) {
+          case CupertinoUserInterfaceLevelData.base:
+            resolved = isHighContrastEnabled ? highContrastColor : color;
+            break;
+          case CupertinoUserInterfaceLevelData.elevated:
+            resolved = isHighContrastEnabled ? highContrastElevatedColor : elevatedColor;
+        }
+        break;
+      case Brightness.dark:
+        switch (level) {
+          case CupertinoUserInterfaceLevelData.base:
+            resolved = isHighContrastEnabled ? darkHighContrastColor : darkColor;
+            break;
+          case CupertinoUserInterfaceLevelData.elevated:
+            resolved = isHighContrastEnabled ? darkHighContrastElevatedColor : darkElevatedColor;
+            break;
+        }
     }
 
-    // If this CupertinoDynamicColor cares about accessibility contrast.
-    if (_isHighContrastDependent) {
-      final bool isHighContrastEnabled = MediaQuery.of(context, nullOk: nullOk)?.highContrast
-        ?? false;
-
-        highContrastNumber = isHighContrastEnabled ? 1 : 0;
-    }
-
-    // If this CupertinoDynamicColor cares about user interface elevation.
-    if (_isInterfaceElevationDependent) {
-      final CupertinoUserInterfaceLevelData level = CupertinoUserInterfaceLevel.of(context, nullOk: nullOk)
-        ?? CupertinoUserInterfaceLevelData.base;
-
-      interfaceElevationNumber = level.index;
-    }
-
-    final Color resolved = _colorMap[brightnessNumber][highContrastNumber][interfaceElevationNumber];
-    return resolved.value == value ? this : CupertinoDynamicColor._(resolved, _colorMap);
+    assert(resolved != null);
+    return resolved.value == value
+      ? this
+      : CupertinoDynamicColor._(
+          resolved,
+          color,
+          darkColor,
+          highContrastColor,
+          darkHighContrastColor,
+          elevatedColor,
+          darkElevatedColor,
+          highContrastElevatedColor,
+          darkHighContrastElevatedColor,
+      );
   }
 
   @override
@@ -425,7 +437,14 @@ class CupertinoDynamicColor extends Color {
 
     return other.runtimeType == runtimeType
         && value == other.value
-        && (identical(_colorMap, other._colorMap) || const DeepCollectionEquality().equals(_colorMap, other._colorMap));
+        && color == other.color
+        && darkColor == other.darkColor
+        && highContrastColor == other.highContrastColor
+        && darkHighContrastColor == other.darkHighContrastColor
+        && elevatedColor == other.elevatedColor
+        && darkElevatedColor == other.darkElevatedColor
+        && highContrastElevatedColor == other.highContrastElevatedColor
+        && darkHighContrastElevatedColor == other.darkHighContrastElevatedColor;
   }
 
   @override
@@ -924,285 +943,282 @@ class CupertinoSystemColors extends InheritedWidget {
     assert(context != null);
     assert(useFallbackValues != null);
     final CupertinoSystemColors widget = context.inheritFromWidgetOfExactType(CupertinoSystemColors);
-    return widget?._data ?? (useFallbackValues ? fallbackValues : null);
-  }
-
-  /// Fallback System Colors, extracted from:
-  /// https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/#dynamic-system-colors
-  /// and iOS 13 beta.
-  @visibleForTesting
-  static CupertinoSystemColorsData get fallbackValues {
-    return CupertinoSystemColorsData(
-      label: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 0, 0, 0),
-        darkColor: const Color.fromARGB(255, 255, 255, 255),
-        highContrastColor: const Color.fromARGB(255, 0, 0, 0),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 255, 255),
-        elevatedColor: const Color.fromARGB(255, 0, 0, 0),
-        darkElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        highContrastElevatedColor: const Color.fromARGB(255, 0, 0, 0),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-      ),
-      secondaryLabel: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 0, 0, 0),
-        darkColor: const Color.fromARGB(255, 255, 255, 255),
-        highContrastColor: const Color.fromARGB(255, 0, 0, 0),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 255, 255),
-        elevatedColor: const Color.fromARGB(255, 0, 0, 0),
-        darkElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        highContrastElevatedColor: const Color.fromARGB(255, 0, 0, 0),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-      ),
-      tertiaryLabel: CupertinoDynamicColor(
-        color: const Color.fromARGB(76, 60, 60, 67),
-        darkColor: const Color.fromARGB(76, 235, 235, 245),
-        highContrastColor: const Color.fromARGB(96, 60, 60, 67),
-        darkHighContrastColor: const Color.fromARGB(96, 235, 235, 245),
-        elevatedColor: const Color.fromARGB(76, 60, 60, 67),
-        darkElevatedColor: const Color.fromARGB(76, 235, 235, 245),
-        highContrastElevatedColor: const Color.fromARGB(96, 60, 60, 67),
-        darkHighContrastElevatedColor: const Color.fromARGB(96, 235, 235, 245),
-      ),
-      quaternaryLabel: CupertinoDynamicColor(
-        color: const Color.fromARGB(45, 60, 60, 67),
-        darkColor: const Color.fromARGB(40, 235, 235, 245),
-        highContrastColor: const Color.fromARGB(66, 60, 60, 67),
-        darkHighContrastColor: const Color.fromARGB(61, 235, 235, 245),
-        elevatedColor: const Color.fromARGB(45, 60, 60, 67),
-        darkElevatedColor: const Color.fromARGB(40, 235, 235, 245),
-        highContrastElevatedColor: const Color.fromARGB(66, 60, 60, 67),
-        darkHighContrastElevatedColor: const Color.fromARGB(61, 235, 235, 245),
-      ),
-      systemFill: CupertinoDynamicColor(
-        color: const Color.fromARGB(51, 120, 120, 128),
-        darkColor: const Color.fromARGB(91, 120, 120, 128),
-        highContrastColor: const Color.fromARGB(71, 120, 120, 128),
-        darkHighContrastColor: const Color.fromARGB(112, 120, 120, 128),
-        elevatedColor: const Color.fromARGB(51, 120, 120, 128),
-        darkElevatedColor: const Color.fromARGB(91, 120, 120, 128),
-        highContrastElevatedColor: const Color.fromARGB(71, 120, 120, 128),
-        darkHighContrastElevatedColor: const Color.fromARGB(112, 120, 120, 128),
-      ),
-      secondarySystemFill: CupertinoDynamicColor(
-        color: const Color.fromARGB(153, 60, 60, 67),
-        darkColor: const Color.fromARGB(153, 235, 235, 245),
-        highContrastColor: const Color.fromARGB(173, 60, 60, 67),
-        darkHighContrastColor: const Color.fromARGB(173, 235, 235, 245),
-        elevatedColor: const Color.fromARGB(153, 60, 60, 67),
-        darkElevatedColor: const Color.fromARGB(153, 235, 235, 245),
-        highContrastElevatedColor: const Color.fromARGB(173, 60, 60, 67),
-        darkHighContrastElevatedColor: const Color.fromARGB(173, 235, 235, 245),
-      ),
-      tertiarySystemFill: CupertinoDynamicColor(
-        color: const Color.fromARGB(30, 118, 118, 128),
-        darkColor: const Color.fromARGB(61, 118, 118, 128),
-        highContrastColor: const Color.fromARGB(51, 118, 118, 128),
-        darkHighContrastColor: const Color.fromARGB(81, 118, 118, 128),
-        elevatedColor: const Color.fromARGB(30, 118, 118, 128),
-        darkElevatedColor: const Color.fromARGB(61, 118, 118, 128),
-        highContrastElevatedColor: const Color.fromARGB(51, 118, 118, 128),
-        darkHighContrastElevatedColor: const Color.fromARGB(81, 118, 118, 128),
-      ),
-      quaternarySystemFill: CupertinoDynamicColor(
-        color: const Color.fromARGB(20, 116, 116, 128),
-        darkColor: const Color.fromARGB(45, 118, 118, 128),
-        highContrastColor: const Color.fromARGB(40, 116, 116, 128),
-        darkHighContrastColor: const Color.fromARGB(66, 118, 118, 128),
-        elevatedColor: const Color.fromARGB(20, 116, 116, 128),
-        darkElevatedColor: const Color.fromARGB(45, 118, 118, 128),
-        highContrastElevatedColor: const Color.fromARGB(40, 116, 116, 128),
-        darkHighContrastElevatedColor: const Color.fromARGB(66, 118, 118, 128),
-      ),
-      placeholderText: CupertinoDynamicColor(
-        color: const Color.fromARGB(76, 60, 60, 67),
-        darkColor: const Color.fromARGB(76, 235, 235, 245),
-        highContrastColor: const Color.fromARGB(96, 60, 60, 67),
-        darkHighContrastColor: const Color.fromARGB(96, 235, 235, 245),
-        elevatedColor: const Color.fromARGB(76, 60, 60, 67),
-        darkElevatedColor: const Color.fromARGB(76, 235, 235, 245),
-        highContrastElevatedColor: const Color.fromARGB(96, 60, 60, 67),
-        darkHighContrastElevatedColor: const Color.fromARGB(96, 235, 235, 245),
-      ),
-      systemBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 255, 255, 255),
-        darkColor: const Color.fromARGB(255, 0, 0, 0),
-        highContrastColor: const Color.fromARGB(255, 255, 255, 255),
-        darkHighContrastColor: const Color.fromARGB(255, 0, 0, 0),
-        elevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        darkElevatedColor: const Color.fromARGB(255, 28, 28, 30),
-        highContrastElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 36, 36, 38),
-      ),
-      secondarySystemBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 242, 242, 247),
-        darkColor: const Color.fromARGB(255, 28, 28, 30),
-        highContrastColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastColor: const Color.fromARGB(255, 36, 36, 38),
-        elevatedColor: const Color.fromARGB(255, 242, 242, 247),
-        darkElevatedColor: const Color.fromARGB(255, 44, 44, 46),
-        highContrastElevatedColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 54, 54, 56),
-      ),
-      tertiarySystemBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 255, 255, 255),
-        darkColor: const Color.fromARGB(255, 44, 44, 46),
-        highContrastColor: const Color.fromARGB(255, 255, 255, 255),
-        darkHighContrastColor: const Color.fromARGB(255, 54, 54, 56),
-        elevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        darkElevatedColor: const Color.fromARGB(255, 58, 58, 60),
-        highContrastElevatedColor: const Color.fromARGB(255, 255, 255, 255),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 68, 68, 70),
-      ),
-      systemGroupedBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 242, 242, 247),
-        darkColor: const Color.fromARGB(255, 0, 0, 0),
-        highContrastColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastColor: const Color.fromARGB(255, 0, 0, 0),
-        elevatedColor: const Color.fromARGB(255, 242, 242, 247),
-        darkElevatedColor: const Color.fromARGB(255, 28, 28, 30),
-        highContrastElevatedColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 36, 36, 38),
-      ),
-      secondarySystemGroupedBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 242, 242, 247),
-        darkColor: const Color.fromARGB(255, 0, 0, 0),
-        highContrastColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastColor: const Color.fromARGB(255, 0, 0, 0),
-        elevatedColor: const Color.fromARGB(255, 242, 242, 247),
-        darkElevatedColor: const Color.fromARGB(255, 28, 28, 30),
-        highContrastElevatedColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 36, 36, 38),
-      ),
-      tertiarySystemGroupedBackground: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 242, 242, 247),
-        darkColor: const Color.fromARGB(255, 44, 44, 46),
-        highContrastColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastColor: const Color.fromARGB(255, 54, 54, 56),
-        elevatedColor: const Color.fromARGB(255, 242, 242, 247),
-        darkElevatedColor: const Color.fromARGB(255, 58, 58, 60),
-        highContrastElevatedColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 68, 68, 70),
-      ),
-      separator: CupertinoDynamicColor(
-        color: const Color.fromARGB(73, 60, 60, 67),
-        darkColor: const Color.fromARGB(153, 84, 84, 88),
-        highContrastColor: const Color.fromARGB(94, 60, 60, 67),
-        darkHighContrastColor: const Color.fromARGB(173, 84, 84, 88),
-        elevatedColor: const Color.fromARGB(73, 60, 60, 67),
-        darkElevatedColor: const Color.fromARGB(153, 84, 84, 88),
-        highContrastElevatedColor: const Color.fromARGB(94, 60, 60, 67),
-        darkHighContrastElevatedColor: const Color.fromARGB(173, 84, 84, 88),
-      ),
-      opaqueSeparator: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 198, 198, 200),
-        darkColor: const Color.fromARGB(255, 56, 56, 58),
-        highContrastColor: const Color.fromARGB(255, 198, 198, 200),
-        darkHighContrastColor: const Color.fromARGB(255, 56, 56, 58),
-        elevatedColor: const Color.fromARGB(255, 198, 198, 200),
-        darkElevatedColor: const Color.fromARGB(255, 56, 56, 58),
-        highContrastElevatedColor: const Color.fromARGB(255, 198, 198, 200),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 56, 56, 58),
-      ),
-      link: CupertinoDynamicColor(
-        color: const Color.fromARGB(255, 0, 122, 255),
-        darkColor: const Color.fromARGB(255, 9, 132, 255),
-        highContrastColor: const Color.fromARGB(255, 0, 122, 255),
-        darkHighContrastColor: const Color.fromARGB(255, 9, 132, 255),
-        elevatedColor: const Color.fromARGB(255, 0, 122, 255),
-        darkElevatedColor: const Color.fromARGB(255, 9, 132, 255),
-        highContrastElevatedColor: const Color.fromARGB(255, 0, 122, 255),
-        darkHighContrastElevatedColor: const Color.fromARGB(255, 9, 132, 255),
-      ),
-      systemBlue: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 0, 122, 255),
-        darkColor: const Color.fromARGB(255, 10, 132, 255),
-        highContrastColor: const Color.fromARGB(255, 0, 64, 221),
-        darkHighContrastColor: const Color.fromARGB(255, 64, 156, 255),
-      ),
-      systemGreen: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 52, 199, 89),
-        darkColor: const Color.fromARGB(255, 48, 209, 88),
-        highContrastColor: const Color.fromARGB(255, 36, 138, 61),
-        darkHighContrastColor: const Color.fromARGB(255, 48, 219, 91),
-      ),
-      systemIndigo: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 88, 86, 214),
-        darkColor: const Color.fromARGB(255, 94, 92, 230),
-        highContrastColor: const Color.fromARGB(255, 54, 52, 163),
-        darkHighContrastColor: const Color.fromARGB(255, 125, 122, 255),
-      ),
-      systemOrange: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 255, 149, 0),
-        darkColor: const Color.fromARGB(255, 255, 159, 10),
-        highContrastColor: const Color.fromARGB(255, 201, 52, 0),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 179, 64),
-      ),
-      systemPink: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 255, 45, 85),
-        darkColor: const Color.fromARGB(255, 255, 55, 95),
-        highContrastColor: const Color.fromARGB(255, 211, 15, 69),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 100, 130),
-      ),
-      systemPurple: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 175, 82, 222),
-        darkColor: const Color.fromARGB(255, 191, 90, 242),
-        highContrastColor: const Color.fromARGB(255, 137, 68, 171),
-        darkHighContrastColor: const Color.fromARGB(255, 218, 143, 255),
-      ),
-      systemRed: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 255, 59, 48),
-        darkColor: const Color.fromARGB(255, 255, 69, 58),
-        highContrastColor: const Color.fromARGB(255, 215, 0, 21),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 105, 97),
-      ),
-      systemTeal: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 90, 200, 250),
-        darkColor: const Color.fromARGB(255, 100, 210, 255),
-        highContrastColor: const Color.fromARGB(255, 0, 113, 164),
-        darkHighContrastColor: const Color.fromARGB(255, 112, 215, 255),
-      ),
-      systemYellow: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 255, 204, 0),
-        darkColor: const Color.fromARGB(255, 255, 214, 10),
-        highContrastColor: const Color.fromARGB(255, 160, 90, 0),
-        darkHighContrastColor: const Color.fromARGB(255, 255, 212, 38),
-      ),
-      systemGray: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 142, 142, 147),
-        darkColor: const Color.fromARGB(255, 142, 142, 147),
-        highContrastColor: const Color.fromARGB(255, 108, 108, 112),
-        darkHighContrastColor: const Color.fromARGB(255, 174, 174, 178),
-      ),
-      systemGray2: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 174, 174, 178),
-        darkColor: const Color.fromARGB(255, 99, 99, 102),
-        highContrastColor: const Color.fromARGB(255, 142, 142, 147),
-        darkHighContrastColor: const Color.fromARGB(255, 124, 124, 128),
-      ),
-      systemGray3: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 199, 199, 204),
-        darkColor: const Color.fromARGB(255, 72, 72, 74),
-        highContrastColor: const Color.fromARGB(255, 174, 174, 178),
-        darkHighContrastColor: const Color.fromARGB(255, 84, 84, 86),
-      ),
-      systemGray4: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 209, 209, 214),
-        darkColor: const Color.fromARGB(255, 58, 58, 60),
-        highContrastColor: const Color.fromARGB(255, 188, 188, 192),
-        darkHighContrastColor: const Color.fromARGB(255, 68, 68, 70),
-      ),
-      systemGray5: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 229, 229, 234),
-        darkColor: const Color.fromARGB(255, 44, 44, 46),
-        highContrastColor: const Color.fromARGB(255, 216, 216, 220),
-        darkHighContrastColor: const Color.fromARGB(255, 54, 54, 56),
-      ),
-      systemGray6: CupertinoDynamicColor.withBrightnessAndContrast(
-        color: const Color.fromARGB(255, 242, 242, 247),
-        darkColor: const Color.fromARGB(255, 28, 28, 30),
-        highContrastColor: const Color.fromARGB(255, 235, 235, 240),
-        darkHighContrastColor: const Color.fromARGB(255, 36, 36, 38),
-      ),
-    );
+    return widget?._data ?? (useFallbackValues ? _kSystemColorsFallback : null);
   }
 }
+
+// Fallback System Colors, extracted from:
+// https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/#dynamic-system-colors
+// and iOS 13 beta.
+const CupertinoSystemColorsData _kSystemColorsFallback = CupertinoSystemColorsData(
+  label: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 0, 0, 0),
+    darkColor: Color.fromARGB(255, 255, 255, 255),
+    highContrastColor: Color.fromARGB(255, 0, 0, 0),
+    darkHighContrastColor: Color.fromARGB(255, 255, 255, 255),
+    elevatedColor: Color.fromARGB(255, 0, 0, 0),
+    darkElevatedColor: Color.fromARGB(255, 255, 255, 255),
+    highContrastElevatedColor: Color.fromARGB(255, 0, 0, 0),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 255, 255, 255),
+  ),
+  secondaryLabel: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 0, 0, 0),
+    darkColor: Color.fromARGB(255, 255, 255, 255),
+    highContrastColor: Color.fromARGB(255, 0, 0, 0),
+    darkHighContrastColor: Color.fromARGB(255, 255, 255, 255),
+    elevatedColor: Color.fromARGB(255, 0, 0, 0),
+    darkElevatedColor: Color.fromARGB(255, 255, 255, 255),
+    highContrastElevatedColor: Color.fromARGB(255, 0, 0, 0),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 255, 255, 255),
+  ),
+  tertiaryLabel: CupertinoDynamicColor(
+    color: Color.fromARGB(76, 60, 60, 67),
+    darkColor: Color.fromARGB(76, 235, 235, 245),
+    highContrastColor: Color.fromARGB(96, 60, 60, 67),
+    darkHighContrastColor: Color.fromARGB(96, 235, 235, 245),
+    elevatedColor: Color.fromARGB(76, 60, 60, 67),
+    darkElevatedColor: Color.fromARGB(76, 235, 235, 245),
+    highContrastElevatedColor: Color.fromARGB(96, 60, 60, 67),
+    darkHighContrastElevatedColor: Color.fromARGB(96, 235, 235, 245),
+  ),
+  quaternaryLabel: CupertinoDynamicColor(
+    color: Color.fromARGB(45, 60, 60, 67),
+    darkColor: Color.fromARGB(40, 235, 235, 245),
+    highContrastColor: Color.fromARGB(66, 60, 60, 67),
+    darkHighContrastColor: Color.fromARGB(61, 235, 235, 245),
+    elevatedColor: Color.fromARGB(45, 60, 60, 67),
+    darkElevatedColor: Color.fromARGB(40, 235, 235, 245),
+    highContrastElevatedColor: Color.fromARGB(66, 60, 60, 67),
+    darkHighContrastElevatedColor: Color.fromARGB(61, 235, 235, 245),
+  ),
+  systemFill: CupertinoDynamicColor(
+    color: Color.fromARGB(51, 120, 120, 128),
+    darkColor: Color.fromARGB(91, 120, 120, 128),
+    highContrastColor: Color.fromARGB(71, 120, 120, 128),
+    darkHighContrastColor: Color.fromARGB(112, 120, 120, 128),
+    elevatedColor: Color.fromARGB(51, 120, 120, 128),
+    darkElevatedColor: Color.fromARGB(91, 120, 120, 128),
+    highContrastElevatedColor: Color.fromARGB(71, 120, 120, 128),
+    darkHighContrastElevatedColor: Color.fromARGB(112, 120, 120, 128),
+  ),
+  secondarySystemFill: CupertinoDynamicColor(
+    color: Color.fromARGB(153, 60, 60, 67),
+    darkColor: Color.fromARGB(153, 235, 235, 245),
+    highContrastColor: Color.fromARGB(173, 60, 60, 67),
+    darkHighContrastColor: Color.fromARGB(173, 235, 235, 245),
+    elevatedColor: Color.fromARGB(153, 60, 60, 67),
+    darkElevatedColor: Color.fromARGB(153, 235, 235, 245),
+    highContrastElevatedColor: Color.fromARGB(173, 60, 60, 67),
+    darkHighContrastElevatedColor: Color.fromARGB(173, 235, 235, 245),
+  ),
+  tertiarySystemFill: CupertinoDynamicColor(
+    color: Color.fromARGB(30, 118, 118, 128),
+    darkColor: Color.fromARGB(61, 118, 118, 128),
+    highContrastColor: Color.fromARGB(51, 118, 118, 128),
+    darkHighContrastColor: Color.fromARGB(81, 118, 118, 128),
+    elevatedColor: Color.fromARGB(30, 118, 118, 128),
+    darkElevatedColor: Color.fromARGB(61, 118, 118, 128),
+    highContrastElevatedColor: Color.fromARGB(51, 118, 118, 128),
+    darkHighContrastElevatedColor: Color.fromARGB(81, 118, 118, 128),
+  ),
+  quaternarySystemFill: CupertinoDynamicColor(
+    color: Color.fromARGB(20, 116, 116, 128),
+    darkColor: Color.fromARGB(45, 118, 118, 128),
+    highContrastColor: Color.fromARGB(40, 116, 116, 128),
+    darkHighContrastColor: Color.fromARGB(66, 118, 118, 128),
+    elevatedColor: Color.fromARGB(20, 116, 116, 128),
+    darkElevatedColor: Color.fromARGB(45, 118, 118, 128),
+    highContrastElevatedColor: Color.fromARGB(40, 116, 116, 128),
+    darkHighContrastElevatedColor: Color.fromARGB(66, 118, 118, 128),
+  ),
+  placeholderText: CupertinoDynamicColor(
+    color: Color.fromARGB(76, 60, 60, 67),
+    darkColor: Color.fromARGB(76, 235, 235, 245),
+    highContrastColor: Color.fromARGB(96, 60, 60, 67),
+    darkHighContrastColor: Color.fromARGB(96, 235, 235, 245),
+    elevatedColor: Color.fromARGB(76, 60, 60, 67),
+    darkElevatedColor: Color.fromARGB(76, 235, 235, 245),
+    highContrastElevatedColor: Color.fromARGB(96, 60, 60, 67),
+    darkHighContrastElevatedColor: Color.fromARGB(96, 235, 235, 245),
+  ),
+  systemBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 255, 255, 255),
+    darkColor: Color.fromARGB(255, 0, 0, 0),
+    highContrastColor: Color.fromARGB(255, 255, 255, 255),
+    darkHighContrastColor: Color.fromARGB(255, 0, 0, 0),
+    elevatedColor: Color.fromARGB(255, 255, 255, 255),
+    darkElevatedColor: Color.fromARGB(255, 28, 28, 30),
+    highContrastElevatedColor: Color.fromARGB(255, 255, 255, 255),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 36, 36, 38),
+  ),
+  secondarySystemBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 242, 242, 247),
+    darkColor: Color.fromARGB(255, 28, 28, 30),
+    highContrastColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastColor: Color.fromARGB(255, 36, 36, 38),
+    elevatedColor: Color.fromARGB(255, 242, 242, 247),
+    darkElevatedColor: Color.fromARGB(255, 44, 44, 46),
+    highContrastElevatedColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 54, 54, 56),
+  ),
+  tertiarySystemBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 255, 255, 255),
+    darkColor: Color.fromARGB(255, 44, 44, 46),
+    highContrastColor: Color.fromARGB(255, 255, 255, 255),
+    darkHighContrastColor: Color.fromARGB(255, 54, 54, 56),
+    elevatedColor: Color.fromARGB(255, 255, 255, 255),
+    darkElevatedColor: Color.fromARGB(255, 58, 58, 60),
+    highContrastElevatedColor: Color.fromARGB(255, 255, 255, 255),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 68, 68, 70),
+  ),
+  systemGroupedBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 242, 242, 247),
+    darkColor: Color.fromARGB(255, 0, 0, 0),
+    highContrastColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastColor: Color.fromARGB(255, 0, 0, 0),
+    elevatedColor: Color.fromARGB(255, 242, 242, 247),
+    darkElevatedColor: Color.fromARGB(255, 28, 28, 30),
+    highContrastElevatedColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 36, 36, 38),
+  ),
+  secondarySystemGroupedBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 242, 242, 247),
+    darkColor: Color.fromARGB(255, 0, 0, 0),
+    highContrastColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastColor: Color.fromARGB(255, 0, 0, 0),
+    elevatedColor: Color.fromARGB(255, 242, 242, 247),
+    darkElevatedColor: Color.fromARGB(255, 28, 28, 30),
+    highContrastElevatedColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 36, 36, 38),
+  ),
+  tertiarySystemGroupedBackground: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 242, 242, 247),
+    darkColor: Color.fromARGB(255, 44, 44, 46),
+    highContrastColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastColor: Color.fromARGB(255, 54, 54, 56),
+    elevatedColor: Color.fromARGB(255, 242, 242, 247),
+    darkElevatedColor: Color.fromARGB(255, 58, 58, 60),
+    highContrastElevatedColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 68, 68, 70),
+  ),
+  separator: CupertinoDynamicColor(
+    color: Color.fromARGB(73, 60, 60, 67),
+    darkColor: Color.fromARGB(153, 84, 84, 88),
+    highContrastColor: Color.fromARGB(94, 60, 60, 67),
+    darkHighContrastColor: Color.fromARGB(173, 84, 84, 88),
+    elevatedColor: Color.fromARGB(73, 60, 60, 67),
+    darkElevatedColor: Color.fromARGB(153, 84, 84, 88),
+    highContrastElevatedColor: Color.fromARGB(94, 60, 60, 67),
+    darkHighContrastElevatedColor: Color.fromARGB(173, 84, 84, 88),
+  ),
+  opaqueSeparator: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 198, 198, 200),
+    darkColor: Color.fromARGB(255, 56, 56, 58),
+    highContrastColor: Color.fromARGB(255, 198, 198, 200),
+    darkHighContrastColor: Color.fromARGB(255, 56, 56, 58),
+    elevatedColor: Color.fromARGB(255, 198, 198, 200),
+    darkElevatedColor: Color.fromARGB(255, 56, 56, 58),
+    highContrastElevatedColor: Color.fromARGB(255, 198, 198, 200),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 56, 56, 58),
+  ),
+  link: CupertinoDynamicColor(
+    color: Color.fromARGB(255, 0, 122, 255),
+    darkColor: Color.fromARGB(255, 9, 132, 255),
+    highContrastColor: Color.fromARGB(255, 0, 122, 255),
+    darkHighContrastColor: Color.fromARGB(255, 9, 132, 255),
+    elevatedColor: Color.fromARGB(255, 0, 122, 255),
+    darkElevatedColor: Color.fromARGB(255, 9, 132, 255),
+    highContrastElevatedColor: Color.fromARGB(255, 0, 122, 255),
+    darkHighContrastElevatedColor: Color.fromARGB(255, 9, 132, 255),
+  ),
+  systemBlue: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 0, 122, 255),
+    darkColor: Color.fromARGB(255, 10, 132, 255),
+    highContrastColor: Color.fromARGB(255, 0, 64, 221),
+    darkHighContrastColor: Color.fromARGB(255, 64, 156, 255),
+  ),
+  systemGreen: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 52, 199, 89),
+    darkColor: Color.fromARGB(255, 48, 209, 88),
+    highContrastColor: Color.fromARGB(255, 36, 138, 61),
+    darkHighContrastColor: Color.fromARGB(255, 48, 219, 91),
+  ),
+  systemIndigo: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 88, 86, 214),
+    darkColor: Color.fromARGB(255, 94, 92, 230),
+    highContrastColor: Color.fromARGB(255, 54, 52, 163),
+    darkHighContrastColor: Color.fromARGB(255, 125, 122, 255),
+  ),
+  systemOrange: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 255, 149, 0),
+    darkColor: Color.fromARGB(255, 255, 159, 10),
+    highContrastColor: Color.fromARGB(255, 201, 52, 0),
+    darkHighContrastColor: Color.fromARGB(255, 255, 179, 64),
+  ),
+  systemPink: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 255, 45, 85),
+    darkColor: Color.fromARGB(255, 255, 55, 95),
+    highContrastColor: Color.fromARGB(255, 211, 15, 69),
+    darkHighContrastColor: Color.fromARGB(255, 255, 100, 130),
+  ),
+  systemPurple: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 175, 82, 222),
+    darkColor: Color.fromARGB(255, 191, 90, 242),
+    highContrastColor: Color.fromARGB(255, 137, 68, 171),
+    darkHighContrastColor: Color.fromARGB(255, 218, 143, 255),
+  ),
+  systemRed: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 255, 59, 48),
+    darkColor: Color.fromARGB(255, 255, 69, 58),
+    highContrastColor: Color.fromARGB(255, 215, 0, 21),
+    darkHighContrastColor: Color.fromARGB(255, 255, 105, 97),
+  ),
+  systemTeal: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 90, 200, 250),
+    darkColor: Color.fromARGB(255, 100, 210, 255),
+    highContrastColor: Color.fromARGB(255, 0, 113, 164),
+    darkHighContrastColor: Color.fromARGB(255, 112, 215, 255),
+  ),
+  systemYellow: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 255, 204, 0),
+    darkColor: Color.fromARGB(255, 255, 214, 10),
+    highContrastColor: Color.fromARGB(255, 160, 90, 0),
+    darkHighContrastColor: Color.fromARGB(255, 255, 212, 38),
+  ),
+  systemGray: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 142, 142, 147),
+    darkColor: Color.fromARGB(255, 142, 142, 147),
+    highContrastColor: Color.fromARGB(255, 108, 108, 112),
+    darkHighContrastColor: Color.fromARGB(255, 174, 174, 178),
+  ),
+  systemGray2: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 174, 174, 178),
+    darkColor: Color.fromARGB(255, 99, 99, 102),
+    highContrastColor: Color.fromARGB(255, 142, 142, 147),
+    darkHighContrastColor: Color.fromARGB(255, 124, 124, 128),
+  ),
+  systemGray3: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 199, 199, 204),
+    darkColor: Color.fromARGB(255, 72, 72, 74),
+    highContrastColor: Color.fromARGB(255, 174, 174, 178),
+    darkHighContrastColor: Color.fromARGB(255, 84, 84, 86),
+  ),
+  systemGray4: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 209, 209, 214),
+    darkColor: Color.fromARGB(255, 58, 58, 60),
+    highContrastColor: Color.fromARGB(255, 188, 188, 192),
+    darkHighContrastColor: Color.fromARGB(255, 68, 68, 70),
+  ),
+  systemGray5: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 229, 229, 234),
+    darkColor: Color.fromARGB(255, 44, 44, 46),
+    highContrastColor: Color.fromARGB(255, 216, 216, 220),
+    darkHighContrastColor: Color.fromARGB(255, 54, 54, 56),
+  ),
+  systemGray6: CupertinoDynamicColor.withBrightnessAndContrast(
+    color: Color.fromARGB(255, 242, 242, 247),
+    darkColor: Color.fromARGB(255, 28, 28, 30),
+    highContrastColor: Color.fromARGB(255, 235, 235, 240),
+    darkHighContrastColor: Color.fromARGB(255, 36, 36, 38),
+  ),
+);

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -224,6 +224,9 @@ class CupertinoDynamicColor extends Color {
       assert(highContrastElevatedColor != null),
       assert(darkHighContrastElevatedColor != null),
       assert(_effectiveColor != null),
+      // The super constructor has to be called with a dummy value in order to mark
+      // this constructor const.
+      // The field `value` is overriden in the class implementation.
       super(0);
 
   final Color _effectiveColor;
@@ -401,6 +404,7 @@ class CupertinoDynamicColor extends Color {
             break;
           case CupertinoUserInterfaceLevelData.elevated:
             resolved = isHighContrastEnabled ? highContrastElevatedColor : elevatedColor;
+            break;
         }
         break;
       case Brightness.dark:
@@ -415,19 +419,17 @@ class CupertinoDynamicColor extends Color {
     }
 
     assert(resolved != null);
-    return resolved.value == value
-      ? this
-      : CupertinoDynamicColor._(
-          resolved,
-          color,
-          darkColor,
-          highContrastColor,
-          darkHighContrastColor,
-          elevatedColor,
-          darkElevatedColor,
-          highContrastElevatedColor,
-          darkHighContrastElevatedColor,
-      );
+    return CupertinoDynamicColor._(
+      resolved,
+      color,
+      darkColor,
+      highContrastColor,
+      darkHighContrastColor,
+      elevatedColor,
+      darkElevatedColor,
+      highContrastElevatedColor,
+      darkHighContrastElevatedColor,
+    );
   }
 
   @override

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -38,7 +38,7 @@ const Color color7 = Color(0xFF000007);
 
 // A color that depends on color vibrancy, accessibility contrast, as well as user
 // interface elevation.
-final CupertinoDynamicColor dynamicColor = CupertinoDynamicColor(
+const CupertinoDynamicColor dynamicColor = CupertinoDynamicColor(
   color: color0,
   darkColor: color1,
   elevatedColor: color2,
@@ -50,7 +50,7 @@ final CupertinoDynamicColor dynamicColor = CupertinoDynamicColor(
 );
 
 // A color that uses [color0] in every circumstance.
-final Color notSoDynamicColor1 = CupertinoDynamicColor(
+const Color notSoDynamicColor1 = CupertinoDynamicColor(
   color: color0,
   darkColor: color0,
   darkHighContrastColor: color0,
@@ -62,7 +62,7 @@ final Color notSoDynamicColor1 = CupertinoDynamicColor(
 );
 
 // A color that uses [color1] for light mode, and [color0] for dark mode.
-final Color vibrancyDependentColor1 = CupertinoDynamicColor(
+const Color vibrancyDependentColor1 = CupertinoDynamicColor(
   color: color1,
   elevatedColor: color1,
   highContrastColor: color1,
@@ -75,7 +75,7 @@ final Color vibrancyDependentColor1 = CupertinoDynamicColor(
 
 // A color that uses [color1] for normal contrast mode, and [color0] for high
 // contrast mode.
-final Color contrastDependentColor1 = CupertinoDynamicColor(
+const Color contrastDependentColor1 = CupertinoDynamicColor(
   color: color1,
   darkColor: color1,
   elevatedColor: color1,
@@ -88,7 +88,7 @@ final Color contrastDependentColor1 = CupertinoDynamicColor(
 
 // A color that uses [color1] for base interface elevation, and [color0] for elevated
 // interface elevation.
-final Color elevationDependentColor1 = CupertinoDynamicColor(
+const Color elevationDependentColor1 = CupertinoDynamicColor(
   color: color1,
   darkColor: color1,
   highContrastColor: color1,
@@ -101,7 +101,7 @@ final Color elevationDependentColor1 = CupertinoDynamicColor(
 
 void main() {
   test('== works as expected', () {
-    expect(dynamicColor, CupertinoDynamicColor(
+    expect(dynamicColor, const CupertinoDynamicColor(
         color: color0,
         darkColor: color1,
         elevatedColor: color2,
@@ -117,7 +117,7 @@ void main() {
 
     expect(notSoDynamicColor1, isNot(contrastDependentColor1));
 
-    expect(vibrancyDependentColor1, isNot(CupertinoDynamicColor(
+    expect(vibrancyDependentColor1, isNot(const CupertinoDynamicColor(
       color: color0,
       elevatedColor: color0,
       highContrastColor: color0,
@@ -147,7 +147,7 @@ void main() {
     expect(elevationDependentColor1.toString(), 'CupertinoDynamicColor(*color = Color(0xff000001)*, elevatedColor = Color(0xff000000))');
 
     expect(
-      CupertinoDynamicColor.withBrightnessAndContrast(
+      const CupertinoDynamicColor.withBrightnessAndContrast(
         color: color0,
         darkColor: color1,
         highContrastColor: color2,
@@ -161,21 +161,22 @@ void main() {
   });
 
   test('withVibrancy constructor creates colors that may depend on vibrancy', () {
-    expect(vibrancyDependentColor1, CupertinoDynamicColor.withBrightness(
+    expect(vibrancyDependentColor1, const CupertinoDynamicColor.withBrightness(
       color: color1,
       darkColor: color0,
     ));
   });
 
   test('withVibrancyAndContrast constructor creates colors that may depend on contrast and vibrancy', () {
-    expect(contrastDependentColor1, CupertinoDynamicColor.withBrightnessAndContrast(
+    expect(contrastDependentColor1, const CupertinoDynamicColor.withBrightnessAndContrast(
       color: color1,
       darkColor: color1,
       highContrastColor: color0,
       darkHighContrastColor: color0,
     ));
 
-    expect(CupertinoDynamicColor(
+    expect(
+      const CupertinoDynamicColor(
         color: color0,
         darkColor: color1,
         highContrastColor: color2,
@@ -185,17 +186,18 @@ void main() {
         highContrastElevatedColor: color2,
         darkHighContrastElevatedColor: color3,
       ),
-      CupertinoDynamicColor.withBrightnessAndContrast(
+      const CupertinoDynamicColor.withBrightnessAndContrast(
         color: color0,
         darkColor: color1,
         highContrastColor: color2,
         darkHighContrastColor: color3,
-    ));
+      )
+    );
   });
 
   testWidgets('Dynamic colors that are not actually dynamic should not claim dependencies',
     (WidgetTester tester) async {
-      await tester.pumpWidget(DependentWidget(color: notSoDynamicColor1));
+      await tester.pumpWidget(const DependentWidget(color: notSoDynamicColor1));
 
       expect(tester.takeException(), null);
       expect(find.byType(DependentWidget), paints..rect(color: color0));
@@ -206,8 +208,8 @@ void main() {
     'and its resolved color should change when its dependency changes',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(platformBrightness: Brightness.light),
+        const MediaQuery(
+          data: MediaQueryData(platformBrightness: Brightness.light),
           child: DependentWidget(color: vibrancyDependentColor1),
         ),
       );
@@ -218,8 +220,8 @@ void main() {
 
       // Changing color vibrancy works.
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(platformBrightness: Brightness.dark),
+        const MediaQuery(
+          data: MediaQueryData(platformBrightness: Brightness.dark),
           child: DependentWidget(color: vibrancyDependentColor1),
         ),
       );
@@ -230,10 +232,10 @@ void main() {
 
       // CupertinoTheme should take percedence over MediaQuery.
       await tester.pumpWidget(
-        CupertinoTheme(
-          data: const CupertinoThemeData(brightness: Brightness.light),
+        const CupertinoTheme(
+          data: CupertinoThemeData(brightness: Brightness.light),
           child: MediaQuery(
-            data: const MediaQueryData(platformBrightness: Brightness.dark),
+            data: MediaQueryData(platformBrightness: Brightness.dark),
             child: DependentWidget(color: vibrancyDependentColor1),
           ),
         ),
@@ -249,8 +251,8 @@ void main() {
     'and its resolved color should change when its dependency changes',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(highContrast: false),
+        const MediaQuery(
+          data: MediaQueryData(highContrast: false),
           child: DependentWidget(color: contrastDependentColor1),
         ),
       );
@@ -261,8 +263,8 @@ void main() {
 
       // Changing accessibility contrast works.
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(highContrast: true),
+        const MediaQuery(
+          data: MediaQueryData(highContrast: true),
           child: DependentWidget(color: contrastDependentColor1),
         ),
       );
@@ -272,7 +274,7 @@ void main() {
       expect(find.byType(DependentWidget), isNot(paints..rect(color: color1)));
 
       // Asserts when the required dependency is missing.
-      await tester.pumpWidget(DependentWidget(color: contrastDependentColor1));
+      await tester.pumpWidget(const DependentWidget(color: contrastDependentColor1));
       expect(tester.takeException()?.toString(), contains('does not contain a MediaQuery'));
   });
 
@@ -281,7 +283,7 @@ void main() {
     'and its resolved color should change when its dependency changes',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        CupertinoUserInterfaceLevel(
+        const CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.base,
           child: DependentWidget(color: elevationDependentColor1),
         ),
@@ -293,7 +295,7 @@ void main() {
 
       // Changing UI elevation works.
       await tester.pumpWidget(
-        CupertinoUserInterfaceLevel(
+        const CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
           child: DependentWidget(color: elevationDependentColor1),
         ),
@@ -304,12 +306,12 @@ void main() {
       expect(find.byType(DependentWidget), isNot(paints..rect(color: color1)));
 
       // Asserts when the required dependency is missing.
-      await tester.pumpWidget(DependentWidget(color: elevationDependentColor1));
+      await tester.pumpWidget(const DependentWidget(color: elevationDependentColor1));
       expect(tester.takeException()?.toString(), contains('does not contain a CupertinoUserInterfaceLevel'));
   });
 
   testWidgets('Dynamic color with all 3 depedencies works', (WidgetTester tester) async {
-    final Color dynamicRainbowColor1 = CupertinoDynamicColor(
+    const Color dynamicRainbowColor1 = CupertinoDynamicColor(
       color: color0,
       darkColor: color1,
       highContrastColor: color2,
@@ -321,8 +323,8 @@ void main() {
     );
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.light, highContrast: false),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.light, highContrast: false),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.base,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -332,8 +334,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color0));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: false),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.dark, highContrast: false),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.base,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -343,8 +345,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color1));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.light, highContrast: true),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.light, highContrast: true),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.base,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -354,8 +356,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color2));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.base,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -365,8 +367,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color3));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: false),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.dark, highContrast: false),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -376,8 +378,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color4));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.light, highContrast: true),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.light, highContrast: true),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -387,8 +389,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color5));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -398,8 +400,8 @@ void main() {
     expect(find.byType(DependentWidget), paints..rect(color: color6));
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(platformBrightness: Brightness.light, highContrast: false),
+      const MediaQuery(
+        data: MediaQueryData(platformBrightness: Brightness.light, highContrast: false),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
           child: DependentWidget(color: dynamicRainbowColor1),
@@ -418,9 +420,20 @@ void main() {
       return const Placeholder();
     }
 
+    const CupertinoDynamicColor kSystemBackground = CupertinoDynamicColor(
+      color: Color.fromARGB(255, 255, 255, 255),
+      darkColor: Color.fromARGB(255, 0, 0, 0),
+      highContrastColor: Color.fromARGB(255, 255, 255, 255),
+      darkHighContrastColor: Color.fromARGB(255, 0, 0, 0),
+      elevatedColor: Color.fromARGB(255, 255, 255, 255),
+      darkElevatedColor: Color.fromARGB(255, 28, 28, 30),
+      highContrastElevatedColor: Color.fromARGB(255, 255, 255, 255),
+      darkHighContrastElevatedColor: Color.fromARGB(255, 36, 36, 38),
+    );
+
     testWidgets('exists in CupertinoApp', (WidgetTester tester) async {
       await tester.pumpWidget(CupertinoApp(home: Builder(builder: systemColorGetter)));
-      expect(colors.systemBackground, CupertinoSystemColors.fallbackValues.systemBackground);
+      expect(colors.systemBackground, kSystemBackground);
     });
 
     testWidgets('resolves against its own BuildContext', (WidgetTester tester) async {
@@ -442,8 +455,8 @@ void main() {
       );
 
       // In widget tests the OS colors should fallback to `fallbackValues`.
-      expect(colors.systemBackground, isNot(CupertinoSystemColors.fallbackValues.systemBackground));
-      expect(colors.systemBackground.value, CupertinoSystemColors.fallbackValues.systemBackground.darkElevatedColor.value);
+      expect(colors.systemBackground, isNot(kSystemBackground));
+      expect(colors.systemBackground.value, kSystemBackground.darkElevatedColor.value);
 
       colors = null;
       // Changing dependencies works.
@@ -464,7 +477,7 @@ void main() {
         ),
       );
 
-      expect(colors.systemBackground.value, CupertinoSystemColors.fallbackValues.systemBackground.elevatedColor.value);
+      expect(colors.systemBackground.value, kSystemBackground.elevatedColor.value);
     });
   });
 
@@ -472,7 +485,7 @@ void main() {
     CupertinoDynamicColor color;
     await tester.pumpWidget(
       CupertinoApp(
-        theme: CupertinoThemeData(
+        theme: const CupertinoThemeData(
           brightness: Brightness.dark,
           primaryColor: dynamicColor,
         ),
@@ -490,7 +503,7 @@ void main() {
     // Changing dependencies works.
     await tester.pumpWidget(
       CupertinoApp(
-        theme: CupertinoThemeData(
+        theme: const CupertinoThemeData(
           brightness: Brightness.light,
           primaryColor: dynamicColor,
         ),
@@ -508,7 +521,7 @@ void main() {
     // Having a dependency below the CupertinoTheme widget works.
     await tester.pumpWidget(
       CupertinoApp(
-        theme: CupertinoThemeData(primaryColor: dynamicColor),
+        theme: const CupertinoThemeData(primaryColor: dynamicColor),
         home: MediaQuery(
           data: const MediaQueryData(platformBrightness: Brightness.light, highContrast: false),
           child: CupertinoUserInterfaceLevel(
@@ -530,7 +543,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         // No brightness is explicitly specified here so it should defer to MediaQuery.
-        theme: CupertinoThemeData(primaryColor: dynamicColor),
+        theme: const CupertinoThemeData(primaryColor: dynamicColor),
         home: MediaQuery(
           data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
           child: CupertinoUserInterfaceLevel(
@@ -559,7 +572,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(
-            cupertinoOverrideTheme: CupertinoThemeData(
+            cupertinoOverrideTheme: const CupertinoThemeData(
               brightness: Brightness.dark,
               primaryColor: dynamicColor,
             ),
@@ -587,7 +600,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(
-            cupertinoOverrideTheme: CupertinoThemeData(
+            cupertinoOverrideTheme: const CupertinoThemeData(
               brightness: Brightness.dark,
               primaryColor: dynamicColor,
             ),
@@ -614,7 +627,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           // This will create a MaterialBasedCupertinoThemeData with primaryColor set to `dynamicColor`.
-          theme: ThemeData(colorScheme: ColorScheme.dark(primary: dynamicColor)),
+          theme: ThemeData(colorScheme: const ColorScheme.dark(primary: dynamicColor)),
           home: MediaQuery(
             data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
             child: CupertinoUserInterfaceLevel(
@@ -637,16 +650,16 @@ void main() {
   });
 
   group('CupertinoSystemColors', () {
-    final Color dynamicColor0 = CupertinoDynamicColor.withBrightness(
-      color: const Color(0x00000000),
-      darkColor: const Color(0x00000000)
+    const Color dynamicColor0 = CupertinoDynamicColor.withBrightness(
+      color: Color(0x00000000),
+      darkColor: Color(0x00000000)
     );
-    final Color dynamicColor1 = CupertinoDynamicColor.withBrightness(
-      color: const Color(0x00000001),
-      darkColor: const Color(0x00000000)
+    const Color dynamicColor1 = CupertinoDynamicColor.withBrightness(
+      color: Color(0x00000001),
+      darkColor: Color(0x00000000)
     );
 
-    final CupertinoSystemColorsData system0 = CupertinoSystemColorsData(
+    const CupertinoSystemColorsData system0 = CupertinoSystemColorsData(
       label: dynamicColor0,
       secondaryLabel: dynamicColor0,
       tertiaryLabel: dynamicColor0,

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -191,7 +191,7 @@ void main() {
         darkColor: color1,
         highContrastColor: color2,
         darkHighContrastColor: color3,
-      )
+      ),
     );
   });
 

--- a/packages/flutter/test/cupertino/slider_test.dart
+++ b/packages/flutter/test/cupertino/slider_test.dart
@@ -11,6 +11,17 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
+const CupertinoDynamicColor _kSystemFill = CupertinoDynamicColor(
+  color: Color.fromARGB(51, 120, 120, 128),
+  darkColor: Color.fromARGB(91, 120, 120, 128),
+  highContrastColor: Color.fromARGB(71, 120, 120, 128),
+  darkHighContrastColor: Color.fromARGB(112, 120, 120, 128),
+  elevatedColor: Color.fromARGB(51, 120, 120, 128),
+  darkElevatedColor: Color.fromARGB(91, 120, 120, 128),
+  highContrastElevatedColor: Color.fromARGB(71, 120, 120, 128),
+  darkHighContrastElevatedColor: Color.fromARGB(112, 120, 120, 128),
+);
+
 void main() {
 
   Future<void> _dragSlider(WidgetTester tester, Key sliderKey) {
@@ -441,15 +452,15 @@ void main() {
   });
 
   testWidgets('Themes can be overridden by dynamic colors', (WidgetTester tester) async {
-    final CupertinoDynamicColor activeColor = CupertinoDynamicColor(
-      color: const Color(0x00000001),
-      darkColor: const Color(0x00000002),
-      elevatedColor: const Color(0x00000003),
-      highContrastColor: const Color(0x00000004),
-      darkElevatedColor: const Color(0x00000005),
-      darkHighContrastColor: const Color(0x00000006),
-      highContrastElevatedColor: const Color(0x00000007),
-      darkHighContrastElevatedColor: const Color(0x00000008),
+    const CupertinoDynamicColor activeColor = CupertinoDynamicColor(
+      color: Color(0x00000001),
+      darkColor: Color(0x00000002),
+      elevatedColor: Color(0x00000003),
+      highContrastColor: Color(0x00000004),
+      darkElevatedColor: Color(0x00000005),
+      darkHighContrastColor: Color(0x00000006),
+      highContrastElevatedColor: Color(0x00000007),
+      darkHighContrastElevatedColor: Color(0x00000008),
     );
 
     Widget withTraits(Brightness brightness, CupertinoUserInterfaceLevelData level, bool highContrast) {
@@ -512,12 +523,12 @@ void main() {
 
     expect(
       find.byType(CupertinoSlider),
-      paints..rrect(color: CupertinoSystemColors.fallbackValues.systemFill.color),
+      paints..rrect(color: _kSystemFill.color),
     );
 
     expect(
       find.byType(CupertinoSlider),
-      isNot(paints..rrect(color: CupertinoSystemColors.fallbackValues.systemFill.darkColor)),
+      isNot(paints..rrect(color: _kSystemFill.darkColor)),
     );
 
     await tester.pumpWidget(
@@ -535,12 +546,12 @@ void main() {
 
     expect(
       find.byType(CupertinoSlider),
-      paints..rrect(color: CupertinoSystemColors.fallbackValues.systemFill.darkColor),
+      paints..rrect(color: _kSystemFill.darkColor),
     );
 
     expect(
       find.byType(CupertinoSlider),
-      isNot(paints..rrect(color: CupertinoSystemColors.fallbackValues.systemFill.color)),
+      isNot(paints..rrect(color: _kSystemFill.color)),
     );
   });
 }


### PR DESCRIPTION
## Description

make `CupertinoDynamicColor`'s constructors const, in order to use a `CupertinoDynamicColor` as the default value of a function argument. This change would allow us to provide a default `CupertinoDynamicColor` in the constructor of the following widget, without breaking its current API:

```dart
class SomeWidget extends StatelessWidget {
  const SomeWidget({ Key key, this.color = defaultColor }) : super(key: key);
}
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Tests

No new tests were added: existing tests should be able to cover this.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
