### PR TITLE
Fix crash on vswhere search from flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -190,20 +190,24 @@ class VisualStudio {
   }
 
   /// Checks if the given installation has issues that the user must resolve.
-  /// 
+  ///
   /// Returns false if the required information is missing since older versions
   /// of Windows might not include them.
   bool installationHasIssues(Map<String, dynamic>installationDetails) {
     assert(installationDetails != null);
-    if (installationDetails[_isCompleteKey] == null ||
-        installationDetails[_isRebootRequiredKey] == null ||
-        installationDetails[_isLaunchableKey] == null) {
-      return false;
+    if (installationDetails[_isCompleteKey] != null && !installationDetails[_isCompleteKey]) {
+      return true;
     }
 
-    return installationDetails[_isCompleteKey] == false ||
-      installationDetails[_isRebootRequiredKey] == true ||
-      installationDetails[_isLaunchableKey] == false;
+    if (installationDetails[_isLaunchableKey] != null && !installationDetails[_isLaunchableKey]) {
+      return true;
+    } 
+
+    if (installationDetails[_isRebootRequiredKey] != null && installationDetails[_isRebootRequiredKey]) {
+      return true;
+    }
+     
+    return false;
   }
 
   /// Returns the details dictionary for the latest version of Visual Studio

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -48,10 +48,10 @@ class VisualStudio {
   // avoid false negatives.
 
   /// True there is complete installation of Visual Studio.
-  bool get isComplete => _bestVisualStudioDetails[_isCompleteKey] ?? true;
+  bool get isComplete => _bestVisualStudioDetails[_isCompleteKey] ?? false;
 
   /// True if Visual Studio is launchable.
-  bool get isLaunchable => _bestVisualStudioDetails[_isLaunchableKey] ?? true;
+  bool get isLaunchable => _bestVisualStudioDetails[_isLaunchableKey] ?? false;
 
     /// True if the Visual Studio installation is as pre-release version.
   bool get isPrerelease => _bestVisualStudioDetails[_isPrereleaseKey] ?? false;

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -35,10 +35,6 @@ class VisualStudio {
   String get displayVersion =>
       _bestVisualStudioDetails[_catalogKey][_catalogDisplayVersionKey];
 
-  /// True if the Visual Studio installation is as pre-release version.
-  bool get isPrerelease =>
-      _bestVisualStudioDetails[_catalogKey][_isPrereleaseKey];
-
   /// The directory where Visual Studio is installed.
   String get installLocation => _bestVisualStudioDetails[_installationPathKey];
 
@@ -47,14 +43,21 @@ class VisualStudio {
   /// For instance: "15.4.27004.2002".
   String get fullVersion => _bestVisualStudioDetails[_fullVersionKey];
 
+  // Properties that determine the status of the installation. There might be
+  // Windows versions that don't include them, so default to a "valid" value to
+  // avoid false negatives.
+
   /// True there is complete installation of Visual Studio.
-  bool get isComplete => _bestVisualStudioDetails[_isCompleteKey];
+  bool get isComplete => _bestVisualStudioDetails[_isCompleteKey] ?? true;
 
   /// True if Visual Studio is launchable.
-  bool get isLaunchable => _bestVisualStudioDetails[_isLaunchableKey];
+  bool get isLaunchable => _bestVisualStudioDetails[_isLaunchableKey] ?? true;
+
+    /// True if the Visual Studio installation is as pre-release version.
+  bool get isPrerelease => _bestVisualStudioDetails[_isPrereleaseKey] ?? false;
 
   /// True if a reboot is required to complete the Visual Studio installation.
-  bool get isRebootRequired => _bestVisualStudioDetails[_isRebootRequiredKey];
+  bool get isRebootRequired => _bestVisualStudioDetails[_isRebootRequiredKey] ?? false;
 
   /// The name of the recommended Visual Studio installer workload.
   String get workloadDescription => 'Desktop development with C++';
@@ -141,15 +144,13 @@ class VisualStudio {
   /// The 'catalog' entry containing more details.
   static const String _catalogKey = 'catalog';
 
+  /// The key for a pre-release version.
+  static const String _isPrereleaseKey = 'isPrerelease';
+
   /// The user-friendly version.
   ///
   /// This key is under the 'catalog' entry.
   static const String _catalogDisplayVersionKey = 'productDisplayVersion';
-
-  /// The key for a pre-release version.
-  ///
-  /// This key is under the 'catalog' entry.
-  static const String _isPrereleaseKey = 'productMilestoneIsPreRelease';
 
   /// vswhere argument keys
   static const String _prereleaseKey = '-prerelease';

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -190,11 +190,16 @@ class VisualStudio {
   }
 
   /// Checks if the given installation has issues that the user must resolve.
+  /// 
+  /// Returns false if the required information is missing since older versions
+  /// of Windows might not include them.
   bool installationHasIssues(Map<String, dynamic>installationDetails) {
     assert(installationDetails != null);
-    assert(installationDetails[_isCompleteKey] != null);
-    assert(installationDetails[_isRebootRequiredKey] != null);
-    assert(installationDetails[_isLaunchableKey] != null);
+    if (installationDetails[_isCompleteKey] == null ||
+        installationDetails[_isRebootRequiredKey] == null ||
+        installationDetails[_isLaunchableKey] == null) {
+      return false;
+    }
 
     return installationDetails[_isCompleteKey] == false ||
       installationDetails[_isRebootRequiredKey] == true ||

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -201,12 +201,12 @@ class VisualStudio {
 
     if (installationDetails[_isLaunchableKey] != null && !installationDetails[_isLaunchableKey]) {
       return true;
-    } 
+    }
 
     if (installationDetails[_isRebootRequiredKey] != null && installationDetails[_isRebootRequiredKey]) {
       return true;
     }
-     
+
     return false;
   }
 

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -44,7 +44,7 @@ class VisualStudio {
   String get fullVersion => _bestVisualStudioDetails[_fullVersionKey];
 
   // Properties that determine the status of the installation. There might be
-  // Windows versions that don't include them, so default to a "valid" value to
+  // Visual Studio versions that don't include them, so default to a "valid" value to
   // avoid false negatives.
 
   /// True there is complete installation of Visual Studio.
@@ -192,7 +192,7 @@ class VisualStudio {
   /// Checks if the given installation has issues that the user must resolve.
   ///
   /// Returns false if the required information is missing since older versions
-  /// of Windows might not include them.
+  /// of Visual Studio might not include them.
   bool installationHasIssues(Map<String, dynamic>installationDetails) {
     assert(installationDetails != null);
     if (installationDetails[_isCompleteKey] != null && !installationDetails[_isCompleteKey]) {

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -46,6 +46,17 @@ void main() {
     }
   };
 
+  // A version of a response that doesn't include certain installation status 
+  // information that might be missing in older Windows versions.
+  const Map<String, dynamic> _oldResponse = <String, dynamic>{
+    'installationPath': visualStudioPath,
+    'displayName': 'Visual Studio Community 2017',
+    'installationVersion': '15.9.28307.665',
+    'catalog': <String, dynamic>{
+      'productDisplayVersion': '15.9.12',
+    }
+  };
+
   // Arguments for a vswhere query to search for an installation with the required components.
   const List<String> _requiredComponents = <String>[
     'Microsoft.Component.MSBuild',
@@ -151,6 +162,19 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext('isInstalled returns true even with missing status information', () {
+      setMockCompatibleVisualStudioInstallation(null);
+      setMockPrereleaseVisualStudioInstallation(null);
+      setMockAnyVisualStudioInstallation(_oldResponse);
+
+      visualStudio = VisualStudio();
+      expect(visualStudio.isInstalled, true);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFilesystem,
+      Platform: () => windowsPlatform,
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('isInstalled returns true when VS is present but missing components', () {
       setMockCompatibleVisualStudioInstallation(null);
       setMockPrereleaseVisualStudioInstallation(null);
@@ -171,7 +195,6 @@ void main() {
       final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
         ..['isPrerelease'] = true;
       setMockPrereleaseVisualStudioInstallation(response);
-
 
       visualStudio = VisualStudio();
       expect(visualStudio.isInstalled, true);

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -47,7 +47,7 @@ void main() {
   };
 
   // A version of a response that doesn't include certain installation status
-  // information that might be missing in older Windows versions.
+  // information that might be missing in older Visual Studio versions.
   const Map<String, dynamic> _oldResponse = <String, dynamic>{
     'installationPath': visualStudioPath,
     'displayName': 'Visual Studio Community 2017',

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -40,9 +40,9 @@ void main() {
     'isRebootRequired': false,
     'isComplete': true,
     'isLaunchable': true,
+    'isPrerelease': false,
     'catalog': <String, dynamic>{
       'productDisplayVersion': '15.9.12',
-      'productMilestoneIsPreRelease': true,
     }
   };
 
@@ -169,12 +169,7 @@ void main() {
       setMockAnyVisualStudioInstallation(null);
 
       final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
-        ..addAll(<String, dynamic>{
-          'catalog': <String, dynamic>{
-            'productDisplayVersion': '15.9.12',
-            'productMilestoneIsPreRelease': true,
-          }
-        });
+        ..['isPrerelease'] = true;
       setMockPrereleaseVisualStudioInstallation(response);
 
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -46,7 +46,7 @@ void main() {
     }
   };
 
-  // A version of a response that doesn't include certain installation status 
+  // A version of a response that doesn't include certain installation status
   // information that might be missing in older Windows versions.
   const Map<String, dynamic> _oldResponse = <String, dynamic>{
     'installationPath': visualStudioPath,


### PR DESCRIPTION
## Description

Fixes a crash introduced on https://github.com/flutter/flutter/pull/40011 due to an incorrect type in the vswhere search

## Related Issues
Fixes https://github.com/flutter/flutter/issues/40238


## Tests

Relevant tests in visual_studio_test.dart were updated

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.