### PR TITLE
Roll build runner and remove delay

### DIFF
--- a/dev/integration_tests/android_views/pubspec.yaml
+++ b/dev/integration_tests/android_views/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  path_provider: 1.2.2
+  path_provider: 1.3.0
   collection: 1.14.11
   assets_for_android_views:
     git:
@@ -81,4 +81,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# PUBSPEC CHECKSUM: 1658
+# PUBSPEC CHECKSUM: 4b57

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -129,12 +129,6 @@ class WebFs {
 
   /// Recompile the web application and return whether this was successful.
   Future<bool> recompile() async {
-    // TODO(jonahwilliams): build_daemon is still watching for sources, which means we can
-    // easily miss changes when hot restart is triggered by IDEs. Until we fix this, add a
-    // delay to allow filesystem watches to gather all required source files. This duration
-    // was chosen arbitrarily.
-    // See https://github.com/flutter/flutter/issues/39696
-    await Future<void>.delayed(const Duration(milliseconds: 150));
     _client.startBuild();
     await for (BuildResults results in _client.buildResults) {
       final BuildResult result = results.results.firstWhere((BuildResult result) {

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   test_core: 0.2.5
 
   # Code generation dependencies
-  build_runner_core: 3.0.9
+  build_runner_core: 3.1.0
   dart_style: 1.2.9
   code_builder: 3.2.0
   build: 1.1.6
@@ -124,7 +124,7 @@ dev_dependencies:
   mockito: 4.1.1
   file_testing: 2.1.0
   test: 1.6.3
-  build_runner: 1.6.7
+  build_runner: 1.6.8
   build_vm_compilers: 1.0.3
   build_test: 0.10.8
 
@@ -136,4 +136,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 9ea0
+# PUBSPEC CHECKSUM: 1699


### PR DESCRIPTION
## Description

The new version of build_runner/core will do a filesystem scan on demand in manual mode, resolving the timing issue with hot restart.

Fixes https://github.com/flutter/flutter/issues/39696 