### PR TITLE
Show outdated CocoaPods version in hint text

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -167,8 +167,8 @@ class UserMessages {
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';
-  String cocoaPodsOutdated(String recVersion, String consequence, String upgradeInstructions) =>
-      'CocoaPods out of date ($recVersion is recommended).\n'
+  String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
+      'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -45,8 +45,9 @@ class CocoaPodsValidator extends DoctorValidator {
             userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       } else {
         status = ValidationType.partial;
+        final String currentVersionText = await cocoaPods.cocoaPodsVersionText;
         messages.add(ValidationMessage.hint(
-            userMessages.cocoaPodsOutdated(cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+            userMessages.cocoaPodsOutdated(currentVersionText, cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       }
     }
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
@@ -62,9 +62,20 @@ void main() {
     testUsingContext('Emits partial status when CocoaPods version is too low', () async {
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.belowRecommendedVersion);
+      const String currentVersion = '1.4.0';
+      when(cocoaPods.cocoaPodsVersionText)
+          .thenAnswer((_) async => currentVersion);
+      const String recommendedVersion = '1.8.0';
+      when(cocoaPods.cocoaPodsRecommendedVersion)
+          .thenAnswer((_) => recommendedVersion);
       const CocoaPodsValidator workflow = CocoaPodsValidator();
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
+      expect(result.messages.length, 1);
+      final ValidationMessage message = result.messages.first;
+      expect(message.type, ValidationMessageType.hint);
+      expect(message.message, contains('CocoaPods $currentVersion out of date'));
+      expect(message.message, contains('($recommendedVersion is recommended)'));
     }, overrides: <Type, Generator>{
       CocoaPods: () => cocoaPods,
     });


### PR DESCRIPTION
## Description

Was:
```
CocoaPods out of date (1.6.0 is recommended).
```
Now:
```
CocoaPods 1.4.0 out of date (1.6.0 is recommended).
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40116.

## Tests

Updated CocoaPods validator test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
