### PR TITLE
Update PopupMenu layout

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
@@ -27,10 +28,8 @@ import 'theme.dart';
 // void setState(VoidCallback fn) { }
 
 const Duration _kMenuDuration = Duration(milliseconds: 300);
-const double _kBaselineOffsetFromBottom = 20.0;
 const double _kMenuCloseIntervalEnd = 2.0 / 3.0;
 const double _kMenuHorizontalPadding = 16.0;
-const double _kMenuItemHeight = kMinInteractiveDimension;
 const double _kMenuDividerHeight = 16.0;
 const double _kMenuMaxWidth = 5.0 * _kMenuWidthStep;
 const double _kMenuMinWidth = 2.0 * _kMenuWidthStep;
@@ -122,6 +121,49 @@ class _PopupMenuDividerState extends State<PopupMenuDivider> {
   Widget build(BuildContext context) => Divider(height: widget.height);
 }
 
+// This widget only exists to enable _PopupMenuRoute to save the sizes of
+// each menu item. The sizes are used by _PopupMenuRouteLayout to compute the
+// y coordinate of the menu's origin so that the center of selected menu
+// item lines up with the center of its PopupMenuButton.
+class _MenuItem extends SingleChildRenderObjectWidget {
+  const _MenuItem({
+    Key key,
+    @required this.onLayout,
+    Widget child,
+  }) : assert(onLayout != null), super(key: key, child: child);
+
+  final ValueChanged<Size> onLayout;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderMenuItem(onLayout);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant _RenderMenuItem renderObject) {
+    renderObject.onLayout = onLayout;
+  }
+}
+
+class _RenderMenuItem extends RenderShiftedBox {
+  _RenderMenuItem(this.onLayout, [RenderBox child]) : assert(onLayout != null), super(child);
+
+  ValueChanged<Size> onLayout;
+
+  @override
+  void performLayout() {
+    if (child == null) {
+      size = Size.zero;
+    } else {
+      child.layout(constraints, parentUsesSize: true);
+      size = constraints.constrain(child.size);
+    }
+    final BoxParentData childParentData = child.parentData;
+    childParentData.offset = Offset.zero;
+    onLayout(size);
+  }
+}
+
 /// An item in a material design popup menu.
 ///
 /// To show a popup menu, use the [showMenu] function. To create a button that
@@ -166,34 +208,33 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   ///
   /// By default, the item is [enabled].
   ///
-  /// The `height` and `enabled` arguments must not be null.
+  /// The `enabled` argument must not be null.
   const PopupMenuItem({
     Key key,
     this.value,
     this.enabled = true,
-    this.height = _kMenuItemHeight,
+    this.height,
     this.textStyle,
     @required this.child,
   }) : assert(enabled != null),
-       assert(height != null),
        super(key: key);
 
   /// The value that will be returned by [showMenu] if this entry is selected.
   final T value;
 
-  /// Whether the user is permitted to select this entry.
+  /// Whether the user is permitted to select this item.
   ///
   /// Defaults to true. If this is false, then the item will not react to
   /// touches.
   final bool enabled;
 
-  /// The height of the entry.
+  /// The minimum height height of the menu item.
   ///
   /// Defaults to kMinInteractiveDimension pixels.
   @override
   final double height;
 
-  /// The text style of the popup menu entry.
+  /// The text style of the popup menu item.
   ///
   /// If this property is null, then [PopupMenuThemeData.textStyle] is used.
   /// If [PopupMenuThemeData.textStyle] is also null, then [ThemeData.textTheme.subhead] is used.
