### PR TITLE
Warn when build number and version can't be parsed on iOS

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -152,6 +152,9 @@ String validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String bui
     // See CFBundleVersion at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildNumber = buildNumber.replaceAll(disallowed, '');
+    if (tmpBuildNumber.isEmpty) {
+      return null;
+    }
     final List<String> segments = tmpBuildNumber
         .split('.')
         .where((String segment) => segment.isNotEmpty)
@@ -196,6 +199,9 @@ String validatedBuildNameForPlatform(TargetPlatform targetPlatform, String build
     // See CFBundleShortVersionString at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildName = buildName.replaceAll(disallowed, '');
+    if (tmpBuildName.isEmpty) {
+      return null;
+    }
     final List<String> segments = tmpBuildName
         .split('.')
         .where((String segment) => segment.isNotEmpty)

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -183,16 +183,15 @@ List<String> _xcodeBuildSettingsLines({
     buildNumber ??= validatedBuildNumberForPlatform(TargetPlatform.ios, buildNameToParse);
   }
 
-  if (buildNameIsMissing && buildNumberIsMissing) {
-    printError('Warning: Missing build name (CFBundleShortVersionString), defaulting to $defaultBuildName.\n'
-        'Missing build number (CFBundleVersion), defaulting to $defaultBuildNumber.\nSet a build name and '
-        'number in the pubspec.yaml version before submitting to the App Store.');
-  } else if (buildNameIsMissing) {
-    printError('Warning: Missing build name (CFBundleShortVersionString), defaulting to $defaultBuildName.\n'
-        'Set a build name in the pubspec.yaml version before submitting to the App Store.');
-  } else if (buildNumberIsMissing) {
-    printError('Warning: Missing build number (CFBundleVersion), defaulting to $defaultBuildNumber.\n'
-        'Set a build number in the pubspec.yaml version before submitting to the App Store.');
+  if (buildNameIsMissing) {
+    printError('Warning: Missing build name (CFBundleShortVersionString), defaulting to $defaultBuildName.');
+  }
+  if (buildNumberIsMissing) {
+    printError('Warning: Missing build number (CFBundleVersion), defaulting to $defaultBuildNumber.');
+  }
+  if (buildNameIsMissing || buildNumberIsMissing) {
+    printError('Action Required: You must set a build name and number in the pubspec.yaml '
+               'file version field before submitting to the App Store.');
   }
 
   if (buildName == null && buildNumber == null) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -159,19 +159,52 @@ List<String> _xcodeBuildSettingsLines({
   }
 
   final String buildNameToParse = buildInfo?.buildName ?? project.manifest.buildName;
-  final String buildName = validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse);
-  if (buildName != null) {
-    xcodeBuildSettings.add('FLUTTER_BUILD_NAME=$buildName');
+  final bool buildNameIsMissing = buildNameToParse == null || buildNameToParse.isEmpty;
+  String buildName;
+  const String defaultBuildName = '1.0.0';
+  if (buildNameIsMissing) {
+    buildName = defaultBuildName;
+  } else {
+    buildName = validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse);
   }
 
-  String buildNumber = validatedBuildNumberForPlatform(TargetPlatform.ios, buildInfo?.buildNumber ?? project.manifest.buildNumber);
-  // Drop back to parsing build name if build number is not present. Build number is optional in the manifest, but
-  // FLUTTER_BUILD_NUMBER is required as the backing value for the required CFBundleVersion.
-  buildNumber ??= validatedBuildNumberForPlatform(TargetPlatform.ios, buildNameToParse);
+  final String buildNumberToParse = buildInfo?.buildNumber ?? project.manifest.buildNumber;
+  final bool buildNumberIsMissing =
+      (buildNumberToParse == null || buildNumberToParse.isEmpty) && buildNameIsMissing;
+  String buildNumber;
 
-  if (buildNumber != null) {
-    xcodeBuildSettings.add('FLUTTER_BUILD_NUMBER=$buildNumber');
+  const String defaultBuildNumber = '1';
+  if (buildNumberIsMissing) {
+    buildNumber = defaultBuildNumber;
+  } else {
+    buildNumber = validatedBuildNumberForPlatform(TargetPlatform.ios, buildNumberToParse);
+    // Drop back to parsing build name if build number is not present. Build number is optional in the manifest, but
+    // FLUTTER_BUILD_NUMBER is required as the backing value for the required CFBundleVersion.
+    buildNumber ??= validatedBuildNumberForPlatform(TargetPlatform.ios, buildNameToParse);
   }
+
+  if (buildNameIsMissing && buildNumberIsMissing) {
+    printError('Warning: Missing build name (CFBundleShortVersionString), defaulting to $defaultBuildName.\n'
+        'Missing build number (CFBundleVersion), defaulting to $defaultBuildNumber.\nSet a build name and '
+        'number in the pubspec.yaml version before submitting to the App Store.');
+  } else if (buildNameIsMissing) {
+    printError('Warning: Missing build name (CFBundleShortVersionString), defaulting to $defaultBuildName.\n'
+        'Set a build name in the pubspec.yaml version before submitting to the App Store.');
+  } else if (buildNumberIsMissing) {
+    printError('Warning: Missing build number (CFBundleVersion), defaulting to $defaultBuildNumber.\n'
+        'Set a build number in the pubspec.yaml version before submitting to the App Store.');
+  }
+
+  if (buildName == null && buildNumber == null) {
+    throwToolExit('Cannot parse build number $buildNumberToParse or build name $buildNameToParse, check pubspec.yaml version.');
+  } else if (buildName == null) {
+    throwToolExit('Cannot parse build name $buildNameToParse, check pubspec.yaml version.');
+  } else if (buildNumber == null) {
+    throwToolExit('Cannot parse build number $buildNumberToParse, check pubspec.yaml version.');
+  }
+
+  xcodeBuildSettings.add('FLUTTER_BUILD_NAME=$buildName');
+  xcodeBuildSettings.add('FLUTTER_BUILD_NUMBER=$buildNumber');
 
   if (artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = artifacts;

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     testUsingContext('CFBundleVersion for iOS', () async {
       String buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, 'xyz');
-      expect(buildName, '0');
+      expect(buildName, isNull);
       buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '0.0.1');
       expect(buildName, '0.0.1');
       buildName = validatedBuildNumberForPlatform(TargetPlatform.ios, '123.xyz');
@@ -38,7 +38,7 @@ void main() {
 
     testUsingContext('CFBundleShortVersionString for iOS', () async {
       String buildName = validatedBuildNameForPlatform(TargetPlatform.ios, 'xyz');
-      expect(buildName, '0.0.0');
+      expect(buildName, isNull);
       buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '0.0.1');
       expect(buildName, '0.0.1');
       buildName = validatedBuildNameForPlatform(TargetPlatform.ios, '123.456.xyz');

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -629,6 +629,41 @@ flutter:
         expectedBuildNumber: '3',
       );
     });
+
+    testUsingOsxContext('default build name and number when version is missing', () async {
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+      const BuildInfo buildInfo = BuildInfo(BuildMode.release, null);
+      await checkBuildVersion(
+        manifestString: manifest,
+        buildInfo: buildInfo,
+        expectedBuildName: '1.0.0',
+        expectedBuildNumber: '1',
+      );
+    });
+
+    testUsingOsxContext('fail when build name cannot be parsed', () async {
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+      const BuildInfo buildInfo = BuildInfo(BuildMode.release, null, buildName: 'abc', buildNumber: '1');
+
+      const String stderr = 'Cannot parse build name abc, check pubspec.yaml version.';
+      expect(() async => await checkBuildVersion(
+        manifestString: manifest,
+        buildInfo: buildInfo
+      ),
+      throwsToolExit(message: stderr));
+    });
   });
 }
 


### PR DESCRIPTION
## Description

Build number and build version are required on iOS.  Fall back to default values if one can't be parsed from the pubspec version, but warn that they need to set one before submitting to the App Store.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/38610.
See also https://github.com/flutter/flutter/pull/37036.

## Tests

Updated xcodeproj_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.