### PR TITLE
Diagnose layout scroll perf

### DIFF
--- a/examples/layers/raw/shader_warm_up.dart
+++ b/examples/layers/raw/shader_warm_up.dart
@@ -16,9 +16,7 @@ Future<void> beginFrame(Duration timeStamp) async {
   final ui.Canvas canvas = ui.Canvas(recorder, paintBounds);
   final ui.Paint backgroundPaint = ui.Paint()..color = Colors.white;
   canvas.drawRect(paintBounds, backgroundPaint);
-  await const DefaultShaderWarmUp(
-          drawCallSpacing: 80.0, canvasSize: ui.Size(1024, 1024))
-      .warmUpOnCanvas(canvas);
+  await const DefaultShaderWarmUp().warmUpOnCanvas(canvas);
   final ui.Picture picture = recorder.endRecording();
 
   // COMPOSITE

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -56,12 +56,12 @@ abstract class ShaderWarmUp {
 
   /// The size of the warm up image.
   ///
-  /// The exact size shouldn't matter much as long as all draws are onscreen.
-  /// 100x100 is an arbitrary small size that's easy to fit significant draw
-  /// calls onto.
+  /// The exact size shouldn't matter much as long as it's not too far away from
+  /// the target device's screen. 1024x1024 is a good choice as it is within an
+  /// order of magnitude of most devices.
   ///
   /// A custom shader warm up can override this based on targeted devices.
-  ui.Size get size => const ui.Size(100.0, 100.0);
+  ui.Size get size => const ui.Size(1024.0, 1024.0);
 
   /// Trigger draw operations on a given canvas to warm up GPU shader
   /// compilation cache.
@@ -99,20 +99,7 @@ abstract class ShaderWarmUp {
 /// issues seen so far.
 class DefaultShaderWarmUp extends ShaderWarmUp {
   /// Allow [DefaultShaderWarmUp] to be used as the default value of parameters.
-  const DefaultShaderWarmUp(
-      {this.drawCallSpacing = 0.0,
-      this.canvasSize = const ui.Size(100.0, 100.0)});
-
-  /// Constant that can be used to space out draw calls for visualizing the draws
-  /// for debugging purposes (example: 80.0).  Be sure to also change your canvas
-  /// size.
-  final double drawCallSpacing;
-
-  /// Value that returned by this.size to control canvas size where draws happen.
-  final ui.Size canvasSize;
-
-  @override
-  ui.Size get size => canvasSize;
+  const DefaultShaderWarmUp();
 
   /// Trigger common draw operations on a canvas to warm up GPU shader
   /// compilation cache.
@@ -170,22 +157,22 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
       canvas.save();
       for (ui.Paint paint in paints) {
         canvas.drawPath(paths[i], paint);
-        canvas.translate(drawCallSpacing, 0.0);
+        canvas.translate(80.0, 0.0);
       }
       canvas.restore();
-      canvas.translate(0.0, drawCallSpacing);
+      canvas.translate(0.0, 80.0);
     }
 
     // Warm up shadow shaders.
     const ui.Color black = ui.Color(0xFF000000);
     canvas.save();
     canvas.drawShadow(rrectPath, black, 10.0, true);
-    canvas.translate(drawCallSpacing, 0.0);
+    canvas.translate(80.0, 0.0);
     canvas.drawShadow(rrectPath, black, 10.0, false);
     canvas.restore();
 
     // Warm up text shaders.
-    canvas.translate(0.0, drawCallSpacing);
+    canvas.translate(0.0, 80.0);
     final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(
       ui.ParagraphStyle(textDirection: ui.TextDirection.ltr),
     )..pushStyle(ui.TextStyle(color: black))..addText('_');

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -193,8 +193,8 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
         ..clipRRect(ui.RRect.fromLTRBR(8, 8, 328, 248, const ui.Radius.circular(16)))
         ..drawRect(const ui.Rect.fromLTRB(10, 10, 320, 240), ui.Paint())
         ..restore();
-      canvas.translate(drawCallSpacing, 0.0);
+      canvas.translate(80.0, 0.0);
     }
-    canvas.translate(0.0, drawCallSpacing);
+    canvas.translate(0.0, 80.0);
   }
 }


### PR DESCRIPTION
This change reverts the changes of 9b150f134b9b6ba103ec305f489645b5fee905d2 (along with additional related edits) to restore the performance of complex_layout_scroll_perf__memory as per https://github.com/flutter/flutter/issues/40406.

It may be more appropriate to fix the underlying issue than to revert the commit since it is not clear why reducing the size used during shader warmup should cause a memory benchmark to start showing more heap usage, but this PR provides a useful patch to help diagnose the issue.