### PR TITLE
Keep Flutter.framework binaries writable so they can be code signed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -532,7 +532,6 @@ task:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts dev/bots/test.dart
     - name: add2app-macos
-      skip: true # https://github.com/flutter/flutter/issues/39507
       env:
         SHARD: add2app_test
       setup_xcpretty_script:

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -142,11 +142,11 @@ BuildApp() {
     mkdir "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_podspec}" "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}/engine"
-    RunCommand find "${derived_dir}/engine/Flutter.framework" -type f -exec chmod a-w "{}" \;
+    RunCommand find "${derived_dir}/engine/Flutter.framework" -type f -exec grep -Il '.' {} \; | xargs chmod a-w
   else
     RunCommand rm -rf -- "${derived_dir}/Flutter.framework"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}"
-    RunCommand find "${derived_dir}/Flutter.framework" -type f -exec chmod a-w "{}" \;
+    RunCommand find "${derived_dir}/Flutter.framework" -type f -exec grep -Il '.' {} \; | xargs chmod a-w
   fi
 
   RunCommand pushd "${project_path}" > /dev/null

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -142,10 +142,12 @@ BuildApp() {
     mkdir "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_podspec}" "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}/engine"
+    # Make non-binary files read-only to discourage editing headers, but allow binary code-signing.
     RunCommand find "${derived_dir}/engine/Flutter.framework" -type f -exec grep -Il '.' {} \; | xargs chmod a-w
   else
     RunCommand rm -rf -- "${derived_dir}/Flutter.framework"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}"
+    # Make non-binary files read-only to discourage editing headers, but allow binary code-signing.
     RunCommand find "${derived_dir}/Flutter.framework" -type f -exec grep -Il '.' {} \; | xargs chmod a-w
   fi
 


### PR DESCRIPTION
## Description

Flutter.framework files were made read-only to "Provide a strong hint to developers that editing Flutter framework headers isn't supported" (https://github.com/flutter/flutter/commit/cb2b89c389e06c2cceb1a3361d520eaccb4cec8c)  However this is making the Flutter binary readonly, which is being copied into the final embedded Frameworks directories, then can't be codesigned.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39507. 

## Tests

Turn back on add2app shard.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.