### PR TITLE
workaround for mangled web sdk source map packages

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -281,14 +281,13 @@ class WebFs {
         ));
         return Response.ok(file.readAsBytesSync());
       } else if (request.url.path.endsWith('.dart')) {
-        print(request.url.path);
         // This is likely a sourcemap request. The first segment is the
         // package name, and the rest is the path to the file relative to
         // the package uri. For example, `foo/bar.dart` would represent a
         // file at a path like `foo/lib/bar.dart`. If there is no leading
         // segment, then we assume it is from the current package.
 
-        // Handle sdk requests have mangled urls from engine build.
+        // Handle sdk requests that have mangled urls from engine build.
         if (request.url.path.contains('flutter_web_sdk')) {
           // Note: the request is a uri and not a file path, so they always use `/`.
           final String sdkPath = fs.path.joinAll(request.url.path.split('flutter_web_sdk/').last.split('/'));

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -290,7 +290,8 @@ class WebFs {
 
         // Handle sdk requests have mangled urls from engine build.
         if (request.url.path.contains('flutter_web_sdk')) {
-          final String sdkPath = request.url.path.split('flutter_web_sdk/').last;
+          // Note: the request is a uri and not a file path, so they always use `/`.
+          final String sdkPath = fs.path.joinAll(request.url.path.split('flutter_web_sdk/').last.split('/'));
           final String webSdkPath = artifacts.getArtifactPath(Artifact.flutterWebSdk);
           return Response.ok(fs.file(fs.path.join(webSdkPath, sdkPath)).readAsBytesSync());
         }

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -262,7 +262,7 @@ class WebFs {
         return Response.ok(file.readAsBytesSync(), headers: <String, String>{
           'Content-Type': 'text/javascript',
         });
-      } else if (request.url.path.contains('dart_sdk')) {
+      } else if (request.url.path.endsWith('dart_sdk.js')) {
         final File file = fs.file(fs.path.join(
           artifacts.getArtifactPath(Artifact.flutterWebSdk),
           'kernel',
@@ -272,12 +272,29 @@ class WebFs {
         return Response.ok(file.readAsBytesSync(), headers: <String, String>{
           'Content-Type': 'text/javascript',
         });
+      } else if (request.url.path.endsWith('dart_sdk.js.map')) {
+        final File file = fs.file(fs.path.join(
+          artifacts.getArtifactPath(Artifact.flutterWebSdk),
+          'kernel',
+          'amd',
+          'dart_sdk.js.map',
+        ));
+        return Response.ok(file.readAsBytesSync());
       } else if (request.url.path.endsWith('.dart')) {
+        print(request.url.path);
         // This is likely a sourcemap request. The first segment is the
         // package name, and the rest is the path to the file relative to
         // the package uri. For example, `foo/bar.dart` would represent a
         // file at a path like `foo/lib/bar.dart`. If there is no leading
         // segment, then we assume it is from the current package.
+
+        // Handle sdk requests have mangled urls from engine build.
+        if (request.url.path.contains('flutter_web_sdk')) {
+          final String sdkPath = request.url.path.split('flutter_web_sdk/').last;
+          final String webSdkPath = artifacts.getArtifactPath(Artifact.flutterWebSdk);
+          return Response.ok(fs.file(fs.path.join(webSdkPath, sdkPath)).readAsBytesSync());
+        }
+
         final String packageName = request.url.pathSegments.length == 1
           ? flutterProject.manifest.appName
           : request.url.pathSegments.first;


### PR DESCRIPTION
## Description

The source maps produced by our prebuilt dart sdk seem to contain absolute paths based on how LUCI built it. Work around by using heuristics to map them to the correct web sdk sources.
