### PR TITLE
Null TextWidthBasis docs

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -374,7 +374,7 @@ class SelectableText extends StatefulWidget {
   /// {@macro flutter.widgets.edtiableText.scrollPhysics}
   final ScrollPhysics scrollPhysics;
 
-  /// Defines how to consider the width of the rendered text.
+  /// Defines how to measure the width of the rendered text.
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -374,7 +374,7 @@ class SelectableText extends StatefulWidget {
   /// {@macro flutter.widgets.edtiableText.scrollPhysics}
   final ScrollPhysics scrollPhysics;
 
-  /// {@macro flutter.dart:ui.text.TextWidthBasis}
+  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -374,7 +374,7 @@ class SelectableText extends StatefulWidget {
   /// {@macro flutter.widgets.edtiableText.scrollPhysics}
   final ScrollPhysics scrollPhysics;
 
-  /// Defines how to measure the width of the rendered text.
+  /// {@macro flutter.painting.textPainter.textWidthBasis}
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -374,7 +374,7 @@ class SelectableText extends StatefulWidget {
   /// {@macro flutter.widgets.edtiableText.scrollPhysics}
   final ScrollPhysics scrollPhysics;
 
-  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
+  /// Defines how to consider the width of the rendered text.
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -323,7 +323,9 @@ class TextPainter {
     _needsLayout = true;
   }
 
+  /// {@template flutter.painting.textPainter.textWidthBasis}
   /// Defines how to measure the width of the rendered text.
+  /// {@endtemplate}
   TextWidthBasis get textWidthBasis => _textWidthBasis;
   TextWidthBasis _textWidthBasis;
   set textWidthBasis(TextWidthBasis value) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -79,7 +79,7 @@ class PlaceholderDimensions {
   }
 }
 
-/// The different ways of considering the width of one or more lines of text.
+/// The different ways of measuring the width of one or more lines of text.
 ///
 /// See [Text.textWidthBasis], for example.
 enum TextWidthBasis {
@@ -323,7 +323,7 @@ class TextPainter {
     _needsLayout = true;
   }
 
-  /// Defines how to consider the width of the rendered text.
+  /// Defines how to measure the width of the rendered text.
   TextWidthBasis get textWidthBasis => _textWidthBasis;
   TextWidthBasis _textWidthBasis;
   set textWidthBasis(TextWidthBasis value) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -81,7 +81,7 @@ class PlaceholderDimensions {
 
 /// The different ways of considering the width of one or more lines of text.
 ///
-/// See [Text.widthType].
+/// See [Text.textWidthBasis].
 enum TextWidthBasis {
   /// Multiline text will take up the full width given by the parent. For single
   /// line text, only the minimum amount of width needed to contain the text
@@ -323,7 +323,7 @@ class TextPainter {
     _needsLayout = true;
   }
 
-  /// {@macro flutter.dart:ui.text.TextWidthBasis}
+  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
   TextWidthBasis get textWidthBasis => _textWidthBasis;
   TextWidthBasis _textWidthBasis;
   set textWidthBasis(TextWidthBasis value) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -81,7 +81,7 @@ class PlaceholderDimensions {
 
 /// The different ways of considering the width of one or more lines of text.
 ///
-/// See [Text.textWidthBasis].
+/// See [Text.textWidthBasis], for example.
 enum TextWidthBasis {
   /// Multiline text will take up the full width given by the parent. For single
   /// line text, only the minimum amount of width needed to contain the text
@@ -323,7 +323,7 @@ class TextPainter {
     _needsLayout = true;
   }
 
-  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
+  /// Defines how to consider the width of the rendered text.
   TextWidthBasis get textWidthBasis => _textWidthBasis;
   TextWidthBasis _textWidthBasis;
   set textWidthBasis(TextWidthBasis value) {

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -411,7 +411,7 @@ class Text extends StatelessWidget {
   /// ```
   final String semanticsLabel;
 
-  /// Defines how to measure the width of the rendered text.
+  /// {@macro flutter.painting.textPainter.textWidthBasis}
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -135,6 +135,7 @@ class DefaultTextStyle extends InheritedTheme {
   final int maxLines;
 
   /// The strategy to use when calculating the width of the Text.
+  ///
   /// See [TextWidthBasis] for possible values and their implications.
   final TextWidthBasis textWidthBasis;
 
@@ -410,7 +411,7 @@ class Text extends StatelessWidget {
   /// ```
   final String semanticsLabel;
 
-  /// {@macro flutter.dart:ui.text.TextWidthBasis}
+  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -411,7 +411,7 @@ class Text extends StatelessWidget {
   /// ```
   final String semanticsLabel;
 
-  /// {@macro flutter.dart:ui.Text.TextWidthBasis}
+  /// Defines how to consider the width of the rendered text.
   final TextWidthBasis textWidthBasis;
 
   @override

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -411,7 +411,7 @@ class Text extends StatelessWidget {
   /// ```
   final String semanticsLabel;
 
-  /// Defines how to consider the width of the rendered text.
+  /// Defines how to measure the width of the rendered text.
   final TextWidthBasis textWidthBasis;
 
   @override


### PR DESCRIPTION
## Description

Some pages in the docs for `textWidthBasis` properties were showing up as `null` (i.e. [RenderParagraph.textWidthBasis](https://api.flutter.dev/flutter/rendering/RenderParagraph/textWidthBasis.html)).  I think this was due to not capitalizing `text` in my macro?

## Related Issues

Closes https://github.com/flutter/flutter/issues/39640

## Tests

None, just a docs fix.