### PR TITLE
Updates CORS origin for snippets to a wildcard.

### DIFF
--- a/dev/docs/firebase.json
+++ b/dev/docs/firebase.json
@@ -9,11 +9,11 @@
     ],
     "headers": [
       {
-        "source": "snippets/**",
+        "source": "snippets/**.dart",
         "headers": [
           {
             "key": "Access-Control-Allow-Origin",
-            "value": "https://dartpad.dev"
+            "value": "*"
           }
         ]
       }


### PR DESCRIPTION
## Description

This is a further modification of the Firebase Hosting config used for https://api.flutter.dev, changing the `Access-Control-Allow-Origin` header to a wildcard. See #39345 for the PR that landed the previous setting, which was limited to `https://dartpad.dev`.

I'm doing this for a few reasons:

* The header field only has two valid values: a wildcard or a specific domain. The way to allow multiple domains is to have the server parse the incoming request and then set the Access-Control-Allow-Origin fields based on the origin sent with the request. [Firebase Hosting doesn't support this](https://stackoverflow.com/questions/51057061/firebase-hosting-how-to-put-multiple-links-in-access-control-allow-origin-header), so we're stuck with either a wild card or a locked-in domain and protocol.
* While developing, we won't have dartpad.dev as the origin. That leaves these (unappealing) options:
  - Use a third-party CORS proxy.
  - Run Chrome with the web security flags off.
* While staging, we also won't have dartpad.dev as the origin. That forces us to go the flags route, since we wouldn't want to commit and stage a version that includes the URL of a third-party proxy.
* Anyone who wants to fork DartPad and create their own site will have to remove the sample-loading code (Since they'll be on another domain) or rehost the samples themselves.

The downside to the change is that it's slightly less secure. Any site could load the Dart files for the samples, though I struggle to imagine a situation where they could be misused.

## Related Issues

None that I know of.

## Tests

No tests have been added as this is a hosting configuration change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.