### PR TITLE
Reland "Expose LineMetrics in TextPainter (#39282)"

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -830,7 +830,8 @@ class TextPainter {
   /// Valid only after [layout] has been called.
   ///
   /// This can potentially return a large amount of data, so it is not recommended
-  /// to repeatedly call this. Instead, cache the results.
+  /// to repeatedly call this. Instead, cache the results. The cached results
+  /// should be invalidated upon sucessful [layout].
   List<ui.LineMetrics> computeLineMetrics() {
     assert(!_needsLayout);
     return _paragraph.computeLineMetrics();

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -808,7 +808,7 @@ class TextPainter {
   /// part of a word, such as spaces, symbols, and punctuation, have word breaks
   /// on both sides. In such cases, this method will return a text range that
   /// contains the given text position.
-  ///ddd
+  ///
   /// Word boundaries are defined more precisely in Unicode Standard Annex #29
   /// <http://www.unicode.org/reports/tr29/#Word_Boundaries>.
   TextRange getWordBoundary(TextPosition position) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' show min, max;
-import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment;
+import 'dart:ui' as ui show Paragraph, ParagraphBuilder, ParagraphConstraints, ParagraphStyle, PlaceholderAlignment, LineMetrics;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -815,5 +815,17 @@ class TextPainter {
     assert(!_needsLayout);
     final List<int> indices = _paragraph.getWordBoundary(position.offset);
     return TextRange(start: indices[0], end: indices[1]);
+  }
+
+  /// Returns the full list of [LineMetrics] that describe in detail the various
+  /// metrics of each laid out line.
+  ///
+  /// Not valid until after layout.
+  ///
+  /// This can potentially return a large amount of data, so it is not recommended
+  /// to repeatedly call this. Instead, cache the results.
+  List<ui.LineMetrics> computeLineMetrics() {
+    assert(!_needsLayout);
+    return _paragraph.computeLineMetrics();
   }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -824,14 +824,14 @@ class TextPainter {
   /// For example, the first line is in the zeroth index.
   ///
   /// [LineMetrics] contains measurements such as ascent, descent, baseline, and
-  /// width for the line as a whole, and may be useful for aligning non-text
-  /// elements to a particular line.
+  /// width for the line as a whole, and may be useful for aligning additional
+  /// widgets to a particular line.
   ///
   /// Valid only after [layout] has been called.
   ///
   /// This can potentially return a large amount of data, so it is not recommended
   /// to repeatedly call this. Instead, cache the results. The cached results
-  /// should be invalidated upon sucessful [layout].
+  /// should be invalidated upon the next sucessful [layout].
   List<ui.LineMetrics> computeLineMetrics() {
     assert(!_needsLayout);
     return _paragraph.computeLineMetrics();

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -808,7 +808,7 @@ class TextPainter {
   /// part of a word, such as spaces, symbols, and punctuation, have word breaks
   /// on both sides. In such cases, this method will return a text range that
   /// contains the given text position.
-  ///
+  ///ddd
   /// Word boundaries are defined more precisely in Unicode Standard Annex #29
   /// <http://www.unicode.org/reports/tr29/#Word_Boundaries>.
   TextRange getWordBoundary(TextPosition position) {
@@ -820,7 +820,14 @@ class TextPainter {
   /// Returns the full list of [LineMetrics] that describe in detail the various
   /// metrics of each laid out line.
   ///
-  /// Not valid until after layout.
+  /// The [LineMetrics] list is presented in the order of the lines they represent.
+  /// For example, the first line is in the zeroth index.
+  ///
+  /// [LineMetrics] contains measurements such as ascent, descent, baseline, and
+  /// width for the line as a whole, and may be useful for aligning non-text
+  /// elements to a particular line.
+  ///
+  /// Valid only after [layout] has been called.
   ///
   /// This can potentially return a large amount of data, so it is not recommended
   /// to repeatedly call this. Instead, cache the results.

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -789,5 +789,5 @@ void main() {
     expect(lines[1].lineNumber, 1);
     expect(lines[2].lineNumber, 2);
     expect(lines[3].lineNumber, 3);
-  }, skip: isBrowser);
+  }, skip: !isLinux);
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -741,7 +741,7 @@ void main() {
 
     painter.layout(maxWidth: 300);
 
-    List<ui.LineMetrics> lines = painter.computeLineMetrics();
+    final List<ui.LineMetrics> lines = painter.computeLineMetrics();
 
     expect(lines.length, 4);
 

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -729,4 +729,65 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[12], const TextBox.fromLTRBD(300, 30, 351, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
   }, skip: isBrowser);
+
+  test('TextPainter line metrics', () {
+    final TextPainter painter = TextPainter()
+      ..textDirection = TextDirection.ltr;
+
+    const String text = 'test1\nhello line two really long for soft break\nfinal line 4';
+    painter.text = const TextSpan(
+      text: text,
+    );
+
+    painter.layout(maxWidth: 300);
+
+    List<ui.LineMetrics> lines = painter.computeLineMetrics();
+
+    expect(lines.length, 4);
+
+    expect(lines[0].hardBreak, true);
+    expect(lines[1].hardBreak, false);
+    expect(lines[2].hardBreak, true);
+    expect(lines[3].hardBreak, true);
+
+    expect(lines[0].ascent, 11.199999809265137);
+    expect(lines[1].ascent, 11.199999809265137);
+    expect(lines[2].ascent, 11.199999809265137);
+    expect(lines[3].ascent, 11.199999809265137);
+
+    expect(lines[0].descent, 2.799999952316284);
+    expect(lines[1].descent, 2.799999952316284);
+    expect(lines[2].descent, 2.799999952316284);
+    expect(lines[3].descent, 2.799999952316284);
+
+    expect(lines[0].unscaledAscent, 11.199999809265137);
+    expect(lines[1].unscaledAscent, 11.199999809265137);
+    expect(lines[2].unscaledAscent, 11.199999809265137);
+    expect(lines[3].unscaledAscent, 11.199999809265137);
+
+    expect(lines[0].baseline, 11.200000047683716);
+    expect(lines[1].baseline, 25.200000047683716);
+    expect(lines[2].baseline, 39.200000047683716);
+    expect(lines[3].baseline, 53.200000047683716);
+
+    expect(lines[0].height, 14);
+    expect(lines[1].height, 14);
+    expect(lines[2].height, 14);
+    expect(lines[3].height, 14);
+
+    expect(lines[0].width, 70);
+    expect(lines[1].width, 294);
+    expect(lines[2].width, 266);
+    expect(lines[3].width, 168);
+
+    expect(lines[0].left, 0);
+    expect(lines[1].left, 0);
+    expect(lines[2].left, 0);
+    expect(lines[3].left, 0);
+
+    expect(lines[0].lineNumber, 0);
+    expect(lines[1].lineNumber, 1);
+    expect(lines[2].lineNumber, 2);
+    expect(lines[3].lineNumber, 3);
+  }, skip: isBrowser);
 }


### PR DESCRIPTION
Reland the patch with the text painter test running on only linux.

See #39282 for the original PR.