### PR TITLE
Use dpr and window size from binding for accessibility guide

### DIFF
--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -201,7 +201,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     final ByteData byteData = await tester.binding.runAsync<ByteData>(() async {
       // Needs to be the same pixel ratio otherwise our dimensions won't match the
       // last transform layer.
-      image = await layer.toImage(renderView.paintBounds, pixelRatio: 1 / 3);
+      image = await layer.toImage(renderView.paintBounds, pixelRatio: 1 / tester.binding.window.devicePixelRatio);
       return image.toByteData();
     });
 
@@ -260,7 +260,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
         return result;
       }
 
-      if (_isNodeOffScreen(paintBounds)) {
+      if (_isNodeOffScreen(paintBounds, tester.binding.window)) {
         return result;
       }
       final List<int> subset = _subsetToRect(byteData, paintBounds, image.width, image.height);
@@ -302,13 +302,14 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
 
   // Returns a rect that is entirely on screen, or null if it is too far off.
   //
-  // Given an 1800 * 2400 pixel buffer, can we actually get all the data from
-  // this node? allow a small delta overlap before culling the node.
-  bool _isNodeOffScreen(Rect paintBounds) {
+  // Given a pixel buffer based on the physical window size, can we actually
+  // get all the data from this node? allow a small delta overlap before
+  // culling the node.
+  bool _isNodeOffScreen(Rect paintBounds, ui.Window window) {
     return paintBounds.top < -50.0
       || paintBounds.left <  -50.0
-      || paintBounds.bottom > 2400.0 + 50.0
-      || paintBounds.right > 1800.0 + 50.0;
+      || paintBounds.bottom > (window.physicalSize.height * window.devicePixelRatio) + 50.0
+      || paintBounds.right > (window.physicalSize.width * window.devicePixelRatio)  + 50.0;
   }
 
   List<int> _subsetToRect(ByteData data, Rect paintBounds, int width, int height) {

--- a/packages/flutter_test/test/accessibility_window_test.dart
+++ b/packages/flutter_test/test/accessibility_window_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Fails correctly with configured screen size - small', (WidgetTester tester) async {
+    tester.binding.window.devicePixelRatioTestValue = 1.2;
+    tester.binding.window.physicalSizeTestValue = const Size(250, 300);
+
+    final RaisedButton invalidButton = RaisedButton(
+      onPressed: () {},
+      child: const Text('Button'),
+      textColor: Colors.orange,
+      color: Colors.orangeAccent,
+    );
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: invalidButton)));
+
+    final Evaluation result = await textContrastGuideline.evaluate(tester);
+    expect(result.passed, false);
+  });
+
+  testWidgets('Fails correctly with configured screen size - large', (WidgetTester tester) async {
+    tester.binding.window.devicePixelRatioTestValue = 4.2;
+    tester.binding.window.physicalSizeTestValue = const Size(2500, 3000);
+
+    final RaisedButton invalidButton = RaisedButton(
+      onPressed: () {},
+      child: const Text('Button'),
+      textColor: Colors.orange,
+      color: Colors.orangeAccent,
+    );
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: invalidButton)));
+
+    final Evaluation result = await textContrastGuideline.evaluate(tester);
+    expect(result.passed, false);
+  });
+}


### PR DESCRIPTION
## Description

Previously the contrast test logic assumed 800x600 and a dpr of 3.0. Remove the hardcoded values and replace with a lookup on the binding's window to support different screen sizes and resolutions.

