### PR TITLE
Revert "Add handling of 'TextInput.clearClient' message from platform…

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -632,7 +632,7 @@ abstract class TextInputClient {
 /// See also:
 ///
 ///  * [TextInput.attach]
-class TextInputConnection with ChangeNotifier {
+class TextInputConnection {
   TextInputConnection._(this._client)
     : assert(_client != null),
       _id = _nextId++;
@@ -667,18 +667,11 @@ class TextInputConnection with ChangeNotifier {
   void close() {
     if (attached) {
       SystemChannels.textInput.invokeMethod<void>('TextInput.clearClient');
-      _onConnectionClosed();
-      _clientHandler._scheduleHide();
+      _clientHandler
+        .._currentConnection = null
+        .._scheduleHide();
     }
     assert(!attached);
-  }
-
-  /// Clear out the current text input connection.
-  ///
-  /// Call this method when the current text input connection has cleared.
-  void _onConnectionClosed() {
-    _clientHandler._currentConnection = null;
-    notifyListeners();
   }
 }
 
@@ -759,9 +752,6 @@ class _TextInputClientHandler {
         break;
       case 'TextInputClient.updateFloatingCursor':
         _currentConnection._client.updateFloatingCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
-        break;
-      case 'TextInputClient.onConnectionClosed':
-        _currentConnection._onConnectionClosed();
         break;
       default:
         throw MissingPluginException();

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -88,44 +88,5 @@ void main() {
       expect(signed.hashCode == signedDecimal.hashCode, false);
       expect(decimal.hashCode == signedDecimal.hashCode, false);
     });
-
-    test('The framework TextInputConnection closes when the platform loses its input connection', () async {
-      // Assemble a TextInputConnection so we can verify its change in state.
-      final TextInputClient client = NoOpTextInputClient();
-      const TextInputConfiguration configuration = TextInputConfiguration();
-      final TextInputConnection textInputConnection = TextInput.attach(client, configuration);
-
-      // Verify that TextInputConnection think its attached to a client. This is
-      // an intermediate verification of expected state.
-      expect(textInputConnection.attached, true);
-
-      // Pretend that the platform has lost its input connection.
-      final ByteData messageBytes = const JSONMessageCodec().encodeMessage(
-          <String, dynamic>{
-            'args': <dynamic>[1],
-            'method': 'TextInputClient.onConnectionClosed',
-          }
-      );
-      ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-        'flutter/textinput',
-        messageBytes,
-        (ByteData _) {},
-      );
-
-      // Verify that textInputConnection no longer think its attached to an input
-      // connection. This is the critical verification of this test.
-      expect(textInputConnection.attached, false);
-    });
   });
-}
-
-class NoOpTextInputClient extends TextInputClient {
-  @override
-  void performAction(TextInputAction action) {}
-
-  @override
-  void updateEditingValue(TextEditingValue value) {}
-
-  @override
-  void updateFloatingCursor(RawFloatingCursorPoint point) {}
 }


### PR DESCRIPTION
Reverts a fix that was merged to correct a text input issue where leaving a Flutter app and coming back on Android puts Flutter's input system in an inconsistent state that won't allow reselecting the previously selected text field.

That fix introduced a number of regressions elsewhere. It is unclear why the regressions have occurred, so we are reverting.

For future reference, my current theory is this. On the engine side, we watch for Android closing the input connection so that we can forward that info to Flutter. When I implemented that behavior, I assumed that Android only closed connections when input is truly lost for a given input connection. However, based on carefully watching the Flutter gallery app for its phone number field, I think that what Android does is initially show a regular keyboard, and then Flutter tells Android to switch to a number keyboard, which, I think, causes Android to report the input connection is closed before re-opening the input connection with the new type of keyboard. This may be the root cause of the regression. Maybe the embedding's existing logic for opening an input connection is slightly wrong and needs to be updated.