### PR TITLE
Fix for broken LocalFileComparator output

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -129,7 +129,7 @@ class LocalFileComparator extends GoldenFileComparator {
       + '_'
       + failure
       + '.png';
-    return File(_path.join('failures', testName));
+    return File(_path.join(basedir.path, 'failures', testName));
   }
 }
 

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -72,7 +72,6 @@ class LocalFileComparator extends GoldenFileComparator {
     final path.Context context = _getPath(pathStyle);
     final String testFilePath = context.fromUri(testFile);
     final String testDirectoryPath = context.dirname(testFilePath);
-    print(' _getBaseDir: ${context.toUri(testDirectoryPath + context.separator)}');
     return context.toUri(testDirectoryPath + context.separator);
   }
 
@@ -104,7 +103,6 @@ class LocalFileComparator extends GoldenFileComparator {
         diffs.forEach((String name, Object untypedImage) {
           final Image image = untypedImage;
           final File output = _getFailureFile(name, golden);
-          print('Comparator output: $output');
           output.parent.createSync(recursive: true);
           output.writeAsBytesSync(encodePng(image));
         });

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -72,6 +72,7 @@ class LocalFileComparator extends GoldenFileComparator {
     final path.Context context = _getPath(pathStyle);
     final String testFilePath = context.fromUri(testFile);
     final String testDirectoryPath = context.dirname(testFilePath);
+    print(' _getBaseDir: ${context.toUri(testDirectoryPath + context.separator)}');
     return context.toUri(testDirectoryPath + context.separator);
   }
 
@@ -130,7 +131,10 @@ class LocalFileComparator extends GoldenFileComparator {
       + '_'
       + failure
       + '.png';
-    return File(basedir.path + path.separator + 'failures' + path.separator + testName);
+    return File(_path.join(
+      _path.fromUri(basedir),
+      _path.fromUri(Uri.parse('failures/$testName')),
+    ));
   }
 }
 

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -130,7 +130,7 @@ class LocalFileComparator extends GoldenFileComparator {
       + '_'
       + failure
       + '.png';
-    return File(path.join(basedir.path, 'failures', testName));
+    return File(basedir.path + path.separator + 'failures' + path.separator + testName);
   }
 }
 

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -103,6 +103,7 @@ class LocalFileComparator extends GoldenFileComparator {
         diffs.forEach((String name, Object untypedImage) {
           final Image image = untypedImage;
           final File output = _getFailureFile(name, golden);
+          print('Comparator output: $output');
           output.parent.createSync(recursive: true);
           output.writeAsBytesSync(encodePng(image));
         });

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -130,7 +130,7 @@ class LocalFileComparator extends GoldenFileComparator {
       + '_'
       + failure
       + '.png';
-    return File(_path.join(basedir.path, 'failures', testName));
+    return File(path.join(basedir.path, 'failures', testName));
   }
 }
 

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -156,6 +156,9 @@ void main() {
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
+            print(error.message);
+            print(comparator.basedir);
+            print(fix('${comparator.basedir.path}failures/golden_masterImage.png'));
             final io.File master = fs.file(
               fix('${comparator.basedir.path}failures/golden_masterImage.png')
             );

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -150,6 +150,8 @@ void main() {
       group('fails', () {
 
         test('and generates correct output in the correct location', () async {
+          comparator = LocalFileComparator(Uri.parse('local_test.dart'), pathStyle: fs.path.style);
+          print('comparator basedir: ${comparator.basedir}');
           await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
           try {
             await doComparison();

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -156,19 +156,19 @@ void main() {
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
-            print(comparator.basedir);
-            print(fix('${comparator.basedir.path}failures/golden_masterImage.png'));
+            print(error.message);
+            print(fix('/failures/golden_masterImage.png'));
             final io.File master = fs.file(
-              fix('${comparator.basedir.path}failures/golden_masterImage.png')
+              fix('/failures/golden_masterImage.png')
             );
             final io.File test = fs.file(
-              fix('${comparator.basedir.path}failures/golden_testImage.png')
+              fix('/failures/golden_testImage.png')
             );
             final io.File isolated = fs.file(
-              fix('${comparator.basedir.path}failures/golden_isolatedDiff.png')
+              fix('/failures/golden_isolatedDiff.png')
             );
             final io.File masked = fs.file(
-              fix('${comparator.basedir.path}failures/golden_maskedDiff.png')
+              fix('/failures/golden_maskedDiff.png')
             );
             expect(master.existsSync(), isTrue);
             expect(test.existsSync(), isTrue);

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -156,10 +156,10 @@ void main() {
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
-            final io.File master = fs.file('/failures/golden_masterImage.png');
-            final io.File test = fs.file('/failures/golden_testImage.png');
-            final io.File isolated = fs.file('/failures/golden_isolatedDiff.png');
-            final io.File masked = fs.file('/failures/golden_maskedDiff.png');
+            final io.File master = fs.file(fix('/failures/golden_masterImage.png'));
+            final io.File test = fs.file(fix('/failures/golden_testImage.png'));
+            final io.File isolated = fs.file(fix('/failures/golden_isolatedDiff.png'));
+            final io.File masked = fs.file(fix('/failures/golden_maskedDiff.png'));
             expect(master.existsSync(), isTrue);
             expect(test.existsSync(), isTrue);
             expect(isolated.existsSync(), isTrue);

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -151,15 +151,12 @@ void main() {
 
         test('and generates correct output in the correct location', () async {
           comparator = LocalFileComparator(Uri.parse('local_test.dart'), pathStyle: fs.path.style);
-          print('comparator basedir: ${comparator.basedir}');
           await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
           try {
             await doComparison();
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
-            print(error.message);
-            print(fix('/failures/golden_masterImage.png'));
             final io.File master = fs.file(
               fix('/failures/golden_masterImage.png')
             );

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -148,6 +148,25 @@ void main() {
       });
 
       group('fails', () {
+
+        test('and generates correct output in the correct location', () async {
+          await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
+          try {
+            await doComparison();
+            fail('TestFailure expected but not thrown.');
+          } on TestFailure catch (error) {
+            expect(error.message, contains('% diff detected'));
+            final io.File master = fs.file('/failures/golden_masterImage.png');
+            final io.File test = fs.file('/failures/golden_testImage.png');
+            final io.File isolated = fs.file('/failures/golden_isolatedDiff.png');
+            final io.File masked = fs.file('/failures/golden_maskedDiff.png');
+            expect(master.existsSync(), isTrue);
+            expect(test.existsSync(), isTrue);
+            expect(isolated.existsSync(), isTrue);
+            expect(masked.existsSync(), isTrue);
+          }
+        });
+
         test('when golden file does not exist', () async {
           try {
             await doComparison();

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -156,7 +156,6 @@ void main() {
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
-            print(error.message);
             print(comparator.basedir);
             print(fix('${comparator.basedir.path}failures/golden_masterImage.png'));
             final io.File master = fs.file(

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -156,10 +156,18 @@ void main() {
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));
-            final io.File master = fs.file(fix('/failures/golden_masterImage.png'));
-            final io.File test = fs.file(fix('/failures/golden_testImage.png'));
-            final io.File isolated = fs.file(fix('/failures/golden_isolatedDiff.png'));
-            final io.File masked = fs.file(fix('/failures/golden_maskedDiff.png'));
+            final io.File master = fs.file(
+              fix('${comparator.basedir.path}failures/golden_masterImage.png')
+            );
+            final io.File test = fs.file(
+              fix('${comparator.basedir.path}failures/golden_testImage.png')
+            );
+            final io.File isolated = fs.file(
+              fix('${comparator.basedir.path}failures/golden_isolatedDiff.png')
+            );
+            final io.File masked = fs.file(
+              fix('${comparator.basedir.path}failures/golden_maskedDiff.png')
+            );
             expect(master.existsSync(), isTrue);
             expect(test.existsSync(), isTrue);
             expect(isolated.existsSync(), isTrue);


### PR DESCRIPTION
## Description

After refactoring goldens.dart in https://github.com/flutter/flutter/pull/39983 it seems that output relocated to a different place. 😜 This fixes that, and adds a test as well. 



## Tests

I added the following tests:

LocalFileComparator fails and generates correct output in the correct location

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
