### PR TITLE
Update dartdoc to 0.28.5

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -104,7 +104,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.28.4
+"$PUB" global activate dartdoc 0.28.5
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Update dartdoc to version 0.28.5. 

This update has the option to turn off version info in footer by adding the following to dartdoc_options.yaml

`excludeFooterVersion: true`

@dnfield 