### PR TITLE
Wait for first frame in driver tests

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -14,8 +14,7 @@ void main() {
     setUpAll(() async {
       driver = await FlutterDriver.connect();
 
-      // TODO(liyuqian): enable the following once it's proved to be non-flaky by transition_perf_test.dart.
-      // await driver.waitUntilFirstFrameRasterized();
+      await driver.waitUntilFirstFrameRasterized();
     });
 
     tearDownAll(() async {

--- a/examples/flutter_gallery/test_driver/scroll_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/scroll_perf_test.dart
@@ -14,8 +14,7 @@ void main() {
     setUpAll(() async {
       driver = await FlutterDriver.connect();
 
-      // TODO(liyuqian): enable the following once it's proved to be non-flaky by transition_perf_test.dart.
-      // await driver.waitUntilFirstFrameRasterized();
+      await driver.waitUntilFirstFrameRasterized();
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
The transition_perf test is no longer flaky.