### PR TITLE
Make FlutterPluginRegistrant a static framework so add-to-app can use static framework plugins

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -383,6 +383,7 @@ Depends on all your plugins, and provides a function to register them.
   s.source_files =  "Classes", "Classes/**/*.{h,m}"
   s.source           = { :path => '.' }
   s.public_header_files = './Classes/**/*.h'
+  s.static_framework    = true
   s.dependency '{{framework}}'
   {{#plugins}}
   s.dependency '{{name}}'


### PR DESCRIPTION
## Description
If host app Podfiles are using `use_frameworks!` and plugins vended as static frameworks ([google_maps_flutter](https://github.com/flutter/plugins/blob/master/packages/google_maps_flutter/ios/google_maps_flutter.podspec#L20), [google_sign_in](https://github.com/flutter/plugins/blob/9616a32faf6d1066c8f633a30f0bd7dca6fe7e9e/packages/google_sign_in/ios/google_sign_in.podspec#L19) etc) then FlutterPluginRegistrant [must also be a static framework](https://blog.cocoapods.org/CocoaPods-1.4.0/).  I don't see a non-hacky way to parse the plugins at the point the template is generated, so I think FlutterPluginRegistrant just has to always be a static framework.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/31104.

## Tests

I updated module_test_ios to `use_frameworks!` with google_sign_in on top of the new Swift test in https://github.com/flutter/flutter/pull/40302 and confirmed it failed before this change and succeeded after.  Don't have a running CI test for this yet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
