### PR TITLE
Fix single action banner to ensure button alignment

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -143,7 +143,7 @@ class MaterialBanner extends StatelessWidget {
                     padding: leadingPadding,
                     child: leading,
                   ),
-                Flexible(
+                Expanded(
                   child: DefaultTextStyle(
                     style: textStyle,
                     child: content,

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -100,7 +100,7 @@ void main() {
     expect(contentBottomLeft.dx, lessThan(actionsTopRight.dx));
   });
 
-  // Regression for https://github.com/flutter/flutter/issues/39574
+  // Regression test for https://github.com/flutter/flutter/issues/39574
   testWidgets('Single action laid out beside content but aligned to the trailing edge', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -121,6 +121,29 @@ void main() {
     expect(actionsTopRight.dx, bannerTopRight.dx);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/39574
+  testWidgets('Single action laid out beside content but aligned to the trailing edge - RTL', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+        textDirection: TextDirection.rtl,
+          child: MaterialBanner(
+            content: const Text('Content'),
+            actions: <Widget>[
+              FlatButton(
+                child: const Text('Action'),
+                onPressed: () { },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Offset actionsTopLeft = tester.getTopLeft(find.byType(ButtonBar));
+    final Offset bannerTopLeft = tester.getTopLeft(find.byType(MaterialBanner));
+    expect(actionsTopLeft.dx, bannerTopLeft.dx);
+  });
 
   testWidgets('Actions laid out below content if forced override', (WidgetTester tester) async {
     const String contentText = 'Content';

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -100,6 +100,28 @@ void main() {
     expect(contentBottomLeft.dx, lessThan(actionsTopRight.dx));
   });
 
+  // Regression for https://github.com/flutter/flutter/issues/39574
+  testWidgets('Single action laid out beside content but aligned to the trailing edge', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MaterialBanner(
+          content: const Text('Content'),
+          actions: <Widget>[
+            FlatButton(
+              child: const Text('Action'),
+              onPressed: () { },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Offset actionsTopRight = tester.getTopRight(find.byType(ButtonBar));
+    final Offset bannerTopRight = tester.getTopRight(find.byType(MaterialBanner));
+    expect(actionsTopRight.dx, bannerTopRight.dx);
+  });
+
+
   testWidgets('Actions laid out below content if forced override', (WidgetTester tester) async {
     const String contentText = 'Content';
 


### PR DESCRIPTION
## Description

Fixes a small layout issue with a single action `MaterialBanner` to ensure it is aligned to the trailing edge of the banner.

| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/2364772/64202797-fcccb580-ce5f-11e9-826a-ab82d2142597.png">  | <img width="300" src="https://user-images.githubusercontent.com/2364772/64202832-140ba300-ce60-11e9-8b7e-53b3b69759b7.png"> |

## Related Issues

Fixes #39574

## Tests

I added the following tests:

* A test that ensures the placement of the buttons is correct.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
