### PR TITLE
Fix visibility of web server device when Chrome is not available

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -71,6 +71,16 @@ class ChromeLauncher {
 
   static final Completer<Chrome> _currentCompleter = Completer<Chrome>();
 
+  /// Whether we can locate the chrome executable.
+  bool canFindChrome() {
+    final String chrome = findChromeExecutable();
+    try {
+      return processManager.canRun(chrome);
+    } on ArgumentError {
+      return false;
+    }
+  }
+
   /// Launch the chrome browser to a particular `host` page.
   ///
   /// `headless` defaults to false, and controls whether we open a headless or

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -156,6 +156,7 @@ class ChromeDevice extends Device {
 class WebDevices extends PollingDeviceDiscovery {
   WebDevices() : super('chrome');
 
+  final bool _chromeIsAvailable = canFindChrome();
   final ChromeDevice _webDevice = ChromeDevice();
   final WebServerDevice _webServerDevice = WebServerDevice();
 
@@ -165,7 +166,8 @@ class WebDevices extends PollingDeviceDiscovery {
   @override
   Future<List<Device>> pollingGetDevices() async {
     return <Device>[
-      _webDevice,
+      if (_chromeIsAvailable)
+        _webDevice,
       _webServerDevice,
     ];
   }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -15,7 +15,6 @@ import '../features.dart';
 import '../globals.dart';
 import '../project.dart';
 import 'chrome.dart';
-import 'workflow.dart';
 
 class WebApplicationPackage extends ApplicationPackage {
   WebApplicationPackage(this.flutterProject) : super(id: flutterProject.manifest.appName);
@@ -81,7 +80,7 @@ class ChromeDevice extends Device {
   Future<String> get emulatorId async => null;
 
   @override
-  bool isSupported() =>  featureFlags.isWebEnabled && canFindChrome();
+  bool isSupported() =>  featureFlags.isWebEnabled && chromeLauncher.canFindChrome();
 
   @override
   String get name => 'Chrome';
@@ -156,7 +155,7 @@ class ChromeDevice extends Device {
 class WebDevices extends PollingDeviceDiscovery {
   WebDevices() : super('chrome');
 
-  final bool _chromeIsAvailable = canFindChrome();
+  final bool _chromeIsAvailable = chromeLauncher.canFindChrome();
   final ChromeDevice _webDevice = ChromeDevice();
   final WebServerDevice _webServerDevice = WebServerDevice();
 

--- a/packages/flutter_tools/lib/src/web/web_validator.dart
+++ b/packages/flutter_tools/lib/src/web/web_validator.dart
@@ -5,7 +5,6 @@
 import '../base/platform.dart';
 import '../doctor.dart';
 import 'chrome.dart';
-import 'workflow.dart';
 
 /// A validator that checks whether chrome is installed and can run.
 class WebValidator extends DoctorValidator {
@@ -14,7 +13,7 @@ class WebValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     final String chrome = findChromeExecutable();
-    final bool canRunChrome = canFindChrome();
+    final bool canRunChrome = chromeLauncher.canFindChrome();
     final List<ValidationMessage> messages = <ValidationMessage>[
       if (platform.environment.containsKey(kChromeEnvironment))
         if (!canRunChrome)

--- a/packages/flutter_tools/lib/src/web/workflow.dart
+++ b/packages/flutter_tools/lib/src/web/workflow.dart
@@ -19,10 +19,10 @@ class WebWorkflow extends Workflow {
   bool get appliesToHostPlatform => featureFlags.isWebEnabled && (platform.isWindows || platform.isMacOS || platform.isLinux);
 
   @override
-  bool get canLaunchDevices => featureFlags.isWebEnabled && canFindChrome();
+  bool get canLaunchDevices => featureFlags.isWebEnabled;
 
   @override
-  bool get canListDevices => featureFlags.isWebEnabled && canFindChrome();
+  bool get canListDevices => featureFlags.isWebEnabled;
 
   @override
   bool get canListEmulators => false;

--- a/packages/flutter_tools/lib/src/web/workflow.dart
+++ b/packages/flutter_tools/lib/src/web/workflow.dart
@@ -4,10 +4,8 @@
 
 import '../base/context.dart';
 import '../base/platform.dart';
-import '../base/process_manager.dart';
 import '../doctor.dart';
 import '../features.dart';
-import 'chrome.dart';
 
 /// The  web workflow instance.
 WebWorkflow get webWorkflow => context.get<WebWorkflow>();
@@ -26,14 +24,4 @@ class WebWorkflow extends Workflow {
 
   @override
   bool get canListEmulators => false;
-}
-
-/// Whether we can locate the chrome executable.
-bool canFindChrome() {
-  final String chrome = findChromeExecutable();
-  try {
-    return processManager.canRun(chrome);
-  } on ArgumentError {
-    return false;
-  }
 }

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -61,32 +61,33 @@ void main() {
   });
 
   testUsingContext('Chrome device is listed when Chrome is available', () async {
-    when(mockProcessManager.canRun(any)).thenReturn(false);
-    when(mockProcessManager.canRun(argThat(contains('chrome')))).thenReturn(true);
+    when(mockChromeLauncher.canFindChrome()).thenReturn(true);
 
     final WebDevices deviceDiscoverer = WebDevices();
     final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
     expect(devices, contains(isInstanceOf<ChromeDevice>()));
+  }, overrides: <Type, Generator>{
+    ChromeLauncher: () => mockChromeLauncher,
   });
 
   testUsingContext('Chrome device is not listed when Chrome is not available', () async {
-    when(mockProcessManager.canRun(any)).thenReturn(false);
+    when(mockChromeLauncher.canFindChrome()).thenReturn(false);
 
     final WebDevices deviceDiscoverer = WebDevices();
     final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
     expect(devices, isNot(contains(isInstanceOf<ChromeDevice>())));
   }, overrides: <Type, Generator>{
-    ProcessManager: () => mockProcessManager,
+    ChromeLauncher: () => mockChromeLauncher,
   });
 
   testUsingContext('Web Server device is listed even when Chrome is not available', () async {
-    when(mockProcessManager.canRun(any)).thenReturn(false);
+    when(mockChromeLauncher.canFindChrome()).thenReturn(false);
 
     final WebDevices deviceDiscoverer = WebDevices();
     final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
     expect(devices, contains(isInstanceOf<WebServerDevice>()));
   }, overrides: <Type, Generator>{
-    ProcessManager: () => mockProcessManager,
+    ChromeLauncher: () => mockChromeLauncher,
   });
 
   testUsingContext('Chrome invokes version command on non-Windows platforms', () async{

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -60,6 +60,35 @@ void main() {
     expect(await device.portForwarder.forward(1), 1);
   });
 
+  testUsingContext('Chrome device is listed when Chrome is available', () async {
+    when(mockProcessManager.canRun(any)).thenReturn(false);
+    when(mockProcessManager.canRun(argThat(contains('chrome')))).thenReturn(true);
+
+    final WebDevices deviceDiscoverer = WebDevices();
+    final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
+    expect(devices, contains(isInstanceOf<ChromeDevice>()));
+  });
+
+  testUsingContext('Chrome device is not listed when Chrome is not available', () async {
+    when(mockProcessManager.canRun(any)).thenReturn(false);
+
+    final WebDevices deviceDiscoverer = WebDevices();
+    final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
+    expect(devices, isNot(contains(isInstanceOf<ChromeDevice>())));
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => mockProcessManager,
+  });
+
+  testUsingContext('Web Server device is listed even when Chrome is not available', () async {
+    when(mockProcessManager.canRun(any)).thenReturn(false);
+
+    final WebDevices deviceDiscoverer = WebDevices();
+    final List<Device> devices = await deviceDiscoverer.pollingGetDevices();
+    expect(devices, contains(isInstanceOf<WebServerDevice>()));
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => mockProcessManager,
+  });
+
   testUsingContext('Chrome invokes version command on non-Windows platforms', () async{
     when(mockPlatform.isWindows).thenReturn(false);
     when(mockProcessManager.canRun('chrome.foo')).thenReturn(true);

--- a/packages/flutter_tools/test/general.shard/web/workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/workflow_test.dart
@@ -68,11 +68,7 @@ void main() {
     }));
 
     test('does not apply on other platforms', () => testbed.run(() {
-      when(mockProcessManager.canRun('chrome')).thenReturn(false);
       expect(workflow.appliesToHostPlatform, false);
-      expect(workflow.canLaunchDevices, false);
-      expect(workflow.canListDevices, false);
-      expect(workflow.canListEmulators, false);
     }, overrides: <Type, Generator>{
       Platform: () => notSupported,
     }));


### PR DESCRIPTION
This removes the requirement of finding Chrome for all web devices, but does check it before providing the Chrome device.

Fixes #40814.