### PR TITLE
Dont kill other processes when starting desktop application

### DIFF
--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -86,7 +86,6 @@ class LinuxDevice extends Device {
         target: mainPath,
       );
     }
-    await stopApp(package);
     final Process process = await processManager.start(<String>[
       package.executable(debuggingOptions?.buildInfo?.mode)
     ]);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -79,7 +79,6 @@ class MacOSDevice extends Device {
     bool prebuiltApplication = false,
     bool ipv6 = false,
   }) async {
-    // Stop any running applications with the same executable.
     if (!prebuiltApplication) {
       Cache.releaseLockEarly();
       await buildMacOS(

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -96,9 +96,7 @@ class MacOSDevice extends Device {
       return LaunchResult.failed();
     }
 
-    // Make sure to call stop app after we've built.
     _lastBuiltMode = debuggingOptions?.buildInfo?.mode;
-    await stopApp(package);
     final Process process = await processManager.start(<String>[
       executable
     ]);

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -87,7 +87,6 @@ class WindowsDevice extends Device {
         target: mainPath,
       );
     }
-    await stopApp(package);
     final Process process = await processUtils.start(<String>[
       package.executable(debuggingOptions?.buildInfo?.mode)
     ]);


### PR DESCRIPTION
## Description

This is too opinionated of behavior from the tool - it prevents running multiple applications for no good reason.

Fixes https://github.com/flutter/flutter/issues/37889