### PR TITLE
Fixed passing autofocus to MaterialButton, and when rebuilding Focus widget.

### DIFF
--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -367,6 +367,7 @@ class MaterialButton extends StatelessWidget {
       shape: buttonTheme.getShape(this),
       clipBehavior: clipBehavior,
       focusNode: focusNode,
+      autofocus: autofocus,
       animationDuration: buttonTheme.getAnimationDuration(this),
       child: child,
       materialTapTargetSize: materialTapTargetSize ?? theme.materialTapTargetSize,

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -375,6 +375,10 @@ class _FocusState extends State<Focus> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _focusAttachment?.reparent();
+    _handleAutofocus();
+  }
+
+  void _handleAutofocus() {
     if (!_didAutofocus && widget.autofocus) {
       FocusScope.of(context).autofocus(focusNode);
       _didAutofocus = true;
@@ -402,12 +406,15 @@ class _FocusState extends State<Focus> {
     if (oldWidget.focusNode == widget.focusNode) {
       focusNode.skipTraversal = widget.skipTraversal ?? focusNode.skipTraversal;
       focusNode.canRequestFocus = widget.canRequestFocus ?? focusNode.canRequestFocus;
-      return;
+    } else {
+      _focusAttachment.detach();
+      focusNode.removeListener(_handleFocusChanged);
+      _initNode();
     }
 
-    _focusAttachment.detach();
-    focusNode.removeListener(_handleFocusChanged);
-    _initNode();
+    if (oldWidget.autofocus != widget.autofocus) {
+      _handleAutofocus();
+    }
   }
 
   void _handleFocusChanged() {

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 
 void main() {
-  testWidgets('Default MaterialButton meets a11y contrast guidelines', (WidgetTester tester) async {
+  testWidgets('Default $MaterialButton meets a11y contrast guidelines', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -34,5 +34,37 @@ void main() {
     semanticsEnabled: true,
     skip: isBrowser,
   );
+  testWidgets('$MaterialButton gets focus when autofocus is set.', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'MaterialButton');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: MaterialButton(
+            focusNode: focusNode,
+            onPressed: () {},
+            child: Container(width: 100, height: 100, color: const Color(0xffff0000)),
+          ),
+        ),
+      ),
+    );
 
+    await tester.pump();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: MaterialButton(
+            autofocus: true,
+            focusNode: focusNode,
+            onPressed: () {},
+            child: Container(width: 100, height: 100, color: const Color(0xffff0000)),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+  });
 }

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1006,6 +1006,29 @@ void main() {
       expect(rootNode.hasFocus, isTrue);
       expect(rootNode, equals(firstElement.owner.focusManager.rootScope));
     });
+    testWidgets('Can autofocus a node.', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode(debugLabel: 'MaterialButton');
+      await tester.pumpWidget(
+        Focus(
+          focusNode: focusNode,
+          child: Container(),
+        ),
+      );
+
+      await tester.pump();
+      expect(focusNode.hasPrimaryFocus, isFalse);
+
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          focusNode: focusNode,
+          child: Container(),
+        ),
+      );
+
+      await tester.pump();
+      expect(focusNode.hasPrimaryFocus, isTrue);
+    });
   });
   group(Focus, () {
     testWidgets('Focus.of stops at the nearest Focus widget.', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1007,7 +1007,7 @@ void main() {
       expect(rootNode, equals(firstElement.owner.focusManager.rootScope));
     });
     testWidgets('Can autofocus a node.', (WidgetTester tester) async {
-      final FocusNode focusNode = FocusNode(debugLabel: 'MaterialButton');
+      final FocusNode focusNode = FocusNode(debugLabel: 'Test Node');
       await tester.pumpWidget(
         Focus(
           focusNode: focusNode,


### PR DESCRIPTION
## Description

Fixed passing autofocus to MaterialButton, and when rebuilding Focus widget, and added a test for Focus and MaterialButton to test that it works properly.

## Tests

- Added a test for MaterialButton and for Focus to test autofocus, even when autofocus is added after the initial build.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes