### PR TITLE
Allow sending platform messages from plugins to the framework and implement EventChannel

### DIFF
--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -3,3 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/plugin_registry.dart';
+export 'src/plugin_event_channel.dart';

--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/plugin_registry.dart';
 export 'src/plugin_event_channel.dart';
+export 'src/plugin_registry.dart';

--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import 'plugin_registry.dart';
+
+/// A named channel for sending events to the framework-side using streams.
+///
+/// This is the platform-side equivalent of [EventChannel]. Whereas
+/// [EventChannel] receives a stream of events from platform plugins, this
+/// channel sends a stream of events to the handler listening on the
+/// framework-side.
+class PluginEventChannel {
+  PluginEventChannel(
+    this.name, [
+    this.codec = const StandardMethodCodec(),
+    BinaryMessenger binaryMessenger,
+  ])  : assert(name != null),
+        assert(codec != null),
+        _binaryMessenger = binaryMessenger;
+
+  /// The logical channel on which communication happens, not null.
+  final String name;
+
+  /// The message codec used by this channel, not null.
+  final MethodCodec codec;
+
+  /// The messenger used by this channel to send platform messages, not null.
+  BinaryMessenger get binaryMessenger =>
+      _binaryMessenger ?? pluginBinaryMessenger;
+  final BinaryMessenger _binaryMessenger;
+
+  /// Set the stream controller for this event channel.
+  set controller(StreamController controller) {
+    final _EventChannelHandler handler = _EventChannelHandler(
+      name,
+      codec,
+      controller,
+      binaryMessenger,
+    );
+    binaryMessenger.setMessageHandler(
+        name, controller == null ? null : handler.handle);
+  }
+}
+
+class _EventChannelHandler {
+  _EventChannelHandler(this.name, this.codec, this.controller, this.messenger);
+
+  final String name;
+  final MethodCodec codec;
+  final StreamController controller;
+  final BinaryMessenger messenger;
+
+  StreamSubscription subscription;
+
+  Future<ByteData> handle(ByteData message) {
+    final MethodCall call = codec.decodeMethodCall(message);
+    switch (call.method) {
+      case 'listen':
+        return _listen();
+      case 'cancel':
+        return _cancel();
+    }
+    return null;
+  }
+
+  // TODO(hterkelsen): Support arguments.
+  Future<ByteData> _listen() async {
+    if (subscription != null) {
+      await subscription.cancel();
+    }
+    subscription = controller.stream.listen((dynamic event) {
+      messenger.send(name, codec.encodeSuccessEnvelope(event));
+    }, onError: (dynamic error) {
+      messenger.send(name,
+          codec.encodeErrorEnvelope(code: 'error', message: error.toString()));
+    });
+
+    return codec.encodeSuccessEnvelope(null);
+  }
+
+  // TODO(hterkelsen): Support arguments.
+  Future<ByteData> _cancel() async {
+    if (subscription == null) {
+      return codec.encodeErrorEnvelope(
+          code: 'error', message: 'No active stream to cancel.');
+    }
+    await subscription.cancel();
+    subscription = null;
+    return codec.encodeSuccessEnvelope(null);
+  }
+}

--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -10,8 +10,9 @@ import 'plugin_registry.dart';
 /// [EventChannel] receives a stream of events from platform plugins, this
 /// channel sends a stream of events to the handler listening on the
 /// framework-side.
