### PR TITLE
Allow gaps in the initial route

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -361,10 +361,12 @@ class WidgetsApp extends StatefulWidget {
   /// also. For example, if the route was `/a/b/c`, then the app would start
   /// with the three routes `/a`, `/a/b`, and `/a/b/c` loaded, in that order.
   ///
-  /// If any part of this process fails to generate routes, then the
-  /// [initialRoute] is ignored and [Navigator.defaultRouteName] is used instead
-  /// (`/`). This can happen if the app is started with an intent that specifies
-  /// a non-existent route.
+  /// Intermediate routes aren't required to exist. In the example above, `/a`
+  /// and `/a/b` could be skipped if they have no matching route. But `/a/b/c` is
+  /// required to have a route, else [initialRoute] is ignored and
+  /// [Navigator.defaultRouteName] is used instead (`/`). This can happen if the
+  /// app is started with an intent that specifies a non-existent route.
+  ///
   /// The [Navigator] is only built if routes are provided (either via [home],
   /// [routes], [onGenerateRoute], or [onUnknownRoute]); if they are not,
   /// [initialRoute] must be null and [builder] must not be null.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1518,9 +1518,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     if (initialRouteName.startsWith('/') && initialRouteName.length > 1) {
       initialRouteName = initialRouteName.substring(1); // strip leading '/'
       assert(Navigator.defaultRouteName == '/');
-      final List<String> plannedInitialRouteNames = <String>[
-        Navigator.defaultRouteName,
-      ];
       final List<Route<dynamic>> plannedInitialRoutes = <Route<dynamic>>[
         _routeNamed<dynamic>(Navigator.defaultRouteName, allowNull: true, arguments: null),
       ];
@@ -1529,7 +1526,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
         String routeName = '';
         for (String part in routeParts) {
           routeName += '/$part';
-          plannedInitialRouteNames.add(routeName);
           plannedInitialRoutes.add(_routeNamed<dynamic>(routeName, allowNull: true, arguments: null));
         }
       }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1524,7 +1524,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           plannedInitialRoutes.add(_routeNamed<dynamic>(routeName, allowNull: true, arguments: null));
         }
       }
-      if (plannedInitialRoutes.contains(null)) {
+      if (_shouldAbandonInitialRoute(plannedInitialRoutes)) {
         assert(() {
           FlutterError.reportError(
             FlutterErrorDetails(
@@ -1543,7 +1543,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
         }());
         push(_routeNamed<Object>(Navigator.defaultRouteName, arguments: null));
       } else {
-        plannedInitialRoutes.forEach(push);
+        plannedInitialRoutes.where((Route<dynamic> route) => route != null).forEach(push);
       }
     } else {
       Route<Object> route;
@@ -1599,6 +1599,25 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   }
 
   bool _debugLocked = false; // used to prevent re-entrant calls to push, pop, and friends
+
+  bool _shouldAbandonInitialRoute(List<Route<dynamic>> plannedInitialRoutes) {
+    assert(plannedInitialRoutes.isNotEmpty);
+
+    // The last route has to match something in order for it to work.
+    if (plannedInitialRoutes.last == null) {
+      return true;
+    }
+
+    // In web, we don't care if there are gaps in the initial route.
+    // if (kIsWeb) {
+    //   return false;
+    // }
+
+    // Other than web, we check that there's no gaps in the initial route.
+    // return plannedInitialRoutes.contains(null);
+
+    return false;
+  }
 
   Route<T> _routeNamed<T>(String name, { @required Object arguments, bool allowNull = false }) {
     assert(!_debugLocked);

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -783,6 +783,15 @@ class Navigator extends StatefulWidget {
   /// then the [Navigator] would push the following routes on startup: `/`,
   /// `/stocks`, `/stocks/HOOLI`. This enables deep linking while allowing the
   /// application to maintain a predictable route history.
+  ///
+  /// If any of the intermediate routes doesn't exist, it'll simply be skipped.
+  /// In the example above, if `/stocks` doesn't have a corresponding route in
+  /// the app, it'll be skipped and only `/` and `/stocks/HOOLI` will be pushed.
+  ///
+  /// That said, the full route has to map to something in the app in order for
+  /// this to work. In our example, `/stocks/HOOLI` has to map to a route in the
+  /// app. Otherwise, [initialRoute] will be ignored and [defaultRouteName] will
+  /// be used instead.
   final String initialRoute;
 
   /// Called to generate a route for a given [RouteSettings].
@@ -1524,18 +1533,14 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           plannedInitialRoutes.add(_routeNamed<dynamic>(routeName, allowNull: true, arguments: null));
         }
       }
-      if (_shouldAbandonInitialRoute(plannedInitialRoutes)) {
+      if (plannedInitialRoutes.last == null) {
         assert(() {
           FlutterError.reportError(
             FlutterErrorDetails(
               exception:
                 'Could not navigate to initial route.\n'
                 'The requested route name was: "/$initialRouteName"\n'
-                'The following routes were therefore attempted:\n'
-                ' * ${plannedInitialRouteNames.join("\n * ")}\n'
-                'This resulted in the following objects:\n'
-                ' * ${plannedInitialRoutes.join("\n * ")}\n'
-                'One or more of those objects was null, and therefore the initial route specified will be '
+                'There was no corresponding route in the app, and therefore the initial route specified will be '
                 'ignored and "${Navigator.defaultRouteName}" will be used instead.'
             ),
           );
@@ -1599,25 +1604,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   }
 
   bool _debugLocked = false; // used to prevent re-entrant calls to push, pop, and friends
-
-  bool _shouldAbandonInitialRoute(List<Route<dynamic>> plannedInitialRoutes) {
-    assert(plannedInitialRoutes.isNotEmpty);
-
-    // The last route has to match something in order for it to work.
-    if (plannedInitialRoutes.last == null) {
-      return true;
-    }
-
-    // In web, we don't care if there are gaps in the initial route.
-    // if (kIsWeb) {
-    //   return false;
-    // }
-
-    // Other than web, we check that there's no gaps in the initial route.
-    // return plannedInitialRoutes.contains(null);
-
-    return false;
-  }
 
   Route<T> _routeNamed<T>(String name, { @required Object arguments, bool allowNull = false }) {
     assert(!_debugLocked);


### PR DESCRIPTION
## Description

On the web, we would like to allow deep links to work even if there are some gaps in the intermediate routes.

To explain this, here's an example. Say the app is launched with an initial route `/A/B/C` and the app only defines the named routes `/`, `/A` and `/A/B/C` but not `/A/B`.

#### Current behavior
The initial route is ignored and the app goes to `/`.

#### New behavior
The initial route is honored and the following routes are mounted: `/` -> `/A` -> `/A/B/C`.

## Motivation

People use the browser refresh button a lot on the web, and they expect to remain on the same page. This is technically equivalent to deep linking on mobile.

In the flutter gallery, for example, each material demo has a route name of the form `/material/buttons`, but the app doesn't define a route named `/material`. The result here is that when the user refreshes the material buttons demo page, they find themselves back in the home screen of the flutter gallery because flutter fails to mount the `/material` route.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34351

## Tests

I added tests in `test/widgets/navigator_test.dart`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
