### PR TITLE
Mark flutter_gallery__transition_perf as non-flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -620,7 +620,6 @@ tasks:
       Measures the performance of screen transitions in Flutter Gallery on
       Android.
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["linux/android"]
 
   flutter_gallery__transition_perf_with_semantics:


### PR DESCRIPTION
One of our linux/android Moto G4 has alerts (emergency, amber, etc.)
turned on. That's probably the cause of the flakiness. I've turned it
off.

Let's mark this as non-flaky and see if it's fixed. If not, I'll move it
to mac/android and see if that fixes the flakiness.

I think the most important thing to do right now is to mark it as
non-flaky so those who really break the test could get a notification.

See https://github.com/flutter/flutter/issues/39419
