### PR TITLE
PlatformView: recreate surface if the controller changes

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -846,6 +846,9 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 
     if (widget.viewType != oldWidget.viewType) {
       _controller?.dispose();
+      // the _surface has to be recreated as its controller is disposed
+      // setting _surface to null will trigger its creation in build()
+      _surface = null;
 
       // We are about to create a new platform view.
       _platformViewCreated = false;

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -846,8 +846,8 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 
     if (widget.viewType != oldWidget.viewType) {
       _controller?.dispose();
-      // the _surface has to be recreated as its controller is disposed
-      // setting _surface to null will trigger its creation in build()
+      // The _surface has to be recreated as its controller is disposed.
+      // Setting _surface to null will trigger its creation in build().
       _surface = null;
 
       // We are about to create a new platform view.

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2050,6 +2050,7 @@ void main() {
     testWidgets('PlatformViewLink re-initializes when view type changes', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final List<int> ids = <int>[];
+      final List<int> surfaceViewIds = <int>[];
       final List<String> viewTypes = <String>[];
 
       PlatformViewLink createPlatformViewLink(String viewType) {
@@ -2063,6 +2064,7 @@ void main() {
             return controller;
           },
           surfaceFactory: (BuildContext context, PlatformViewController controller) {
+            surfaceViewIds.add(controller.viewId);
             return PlatformViewSurface(
               gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
               controller: controller,
@@ -2093,6 +2095,13 @@ void main() {
 
       expect(
         ids,
+        unorderedEquals(<int>[
+          currentViewId+1, currentViewId+2,
+        ]),
+      );
+
+      expect(
+        surfaceViewIds,
         unorderedEquals(<int>[
           currentViewId+1, currentViewId+2,
         ]),


### PR DESCRIPTION
## Description

Currently the surface of a platform view is only created only one when the state of PlatformViewLink is created. When the PlatformViewLink widget changes, the PlatformViewController in the corresponding state ist also updated. Just the surface is not updated even though it depends on the controller.

This PR changes this behaviour to recreate the surface whenever the controller ist updated.

## Tests

I added the following tests: none

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.
