### PR TITLE
Make some methods on ProgressIndicator public

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -92,8 +92,8 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@endtemplate}
   final String semanticsValue;
 
-  Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
-  Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
+  Color getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
+  Color getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -101,7 +101,7 @@ abstract class ProgressIndicator extends StatefulWidget {
     properties.add(PercentProperty('value', value, showName: false, ifNull: '<indeterminate>'));
   }
 
-  Widget _buildSemanticsWrapper({
+  Widget buildSemanticsWrapper({
     @required BuildContext context,
     @required Widget child,
   }) {
@@ -281,7 +281,7 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
   }
 
   Widget _buildIndicator(BuildContext context, double animationValue, TextDirection textDirection) {
-    return widget._buildSemanticsWrapper(
+    return widget.buildSemanticsWrapper(
       context: context,
       child: Container(
         constraints: const BoxConstraints(
@@ -290,8 +290,8 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
         ),
         child: CustomPaint(
           painter: _LinearProgressIndicatorPainter(
-            backgroundColor: widget._getBackgroundColor(context),
-            valueColor: widget._getValueColor(context),
+            backgroundColor: widget.getBackgroundColor(context),
+            valueColor: widget.getValueColor(context),
             value: widget.value, // may be null
             animationValue: animationValue, // ignored if widget.value is not null
             textDirection: textDirection,
@@ -483,7 +483,7 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> w
   }
 
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
-    return widget._buildSemanticsWrapper(
+    return widget.buildSemanticsWrapper(
       context: context,
       child: Container(
         constraints: const BoxConstraints(
@@ -493,7 +493,7 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> w
         child: CustomPaint(
           painter: _CircularProgressIndicatorPainter(
             backgroundColor: widget.backgroundColor,
-            valueColor: widget._getValueColor(context),
+            valueColor: widget.getValueColor(context),
             value: widget.value, // may be null
             headValue: headValue, // remaining arguments are ignored if widget.value is not null
             tailValue: tailValue,
@@ -647,7 +647,7 @@ class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
   @override
   Widget _buildIndicator(BuildContext context, double headValue, double tailValue, int stepValue, double rotationValue) {
     final double arrowheadScale = widget.value == null ? 0.0 : (widget.value * 2.0).clamp(0.0, 1.0);
-    return widget._buildSemanticsWrapper(
+    return widget.buildSemanticsWrapper(
       context: context,
       child: Container(
         width: _indicatorSize,
@@ -661,7 +661,7 @@ class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
             padding: const EdgeInsets.all(12.0),
             child: CustomPaint(
               painter: _RefreshProgressIndicatorPainter(
-                valueColor: widget._getValueColor(context),
+                valueColor: widget.getValueColor(context),
                 value: null, // Draw the indeterminate progress indicator.
                 headValue: headValue,
                 tailValue: tailValue,


### PR DESCRIPTION
## Description

I'm trying to write a custom extension of ProgressIndicator, and my XProgressIndicatorPainter needs to call these methods from outside the library. I can't add @protected because it's the Painter, not the child ProgressIndicator which calls these. I think there are some larger changes we could make which would make this easier for people to extend into custom progress indicators, but this is the most obvious blocker.

If ProgressIndicator is not meant to be extended outside the library, we should instead make it a private class.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing. (Made this change through github UI, didn't run them)
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR. (Made this change through github UI, didn't run)
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
