### PR TITLE
Rename useProguard method, so Gradle doesn't get confused

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -154,7 +154,7 @@ class FlutterPlugin implements Plugin<Project> {
             }
         }
 
-        if (useProguard(project)) {
+        if (shouldUseProguard(project)) {
             String flutterProguardRules = Paths.get(flutterRoot.absolutePath, "packages", "flutter_tools",
                     "gradle", "flutter_proguard_rules.pro")
             project.android.buildTypes {
@@ -389,8 +389,7 @@ class FlutterPlugin implements Plugin<Project> {
         return false
     }
 
-
-    private static Boolean useProguard(Project project) {
+    private static Boolean shouldUseProguard(Project project) {
         if (project.hasProperty('proguard')) {
             return project.property('proguard').toBoolean()
         }


### PR DESCRIPTION
## Description

In Gradle 5.1.1, the static method `useProguard` has higher precedence over the `useProguard` called in line 163.  This causes a signature clash. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40213

## Tests

This will be tested in https://github.com/flutter/flutter/pull/40181

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
