### PR TITLE
create .dart_tool if it is missing

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -140,6 +140,10 @@ class WebFs {
     @required FlutterProject flutterProject,
     @required BuildInfo buildInfo
   }) async {
+    // workaround for https://github.com/flutter/flutter/issues/38290
+    if (!flutterProject.dartTool.existsSync()) {
+      flutterProject.dartTool.createSync(recursive: true);
+    }
     // Start the build daemon and run an initial build.
     final BuildDaemonClient client = await buildDaemonCreator
       .startBuildDaemon(fs.currentDirectory.path, release: buildInfo.isRelease, profile: buildInfo.isProfile);

--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -72,10 +72,11 @@ void main() {
   });
 
   test('Can create webFs from mocked interfaces', () => testbed.run(() async {
+    final FlutterProject flutterProject = FlutterProject.current();
     await WebFs.start(
       target: fs.path.join('lib', 'main.dart'),
       buildInfo: BuildInfo.debug,
-      flutterProject: FlutterProject.current(),
+      flutterProject: flutterProject,
     );
 
     // The build daemon is told to build once.
@@ -83,6 +84,9 @@ void main() {
 
     // Chrome is launched based on port from above.
     verify(mockChromeLauncher.launch('http://localhost:1234/')).called(1);
+
+    // .dart_tool directory is created.
+    expect(flutterProject.dartTool.existsSync(), true);
   }));
 }
 


### PR DESCRIPTION
## Description

If the .dart_tool directory is missing before the build_daemon starts, create it. Added test case to confirm

Fixes https://github.com/flutter/flutter/issues/38290