### PR TITLE
throw tool exit when chrome fails to connect

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -213,7 +213,14 @@ class WebFs {
     cascade = cascade.add(_assetHandler(flutterProject));
     final HttpServer server = await httpMultiServerFactory(_kHostName, port);
     shelf_io.serveRequests(server, cascade.handler);
-    final Chrome chrome = await chromeLauncher.launch('http://$_kHostName:$port/');
+    Chrome chrome;
+    final String chromeUrl = 'http://$_kHostName:$port/';
+    try {
+      chrome = await chromeLauncher.launch(chromeUrl);
+    } on SocketException {
+      // This seems to only happen on Windows but there is no clear repro yet.
+      throwToolExit('Failed to connect to Chrome at $chromeUrl.');
+    }
     return WebFs(
       client,
       server,

--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -5,7 +5,9 @@
 import 'package:build_daemon/client.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:dwds/dwds.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -83,6 +85,16 @@ void main() {
 
     // Chrome is launched based on port from above.
     verify(mockChromeLauncher.launch('http://localhost:1234/')).called(1);
+  }));
+
+  test('Throws a tool exit when Chrome fails to launch', () => testbed.run(() async {
+    when(mockChromeLauncher.launch('http://localhost:1234/')).thenThrow(const SocketException(''));
+
+    expect(WebFs.start(
+      target: fs.path.join('lib', 'main.dart'),
+      buildInfo: BuildInfo.debug,
+      flutterProject: FlutterProject.current(),
+    ), throwsA(isInstanceOf<ToolExit>()));
   }));
 }
 


### PR DESCRIPTION
## Description

If we can't establish a debug connection with chrome, throw a tool exit instead of crashing with a socket exception. Not quite certain why this happens yet or what other steps we can take.