### PR TITLE
Lower the iteration count on back_button_memory test

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -21,6 +21,9 @@ class BackButtonMemoryTest extends MemoryTest {
   @override
   AndroidDevice get device => super.device;
 
+  @override
+  int get iterationCount => 5;
+
   /// Perform a series of back button suspend and resume cycles.
   @override
   Future<void> useMemory() async {


### PR DESCRIPTION
## Description

The outer iterations default to 10, and this test is consistently hitting the global 15-minute devicelab timeout.  This lowers the outer iterations down to 5 to get the test passing again.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
