### PR TITLE
added notification that dispatches when user actually ends dragging in scrollable

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -106,6 +106,11 @@ abstract class ScrollActivity {
     ScrollEndNotification(metrics: metrics, context: context).dispatch(context);
   }
 
+  /// Dispatch a [ScrollDragEndNotification] with the given metrics.
+  void dispatchScrollDragEndNotification(ScrollMetrics metrics, BuildContext context) {
+    ScrollDragEndNotification(metrics: metrics, context: context).dispatch(context);
+  }
+
   /// Called when the scroll view that is performing this activity changes its metrics.
   void applyNewDimensions() { }
 
@@ -461,6 +466,16 @@ class DragScrollActivity extends ScrollActivity {
     ).dispatch(context);
   }
 
+  @override
+  void dispatchScrollDragEndNotification(ScrollMetrics metrics, BuildContext context){
+      final dynamic lastDetails = _controller.lastDetails;
+      ScrollDragEndNotification(
+          metrics: metrics,
+          context: context,
+          dragDetails: lastDetails is DragEndDetails ? lastDetails : null,
+      ).dispatch(context);
+  }
+  
   @override
   bool get shouldIgnorePointer => true;
 

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -475,7 +475,7 @@ class DragScrollActivity extends ScrollActivity {
           dragDetails: lastDetails is DragEndDetails ? lastDetails : null,
       ).dispatch(context);
   }
-  
+
   @override
   bool get shouldIgnorePointer => true;
 

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -278,29 +278,27 @@ class UserScrollNotification extends ScrollNotification {
   }
 }
 
-/// A notification that is dispatched as soon as pointer is no longer in
-/// contact with the screen i.e drag has been ended in [Scrollable] widget.
+/// A notification that is dispatched as soon as pointer is no longer in contact
+/// with the screen, e.g. when drag has ended in a [Scrollable] widget.
 ///
 /// See also:
 ///
-///  * [ScrollEndNotification], which indicates that scrolling has been ended
-///  * [ScrollEndNotification.dragDetails], null if residualVelocity
-///  causes ballistic simulation, otherwise not null
+///  * [ScrollEndNotification], which indicates that scrolling has been ended.
+///  * [ScrollEndNotification.dragDetails], which is null if residualVelocity
+///  causes ballistic simulation, otherwise not null.
 ///
-/// After [ScrollDragEndNotification], [ScrollEndNotification]
-/// will be dispatched immediately or after some delay(depending on the
-/// residual velocity causes ballistic animation or not)
-///
+/// [ScrollDragEndNotification] is dispatched before [ScrollEndNotification],
+/// and is guaranteed to contain the drag details without modification by any
+/// simulations used by the current [ScrollPhysics].
 class ScrollDragEndNotification extends ScrollNotification {
-  /// Creates a notification that drag in a [Scrollable] widget has been stopped.0
+  /// Creates a notification that drag in a [Scrollable] widget has stopped.
   ScrollDragEndNotification({
       @required ScrollMetrics metrics,
       @required BuildContext context,
       this.dragDetails,
 }) : super(metrics: metrics, context: context);
 
-  /// If the drag in [Scrollable] ends, and pointer is no longer in contact,
-  /// the details about that drag end.
+  /// The [DragEndDetails] at the moment the pointer has released.
   final DragEndDetails dragDetails;
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -278,6 +278,39 @@ class UserScrollNotification extends ScrollNotification {
   }
 }
 
+/// A notification that is dispatched as soon as pointer is no longer in
+/// contact with the screen i.e drag has been ended in [Scrollable] widget.
+///
+/// See also:
+///
+///  * [ScrollEndNotification], which indicates that scrolling has been ended
+///  * [ScrollEndNotification.dragDetails], null if residualVelocity
+///  causes ballistic simulation, otherwise not null
+///
+/// After [ScrollDragEndNotification], [ScrollEndNotification]
+/// will be dispatched immediately or after some delay(depending on the
+/// residual velocity causes ballistic animation or not)
+///
+class ScrollDragEndNotification extends ScrollNotification {
+  /// Creates a notification that drag in a [Scrollable] widget has been stopped.0
+  ScrollDragEndNotification({
+      @required ScrollMetrics metrics,
+      @required BuildContext context,
+      this.dragDetails,
+}) : super(metrics: metrics, context: context);
+
+  /// If the drag in [Scrollable] ends, and pointer is no longer in contact,
+  /// the details about that drag end.
+  final DragEndDetails dragDetails;
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (dragDetails != null)
+      description.add('$dragDetails');
+  }
+}
+
 /// A predicate for [ScrollNotification], used to customize widgets that
 /// listen to notifications from their children.
 typedef ScrollNotificationPredicate = bool Function(ScrollNotification notification);

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -633,6 +633,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       return;
     bool wasScrolling, oldIgnorePointer;
     if (_activity != null) {
+      if (_activity is DragScrollActivity)
+        didEndScrollDrag(); //notifies drag has ended while scrolling
       oldIgnorePointer = _activity.shouldIgnorePointer;
       wasScrolling = _activity.isScrolling;
       if (wasScrolling && !newActivity.isScrolling)
@@ -670,6 +672,11 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     activity.dispatchScrollEndNotification(copyWith(), context.notificationContext);
     if (keepScrollOffset)
       saveScrollOffset();
+  }
+  
+  /// Called by [beginActivity] to report when an scroll drag has been ended.
+  void didEndScrollDrag() {
+    activity.dispatchScrollDragEndNotification(copyWith(), context.notificationContext);
   }
 
   /// Called by [setPixels] to report overscroll when an attempt is made to

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -673,7 +673,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     if (keepScrollOffset)
       saveScrollOffset();
   }
-  
+
   /// Called by [beginActivity] to report when an scroll drag has been ended.
   void didEndScrollDrag() {
     activity.dispatchScrollDragEndNotification(copyWith(), context.notificationContext);

--- a/packages/flutter/test/widgets/scroll_events_test.dart
+++ b/packages/flutter/test/widgets/scroll_events_test.dart
@@ -17,6 +17,8 @@ Widget _buildScroller({ List<String> log }) {
         log.add('scroll-update');
       } else if (notification is ScrollEndNotification) {
         log.add('scroll-end');
+      } else if (notification is ScrollDragEndNotification){
+        log.add('scroll-drag-end');
       }
       return false;
     },
@@ -53,9 +55,9 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(log, equals(<String>['scroll-start', 'scroll-update']));
     await gesture.up();
-    expect(log, equals(<String>['scroll-start', 'scroll-update', 'scroll-end']));
+    expect(log, equals(<String>['scroll-start', 'scroll-update', 'scroll-drag-end', 'scroll-end']));
     await tester.pump(const Duration(seconds: 1));
-    expect(log, equals(<String>['scroll-start', 'scroll-update', 'scroll-end']));
+    expect(log, equals(<String>['scroll-start', 'scroll-update', 'scroll-drag-end', 'scroll-end']));
   });
 
   testWidgets('Scroll animateTo', (WidgetTester tester) async {
@@ -148,14 +150,16 @@ void main() {
     await tester.flingFrom(const Offset(100.0, 100.0), const Offset(-50.0, -50.0), 500.0);
     await tester.pump(const Duration(seconds: 1));
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end']));
     await tester.flingFrom(const Offset(100.0, 100.0), const Offset(-50.0, -50.0), 500.0);
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start', 'scroll-end', 'scroll-start']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end', 'scroll-end', 'scroll-start',
+      'scroll-drag-end']));
     await tester.pump(const Duration(seconds: 1));
     await tester.pump(const Duration(seconds: 1));
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start', 'scroll-end', 'scroll-start', 'scroll-end']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end', 'scroll-end', 'scroll-start',
+      'scroll-drag-end', 'scroll-end']));
   });
 
   testWidgets('fling, pause, fling generates two start/end pairs', (WidgetTester tester) async {
@@ -166,15 +170,17 @@ void main() {
     await tester.flingFrom(const Offset(100.0, 100.0), const Offset(-50.0, -50.0), 500.0);
     await tester.pump(const Duration(seconds: 1));
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end']));
     await tester.pump(const Duration(minutes: 1));
     await tester.flingFrom(const Offset(100.0, 100.0), const Offset(-50.0, -50.0), 500.0);
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start', 'scroll-end', 'scroll-start']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end','scroll-end', 'scroll-start',
+      'scroll-drag-end']));
     await tester.pump(const Duration(seconds: 1));
     await tester.pump(const Duration(seconds: 1));
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log, equals(<String>['scroll-start', 'scroll-end', 'scroll-start', 'scroll-end']));
+    expect(log, equals(<String>['scroll-start', 'scroll-drag-end', 'scroll-end', 'scroll-start',
+      'scroll-drag-end', 'scroll-end']));
   });
 
   testWidgets('fling up ends', (WidgetTester tester) async {
@@ -189,7 +195,7 @@ void main() {
     expect(log.first, equals('scroll-start'));
     expect(log.last, equals('scroll-end'));
     log.removeWhere((String value) => value == 'scroll-update');
-    expect(log.length, equals(2));
+    expect(log.length, equals(3));
     expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, equals(0.0));
   });
 }

--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -93,14 +93,15 @@ void main() {
       ScrollStartNotification,
       UserScrollNotification,
       ScrollUpdateNotification,
+      ScrollDragEndNotification,
       ScrollEndNotification,
       UserScrollNotification,
     ];
     expect(depth0Types, equals(types));
     expect(depth1Types, equals(types));
 
-    expect(depth0Values, equals(<int>[0, 0, 0, 0, 0]));
-    expect(depth1Values, equals(<int>[1, 1, 1, 1, 1]));
+    expect(depth0Values, equals(<int>[0, 0, 0, 0, 0, 0]));
+    expect(depth1Values, equals(<int>[1, 1, 1, 1, 1, 1]));
   });
 
   testWidgets('ScrollNotifications bubble past Scaffold Material', (WidgetTester tester) async {
@@ -145,6 +146,7 @@ void main() {
       ScrollStartNotification,
       UserScrollNotification,
       ScrollUpdateNotification,
+      ScrollDragEndNotification,
       ScrollEndNotification,
       UserScrollNotification,
     ];

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -173,6 +173,7 @@ void main() {
 
     expect(controller.offset, equals(550.0));
     expect(log, equals(<Type>[
+      ScrollDragEndNotification,
       ScrollEndNotification,
       UserScrollNotification,
       ScrollStartNotification,


### PR DESCRIPTION
## Description

I added `ScrollDragEndNotification` that will notify that the pointer is no longer in contact with the screen while dragging Scrollable i.e drag has been ended in `Scrollable` widget.
It is different from `ScrollEndNotification` since `ScrollEndNotification` is dispatched when scrolling has been ended whose dragDetails are null when drag residual velocity causes ballistic simulation that further delays `ScrollEndNotification` (scrolling continues even after flinging). With this PR we can detect that scroll drag has been ended with actual dragDetails before ballistic simulation.

Though in the case of over scrolling. `ScrollDragEndNotification` and` ScrollEndNotification `both will be fired immediately in succession with same dragDetails. 

Note : There will be no need for ScrollDragStartNotification, ScrollDragUpdateNotification since `ScrollStartNotification`, (`ScrollUpdateNotification` or `OverscrollNotification`) are actually providing the same functionality respectively.


### Example Usage 
#### Scrolling in middle
scrolling before `ScrollDragEndNotification`
![beforeScrollDrag](https://user-images.githubusercontent.com/20876020/64477539-7515dc80-d1ba-11e9-8edf-b144a5ed5fca.png)
scrolling after `ScrollDragEndNotification`
![afterScrollDrag](https://user-images.githubusercontent.com/20876020/64477547-8363f880-d1ba-11e9-942e-6a4e8f3e42fc.png)

#### Overscrolling
Overscrolling before `ScrollDragEndNotification`
![OverscrollbeforeScrollDrag](https://user-images.githubusercontent.com/20876020/64477564-ae4e4c80-d1ba-11e9-88a3-b228b54136e7.png)
Overscrolling after `ScrollDragEndNotification`
![OverscrollAfterScrollDrag](https://user-images.githubusercontent.com/20876020/64477577-cfaf3880-d1ba-11e9-9afd-e49f905b9a2c.png)



## Related Issues
Resolves: https://github.com/flutter/flutter/issues/39929


## Tests

Modified the following tests:

- test/widgets/scroll_events_test.dart
- test/widgets/scroll_notification_test.dart
- test/widgets/scroll_view_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and updated tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

@Hixie Sir any sugeestions?