@@ -262,12 +303,14 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
     Widget item = AnimatedDefaultTextStyle(
       style: style,
       duration: kThemeChangeDuration,
-      child: Baseline(
-        baseline: widget.height - _kBaselineOffsetFromBottom,
-        baselineType: style.textBaseline ?? TextBaseline.alphabetic,
+      child: Container(
+        alignment: AlignmentDirectional.centerStart,
+        constraints: BoxConstraints(minHeight: widget.height ?? kMinInteractiveDimension),
+        padding: const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
         child: buildChild(),
       ),
     );
+
     if (!widget.enabled) {
       final bool isDark = theme.brightness == Brightness.dark;
       item = IconTheme.merge(
@@ -278,11 +321,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
 
     return InkWell(
       onTap: widget.enabled ? handleTap : null,
-      child: Container(
-        height: widget.height,
-        padding: const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
-        child: item,
-      ),
+      child: item,
     );
   }
 }
@@ -293,8 +332,8 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
 /// shows a popup menu, consider using [PopupMenuButton].
 ///
 /// A [CheckedPopupMenuItem] is kMinInteractiveDimension pixels high, which
-/// matches the default height of a [PopupMenuItem]. The horizontal layout uses
-/// a [ListTile]; the checkmark is an [Icons.done] icon, shown in the
+/// matches the default minimum height of a [PopupMenuItem]. The horizontal
+/// layout uses [ListTile]; the checkmark is an [Icons.done] icon, shown in the
 /// [ListTile.leading] position.
 ///
 /// {@tool sample}
@@ -460,10 +499,17 @@ class _PopupMenu<T> extends StatelessWidget {
           child: item,
         );
       }
-      children.add(FadeTransition(
-        opacity: opacity,
-        child: item,
-      ));
+      children.add(
+        _MenuItem(
+          onLayout: (Size size) {
+            route.itemSizes[i] = size;
+          },
+          child: FadeTransition(
+            opacity: opacity,
+            child: item,
+          ),
+        ),
+      );
     }
 
     final CurveTween opacity = CurveTween(curve: const Interval(0.0, 1.0 / 3.0));
@@ -518,15 +564,18 @@ class _PopupMenu<T> extends StatelessWidget {
 
 // Positioning of the menu on the screen.
 class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
-  _PopupMenuRouteLayout(this.position, this.selectedItemOffset, this.textDirection);
+  _PopupMenuRouteLayout(this.position, this.itemSizes, this.selectedItemIndex, this.textDirection);
 
   // Rectangle of underlying button, relative to the overlay's dimensions.
   final RelativeRect position;
 
-  // The distance from the top of the menu to the middle of selected item.
-  //
-  // This will be null if there's no item to position in this way.
-  final double selectedItemOffset;
+  // The sizes of each item are computed when the menu is laid out, and before
+  // the route is laid out.
+  List<Size> itemSizes;
+
+  // The index of the selected item, or null if PopupMenuButton.initialValue
+  // was not specified.
+  final int selectedItemIndex;
 
   // Whether to prefer going to the left or to the right.
   final TextDirection textDirection;
@@ -549,10 +598,12 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
     // getConstraintsForChild.
 
     // Find the ideal vertical position.
-    double y;
-    if (selectedItemOffset == null) {
-      y = position.top;
-    } else {
+    double y = position.top;
+    if (selectedItemIndex != null && itemSizes != null) {
+      double selectedItemOffset = _kMenuVerticalPadding;
+      for (int index = 0; index < selectedItemIndex; index += 1)
+        selectedItemOffset += itemSizes[index].height;
+      selectedItemOffset += itemSizes[selectedItemIndex].height / 2;
       y = position.top + (size.height - position.top - position.bottom) / 2.0 - selectedItemOffset;
     }
 
@@ -592,7 +643,10 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_PopupMenuRouteLayout oldDelegate) {
-    return position != oldDelegate.position;
+    return position != oldDelegate.position
+        && selectedItemIndex != oldDelegate.selectedItemIndex
+        && textDirection != oldDelegate.textDirection
+        && listEquals(itemSizes, oldDelegate.itemSizes);
   }
 }
 
@@ -610,10 +664,11 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     this.color,
     this.showMenuContext,
     this.captureInheritedThemes,
