### PR TITLE
Register flutterVersion service in flutter_tools.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -174,7 +174,11 @@ class VMService {
     }
 
     _peer.registerMethod('getFlutterVersion', (rpc.Parameters params) async {
-      return FlutterVersion().toJson();
+      final FlutterVersion version = FlutterVersion();
+      final Map<String, Object> versionJson = version.toJson();
+      versionJson['frameworkRevisionShort'] = version.frameworkRevisionShort;
+      versionJson['engineRevisionShort'] = version.engineRevisionShort;
+      return versionJson;
     });
 
     // If the Flutter Engine doesn't support service registration this will

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -106,9 +106,8 @@ class VMService {
     this.wsAddress,
     ReloadSources reloadSources,
     Restart restart,
-    CompileExpression compileExpression, {
-    bool sendPeerNotifications = true,
-  }) {
+    CompileExpression compileExpression,
+  ) {
     _vm = VM._empty(this);
     _peer.listen().catchError(_connectionError.completeError);
 
@@ -140,12 +139,10 @@ class VMService {
         }
       });
 
-      if (sendPeerNotifications) {
-        _peer.sendNotification('registerService', <String, String>{
-          'service': 'reloadSources',
-          'alias': 'Flutter Tools',
-        });
-      }
+      _peer.sendNotification('registerService', <String, String>{
+        'service': 'reloadSources',
+        'alias': 'Flutter Tools',
+      });
     }
 
     if (restart != null) {
@@ -166,12 +163,10 @@ class VMService {
         }
       });
 
-      if (sendPeerNotifications) {
-        _peer.sendNotification('registerService', <String, String>{
-          'service': 'hotRestart',
-          'alias': 'Flutter Tools',
-        });
-      }
+      _peer.sendNotification('registerService', <String, String>{
+        'service': 'hotRestart',
+        'alias': 'Flutter Tools',
+      });
     }
 
     _peer.registerMethod('flutterVersion', (rpc.Parameters params) async {
@@ -182,12 +177,10 @@ class VMService {
       return versionJson;
     });
 
-    if (sendPeerNotifications) {
-      _peer.sendNotification('registerService', <String, String>{
-        'service': 'flutterVersion',
-        'alias': 'Flutter Tools',
-      });
-    }
+    _peer.sendNotification('registerService', <String, String>{
+      'service': 'flutterVersion',
+      'alias': 'Flutter Tools',
+    });
 
     if (compileExpression != null) {
       _peer.registerMethod('compileExpression', (rpc.Parameters params) async {
@@ -221,12 +214,10 @@ class VMService {
         }
       });
 
-      if (sendPeerNotifications) {
-        _peer.sendNotification('registerService', <String, String>{
-          'service': 'compileExpression',
-          'alias': 'Flutter Tools',
-        });
-      }
+      _peer.sendNotification('registerService', <String, String>{
+        'service': 'compileExpression',
+        'alias': 'Flutter Tools',
+      });
     }
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -139,8 +139,6 @@ class VMService {
         }
       });
 
-      // If the Flutter Engine doesn't support service registration this will
-      // have no effect
       _peer.sendNotification('registerService', <String, String>{
         'service': 'reloadSources',
         'alias': 'Flutter Tools',
@@ -165,15 +163,13 @@ class VMService {
         }
       });
 
-      // If the Flutter Engine doesn't support service registration this will
-      // have no effect
       _peer.sendNotification('registerService', <String, String>{
         'service': 'hotRestart',
         'alias': 'Flutter Tools',
       });
     }
 
