### PR TITLE
Add null check to _IndicatorPainter._tabOffsetsEqual() to prevent crash

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -419,18 +419,8 @@ class _IndicatorPainter extends CustomPainter {
   }
 
   static bool _tabOffsetsEqual(List<double> a, List<double> b) {
-    // TODO(shihaohong): Null checks were added because of crashes in apps
-    // where a and/or b become null.
-    //
-    // Tab offsets are defined at layout, which should happen before paint
-    // is first called. However, it seems like shouldRepaint is being called
-    // before layout. It is unclear how an app could enter this state, but
-    // it proved difficult to effectively reproduce this issue. In reality,
-    // this state should never occur and the underlying cause should be fixed.
-    // Once a clear reproduction can be created and a regression test is
-    // written, these checks should be removed.
-    //
-    // See https://github.com/flutter/flutter/issues/40014 for more details.
+    // TODO(shihaohong): The following null check should be replaced when a fix
+    // for https://github.com/flutter/flutter/issues/40014 is available.
     if (a == null || b == null || a.length != b.length)
       return false;
     for (int i = 0; i < a.length; i += 1) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -419,13 +419,16 @@ class _IndicatorPainter extends CustomPainter {
   }
 
   static bool _tabOffsetsEqual(List<double> a, List<double> b) {
-    // TODO(shihaohong): These null checks were added since crashes in apps
-    // where a and/or b become null. However, it is unclear how an app
-    // could enter this state. Tab offsets are defined at layout,
-    // which should happen before paint is first called. However, it seems
-    // like shouldRepaint is being called before layout. In reality, we should
-    // avoid this state from occuring and fix the underlying cause. Once a
-    // regression test has been written, these checks should be removed.
+    // TODO(shihaohong): Null checks were added because of crashes in apps
+    // where a and/or b become null.
+    //
+    // Tab offsets are defined at layout, which should happen before paint
+    // is first called. However, it seems like shouldRepaint is being called
+    // before layout. It is unclear how an app could enter this state, but
+    // it proved difficult to effectively reproduce this issue. In reality,
+    // this state should never occur and the underlying cause should be fixed.
+    // Once a clear reproduction can be created and a regression test is
+    // written, these checks should be removed.
     //
     // See https://github.com/flutter/flutter/issues/35997 for more details.
     if (a == null || b == null || a.length != b.length)

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -424,7 +424,8 @@ class _IndicatorPainter extends CustomPainter {
     // could enter this state. Tab offsets are defined at layout,
     // which should happen before paint is first called. However, it seems
     // like shouldRepaint is being called before layout. In reality, we should
-    // avoid this state from occuring and write a regression test against it.
+    // avoid this state from occuring and fix the underlying cause. Once a
+    // regression test has been written, these checks should be removed.
     //
     // See https://github.com/flutter/flutter/issues/35997 for more details.
     if (a == null || b == null || a.length != b.length)

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -430,7 +430,7 @@ class _IndicatorPainter extends CustomPainter {
     // Once a clear reproduction can be created and a regression test is
     // written, these checks should be removed.
     //
-    // See https://github.com/flutter/flutter/issues/35997 for more details.
+    // See https://github.com/flutter/flutter/issues/40014 for more details.
     if (a == null || b == null || a.length != b.length)
       return false;
     for (int i = 0; i < a.length; i += 1) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -419,7 +419,15 @@ class _IndicatorPainter extends CustomPainter {
   }
 
   static bool _tabOffsetsEqual(List<double> a, List<double> b) {
-    if (a?.length != b?.length)
+    // TODO(shihaohong): These null checks were added since crashes in apps
+    // where a and/or b become null. However, it is unclear how an app
+    // could enter this state. Tab offsets are defined at layout,
+    // which should happen before paint is first called. However, it seems
+    // like shouldRepaint is being called before layout. In reality, we should
+    // avoid this state from occuring and write a regression test against it.
+    //
+    // See https://github.com/flutter/flutter/issues/35997 for more details.
+    if (a == null || b == null || a.length != b.length)
       return false;
     for (int i = 0; i < a.length; i += 1) {
       if (a[i] != b[i])

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -505,7 +505,9 @@ void main() {
     );
   }, skip: isBrowser);
 
-  testWidgets('Cursor layout has correct width', (WidgetTester tester) async {
+  // TODO(hansmuller): restore these tests after the fix for #24876 has landed.
+  /*
+  testWidgets('cursor layout has correct width', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
         overlay(
@@ -524,9 +526,9 @@ void main() {
       matchesGoldenFile('text_field_test.0.0.png'),
     );
     EditableText.debugDeterministicCursor = false;
-  }, skip: !isLinux);
+  }, skip: !Platform.isLinux);
 
-  testWidgets('Cursor layout has correct radius', (WidgetTester tester) async {
+  testWidgets('cursor layout has correct radius', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
         overlay(
@@ -546,7 +548,8 @@ void main() {
       matchesGoldenFile('text_field_test.1.0.png'),
     );
     EditableText.debugDeterministicCursor = false;
-  }, skip: !isLinux);
+  }, skip: !Platform.isLinux);
+  */
 
   testWidgets('Overflowing a line with spaces stops the cursor at the end', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -505,9 +505,7 @@ void main() {
     );
   }, skip: isBrowser);
 
-  // TODO(hansmuller): restore these tests after the fix for #24876 has landed.
-  /*
-  testWidgets('cursor layout has correct width', (WidgetTester tester) async {
+  testWidgets('Cursor layout has correct width', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
         overlay(
@@ -526,9 +524,9 @@ void main() {
       matchesGoldenFile('text_field_test.0.0.png'),
     );
     EditableText.debugDeterministicCursor = false;
-  }, skip: !Platform.isLinux);
+  }, skip: !isLinux);
 
-  testWidgets('cursor layout has correct radius', (WidgetTester tester) async {
+  testWidgets('Cursor layout has correct radius', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
         overlay(
@@ -548,8 +546,7 @@ void main() {
       matchesGoldenFile('text_field_test.1.0.png'),
     );
     EditableText.debugDeterministicCursor = false;
-  }, skip: !Platform.isLinux);
-  */
+  }, skip: !isLinux);
 
   testWidgets('Overflowing a line with spaces stops the cursor at the end', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();


### PR DESCRIPTION
## Description

The _IndicatorPainter._tabOffsetsEqual() method in [material/tabs.dart](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/tabs.dart#L421) compares cached lists of the x-offsets of its tabbar's tabs:

```dart
  static bool _tabOffsetsEqual(List<double> a, List<double> b) {
    if (a?.length != b?.length)
      return false;
    for (int i = 0; i < a.length; i += 1) {
      if (a[i] != b[i])
        return false;
    }
    return true;
  }
```

Here `a` and `b` are the values of _IndicatorPainter_currentTabOffsets. The offsets are computed each time the tabbar is laid out.

If either a or b are null the code will crash. However this function is called by `shouldRepaint()` and it's assumed that layout will have completed before shouldRepaint() calls _tabOffsetsEqual().

The crash has occurred intermittently in the field but we have not been able to reproduce it. 

FTR: This scenario used to be [guarded against](https://github.com/flutter/flutter/pull/13164/files#diff-6d433f126d05f45352a40b9bb916ac70L317), but the assert was removed.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/35997
Related to https://github.com/flutter/flutter/pull/39833

### TODO:

- [x] File an issue for a necessary, deeper fix with a regression test (https://github.com/flutter/flutter/issues/40014)

## Tests

I added the following tests:

n/a - Since the crash scenario cannot be properly replicated, a regression test cannot be written.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
