### PR TITLE
Revert "Replace deprecated onReportTimings w/ frameTimings"

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -202,10 +202,14 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
     if (!kReleaseMode) {
       int frameNumber = 0;
 
-      window.frameTimings.listen((FrameTiming frameTiming) {
-        frameNumber += 1;
-        _profileFramePostEvent(frameNumber, frameTiming);
-      });
+      // use frameTimings. https://github.com/flutter/flutter/issues/38838
+      // ignore: deprecated_member_use
+      window.onReportTimings = (List<FrameTiming> timings) {
+        for (FrameTiming frameTiming in timings) {
+          frameNumber += 1;
+          _profileFramePostEvent(frameNumber, frameTiming);
+        }
+      };
     }
   }
 

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -79,11 +79,12 @@ class TestServiceExtensionsBinding extends BindingBase
     await flushMicrotasks();
     if (ui.window.onDrawFrame != null)
       ui.window.onDrawFrame();
-    final Future<ui.FrameTiming> firstFrameEventFired = window.frameTimings.first;
-    ui.window.debugReportTimings(<ui.FrameTiming>[
-      ui.FrameTiming(List<int>.filled(ui.FramePhase.values.length, 0)),
-    ]);
-    await firstFrameEventFired;
+    // use frameTimings. https://github.com/flutter/flutter/issues/38838
+    // ignore: deprecated_member_use
+    if (ui.window.onReportTimings != null)
+      // use frameTimings. https://github.com/flutter/flutter/issues/38838
+      // ignore: deprecated_member_use
+      ui.window.onReportTimings(<ui.FrameTiming>[]);
   }
 
   @override

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -132,17 +132,14 @@ void main() {
   });
 
   test('Flutter.Frame event fired', () async {
-    // We can't use Future in scheduler_test so we'll use dynamic instead.
-    final dynamic firstFrameEventFired = window.frameTimings.first;
-
-    window.debugReportTimings(<FrameTiming>[FrameTiming(<int>[
+    // use frameTimings. https://github.com/flutter/flutter/issues/38838
+    // ignore: deprecated_member_use
+    window.onReportTimings(<FrameTiming>[FrameTiming(<int>[
       // build start, build finish
       10000, 15000,
       // raster start, raster finish
       16000, 20000,
     ])]);
-
-    await firstFrameEventFired;
 
     final List<Map<String, dynamic>> events = scheduler.getEventsDispatched('Flutter.Frame');
     expect(events, hasLength(1));

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -286,7 +286,15 @@ class TestWindow implements Window {
   }
 
   @override
-  Stream<FrameTiming> get frameTimings => _window.frameTimings;
+  // use frameTimings. https://github.com/flutter/flutter/issues/38838
+  // ignore: deprecated_member_use
+  TimingsCallback get onReportTimings => _window.onReportTimings;
+  @override
+  set onReportTimings(TimingsCallback callback) {
+    // use frameTimings. https://github.com/flutter/flutter/issues/38838
+    // ignore: deprecated_member_use
+    _window.onReportTimings = callback;
+  }
 
   @override
   PointerDataPacketCallback get onPointerDataPacket => _window.onPointerDataPacket;


### PR DESCRIPTION
Reverts flutter/flutter#38861

Reason for revert: Stream is considered a bad API: https://github.com/flutter/engine/pull/11041#issuecomment-526892247