### PR TITLE
[flutter_tools] Add a timeout to another showBuildSettings command

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -279,6 +279,9 @@ class BufferLogger extends Logger {
   String get traceText => _trace.toString();
 
   @override
+  bool get hasTerminal => false;
+
+  @override
   void printError(
     String message, {
     StackTrace stackTrace,

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -32,6 +32,7 @@ import 'features.dart';
 import 'fuchsia/fuchsia_device.dart' show FuchsiaDeviceTools;
 import 'fuchsia/fuchsia_sdk.dart' show FuchsiaSdk, FuchsiaArtifacts;
 import 'fuchsia/fuchsia_workflow.dart' show FuchsiaWorkflow;
+import 'ios/devices.dart' show IOSDeploy;
 import 'ios/ios_workflow.dart';
 import 'ios/mac.dart';
 import 'ios/simulators.dart';
@@ -90,6 +91,7 @@ Future<T> runInContext<T>(
       GenSnapshot: () => const GenSnapshot(),
       HotRunnerConfig: () => HotRunnerConfig(),
       IMobileDevice: () => IMobileDevice(),
+      IOSDeploy: () => const IOSDeploy(),
       IOSSimulatorUtils: () => IOSSimulatorUtils(),
       IOSWorkflow: () => const IOSWorkflow(),
       KernelCompilerFactory: () => const KernelCompilerFactory(),

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../application_package.dart';
 import '../artifacts.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -27,6 +28,8 @@ import 'mac.dart';
 
 class IOSDeploy {
   const IOSDeploy();
+
+  static IOSDeploy get instance => context.get<IOSDeploy>();
 
   /// Installs and runs the specified app bundle using ios-deploy, then returns
   /// the exit code.
@@ -365,7 +368,7 @@ class IOSDevice extends Device {
         );
       }
 
-      final int installationResult = await const IOSDeploy().runApp(
+      final int installationResult = await IOSDeploy.instance.runApp(
         deviceId: id,
         bundlePath: bundle.path,
         launchArguments: launchArguments,

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -103,7 +103,10 @@ void main() {
       // MockProcessManager has an implementation of start() that returns the
       // result of processFactory.
       flakyProcessManager = MockProcessManager();
-      flakyProcessManager.processFactory = flakyProcessFactory(1, delay: delay);
+      flakyProcessManager.processFactory = flakyProcessFactory(
+        flakes: 1,
+        delay: delay,
+      );
     });
 
     testUsingContext('flaky process fails without retry', () async {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
@@ -12,14 +14,19 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
+import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
+import 'package:quiver/testing/async.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -31,6 +38,7 @@ class MockCache extends Mock implements Cache {}
 class MockDirectory extends Mock implements Directory {}
 class MockFileSystem extends Mock implements FileSystem {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
+class MockIOSDeploy extends Mock implements IOSDeploy {}
 class MockXcode extends Mock implements Xcode {}
 class MockFile extends Mock implements File {}
 class MockPortForwarder extends Mock implements DevicePortForwarder {}
@@ -71,6 +79,11 @@ void main() {
       MockProcessManager mockProcessManager;
       MockDeviceLogReader mockLogReader;
       MockPortForwarder mockPortForwarder;
+      MockIMobileDevice mockIMobileDevice;
+      MockIOSDeploy mockIosDeploy;
+
+      Directory tempDir;
+      Directory projectDir;
 
       const int devicePort = 499;
       const int hostPort = 42;
@@ -86,6 +99,8 @@ void main() {
       );
 
       setUp(() {
+        Cache.disableLocking();
+
         mockApp = MockIOSApp();
         mockArtifacts = MockArtifacts();
         mockCache = MockCache();
@@ -94,6 +109,11 @@ void main() {
         mockProcessManager = MockProcessManager();
         mockLogReader = MockDeviceLogReader();
         mockPortForwarder = MockPortForwarder();
+        mockIMobileDevice = MockIMobileDevice();
+        mockIosDeploy = MockIOSDeploy();
+
+        tempDir = fs.systemTempDirectory.createTempSync('flutter_tools_create_test.');
+        projectDir = tempDir.childDirectory('flutter_project');
 
         when(
             mockArtifacts.getArtifactPath(
@@ -126,10 +146,16 @@ void main() {
             .thenAnswer(
                 (_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', ''))
             );
+
+        when(mockIMobileDevice.getInfoForDevice(any, 'CPUArchitecture'))
+            .thenAnswer((_) => Future<String>.value('arm64'));
       });
 
       tearDown(() {
         mockLogReader.dispose();
+        tryToDelete(tempDir);
+
+        Cache.enableLocking();
       });
 
       testUsingContext(' succeeds in debug mode', () async {
@@ -202,6 +228,91 @@ void main() {
         Platform: () => macPlatform,
         ProcessManager: () => mockProcessManager,
       });
+
+      void testNonPrebuilt({
+        @required bool showBuildSettingsFlakes,
+      }) {
+        const String name = ' non-prebuilt succeeds in debug mode';
+        testUsingContext(name + ' flaky: $showBuildSettingsFlakes', () async {
+          final Directory targetBuildDir =
+              projectDir.childDirectory('build/ios/iphoneos/Debug-arm64');
+
+          // The -showBuildSettings calls have a timeout and so go through
+          // processManager.start().
+          mockProcessManager.processFactory = flakyProcessFactory(
+            flakes: showBuildSettingsFlakes ? 1 : 0,
+            delay: const Duration(seconds: 62),
+            filter: (List<String> args) => args.contains('-showBuildSettings'),
+            stdout:
+                () => Stream<String>
+                  .fromIterable(
+                      <String>['TARGET_BUILD_DIR = ${targetBuildDir.path}\n'])
+                  .transform(utf8.encoder),
+          );
+
+          // Make all other subcommands succeed.
+          when(mockProcessManager.run(
+              any,
+              workingDirectory: anyNamed('workingDirectory'),
+              environment: anyNamed('environment'),
+          )).thenAnswer((Invocation inv) {
+            return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
+          });
+
+          // Deploy works.
+          when(mockIosDeploy.runApp(
+            deviceId: anyNamed('deviceId'),
+            bundlePath: anyNamed('bundlePath'),
+            launchArguments: anyNamed('launchArguments'),
+          )).thenAnswer((_) => Future<int>.value(0));
+
+          // Create a dummy project to avoid mocking out the whole directory
+          // structure expected by device.startApp().
+          Cache.flutterRoot = '../..';
+          final CreateCommand command = CreateCommand();
+          final CommandRunner<void> runner = createTestCommandRunner(command);
+          await runner.run(<String>[
+            'create',
+            '--no-pub',
+            projectDir.path,
+          ]);
+
+          final IOSApp app =
+              AbsoluteBuildableIOSApp(FlutterProject.fromDirectory(projectDir).ios);
+          final IOSDevice device = IOSDevice('123');
+
+          // Pre-create the expected build products.
+          targetBuildDir.createSync(recursive: true);
+          projectDir.childDirectory('build/ios/iphoneos/Runner.app').createSync(recursive: true);
+
+          final Completer<LaunchResult> completer = Completer<LaunchResult>();
+          FakeAsync().run((FakeAsync time) {
+            device.startApp(
+              app,
+              prebuiltApplication: false,
+              debuggingOptions: DebuggingOptions.disabled(const BuildInfo(BuildMode.debug, null)),
+              platformArgs: <String, dynamic>{},
+            ).then((LaunchResult result) {
+              completer.complete(result);
+            });
+            time.flushMicrotasks();
+            time.elapse(const Duration(seconds: 65));
+          });
+          final LaunchResult launchResult = await completer.future;
+          expect(launchResult.started, isTrue);
+          expect(launchResult.hasObservatory, isFalse);
+          expect(await device.stopApp(mockApp), isFalse);
+        }, overrides: <Type, Generator>{
+          DoctorValidatorsProvider: () => FakeIosDoctorProvider(),
+          IMobileDevice: () => mockIMobileDevice,
+          IOSDeploy: () => mockIosDeploy,
+          Platform: () => macPlatform,
+          ProcessManager: () => mockProcessManager,
+        });
+      }
+
+      testNonPrebuilt(showBuildSettingsFlakes: false);
+      testNonPrebuilt(showBuildSettingsFlakes: true);
     });
 
     group('Process calls', () {
@@ -498,4 +609,30 @@ flutter:
     FileSystem: () => MemoryFileSystem(),
     Platform: () => macPlatform,
   });
+}
+
+class AbsoluteBuildableIOSApp extends BuildableIOSApp {
+  AbsoluteBuildableIOSApp(IosProject project) : super(project);
+
+  @override
+  String get deviceBundlePath =>
+      fs.path.join(project.parent.directory.path, 'build', 'ios', 'iphoneos', name);
+
+}
+
+class FakeIosDoctorProvider implements DoctorValidatorsProvider {
+  List<Workflow> _workflows;
+
+  @override
+  List<DoctorValidator> get validators => <DoctorValidator>[];
+
+  @override
+  List<Workflow> get workflows {
+    if (_workflows == null) {
+      _workflows = <Workflow>[];
+      if (iosWorkflow.appliesToHostPlatform)
+        _workflows.add(iosWorkflow);
+    }
+    return _workflows;
+  }
 }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -153,8 +153,10 @@ void main() {
 
     testUsingContext('build settings flakes', () async {
       const Duration delay = Duration(seconds: 1);
-      mockProcessManager.processFactory =
-          mocks.flakyProcessFactory(1, delay: delay + const Duration(seconds: 1));
+      mockProcessManager.processFactory = mocks.flakyProcessFactory(
+        flakes: 1,
+        delay: delay + const Duration(seconds: 1),
+      );
       expect(await xcodeProjectInterpreter.getBuildSettingsAsync(
                  '', '', timeout: delay),
              const <String, String>{});


### PR DESCRIPTION
## Description

I missed a `-showBuildSettings` command in my previous PR: https://github.com/flutter/flutter/pull/39280

## Related Issues

https://github.com/flutter/flutter/issues/35988

## Tests

I added the following tests:

Added a couple of tests to devices_test.dart that exercise `IosDevice.startApp()` in the case where the app is not pre-built, which triggers a build, which calls xcode with `-showBuildSettings`.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.