### PR TITLE
Center action icons of swipe to dismiss example

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -245,14 +245,18 @@ class _LeaveBehindListItem extends StatelessWidget {
         },
         background: Container(
           color: theme.primaryColor,
-          child: const ListTile(
-            leading: Icon(Icons.delete, color: Colors.white, size: 36.0),
+          child: const Center(
+            child: ListTile(
+              leading: Icon(Icons.delete, color: Colors.white, size: 36.0),
+            ),
           ),
         ),
         secondaryBackground: Container(
           color: theme.primaryColor,
-          child: const ListTile(
-            trailing: Icon(Icons.archive, color: Colors.white, size: 36.0),
+          child: const Center(
+            child: ListTile(
+              trailing: Icon(Icons.archive, color: Colors.white, size: 36.0),
+            ),
           ),
         ),
         child: Container(


### PR DESCRIPTION
## Description

Action icons in "Swipe to dismiss" example are not vertically centered. This RP fixex them to be vertically centered.

master: 
![master](https://user-images.githubusercontent.com/99586/64090754-c885c600-cd87-11e9-9236-9eb07ee8c23b.png)

PR: 
![pr](https://user-images.githubusercontent.com/99586/64090755-c885c600-cd87-11e9-8834-67e9c70ef0f1.png)


## Related Issues

## Tests

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.