### PR TITLE
Update validation to support Xcode11 version

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -226,19 +226,20 @@ Future<void> validateBitcode(BuildMode buildMode, TargetPlatform targetPlatform)
 }
 
 Version _parseVersionFromClang(String clangVersion) {
-  const String prefix = 'Apple LLVM version ';
+  final RegExp pattern = RegExp(r'Apple (LLVM|clang) version (\d+\.\d+\.\d+) ');
   void _invalid() {
     throwToolExit('Unable to parse Clang version from "$clangVersion". '
-                  'Expected a string like "$prefix #.#.# (clang-####.#.##.#)".');
+                  'Expected a string like "Apple (LLVM|clang) #.#.# (clang-####.#.##.#)".');
   }
-  if (clangVersion == null || clangVersion.length <= prefix.length || !clangVersion.startsWith(prefix)) {
+
+  if (clangVersion == null || clangVersion.isEmpty) {
     _invalid();
   }
-  final int lastSpace = clangVersion.lastIndexOf(' ');
-  if (lastSpace == -1) {
+  final RegExpMatch match = pattern.firstMatch(clangVersion);
+  if (match == null || match.groupCount != 2) {
     _invalid();
   }
-  final Version version = Version.parse(clangVersion.substring(prefix.length, lastSpace));
+  final Version version = Version.parse(match.group(2));
   if (version == null) {
     _invalid();
   }


### PR DESCRIPTION
## Description

Xcode 11 has a different version string for clang. Updates the existing check with a regexp that supports old and new, adds some tests.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39458

## Tests

I added the following tests:

Coverage for old, new, and invalid strings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
