### PR TITLE
remove timeouts from web test platform.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -528,12 +528,7 @@ class BrowserManager {
       }
       completer.completeError(error, stackTrace);
     }));
-
-    return completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
-      chrome.close();
-      throwToolExit('Timed out waiting for ${runtime.name} to connect.');
-      return;
-    });
+    return completer.future;
   }
 
   /// Loads [_BrowserEnvironment].


### PR DESCRIPTION
## Description

30 seconds might not be enough time to load all of the required files. 