### PR TITLE
remove input files argument to target

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -113,7 +113,7 @@ abstract class Target {
   List<Source> get outputs;
 
   /// The action which performs this build step.
-  Future<void> build(List<File> inputFiles, Environment environment);
+  Future<void> build(Environment environment);
 
   /// Collect hashes for all inputs to determine if any have changed.
   ///
@@ -585,7 +585,7 @@ class _BuildInstance {
         }
       } else {
         printStatus('${target.name}: Starting');
-        await target.build(inputs, environment);
+        await target.build(environment);
         printStatus('${target.name}: Complete');
 
         final List<File> outputs = target.resolveOutputs(environment, implicit: true);

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -74,7 +74,7 @@ class CopyAssets extends Target {
   ];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final Directory output = environment
       .buildDir
       .childDirectory('flutter_assets');
@@ -128,7 +128,7 @@ class FlutterPlugins extends Target {
   ];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     // The pubspec may change for reasons other than plugins changing, so we compare
     // the manifest before writing. Some hosting build systems use timestamps
     // so we need to be careful to avoid tricking them into doing more work than

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -81,7 +81,7 @@ class KernelSnapshot extends Target {
   List<Target> get dependencies => <Target>[];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final KernelCompiler compiler = await kernelCompilerFactory.create(
       FlutterProject.fromDirectory(environment.projectDir),
     );
@@ -118,7 +118,7 @@ abstract class AotElfBase extends Target {
   const AotElfBase();
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final AOTSnapshotter snapshotter = AOTSnapshotter(reportTimings: false);
     final String outputPath = environment.buildDir.path;
     if (environment.defines[kBuildMode] == null) {

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -20,7 +20,7 @@ abstract class AotAssemblyBase extends Target {
   const AotAssemblyBase();
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final AOTSnapshotter snapshotter = AOTSnapshotter(reportTimings: false);
     final String outputPath = environment.buildDir.path;
     if (environment.defines[kBuildMode] == null) {

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -36,12 +36,11 @@ class UnpackLinux extends Target {
   List<Target> get dependencies => <Target>[];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final String basePath = artifacts.getArtifactPath(Artifact.linuxDesktopPath);
-    for (File input in inputFiles) {
-      if (fs.path.basename(input.path) == 'linux.dart') {
-        continue;
-      }
+    for (File input in fs.directory(basePath)
+        .listSync(recursive: true)
+        .whereType<File>()) {
       final String outputPath = fs.path.join(
         environment.projectDir.path,
         'linux',

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -113,7 +113,7 @@ abstract class UnpackMacOS extends Target {
   List<Target> get dependencies => <Target>[];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     if (environment.defines[kBuildMode] == null) {
       throw MissingDefineException(kBuildMode, 'unpack_macos');
     }
@@ -191,7 +191,7 @@ class DebugMacOSFramework extends Target {
   String get name => 'debug_macos_framework';
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     final File outputFile = fs.file(fs.path.join(
         environment.buildDir.path, 'App.framework', 'App'));
     outputFile.createSync(recursive: true);
@@ -236,7 +236,7 @@ class CompileMacOSFramework extends Target {
   String get name => 'compile_macos_framework';
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     if (environment.defines[kBuildMode] == null) {
       throw MissingDefineException(kBuildMode, 'compile_macos_framework');
     }
@@ -302,7 +302,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
   ];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     if (environment.defines[kBuildMode] == null) {
       throw MissingDefineException(kBuildMode, 'compile_macos_framework');
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -39,13 +39,12 @@ class UnpackWindows extends Target {
   List<Target> get dependencies => const <Target>[];
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) async {
+  Future<void> build(Environment environment) async {
     // This path needs to match the prefix in the rule below.
     final String basePath = artifacts.getArtifactPath(Artifact.windowsDesktopPath);
-    for (File input in inputFiles) {
-      if (fs.path.basename(input.path) == 'windows.dart') {
-        continue;
-      }
+    for (File input in fs.directory(basePath)
+        .listSync(recursive: true)
+        .whereType<File>()) {
       final String outputPath = fs.path.join(
         environment.projectDir.path,
         'windows',

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -40,7 +40,7 @@ void main() {
     when(mockPlatform.isWindows).thenReturn(false);
 
     /// Create various testing targets.
-    fooTarget = TestTarget((List<File> inputFiles, Environment environment) async {
+    fooTarget = TestTarget((Environment environment) async {
       environment
         .buildDir
         .childFile('out')
@@ -56,7 +56,7 @@ void main() {
         Source.pattern('{BUILD_DIR}/out'),
       ]
       ..dependencies = <Target>[];
-    barTarget = TestTarget((List<File> inputFiles, Environment environment) async {
+    barTarget = TestTarget((Environment environment) async {
       environment.buildDir
         .childFile('bar')
         ..createSync(recursive: true)
@@ -71,7 +71,7 @@ void main() {
         Source.pattern('{BUILD_DIR}/bar'),
       ]
       ..dependencies = <Target>[];
-    fizzTarget = TestTarget((List<File> inputFiles, Environment environment) async {
+    fizzTarget = TestTarget((Environment environment) async {
       throw Exception('something bad happens');
     })
       ..name = 'fizz'
@@ -82,7 +82,7 @@ void main() {
         Source.pattern('{BUILD_DIR}/fizz'),
       ]
       ..dependencies = <Target>[fooTarget];
-    sharedTarget = TestTarget((List<File> inputFiles, Environment environment) async {
+    sharedTarget = TestTarget((Environment environment) async {
       shared += 1;
     })
       ..name = 'shared'
@@ -116,7 +116,7 @@ void main() {
   }));
 
   test('Throws exception if it does not produce a specified output', () => testbed.run(() async {
-    final Target badTarget = TestTarget((List<File> inputFiles, Environment environment) async {})
+    final Target badTarget = TestTarget((Environment environment) async {})
       ..inputs = const <Source>[
         Source.pattern('{PROJECT_DIR}/foo.dart'),
       ]
@@ -251,10 +251,10 @@ T nonconst<T>(T input) => input;
 class TestTarget extends Target {
   TestTarget([this._build]);
 
-  final Future<void> Function(List<File> inputFiles, Environment environment) _build;
+  final Future<void> Function(Environment environment) _build;
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) => _build(inputFiles, environment);
+  Future<void> build(Environment environment) => _build(environment);
 
   @override
   List<Target> dependencies = <Target>[];

--- a/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
@@ -64,10 +64,10 @@ void main() {
 class TestTarget extends Target {
   TestTarget([this._build]);
 
-  final Future<void> Function(List<File> inputFiles, Environment environment) _build;
+  final Future<void> Function(Environment environment) _build;
 
   @override
-  Future<void> build(List<File> inputFiles, Environment environment) => _build(inputFiles, environment);
+  Future<void> build(Environment environment) => _build(environment);
 
   @override
   List<Target> dependencies = <Target>[];

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -71,7 +71,7 @@ flutter:
     fs.file('pubspec.yaml')
       ..writeAsStringSync('name: foo\ndependencies:\n  foo: any\n');
 
-    await const FlutterPlugins().build(<File>[], Environment(
+    await const FlutterPlugins().build(Environment(
       outputDir: fs.currentDirectory,
       projectDir: fs.currentDirectory,
     ));

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -135,7 +135,7 @@ flutter_tools:lib/''');
       return const CompilerOutput('example', 0, <Uri>[]);
     });
 
-    await const KernelSnapshot().build(<File>[], androidEnvironment);
+    await const KernelSnapshot().build(androidEnvironment);
   }, overrides: <Type, Generator>{
     KernelCompilerFactory: () => MockKernelCompilerFactory(),
   }));
@@ -159,7 +159,7 @@ flutter_tools:lib/''');
       return const CompilerOutput('example', 0, <Uri>[]);
     });
 
-    await const KernelSnapshot().build(<File>[], Environment(
+    await const KernelSnapshot().build(Environment(
         outputDir: fs.currentDirectory,
         projectDir: fs.currentDirectory,
         defines: <String, String>{

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -102,7 +102,7 @@ void main() {
       }
       return FakeProcessResult()..exitCode = 0;
     });
-    await const DebugUnpackMacOS().build(<File>[], environment);
+    await const DebugUnpackMacOS().build(environment);
 
     expect(fs.directory('$_kOutputPrefix').existsSync(), true);
     for (File file in inputs) {
@@ -116,7 +116,7 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('testing');
 
-    expect(() async => await const DebugMacOSBundleFlutterAssets().build(<File>[], environment),
+    expect(() async => await const DebugMacOSBundleFlutterAssets().build(environment),
         throwsA(isInstanceOf<Exception>()));
   }));
 
@@ -137,7 +137,7 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('testing');
 
-    await const DebugMacOSBundleFlutterAssets().build(<File>[], environment);
+    await const DebugMacOSBundleFlutterAssets().build(environment);
 
     expect(fs.file(outputKernel).readAsStringSync(), 'testing');
     expect(fs.file(outputPlist).readAsStringSync(), contains('io.flutter.flutter.app'));
@@ -156,7 +156,7 @@ void main() {
         'flutter_assets', 'vm_snapshot_data');
     final String precompiledIsolate = fs.path.join('App.framework', 'Resources',
         'flutter_assets', 'isolate_snapshot_data');
-    await const ProfileMacOSBundleFlutterAssets().build(<File>[], environment..defines[kBuildMode] = 'profile');
+    await const ProfileMacOSBundleFlutterAssets().build(environment..defines[kBuildMode] = 'profile');
 
     expect(fs.file(outputKernel).existsSync(), false);
     expect(fs.file(precompiledVm).existsSync(), false);
@@ -186,7 +186,7 @@ void main() {
 # Generated
 sky_engine:file:///bin/cache/pkg/sky_engine/lib/
 flutter_tools:lib/''');
-    await const CompileMacOSFramework().build(<File>[], environment..defines[kBuildMode] = 'release');
+    await const CompileMacOSFramework().build(environment..defines[kBuildMode] = 'release');
   }, overrides: <Type, Generator>{
     GenSnapshot: () => MockGenSnapshot(),
     Xcode: () => MockXCode(),


### PR DESCRIPTION
## Description

These were only used by a single rule - replace that with the artifact lookup to simplify target API.
