### PR TITLE
Fixed Selectable text align is broken

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -614,7 +614,6 @@ class RenderParagraph extends RenderBox
     // If you remove this call, make sure that changing the textAlign still
     // works properly.
     _layoutTextWithConstraints(constraints);
-
     assert(() {
       if (debugRepaintTextRainbowEnabled) {
         final Paint paint = Paint()

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -614,6 +614,7 @@ class RenderParagraph extends RenderBox
     // If you remove this call, make sure that changing the textAlign still
     // works properly.
     _layoutTextWithConstraints(constraints);
+
     assert(() {
       if (debugRepaintTextRainbowEnabled) {
         final Paint paint = Paint()

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1159,7 +1159,7 @@ void main() {
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
 
-    expect(topLeft.dx, equals(278.0));
+    expect(topLeft.dx, equals(399.0));
   });
 
   testWidgets('Can align to center within center', (WidgetTester tester) async {
@@ -3477,22 +3477,22 @@ void main() {
     Offset topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 4)).topLeft,
     );
-    expect(topLeft.dx, equals(306));
+    expect(topLeft.dx, equals(427));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 3)).topLeft,
     );
-    expect(topLeft.dx, equals(292));
+    expect(topLeft.dx, equals(413));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
-    expect(topLeft.dx, equals(278));
+    expect(topLeft.dx, equals(399));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 1)).topLeft,
     );
-    expect(topLeft.dx, equals(264));
+    expect(topLeft.dx, equals(385));
   });
 
   testWidgets('Caret indexes into trailing whitespace center align', (WidgetTester tester) async {
@@ -3513,33 +3513,32 @@ void main() {
     Offset topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 7)).topLeft,
     );
-    expect(topLeft.dx, equals(362));
+    expect(topLeft.dx, equals(469));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 8)).topLeft,
     );
-    // Caret is capped at text length.
-    expect(topLeft.dx, equals(362));
+    expect(topLeft.dx, equals(483));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 4)).topLeft,
     );
-    expect(topLeft.dx, equals(334));
+    expect(topLeft.dx, equals(427));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 3)).topLeft,
     );
-    expect(topLeft.dx, equals(320));
+    expect(topLeft.dx, equals(413));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
-    expect(topLeft.dx, equals(306));
+    expect(topLeft.dx, equals(399));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 1)).topLeft,
     );
-    expect(topLeft.dx, equals(292));
+    expect(topLeft.dx, equals(385));
   });
 
   testWidgets('selection handles are rendered and not faded away', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

 when forceLine = false, it does not respect the constraint minWidth and always hardcoded it to zero.
This will cause problem when textpaint always tries to use smallest width possible.

This pr makes sure it will use constraint minwidth in case of forceLine = false.



## Related Issues

https://github.com/flutter/flutter/issues/40444

## Tests

I added the following tests:

Existing test should covered

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
