### PR TITLE
Let Material BackButton have a custom onPressed handler

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1253,7 +1253,8 @@ class CupertinoNavigationBarBackButton extends StatelessWidget {
   /// to pop the [Navigator].
   ///
   /// It can, for instance, be used to pop the platform's navigation stack
-  /// instead of Flutter's [Navigator].
+  /// via [SystemNavigator] instead of Flutter's [Navigator] in add-to-app
+  /// situations.
   ///
   /// Defaults to null.
   final VoidCallback onPressed;

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -85,7 +85,8 @@ class BackButton extends StatelessWidget {
   /// to pop the [Navigator].
   ///
   /// It can, for instance, be used to pop the platform's navigation stack
-  /// instead of Flutter's [Navigator].
+  /// via [SytemNavigator] instead of Flutter's [Navigator] in add-to-app
+  /// situations.
   ///
   /// Defaults to null.
   final VoidCallback onPressed;

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -48,7 +48,8 @@ class BackButtonIcon extends StatelessWidget {
 ///
 /// A [BackButton] is an [IconButton] with a "back" icon appropriate for the
 /// current [TargetPlatform]. When pressed, the back button calls
-/// [Navigator.maybePop] to return to the previous route.
+/// [Navigator.maybePop] to return to the previous route unless a custom
+/// [onPressed] callback is provided.
 ///
 /// When deciding to display a [BackButton], consider using
 /// `ModalRoute.of(context)?.canPop` to check whether the current route can be
@@ -72,13 +73,22 @@ class BackButtonIcon extends StatelessWidget {
 class BackButton extends StatelessWidget {
   /// Creates an [IconButton] with the appropriate "back" icon for the current
   /// target platform.
-  const BackButton({ Key key, this.color }) : super(key: key);
+  const BackButton({ Key key, this.color, this.onPressed }) : super(key: key);
 
   /// The color to use for the icon.
   ///
   /// Defaults to the [IconThemeData.color] specified in the ambient [IconTheme],
   /// which usually matches the ambient [Theme]'s [ThemeData.iconTheme].
   final Color color;
+
+  /// An override callback to perform instead of the default behavior which is
+  /// to pop the [Navigator].
+  ///
+  /// It can, for instance, be used to pop the platform's navigation stack
+  /// instead of Flutter's [Navigator].
+  ///
+  /// Defaults to null.
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -88,7 +98,11 @@ class BackButton extends StatelessWidget {
       color: color,
       tooltip: MaterialLocalizations.of(context).backButtonTooltip,
       onPressed: () {
-        Navigator.maybePop(context);
+        if (onPressed != null) {
+          onPressed();
+        } else {
+          Navigator.maybePop(context);
+        }
       },
     );
   }

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -34,6 +34,37 @@ void main() {
     expect(find.text('Home'), findsOneWidget);
   });
 
+  testWidgets('BackButton onPressed overrides default pop behavior', (WidgetTester tester) async {
+      bool backPressed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: const Material(child: Text('Home')),
+          routes: <String, WidgetBuilder>{
+            '/next': (BuildContext context) {
+              return Material(
+                child: Center(
+                  child: BackButton(onPressed: () => backPressed = true),
+                ),
+              );
+            },
+          },
+        )
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(BackButton));
+
+      await tester.pumpAndSettle();
+
+      // We're still on the second page.
+      expect(find.text('Home'), findsNothing);
+      // But the custom callback is called.
+      expect(backPressed, true);
+  });
+
   testWidgets('BackButton icon', (WidgetTester tester) async {
     final Key iOSKey = UniqueKey();
     final Key androidKey = UniqueKey();


### PR DESCRIPTION
## Description

In add-to-app, you'd want to use the widget and the visual but not pop our Flutter navigator. 

Basically https://github.com/flutter/flutter/pull/32469 for Material

## Related Issues

Fixes https://github.com/flutter/flutter/issues/27318

## Tests

I added the following tests:

Added back_button_test.dart test case.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes