### PR TITLE
Add an ephemeral directory for Linux

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -37,7 +37,7 @@ or
   String cacheDirectory;
   switch (targetPlatform) {
     case 'linux-x64':
-      cacheDirectory = 'linux/flutter';
+      cacheDirectory = 'linux/flutter/ephemeral';
       break;
     case 'windows-x64':
       cacheDirectory = 'windows/flutter/ephemeral';

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -51,8 +51,14 @@ class CleanCommand extends FlutterCommand {
     final Directory iosEphemeralDirectory = flutterProject.ios.ephemeralDirectory;
     deleteFile(iosEphemeralDirectory);
 
+    final Directory linuxEphemeralDirectory = flutterProject.linux.ephemeralDirectory;
+    deleteFile(linuxEphemeralDirectory);
+
     final Directory macosEphemeralDirectory = flutterProject.macos.ephemeralDirectory;
     deleteFile(macosEphemeralDirectory);
+
+    final Directory windowsEphemeralDirectory = flutterProject.windows.ephemeralDirectory;
+    deleteFile(windowsEphemeralDirectory);
 
     return const FlutterCommandResult(ExitStatus.success);
   }

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -34,7 +34,7 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   }
 
   /// Cache flutter configuration files in the linux directory.
-  linuxProject.cacheDirectory.childFile('generated_config')
+  linuxProject.generatedMakeConfigFile
     ..createSync(recursive: true)
     ..writeAsStringSync(buffer.toString());
 
@@ -52,7 +52,7 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   final Process process = await processManager.start(<String>[
     'make',
     '-C',
-    linuxProject.editableHostAppDirectory.path,
+    linuxProject.makeFile.parent.path,
   ], runInShell: true);
   final Status status = logger.startProgress(
     'Building Linux application...',

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -793,16 +793,26 @@ class LinuxProject {
 
   final FlutterProject project;
 
-  Directory get editableHostAppDirectory => project.directory.childDirectory('linux');
+  Directory get _editableDirectory => project.directory.childDirectory('linux');
 
-  // TODO(stuartmorgan): Move to using an ephemeralDirectory to match the other
-  // desktop projects.
-  Directory get cacheDirectory => editableHostAppDirectory.childDirectory('flutter');
+  /// The directory in the project that is managed by Flutter. As much as
+  /// possible, files that are edited by Flutter tooling after initial project
+  /// creation should live here.
+  Directory get managedDirectory => _editableDirectory.childDirectory('flutter');
 
-  bool existsSync() => editableHostAppDirectory.existsSync();
+  /// The subdirectory of [managedDirectory] that contains files that are
+  /// generated on the fly. All generated files that are not intended to be
+  /// checked in should live here.
+  Directory get ephemeralDirectory => managedDirectory.childDirectory('ephemeral');
+
+  bool existsSync() => _editableDirectory.existsSync();
 
   /// The Linux project makefile.
-  File get makeFile => editableHostAppDirectory.childFile('Makefile');
+  File get makeFile => _editableDirectory.childFile('Makefile');
+
+  /// Contains definitions for FLUTTER_ROOT, LOCAL_ENGINE, and more flags for
+  /// the build.
+  File get generatedMakeConfigFile => ephemeralDirectory.childFile('generated_config.mk');
 }
 
 /// The Fuchisa sub project

--- a/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
@@ -100,7 +100,7 @@ void main() {
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     );
-    expect(fs.file('linux/flutter/generated_config').existsSync(), true);
+    expect(fs.file('linux/flutter/ephemeral/generated_config.mk').existsSync(), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/general.shard/commands/clean_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/clean_test.dart
@@ -41,7 +41,9 @@ void main() {
     projectUnderTest.dartTool.createSync(recursive: true);
     projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
     projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
+    projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
     projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
+    projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
   });
 
   group(CleanCommand, () {
@@ -53,7 +55,9 @@ void main() {
       expect(projectUnderTest.dartTool.existsSync(), isFalse);
       expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
       expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
+      expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
       expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);
+      expect(projectUnderTest.windows.ephemeralDirectory.existsSync(), isFalse);
 
       verify(xcodeProjectInterpreter.cleanWorkspace(any, 'Runner')).called(2);
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Moves the generated config into that directory. Matches the structure of
the other desktop projects.

## Related Issues

Fixes #40265

## Tests

I added the following tests: None; updated existing tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
