### PR TITLE
fix recursiveCopy to preserve executable bit

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -124,6 +124,11 @@ void recursiveCopy(Directory source, Directory target) {
     else if (entity is File) {
       final File dest = File(path.join(target.path, name));
       dest.writeAsBytesSync(entity.readAsBytesSync());
+      // Preserve executable bit
+      final String modes = entity.statSync().modeString();
+      if (modes != null && modes.contains('x')) {
+        makeExecutable(dest);
+      }
     }
   }
 }
@@ -132,6 +137,23 @@ FileSystemEntity move(FileSystemEntity whatToMove,
     {Directory to, String name}) {
   return whatToMove
       .renameSync(path.join(to.path, name ?? path.basename(whatToMove.path)));
+}
+
+/// Equivalent of `chmod a+x file`
+void makeExecutable(File file) {
+  final ProcessResult result = _processManager.runSync(<String>[
+    'chmod',
+    'a+x',
+    file.path,
+  ]);
+
+  if (result.exitCode != 0) {
+    throw FileSystemException(
+      'Error making ${file.path} executable.\n'
+      '${result.stderr}',
+      file.path,
+    );
+  }
 }
 
 /// Equivalent of `mkdir directory`.

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -141,6 +141,10 @@ FileSystemEntity move(FileSystemEntity whatToMove,
 
 /// Equivalent of `chmod a+x file`
 void makeExecutable(File file) {
+  // Windows files do not have an executable bit
+  if (Platform.isWindows) {
+    return;
+  }
   final ProcessResult result = _processManager.runSync(<String>[
     'chmod',
     'a+x',


### PR DESCRIPTION
## Description

Copying the fix from [this PR](https://github.com/flutter/flutter/pull/39145) to `gradle.dart#311`, the recursive copying should check if the target file had the executable bit set, and then make the copied file executable. This was causing `smoke_catalina_hot_mode_dev_cycle__benchmark` devicelab test to be flaky.