### PR TITLE
Update ToggleButtons constraints default and add new constraints parameter

### DIFF
--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
+import 'constants.dart';
 import 'debug.dart';
 import 'theme.dart';
 import 'theme_data.dart';
@@ -800,7 +801,7 @@ class _ToggleButton extends StatelessWidget {
     }
 
     final TextStyle currentTextStyle = textStyle ?? toggleButtonsTheme.textStyle ?? theme.textTheme.body1;
-    final BoxConstraints currentConstraints = constraints ?? toggleButtonsTheme.constraints ?? const BoxConstraints(minWidth: 48.0, minHeight: 48.0);
+    final BoxConstraints currentConstraints = constraints ?? toggleButtonsTheme.constraints ?? const BoxConstraints(minWidth: kMinInteractiveDimension, minHeight: kMinInteractiveDimension);
 
     final Widget result = ClipRRect(
       borderRadius: clipRadius,

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -166,6 +166,7 @@ class ToggleButtons extends StatelessWidget {
     @required this.isSelected,
     this.onPressed,
     this.textStyle,
+    this.constraints,
     this.color,
     this.selectedColor,
     this.disabledColor,
@@ -222,6 +223,14 @@ class ToggleButtons extends StatelessWidget {
   /// [selectedColor] or [disabledColor] depending on whether the buttons
   /// are active, selected, or disabled.
   final TextStyle textStyle;
+
+  /// Defines the button's size.
+  ///
+  /// Typically used to constrain the button's minimum size.
+  ///
+  /// If this property is null, then
+  /// BoxConstraints(minWidth: 48.0, minHeight: 48.0) is be used.
+  final BoxConstraints constraints;
 
   /// The color for descendant [Text] and [Icon] widgets if the button is
   /// enabled and not selected.
@@ -578,6 +587,7 @@ class ToggleButtons extends StatelessWidget {
           return _ToggleButton(
             selected: isSelected[index],
             textStyle: textStyle,
+            constraints: constraints,
             color: color,
             selectedColor: selectedColor,
             disabledColor: disabledColor,
@@ -645,6 +655,7 @@ class _ToggleButton extends StatelessWidget {
     Key key,
     this.selected = false,
     this.textStyle,
+    this.constraints,
     this.color,
     this.selectedColor,
     this.disabledColor,
@@ -670,6 +681,11 @@ class _ToggleButton extends StatelessWidget {
 
   /// The [TextStyle] to apply to any text that appears in this button.
   final TextStyle textStyle;
+
+  /// Defines the button's size.
+  ///
+  /// Typically used to constrain the button's minimum size.
+  final BoxConstraints constraints;
 
   /// The color for [Text] and [Icon] widgets if the button is enabled.
   ///
@@ -784,6 +800,7 @@ class _ToggleButton extends StatelessWidget {
     }
 
     final TextStyle currentTextStyle = textStyle ?? toggleButtonsTheme.textStyle ?? theme.textTheme.body1;
+    final BoxConstraints currentConstraints = constraints ?? toggleButtonsTheme.constraints ?? const BoxConstraints(minWidth: 48.0, minHeight: 48.0);
 
     final Widget result = ClipRRect(
       borderRadius: clipRadius,
@@ -791,6 +808,7 @@ class _ToggleButton extends StatelessWidget {
         textStyle: currentTextStyle.copyWith(
           color: currentColor,
         ),
+        constraints: currentConstraints,
         elevation: 0.0,
         highlightElevation: 0.0,
         fillColor: currentFillColor,

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -217,8 +217,8 @@ class ToggleButtonsThemeData extends Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     textStyle?.debugFillProperties(properties, prefix: 'textStyle.');
-    properties.add(ColorProperty('color', color, defaultValue: null));
     properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null));
+    properties.add(ColorProperty('color', color, defaultValue: null));
     properties.add(ColorProperty('selectedColor', selectedColor, defaultValue: null));
     properties.add(ColorProperty('disabledColor', disabledColor, defaultValue: null));
     properties.add(ColorProperty('fillColor', fillColor, defaultValue: null));

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -51,6 +51,11 @@ class ToggleButtonsThemeData extends Diagnosticable {
   /// are active, selected, or disabled.
   final TextStyle textStyle;
 
+  /// Defines the button's size.
+  ///
+  /// Typically used to constrain the button's minimum size.
+  final BoxConstraints constraints;
+
   /// The color for descendant [Text] and [Icon] widgets if the toggle button
   /// is enabled.
   final Color color;
@@ -104,6 +109,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
   /// new values.
   ToggleButtonsThemeData copyWith({
     TextStyle textStyle,
+    BoxConstraints constraints,
     Color color,
     Color selectedColor,
     Color disabledColor,
@@ -120,6 +126,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
   }) {
     return ToggleButtonsThemeData(
       textStyle: textStyle ?? this.textStyle,
+      constraints: constraints ?? this.constraints,
       color: color ?? this.color,
       selectedColor: selectedColor ?? this.selectedColor,
       disabledColor: disabledColor ?? this.disabledColor,
@@ -143,6 +150,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
       return null;
     return ToggleButtonsThemeData(
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      constraints: BoxConstraints.lerp(a?.constraints, b?.constraints, t),
       color: Color.lerp(a?.color, b?.color, t),
       selectedColor: Color.lerp(a?.selectedColor, b?.selectedColor, t),
       disabledColor: Color.lerp(a?.disabledColor, b?.disabledColor, t),
@@ -163,6 +171,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
   int get hashCode {
     return hashValues(
       textStyle,
+      constraints,
       color,
       selectedColor,
       disabledColor,
@@ -187,6 +196,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
       return false;
     final ToggleButtonsThemeData typedOther = other;
     return typedOther.textStyle == textStyle
+        && typedOther.constraints == constraints
         && typedOther.color == color
         && typedOther.selectedColor == selectedColor
         && typedOther.disabledColor == disabledColor
@@ -207,6 +217,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
     super.debugFillProperties(properties);
     textStyle?.debugFillProperties(properties, prefix: 'textStyle.');
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null));
     properties.add(ColorProperty('selectedColor', selectedColor, defaultValue: null));
     properties.add(ColorProperty('disabledColor', disabledColor, defaultValue: null));
     properties.add(ColorProperty('fillColor', fillColor, defaultValue: null));

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -29,6 +29,7 @@ class ToggleButtonsThemeData extends Diagnosticable {
   /// [ToggleButtons].
   const ToggleButtonsThemeData({
     this.textStyle,
+    this.constraints,
     this.color,
     this.selectedColor,
     this.disabledColor,

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -322,6 +322,98 @@ void main() {
     expect(textStyle.color, isNot(Colors.orange));
   });
 
+  testWidgets('Default BoxConstraints', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[false, false, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Icon(Icons.check),
+              Icon(Icons.access_alarm),
+              Icon(Icons.cake),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Rect firstRect = tester.getRect(find.byType(RawMaterialButton).at(0));
+    expect(firstRect.width, 48.0);
+    expect(firstRect.height, 48.0);
+    final Rect secondRect = tester.getRect(find.byType(RawMaterialButton).at(1));
+    expect(secondRect.width, 48.0);
+    expect(secondRect.height, 48.0);
+    final Rect thirdRect = tester.getRect(find.byType(RawMaterialButton).at(2));
+    expect(thirdRect.width, 48.0);
+    expect(thirdRect.height, 48.0);
+  });
+
+  testWidgets('Custom BoxConstraints', (WidgetTester tester) async {
+    // Test for minimum constraints
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            constraints: const BoxConstraints(
+              minWidth: 50.0,
+              minHeight: 60.0,
+            ),
+            isSelected: const <bool>[false, false, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Icon(Icons.check),
+              Icon(Icons.access_alarm),
+              Icon(Icons.cake),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    Rect firstRect = tester.getRect(find.byType(RawMaterialButton).at(0));
+    expect(firstRect.width, 50.0);
+    expect(firstRect.height, 60.0);
+    Rect secondRect = tester.getRect(find.byType(RawMaterialButton).at(1));
+    expect(secondRect.width, 50.0);
+    expect(secondRect.height, 60.0);
+    Rect thirdRect = tester.getRect(find.byType(RawMaterialButton).at(2));
+    expect(thirdRect.width, 50.0);
+    expect(thirdRect.height, 60.0);
+
+    // Test for maximum constraints
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            constraints: const BoxConstraints(
+              maxWidth: 20.0,
+              maxHeight: 10.0,
+            ),
+            isSelected: const <bool>[false, false, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Icon(Icons.check),
+              Icon(Icons.access_alarm),
+              Icon(Icons.cake),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    firstRect = tester.getRect(find.byType(RawMaterialButton).at(0));
+    expect(firstRect.width, 20.0);
+    expect(firstRect.height, 10.0);
+    secondRect = tester.getRect(find.byType(RawMaterialButton).at(1));
+    expect(secondRect.width, 20.0);
+    expect(secondRect.height, 10.0);
+    thirdRect = tester.getRect(find.byType(RawMaterialButton).at(2));
+    expect(thirdRect.width, 20.0);
+    expect(thirdRect.height, 10.0);
+  });
+
   testWidgets(
     'Default text/icon colors for enabled, selected and disabled states',
     (WidgetTester tester) async {

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -25,6 +25,7 @@ void main() {
   test('ToggleButtonsThemeData defaults', () {
     const ToggleButtonsThemeData themeData = ToggleButtonsThemeData();
     expect(themeData.textStyle, null);
+    expect(themeData.constraints, null);
     expect(themeData.color, null);
     expect(themeData.selectedColor, null);
     expect(themeData.disabledColor, null);
@@ -41,6 +42,7 @@ void main() {
 
     const ToggleButtonsTheme theme = ToggleButtonsTheme(data: ToggleButtonsThemeData());
     expect(theme.data.textStyle, null);
+    expect(theme.data.constraints, null);
     expect(theme.data.color, null);
     expect(theme.data.selectedColor, null);
     expect(theme.data.disabledColor, null);
@@ -72,6 +74,7 @@ void main() {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const ToggleButtonsThemeData(
       textStyle: TextStyle(fontSize: 10),
+      constraints: BoxConstraints(minHeight: 10.0, maxHeight: 20.0),
       color: Color(0xfffffff0),
       selectedColor: Color(0xfffffff1),
       disabledColor: Color(0xfffffff2),
@@ -95,6 +98,7 @@ void main() {
      expect(description, <String>[
       'textStyle.inherit: true',
       'textStyle.size: 10.0',
+      'constraints: BoxConstraints(0.0<=w<=Infinity, 10.0<=h<=20.0)',
       'color: Color(0xfffffff0)',
       'selectedColor: Color(0xfffffff1)',
       'disabledColor: Color(0xfffffff2)',
@@ -152,6 +156,78 @@ void main() {
     expect(textStyle.textBaseline, TextBaseline.ideographic);
     expect(textStyle.fontSize, 20.0);
     expect(textStyle.color, isNot(Colors.orange));
+  });
+
+  testWidgets('Custom BoxConstraints', (WidgetTester tester) async {
+    // Test for minimum constraints
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtonsTheme(
+            data: const ToggleButtonsThemeData(
+              constraints: BoxConstraints(
+                minWidth: 50.0,
+                minHeight: 60.0,
+              ),
+            ),
+            child: ToggleButtons(
+              isSelected: const <bool>[false, false, false],
+              onPressed: (int index) {},
+              children: const <Widget>[
+                Icon(Icons.check),
+                Icon(Icons.access_alarm),
+                Icon(Icons.cake),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    Rect firstRect = tester.getRect(find.byType(RawMaterialButton).at(0));
+    expect(firstRect.width, 50.0);
+    expect(firstRect.height, 60.0);
+    Rect secondRect = tester.getRect(find.byType(RawMaterialButton).at(1));
+    expect(secondRect.width, 50.0);
+    expect(secondRect.height, 60.0);
+    Rect thirdRect = tester.getRect(find.byType(RawMaterialButton).at(2));
+    expect(thirdRect.width, 50.0);
+    expect(thirdRect.height, 60.0);
+
+    // Test for maximum constraints
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtonsTheme(
+            data: const ToggleButtonsThemeData(
+              constraints: BoxConstraints(
+                maxWidth: 20.0,
+                maxHeight: 10.0,
+              ),
+            ),
+            child: ToggleButtons(
+              isSelected: const <bool>[false, false, false],
+              onPressed: (int index) {},
+              children: const <Widget>[
+                Icon(Icons.check),
+                Icon(Icons.access_alarm),
+                Icon(Icons.cake),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    firstRect = tester.getRect(find.byType(RawMaterialButton).at(0));
+    expect(firstRect.width, 20.0);
+    expect(firstRect.height, 10.0);
+    secondRect = tester.getRect(find.byType(RawMaterialButton).at(1));
+    expect(secondRect.width, 20.0);
+    expect(secondRect.height, 10.0);
+    thirdRect = tester.getRect(find.byType(RawMaterialButton).at(2));
+    expect(thirdRect.width, 20.0);
+    expect(thirdRect.height, 10.0);
   });
 
   testWidgets(


### PR DESCRIPTION
## Description

Currently, there is no way to control the constraints of each button in the ToggleButtons widget. It currently defaults to const `BoxConstraints(minWidth: 88.0, minHeight: 36.0)`, which is the constraints for RawMaterialButton, but this is undesirable if we want it to look like the square toggle buttons. 

![image](https://user-images.githubusercontent.com/27032613/63657627-fd2ac980-c758-11e9-8812-fab645ce7950.png)

This PR does the following: 
1) Sets ToggleButtons' default BoxConstraints to BoxConstraints(minWidth: 48.0, minHeight: 48.0)
2) Adds a `constraints` parameter to ToggleButtons and ToggleButtonsTheme

## Required Follow-up
- [x] Update flutter/assets-for-api-docs to ensure that the defaults in the code sample are updated

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39216

## Tests

I added the following tests:

1) Test for ToggleButtons default and custom constraints
2) Test for custom ToggleButtonsTheme
3) Updated existing test to account for new `constraints` parameter

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). - TODO: send email and link here once LGTM is received
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
