### PR TITLE
Place hot reload artifacts in a temp directory

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -715,9 +715,7 @@ abstract class ResidentRunner {
   ///
   /// Throws an [AssertionError] if [Devce.supportsScreenshot] is not true.
   Future<void> screenshot(FlutterDevice device) async {
-    if (!device.device.supportsScreenshot) {
-      throwToolExit('Device ${device.device.name} does not support screenshots.');
-    }
+    assert(device.device.supportsScreenshot);
 
     final Status status = logger.startProgress('Taking screenshot for ${device.device.name}...', timeout: timeoutConfiguration.fastOperation);
     final File outputFile = getUniqueFile(fs.currentDirectory, 'flutter', 'png');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -856,7 +856,7 @@ abstract class ResidentRunner {
   @mustCallSuper
   Future<void> preExit() async {
     // If _dillOutputPath is null, we created a temporary directory for the dill.
-    if (_dillOutputPath == null) {
+    if (_dillOutputPath == null && artifactDirectory.existsSync()) {
       artifactDirectory.deleteSync(recursive: true);
     }
   }

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -206,5 +206,6 @@ class ColdRunner extends ResidentRunner {
       if (device.vmServices == null || device.vmServices.isEmpty)
         await device.device.stopApp(device.package);
     }
+    await super.preExit();
   }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1010,6 +1010,7 @@ class HotRunner extends ResidentRunner {
   Future<void> preExit() async {
     await _cleanupDevFS();
     await hotRunnerConfig.runPreShutdownOperations();
+    await super.preExit();
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -298,6 +298,20 @@ void main() {
     Usage: () => MockUsage(),
   }));
 
+  test('ResidentRunner uses temp directory when there is no output dill path', () => testbed.run(() {
+    expect(residentRunner.artifactDirectory.path, contains('_fluttter_tool'));
+
+    final ResidentRunner otherRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      dillOutputPath: fs.path.join('foobar', 'app.dill'),
+    );
+    expect(otherRunner.artifactDirectory.path, contains('foobar'));
+  }));
+
   test('ResidentRunner printHelpDetails', () => testbed.run(() {
     when(mockDevice.supportsHotRestart).thenReturn(true);
     when(mockDevice.supportsScreenshot).thenReturn(true);
@@ -376,7 +390,7 @@ void main() {
     when(mockDevice.supportsScreenshot).thenReturn(false);
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
-        throwsA(isInstanceOf<AssertionError>()));
+        throwsA(isInstanceOf<ToolExit>()));
   }));
 
   test('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -390,7 +390,7 @@ void main() {
     when(mockDevice.supportsScreenshot).thenReturn(false);
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
-        throwsA(isInstanceOf<ToolExit>()));
+        throwsA(isInstanceOf<AssertionError>()));
   }));
 
   test('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {


### PR DESCRIPTION
## Description

When there is no provided outputDillPath, we assume a path of `build/app.dill`. Instead, create and use a temp directory so that multiple running hot reload instances do not interfere with each other.

Fixes #18566

We lose _some_ benefit from initialize from dill, but this unblocks a lot of workflows for IDEs
