### PR TITLE
Keep Flutter.framework binaries writable so they can be code signed

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -142,11 +142,13 @@ BuildApp() {
     mkdir "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_podspec}" "${derived_dir}/engine"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}/engine"
-    RunCommand find "${derived_dir}/engine/Flutter.framework" -type f -exec chmod a-w "{}" \;
+    # Make headers, plists, and modulemap files read-only to discourage editing.
+    RunCommand find "${derived_dir}/engine/Flutter.framework" -type f \( -name '*.h' -o -name '*.modulemap' -o -name '*.plist' \) -exec chmod a-w "{}" \;
   else
     RunCommand rm -rf -- "${derived_dir}/Flutter.framework"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}"
-    RunCommand find "${derived_dir}/Flutter.framework" -type f -exec chmod a-w "{}" \;
+    # Make headers, plists, and modulemap files read-only to discourage editing.
+    RunCommand find "${derived_dir}/Flutter.framework" -type f \( -name '*.h' -o -name '*.modulemap' -o -name '*.plist' \) -exec chmod a-w "{}" \;
   fi
 
   RunCommand pushd "${project_path}" > /dev/null


### PR DESCRIPTION
## Description

Flutter.framework files were made read-only to "Provide a strong hint to developers that editing Flutter framework headers isn't supported" (https://github.com/flutter/flutter/commit/cb2b89c389e06c2cceb1a3361d520eaccb4cec8c)  However this is making the Flutter binary readonly, which is being copied into the final embedded Frameworks directories, then can't be codesigned.

Only make headers, modulemaps, and plists readonly.

```shell
$ find Flutter/Flutter.framework -type f \( -name '*.h' -o -name '*.modulemap' -o -name '*.plist' \)   
Flutter/Flutter.framework/Headers/FlutterEngine.h
Flutter/Flutter.framework/Headers/FlutterChannels.h
Flutter/Flutter.framework/Headers/FlutterPlugin.h
Flutter/Flutter.framework/Headers/FlutterAppDelegate.h
Flutter/Flutter.framework/Headers/FlutterTexture.h
Flutter/Flutter.framework/Headers/FlutterPlatformViews.h
Flutter/Flutter.framework/Headers/FlutterHeadlessDartRunner.h
Flutter/Flutter.framework/Headers/FlutterCodecs.h
Flutter/Flutter.framework/Headers/Flutter.h
Flutter/Flutter.framework/Headers/FlutterViewController.h
Flutter/Flutter.framework/Headers/FlutterMacros.h
Flutter/Flutter.framework/Headers/FlutterDartProject.h
Flutter/Flutter.framework/Headers/FlutterPluginAppLifeCycleDelegate.h
Flutter/Flutter.framework/Headers/FlutterBinaryMessenger.h
Flutter/Flutter.framework/Headers/FlutterCallbackCache.h
Flutter/Flutter.framework/Modules/module.modulemap
Flutter/Flutter.framework/Info.plist
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39507. 
Another attempt at https://github.com/flutter/flutter/pull/39539.

## Tests

add2app gets past codesigning for me, but it's still flaky so I didn't turn it back on.  See https://github.com/flutter/flutter/issues/40173.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.