### PR TITLE
disable low value linux tests

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -90,19 +90,21 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  codegen_integration_linux:
-    description: >
-      Runs codegeneration and verifies that it can execute
-      correctly.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+  # TODO(jonahwilliams): re-enable with https://github.com/flutter/flutter/issues/39597
+  # codegen_integration_linux:
+  #   description: >
+  #     Runs codegeneration and verifies that it can execute
+  #     correctly.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
 
-  uncaught_image_error_linux:
-    description: >
-      Ensures that an error thrown into the zone can be caught by the ImageStream
-      completer
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+  # TODO(jonahwilliams): re-enable with https://github.com/flutter/flutter/issues/39597
+  # uncaught_image_error_linux:
+  #   description: >
+  #     Ensures that an error thrown into the zone can be caught by the ImageStream
+  #     completer
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
 
   flutter_gallery_android__compile:
     description: >
@@ -344,18 +346,20 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  linux_chrome_dev_mode:
-    description: >
-      Run flutter web on the devicelab and hot restart.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-    flaky: true
+  # TODO(jonahwilliams): re-enable with https://github.com/flutter/flutter/issues/39597
+  # linux_chrome_dev_mode:
+  #   description: >
+  #     Run flutter web on the devicelab and hot restart.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
+  #   flaky: true
 
-  web_size__compile_test:
-    description: >
-      Measures the size of a dart2js bundle.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+  # TODO(jonahwilliams): re-enable with https://github.com/flutter/flutter/issues/39597
+  # web_size__compile_test:
+  #   description: >
+  #     Measures the size of a dart2js bundle.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
 
   image_list_reported_duration:
     description: >
@@ -369,11 +373,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  build_benchmark:
-    description: >
-      Measures APK build performance across config changes.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
+  # TODO(jonahwilliams): re-enable with https://github.com/flutter/flutter/issues/39597
+  # build_benchmark:
+  #   description: >
+  #     Measures APK build performance across config changes.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
 
   # iOS on-device tests
 
@@ -522,7 +527,7 @@ tasks:
       Run flutter web on the devicelab and hot restart.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: true # marekd as flaky while infra is under heavy development
+    flaky: true # marked as flaky while infra is under heavy development
 
   build_benchmark_ios:
     description: >


### PR DESCRIPTION
## Description

Because of the extremely poor state of the linux devicelab, throw everything overboard that either hasn't failed recently or doesn't provide sufficient value.