### PR TITLE
Return WidgetSpans from getSpanForPosition

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -442,8 +442,14 @@ class RenderParagraph extends RenderBox
     _layoutTextWithConstraints(constraints);
     final Offset offset = entry.localPosition;
     final TextPosition position = _textPainter.getPositionForOffset(offset);
-    final TextSpan span = _textPainter.text.getSpanForPosition(position);
-    span?.recognizer?.addPointer(event);
+    final InlineSpan span = _textPainter.text.getSpanForPosition(position);
+    if (span == null) {
+      return;
+    }
+    if (span is TextSpan) {
+      final TextSpan textSpan = span;
+      textSpan.recognizer?.addPointer(event);
+    }
   }
 
   bool _needsClipping = false;

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -128,6 +128,10 @@ class WidgetSpan extends PlaceholderSpan {
 
   @override
   InlineSpan getSpanForPositionVisitor(TextPosition position, Accumulator offset) {
+    if (position.offset == offset.value) {
+      return this;
+    }
+    offset.increment(1);
     return null;
   }
 

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -229,9 +229,9 @@ void main() {
       ],
     );
 
-    expect(textSpan.getSpanForPosition(TextPosition(offset: 0)).runtimeType, TextSpan);
-    expect(textSpan.getSpanForPosition(TextPosition(offset: 1)).runtimeType, TextSpan);
-    expect(textSpan.getSpanForPosition(TextPosition(offset: 2)).runtimeType, WidgetSpan);
-    expect(textSpan.getSpanForPosition(TextPosition(offset: 3)).runtimeType, TextSpan);
+    expect(textSpan.getSpanForPosition(const TextPosition(offset: 0)).runtimeType, TextSpan);
+    expect(textSpan.getSpanForPosition(const TextPosition(offset: 1)).runtimeType, TextSpan);
+    expect(textSpan.getSpanForPosition(const TextPosition(offset: 2)).runtimeType, WidgetSpan);
+    expect(textSpan.getSpanForPosition(const TextPosition(offset: 3)).runtimeType, TextSpan);
   });
 }

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -209,4 +209,29 @@ void main() {
     expect(textSpan1.compareTo(textSpan1), RenderComparison.identical);
     expect(textSpan2.compareTo(textSpan2), RenderComparison.identical);
   });
+
+  test('GetSpanForPosition with WidgetSpan', () {
+    const TextSpan textSpan = TextSpan(
+      text: 'a',
+      children: <InlineSpan>[
+        TextSpan(text: 'b'),
+        WidgetSpan(
+          child: Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                WidgetSpan(child: SizedBox(width: 10, height: 10)),
+                TextSpan(text: 'The sky is falling :)'),
+              ],
+            ),
+          ),
+        ),
+        TextSpan(text: 'c'),
+      ],
+    );
+
+    expect(textSpan.getSpanForPosition(TextPosition(offset: 0)).runtimeType, TextSpan);
+    expect(textSpan.getSpanForPosition(TextPosition(offset: 1)).runtimeType, TextSpan);
+    expect(textSpan.getSpanForPosition(TextPosition(offset: 2)).runtimeType, WidgetSpan);
+    expect(textSpan.getSpanForPosition(TextPosition(offset: 3)).runtimeType, TextSpan);
+  });
 }


### PR DESCRIPTION
Properly return `WidgetSpan`s from `getSpanForPosition`.

Fixes https://github.com/flutter/flutter/issues/36806