### PR TITLE
handle browser refresh

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -107,8 +107,9 @@ class WebFs {
     final Completer<DebugConnection> firstConnection = Completer<DebugConnection>();
     _connectedApps =  _dwds.connectedApps.listen((AppConnection appConnection) async {
       appConnection.runMain();
+      final DebugConnection debugConnection = await _dwds.debugConnection(appConnection);
       if (!firstConnection.isCompleted) {
-        firstConnection.complete(await _dwds.debugConnection(appConnection));
+        firstConnection.complete(debugConnection);
       }
     });
     return firstConnection.future;

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -90,6 +90,7 @@ class WebFs {
   final Dwds _dwds;
   final Chrome _chrome;
   final BuildDaemonClient _client;
+  StreamSubscription<void> _connectedApps;
 
   static const String _kHostName = 'localhost';
 
@@ -98,13 +99,19 @@ class WebFs {
     await _dwds.stop();
     await _server.close(force: true);
     await _chrome.close();
+    await _connectedApps?.cancel();
   }
 
   /// Retrieve the [DebugConnection] for the current application.
   Future<DebugConnection> runAndDebug() async {
-    final AppConnection appConnection = await _dwds.connectedApps.first;
-    appConnection.runMain();
-    return _dwds.debugConnection(appConnection);
+    final Completer<DebugConnection> firstConnection = Completer<DebugConnection>();
+    _connectedApps =  _dwds.connectedApps.listen((AppConnection appConnection) async {
+      appConnection.runMain();
+      if (!firstConnection.isCompleted) {
+        firstConnection.complete(await _dwds.debugConnection(appConnection));
+      }
+    });
+    return firstConnection.future;
   }
 
   /// Perform a hard refresh of all connected browser tabs.


### PR DESCRIPTION
## Description

When the browser is refreshed, ensure the newly connected app calls runMain. The same vmservice can be reused and does not need to be updated.

## tests

Covered by existing cases