### PR TITLE
Extract some onPress methods

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -64,75 +64,19 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
                     children: <Widget>[
                       CupertinoButton.filled(
                         child: const Text('Alert'),
-                        onPressed: () {
-                          showDemoDialog(
-                            context: context,
-                            child: CupertinoAlertDialog(
-                              title: const Text('Discard draft?'),
-                              actions: <Widget>[
-                                CupertinoDialogAction(
-                                  child: const Text('Discard'),
-                                  isDestructiveAction: true,
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Discard');
-                                  },
-                                ),
-                                CupertinoDialogAction(
-                                  child: const Text('Cancel'),
-                                  isDefaultAction: true,
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Cancel');
-                                  },
-                                ),
-                              ],
-                            ),
-                          );
-                        },
+                        onPressed: () => _onAlertPress(context),
                       ),
                       const Padding(padding: EdgeInsets.all(8.0)),
                       CupertinoButton.filled(
                         child: const Text('Alert with Title'),
                         padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 36.0),
-                        onPressed: () {
-                          showDemoDialog(
-                            context: context,
-                            child: CupertinoAlertDialog(
-                              title: const Text('Allow "Maps" to access your location while you are using the app?'),
-                              content: const Text('Your current location will be displayed on the map and used '
-                                'for directions, nearby search results, and estimated travel times.'),
-                              actions: <Widget>[
-                                CupertinoDialogAction(
-                                  child: const Text('Don\'t Allow'),
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Disallow');
-                                  },
-                                ),
-                                CupertinoDialogAction(
-                                  child: const Text('Allow'),
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Allow');
-                                  },
-                                ),
-                              ],
-                            ),
-                          );
-                        },
+                        onPressed: () => _onAlertWithTitlePress(context),
                       ),
                       const Padding(padding: EdgeInsets.all(8.0)),
                       CupertinoButton.filled(
                         child: const Text('Alert with Buttons'),
                         padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 36.0),
-                        onPressed: () {
-                          showDemoDialog(
-                            context: context,
-                            child: const CupertinoDessertDialog(
-                              title: Text('Select Favorite Dessert'),
-                              content: Text('Please select your favorite type of dessert from the '
-                                'list below. Your selection will be used to customize the suggested '
-                                'list of eateries in your area.'),
-                            ),
-                          );
-                        },
+                        onPressed: () => _onAlertWithButtonsPress(context),
                       ),
                       const Padding(padding: EdgeInsets.all(8.0)),
                       CupertinoButton.filled(
@@ -149,42 +93,7 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
                       CupertinoButton.filled(
                         child: const Text('Action Sheet'),
                         padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 36.0),
-                        onPressed: () {
-                          showDemoActionSheet(
-                            context: context,
-                            child: CupertinoActionSheet(
-                              title: const Text('Favorite Dessert'),
-                              message: const Text('Please select the best dessert from the options below.'),
-                              actions: <Widget>[
-                                CupertinoActionSheetAction(
-                                  child: const Text('Profiteroles'),
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Profiteroles');
-                                  },
-                                ),
-                                CupertinoActionSheetAction(
-                                  child: const Text('Cannolis'),
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Cannolis');
-                                  },
-                                ),
-                                CupertinoActionSheetAction(
-                                  child: const Text('Trifle'),
-                                  onPressed: () {
-                                    Navigator.pop(context, 'Trifle');
-                                  },
-                                ),
-                              ],
-                              cancelButton: CupertinoActionSheetAction(
-                                child: const Text('Cancel'),
-                                isDefaultAction: true,
-                                onPressed: () {
-                                  Navigator.pop(context, 'Cancel');
-                                },
-                              ),
-                            ),
-                          );
-                        },
+                        onPressed: () => _onActionSheetPress(context),
                       ),
                     ],
                   ),