-  });
+  }) : itemSizes = List<Size>(items.length);
 
   final RelativeRect position;
   final List<PopupMenuEntry<T>> items;
+  final List<Size> itemSizes;
   final dynamic initialValue;
   final double elevation;
   final ThemeData theme;
@@ -647,15 +702,12 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    double selectedItemOffset;
+
+    int selectedItemIndex;
     if (initialValue != null) {
-      double y = _kMenuVerticalPadding;
-      for (PopupMenuEntry<T> entry in items) {
-        if (entry.represents(initialValue)) {
-          selectedItemOffset = y + entry.height / 2.0;
-          break;
-        }
-        y += entry.height;
+      for (int index = 0; selectedItemIndex == null && index < items.length; index += 1) {
+        if (items[index].represents(initialValue))
+          selectedItemIndex = index;
       }
     }
 
@@ -681,7 +733,8 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
           return CustomSingleChildLayout(
             delegate: _PopupMenuRouteLayout(
               position,
-              selectedItemOffset,
+              itemSizes,
+              selectedItemIndex,
               Directionality.of(context),
             ),
             child: menu,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -647,7 +647,7 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
     // If called when the old and new itemSizes have been initialized then
     // we expect them to have the same length because there's no practical
     // way to change length of the items list once the menu has been shown.
-    assert(itemSizes == null || oldDelegate.itemSizes == null || itemSizes.length == oldDelegate.itemSizes.length);
+    assert(itemSizes.length == oldDelegate.itemSizes.length);
 
     return position != oldDelegate.position
         || selectedItemIndex != oldDelegate.selectedItemIndex

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -644,10 +644,15 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_PopupMenuRouteLayout oldDelegate) {
+    // If called when the old and new itemSizes have been initialized then
+    // we expect them to have the same length because there's no practical
+    // way to change length of the items list once the menu has been shown.
+    assert(itemSizes == null || oldDelegate.itemSizes == null || itemSizes.length == oldDelegate.itemSizes.length);
+
     return position != oldDelegate.position
         || selectedItemIndex != oldDelegate.selectedItemIndex
         || textDirection != oldDelegate.textDirection
-        || listEquals(itemSizes, oldDelegate.itemSizes);
+        || !listEquals(itemSizes, oldDelegate.itemSizes);
   }
 }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -208,15 +208,16 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   ///
   /// By default, the item is [enabled].
   ///
-  /// The `enabled` argument must not be null.
+  /// The `enabled` and `height` arguments must not be null.
   const PopupMenuItem({
     Key key,
     this.value,
     this.enabled = true,
-    this.height,
+    this.height = kMinInteractiveDimension,
     this.textStyle,
     @required this.child,
   }) : assert(enabled != null),
+       assert(height != null),
        super(key: key);
 
   /// The value that will be returned by [showMenu] if this entry is selected.
@@ -230,7 +231,7 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
 
   /// The minimum height height of the menu item.
   ///
-  /// Defaults to kMinInteractiveDimension pixels.
+  /// Defaults to [kMinInteractiveDimension] pixels.
   @override
   final double height;
 
