### PR TITLE
Adding the possibility to keep alive the children of a TabBarView widget.

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1104,6 +1104,28 @@ class _TabBarState extends State<TabBar> {
   }
 }
 
+class _KeepChildAlive extends StatefulWidget {
+  const _KeepChildAlive({Key key, this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  _KeepChildAliveState createState() => _KeepChildAliveState();
+}
+
+class _KeepChildAliveState extends State<_KeepChildAlive> with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}
+
+
+
 /// A page view that displays the widget which corresponds to the currently
 /// selected tab.
 ///
@@ -1125,9 +1147,11 @@ class TabBarView extends StatefulWidget {
     @required this.children,
     this.controller,
     this.physics,
+    this.keepChildrenAlive = false,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : assert(children != null),
        assert(dragStartBehavior != null),
+       assert(keepChildrenAlive != null),
        super(key: key);
 
   /// This widget's selection and animation state.
@@ -1152,6 +1176,12 @@ class TabBarView extends StatefulWidget {
   ///
   /// Defaults to matching platform conventions.
   final ScrollPhysics physics;
+
+  /// Whether or not children should be kept alive.
+  ///
+  /// If true, the state of the children will be kept in memory by wrapping them
+  /// inside a [_KeepChildAlive]
+  final bool keepChildrenAlive;
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
@@ -1233,8 +1263,17 @@ class _TabBarViewState extends State<TabBarView> {
   }
 
   void _updateChildren() {
-    _children = widget.children;
-    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(widget.children);
+    if (widget.keepChildrenAlive) {
+      _children = List<Widget>.generate(
+          widget.children.length,
+              (int index) => _KeepChildAlive(child: widget.children[index])
+      );
+    }
+    else {
+      _children = widget.children;
+    }
+
+    _childrenWithKey = KeyedSubtree.ensureUniqueKeysForList(_children);
   }
 
   void _handleTabControllerAnimationTick() {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1115,13 +1115,13 @@ class _KeepChildAlive extends StatefulWidget {
 
 class _KeepChildAliveState extends State<_KeepChildAlive> with AutomaticKeepAliveClientMixin {
   @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
     super.build(context);
     return widget.child;
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }
 
 


### PR DESCRIPTION
## Description

The goal of this PR is to make it easier to keep alive the children of a TabBarView with a simple boolean. 

Before that, you were obliged to use the AutomaticKeepAliveClientMixin mixin on each child. 

## Related Issues

https://github.com/flutter/flutter/issues/38761

## Tests

I added the following tests:

'Making sure that the keepChildreAlive boolean works as intended' in  test\material\tab_tests.dart

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
