### PR TITLE
Add an ephemeral directory to Windows projects

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -40,7 +40,7 @@ or
       cacheDirectory = 'linux/flutter';
       break;
     case 'windows-x64':
-      cacheDirectory = 'windows/flutter';
+      cacheDirectory = 'windows/flutter/ephemeral';
       break;
     default:
       stderr.write('Unsupported target platform $targetPlatform');

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -752,11 +752,19 @@ class WindowsProject {
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
-  Directory get _cacheDirectory => _editableDirectory.childDirectory('flutter');
+  /// The directory in the project that is managed by Flutter. As much as
+  /// possible, files that are edited by Flutter tooling after initial project
+  /// creation should live here.
+  Directory get managedDirectory => _editableDirectory.childDirectory('flutter');
+
+  /// The subdirectory of [managedDirectory] that contains files that are
+  /// generated on the fly. All generated files that are not intended to be
+  /// checked in should live here.
+  Directory get ephemeralDirectory => managedDirectory.childDirectory('ephemeral');
 
   /// Contains definitions for FLUTTER_ROOT, LOCAL_ENGINE, and more flags for
   /// the build.
-  File get generatedPropertySheetFile => _cacheDirectory.childFile('Generated.props');
+  File get generatedPropertySheetFile => ephemeralDirectory.childFile('Generated.props');
 
   // The MSBuild project file.
   File get vcprojFile => _editableDirectory.childFile('Runner.vcxproj');
@@ -767,7 +775,7 @@ class WindowsProject {
   /// The file where the VS build will write the name of the built app.
   ///
   /// Ideally this will be replaced in the future with inspection of the project.
-  File get nameFile => _cacheDirectory.childFile('exe_filename');
+  File get nameFile => ephemeralDirectory.childFile('exe_filename');
 }
 
 /// The Linux sub project.
@@ -778,6 +786,8 @@ class LinuxProject {
 
   Directory get editableHostAppDirectory => project.directory.childDirectory('linux');
 
+  // TODO(stuartmorgan): Move to using an ephemeralDirectory to match the other
+  // desktop projects.
   Directory get cacheDirectory => editableHostAppDirectory.childDirectory('flutter');
 
   bool existsSync() => editableHostAppDirectory.existsSync();

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -22,6 +22,7 @@ import 'visual_studio.dart';
 Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {String target}) async {
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': Cache.flutterRoot,
+    'FLUTTER_EPHEMERAL_DIR': windowsProject.ephemeralDirectory.path,
     'PROJECT_DIR': windowsProject.project.directory.path,
     'TRACK_WIDGET_CREATION': (buildInfo?.trackWidgetCreation == true).toString(),
   };

--- a/packages/flutter_tools/test/general.shard/commands/build_windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_windows_test.dart
@@ -129,7 +129,7 @@ void main() {
     );
 
     // Spot-check important elements from the properties file.
-    final File propsFile = fs.file(r'C:\windows\flutter\Generated.props');
+    final File propsFile = fs.file(r'C:\windows\flutter\ephemeral\Generated.props');
     expect(propsFile.existsSync(), true);
     final xml.XmlDocument props = xml.parse(propsFile.readAsStringSync());
     expect(props.findAllElements('PropertyGroup').first.getAttribute('Label'), 'UserMacros');


### PR DESCRIPTION
## Description

Moves files generated in windows/flutter/ as part of the build to an ephemeral/ subdirectory, matching the approach used on macOS (and in the future, Windows).

Adds that directory to the generated properties file to minimize hard-coding of paths in the project.

## Tests

I added the following tests: None. Updated existing tests.

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

This is a breaking change for Windows, which is explicitly not stable.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
