### PR TITLE
Dark Mode R: Refresh Control 

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -75,13 +75,16 @@ class CupertinoColors {
   // Value derived from screenshot from the dark themed Apple Watch app.
   static const Color darkBackgroundGray = Color(0xFF171717);
 
-  /// Used in iOS 11 for unselected selectables such as tab bar items in their
+  /// Used in iOS 13 for unselected selectables such as tab bar items in their
   /// inactive state or de-emphasized subtitles and details text.
   ///
   /// Not the same gray as disabled buttons etc.
   ///
-  /// This is SystemGrayColor in the iOS palette.
-  static const Color inactiveGray = Color(0xFF8E8E93);
+  /// This is the disabled color in the iOS palette.
+  static const Color inactiveGray = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFF999999),
+    darkColor: Color(0xFF757575),
+  );
 
   /// Used for iOS 10 for destructive actions such as the delete actions in
   /// table view cells and dialogs.

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -379,9 +379,9 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
                 opacity: opacityCurve.transform(
                   min(pulledExtent / refreshTriggerPullDistance, 1.0)
                 ),
-                child: const Icon(
+                child: Icon(
                   CupertinoIcons.down_arrow,
-                  color: CupertinoColors.inactiveGray,
+                  color: CupertinoDynamicColor.resolve(CupertinoColors.inactiveGray, context),
                   size: 36.0,
                 ),
               )

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1403,6 +1403,50 @@ void main() {
         debugDefaultTargetPlatformOverride = null;
       },
     );
+
+    testWidgets('buildSimpleRefreshIndicator dark mode', (WidgetTester tester) async {
+      const CupertinoDynamicColor color = CupertinoColors.inactiveGray;
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(platformBrightness: Brightness.light),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Builder(
+              builder: (BuildContext context) {
+                return CupertinoSliverRefreshControl.buildSimpleRefreshIndicator(
+                  context,
+                  RefreshIndicatorMode.drag,
+                  10, 10, 10,
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.widget<Icon>(find.byType(Icon)).color.value, color.color.value);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(platformBrightness: Brightness.dark),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Builder(
+              builder: (BuildContext context) {
+                return CupertinoSliverRefreshControl.buildSimpleRefreshIndicator(
+                  context,
+                  RefreshIndicatorMode.drag,
+                  10, 10, 10,
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.widget<Icon>(find.byType(Icon)).color.value, color.darkColor.value);
+    });
   };
 
   group('UI tests long list', uiTestGroup);

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -699,7 +699,7 @@ void main() {
           const Rect.fromLTRB(463.3333435058594, -0.916666666666668, 465.3333435058594, 17.083333015441895),
           const Radius.circular(2.0),
         ),
-        color: const Color(0xff8e8e93),
+        color: const Color(0xff999999),
       )
       ..rrect(
         rrect: RRect.fromRectAndRadius(

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -724,7 +724,7 @@ void main() {
           const Rect.fromLTRB(191.3333282470703, -0.916666666666668, 193.3333282470703, 17.083333015441895),
           const Radius.circular(2.0),
         ),
-        color: const Color(0xff8e8e93),
+        color: const Color(0xff999999),
       )
       ..rrect(
         rrect: RRect.fromRectAndRadius(


### PR DESCRIPTION
## Description

CupertinoSliverRefreshControl. Router is done in a previous PR (but the shadow color may need to be revised in the future).

## Related Issues

part of #35541

## Tests

I added the following tests:

- buildSimpleRefreshIndicator dark mode

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
