### PR TITLE
Make debugBuilding available in release mode

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2238,6 +2238,9 @@ class BuildOwner {
 
   /// Whether this widget tree is in the build phase.
   bool get isBuilding => _isBuilding;
+  /// Whether this widget tree is in the build phase.
+  @Deprecated('use BuildOwner.isBuilding instead')
+  bool get debugBuilding => _isBuilding;
   bool _isBuilding = false;
   Element _debugCurrentBuildTarget;
 

--- a/packages/flutter/test/widgets/build_owner_test.dart
+++ b/packages/flutter/test/widgets/build_owner_test.dart
@@ -6,16 +6,46 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('BuildOwner.isBuilding is true when the widget tree builds, and false otherwise',
+  testWidgets('BuildOwner.isBuilding is true inside didChangeDependencies/build and false otherwise',
     (WidgetTester tester) async {
       expect(tester.binding.buildOwner.isBuilding, isFalse);
 
-      await tester.pumpWidget(Builder(builder: (BuildContext _) {
-        expect(tester.binding.buildOwner.isBuilding, isTrue);
-        return Container();
-      }));
+      await tester.pumpWidget(
+        _Stateful(
+          didChangeDependencies: () {
+            expect(tester.binding.buildOwner.isBuilding, isTrue);
+          },
+          builder: (BuildContext _) {
+            expect(tester.binding.buildOwner.isBuilding, isTrue);
+            return Container();
+          },
+        ),
+      );
 
       expect(tester.binding.buildOwner.isBuilding, isFalse);
     },
   );
+}
+
+class _Stateful extends StatefulWidget {
+  const _Stateful({Key key, this.didChangeDependencies, this.builder}) : super(key: key);
+
+  final VoidCallback didChangeDependencies;
+  final WidgetBuilder builder;
+
+  @override
+  _StatefulState createState() => _StatefulState();
+}
+
+class _StatefulState extends State<_Stateful> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.didChangeDependencies?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context);
+  }
 }

--- a/packages/flutter/test/widgets/build_owner_test.dart
+++ b/packages/flutter/test/widgets/build_owner_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  testWidgets('BuildOwner.isBuilding is true when the widget tree builds, and false otherwise',
+    (WidgetTester tester) async {
+      expect(tester.binding.buildOwner.isBuilding, isFalse);
+
+      await tester.pumpWidget(Builder(builder: (BuildContext _) {
+        expect(tester.binding.buildOwner.isBuilding, isTrue);
+        return Container();
+      }));
+
+      expect(tester.binding.buildOwner.isBuilding, isFalse);
+    },
+  );
+}


### PR DESCRIPTION
## Description

This makes `BuildOwner.debugBuilding` available in release mode.
It therefore allows `Element` to do custom behavior based on whether the widget tree is building or not.

The main use-case is to know when to call `inheritFromElement` or not inside the classical static `.of` method:

```dart
static T of(BuildContext context) {
    final inheritedElement = context.ancestorInheritedElementForWidgetOfExactType(T);
    if (context.owner.isBuilding) {
      context.inheritFromElement(inheritedElement);
    }
    return inheritedElement;
}
```

This PR does not update the existing  `.of` methods to use that logic (as it is for a 3rd party package).
If these changes are accepted, it may be a good idea to apply that logic to built-in InheritedWidgets, like Theme.of/Scrollable.of.

## Related Issues

closes https://github.com/flutter/flutter/issues/34724

## Tests

I added the following tests:

- packages/fluter/test/widgets/build_owner_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*

^ I've read through [Handling breaking changes], but I don't fully understand the process.
Should I mail flutter-announce@googlegroups.com directly?

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
