### PR TITLE
[flutter_tool] Add onError callback to asyncGuard. Use it in Doctor

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -143,8 +143,15 @@ class Doctor {
   List<ValidatorTask> startValidatorTasks() {
     final List<ValidatorTask> tasks = <ValidatorTask>[];
     for (DoctorValidator validator in validators) {
+      // We use an asyncGuard() here to be absolutely certain that
+      // DoctorValidators do not result in an uncaught exception. Since the
+      // Future returned by the asyncGuard() is not awaited, we pass an
+      // onError callback to it and translate errors into ValidationResults.
       final Future<ValidationResult> result =
-          asyncGuard<ValidationResult>(() => validator.validate());
+          asyncGuard<ValidationResult>(validator.validate,
+            onError: (Object exception, StackTrace stackTrace) {
+              return ValidationResult.crash(exception, stackTrace);
+            });
       tasks.add(ValidatorTask(validator, result));
     }
     return tasks;

--- a/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/doctor_test.dart
@@ -4,24 +4,25 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/process_manager.dart';
-import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/web/workflow.dart';
-import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
-
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/proxy_validator.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
 import 'package:flutter_tools/src/vscode/vscode_validator.dart';
+import 'package:flutter_tools/src/web/workflow.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+import 'package:quiver/testing/async.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -333,6 +334,34 @@ void main() {
       expect(await FakeCrashingDoctor().diagnose(verbose: true), isFalse);
       expect(testLogger.statusText, contains('#0      CrashingValidator.validate'));
     }, overrides: noColorTerminalOverride);
+
+
+    testUsingContext('validate non-verbose output format for run with an async crash', () async {
+      final Completer<void> completer = Completer<void>();
+      await FakeAsync().run((FakeAsync time) {
+        unawaited(FakeAsyncCrashingDoctor(time).diagnose(verbose: false).then((bool r) {
+          expect(r, isFalse);
+          completer.complete(null);
+        }));
+        time.elapse(const Duration(seconds: 1));
+        time.flushMicrotasks();
+        return completer.future;
+      });
+      expect(testLogger.statusText, equals(
+              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              '[✓] Passing Validator (with statusInfo)\n'
+              '[✓] Another Passing Validator (with statusInfo)\n'
+              '[☠] Async crashing validator (the doctor check crashed)\n'
+              '    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, '
+              'please let us know about this issue at https://github.com/flutter/flutter/issues.\n'
+              '    ✗ fatal error\n'
+              '[✓] Validators are fun (with statusInfo)\n'
+              '[✓] Four score and seven validators ago (with statusInfo)\n'
+              '\n'
+              '! Doctor found issues in 1 category.\n'
+      ));
+    }, overrides: noColorTerminalOverride);
+
 
     testUsingContext('validate non-verbose output format when only one category fails', () async {
       expect(await FakeSinglePassingDoctor().diagnose(verbose: false), isTrue);
@@ -691,6 +720,24 @@ class CrashingValidator extends DoctorValidator {
   }
 }
 
+class AsyncCrashingValidator extends DoctorValidator {
+  AsyncCrashingValidator(this._time) : super('Async crashing validator');
+
+  final FakeAsync _time;
+
+  @override
+  Future<ValidationResult> validate() {
+    const Duration delay = Duration(seconds: 1);
+    final Future<ValidationResult> result = Future<ValidationResult>
+        .delayed(delay).then((_) {
+      throw 'fatal error';
+    });
+    _time.elapse(const Duration(seconds: 1));
+    _time.flushMicrotasks();
+    return result;
+  }
+}
+
 /// A doctor that fails with a missing [ValidationResult].
 class FakeDoctor extends Doctor {
   List<DoctorValidator> _validators;
@@ -765,6 +812,27 @@ class FakeCrashingDoctor extends Doctor {
       _validators.add(PassingValidator('Passing Validator'));
       _validators.add(PassingValidator('Another Passing Validator'));
       _validators.add(CrashingValidator());
+      _validators.add(PassingValidator('Validators are fun'));
+      _validators.add(PassingValidator('Four score and seven validators ago'));
+    }
+    return _validators;
+  }
+}
+
+/// A doctor with a validator that throws an exception.
+class FakeAsyncCrashingDoctor extends Doctor {
+  FakeAsyncCrashingDoctor(this._time);
+
+  final FakeAsync _time;
+
+  List<DoctorValidator> _validators;
+  @override
+  List<DoctorValidator> get validators {
+    if (_validators == null) {
+      _validators = <DoctorValidator>[];
+      _validators.add(PassingValidator('Passing Validator'));
+      _validators.add(PassingValidator('Another Passing Validator'));
+      _validators.add(AsyncCrashingValidator(_time));
       _validators.add(PassingValidator('Validators are fun'));
       _validators.add(PassingValidator('Four score and seven validators ago'));
     }


### PR DESCRIPTION
## Description

Prior to this PR `asyncGuard` was not correct in cases where the returned `Future` was not immediately awaited. In these cases the returned `Future` could be completed with an error before an error handler could be attached. This would cause `asyncGuard()` to still allow some unhandled exceptions to propagate to the containing Zone's unhandled exception handler.

This PR adds an `onError` callback to `asyncGuard` to hanlde this situation.

## Related Issues

Crash in a doctor in crash reporting.

## Tests

I added the following tests:

Tests in doctor_test.dart and async_guard_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.