### PR TITLE
Lower the iterations on flutter_gallery__back_button_memory

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -26,7 +26,7 @@ class BackButtonMemoryTest extends MemoryTest {
   Future<void> useMemory() async {
     await launchApp();
     await recordStart();
-    for (int iteration = 0; iteration < 10; iteration += 1) {
+    for (int iteration = 0; iteration < 8; iteration += 1) {
       print('back/forward iteration $iteration');
 
       // Push back button, wait for it to be seen by the Flutter app.

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -322,7 +322,7 @@ class AndroidDevice implements Device {
         process.exitCode.then<void>((int exitCode) {
           print('adb logcat process terminated with exit code $exitCode');
           if (!aborted) {
-            stream.addError(BuildFailedError('adb logcat failed with exit code $exitCode.'));
+            stream.addError(BuildFailedError('adb logcat failed with exit code $exitCode.\n'));
             processDone.complete();
           }
         });


### PR DESCRIPTION
## Description

It was hitting the global devicelab 15 minute timeout.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