-    _peer.registerMethod('getFlutterVersion', (rpc.Parameters params) async {
+    _peer.registerMethod('flutterVersion', (rpc.Parameters params) async {
       final FlutterVersion version = FlutterVersion();
       final Map<String, Object> versionJson = version.toJson();
       versionJson['frameworkRevisionShort'] = version.frameworkRevisionShort;
@@ -181,10 +177,8 @@ class VMService {
       return versionJson;
     });
 
-    // If the Flutter Engine doesn't support service registration this will
-    // have no effect
     _peer.sendNotification('registerService', <String, String>{
-      'service': 'getFlutterVersion',
+      'service': 'flutterVersion',
       'alias': 'Flutter Tools',
     });
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -20,6 +20,7 @@ import 'base/io.dart' as io;
 import 'base/utils.dart';
 import 'convert.dart' show base64;
 import 'globals.dart';
+import 'version.dart';
 import 'vmservice_record_replay.dart';
 
 /// Override `WebSocketConnector` in [context] to use a different constructor
@@ -171,6 +172,17 @@ class VMService {
         'alias': 'Flutter Tools',
       });
     }
+
+    _peer.registerMethod('getFlutterVersion', (rpc.Parameters params) async {
+      return FlutterVersion().toJson();
+    });
+
+    // If the Flutter Engine doesn't support service registration this will
+    // have no effect
+    _peer.sendNotification('registerService', <String, String>{
+      'service': 'getFlutterVersion',
+      'alias': 'Flutter Tools',
+    });
 
     if (compileExpression != null) {
       _peer.registerMethod('compileExpression', (rpc.Parameters params) async {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -106,8 +106,9 @@ class VMService {
     this.wsAddress,
     ReloadSources reloadSources,
     Restart restart,
-    CompileExpression compileExpression,
-  ) {
+    CompileExpression compileExpression, {
+    bool sendPeerNotifications = true,
+  }) {
     _vm = VM._empty(this);
     _peer.listen().catchError(_connectionError.completeError);
 
@@ -139,10 +140,12 @@ class VMService {
         }
       });
 
-      _peer.sendNotification('registerService', <String, String>{
-        'service': 'reloadSources',
-        'alias': 'Flutter Tools',
-      });
+      if (sendPeerNotifications) {
+        _peer.sendNotification('registerService', <String, String>{
+          'service': 'reloadSources',
+          'alias': 'Flutter Tools',
+        });
+      }
     }
 
     if (restart != null) {
@@ -163,10 +166,12 @@ class VMService {
         }
       });
 
-      _peer.sendNotification('registerService', <String, String>{
-        'service': 'hotRestart',
-        'alias': 'Flutter Tools',
-      });
+      if (sendPeerNotifications) {
+        _peer.sendNotification('registerService', <String, String>{
+          'service': 'hotRestart',
+          'alias': 'Flutter Tools',
+        });
+      }
     }
 
     _peer.registerMethod('flutterVersion', (rpc.Parameters params) async {
@@ -177,10 +182,12 @@ class VMService {
       return versionJson;
     });
 
-    _peer.sendNotification('registerService', <String, String>{
-      'service': 'flutterVersion',
-      'alias': 'Flutter Tools',
-    });
+    if (sendPeerNotifications) {
+      _peer.sendNotification('registerService', <String, String>{
+        'service': 'flutterVersion',
+        'alias': 'Flutter Tools',
+      });
+    }
 
     if (compileExpression != null) {
       _peer.registerMethod('compileExpression', (rpc.Parameters params) async {
@@ -214,10 +221,12 @@ class VMService {
         }
       });
 
-      _peer.sendNotification('registerService', <String, String>{
-        'service': 'compileExpression',
-        'alias': 'Flutter Tools',
-      });
+      if (sendPeerNotifications) {
+        _peer.sendNotification('registerService', <String, String>{
+          'service': 'compileExpression',
+          'alias': 'Flutter Tools',
+        });
+      }
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -52,8 +52,11 @@ class MockPeer implements rpc.Peer {
 
   @override
   void sendNotification(String method, [ dynamic parameters ]) {
-    throw 'unexpected call to sendNotification';
+    // this does get called
+    sentNotifications.putIfAbsent(method, () => <dynamic>[]).add(parameters);
   }
+
+  Map<String, List<dynamic>> sentNotifications = <String, List<dynamic>>{};
 
   bool isolatesEnabled = false;
 
@@ -191,7 +194,13 @@ void main() {
         bool done = false;
         final MockPeer mockPeer = MockPeer();
         expect(mockPeer.returnedFromSendRequest, 0);
-        final VMService vmService = VMService(mockPeer, null, null, null, null, null, sendPeerNotifications: false);
+        final VMService vmService = VMService(mockPeer, null, null, null, null, null);
+        expect(mockPeer.sentNotifications, contains('registerService'));
+        final List<String> registeredServices =
+          mockPeer.sentNotifications['registerService']
+            .map((dynamic service) => (service as Map<String, String>)['service'])
+            .toList();
+        expect(registeredServices, contains('flutterVersion'));
         vmService.getVM().then((void value) { done = true; });
         expect(done, isFalse);
         expect(mockPeer.returnedFromSendRequest, 0);

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -191,7 +191,7 @@ void main() {
         bool done = false;
         final MockPeer mockPeer = MockPeer();
         expect(mockPeer.returnedFromSendRequest, 0);
-        final VMService vmService = VMService(mockPeer, null, null, null, null, null);
+        final VMService vmService = VMService(mockPeer, null, null, null, null, null, sendPeerNotifications: false);
         vmService.getVM().then((void value) { done = true; });
         expect(done, isFalse);
         expect(mockPeer.returnedFromSendRequest, 0);


### PR DESCRIPTION
Calling this service will return an output as such: 
```
{
  frameworkVersion: 1.9.2-pre.163, 
  channel: unknown, 
  repositoryUrl: unknown source,
  frameworkRevision: df05b8f1d80307b0eca043967bdf9b9956ea7240,
  frameworkCommitDate: 2019-08-29 15:08:05 -0700,
  engineRevision: 2d6631ae5d1c480dc941bf9e79099fef7bc640d5,
  dartSdkVersion: 2.5.0,
  frameworkRevisionShort: df05b8f1d8, 
  engineRevisionShort: 2d6631ae5d
}
```
The `frameworkRevisionShort` and `engineRevisionShort` fields are added on to FlutterVersion.toJson() so that we do not have to duplicate the `_shortGitRevision` method from flutter tools. We will consume this service in DevTools.

Fixes https://github.com/flutter/flutter/issues/39106.