### PR TITLE
Remove failing devicelab tests

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -327,14 +327,14 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  flutter_gallery_instrumentation_test:
-    description: >
-      Same as flutter_gallery__transition_perf but uses Android instrumentation
-      framework, and therefore does not require a host computer to run. This
-      test can run on off-the-shelf infrastructures, such as Firebase Test Lab.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-    flaky: true
+  # flutter_gallery_instrumentation_test:
+  #   description: >
+  #     Same as flutter_gallery__transition_perf but uses Android instrumentation
+  #     framework, and therefore does not require a host computer to run. This
+  #     test can run on off-the-shelf infrastructures, such as Firebase Test Lab.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
+  #   flaky: true
 
   flutter_attach_test:
     description: >
@@ -524,12 +524,12 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  macos_chrome_dev_mode:
-    description: >
-      Run flutter web on the devicelab and hot restart.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-    flaky: true # marked as flaky while infra is under heavy development
+  # macos_chrome_dev_mode:
+  #   description: >
+  #     Run flutter web on the devicelab and hot restart.
+  #   stage: devicelab_ios
+  #   required_agent_capabilities: ["mac/ios"]
+  #   flaky: true # marked as flaky while infra is under heavy development
 
   build_benchmark_ios:
     description: >
@@ -587,11 +587,11 @@ tasks:
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
 
-  run_without_leak_win:
-    description: >
-      Checks that `flutter run` does not leak dart.exe on Windows.
-    stage: devicelab_win
-    required_agent_capabilities: ["windows/android"]
+  # run_without_leak_win:
+  #   description: >
+  #     Checks that `flutter run` does not leak dart.exe on Windows.
+  #   stage: devicelab_win
+  #   required_agent_capabilities: ["windows/android"]
 
   # Tests running on Linux hosts
 
@@ -658,23 +658,23 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  run_without_leak_linux:
-    description: >
-      Checks that `flutter run` does not leak dart on Linux.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-    flaky: true
+  # run_without_leak_linux:
+  #   description: >
+  #     Checks that `flutter run` does not leak dart on Linux.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
+  #   flaky: true
 
-  run_without_leak_mac:
-    description: >
-      Checks that `flutter run` does not leak dart on macOS.
-    stage: devicelab
-    required_agent_capabilities: ["mac/android"]
-    flaky: true
+  # run_without_leak_mac:
+  #   description: >
+  #     Checks that `flutter run` does not leak dart on macOS.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["mac/android"]
+  #   flaky: true
 
-  android_splash_screen_integration_test:
-    description: >
-      Runs end-to-end test of Flutter's Android splash behavior.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-    flaky: true
+  # android_splash_screen_integration_test:
+  #   description: >
+  #     Runs end-to-end test of Flutter's Android splash behavior.
+  #   stage: devicelab
+  #   required_agent_capabilities: ["linux/android"]
+  #   flaky: true


### PR DESCRIPTION
## Description

These tests have not been passing (potentially ever?) on the entire page of the devicelab. Disable to reclaim some capacity.

The leak_windows test is passing but that is because we're manually killing the processes on windows.

The chrome dev mode is flaky and not necessary to run.