### PR TITLE
Add a null check to tabs.dart to fix a crash.

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -419,6 +419,8 @@ class _IndicatorPainter extends CustomPainter {
   }
 
   static bool _tabOffsetsEqual(List<double> a, List<double> b) {
+    if (a == null && b == null)
+      return true;
     if (a?.length != b?.length)
       return false;
     for (int i = 0; i < a.length; i += 1) {


### PR DESCRIPTION
## Description

Fixes a crash where both variables are null. If only one variable is non-null, the next line will return false.

#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51)
#1      _IndicatorPainter._tabOffsetsEqual (package:flutter/src/material/tabs.dart:424)
#2      _IndicatorPainter.shouldRepaint (package:flutter/src/material/tabs.dart:437)
#3      RenderCustomPaint._didUpdatePainter (package:flutter/src/rendering/custom_paint.dart:440)
#4      RenderCustomPaint.set:painter (package:flutter/src/rendering/custom_paint.dart:405)
#5      CustomPaint.updateRenderObject (package:flutter/src/widgets/basic.dart:526)
#6      RenderObjectElement.update (package:flutter/src/widgets/framework.dart:4754)
#7      SingleChildRenderObjectElement.update (package:flutter/src/widgets/framework.dart:5125)
#8      Element.updateChild (package:flutter/src/widgets/framework.dart:2886)

## Tests

Straightforward null check, so did not add tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
