### PR TITLE
Specify ifTrue and ifFalse for strut FlagProperty

### DIFF
--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -597,7 +597,7 @@ class StrutStyle extends Diagnosticable {
     ));
     styles.add(EnumProperty<FontStyle>('${prefix}style', fontStyle, defaultValue: null));
     styles.add(DoubleProperty('${prefix}height', height, unit: 'x', defaultValue: null));
-    styles.add(FlagProperty('${prefix}forceStrutHeight', value: forceStrutHeight, defaultValue: null));
+    styles.add(FlagProperty('${prefix}forceStrutHeight', value: forceStrutHeight, defaultValue: null, ifTrue: '$prefix<strut height forced>', ifFalse: '$prefix<strut height normal>'));
 
     final bool styleSpecified = styles.any((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info));
     styles.forEach(properties.add);

--- a/packages/flutter/test/painting/strut_style_test.dart
+++ b/packages/flutter/test/painting/strut_style_test.dart
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show StrutStyle;
-
 import 'package:flutter/painting.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
   test('StrutStyle diagnostics test', () {
-    final StrutStyle s0 = StrutStyle(
+    const StrutStyle s0 = StrutStyle(
       fontFamily: 'Serif',
       fontSize: 14,
     );
@@ -18,7 +16,7 @@ void main() {
       equals('StrutStyle(family: Serif, size: 14.0)'),
     );
 
-    final StrutStyle s1 = StrutStyle(
+    const StrutStyle s1 = StrutStyle(
       fontFamily: 'Serif',
       fontSize: 14,
       forceStrutHeight: true,
@@ -31,7 +29,7 @@ void main() {
       equals('StrutStyle(family: Serif, size: 14.0, <strut height forced>)'),
     );
 
-    final StrutStyle s2 = StrutStyle(
+    const StrutStyle s2 = StrutStyle(
       fontFamily: 'Serif',
       fontSize: 14,
       forceStrutHeight: false,
@@ -41,13 +39,13 @@ void main() {
       equals('StrutStyle(family: Serif, size: 14.0, <strut height normal>)'),
     );
 
-    final StrutStyle s3 = StrutStyle();
+    const StrutStyle s3 = StrutStyle();
     expect(
       s3.toString(),
       equals('StrutStyle'),
     );
 
-    final StrutStyle s4 = StrutStyle(
+    const StrutStyle s4 = StrutStyle(
       forceStrutHeight: false,
     );
     expect(
@@ -55,7 +53,7 @@ void main() {
       equals('StrutStyle(<strut height normal>)'),
     );
 
-    final StrutStyle s5 = StrutStyle(
+    const StrutStyle s5 = StrutStyle(
       forceStrutHeight: true,
     );
     expect(

--- a/packages/flutter/test/painting/strut_style_test.dart
+++ b/packages/flutter/test/painting/strut_style_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui show StrutStyle;
+
+import 'package:flutter/painting.dart';
+import '../flutter_test_alternative.dart';
+
+void main() {
+  test('StrutStyle diagnostics test', () {
+    final StrutStyle s0 = StrutStyle(
+      fontFamily: 'Serif',
+      fontSize: 14,
+    );
+    expect(
+      s0.toString(),
+      equals('StrutStyle(family: Serif, size: 14.0)'),
+    );
+
+    final StrutStyle s1 = StrutStyle(
+      fontFamily: 'Serif',
+      fontSize: 14,
+      forceStrutHeight: true,
+    );
+    expect(s1.fontFamily, 'Serif');
+    expect(s1.fontSize, 14.0);
+    expect(s1, equals(s1));
+    expect(
+      s1.toString(),
+      equals('StrutStyle(family: Serif, size: 14.0, <strut height forced>)'),
+    );
+
+    final StrutStyle s2 = StrutStyle(
+      fontFamily: 'Serif',
+      fontSize: 14,
+      forceStrutHeight: false,
+    );
+    expect(
+      s2.toString(),
+      equals('StrutStyle(family: Serif, size: 14.0, <strut height normal>)'),
+    );
+
+    final StrutStyle s3 = StrutStyle();
+    expect(
+      s3.toString(),
+      equals('StrutStyle'),
+    );
+
+    final StrutStyle s4 = StrutStyle(
+      forceStrutHeight: false,
+    );
+    expect(
+      s4.toString(),
+      equals('StrutStyle(<strut height normal>)'),
+    );
+
+    final StrutStyle s5 = StrutStyle(
+      forceStrutHeight: true,
+    );
+    expect(
+      s5.toString(),
+      equals('StrutStyle(<strut height forced>)'),
+    );
+  });
+}


### PR DESCRIPTION
This adds the missing properties that are required for FlagProperty to function properly.

Fixes https://github.com/flutter/flutter/issues/40296