### PR TITLE
remove dart dir chrome profile

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -79,11 +79,7 @@ class ChromeLauncher {
   /// `skipCheck` does not attempt to make a devtools connection before returning.
   Future<Chrome> launch(String url, { bool headless = false, bool skipCheck = false }) async {
     final String chromeExecutable = findChromeExecutable();
-    final Directory dataDir = fs.directory('.dart_tool')
-      .childDirectory('chrome_profile');
-    if (!dataDir.existsSync()) {
-      dataDir.createSync(recursive: true);
-    }
+    final Directory dataDir = fs.systemTempDirectory.createTempSync('flutter_tool_');
     final int port = await os.findFreePort();
     final List<String> args = <String>[
       chromeExecutable,

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process_manager.dart';
@@ -22,10 +23,12 @@ void main() {
   setUp(() {
     final MockPlatform platform = MockPlatform();
     when(platform.isWindows).thenReturn(false);
+    final MockFileSystem mockFileSystem = MockFileSystem();
     testbed = Testbed(overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Platform: () => platform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
+      FileSystem: () => mockFileSystem,
     });
   });
 
@@ -36,9 +39,13 @@ void main() {
     when(platform.environment).thenReturn(<String, String>{
       kChromeEnvironment: 'example_chrome'
     });
+    final Directory mockDirectory = MockDirectory();
+    when(fs.systemTempDirectory).thenReturn(mockDirectory);
+    when(mockDirectory.createTempSync(any)).thenReturn(mockDirectory);
+    when(mockDirectory.path).thenReturn('example');
     when(processManager.start(<String>[
       'example_chrome',
-      '--user-data-dir=.dart_tool/chrome_profile',
+      '--user-data-dir=example',
       '--remote-debugging-port=1234',
       '--disable-background-timer-throttling',
       '--disable-extensions',
@@ -66,3 +73,5 @@ void main() {
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockPlatform extends Mock implements Platform {}
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
+class MockFileSystem extends Mock implements FileSystem {}
+class MockDirectory extends Mock implements Directory {}


### PR DESCRIPTION
## Description

It turns out that if we use a fixed data dir, then we can't launch multiple instances of chrome (devtools will fail to serve/connect). Go back to using temp directory.