### PR TITLE
Use feature flags to control build command visibility

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
+++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
@@ -36,7 +36,7 @@ class BuildLinuxCommand extends BuildSubCommand {
   final String name = 'linux';
 
   @override
-  bool hidden = true;
+  bool get hidden => !featureFlags.isLinuxEnabled || !platform.isLinux;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
@@ -45,7 +45,7 @@ class BuildLinuxCommand extends BuildSubCommand {
   };
 
   @override
-  String get description => 'build the Linux desktop target (Experimental).';
+  String get description => 'build the Linux desktop target.';
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -25,7 +25,7 @@ class BuildMacosCommand extends BuildSubCommand {
   final String name = 'macos';
 
   @override
-  bool hidden = true;
+  bool get hidden => !featureFlags.isMacOSEnabled || !platform.isMacOS;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -31,7 +31,7 @@ class BuildWebCommand extends BuildSubCommand {
   final String name = 'web';
 
   @override
-  bool get hidden => true;
+  bool get hidden => !featureFlags.isWebEnabled;
 
   @override
   final String description = 'build a web application bundle.';

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -36,7 +36,7 @@ class BuildWindowsCommand extends BuildSubCommand {
   final String name = 'windows';
 
   @override
-  bool hidden = true;
+  bool get hidden => !featureFlags.isWindowsEnabled || !platform.isWindows;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{

--- a/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_linux.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/linux/makefile.dart';
@@ -161,6 +162,24 @@ BINARY_NAME=fizz_bar
     ProcessManager: () => mockProcessManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+  });
+
+  testUsingContext('hidden when not enabled on Linux host', () {
+    when(platform.isLinux).thenReturn(true);
+
+    expect(BuildLinuxCommand().hidden, true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+     Platform: () => MockPlatform(),
+  });
+
+  testUsingContext('Not hidden when enabled and on Linux host', () {
+    when(platform.isLinux).thenReturn(true);
+
+    expect(BuildLinuxCommand().hidden, false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+    Platform: () => MockPlatform(),
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_macos.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -178,6 +179,24 @@ void main() {
         throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
+  });
+
+  testUsingContext('hidden when not enabled on macOS host', () {
+    when(platform.isMacOS).thenReturn(true);
+
+    expect(BuildMacosCommand().hidden, true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
+     Platform: () => MockPlatform(),
+  });
+
+  testUsingContext('Not hidden when enabled and on macOS host', () {
+    when(platform.isMacOS).thenReturn(true);
+
+    expect(BuildMacosCommand().hidden, false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    Platform: () => MockPlatform(),
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/commands/build_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_web_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -94,6 +95,18 @@ void main() {
         throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
+  }));
+
+  test('hidden if feature flag is not enabled', () => testbed.run(() async {
+    expect(BuildWebCommand().hidden, true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
+  }));
+
+  test('not hidden if feature flag is enabled', () => testbed.run(() async {
+    expect(BuildWebCommand().hidden, false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   }));
 }
 

--- a/packages/flutter_tools/test/general.shard/commands/build_windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_windows_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_windows.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/windows/visual_studio.dart';
@@ -172,6 +173,24 @@ void main() {
     Platform: () => windowsPlatform,
     VisualStudio: () => mockVisualStudio,
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+  });
+
+  testUsingContext('hidden when not enabled on Windows host', () {
+    when(platform.isWindows).thenReturn(true);
+
+    expect(BuildWindowsCommand().hidden, true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
+     Platform: () => MockPlatform(),
+  });
+
+  testUsingContext('Not hidden when enabled and on Windows host', () {
+    when(platform.isWindows).thenReturn(true);
+
+    expect(BuildWindowsCommand().hidden, false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+    Platform: () => MockPlatform(),
   });
 }
 


### PR DESCRIPTION
## Description

Control visibility of build sub command via feature flags and host platform, instead of hiding them.

Fixes https://github.com/flutter/flutter/issues/39548