### PR TITLE
Revert "Show search app bar theme"

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -198,9 +198,6 @@ abstract class SearchDelegate<T> {
       primaryIconTheme: theme.primaryIconTheme.copyWith(color: Colors.grey),
       primaryColorBrightness: Brightness.light,
       primaryTextTheme: theme.textTheme,
-      inputDecorationTheme: theme.inputDecorationTheme.copyWith(
-        border: InputBorder.none,
-      ),
     );
   }
 
@@ -503,24 +500,28 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
       namesRoute: true,
       label: routeName,
       child: Scaffold(
-        appBar: _ThemedPreferredSizeWidget(
-          theme: theme,
-          child: AppBar(
-            leading: widget.delegate.buildLeading(context),
-            title: TextField(
-              controller: widget.delegate._queryTextController,
-              focusNode: focusNode,
-              textInputAction: widget.delegate.textInputAction,
-              keyboardType: widget.delegate.keyboardType,
-              onSubmitted: (String _) {
-                widget.delegate.showResults(context);
-              },
-              decoration: InputDecoration(
-                hintText: searchFieldLabel,
-              ),
+        appBar: AppBar(
+          backgroundColor: theme.primaryColor,
+          iconTheme: theme.primaryIconTheme,
+          textTheme: theme.primaryTextTheme,
+          brightness: theme.primaryColorBrightness,
+          leading: widget.delegate.buildLeading(context),
+          title: TextField(
+            controller: widget.delegate._queryTextController,
+            focusNode: focusNode,
+            style: theme.textTheme.title,
+            textInputAction: widget.delegate.textInputAction,
+            keyboardType: widget.delegate.keyboardType,
+            onSubmitted: (String _) {
+              widget.delegate.showResults(context);
+            },
+            decoration: InputDecoration(
+              border: InputBorder.none,
+              hintText: searchFieldLabel,
+              hintStyle: theme.inputDecorationTheme.hintStyle,
             ),
-            actions: widget.delegate.buildActions(context),
           ),
+          actions: widget.delegate.buildActions(context),
         ),
         body: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
@@ -529,22 +530,4 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
       ),
     );
   }
-}
-
-class _ThemedPreferredSizeWidget extends StatelessWidget implements PreferredSizeWidget {
-  const _ThemedPreferredSizeWidget({ this.theme, this.child });
-
-  final ThemeData theme;
-  final PreferredSizeWidget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Theme(
-      data: theme,
-      child: child,
-    );
-  }
-
-  @override
-  Size get preferredSize => child.preferredSize;
 }

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -100,13 +100,9 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
-    expect(tester.widget<RichText>(
-      find.descendant(
-        of: find.byType(TextField),
-        matching: find.byType(RichText),
-      )).text.style.color,
-      Colors.green,
-    );
+    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+    final Color hintColor = textField.decoration.hintStyle.color;
+    expect(hintColor, delegate.hintTextColor);
   });
 
   testWidgets('Requests suggestions', (WidgetTester tester) async {
@@ -642,49 +638,6 @@ void main() {
       semantics.dispose();
     });
   });
-
-  testWidgets('delegate appBarTheme is applied to the AppBar color on the search page', (WidgetTester tester) async {
-    final _AppBarThemeTestDelegate delegate = _AppBarThemeTestDelegate(
-      appBarColor: Colors.green,
-    );
-    await tester.pumpWidget(TestHomePage(
-      delegate: delegate,
-    ));
-
-    // Open the search page.
-    await tester.tap(find.byTooltip('Search'));
-    await tester.pumpAndSettle();
-
-    expect(tester.widget<Material>(
-      find.descendant(
-        of: find.byType(AppBar),
-        matching: find.byType(Material),
-      )).color,
-      Colors.green,
-    );
-  });
-
-  testWidgets('delegate appBarTheme is applied to the enabledBorder of the TextField on the search page', (WidgetTester tester) async {
-    final _AppBarThemeTestDelegate delegate = _AppBarThemeTestDelegate(
-      enabledBorder: InputBorder.none,
-    );
-    await tester.pumpWidget(TestHomePage(
-      delegate: delegate,
-    ));
-
-    // Open the search page.
-    await tester.tap(find.byTooltip('Search'));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField), 'abc');
-
-    expect(tester.widget<InputDecorator>(
-      find.descendant(
-        of: find.byType(AppBar),
-        matching: find.byType(InputDecorator),
-      )).decoration.enabledBorder,
-      InputBorder.none,
-    );
-  });
 }
 
 class TestHomePage extends StatelessWidget {
@@ -793,26 +746,5 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   @override
   List<Widget> buildActions(BuildContext context) {
     return actions;
-  }
-}
-
-class _AppBarThemeTestDelegate extends _TestSearchDelegate {
-  _AppBarThemeTestDelegate({this.appBarColor, this.enabledBorder});
-
-  final Color appBarColor;
-  final InputBorder enabledBorder;
-
-  @override
-  ThemeData appBarTheme(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    return theme.copyWith(
-      primaryColor: appBarColor,
-      appBarTheme: theme.appBarTheme.copyWith(
-        color: appBarColor,
-      ),
-      inputDecorationTheme: theme.inputDecorationTheme.copyWith(
-        enabledBorder: enabledBorder,
-      ),
-    );
   }
 }


### PR DESCRIPTION
Reverts flutter/flutter#37962

This PR was reverted because it introduced unintended font and icon color changes. Originally the appBar's default text style was Theme.primaryTextTheme and its icon theme was Theme.primaryIconTheme. PR #37962 mistakenly changed these values to Theme.textTheme and Theme.iconTheme respectively.

