### PR TITLE
Added notice to docs that setPreferredOrientations does not always work on iPad

### DIFF
--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -222,8 +222,15 @@ class SystemChrome {
   /// The empty list causes the application to defer to the operating system
   /// default.
   ///
-  /// **Important:** This setting will only be respected on iPad if multitasking is disabled for your app.
-  /// See: https://github.com/flutter/flutter/issues/27235
+  /// ## Limitations
+  /// This setting will only be respected on iPad if multitasking is disabled.
+  ///
+  /// You can decide to opt out of multitasking on iPad, then
+  /// setPreferredOrientations will work but your app will not
+  /// support Slide Over and Split View multitasking anymore.
+  ///
+  /// Should you decide to opt out of multitasking you can do this by
+  /// setting `Requires full screen` to true in the Xcode Deployment Info.
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
     await SystemChannels.platform.invokeMethod<void>(
       'SystemChrome.setPreferredOrientations',

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -222,7 +222,7 @@ class SystemChrome {
   /// The empty list causes the application to defer to the operating system
   /// default.
   ///
-  /// **Important:** This setting will only be respected on iPads if multitasking is disabled for your app.
+  /// **Important:** This setting will only be respected on iPad if multitasking is disabled for your app.
   /// See: https://github.com/flutter/flutter/issues/27235
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
     await SystemChannels.platform.invokeMethod<void>(

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -223,7 +223,7 @@ class SystemChrome {
   /// default.
   ///
   /// **Important:** This setting will only be respected on iPads if multitasking is disabled for your app.
-  /// [More information here]: https://github.com/flutter/flutter/issues/27235
+  /// See: https://github.com/flutter/flutter/issues/27235
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
     await SystemChannels.platform.invokeMethod<void>(
       'SystemChrome.setPreferredOrientations',

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -221,6 +221,9 @@ class SystemChrome {
   /// The `orientation` argument is a list of [DeviceOrientation] enum values.
   /// The empty list causes the application to defer to the operating system
   /// default.
+  ///
+  /// **Important:** This setting will only be respected on iPads if multitasking is disabled for your app.
+  /// [More information here]: https://github.com/flutter/flutter/issues/27235
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
     await SystemChannels.platform.invokeMethod<void>(
       'SystemChrome.setPreferredOrientations',

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -223,6 +223,7 @@ class SystemChrome {
   /// default.
   ///
   /// ## Limitations
+  ///
   /// This setting will only be respected on iPad if multitasking is disabled.
   ///
   /// You can decide to opt out of multitasking on iPad, then
@@ -230,7 +231,7 @@ class SystemChrome {
   /// support Slide Over and Split View multitasking anymore.
   ///
   /// Should you decide to opt out of multitasking you can do this by
-  /// setting `Requires full screen` to true in the Xcode Deployment Info.
+  /// setting "Requires full screen" to true in the Xcode Deployment Info.
   static Future<void> setPreferredOrientations(List<DeviceOrientation> orientations) async {
     await SystemChannels.platform.invokeMethod<void>(
       'SystemChrome.setPreferredOrientations',


### PR DESCRIPTION
## Description

Added a notice to the documentation that setPreferredOrientations does not always work on iPad

## Related Issues

https://github.com/flutter/flutter/issues/27235

## Tests

I added the following tests:

No tests as I only changed documentation

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes