### PR TITLE
Fix double.infinity serialization

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2670,6 +2670,8 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
     if (value is Diagnosticable || value is DiagnosticsNode)
       json['isDiagnosticableValue'] = true;
     if (v is num)
+      // Workaround for https://github.com/flutter/flutter/issues/39937#issuecomment-529558033.
+      // JSON.stringify replaces infinity and NaN with null.
       json['value'] = v.isFinite ? v :  v.toString();
     if (value is String || value is bool || value == null)
       json['value'] = value;

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2669,7 +2669,9 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
     json['defaultLevel'] = describeEnum(_defaultLevel);
     if (value is Diagnosticable || value is DiagnosticsNode)
       json['isDiagnosticableValue'] = true;
-    if (value is num || value is String || value is bool || value == null)
+    if (v is num)
+      json['value'] = v.isFinite ? v :  v.toString();
+    if (value is String || value is bool || value == null)
       json['value'] = value;
     return json;
   }

--- a/packages/flutter/test/foundation/diagnostics_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_test.dart
@@ -1050,6 +1050,10 @@ void main() {
     validateDoublePropertyJsonSerialization(doubleWithUnit);
   });
 
+  test('double.infinity serialization test', () {
+    validateDoublePropertyJsonSerialization(DoubleProperty('double1', double.infinity));
+    validateDoublePropertyJsonSerialization(DoubleProperty('double2', double.negativeInfinity));
+  });
 
   test('unsafe double property test', () {
     final DoubleProperty safe = DoubleProperty.lazy(

--- a/packages/flutter/test/foundation/diagnostics_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_test.dart
@@ -1051,8 +1051,13 @@ void main() {
   });
 
   test('double.infinity serialization test', () {
-    validateDoublePropertyJsonSerialization(DoubleProperty('double1', double.infinity));
-    validateDoublePropertyJsonSerialization(DoubleProperty('double2', double.negativeInfinity));
+    final DoubleProperty infProperty1 = DoubleProperty('double1', double.infinity);
+    validateDoublePropertyJsonSerialization(infProperty1);
+    expect(infProperty1.toString(), equals('double1: Infinity'));
+
+    final DoubleProperty infProperty2 = DoubleProperty('double2', double.negativeInfinity);
+    validateDoublePropertyJsonSerialization(infProperty2);
+    expect(infProperty2.toString(), equals('double2: -Infinity'));
   });
 
   test('unsafe double property test', () {


### PR DESCRIPTION
## Description

Convert infinite numbers to strings before serializing them.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39937

## Tests

I added the following tests:

double.infinity serialization test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
