### PR TITLE
Add macos tripwire file

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -64,7 +64,7 @@ build_outputs_path="${ephemeral_dir}/FlutterOutputs.xcfilelist"
 
 # Unconditionally touch a tripwire file. This can be listed as an input to
 # ensure that the flutter tool always has a chance to use its own cache.
-# Removeing this file as an input requires a separate xcode scheme per
+# Removing this file as an input requires a separate xcode scheme per
 # each build mode (debug/profile/release) and target file.
 touch "${ephemeral_dir}/tripwire"
 

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -62,6 +62,12 @@ ephemeral_dir="${SOURCE_ROOT}/Flutter/ephemeral"
 build_inputs_path="${ephemeral_dir}/FlutterInputs.xcfilelist"
 build_outputs_path="${ephemeral_dir}/FlutterOutputs.xcfilelist"
 
+# Unconditionally touch a tripwire file. This can be listed as an input to
+# ensure that the flutter tool always has a chance to use its own cache.
+# Removeing this file as an input requires a separate xcode scheme per
+# each build mode (debug/profile/release) and target file.
+touch "${ephemeral_dir}/tripwire"
+
 RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics               \
     ${verbose_flag}                                                         \
     ${flutter_engine_flag}                                                  \


### PR DESCRIPTION
## Description

Unconditionally touch a file during the macos_assemble script. Depending on this file as an input allows us to bypass Xcode's build caching and rely on the flutter tool build caching.

This is a requirement to provide the xcfilelist inputs and outputs to xcode, which are then used to ensure the build phases are executed in the correct order.