### PR TITLE
Updates to debugFillProperties to test all properties in slider.dart and slider_test.dart

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -382,15 +382,15 @@ class Slider extends StatefulWidget {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('value', value));
     properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'disabled'));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeStart', onChangeStart, ifNull: 'onChangeStart: null'));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeEnd', onChangeEnd, ifNull: 'onChangeEnd: null'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeStart', onChangeStart));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('onChangeEnd', onChangeEnd));
     properties.add(DoubleProperty('min', min));
     properties.add(DoubleProperty('max', max));
     properties.add(IntProperty('divisions', divisions));
     properties.add(StringProperty('label', label));
     properties.add(ColorProperty('activeColor', activeColor));
     properties.add(ColorProperty('inactiveColor', inactiveColor));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>('semanticFormatterCallback', semanticFormatterCallback, ifNull: 'semanticFormatterCallback: null'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>.has('semanticFormatterCallback', semanticFormatterCallback));
   }
 }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -381,7 +381,7 @@ class Slider extends StatefulWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('value', value));
-    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'onChanged: disabled'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'disabled'));
     properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeStart', onChangeStart, ifNull: 'onChangeStart: null'));
     properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeEnd', onChangeEnd, ifNull: 'onChangeEnd: null'));
     properties.add(DoubleProperty('min', min));

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -381,8 +381,16 @@ class Slider extends StatefulWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('value', value));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChanged', onChanged, ifNull: 'onChanged: disabled'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeStart', onChangeStart, ifNull: 'onChangeStart: null'));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('onChangeEnd', onChangeEnd, ifNull: 'onChangeEnd: null'));
     properties.add(DoubleProperty('min', min));
     properties.add(DoubleProperty('max', max));
+    properties.add(IntProperty('divisions', divisions));
+    properties.add(StringProperty('label', label));
+    properties.add(ColorProperty('activeColor', activeColor));
+    properties.add(ColorProperty('inactiveColor', inactiveColor));
+    properties.add(ObjectFlagProperty<ValueChanged<double>>('semanticFormatterCallback', semanticFormatterCallback, ifNull: 'semanticFormatterCallback: null'));
   }
 }
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1567,8 +1567,8 @@ void main() {
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
-        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
-        .map((DiagnosticsNode node) => node.toString()).toList();
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString()).toList();
 
     expect(description, <String>[
       'value: 50.0',

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1548,35 +1548,40 @@ void main() {
     expect(renderObject.size.height, 200);
   });
 
-  //DiagnosticsProperties Tests
   testWidgets(
       'Slider implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
     const Slider(
-      value: 10.0,
-      min: 0.0,
-      max: 100.0,
       activeColor: Colors.blue,
-      inactiveColor: Colors.blue,
+      divisions: 10,
+      inactiveColor: Colors.grey,
       label: 'Set a value',
+      max: 100.0,
+      min: 0.0,
       onChanged: null,
+      onChangeEnd: null,
+      onChangeStart: null,
+      semanticFormatterCallback: null,
+      value: 50.0,
     ).debugFillProperties(builder);
-
-    print(Slider);
 
     final List<String> description = builder.properties
         .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
         .map((DiagnosticsNode node) => node.toString()).toList();
 
     expect(description, <String>[
-      'value: 10.0',
-      'min: 1.0',
+      'value: 50.0',
+      'onChanged: disabled',
+      'onChangeStart: null',
+      'onChangeEnd: null',
+      'min: 0.0',
       'max: 100.0',
-      'activeColor: Colors.blue',
-      'inactiveColor: Colors.blue',
+      'divisions: 10',
       'label: "Set a value"',
-      'OnChanged: null',
+      'activeColor: MaterialColor(primary value: Color(0xff2196f3))',
+      'inactiveColor: MaterialColor(primary value: Color(0xff9e9e9e))',
+      'semanticFormatterCallback: null',
     ]);
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1573,15 +1573,12 @@ void main() {
     expect(description, <String>[
       'value: 50.0',
       'disabled',
-      'onChangeStart: null',
-      'onChangeEnd: null',
       'min: 0.0',
       'max: 100.0',
       'divisions: 10',
       'label: "Set a value"',
       'activeColor: MaterialColor(primary value: Color(0xff2196f3))',
       'inactiveColor: MaterialColor(primary value: Color(0xff9e9e9e))',
-      'semanticFormatterCallback: null',
     ]);
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1547,4 +1547,36 @@ void main() {
     final RenderBox renderObject = tester.renderObject<RenderBox>(find.byType(Slider));
     expect(renderObject.size.height, 200);
   });
+
+  //DiagnosticsProperties Tests
+  testWidgets(
+      'Slider implements debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+
+    const Slider(
+      value: 10.0,
+      min: 0.0,
+      max: 100.0,
+      activeColor: Colors.blue,
+      inactiveColor: Colors.blue,
+      label: 'Set a value',
+      onChanged: null,
+    ).debugFillProperties(builder);
+
+    print(Slider);
+
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode node) => node.toString()).toList();
+
+    expect(description, <String>[
+      'value: 10.0',
+      'min: 1.0',
+      'max: 100.0',
+      'activeColor: Colors.blue',
+      'inactiveColor: Colors.blue',
+      'label: "Set a value"',
+      'OnChanged: null',
+    ]);
+  });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1572,7 +1572,7 @@ void main() {
 
     expect(description, <String>[
       'value: 50.0',
-      'onChanged: disabled',
+      'disabled',
       'onChangeStart: null',
       'onChangeEnd: null',
       'min: 0.0',


### PR DESCRIPTION
## Description

* This PR is to add DiagnosticsProperties tests to Material Slider, to address issue #25671

## Related Issues

* No related issues

## Tests

I added the following tests:

* DiagnosticsProperties

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
