### PR TITLE
remove a period from the service protocol printout

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -208,7 +208,7 @@ class ResidentWebRunner extends ResidentRunner {
       websocketUri = Uri.parse(_debugConnection.uri);
     }
     if (websocketUri != null) {
-      printStatus('Debug service listening on $websocketUri.');
+      printStatus('Debug service listening on $websocketUri');
     }
     connectionInfoCompleter?.complete(
       DebugConnectionInfo(wsUri: websocketUri)


### PR DESCRIPTION
## Description

- remove a period from the service protocol printout

If users include the period (when copying and pasting the url to a tool like devtools), they'll see an error when trying to connect.

@jonahwilliams 
