### PR TITLE
Invalidate macOS pods on plugin changes

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -502,10 +502,14 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   final List<Plugin> plugins = findPlugins(project);
   final bool changed = _writeFlutterPluginsList(project, plugins);
   if (changed) {
-    if (checkProjects && !project.ios.existsSync()) {
-      return;
+    if (!checkProjects || project.ios.existsSync()) {
+      cocoaPods.invalidatePodInstallOutput(project.ios);
     }
-    cocoaPods.invalidatePodInstallOutput(project.ios);
+    // TODO(stuartmorgan): Potentially add checkProjects once a decision has
+    // made about how to handle macOS in existing projects.
+    if (project.macos.existsSync()) {
+      cocoaPods.invalidatePodInstallOutput(project.macos);
+    }
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -11,7 +11,6 @@ import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import 'project_test.dart';
 
 class MockFlutterProject extends Mock implements FlutterProject {}
 class MockIosProject extends Mock implements IosProject {}
@@ -66,7 +65,7 @@ flutter:
   group('refreshPlugins', () {
     testUsingContext('Refreshing the plugin list is a no-op when the plugins list stays empty', () {
       refreshPluginsList(flutterProject);
-      expectNotExists(flutterProject.flutterPluginsFile);
+      expect(flutterProject.flutterPluginsFile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
@@ -76,7 +75,7 @@ flutter:
       when(iosProject.existsSync()).thenReturn(false);
       when(macosProject.existsSync()).thenReturn(false);
       refreshPluginsList(flutterProject);
-      expectNotExists(flutterProject.flutterPluginsFile);
+      expect(flutterProject.flutterPluginsFile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
@@ -86,7 +85,7 @@ flutter:
       when(iosProject.existsSync()).thenReturn(false);
       when(macosProject.existsSync()).thenReturn(false);
       refreshPluginsList(flutterProject);
-      expectExists(flutterProject.flutterPluginsFile);
+      expect(flutterProject.flutterPluginsFile.existsSync(), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });
@@ -98,8 +97,8 @@ flutter:
       when(iosProject.existsSync()).thenReturn(true);
       when(macosProject.existsSync()).thenReturn(true);
       refreshPluginsList(flutterProject);
-      expectNotExists(iosProject.podManifestLock);
-      expectNotExists(macosProject.podManifestLock);
+      expect(iosProject.podManifestLock.existsSync(), false);
+      expect(macosProject.podManifestLock.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
     });

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   setUp(() async {
     fs = MemoryFileSystem();
-  
+
     // Add basic properties to the Flutter project and subprojects
     flutterProject = MockFlutterProject();
     when(flutterProject.directory).thenReturn(fs.directory('/'));

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1,0 +1,107 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/dart/package_map.dart';
+import 'package:flutter_tools/src/plugins.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:mockito/mockito.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+import 'project_test.dart';
+
+class MockFlutterProject extends Mock implements FlutterProject {}
+class MockIosProject extends Mock implements IosProject {}
+class MockMacOSProject extends Mock implements MacOSProject {}
+
+void main() {
+  FileSystem fs;
+  MockFlutterProject flutterProject;
+  MockIosProject iosProject;
+  MockMacOSProject macosProject;
+  File packagesFile;
+  Directory dummyPackageDirectory;
+
+  setUp(() async {
+    fs = MemoryFileSystem();
+  
+    // Add basic properties to the Flutter project and subprojects
+    flutterProject = MockFlutterProject();
+    when(flutterProject.directory).thenReturn(fs.directory('/'));
+    when(flutterProject.flutterPluginsFile).thenReturn(flutterProject.directory.childFile('.plugins'));
+    iosProject = MockIosProject();
+    when(flutterProject.ios).thenReturn(iosProject);
+    when(iosProject.podManifestLock).thenReturn(flutterProject.directory.childDirectory('ios').childFile('Podfile.lock'));
+    macosProject = MockMacOSProject();
+    when(flutterProject.macos).thenReturn(macosProject);
+    when(macosProject.podManifestLock).thenReturn(flutterProject.directory.childDirectory('macos').childFile('Podfile.lock'));
+
+    // Set up a simple .packages file for all the tests to use, pointing to one package.
+    dummyPackageDirectory = fs.directory('/pubcache/apackage/lib/');
+    packagesFile = fs.file(fs.path.join(flutterProject.directory.path, PackageMap.globalPackagesPath));
+    packagesFile..createSync(recursive: true)
+        ..writeAsStringSync('apackage:file://${dummyPackageDirectory.path}');
+  });
+
+  // Makes the dummy package pointed to by packagesFile look like a plugin.
+  void configureDummyPackageAsPlugin() {
+    dummyPackageDirectory.parent.childFile('pubspec.yaml')..createSync(recursive: true)..writeAsStringSync('''
+flutter:
+  plugin:
+    platforms:
+      ios:
+        pluginClass: FLESomePlugin
+''');
+  }
+
+  // Creates the files that would indicate that pod install has run for the
+  // given project.
+  void simulatePodInstallRun(XcodeBasedProject project) {
+    project.podManifestLock.createSync(recursive: true);
+  }
+
+  group('refreshPlugins', () {
+    testUsingContext('Refreshing the plugin list is a no-op when the plugins list stays empty', () {
+      refreshPluginsList(flutterProject);
+      expectNotExists(flutterProject.flutterPluginsFile);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+    });
+
+    testUsingContext('Refreshing the plugin list deletes the plugin file when there were plugins but no longer are', () {
+      flutterProject.flutterPluginsFile.createSync();
+      when(iosProject.existsSync()).thenReturn(false);
+      when(macosProject.existsSync()).thenReturn(false);
+      refreshPluginsList(flutterProject);
+      expectNotExists(flutterProject.flutterPluginsFile);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+    });
+
+    testUsingContext('Refreshing the plugin list creates a plugin directory when there are plugins', () {
+      configureDummyPackageAsPlugin();
+      when(iosProject.existsSync()).thenReturn(false);
+      when(macosProject.existsSync()).thenReturn(false);
+      refreshPluginsList(flutterProject);
+      expectExists(flutterProject.flutterPluginsFile);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+    });
+
+    testUsingContext('Changes to the plugin list invalidates the Cocoapod lockfiles', () {
+      simulatePodInstallRun(iosProject);
+      simulatePodInstallRun(macosProject);
+      configureDummyPackageAsPlugin();
+      when(iosProject.existsSync()).thenReturn(true);
+      when(macosProject.existsSync()).thenReturn(true);
+      refreshPluginsList(flutterProject);
+      expectNotExists(iosProject.podManifestLock);
+      expectNotExists(macosProject.podManifestLock);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+    });
+  });
+}


### PR DESCRIPTION
## Description

When the plugin list changes, iOS pods are invalidated, but that was
never wired up for macOS.

## Related Issues

Should fix #39327

## Tests

I added the following tests: None

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
