### PR TITLE
Make CupertinoDynamicColor.resolve return null when given a null color

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -325,7 +325,7 @@ class CupertinoDynamicColor extends Color {
   /// Resolves the given [Color] by calling [resolveFrom].
   ///
   /// If the given color is already a concrete [Color], it will be returned as is.
-  /// If the given color is null, returns null for convenience.
+  /// If the given color is null, returns null.
   /// If the given color is a [CupertinoDynamicColor], but the given [BuildContext]
   /// lacks the dependencies required to the color resolution, the default trait
   /// value will be used ([Brightness.light] platform brightness, normal contrast,

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -325,13 +325,15 @@ class CupertinoDynamicColor extends Color {
   /// Resolves the given [Color] by calling [resolveFrom].
   ///
   /// If the given color is already a concrete [Color], it will be returned as is.
+  /// If the given color is null, returns null for convenience.
   /// If the given color is a [CupertinoDynamicColor], but the given [BuildContext]
   /// lacks the dependencies required to the color resolution, the default trait
   /// value will be used ([Brightness.light] platform brightness, normal contrast,
   /// [CupertinoUserInterfaceLevelData.base] elevation level), unless [nullOk] is
   /// set to false, in which case an exception will be thrown.
   static Color resolve(Color resolvable, BuildContext context, { bool nullOk = true }) {
-    assert(resolvable != null);
+    if (resolvable == null)
+      return null;
     assert(context != null);
     return (resolvable is CupertinoDynamicColor)
       ? resolvable.resolveFrom(context, nullOk: nullOk)

--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -216,7 +216,7 @@ class CupertinoTextThemeData extends Diagnosticable {
   /// Returns a copy of the current [CupertinoTextThemeData] with all the colors
   /// resolved against the given [BuildContext].
   CupertinoTextThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
-    Color convertColor(Color color) => color == null ? null : CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
+    Color convertColor(Color color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
     TextStyle resolveTextStyle(TextStyle textStyle) {
       return textStyle?.copyWith(

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -248,7 +248,7 @@ class CupertinoThemeData extends Diagnosticable {
   /// It will be called in [CupertinoTheme.of].
   @protected
   CupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
-    Color convertColor(Color color) => color == null ? null : CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
+    Color convertColor(Color color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
     return copyWith(
       primaryColor: convertColor(primaryColor),
@@ -329,9 +329,7 @@ class _NoDefaultCupertinoThemeData extends CupertinoThemeData {
 
   @override
   _NoDefaultCupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
-    Color convertColor(Color color) => color == null
-      ? null
-      : CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
+    Color convertColor(Color color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
     return _NoDefaultCupertinoThemeData(
       brightness,

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -160,6 +160,10 @@ void main() {
     );
   });
 
+  test('can resolve null color', () {
+    expect(CupertinoDynamicColor.resolve(null, null), isNull);
+  });
+
   test('withVibrancy constructor creates colors that may depend on vibrancy', () {
     expect(vibrancyDependentColor1, const CupertinoDynamicColor.withBrightness(
       color: color1,


### PR DESCRIPTION
## Description

For convenience.

## Tests

I added the following tests:

- can resolve null color

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
