### PR TITLE
Do not render any frames when just initializing Bindings

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -138,14 +138,13 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
   /// Creates a [RenderView] object to be the root of the
   /// [RenderObject] rendering tree, and initializes it so that it
-  /// will be rendered when the engine is next ready to display a
-  /// frame.
+  /// will be rendered when the next frame is requested.
   ///
   /// Called automatically when the binding is created.
   void initRenderView() {
     assert(renderView == null);
     renderView = RenderView(configuration: createViewConfiguration(), window: window);
-    renderView.scheduleInitialFrame();
+    renderView.prepareInitialFrame();
   }
 
   /// The object that manages state about currently connected mice, for hover

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -74,7 +74,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// The configuration is initially set by the `configuration` argument
   /// passed to the constructor.
   ///
-  /// Always call [scheduleInitialFrame] before changing the configuration.
+  /// Always call [prepareInitialFrame] before changing the configuration.
   set configuration(ViewConfiguration value) {
     assert(value != null);
     if (configuration == value)
@@ -110,16 +110,28 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
 
   /// Bootstrap the rendering pipeline by scheduling the first frame.
   ///
+  /// Deprecated. Call [prepareInitialFrame] followed by a call to
+  /// [PipelineOwner.requestVisualUpdate] on [owner] instead.
+  @Deprecated('Call prepareInitialFrame followed by owner.requestVisualUpdate() instead.')
+  void scheduleInitialFrame() {
+    prepareInitialFrame();
+    owner.requestVisualUpdate();
+  }
+
+  /// Bootstrap the rendering pipeline by preparing the first frame.
+  ///
   /// This should only be called once, and must be called before changing
   /// [configuration]. It is typically called immediately after calling the
   /// constructor.
-  void scheduleInitialFrame() {
+  ///
+  /// This does not actually schedule the first frame. Call
+  /// [PipelineOwner.requestVisualUpdate] on [owner] to do that.
+  void prepareInitialFrame() {
     assert(owner != null);
     assert(_rootTransform == null);
     scheduleInitialLayout();
     scheduleInitialPaint(_updateMatricesAndCreateNewRootLayer());
     assert(_rootTransform != null);
-    owner.requestVisualUpdate();
   }
 
   Matrix4 _rootTransform;

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -194,8 +194,6 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   void initInstances() {
     super.initInstances();
     _instance = this;
-    window.onBeginFrame = _handleBeginFrame;
-    window.onDrawFrame = _handleDrawFrame;
     SystemChannels.lifecycle.setMessageHandler(_handleLifecycleMessage);
     readInitialLifecycleStateFromNativeWindow();
 
@@ -652,6 +650,14 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
       scheduleFrame();
   }
 
+  @protected
+  void registerFrameCallbacks() {
+    assert(window.onBeginFrame == null);
+    assert(window.onDrawFrame == null);
+    window.onBeginFrame = _handleBeginFrame;
+    window.onDrawFrame = _handleDrawFrame;
+  }
+
   /// Schedules a new frame using [scheduleFrame] if this object is not
   /// currently producing a frame.
   ///
@@ -713,6 +719,9 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
         debugPrintStack(label: 'scheduleFrame() called. Current phase is $schedulerPhase.');
       return true;
     }());
+    if (window.onBeginFrame == null) {
+      registerFrameCallbacks();
+    }
     window.scheduleFrame();
     _hasScheduledFrame = true;
   }

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -651,11 +651,9 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   }
 
   @protected
-  void registerFrameCallbacks() {
-    assert(window.onBeginFrame == null);
-    assert(window.onDrawFrame == null);
-    window.onBeginFrame = _handleBeginFrame;
-    window.onDrawFrame = _handleDrawFrame;
+  void ensureFrameCallbacksRegistered() {
+    window.onBeginFrame ??= _handleBeginFrame;
+    window.onDrawFrame ??= _handleDrawFrame;
   }
 
   /// Schedules a new frame using [scheduleFrame] if this object is not
@@ -719,9 +717,7 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
         debugPrintStack(label: 'scheduleFrame() called. Current phase is $schedulerPhase.');
       return true;
     }());
