### PR TITLE
Adds list required components when VS is not installed

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -190,9 +190,10 @@ class UserMessages {
       'Visual Studio is missing necessary components. Please re-run the '
       'Visual Studio installer for the "$workload" workload, and include these components:\n'
       '  ${components.join('\n  ')}';
-  String get visualStudioMissing =>
+  String visualStudioMissing(String workload, List<String> components) =>
       'Visual Studio not installed; this is necessary for Windows development.\n'
-      'Download at https://visualstudio.microsoft.com/downloads/.';
+      'Download at https://visualstudio.microsoft.com/downloads/.\n'
+      'Please include the "$workload" workload, and the following components:\n  ${components.join('\n  ')}';
   String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
       'supported by Flutter yet.';
   String get visualStudioNotLaunchable =>

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -193,7 +193,7 @@ class UserMessages {
   String visualStudioMissing(String workload, List<String> components) =>
       'Visual Studio not installed; this is necessary for Windows development.\n'
       'Download at https://visualstudio.microsoft.com/downloads/.\n'
-      'Please include the "$workload" workload, and the following components:\n  ${components.join('\n  ')}';
+      'Please install the "$workload" workload, including following components:\n  ${components.join('\n  ')}';
   String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
       'supported by Flutter yet.';
   String get visualStudioNotLaunchable =>

--- a/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
@@ -12,6 +12,8 @@ VisualStudioValidator get visualStudioValidator => context.get<VisualStudioValid
 class VisualStudioValidator extends DoctorValidator {
   const VisualStudioValidator() : super('Visual Studio - develop for Windows');
 
+  int get majorVersion => int.tryParse(visualStudio.fullVersion.split('.')[0]);
+
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
@@ -46,7 +48,6 @@ class VisualStudioValidator extends DoctorValidator {
         messages.add(ValidationMessage.error(userMessages.visualStudioNotLaunchable));
       } else  if (!visualStudio.hasNecessaryComponents) {
         status = ValidationType.partial;
-        final int majorVersion = int.tryParse(visualStudio.fullVersion.split('.')[0]);
         messages.add(ValidationMessage.error(
             userMessages.visualStudioMissingComponents(
                 visualStudio.workloadDescription,
@@ -57,7 +58,12 @@ class VisualStudioValidator extends DoctorValidator {
       versionInfo = '${visualStudio.displayName} ${visualStudio.displayVersion}';
     } else {
       status = ValidationType.missing;
-      messages.add(ValidationMessage.error(userMessages.visualStudioMissing));
+      messages.add(ValidationMessage.error(
+        userMessages.visualStudioMissing(
+          visualStudio.workloadDescription,
+          visualStudio.necessaryComponentDescriptions(majorVersion)
+        )
+      ));
     }
 
     return ValidationResult(status, messages, statusInfo: versionInfo);

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
@@ -26,6 +26,9 @@ void main() {
       when(mockVisualStudio.isLaunchable).thenReturn(true);
       when(mockVisualStudio.isRebootRequired).thenReturn(false);
       when(mockVisualStudio.hasNecessaryComponents).thenReturn(true);
+      when(mockVisualStudio.workloadDescription).thenReturn('Desktop development');
+      when(mockVisualStudio.necessaryComponentDescriptions(any)).thenReturn(<String>['A', 'B']);
+      when(mockVisualStudio.fullVersion).thenReturn('15.1');
     });
 
     testUsingContext('Emits a message when Visual Studio is a pre-release version', () async {
@@ -87,9 +90,6 @@ void main() {
 
     testUsingContext('Emits partial status when Visual Studio is installed without necessary components', () async {
       when(visualStudio.hasNecessaryComponents).thenReturn(false);
-      when(visualStudio.workloadDescription).thenReturn('Desktop development');
-      when(visualStudio.necessaryComponentDescriptions(any)).thenReturn(<String>['A', 'B']);
-      when(visualStudio.fullVersion).thenReturn('15.1');
       const VisualStudioValidator validator = VisualStudioValidator();
       final ValidationResult result = await validator.validate();
       expect(result.type, ValidationType.partial);
@@ -109,7 +109,12 @@ void main() {
       when(visualStudio.isInstalled).thenReturn(false);
       const VisualStudioValidator validator = VisualStudioValidator();
       final ValidationResult result = await validator.validate();
-      final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioMissing);
+      final ValidationMessage expectedMessage = ValidationMessage.error(
+        userMessages.visualStudioMissing(
+          visualStudio.workloadDescription,
+          visualStudio.necessaryComponentDescriptions(validator.majorVersion)
+        )
+      );
       expect(result.messages.contains(expectedMessage), true);
       expect(result.type, ValidationType.missing);
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Adds a list of required components to the user message when Visual Studio is not installed. This list is currently only shown if the user has an incomplete installation.

Example of the message:

```
[X] Visual Studio - develop for Windows
    X Visual Studio not installed; this is necessary for Windows development.
      Download at https://visualstudio.microsoft.com/downloads/.
      Please include the "Desktop development with C++" workload, and the following components:
        MSBuild
        MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.21)
        Windows 10 SDK (10.0.17763.0)
```

## Related Issues

https://github.com/flutter/flutter/issues/40267

## Tests

Updated visual_studio_validator_test.dart 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