@@ -305,7 +306,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
       duration: kThemeChangeDuration,
       child: Container(
         alignment: AlignmentDirectional.centerStart,
-        constraints: BoxConstraints(minHeight: widget.height ?? kMinInteractiveDimension),
+        constraints: BoxConstraints(minHeight: widget.height),
         padding: const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
         child: buildChild(),
       ),

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -645,9 +645,9 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
   @override
   bool shouldRelayout(_PopupMenuRouteLayout oldDelegate) {
     return position != oldDelegate.position
-        && selectedItemIndex != oldDelegate.selectedItemIndex
-        && textDirection != oldDelegate.textDirection
-        && listEquals(itemSizes, oldDelegate.itemSizes);
+        || selectedItemIndex != oldDelegate.selectedItemIndex
+        || textDirection != oldDelegate.textDirection
+        || listEquals(itemSizes, oldDelegate.itemSizes);
   }
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -691,8 +691,6 @@ void main() {
   });
 
   testWidgets('PopupMenuItem child height is a minium, child is vertically centered', (WidgetTester tester) async {
-    // This is a regression test for https://github.com/flutter/flutter/issues/39508.
-
     final Key popupMenuButtonKey = UniqueKey();
     final Type menuItemType = const PopupMenuItem<String>(child: Text('item')).runtimeType;
 
@@ -706,31 +704,39 @@ void main() {
               onSelected: (String result) { },
               itemBuilder: (BuildContext context) {
                 return <PopupMenuEntry<String>>[
-                  const PopupMenuItem<String>( // Item's height = 48 (height == minHeight is 48).
-                    child: Text('Item 0'),
+                  // This menu item's height will be 48 because the the default minimum height
+                  // is 48 and the height of the text is less than 48.
+                  const PopupMenuItem<String>(
                     value: '0',
+                    child: Text('Item 0'),
                   ),
-                  const PopupMenuItem<String>( // Item's height = 50 (height == minHeight is 50).
+                  // This menu item's height parameter specifies its minium height. The
+                  // overall height of the menu item will be 50 because the child's
+                  // height 40, is less than 50.
+                  const PopupMenuItem<String>(
                     height: 50,
+                    value: '1',
                     child: SizedBox(
                       height: 40,
                       child: Text('Item 1'),
                     ),
-                    value: '1',
                   ),
-                  const PopupMenuItem<String>( // Item's height = 75 (height == minHeight is 75).
+                  // This menu item's height parameter specifies its minium height, so the
+                  // overall height of the menu item will be 75.
+                  const PopupMenuItem<String>(
                     height: 75,
+                    value: '2',
                     child: SizedBox(
                       child: Text('Item 2'),
                     ),
-                    value: '2',
                   ),
-                  const PopupMenuItem<String>( // Item's height = 100.
+                  // This menu item's height will be 100.
+                  const PopupMenuItem<String>(
+                    value: '3',
                     child: SizedBox(
                       height: 100,
                       child: Text('Item 3'),
                     ),
-                    value: '3',
                   ),
                 ];
               },
@@ -767,8 +773,6 @@ void main() {
   });
 
   testWidgets('Update PopupMenuItem layout while the menu is visible', (WidgetTester tester) async {
-    // This is a regression test for https://github.com/flutter/flutter/issues/39508.
-
     final Key popupMenuButtonKey = UniqueKey();
     final Type menuItemType = const PopupMenuItem<String>(child: Text('item')).runtimeType;
 
@@ -796,12 +800,12 @@ void main() {
             itemBuilder: (BuildContext context) {
               return <PopupMenuEntry<String>>[
                 const PopupMenuItem<String>(
-                  child: Text('Item 0'),
                   value: '0',
+                  child: Text('Item 0'),
                 ),
-                PopupMenuItem<String>(
-                  child: const Text('Item 1'),
+                const PopupMenuItem<String>(
                   value: '1',
+                  child: Text('Item 1'),
                 ),
               ];
             },

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -690,7 +690,7 @@ void main() {
     await tester.tap(find.text('Menu Button'));
   });
 
-  testWidgets('PopupMenuItem child height is a minium, child is vertically centered', (WidgetTester tester) async {
+  testWidgets('PopupMenuItem child height is a minimum, child is vertically centered', (WidgetTester tester) async {
     final Key popupMenuButtonKey = UniqueKey();
     final Type menuItemType = const PopupMenuItem<String>(child: Text('item')).runtimeType;
 

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -78,20 +78,20 @@ void main() {
     Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
-    expect(topLeft, const Offset(392.0, 298.3999996185303));
-    expect(topRight, const Offset(596.0, 298.3999996185303));
-    expect(bottomLeft, const Offset(392.0, 315.3999996185303));
-    expect(bottomRight, const Offset(596.0, 315.3999996185303));
+    expect(topLeft, const Offset(392.0, 299.5));
+    expect(topRight, const Offset(596.0, 299.5));
+    expect(bottomLeft, const Offset(392.0, 316.5));
+    expect(bottomRight, const Offset(596.0, 316.5));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, const Offset(392.0, 346.3999996185303));
-    expect(topRight, const Offset(477.0, 346.3999996185303));
-    expect(bottomLeft, const Offset(392.0, 363.3999996185303));
-    expect(bottomRight, const Offset(477.0, 363.3999996185303));
+    expect(topLeft, const Offset(392.0, 347.5));
+    expect(topRight, const Offset(477.0, 347.5));
+    expect(bottomLeft, const Offset(392.0, 364.5));
+    expect(bottomRight, const Offset(477.0, 364.5));
   }, skip: !isLinux);
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
@@ -165,19 +165,19 @@ void main() {
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
 
-    expect(topLeft, const Offset(392.0, 299.19999980926514));
-    expect(topRight, const Offset(584.0, 299.19999980926514));
-    expect(bottomLeft, const Offset(392.0, 315.19999980926514));
-    expect(bottomRight, const Offset(584.0, 315.19999980926514));
+    expect(topLeft, const Offset(392.0, 300.0));
+    expect(topRight, const Offset(584.0, 300.0));
+    expect(bottomLeft, const Offset(392.0, 316));
+    expect(bottomRight, const Offset(584.0, 316));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, const Offset(392.0, 347.19999980926514));
-    expect(topRight, const Offset(472.0, 347.19999980926514));
-    expect(bottomLeft, const Offset(392.0, 363.19999980926514));
-    expect(bottomRight, const Offset(472.0, 363.19999980926514));
+    expect(topLeft, const Offset(392.0, 348.0));
+    expect(topRight, const Offset(472.0, 348.0));
+    expect(bottomLeft, const Offset(392.0, 364.0));
+    expect(bottomRight, const Offset(472.0, 364.0));
   }, skip: !isLinux);
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/39508

This is a breaking change.

The height of a popup menu item is no longer fixed, the height parameter now specifies the item's _minimum_ height. The actual height of a menu item will be larger, if the intrinsic height of the menu item's child is larger than the minimum. The default minimum item height is 48, and the default font size is only 16, so the height of most menu items and menus will remain the same.

A menu item's child is now vertically centered, rather than having its baseline positioned 20 pixels from the bottom of the item. This turns out to be what the material design spec requires. Despite appearances in the diagram below, the text's bounding box is required to be vertically centered, not the text baseline.

![menu_spec](https://user-images.githubusercontent.com/1377460/64660501-7252fb80-d3f5-11e9-98cd-12ca93f17bfa.png)


As you can see from the screenshots below, the change has a negligible impact for the default menu item text style, a small impact when the system's text scale factor is maximimzed, and a large corrective impact when a jumbo menu item text style is specified.

## Default PopupMenuitem (new, old)
![compare_default](https://user-images.githubusercontent.com/1377460/64646565-36f00700-d3cc-11e9-86f1-56e9247a0f6f.png)

## Deafult PopupMenuItem with large textScaleFactor (new, old)
![compare_large](https://user-images.githubusercontent.com/1377460/64646625-51c27b80-d3cc-11e9-8135-eb5e820c9df9.png)

## PopupMenuItem with a jumbo text style (new, old)
![compare_jumbo](https://user-images.githubusercontent.com/1377460/64646679-669f0f00-d3cc-11e9-925f-f8a4c5579387.png)

## Breaking change.

For apps that specified fixed height menu items, where the height was greater than 48 (the minimum height for a11y), and not the same as the item's intrinsic height,  the menu item's child can be enclosed in a SizedBox:

```dart
// original code
PopupMenuItem<String>(
  height: 50,
  child: Text('Item'),
)

// updated code
PopupMenuItem<String>(
  child: SizedBox(
    height: 50,
    child: Text('Item'),
  ),
)
```




