### PR TITLE
Update manifest.yaml

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -517,13 +517,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  macos_chrome_dev_mode:
-    description: >
-      Run flutter web on the devicelab and hot restart.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-    flaky: true # marekd as flaky while infra is under heavy development
-
   build_benchmark_ios:
     description: >
       Measures iOS build performance across config changes.


### PR DESCRIPTION
This test is spawning chrome windows and failing to close them on macs. It need to be fixed before re-enabling.