### PR TITLE
fix copy command and remove resolve sync for macOS assemble

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -146,11 +146,11 @@ abstract class Target {
     final File stamp = _findStampFile(environment);
     final List<String> inputPaths = <String>[];
     for (File input in inputs) {
-      inputPaths.add(input.resolveSymbolicLinksSync());
+      inputPaths.add(input.path);
     }
     final List<String> outputPaths = <String>[];
     for (File output in outputs) {
-      outputPaths.add(output.resolveSymbolicLinksSync());
+      outputPaths.add(output.path);
     }
     final Map<String, Object> result = <String, Object>{
       'inputs': inputPaths,

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -502,7 +502,7 @@ class _BuildInstance {
           outputFiles[output.path] = output;
         }
       } else {
-        printStatus('${node.target.name}: Starting');
+        printStatus('${node.target.name}: Starting due to ${node.invalidatedReasons}');
         await node.target.build(environment);
         printStatus('${node.target.name}: Complete');
 
@@ -653,8 +653,13 @@ class Node {
   /// Output file paths from the previous invocation of this build node.
   final Set<String> previousOutputs = <String>{};
 
-  /// Inout file paths from the previous invocation of this build node.
+  /// Input file paths from the previous invocation of this build node.
   final Set<String> previousInputs = <String>{};
+
+  /// One or more reasons why a task was invalidated.
+  ///
+  /// May be empty if the task was skipped.
+  final Set<InvalidedReason> invalidatedReasons = <InvalidedReason>{};
 
   /// Whether this node needs an action performed.
   bool get dirty => _dirty;
@@ -685,6 +690,7 @@ class Node {
       if (fileHashStore.currentHashes.containsKey(absolutePath)) {
         final String currentHash = fileHashStore.currentHashes[absolutePath];
         if (currentHash != previousHash) {
+          invalidatedReasons.add(InvalidedReason.inputChanged);
           _dirty = true;
         }
       } else {
@@ -698,11 +704,13 @@ class Node {
       // output paths changed.
       if (!currentOutputPaths.contains(previousOutput)) {
         _dirty = true;
+        invalidatedReasons.add(InvalidedReason.outputSetChanged);
         // if this isn't a current output file there is no reason to compute the hash.
         continue;
       }
       final File file = fs.file(previousOutput);
       if (!file.existsSync()) {
+        invalidatedReasons.add(InvalidedReason.outputMissing);
         _dirty = true;
         continue;
       }
@@ -711,6 +719,7 @@ class Node {
       if (fileHashStore.currentHashes.containsKey(absolutePath)) {
         final String currentHash = fileHashStore.currentHashes[absolutePath];
         if (currentHash != previousHash) {
+          invalidatedReasons.add(InvalidedReason.outputChanged);
           _dirty = true;
         }
       } else {
@@ -728,9 +737,25 @@ class Node {
     if (sourcesToHash.isNotEmpty) {
       final List<File> dirty = await fileHashStore.hashFiles(sourcesToHash);
       if (dirty.isNotEmpty) {
+        invalidatedReasons.add(InvalidedReason.inputChanged);
         _dirty = true;
       }
     }
     return !_dirty;
   }
+}
+
+/// A description of why a task was rerun.
+enum InvalidedReason {
+  /// An input file has an updated hash.
+  inputChanged,
+
+  /// An output file has an updated hash.
+  outputChanged,
+
+  /// An output file that is expected is missing.
+  outputMissing,
+
+  /// The set of expected output files changed.
+  outputSetChanged,
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -122,9 +122,12 @@ abstract class UnpackMacOS extends Target {
     if (basePath.endsWith(fs.path.separator)) {
       basePath = basePath.substring(0, basePath.length);
     }
-    final File targetDirectory = environment
+    final Directory targetDirectory = environment
       .outputDir
-      .childFile('FlutterMacOS.framework');
+      .childDirectory('FlutterMacOS.framework');
+    if (targetDirectory.existsSync()) {
+      targetDirectory.deleteSync(recursive: true);
+    }
     final ProcessResult result = await processManager
         .run(<String>['cp', '-R', basePath, targetDirectory.path]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -118,11 +118,13 @@ abstract class UnpackMacOS extends Target {
       throw MissingDefineException(kBuildMode, 'unpack_macos');
     }
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
-    final String basePath = artifacts.getArtifactPath(Artifact.flutterMacOSFramework, mode: buildMode);
-    final Directory targetDirectory = environment
+    String basePath = artifacts.getArtifactPath(Artifact.flutterMacOSFramework, mode: buildMode);
+    if (basePath.endsWith(fs.path.separator)) {
+      basePath = basePath.substring(0, basePath.length);
+    }
+    final File targetDirectory = environment
       .outputDir
-      .childDirectory('FlutterMacOS.framework');
-
+      .childFile('FlutterMacOS.framework');
     final ProcessResult result = await processManager
         .run(<String>['cp', '-R', basePath, targetDirectory.path]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -118,10 +118,7 @@ abstract class UnpackMacOS extends Target {
       throw MissingDefineException(kBuildMode, 'unpack_macos');
     }
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
-    String basePath = artifacts.getArtifactPath(Artifact.flutterMacOSFramework, mode: buildMode);
-    if (basePath.endsWith(fs.path.separator)) {
-      basePath = basePath.substring(0, basePath.length);
-    }
+    final String basePath = artifacts.getArtifactPath(Artifact.flutterMacOSFramework, mode: buildMode);
     final Directory targetDirectory = environment
       .outputDir
       .childDirectory('FlutterMacOS.framework');

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -290,6 +290,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
   @override
   List<Source> get inputs => const <Source>[
     Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    Source.pattern('{BUILD_DIR}/App.framework/App'),
     Source.behavior(MacOSAssetBehavior())
   ];
 

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -149,7 +149,7 @@ void writeListIfChanged(List<File> files, String path) {
   final StringBuffer buffer = StringBuffer();
   // These files are already sorted.
   for (File file in files) {
-    buffer.writeln(file.resolveSymbolicLinksSync());
+    buffer.writeln(file.path);
   }
   final String newContents = buffer.toString();
   if (!file.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -85,17 +85,20 @@ void main() {
     for (File input in inputs) {
       input.createSync(recursive: true);
     }
+    // Create output directory so we can test that it is deleted.
+    environment.outputDir.childDirectory(_kOutputPrefix)
+        .createSync(recursive: true);
+
     when(processManager.run(any)).thenAnswer((Invocation invocation) async {
       final List<String> arguments = invocation.positionalArguments.first;
       final String sourcePath = arguments[arguments.length - 2];
       final String targetPath = arguments.last;
-      // Verify there are no trailing `/`.
-      expect(sourcePath, isNot(endsWith(fs.path.separator)));
-      expect(targetPath, isNot(endsWith(fs.path.separator)));
-
       final Directory source = fs.directory(sourcePath);
-      final Directory target = fs.directory(targetPath)
-        ..createSync(recursive: true);
+      final Directory target = fs.directory(targetPath);
+
+      // verify directory was deleted by command.
+      expect(target.existsSync(), false);
+      target.createSync(recursive: true);
 
       for (FileSystemEntity entity in source.listSync(recursive: true)) {
         if (entity is File) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -87,9 +87,16 @@ void main() {
     }
     when(processManager.run(any)).thenAnswer((Invocation invocation) async {
       final List<String> arguments = invocation.positionalArguments.first;
-      final Directory source = fs.directory(arguments[arguments.length - 2]);
-      final Directory target = fs.directory(arguments.last)
+      final String sourcePath = arguments[arguments.length - 2];
+      final String targetPath = arguments.last;
+      // Verify there are no trailing `/`.
+      expect(sourcePath, isNot(endsWith(fs.path.separator)));
+      expect(targetPath, isNot(endsWith(fs.path.separator)));
+
+      final Directory source = fs.directory(sourcePath);
+      final Directory target = fs.directory(targetPath)
         ..createSync(recursive: true);
+
       for (FileSystemEntity entity in source.listSync(recursive: true)) {
         if (entity is File) {
           final String relative = fs.path.relative(entity.path, from: source.path);


### PR DESCRIPTION
## Description

Delete the macOS directory before copying if we've decided that it is invalid. If a test fails, ensure we don't call `resolveSymbolicLinksSync` which requires the file to exist.

Adds test case to ensure that we delete the directory.

Fixes https://github.com/google/flutter-desktop-embedding/issues/555