### PR TITLE
Prevent exception when creating a Divider borderSide

### DIFF
--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -117,9 +117,20 @@ class Divider extends StatelessWidget {
   /// ```
   /// {@end-tool}
   static BorderSide createBorderSide(BuildContext context, { Color color, double width }) {
+    final Color themeColor = context != null ? (DividerTheme.of(context).color ?? Theme.of(context).dividerColor) : null;
+    final double themeWidth = context != null ? DividerTheme.of(context).thickness : null;
+    final double resolvedWidth = width ?? themeWidth ?? 0.0;
+
+    // Prevent assertion since it is possible that context is null and no color
+    // is specified.
+    if (color == null && themeColor == null) {
+      return BorderSide(
+        width: resolvedWidth,
+      );
+    }
     return BorderSide(
-      color: color ?? DividerTheme.of(context).color ?? Theme.of(context).dividerColor,
-      width: width ?? DividerTheme.of(context).thickness ?? 0.0,
+      color: color ?? themeColor,
+      width: resolvedWidth,
     );
   }
 

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -91,13 +91,17 @@ class Divider extends StatelessWidget {
   /// {@end-tool}
   final Color color;
 
-  /// Computes the [BorderSide] that represents a divider of the specified
-  /// color, or, if there is no specified color, of the default
-  /// [ThemeData.dividerColor] specified in the ambient [Theme].
+  /// Computes the [BorderSide] that represents a divider..
   ///
-  /// The `width` argument can be used to override the default width of the
-  /// divider border, which defaults to 0.0 (a hairline border).
+  /// If [color] is null, then [DividerThemeData.color] is used. If that is also
+  /// null, then [ThemeData.dividerColor] is used.
   ///
+  /// If [width] is null, then [DividerThemeData.thickness] is used. If that is
+  /// also null, then this defaults to 0.0 (a hairline border).
+  ///
+  /// If [context] is null, the default color of [BorderSide] is used and the
+  /// default width of 0.0 is used.
+  /// 
   /// {@tool sample}
   ///
   /// This example uses this method to create a box that has a divider above and
@@ -117,10 +121,11 @@ class Divider extends StatelessWidget {
   /// ```
   /// {@end-tool}
   static BorderSide createBorderSide(BuildContext context, { Color color, double width }) {
-    final Color themeColor = context != null ? (DividerTheme.of(context).color ?? Theme.of(context).dividerColor) : null;
-    final Color effectiveColor = color ?? themeColor;
-    final double themeWidth = context != null ? DividerTheme.of(context).thickness : null;
-    final double effectiveWidth = width ?? themeWidth ?? 0.0;
+    final Color effectiveColor = color
+        ?? (context != null ? (DividerTheme.of(context).color ?? Theme.of(context).dividerColor) : null);
+    final double effectiveWidth =  width
+        ?? (context != null ? DividerTheme.of(context).thickness : null)
+        ?? 0.0;
 
     // Prevent assertion since it is possible that context is null and no color
     // is specified.

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -118,19 +118,20 @@ class Divider extends StatelessWidget {
   /// {@end-tool}
   static BorderSide createBorderSide(BuildContext context, { Color color, double width }) {
     final Color themeColor = context != null ? (DividerTheme.of(context).color ?? Theme.of(context).dividerColor) : null;
+    final Color effectiveColor = color ?? themeColor;
     final double themeWidth = context != null ? DividerTheme.of(context).thickness : null;
-    final double resolvedWidth = width ?? themeWidth ?? 0.0;
+    final double effectiveWidth = width ?? themeWidth ?? 0.0;
 
     // Prevent assertion since it is possible that context is null and no color
     // is specified.
-    if (color == null && themeColor == null) {
+    if (effectiveColor == null) {
       return BorderSide(
-        width: resolvedWidth,
+        width: effectiveWidth,
       );
     }
     return BorderSide(
-      color: color ?? themeColor,
-      width: resolvedWidth,
+      color: effectiveColor,
+      width: effectiveWidth,
     );
   }
 

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -101,7 +101,7 @@ class Divider extends StatelessWidget {
   ///
   /// If [context] is null, the default color of [BorderSide] is used and the
   /// default width of 0.0 is used.
-  /// 
+  ///
   /// {@tool sample}
   ///
   /// This example uses this method to create a box that has a divider above and

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -206,7 +206,8 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/39533
   testWidgets('createBorderSide does not throw exception with null context', (WidgetTester tester) async {
-    Divider.createBorderSide(null);
     // Passing a null context used to throw an exception but no longer does.
+    expect(() => Divider.createBorderSide(null), isNot(throwsAssertionError));
+    expect(() => Divider.createBorderSide(null), isNot(throwsNoSuchMethodError));
   });
 }

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -203,4 +203,10 @@ void main() {
     expect(lineRect.top, dividerRect.top + customIndent);
     expect(lineRect.bottom, dividerRect.bottom - customIndent);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/39533
+  testWidgets('createBorderSide does not throw exception with null context', (WidgetTester tester) async {
+    Divider.createBorderSide(null);
+    // Passing a null context used to throw an exception but no longer does.
+  });
 }


### PR DESCRIPTION
## Description

Check for a null context in the `Divider.createBorderSide` function and ensure no exception occurs.

## Related Issues

Fixes #39533 

## Tests

I added the following tests:

* A test that would have thrown exceptions before this change

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
