### PR TITLE
[windows] Refactor to optimize vswhere queries

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -18,11 +18,11 @@ class VisualStudio {
   /// Versions older than 2017 Update 2 won't be detected, so error messages to
   /// users should take into account that [false] may mean that the user may
   /// have an old version rather than no installation at all.
-  bool get isInstalled => _bestVisualStudioDetails != null;
+  bool get isInstalled => _bestVisualStudioDetails.isNotEmpty;
 
   /// True if there is a version of Visual Studio with all the components
   /// necessary to build the project.
-  bool get hasNecessaryComponents => _usableVisualStudioDetails != null;
+  bool get hasNecessaryComponents => _usableVisualStudioDetails.isNotEmpty;
 
   /// The name of the Visual Studio install.
   ///
@@ -32,8 +32,7 @@ class VisualStudio {
   /// The user-friendly version number of the Visual Studio install.
   ///
   /// For instance: "15.4.0".
-  String get displayVersion =>
-      _bestVisualStudioDetails[_catalogKey][_catalogDisplayVersionKey];
+  String get displayVersion => _bestVisualStudioDetails[_catalogKey][_catalogDisplayVersionKey];
 
   /// The directory where Visual Studio is installed.
   String get installLocation => _bestVisualStudioDetails[_installationPathKey];
@@ -47,11 +46,25 @@ class VisualStudio {
   // Visual Studio versions that don't include them, so default to a "valid" value to
   // avoid false negatives.
 
-  /// True there is complete installation of Visual Studio.
-  bool get isComplete => _bestVisualStudioDetails[_isCompleteKey] ?? false;
+  /// True if there is a complete installation of Visual Studio.
+  ///
+  /// False if installation is not found.
+  bool get isComplete {
+    if (_bestVisualStudioDetails.isEmpty) {
+      return false;
+    }
+    return _bestVisualStudioDetails[_isCompleteKey] ?? true;
+  }
 
   /// True if Visual Studio is launchable.
-  bool get isLaunchable => _bestVisualStudioDetails[_isLaunchableKey] ?? false;
+  ///
+  /// False if installation is not found.
+  bool get isLaunchable {
+    if (_bestVisualStudioDetails.isEmpty) {
+      return false;
+    }
+    return _bestVisualStudioDetails[_isLaunchableKey] ?? true;
+  }
 
     /// True if the Visual Studio installation is as pre-release version.
   bool get isPrerelease => _bestVisualStudioDetails[_isPrereleaseKey] ?? false;
@@ -75,7 +88,7 @@ class VisualStudio {
   /// the components necessary to build.
   String get vcvarsPath {
     final Map<String, dynamic> details = _usableVisualStudioDetails;
-    if (details == null) {
+    if (details.isEmpty) {
       return null;
     }
     return fs.path.join(
@@ -211,39 +224,53 @@ class VisualStudio {
   }
 
   /// Returns the details dictionary for the latest version of Visual Studio
-  /// that has all required components.
+  /// that has all required components, or {} if there is no such installation.
+  ///
+  /// If no installation is found, the cached VS details are set to an empty map
+  /// to avoid repeating vswhere queries that have already not found an installation.
   Map<String, dynamic> _cachedUsableVisualStudioDetails;
   Map<String, dynamic> get _usableVisualStudioDetails {
-    _cachedUsableVisualStudioDetails ??=
+    Map<String, dynamic> visualStudioDetails =
         _visualStudioDetails(requiredComponents: _requiredComponents().keys);
     // If a stable version is not found, try searching for a pre-release version.
-    _cachedUsableVisualStudioDetails ??= _visualStudioDetails(
+    visualStudioDetails ??= _visualStudioDetails(
         requiredComponents: _requiredComponents().keys,
         additionalArguments: <String>[_prereleaseKey]);
-    if (_cachedUsableVisualStudioDetails != null) {
-      if (installationHasIssues(_cachedUsableVisualStudioDetails)) {
-        _cachedAnyVisualStudioDetails = _cachedUsableVisualStudioDetails;
-        return null;
+
+    if (visualStudioDetails != null) {
+      if (installationHasIssues(visualStudioDetails)) {
+        _cachedAnyVisualStudioDetails = visualStudioDetails;
+      } else {
+        _cachedUsableVisualStudioDetails = visualStudioDetails;
       }
     }
+    _cachedUsableVisualStudioDetails ??= <String, dynamic>{};
     return _cachedUsableVisualStudioDetails;
   }
 
   /// Returns the details dictionary of the latest version of Visual Studio,
-  /// regardless of components.
+  /// regardless of components, or {} if no such installation is found.
+  ///
+  /// If no installation is found, the cached
+  /// VS details are set to an empty map to avoid repeating vswhere queries that
+  /// have already not found an installation.
   Map<String, dynamic> _cachedAnyVisualStudioDetails;
   Map<String, dynamic> get _anyVisualStudioDetails {
     // Search for all types of installations.
     _cachedAnyVisualStudioDetails ??= _visualStudioDetails(
         additionalArguments: <String>[_prereleaseKey, '-all']);
+    // Add a sentinel empty value to avoid querying vswhere again.
+    _cachedAnyVisualStudioDetails ??= <String, dynamic>{};
     return _cachedAnyVisualStudioDetails;
   }
 
   /// Returns the details dictionary of the best available version of Visual
-  /// Studio. If there's a version that has all the required components, that
+  /// Studio.
+  ///
+  /// If there's a version that has all the required components, that
   /// will be returned, otherwise returs the lastest installed version (if any).
   Map<String, dynamic> get _bestVisualStudioDetails {
-    if (_usableVisualStudioDetails != null) {
+    if (_usableVisualStudioDetails.isNotEmpty) {
       return _usableVisualStudioDetails;
     }
     return _anyVisualStudioDetails;

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -32,7 +32,12 @@ class VisualStudio {
   /// The user-friendly version number of the Visual Studio install.
   ///
   /// For instance: "15.4.0".
-  String get displayVersion => _bestVisualStudioDetails[_catalogKey][_catalogDisplayVersionKey];
+  String get displayVersion {
+    if (_bestVisualStudioDetails[_catalogKey] == null) {
+      return null;
+    }
+    return _bestVisualStudioDetails[_catalogKey][_catalogDisplayVersionKey];
+  }
 
   /// The directory where Visual Studio is installed.
   String get installLocation => _bestVisualStudioDetails[_installationPathKey];

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -235,6 +235,9 @@ class VisualStudio {
   /// to avoid repeating vswhere queries that have already not found an installation.
   Map<String, dynamic> _cachedUsableVisualStudioDetails;
   Map<String, dynamic> get _usableVisualStudioDetails {
+    if (_cachedUsableVisualStudioDetails != null) {
+      return _cachedUsableVisualStudioDetails;
+    }
     Map<String, dynamic> visualStudioDetails =
         _visualStudioDetails(requiredComponents: _requiredComponents().keys);
     // If a stable version is not found, try searching for a pre-release version.

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -196,6 +196,9 @@ void main() {
       expect(visualStudio.isRebootRequired, false);
       expect(visualStudio.isLaunchable, false);
       expect(visualStudio.displayName, null);
+      expect(visualStudio.displayVersion, null);
+      expect(visualStudio.installLocation, null);
+      expect(visualStudio.fullVersion, null);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
       Platform: () => windowsPlatform,

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -184,6 +184,24 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('VisualStudio getters return the right values if no installation is found', () {
+      setMockCompatibleVisualStudioInstallation(null);
+      setMockPrereleaseVisualStudioInstallation(null);
+      setMockAnyVisualStudioInstallation(null);
+
+      visualStudio = VisualStudio();
+      expect(visualStudio.isInstalled, false);
+      expect(visualStudio.hasNecessaryComponents, false);
+      expect(visualStudio.isComplete, false);
+      expect(visualStudio.isRebootRequired, false);
+      expect(visualStudio.isLaunchable, false);
+      expect(visualStudio.displayName, null);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFilesystem,
+      Platform: () => windowsPlatform,
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('isInstalled returns true even with missing status information', () {
       setMockCompatibleVisualStudioInstallation(null);
       setMockPrereleaseVisualStudioInstallation(null);


### PR DESCRIPTION
## Description
visual_studio.dart is not keeping track whether it has queried vswhere and didn't find an installation, of it hasn't performed any queries at all. This may cause unnecessary queries on the former case. This PR assigns a sentinel value of an empty map to the cached installation details to avoid repeating the queries.

## Related Issues
https://github.com/flutter/flutter/issues/40196

## Tests

I added the following tests:

This is a refactor so the behavior should continue as before.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