-class PluginEventChannel {
-  PluginEventChannel(
+class PluginEventChannel<T> {
+  /// Creates a new plugin event channel.
+  const PluginEventChannel(
     this.name, [
     this.codec = const StandardMethodCodec(),
     BinaryMessenger binaryMessenger,
@@ -31,8 +32,8 @@ class PluginEventChannel {
   final BinaryMessenger _binaryMessenger;
 
   /// Set the stream controller for this event channel.
-  set controller(StreamController controller) {
-    final _EventChannelHandler handler = _EventChannelHandler(
+  set controller(StreamController<T> controller) {
+    final _EventChannelHandler<T> handler = _EventChannelHandler<T>(
       name,
       codec,
       controller,
@@ -43,15 +44,15 @@ class PluginEventChannel {
   }
 }
 
-class _EventChannelHandler {
+class _EventChannelHandler<T> {
   _EventChannelHandler(this.name, this.codec, this.controller, this.messenger);
 
   final String name;
   final MethodCodec codec;
-  final StreamController controller;
+  final StreamController<T> controller;
   final BinaryMessenger messenger;
 
-  StreamSubscription subscription;
+  StreamSubscription<T> subscription;
 
   Future<ByteData> handle(ByteData message) {
     final MethodCall call = codec.decodeMethodCall(message);

--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -1,3 +1,7 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:flutter/services.dart';
@@ -10,6 +14,11 @@ import 'plugin_registry.dart';
 /// [EventChannel] receives a stream of events from platform plugins, this
 /// channel sends a stream of events to the handler listening on the
 /// framework-side.
+///
+/// The channel [name] must not be null. If no [codec] is provided, then
+/// [StandardMethodCodec] is used. If no [binaryMessenger] is provided, then
+/// [pluginBinaryMessenger], which sends messages to the framework-side,
+/// is used.
 class PluginEventChannel<T> {
   /// Creates a new plugin event channel.
   const PluginEventChannel(
@@ -20,13 +29,21 @@ class PluginEventChannel<T> {
         assert(codec != null),
         _binaryMessenger = binaryMessenger;
 
-  /// The logical channel on which communication happens, not null.
+  /// The logical channel on which communication happens.
+  ///
+  /// This must not be null.
   final String name;
 
-  /// The message codec used by this channel, not null.
+  /// The message codec used by this channel.
+  ///
+  /// This must not be null. This defaults to [StandardMethodCodec].
   final MethodCodec codec;
 
-  /// The messenger used by this channel to send platform messages, not null.
+  /// The messenger used by this channel to send platform messages.
+  ///
+  /// This must not be null. If not provided, defaults to
+  /// [pluginBinaryMessenger], which sends messages from the platform-side
+  /// to the framework-side.
   BinaryMessenger get binaryMessenger =>
       _binaryMessenger ?? pluginBinaryMessenger;
   final BinaryMessenger _binaryMessenger;

--- a/packages/flutter_web_plugins/lib/src/plugin_registry.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_registry.dart
@@ -96,8 +96,20 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
   /// Sends a platform message from the platform side back to the framework.
   @override
   Future<ByteData> send(String channel, ByteData message) {
-    throw FlutterError(
-        'Cannot send messages from the platform side to the framework.');
+    final Completer<ByteData> completer = Completer<ByteData>();
+    ui.window.onPlatformMessage(channel, message, (ByteData reply) {
+      try {
+        completer.complete(reply);
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'flutter web shell',
+          context: ErrorDescription('during a plugin-to-framework message'),
+        ));
+      }
+    });
+    return completer.future;
   }
 
   @override

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -5,9 +5,7 @@
 @TestOn('chrome') // Uses web-only Flutter SDK
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -38,10 +36,11 @@ void main() {
     });
 
     test('can send events to an $EventChannel', () async {
-      EventChannel listeningChannel = EventChannel('test');
-      PluginEventChannel sendingChannel = PluginEventChannel('test');
+      const EventChannel listeningChannel = EventChannel('test');
+      const PluginEventChannel<String> sendingChannel =
+          PluginEventChannel<String>('test');
 
-      StreamController<String> controller = StreamController();
+      final StreamController<String> controller = StreamController<String>();
       sendingChannel.controller = controller;
 
       expect(listeningChannel.receiveBroadcastStream(),
@@ -53,10 +52,11 @@ void main() {
     });
 
     test('can send errors to an $EventChannel', () async {
-      EventChannel listeningChannel = EventChannel('test2');
-      PluginEventChannel sendingChannel = PluginEventChannel('test2');
+      const EventChannel listeningChannel = EventChannel('test2');
+      const PluginEventChannel<String> sendingChannel =
+          PluginEventChannel<String>('test2');
 
-      StreamController<String> controller = StreamController();
+      final StreamController<String> controller = StreamController<String>();
       sendingChannel.controller = controller;
 
       expect(
@@ -69,11 +69,12 @@ void main() {
     });
 
     test('receives a listen event', () async {
-      EventChannel listeningChannel = EventChannel('test3');
-      PluginEventChannel sendingChannel = PluginEventChannel('test3');
+      const EventChannel listeningChannel = EventChannel('test3');
+      const PluginEventChannel<String> sendingChannel =
+          PluginEventChannel<String>('test3');
 
-      StreamController<String> controller =
-          StreamController(onListen: expectAsync0<void>(() {}, count: 1));
+      final StreamController<String> controller = StreamController<String>(
+          onListen: expectAsync0<void>(() {}, count: 1));
       sendingChannel.controller = controller;
 
       expect(listeningChannel.receiveBroadcastStream(),
@@ -84,16 +85,19 @@ void main() {
     });
 
     test('receives a cancel event', () async {
-      EventChannel listeningChannel = EventChannel('test4');
-      PluginEventChannel sendingChannel = PluginEventChannel('test4');
+      const EventChannel listeningChannel = EventChannel('test4');
+      const PluginEventChannel<String> sendingChannel =
+          PluginEventChannel<String>('test4');
 
-      StreamController<String> controller =
-          StreamController(onCancel: expectAsync0<void>(() {}));
+      final StreamController<String> controller =
+          StreamController<String>(onCancel: expectAsync0<void>(() {}));
       sendingChannel.controller = controller;
 
-      final Stream eventStream = listeningChannel.receiveBroadcastStream();
-      StreamSubscription subscription;
-      subscription = eventStream.listen(expectAsync1<void, dynamic>((dynamic x) {
+      final Stream<dynamic> eventStream =
+          listeningChannel.receiveBroadcastStream();
+      StreamSubscription<dynamic> subscription;
+      subscription =
+          eventStream.listen(expectAsync1<void, dynamic>((dynamic x) {
         expect(x, equals('hello'));
         subscription.cancel();
       }));

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -1,0 +1,104 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('chrome') // Uses web-only Flutter SDK
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+class TestPlugin {
+  static void registerWith(Registrar registrar) {
+    final MethodChannel channel = MethodChannel(
+      'test_plugin',
+      const StandardMethodCodec(),
+      registrar.messenger,
+    );
+    final TestPlugin testPlugin = TestPlugin();
+    channel.setMethodCallHandler(testPlugin.handleMethodCall);
+  }
+
+  static final List<String> calledMethods = <String>[];
+
+  Future<void> handleMethodCall(MethodCall call) async {
+    calledMethods.add(call.method);
+  }
+}
+
+void main() {
+  group('Plugin Event Channel', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      webPluginRegistry.registerMessageHandler();
+    });
+
+    test('can send events to an $EventChannel', () async {
+      EventChannel listeningChannel = EventChannel('test');
+      PluginEventChannel sendingChannel = PluginEventChannel('test');
+
+      StreamController<String> controller = StreamController();
+      sendingChannel.controller = controller;
+
+      expect(listeningChannel.receiveBroadcastStream(),
+          emitsInOrder(<String>['hello', 'world']));
+
+      controller.add('hello');
+      controller.add('world');
+      await controller.close();
+    });
+
+    test('can send errors to an $EventChannel', () async {
+      EventChannel listeningChannel = EventChannel('test2');
+      PluginEventChannel sendingChannel = PluginEventChannel('test2');
+
+      StreamController<String> controller = StreamController();
+      sendingChannel.controller = controller;
+
+      expect(
+          listeningChannel.receiveBroadcastStream(),
+          emitsError(predicate<dynamic>((dynamic e) =>
+              e is PlatformException && e.message == 'Test error')));
+
+      controller.addError('Test error');
+      await controller.close();
+    });
+
+    test('receives a listen event', () async {
+      EventChannel listeningChannel = EventChannel('test3');
+      PluginEventChannel sendingChannel = PluginEventChannel('test3');
+
+      StreamController<String> controller =
+          StreamController(onListen: expectAsync0<void>(() {}, count: 1));
+      sendingChannel.controller = controller;
+
+      expect(listeningChannel.receiveBroadcastStream(),
+          emitsInOrder(<String>['hello']));
+
+      controller.add('hello');
+      await controller.close();
+    });
+
+    test('receives a cancel event', () async {
+      EventChannel listeningChannel = EventChannel('test4');
+      PluginEventChannel sendingChannel = PluginEventChannel('test4');
+
+      StreamController<String> controller =
+          StreamController(onCancel: expectAsync0<void>(() {}));
+      sendingChannel.controller = controller;
+
+      final Stream eventStream = listeningChannel.receiveBroadcastStream();
+      StreamSubscription subscription;
+      subscription = eventStream.listen(expectAsync1<void, dynamic>((dynamic x) {
+        expect(x, equals('hello'));
+        subscription.cancel();
+      }));
+
+      controller.add('hello');
+    });
+  });
+}

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -10,24 +10,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-class TestPlugin {
-  static void registerWith(Registrar registrar) {
-    final MethodChannel channel = MethodChannel(
-      'test_plugin',
-      const StandardMethodCodec(),
-      registrar.messenger,
-    );
-    final TestPlugin testPlugin = TestPlugin();
-    channel.setMethodCallHandler(testPlugin.handleMethodCall);
-  }
-
-  static final List<String> calledMethods = <String>[];
-
-  Future<void> handleMethodCall(MethodCall call) async {
-    calledMethods.add(call.method);
-  }
-}
-
 void main() {
   group('Plugin Event Channel', () {
     setUp(() {

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -4,6 +4,8 @@
 
 @TestOn('chrome') // Uses web-only Flutter SDK
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -31,13 +33,12 @@ void main() {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
       webPluginRegistry.registerMessageHandler();
-    });
-
-    test('Can register a plugin', () {
-      TestPlugin.calledMethods.clear();
-
       final Registrar registrar = webPluginRegistry.registrarFor(TestPlugin);
       TestPlugin.registerWith(registrar);
+    });
+
+    test('can register a plugin', () {
+      TestPlugin.calledMethods.clear();
 
       const MethodChannel frameworkChannel =
           MethodChannel('test_plugin', StandardMethodCodec());
@@ -46,12 +47,15 @@ void main() {
       expect(TestPlugin.calledMethods, <String>['test1']);
     });
 
-    test('Throws when trying to send a platform message to the framework', () {
+    test('can send a message from the plugin to the framework', () {
+    });
+
+    test('throws when trying to send a platform message to the framework', () {
       expect(() => pluginBinaryMessenger.send('test', ByteData(0)),
           throwsFlutterError);
     });
 
-    test('Throws when trying to set a mock handler', () {
+    test('throws when trying to set a mock handler', () {
       expect(
           () => pluginBinaryMessenger.setMockMessageHandler(
               'test', (ByteData data) async => ByteData(0)),

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -4,8 +4,6 @@
 
 @TestOn('chrome') // Uses web-only Flutter SDK
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -44,7 +42,7 @@ void main() {
           MethodChannel('test_plugin', StandardMethodCodec());
       frameworkChannel.invokeMethod<void>('test1');
 
-      expect(TestPlugin.calledMethods, equals(['test1']));
+      expect(TestPlugin.calledMethods, equals(<String>['test1']));
     });
 
     test('can send a message from the plugin to the framework', () async {
@@ -54,15 +52,16 @@ void main() {
       ServicesBinding.instance.defaultBinaryMessenger
           .setMessageHandler('test_send', (ByteData data) {
         loggedMessages.add(codec.decodeMessage(data));
+        return null;
       });
 
       await pluginBinaryMessenger.send(
           'test_send', codec.encodeMessage('hello'));
-      expect(loggedMessages, equals(['hello']));
+      expect(loggedMessages, equals(<String>['hello']));
 
       await pluginBinaryMessenger.send(
           'test_send', codec.encodeMessage('world'));
-      expect(loggedMessages, equals(['hello', 'world']));
+      expect(loggedMessages, equals(<String>['hello', 'world']));
 
       ServicesBinding.instance.defaultBinaryMessenger
           .setMessageHandler('test_send', null);

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -44,15 +44,28 @@ void main() {
           MethodChannel('test_plugin', StandardMethodCodec());
       frameworkChannel.invokeMethod<void>('test1');
 
-      expect(TestPlugin.calledMethods, <String>['test1']);
+      expect(TestPlugin.calledMethods, equals(['test1']));
     });
 
-    test('can send a message from the plugin to the framework', () {
-    });
+    test('can send a message from the plugin to the framework', () async {
+      const StandardMessageCodec codec = StandardMessageCodec();
 
-    test('throws when trying to send a platform message to the framework', () {
-      expect(() => pluginBinaryMessenger.send('test', ByteData(0)),
-          throwsFlutterError);
+      final List<String> loggedMessages = <String>[];
+      ServicesBinding.instance.defaultBinaryMessenger
+          .setMessageHandler('test_send', (ByteData data) {
+        loggedMessages.add(codec.decodeMessage(data));
+      });
+
+      await pluginBinaryMessenger.send(
+          'test_send', codec.encodeMessage('hello'));
+      expect(loggedMessages, equals(['hello']));
+
+      await pluginBinaryMessenger.send(
+          'test_send', codec.encodeMessage('world'));
+      expect(loggedMessages, equals(['hello', 'world']));
+
+      ServicesBinding.instance.defaultBinaryMessenger
+          .setMessageHandler('test_send', null);
     });
 
     test('throws when trying to set a mock handler', () {


### PR DESCRIPTION
## Description

Allows sending platform messages from the plugin side to the framework side. Also adds `PluginEventChannel` to support `EventChannel` in web plugins.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39981

## Tests

I added the following tests:

Added `plugin_event_channel_test.dart` which tests `PluginEventChannel` and added a simple test to `plugin_registry_test.dart` which tests that basic send events work.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
