### PR TITLE
Pass local engine in flutter_test_performance benchmark

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -38,13 +38,10 @@ enum TestStep {
 
 Future<int> runTest({bool coverage = false}) async {
   final Stopwatch clock = Stopwatch()..start();
-  final List<String> arguments = <String>[
-    'test',
-  ];
-  if (coverage) {
-    arguments.add('--coverage');
-  }
-  arguments.add(path.join('flutter_test', 'trivial_widget_test.dart'));
+  final List<String> arguments = flutterCommandArgs('test', <String>[
+    if (coverage) '--coverage',
+    path.join('flutter_test', 'trivial_widget_test.dart'),
+  ]);
   final Process analysis = await startProcess(
     path.join(flutterDirectory.path, 'bin', 'flutter'),
     arguments,


### PR DESCRIPTION
In order to measure `flutter_test_performance` benchmark locally with modified engine, benchmark should pass --local-engine argument to the underlying 'flutter test' command (via `flutterCommandArgs`).
