### PR TITLE
CupertinoPageScaffold dark mode

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
+import 'colors.dart';
 import 'constants.dart';
 import 'icons.dart';
 import 'page_scaffold.dart';
@@ -371,7 +372,11 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
 
   /// True if the navigation bar's background color has no transparency.
   @override
-  bool get fullObstruction => backgroundColor == null ? null : backgroundColor.alpha == 0xFF;
+  bool shouldFullyObstruct(BuildContext context) {
+    final Color backgroundColor = CupertinoDynamicColor.resolve(this.backgroundColor, context)
+                               ?? CupertinoTheme.of(context).barBackgroundColor;
+    return backgroundColor.alpha == 0xFF;
+  }
 
   @override
   Size get preferredSize {

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'theme.dart';
 
 /// Implements a single iOS application page's layout.
@@ -112,8 +113,7 @@ class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {
           ? existingMediaQuery.viewInsets.copyWith(bottom: 0.0)
           : existingMediaQuery.viewInsets;
 
-      final bool fullObstruction =
-        widget.navigationBar.fullObstruction ?? CupertinoTheme.of(context).barBackgroundColor.alpha == 0xFF;
+      final bool fullObstruction = widget.navigationBar.shouldFullyObstruct(context);
 
       // If navigation bar is opaquely obstructing, directly shift the main content
       // down. If translucent, let main content draw behind navigation bar but hint the
@@ -191,7 +191,8 @@ class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {
 
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: widget.backgroundColor ?? CupertinoTheme.of(context).scaffoldBackgroundColor,
+        color: CupertinoDynamicColor.resolve(widget.backgroundColor, context)
+            ?? CupertinoTheme.of(context).scaffoldBackgroundColor,
       ),
       child: Stack(
         children: stacked,
@@ -210,5 +211,5 @@ abstract class ObstructingPreferredSizeWidget extends PreferredSizeWidget {
   /// size.
   ///
   /// If false, this widget partially obstructs.
-  bool get fullObstruction;
+  bool shouldFullyObstruct(BuildContext context);
 }

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../painting/mocks_for_image_cache.dart';
+import '../rendering/mock_canvas.dart';
 
 /// Integration tests testing both [CupertinoPageScaffold] and [CupertinoTabScaffold].
 void main() {
@@ -51,6 +52,72 @@ void main() {
     // it's pushed down by the opaque navigation bar whose height is 44 px,
     // and the 20 px [MediaQuery] top padding is fully absorbed by the navigation bar.
     expect(tester.getRect(find.byType(Container)), const Rect.fromLTRB(0, 44, 800, 600));
+  });
+
+  testWidgets('dark mode and obstruction work', (WidgetTester tester) async {
+    const Color dynamicColor = CupertinoDynamicColor.withBrightness(
+      color: Color(0xFFF8F8F8),
+      darkColor: Color(0xEE333333),
+    );
+
+    const CupertinoDynamicColor backgroundColor = CupertinoDynamicColor.withBrightness(
+      color: Color(0xFFFFFFFF),
+      darkColor: Color(0xFF000000),
+    );
+
+    BuildContext childContext;
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          platformBrightness: Brightness.light,
+          viewInsets: EdgeInsets.only(top: 20),
+        ),
+        child: CupertinoPageScaffold(
+          backgroundColor: backgroundColor,
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+            backgroundColor: dynamicColor,
+          ),
+          child: Builder(
+            builder: (BuildContext context) {
+              childContext = context;
+              return Container();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(MediaQuery.of(childContext).padding.top, 0);
+    expect(find.byType(CupertinoPageScaffold), paints..rect(color: backgroundColor.color));
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          platformBrightness: Brightness.dark,
+          viewInsets: EdgeInsets.only(top: 20),
+        ),
+        child: CupertinoPageScaffold(
+          backgroundColor: backgroundColor,
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+            backgroundColor: dynamicColor,
+          ),
+          child: Builder(
+            builder: (BuildContext context) {
+              childContext = context;
+              return Container();
+            },
+          ),
+        ),
+      ),
+    ));
+
+
+    expect(MediaQuery.of(childContext).padding.top, greaterThan(0));
+    expect(find.byType(CupertinoPageScaffold), paints..rect(color: backgroundColor.darkColor));
   });
 
   testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -66,55 +66,36 @@ void main() {
     );
 
     BuildContext childContext;
-    await tester.pumpWidget(Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(
-          platformBrightness: Brightness.light,
-          viewInsets: EdgeInsets.only(top: 20),
-        ),
-        child: CupertinoPageScaffold(
-          backgroundColor: backgroundColor,
-          navigationBar: const CupertinoNavigationBar(
-            middle: Text('Title'),
-            backgroundColor: dynamicColor,
+    Widget scaffoldWithBrightness(Brightness brightness) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData(
+            platformBrightness: brightness,
+            viewInsets: const EdgeInsets.only(top: 20),
           ),
-          child: Builder(
-            builder: (BuildContext context) {
-              childContext = context;
-              return Container();
-            },
+          child: CupertinoPageScaffold(
+            backgroundColor: backgroundColor,
+            navigationBar: const CupertinoNavigationBar(
+              middle: Text('Title'),
+              backgroundColor: dynamicColor,
+            ),
+            child: Builder(
+              builder: (BuildContext context) {
+                childContext = context;
+                return Container();
+              },
+            ),
           ),
         ),
-      ),
-    ));
+      );
+    }
+    await tester.pumpWidget(scaffoldWithBrightness(Brightness.light));
 
     expect(MediaQuery.of(childContext).padding.top, 0);
     expect(find.byType(CupertinoPageScaffold), paints..rect(color: backgroundColor.color));
 
-    await tester.pumpWidget(Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(
-          platformBrightness: Brightness.dark,
-          viewInsets: EdgeInsets.only(top: 20),
-        ),
-        child: CupertinoPageScaffold(
-          backgroundColor: backgroundColor,
-          navigationBar: const CupertinoNavigationBar(
-            middle: Text('Title'),
-            backgroundColor: dynamicColor,
-          ),
-          child: Builder(
-            builder: (BuildContext context) {
-              childContext = context;
-              return Container();
-            },
-          ),
-        ),
-      ),
-    ));
-
+    await tester.pumpWidget(scaffoldWithBrightness(Brightness.dark));
 
     expect(MediaQuery.of(childContext).padding.top, greaterThan(0));
     expect(find.byType(CupertinoPageScaffold), paints..rect(color: backgroundColor.darkColor));


### PR DESCRIPTION
## Description

minor change but breaks the current API.

## Related Issues

https://github.com/flutter/flutter/issues/35541

## Tests

I added the following tests:

- dark mode and obstruction work

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
