### PR TITLE
[BUG] Process all children of intent-filter instead of just the first one to identify default activity

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -496,6 +496,23 @@ class _Attribute extends _Entry {
 class ApkManifestData {
   ApkManifestData._(this._data);
 
+  static bool isAttributeWithValuePresent(_Element baseElement,
+      String childElement, String attributeName, String attributeValue) {
+    final Iterable<_Element> allElements = baseElement.allElements(
+        childElement).cast<_Element>();
+    bool isPresent;
+    for (_Element oneElement in allElements) {
+      final String elementAttributeValue = oneElement
+          ?.firstAttribute(attributeName)
+          ?.value;
+      isPresent = elementAttributeValue != null &&
+          elementAttributeValue.startsWith(attributeValue);
+      if (isPresent)
+        break;
+    }
+    return isPresent;
+  }
+
   static ApkManifestData parseFromXmlDump(String data) {
     if (data == null || data.trim().isEmpty)
       return null;
@@ -548,21 +565,19 @@ class ApkManifestData {
       }
 
       for (_Element element in intentFilters) {
-        final _Element action = element.firstElement('action');
-        final _Element category = element.firstElement('category');
-        final String actionAttributeValue = action
-            ?.firstAttribute('android:name')
-            ?.value;
-        final String categoryAttributeValue =
-            category?.firstAttribute('android:name')?.value;
-        final bool isMainAction = actionAttributeValue != null &&
-            actionAttributeValue.startsWith('"android.intent.action.MAIN"');
-        final bool isLauncherCategory = categoryAttributeValue != null &&
-            categoryAttributeValue.startsWith('"android.intent.category.LAUNCHER"');
-        if (isMainAction && isLauncherCategory) {
-          launchActivity = activity;
-          break;
+        final bool isMainAction = isAttributeWithValuePresent(
+            element, 'action', 'android:name', '"android.intent.action.MAIN"');
+        if (!isMainAction) {
+          continue;
         }
+        final bool isLauncherCategory = isAttributeWithValuePresent(
+            element, 'category', 'android:name',
+            '"android.intent.category.LAUNCHER"');
+        if (!isLauncherCategory) {
+          continue;
+        }
+        launchActivity = activity;
+        break;
       }
       if (launchActivity != null) {
         break;

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -500,7 +500,7 @@ class ApkManifestData {
       String childElement, String attributeName, String attributeValue) {
     final Iterable<_Element> allElements = baseElement.allElements(
         childElement).cast<_Element>();
-    bool isPresent;
+    bool isPresent = false;
     for (_Element oneElement in allElements) {
       final String elementAttributeValue = oneElement
           ?.firstAttribute(attributeName)

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -500,17 +500,16 @@ class ApkManifestData {
       String childElement, String attributeName, String attributeValue) {
     final Iterable<_Element> allElements = baseElement.allElements(
         childElement).cast<_Element>();
-    bool isPresent = false;
     for (_Element oneElement in allElements) {
       final String elementAttributeValue = oneElement
           ?.firstAttribute(attributeName)
           ?.value;
-      isPresent = elementAttributeValue != null &&
-          elementAttributeValue.startsWith(attributeValue);
-      if (isPresent)
-        break;
+      if (elementAttributeValue != null &&
+          elementAttributeValue.startsWith(attributeValue)) {
+        return true;
+      }
     }
-    return isPresent;
+    return false;
   }
 
   static ApkManifestData parseFromXmlDump(String data) {

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -195,6 +195,13 @@ void main() {
       expect(
           logger.errorText, 'Error running io.flutter.examples.hello_world. Default activity not found\n');
     }, overrides: noColorTerminalOverride);
+
+    testUsingContext('Parsing manifest with Activity that has multiple category, android.intent.category.LAUNCHER and android.intent.category.DEFAULT', () {
+      final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithLauncherAndDefaultActivity);
+      expect(data, isNotNull);
+      expect(data.packageName, 'io.flutter.examples.hello_world');
+      expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity');
+    }, overrides: noColorTerminalOverride);
   });
 
   group('PrebuiltIOSApp', () {
@@ -559,6 +566,43 @@ const String _aaptDataWithNoLauncherActivity =
         E: intent-filter (line=42)
           E: action (line=43)
             A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")''';
+
+const String _aaptDataWithLauncherAndDefaultActivity =
+'''N: android=http://schemas.android.com/apk/res/android
+  N: dist=http://schemas.android.com/apk/distribution
+    E: manifest (line=7)
+      A: android:versionCode(0x0101021b)=(type 0x10)0x1
+      A: android:versionName(0x0101021c)="1.0" (Raw: "1.0")
+      A: android:compileSdkVersion(0x01010572)=(type 0x10)0x1c
+      A: android:compileSdkVersionCodename(0x01010573)="9" (Raw: "9")
+      A: package="io.flutter.examples.hello_world" (Raw: "io.flutter.examples.hello_world")
+      A: platformBuildVersionCode=(type 0x10)0x1
+      A: platformBuildVersionName=(type 0x4)0x3f800000
+      E: uses-sdk (line=13)
+        A: android:minSdkVersion(0x0101020c)=(type 0x10)0x10
+        A: android:targetSdkVersion(0x01010270)=(type 0x10)0x1c
+      E: dist:module (line=17)
+        A: dist:instant=(type 0x12)0xffffffff
+      E: uses-permission (line=24)
+        A: android:name(0x01010003)="android.permission.INTERNET" (Raw: "android.permission.INTERNET")
+      E: application (line=32)
+        A: android:label(0x01010001)="hello_world" (Raw: "hello_world")
+        A: android:icon(0x01010002)=@0x7f010000
+        A: android:name(0x01010003)="io.flutter.app.FlutterApplication" (Raw: "io.flutter.app.FlutterApplication")
+        E: activity (line=36)
+          A: android:theme(0x01010000)=@0x01030009
+          A: android:name(0x01010003)="io.flutter.examples.hello_world.MainActivity" (Raw: "io.flutter.examples.hello_world.MainActivity")
+          A: android:launchMode(0x0101001d)=(type 0x10)0x1
+          A: android:configChanges(0x0101001f)=(type 0x11)0x400037b4
+          A: android:windowSoftInputMode(0x0101022b)=(type 0x11)0x10
+          A: android:hardwareAccelerated(0x010102d3)=(type 0x12)0xffffffff
+          E: intent-filter (line=43)
+            E: action (line=44)
+              A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")
+            E: category (line=46)
+              A: android:name(0x01010003)="android.intent.category.DEFAULT" (Raw: "android.intent.category.DEFAULT")
+              A: android:name(0x01010003)="android.intent.category.LAUNCHER" (Raw: "android.intent.category.LAUNCHER")
+''';
 
 const String _aaptDataWithDistNamespace =
 '''N: android=http://schemas.android.com/apk/res/android

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -601,6 +601,7 @@ const String _aaptDataWithLauncherAndDefaultActivity =
               A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")
             E: category (line=46)
               A: android:name(0x01010003)="android.intent.category.DEFAULT" (Raw: "android.intent.category.DEFAULT")
+            E: category (line=47)
               A: android:name(0x01010003)="android.intent.category.LAUNCHER" (Raw: "android.intent.category.LAUNCHER")
 ''';
 


### PR DESCRIPTION
`flutter run` looks for default activity to run the application, for that, we were checking the first action and first category in the intent filter, but it is possible that the one we are looking for is not the first one.

This PR fixes that behaviour by iterating over all the actions and
categories of intent-filter.

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

## Related Issues
https://github.com/flutter/flutter/issues/29335
Fixes https://github.com/flutter/flutter/issues/28223

## Tests

I have tested the change by using these intent filters:
```
<action android:name="android.intent.action.MAIN"/>
<category android:name="android.intent.category.DEFAULT"/>
<category android:name="android.intent.category.LAUNCHER"/>
```
Without my changes, the error message pops up:
```
Error running com.example.test. Default activity not found
Unable to read manifest info from /mnt/data/android/apps/test/build/app/outputs/apk/app.apk.
No application found for TargetPlatform.android_arm64.
Is your project missing an android/app/src/main/AndroidManifest.xml?
Consider running "flutter create ." to create one.
```
And with my changes, it works perfectly.

## Breaking Change
No, this is *not* a breaking change.