-    if (window.onBeginFrame == null) {
-      registerFrameCallbacks();
-    }
+    ensureFrameCallbacksRegistered();
     window.scheduleFrame();
     _hasScheduledFrame = true;
   }

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -70,9 +70,7 @@ class TestServiceExtensionsBinding extends BindingBase
   bool frameScheduled = false;
   @override
   void scheduleFrame() {
-    if (ui.window.onBeginFrame == null) {
-      registerFrameCallbacks();
-    }
+    ensureFrameCallbacksRegistered();
     frameScheduled = true;
   }
   Future<void> doFrame() async {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -70,6 +70,9 @@ class TestServiceExtensionsBinding extends BindingBase
   bool frameScheduled = false;
   @override
   void scheduleFrame() {
+    if (ui.window.onBeginFrame == null) {
+      registerFrameCallbacks();
+    }
     frameScheduled = true;
   }
   Future<void> doFrame() async {
@@ -125,7 +128,7 @@ void main() {
   final List<String> console = <String>[];
 
   setUpAll(() async {
-    binding = TestServiceExtensionsBinding();
+    binding = TestServiceExtensionsBinding()..scheduleFrame();
     expect(binding.frameScheduled, isTrue);
 
     // We need to test this service extension here because the result is true
@@ -139,7 +142,7 @@ void main() {
     firstFrameResult = await binding.testExtension('didSendFirstFrameRasterizedEvent', <String, String>{});
     expect(firstFrameResult, <String, String>{'enabled': 'false'});
 
-    await binding.doFrame(); // initial frame scheduled by creating the binding
+    await binding.doFrame();
 
     expect(binding.debugDidSendFirstFrameEvent, isTrue);
     firstFrameResult = await binding.testExtension('didSendFirstFrameEvent', <String, String>{});

--- a/packages/flutter/test/rendering/independent_layout_test.dart
+++ b/packages/flutter/test/rendering/independent_layout_test.dart
@@ -49,7 +49,7 @@ void main() {
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;
     renderView.prepareInitialFrame();
-    renderView.owner.requestVisualUpdate();
+    pipelineOwner.requestVisualUpdate();
     // Lay out the onscreen in the default binding
     layout(onscreen.root, phase: EnginePhase.paint);
     expect(onscreen.child.hasSize, isTrue);
@@ -79,7 +79,7 @@ void main() {
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;
     renderView.prepareInitialFrame();
-    renderView.owner.requestVisualUpdate();
+    pipelineOwner.requestVisualUpdate();
     // Lay out the offscreen
     pipelineOwner.flushLayout();
     expect(offscreen.child.hasSize, isTrue);

--- a/packages/flutter/test/rendering/independent_layout_test.dart
+++ b/packages/flutter/test/rendering/independent_layout_test.dart
@@ -48,7 +48,8 @@ void main() {
     final PipelineOwner pipelineOwner = PipelineOwner();
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;
-    renderView.scheduleInitialFrame();
+    renderView.prepareInitialFrame();
+    renderView.owner.requestVisualUpdate();
     // Lay out the onscreen in the default binding
     layout(onscreen.root, phase: EnginePhase.paint);
     expect(onscreen.child.hasSize, isTrue);
@@ -77,7 +78,8 @@ void main() {
     final PipelineOwner pipelineOwner = PipelineOwner();
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;
-    renderView.scheduleInitialFrame();
+    renderView.prepareInitialFrame();
+    renderView.owner.requestVisualUpdate();
     // Lay out the offscreen
     pipelineOwner.flushLayout();
     expect(offscreen.child.hasSize, isTrue);

--- a/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
+++ b/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show window;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  test('Instantiating WidgetsFlutterBinding does neither schedule a frame nor register frame callbacks', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/39494.
+
+    // Preconditions.
+    expect(WidgetsBinding.instance, isNull);
+    expect(window.onBeginFrame, isNull);
+    expect(window.onDrawFrame, isNull);
+
+    // Instantiation does nothing with regards to frame scheduling.
+    final WidgetsFlutterBinding binding = WidgetsFlutterBinding.ensureInitialized();
+    expect(binding.hasScheduledFrame, isFalse);
+    expect(window.onBeginFrame, isNull);
+    expect(window.onDrawFrame, isNull);
+
+    // Frame callbacks are registered lazily when a frame is scheduled.
+    binding.scheduleFrame();
+    expect(window.onBeginFrame, isNotNull);
+    expect(window.onDrawFrame, isNotNull);
+  });
+}

--- a/packages/flutter/test/widgets/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widgets/independent_widget_layout_test.dart
@@ -23,7 +23,8 @@ class OffscreenRenderView extends RenderView {
 class OffscreenWidgetTree {
   OffscreenWidgetTree() {
     renderView.attach(pipelineOwner);
-    renderView.scheduleInitialFrame();
+    renderView.prepareInitialFrame();
+    renderView.owner.requestVisualUpdate();
   }
 
   final RenderView renderView = OffscreenRenderView();

--- a/packages/flutter/test/widgets/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widgets/independent_widget_layout_test.dart
@@ -24,7 +24,7 @@ class OffscreenWidgetTree {
   OffscreenWidgetTree() {
     renderView.attach(pipelineOwner);
     renderView.prepareInitialFrame();
-    renderView.owner.requestVisualUpdate();
+    pipelineOwner.requestVisualUpdate();
   }
 
   final RenderView renderView = OffscreenRenderView();

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -834,8 +834,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void initInstances() {
     super.initInstances();
-    window.onBeginFrame = (Duration _) {};
-    window.onDrawFrame = () {};
     _mockFlutterAssets();
   }
 
@@ -976,6 +974,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         _pendingAsyncTasks = null;
       });
     });
+  }
+
+  @override
+  void ensureFrameCallbacksRegistered() {
+    // Leave Window alone, do nothing.
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1361,7 +1361,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       onNeedPaint: _handleViewNeedsPaint,
       window: window,
     );
-    renderView.scheduleInitialFrame();
+    renderView.prepareInitialFrame();
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -834,8 +834,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void initInstances() {
     super.initInstances();
-    window.onBeginFrame = null;
-    window.onDrawFrame = null;
+    window.onBeginFrame = (Duration _) {};
+    window.onDrawFrame = () {};
     _mockFlutterAssets();
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -979,6 +979,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void ensureFrameCallbacksRegistered() {
     // Leave Window alone, do nothing.
+    assert(window.onDrawFrame == null);
+    assert(window.onBeginFrame == null);
   }
 
   @override


### PR DESCRIPTION
## Description

Prior to this change, initializing the WidgetsFlutterBinding (e.g. via `WidgetsFlutterBinding.ensureInitialized`) would register the frame callbacks `onBeginFrame` and `onDrawFrame` with the engine (this allowed to request the engine to render a frame whenever it wanted) and we would actively ask the engine to request the next frame via `Window.scheduleFrame`. In certain situations this caused the engine to request a frame (by calling `onBeginFrame`) when the framework wasn't ready to produce a meaningful frame (e. i. before the root widget was attached via a call to `runApp`). This would cause the framework to produce an empty frame, which in turn caused the engine to take down any splash screen and show a black empty screen.

With this change, initializing the bindings does not register the frame callbacks with the engine so the engine has no chance of requesting a frame from the framework. Instead, the frame callbacks are lazily registered when the first frame is scheduled by the framework via `scheduleFrame`. Additionally, initializing the bindings will no longer schedule a frame. The first frame gets scheduled when the root widget is attached and the framework is therefore ready to produce the first meaningful frame (or you can schedule a frame manually by calling `scheduleFrame` whenever you want).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39494.

## Tests

I added the following tests:

* tests to ensure that the binding neither register any callbacks nor schedules a frame when instantiated.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]): https://groups.google.com/forum/#!topic/flutter-announce/sB8Hxs8lrKI
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
