### PR TITLE
Fix Arm64 detection logic for devices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Martin Staadecker <machstg@gmail.com>
 Igor Katsuba <katsuba.igor@gmail.com>
 Diego Velásquez <diego.velasquez.lopez@gmail.com>
 Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>
+Mark Diener <rpzrpzrpz@gmail.com>

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -190,7 +190,27 @@ class AndroidDevice extends Device {
       // http://developer.android.com/ndk/guides/abis.html (x86, armeabi-v7a, ...)
       switch (await _getProperty('ro.product.cpu.abi')) {
         case 'arm64-v8a':
-          _platform = TargetPlatform.android_arm64;
+
+          //Original code assumed that CPU was enough. But you need to verify 64 bit OS as well.
+          String gabilist = await _getProperty('ro.product.cpu.abilist');
+          if (gabilist == null)
+          {
+            //Have not seen a device without an abilist in adb, but it is possible.
+            _platform = TargetPlatform.android_arm64;
+            break;            
+          }
+
+          //Confirm that our 64 bit arm cpu has a 64 bit OS running on it
+          if (gabilist.contains('arm64-v8a') == true)
+          {
+            _platform = TargetPlatform.android_arm64;
+          }
+          else
+          {
+            //Sorry Amazon Kindle Fire 8, You tried trick me, but you failed.
+            _platform = TargetPlatform.android_arm;
+          }
+
           break;
         case 'x86_64':
           _platform = TargetPlatform.android_x64;


### PR DESCRIPTION
## Description

Flutter tools assumes that all 64 bit ARM cpus are able to run 64 bit code.

There are manufacturers that use 64 bit ARM cpus while installing 32 bit Android OS on it.

Added code that looks at the OS for 32 or 64 bit arm so dev tools do not try to download
64 bit code to 32 bit Operating systems.

## Tests

As far as tests, I have tested with my available android devices including Kindle Fire 8 and Motorola LG v30.

But this is device detection, so it requires physical devices more than I have available.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I signed the [CLA].
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [?] I updated/added relevant documentation (doc comments with `///`).
- [?] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X ] No, this is *not* a breaking change.

