### PR TITLE
Add delay to recompile request for web

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -119,6 +119,11 @@ class WebFs {
 
   /// Recompile the web application and return whether this was successful.
   Future<bool> recompile() async {
+    // TODO(jonahwilliams): build_daemon is still watching for sources, which means we can
+    // easily miss changes when hot restart is triggered by IDEs. Until we fix this, add a
+    // delay to allow filesystem watches to gather all required source files. This duration
+    // was chosen arbitrarily.
+    await Future<void>.delayed(const Duration(milliseconds: 150));
     _client.startBuild();
     await for (BuildResults results in _client.buildResults) {
       final BuildResult result = results.results.firstWhere((BuildResult result) {

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -123,6 +123,7 @@ class WebFs {
     // easily miss changes when hot restart is triggered by IDEs. Until we fix this, add a
     // delay to allow filesystem watches to gather all required source files. This duration
     // was chosen arbitrarily.
+    // See https://github.com/flutter/flutter/issues/39696
     await Future<void>.delayed(const Duration(milliseconds: 150));
     _client.startBuild();
     await for (BuildResults results in _client.buildResults) {


### PR DESCRIPTION
## Description

See https://github.com/flutter/flutter/issues/39696. The delay can be added to the flutter tool which will be easier to roll out and revert once fixed

cc @grouma  @devoncarew 