### PR TITLE
Place existing dill into hot reload temp directory to boost initialization time

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -545,8 +545,19 @@ abstract class ResidentRunner {
           ? fs.systemTempDirectory.createTempSync('_fluttter_tool')
           : fs.file(dillOutputPath).parent,
        assetBundle = AssetBundleFactory.instance.createBundle() {
+
     if (!artifactDirectory.existsSync()) {
       artifactDirectory.createSync(recursive: true);
+    }
+    // TODO(jonahwilliams): this is a temporary work around to regain some of
+    // the initialize from dill performance. Longer term, we should have a
+    // better way to determine where the appropriate dill file is, as this
+    // doesn't work for Android or macOS builds.}
+    if (dillOutputPath == null) {
+      final File existingDill = fs.file(fs.path.join('output', 'app.dill'));
+      if (existingDill.existsSync()) {
+        existingDill.copySync(fs.path.join(artifactDirectory.path, 'app.dill'));
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -545,7 +545,6 @@ abstract class ResidentRunner {
           ? fs.systemTempDirectory.createTempSync('_fluttter_tool')
           : fs.file(dillOutputPath).parent,
        assetBundle = AssetBundleFactory.instance.createBundle() {
-
     if (!artifactDirectory.existsSync()) {
       artifactDirectory.createSync(recursive: true);
     }
@@ -554,7 +553,7 @@ abstract class ResidentRunner {
     // better way to determine where the appropriate dill file is, as this
     // doesn't work for Android or macOS builds.}
     if (dillOutputPath == null) {
-      final File existingDill = fs.file(fs.path.join('output', 'app.dill'));
+      final File existingDill = fs.file(fs.path.join('build', 'app.dill'));
       if (existingDill.existsSync()) {
         existingDill.copySync(fs.path.join(artifactDirectory.path, 'app.dill'));
       }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -35,6 +35,9 @@ void main() {
 
   setUp(() {
     testbed = Testbed(setup: () {
+      fs.file(fs.path.join('build', 'app.dill'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('ABC');
       residentRunner = HotRunner(
         <FlutterDevice>[
           mockFlutterDevice,
@@ -191,6 +194,10 @@ void main() {
     })).called(1);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
+  }));
+
+  test('ResidentRunner copies dill file from build output into temp directory', () => testbed.run(() async {
+    expect(residentRunner.artifactDirectory.childFile('app.dill').readAsStringSync(), 'ABC');
   }));
 
   test('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Attempt to recover some of the performance loss from moving hot reload artifacts to a temporary directory. If there is a dill file in build/app.dill then copy that into temp.