@@ -196,6 +105,105 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
                   ),
               ],
             );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _onAlertPress(BuildContext context) {
+    showDemoDialog(
+      context: context,
+      child: CupertinoAlertDialog(
+        title: const Text('Discard draft?'),
+        actions: <Widget>[
+          CupertinoDialogAction(
+            child: const Text('Discard'),
+            isDestructiveAction: true,
+            onPressed: () {
+              Navigator.pop(context, 'Discard');
+            },
+          ),
+          CupertinoDialogAction(
+            child: const Text('Cancel'),
+            isDefaultAction: true,
+            onPressed: () {
+              Navigator.pop(context, 'Cancel');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onAlertWithTitlePress(BuildContext context) {
+    showDemoDialog(
+      context: context,
+      child: CupertinoAlertDialog(
+        title: const Text('Allow "Maps" to access your location while you are using the app?'),
+        content: const Text('Your current location will be displayed on the map and used '
+          'for directions, nearby search results, and estimated travel times.'),
+        actions: <Widget>[
+          CupertinoDialogAction(
+            child: const Text('Don\'t Allow'),
+            onPressed: () {
+              Navigator.pop(context, 'Disallow');
+            },
+          ),
+          CupertinoDialogAction(
+            child: const Text('Allow'),
+            onPressed: () {
+              Navigator.pop(context, 'Allow');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onAlertWithButtonsPress(BuildContext context) {
+    showDemoDialog(
+      context: context,
+      child: const CupertinoDessertDialog(
+        title: Text('Select Favorite Dessert'),
+        content: Text('Please select your favorite type of dessert from the '
+          'list below. Your selection will be used to customize the suggested '
+          'list of eateries in your area.'),
+      ),
+    );
+  }
+
+  void _onActionSheetPress(BuildContext context)  {
+    showDemoActionSheet(
+      context: context,
+      child: CupertinoActionSheet(
+        title: const Text('Favorite Dessert'),
+        message: const Text('Please select the best dessert from the options below.'),
+        actions: <Widget>[
+          CupertinoActionSheetAction(
+            child: const Text('Profiteroles'),
+            onPressed: () {
+              Navigator.pop(context, 'Profiteroles');
+            },
+          ),
+          CupertinoActionSheetAction(
+            child: const Text('Cannolis'),
+            onPressed: () {
+              Navigator.pop(context, 'Cannolis');
+            },
+          ),
+          CupertinoActionSheetAction(
+            child: const Text('Trifle'),
+            onPressed: () {
+              Navigator.pop(context, 'Trifle');
+            },
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          child: const Text('Cancel'),
+          isDefaultAction: true,
+          onPressed: () {
+            Navigator.pop(context, 'Cancel');
           },
         ),
       ),

--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -120,16 +120,12 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
           CupertinoDialogAction(
             child: const Text('Discard'),
             isDestructiveAction: true,
-            onPressed: () {
-              Navigator.pop(context, 'Discard');
-            },
+            onPressed: () => Navigator.pop(context, 'Discard'),
           ),
           CupertinoDialogAction(
             child: const Text('Cancel'),
             isDefaultAction: true,
-            onPressed: () {
-              Navigator.pop(context, 'Cancel');
-            },
+            onPressed: () => Navigator.pop(context, 'Cancel'),
           ),
         ],
       ),
@@ -146,15 +142,11 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
         actions: <Widget>[
           CupertinoDialogAction(
             child: const Text('Don\'t Allow'),
-            onPressed: () {
-              Navigator.pop(context, 'Disallow');
-            },
+            onPressed: () => Navigator.pop(context, 'Disallow'),
           ),
           CupertinoDialogAction(
             child: const Text('Allow'),
-            onPressed: () {
-              Navigator.pop(context, 'Allow');
-            },
+            onPressed: () => Navigator.pop(context, 'Allow'),
           ),
         ],
       ),
@@ -182,29 +174,21 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
         actions: <Widget>[
           CupertinoActionSheetAction(
             child: const Text('Profiteroles'),
-            onPressed: () {
-              Navigator.pop(context, 'Profiteroles');
-            },
+            onPressed: () => Navigator.pop(context, 'Profiteroles'),
           ),
           CupertinoActionSheetAction(
             child: const Text('Cannolis'),
-            onPressed: () {
-              Navigator.pop(context, 'Cannolis');
-            },
+            onPressed: () => Navigator.pop(context, 'Cannolis'),
           ),
           CupertinoActionSheetAction(
             child: const Text('Trifle'),
-            onPressed: () {
-              Navigator.pop(context, 'Trifle');
-            },
+            onPressed: () => Navigator.pop(context, 'Trifle'),
           ),
         ],
         cancelButton: CupertinoActionSheetAction(
           child: const Text('Cancel'),
           isDefaultAction: true,
-          onPressed: () {
-            Navigator.pop(context, 'Cancel');
-          },
+          onPressed: () => Navigator.pop(context, 'Cancel'),
         ),
       ),
     );


### PR DESCRIPTION
## Description

Refactor Widget tree in `examples/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart` to be shorter by moving `onPress` callback in their own methods.

## Related Issues

https://github.com/flutter/flutter/pull/35516#discussion_r302648476

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
