### PR TITLE
Check phone number formatting in the gallery text fields demo

### DIFF
--- a/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_gallery/demo/material/text_form_field_demo.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -16,8 +17,15 @@ void main() {
     final Finder nameField = find.widgetWithText(TextFormField, 'Name *');
     expect(nameField, findsOneWidget);
 
+    final Finder phoneNumberField = find.widgetWithText(TextFormField, 'Phone Number *');
+    expect(phoneNumberField, findsOneWidget);
+
     final Finder passwordField = find.widgetWithText(TextFormField, 'Password *');
     expect(passwordField, findsOneWidget);
+
+    await tester.enterText(phoneNumberField, '1234567890');
+    await tester.pumpAndSettle();
+    expect(find.text('(123) 456-7890'), findsOneWidget);
 
     await tester.enterText(nameField, '');
     await tester.pumpAndSettle();

--- a/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_gallery/demo/material/text_form_field_demo.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
+++ b/examples/flutter_gallery/test/demo/material/text_form_field_demo_test.dart
@@ -23,6 +23,7 @@ void main() {
     final Finder passwordField = find.widgetWithText(TextFormField, 'Password *');
     expect(passwordField, findsOneWidget);
 
+    // Verify the that the phone number's TextInputFormatter does what's expected.
     await tester.enterText(phoneNumberField, '1234567890');
     await tester.pumpAndSettle();
     expect(find.text('(123) 456-7890'), findsOneWidget);


### PR DESCRIPTION
Checks that the demo's phone number formatter (see `_UsNumberTextInputFormatter`, in examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart, does what's expected.
 
Sadly this test (or a similar driver test) can not check the kinds of failures here reported in https://github.com/flutter/flutter/issues/39047, https://github.com/flutter/flutter/issues/39427, https://github.com/flutter/flutter/issues/39223 because currently there's no support for entering text via the complete implementation of the [TextInput service](https://api.flutter.dev/flutter/services/TextInput-class.html).