### PR TITLE
Add fullscreenDialog argument in PageRouteBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -56,7 +56,7 @@ class PageRouteBuilder<T> extends PageRoute<T> {
   /// Creates a route that delegates to builder callbacks.
   ///
   /// The [pageBuilder], [transitionsBuilder], [opaque], [barrierDismissible],
-  /// and [maintainState] arguments must not be null.
+  /// [maintainState], and [fullscreenDialog] arguments must not be null.
   PageRouteBuilder({
     RouteSettings settings,
     @required this.pageBuilder,
@@ -67,12 +67,14 @@ class PageRouteBuilder<T> extends PageRoute<T> {
     this.barrierColor,
     this.barrierLabel,
     this.maintainState = true,
+    bool fullscreenDialog = false,
   }) : assert(pageBuilder != null),
        assert(transitionsBuilder != null),
+       assert(opaque != null),
        assert(barrierDismissible != null),
        assert(maintainState != null),
-       assert(opaque != null),
-       super(settings: settings);
+       assert(fullscreenDialog != null),
+       super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Used build the route's primary contents.
   ///

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -568,6 +568,15 @@ void main() {
       );
     }
 
+    PageRoute<void> pageRouteBuilder() {
+      return PageRouteBuilder<void>(
+        pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+          return Scaffold(appBar: AppBar(), body: const Text('Page 2'));
+        },
+        fullscreenDialog: true,
+      );
+    }
+
     PageRoute<void> customPageRouteBuilder() {
       return _CustomPageRoute<void>(
         builder: (BuildContext context) {
@@ -587,6 +596,18 @@ void main() {
 
     testWidgets('Close button shows correctly on iOS', (WidgetTester tester) async {
       await expectCloseIcon(tester, TargetPlatform.iOS, Icons.close, materialRouteBuilder);
+    });
+
+    testWidgets('Close button shows correctly with PageRouteBuilder on Android', (WidgetTester tester) async {
+      await expectCloseIcon(tester, TargetPlatform.android, Icons.close, pageRouteBuilder);
+    });
+
+    testWidgets('Close button shows correctly with PageRouteBuilder on Fuchsia', (WidgetTester tester) async {
+      await expectCloseIcon(tester, TargetPlatform.fuchsia, Icons.close, pageRouteBuilder);
+    });
+
+    testWidgets('Close button shows correctly with PageRouteBuilder on iOS', (WidgetTester tester) async {
+      await expectCloseIcon(tester, TargetPlatform.iOS, Icons.close, pageRouteBuilder);
     });
 
     testWidgets('Close button shows correctly with custom page route on Android', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

PageRouteBuilder doesn't have fullscreenDialog argument from PageRoute, so it won't allow us specify fullscreenDialog when customizing page routes. This PR will fix it.

## Related Issues

#40160

## Tests

I added the following tests:

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
